### PR TITLE
Make PrivateKey & PublicKey a value type

### DIFF
--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -14,7 +14,7 @@ using Org.BouncyCastle.Security;
 
 namespace Libplanet.Crypto
 {
-    public class PrivateKey : IEquatable<PrivateKey>
+    public struct PrivateKey : IEquatable<PrivateKey>
     {
         private readonly ECPrivateKeyParameters keyParam;
 
@@ -38,7 +38,7 @@ namespace Libplanet.Crypto
 
         public static bool operator ==(PrivateKey k1, PrivateKey k2)
         {
-            return k1?.Equals(k2) ?? ReferenceEquals(null, k2);
+            return k1.Equals(k2);
         }
 
         public static bool operator !=(PrivateKey k1, PrivateKey k2)

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -5,7 +5,7 @@ using Org.BouncyCastle.Security;
 
 namespace Libplanet.Crypto
 {
-    public class PublicKey : IEquatable<PublicKey>
+    public struct PublicKey : IEquatable<PublicKey>
     {
         private readonly ECPublicKeyParameters _keyParam;
 
@@ -24,7 +24,7 @@ namespace Libplanet.Crypto
 
         public static bool operator ==(PublicKey k1, PublicKey k2)
         {
-            return k1?.Equals(k2) ?? ReferenceEquals(null, k2);
+            return k1.Equals(k2);
         }
 
         public static bool operator !=(PublicKey k1, PublicKey k2)


### PR DESCRIPTION
By making `PrivateKey` and `PublicKey` a value type, these become:

- able to prevent a variable/field from `null`, and
- to eliminate one pointer dereference (indirection) while keeping the same memory layout (note that these types have only one field).

If a nullable variable/field of these types is needed, we could use [nullable types][1] then.

[1]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/