### PR TITLE
Deal with default values of byte string types

### DIFF
--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -13,6 +13,13 @@ namespace Libplanet.Tests
         }
 
         [Fact]
+        public void DefaultConstructor()
+        {
+            Address defaultValue = default;
+            Assert.Equal(new Address(new byte[20]), defaultValue);
+        }
+
+        [Fact]
         public void AddressMustBe20Bytes()
         {
             for (int size = 0; size < 25; size++)

--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -8,6 +8,16 @@ namespace Libplanet.Tests
     public class HashDigestTest
     {
         [Fact]
+        public void DefaultConstructor()
+        {
+            HashDigest<SHA1> sha1Default = default;
+            Assert.Equal(new HashDigest<SHA1>(new byte[20]), sha1Default);
+
+            HashDigest<SHA256> sha256Default = default;
+            Assert.Equal(new HashDigest<SHA256>(new byte[32]), sha256Default);
+        }
+
+        [Fact]
         public void ToHashDigestWorks()
         {
             var b =

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -5,6 +5,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Libplanet.Tests/NonceTest.cs
+++ b/Libplanet.Tests/NonceTest.cs
@@ -12,6 +12,13 @@ namespace Libplanet.Tests
         }
 
         [Fact]
+        public void DefaultConstructor()
+        {
+            Nonce defaultValue = default;
+            Assert.Equal(new Nonce(new byte[0]), defaultValue);
+        }
+
+        [Fact]
         public void ToByteArray()
         {
             byte[] nonceBytes = TestUtils.GetRandomBytes(5);

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -12,8 +12,7 @@ namespace Libplanet
     public partial struct Address
     #pragma warning restore CS0282
     {
-        [Uno.EqualityKey]
-        public readonly ImmutableArray<byte> ByteArray;
+        private ImmutableArray<byte> _byteArray;
 
         public Address(byte[] address)
         {
@@ -27,7 +26,7 @@ namespace Libplanet
                 throw new ArgumentException("address must be 20 bytes");
             }
 
-            ByteArray = address.ToImmutableArray();
+            _byteArray = address.ToImmutableArray();
 
             #pragma warning disable CS0103
             /* Suppress CS0171.
@@ -36,6 +35,20 @@ namespace Libplanet
             _computedHashCode = null;
             _computedKeyHashCode = null;
             #pragma warning restore CS0103
+        }
+
+        [Uno.EqualityKey]
+        public ImmutableArray<byte> ByteArray
+        {
+            get
+            {
+                if (_byteArray.IsDefault)
+                {
+                    _byteArray = new byte[20].ToImmutableArray();
+                }
+
+                return _byteArray;
+            }
         }
 
         [Pure]

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -14,8 +14,7 @@ namespace Libplanet
     {
         public static readonly int Size;
 
-        [Uno.EqualityKey]
-        public readonly ImmutableArray<byte> ByteArray;
+        private ImmutableArray<byte> _byteArray;
 
         static HashDigest()
         {
@@ -38,7 +37,7 @@ namespace Libplanet
                 );
             }
 
-            ByteArray = hashDigest.ToImmutableArray();
+            _byteArray = hashDigest.ToImmutableArray();
 
             #pragma warning disable CS0103
             /* Suppress CS0171.
@@ -47,6 +46,20 @@ namespace Libplanet
             _computedHashCode = null;
             _computedKeyHashCode = null;
             #pragma warning restore CS0103
+        }
+
+        [Uno.EqualityKey]
+        public ImmutableArray<byte> ByteArray
+        {
+            get
+            {
+                if (_byteArray.IsDefault)
+                {
+                    _byteArray = new byte[Size].ToImmutableArray();
+                }
+
+                return _byteArray;
+            }
         }
 
         [Pure]

--- a/Libplanet/Nonce.cs
+++ b/Libplanet/Nonce.cs
@@ -7,11 +7,10 @@ namespace Libplanet
 {
     #pragma warning disable CS0282
     [Uno.GeneratedEquality]
-    public partial struct Nonce : IEquatable<Nonce>
+    public partial struct Nonce
     #pragma warning restore CS0282
     {
-        [Uno.EqualityKey]
-        public readonly ImmutableArray<byte> ByteArray;
+        private ImmutableArray<byte> _byteArray;
 
         public Nonce(byte[] nonce)
         {
@@ -20,7 +19,7 @@ namespace Libplanet
                 throw new NullReferenceException("nonce must not be null");
             }
 
-            ByteArray = nonce.ToImmutableArray();
+            _byteArray = nonce.ToImmutableArray();
 
             #pragma warning disable CS0103
             /* Suppress CS0171.
@@ -29,6 +28,20 @@ namespace Libplanet
             _computedHashCode = null;
             _computedKeyHashCode = null;
             #pragma warning restore CS0103
+        }
+
+        [Uno.EqualityKey]
+        public ImmutableArray<byte> ByteArray
+        {
+            get
+            {
+                if (_byteArray.IsDefault)
+                {
+                    _byteArray = ImmutableArray<byte>.Empty;
+                }
+
+                return _byteArray;
+            }
         }
 
         [Pure]


### PR DESCRIPTION
As [every value type must have its own default constructor, and it cannot be customized][1], we need to deal with default values (that have simply zero-filled and null-referencing members).  This patch makes `Address`, `HashDigest`, and `Nonce` types work with their default states.  See also added unit tests.

[1]: https://stackoverflow.com/a/333840/383405