### PR TITLE
Add HashDigest.FromString

### DIFF
--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -21,5 +21,21 @@ namespace Libplanet.Tests
 
             Assert.Equal(actual, expected);
         }
+
+        [Fact]
+        public void FromStringWorks()
+        {
+            var b =
+                new byte[20]
+                {
+                    0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
+                    0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
+                };
+            var expected = new HashDigest(b);
+            HashDigest actual = HashDigest.FromString(
+                "45a22187e2d8850bb357886958bc3e8560929ccc");
+
+            Assert.Equal(actual, expected);
+        }
     }
 }

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -27,6 +27,11 @@ namespace Libplanet
             return !o1.Equals(o2);
         }
 
+        public static HashDigest FromString(string s)
+        {
+            return new HashDigest(ByteUtil.ParseHex(s));
+        }
+
         public bool HasLeadingZeroBits(int bits)
         {
             var leadingBytes = bits / 8;
@@ -104,7 +109,7 @@ namespace Libplanet
     {
         public static HashDigest ToHashDigest(this string str)
         {
-            return new HashDigest(ByteUtil.ParseHex(str));
+            return HashDigest.FromString(str);
         }
     }
 }


### PR DESCRIPTION
It is convenience that having a method that converts a hex string to `HashDigest` to implement [custom router][nancy-customrouter] for the block explorer.

The code used in `FromString` is taken from [stackoverflow](https://stackoverflow.com/a/26304129). If there are standard API for this, please let me know.


[nancy-customrouter]: https://github.com/NancyFx/Nancy/wiki/Custom-Routing