### PR TITLE
Make HashDigest to check an input length

### DIFF
--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -23,7 +24,7 @@ namespace Libplanet.Tests.Blocks
                 genesis.RewardBeneficiary);
             Assert.Equal(new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }), genesis.Nonce);
             Assert.Equal(
-                new HashDigest(
+                new HashDigest<SHA256>(
                     ByteUtil.ParseHex(
                         "b23717ecdf0b9c83bcc92f5675f827c1ee6808887bf1ce14f0322318174e1007"
                     )
@@ -139,7 +140,7 @@ namespace Libplanet.Tests.Blocks
                 difficulty: genesis.Difficulty,
                 nonce: genesis.Nonce,
                 rewardBeneficiary: genesis.RewardBeneficiary,
-                previousHash: new HashDigest(TestUtils.GetRandomBytes(32)), // invalid
+                previousHash: new HashDigest<SHA256>(TestUtils.GetRandomBytes(32)), // invalid
                 timestamp: genesis.Timestamp,
                 transactions: genesis.Transactions
             );

--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography;
 using Libplanet;
 using Xunit;
 
@@ -15,9 +16,9 @@ namespace Libplanet.Tests
                     0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
                     0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
                 };
-            var expected = new HashDigest(b);
-            HashDigest actual =
-                "45a22187e2d8850bb357886958bc3e8560929ccc".ToHashDigest();
+            var expected = new HashDigest<SHA1>(b);
+            HashDigest<SHA1> actual =
+                "45a22187e2d8850bb357886958bc3e8560929ccc".ToHashDigest<SHA1>();
 
             Assert.Equal(actual, expected);
         }
@@ -31,11 +32,32 @@ namespace Libplanet.Tests
                     0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
                     0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
                 };
-            var expected = new HashDigest(b);
-            HashDigest actual = HashDigest.FromString(
+            var expected = new HashDigest<SHA1>(b);
+            HashDigest<SHA1> actual = HashDigest<SHA1>.FromString(
                 "45a22187e2d8850bb357886958bc3e8560929ccc");
 
             Assert.Equal(actual, expected);
+        }
+
+        [Fact]
+        public void HashDigestDisallowsIncorrectSizedBytes()
+        {
+            for (int i = 0; i < 22; ++i)
+            {
+                if (i == 20)
+                {
+                    new HashDigest<SHA1>(new byte[i]);
+                    HashDigest<SHA1>.FromString(new string('0', i * 2));
+                    continue;
+                }
+
+                Assert.Throws<ArgumentException>(
+                    () => new HashDigest<SHA1>(new byte[i])
+                );
+                Assert.Throws<ArgumentException>(
+                    () => HashDigest<SHA1>.FromString(new string('0', i * 2))
+                );
+            }
         }
     }
 }

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Xunit;
 
 namespace Libplanet.Tests
@@ -32,12 +33,25 @@ namespace Libplanet.Tests
             Assert.True(HasLeadingZeros(new byte[2] { 0x00, 0x7f }, 9));
             Assert.False(HasLeadingZeros(new byte[2] { 0x00, 0x7f }, 10));
             Assert.True(HasLeadingZeros(new byte[2] { 0x00, 0x20 }, 10));
-            Assert.False(HasLeadingZeros(new byte[1] { 0x00 }, 9));
         }
 
         private bool HasLeadingZeros(byte[] bytes, int bits)
         {
-            return new HashDigest(bytes).HasLeadingZeroBits(bits);
+            byte[] digest;
+            if (bytes.Length < HashDigest<SHA256>.Size)
+            {
+                digest = new byte[HashDigest<SHA256>.Size];
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    digest[i] = bytes[i];
+                }
+            }
+            else
+            {
+                digest = bytes;
+            }
+
+            return new HashDigest<SHA256>(digest).HasLeadingZeroBits(bits);
         }
     }
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Serialization;
 using Libplanet.Tx;
@@ -17,7 +18,7 @@ namespace Libplanet.Blocks
         public readonly int Difficulty;
         public readonly Nonce Nonce;
         public readonly Address? RewardBeneficiary;
-        public readonly HashDigest? PreviousHash;
+        public readonly HashDigest<SHA256>? PreviousHash;
         public readonly DateTime Timestamp;
         public readonly IEnumerable<Transaction<T>> Transactions;
 
@@ -28,7 +29,7 @@ namespace Libplanet.Blocks
             int difficulty,
             Nonce nonce,
             Address? rewardBeneficiary,
-            HashDigest? previousHash,
+            HashDigest<SHA256>? previousHash,
             DateTime timestamp,
             IEnumerable<Transaction<T>> transactions)
         {
@@ -41,7 +42,7 @@ namespace Libplanet.Blocks
             Transactions = transactions;
         }
 
-        public HashDigest Hash
+        public HashDigest<SHA256> Hash
         {
             get
             {
@@ -64,7 +65,7 @@ namespace Libplanet.Blocks
             int index,
             int difficulty,
             Address rewardBeneficiary,
-            HashDigest? previousHash,
+            HashDigest<SHA256>? previousHash,
             DateTime timestamp,
             IEnumerable<Transaction<T>> transactions)
         {

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -23,11 +23,11 @@ namespace Libplanet
             }
         }
 
-        public static HashDigest Hash(byte[] bytes)
+        public static HashDigest<SHA256> Hash(byte[] bytes)
         {
             using (SHA256 hashAlgo = SHA256.Create())
             {
-                return new HashDigest(hashAlgo.ComputeHash(bytes));
+                return new HashDigest<SHA256>(hashAlgo.ComputeHash(bytes));
             }
         }
     }


### PR DESCRIPTION
As Each `HashAlgorithm` has its fixed length of bits, `HashDigest` should disallow other sizes than a hash algorithm's fixed length.  To support various hash algorithms, a type parameter was added to `HashDigest`.  For example, `HashDigest<SHA1>` only accepts `byte[20]` and `HashDigest<SHA256>` only accepts `byte[32]`.  See also added unit tests.