### PR TITLE
Revert key types from struct to class & do some refactoring

### DIFF
--- a/Libplanet.Tests/AddressExtensionTest.cs
+++ b/Libplanet.Tests/AddressExtensionTest.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Tests
         [Fact]
         public void CanGetAddress()
         {
-            PublicKey key = PublicKey.FromBytes(ByteUtil.ParseHex(
+            PublicKey key = new PublicKey(ByteUtil.ParseHex(
                 "03438b935389a7ebf838b3ae4125bd28506aa2dd457f20afc843729d3e7d60d728"));
             Assert.Equal(
                 new Address(

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -78,7 +78,7 @@ namespace Libplanet.Tests
         [Fact]
         public void FromPublicKey()
         {
-            PublicKey key = PublicKey.FromBytes(ByteUtil.ParseHex(
+            PublicKey key = new PublicKey(ByteUtil.ParseHex(
                 "03438b935389a7ebf838b3ae4125bd28506aa2dd457f20afc843729d3e7d60d728"));
             Assert.Equal(
                 new Address(

--- a/Libplanet.Tests/Crypto/PrivateKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PrivateKeyTest.cs
@@ -11,14 +11,14 @@ namespace Libplanet.Tests.Crypto
         {
             var bs = ByteUtil.ParseHex(
                 "98669850728c6c410bf42c45fe7c49232d14cfb55b784d8135ae404c7c243fc7");
-            var key = PrivateKey.FromBytes(bs);
+            var key = new PrivateKey(bs);
             Assert.Equal(bs, key.Bytes);
         }
 
         [Fact]
         public void PublicKeyTest()
         {
-            var key = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var key = new PrivateKey(ByteUtil.ParseHex(
                 "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465"));
             var expected = ByteUtil.ParseHex(
                 "04c7c674a223661faefed8515febacc411c0f3569c10c65ec86cdce4d85c7ea26c617f0cf19ce0b10686501e57af1a7002282fefa52845be2267d1f4d7af322974");
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void SignTest()
         {
-            var pk = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var pk = new PrivateKey(ByteUtil.ParseHex(
                 "520938fae079789561268c2933f636d8b5a0011ea04112dbababf295e5ddef88"));
             var payload = ByteUtil.ParseHex(
                 "64373a616374696f6e736c6531303a7075626c69635f6b657936353a04b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a5483440efbbef0657ac2ef6c6ee05db06a94532fda7ddc44a1695e5ce1a3d3c76db393a726563697069656e7432303a8ae72efab09594665112e6d49dfd1941538cf374363a73656e64657232303ab6c03de57ddf0369c7207d2d113adff8205199cf393a74696d657374616d7032373a323031382d30312d30325430333a30343a30352e3030363030305a65");
@@ -44,12 +44,12 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void ECDHtest()
         {
-            var prvKey = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var prvKey = new PrivateKey(ByteUtil.ParseHex(
                 "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465"));
-            var pubKey = PrivateKey
-                .FromBytes(ByteUtil.ParseHex(
-                    "5f706787ac72c1080275c1f398640fb07e9da0b124ae9734b28b8d0f01eda586"))
-                .PublicKey;
+            byte[] pubkeyBytes = ByteUtil.ParseHex(
+                "5f706787ac72c1080275c1f398640fb07e9da0b124ae9734b28b8d0f01eda586"
+            );
+            var pubKey = new PrivateKey(pubkeyBytes).PublicKey;
 
             var expected = ByteUtil.ParseHex(
                 "5935d0476af9df2998efb60383adf2ff23bc928322cfbb738fca88e49d557d7e");
@@ -61,7 +61,7 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void DecryptTest()
         {
-            var prvKey = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var prvKey = new PrivateKey(ByteUtil.ParseHex(
                 "fbc20042b3a707a7d5a1fa577171f49cd3a9e67ab9295757c714e3f2f8c2d573"));
             var cipherText = ByteUtil.ParseHex(
                 "03e31a0dea31e2b1327bd8700ad357cc69314ecad70ae2e4fa5517a33b67cfb1c4faa110d4d27311eff14799d73d3caaa20e357c41c88e1422c764edcce06c06b58644c168a5abf39dcb46b6e2");
@@ -73,11 +73,11 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void EqualsTest()
         {
-            var key1 = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var key1 = new PrivateKey(ByteUtil.ParseHex(
                 "fbc20042b3a707a7d5a1fa577171f49cd3a9e67ab9295757c714e3f2f8c2d573"));
-            var key2 = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var key2 = new PrivateKey(ByteUtil.ParseHex(
                 "fbc20042b3a707a7d5a1fa577171f49cd3a9e67ab9295757c714e3f2f8c2d573"));
-            var key3 = PrivateKey.FromBytes(ByteUtil.ParseHex(
+            var key3 = new PrivateKey(ByteUtil.ParseHex(
                 "fbc20042b3a707a7d5a1fa577171f49cd3a9e67ab9295757c714e3f2f8c2d537"));
 
             Assert.Equal(key1, key2);

--- a/Libplanet.Tests/Crypto/PublicKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PublicKeyTest.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void VerifyTest()
         {
-            var pubKey = PublicKey.FromBytes(ByteUtil.ParseHex(
+            var pubKey = new PublicKey(ByteUtil.ParseHex(
                 "04b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a5483440efbbef0657ac2ef6c6ee05db06a94532fda7ddc44a1695e5ce1a3d3c76db"));
             var payload = ByteUtil.ParseHex(
                 "64373a616374696f6e736c6531303a7075626c69635f6b657936353a04b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a5483440efbbef0657ac2ef6c6ee05db06a94532fda7ddc44a1695e5ce1a3d3c76db393a726563697069656e7432303a8ae72efab09594665112e6d49dfd1941538cf374363a73656e64657232303ab6c03de57ddf0369c7207d2d113adff8205199cf393a74696d657374616d7032373a323031382d30312d30325430333a30343a30352e3030363030305a65");
@@ -32,11 +32,11 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void EqualsTest()
         {
-            var key1 = PublicKey.FromBytes(ByteUtil.ParseHex(
+            var key1 = new PublicKey(ByteUtil.ParseHex(
                 "0446115b0131baccf94a5856ede871295f6f3d352e6847cda9c03e89fe09f732808711ec97af6e341f110a326da1bdb81f5ae3badf76a90b22c8c491aed3aaa296"));
-            var key2 = PublicKey.FromBytes(ByteUtil.ParseHex(
+            var key2 = new PublicKey(ByteUtil.ParseHex(
                 "0246115b0131baccf94a5856ede871295f6f3d352e6847cda9c03e89fe09f73280")); // compressed of key1
-            var key3 = PublicKey.FromBytes(ByteUtil.ParseHex(
+            var key3 = new PublicKey(ByteUtil.ParseHex(
                 "04b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a5483440efbbef0657ac2ef6c6ee05db06a94532fda7ddc44a1695e5ce1a3d3c76db"));
 
             Assert.Equal(key1, key2);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanMake()
         {
-            PrivateKey privateKey = PrivateKey.FromBytes(
+            PrivateKey privateKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76")
             );
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanSerialize()
         {
-            PrivateKey privateKey = PrivateKey.FromBytes(
+            PrivateKey privateKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
@@ -75,7 +75,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanSerializeWithActions()
         {
-            PrivateKey privateKey = PrivateKey.FromBytes(
+            PrivateKey privateKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
@@ -108,7 +108,7 @@ namespace Libplanet.Tests.Tx
             byte[] bytes = ByteUtil.ParseHex(
                 "64373a616374696f6e736c6531303a7075626c69635f6b657936353a0446115b0131baccf94a5856ede871295f6f3d352e6847cda9c03e89fe09f732808711ec97af6e341f110a326da1bdb81f5ae3badf76a90b22c8c491aed3aaa296393a726563697069656e7432303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc363a73656e64657232303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc393a7369676e617475726537313a3045022100d3009449764f77e5e3de701451f16e6555f0ab7d1fcb1533f1c8977a1af099100220254b158567b4b285d2a31bf3a922596ec8deeffc32e4f2d5e5982f4030478f4d393a74696d657374616d7032373a323031382d31312d32315430303a30303a30302e3030303030305a65"
             );
-            PublicKey publicKey = PrivateKey.FromBytes(
+            PublicKey publicKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
@@ -138,7 +138,7 @@ namespace Libplanet.Tests.Tx
         {
             byte[] bytes = ByteUtil.ParseHex(
                 "64373a616374696f6e736c64373a747970655f6964363a61747461636b363a76616c75657364363a746172676574333a6f7263363a776561706f6e343a77616e64656564373a747970655f6964353a736c656570363a76616c75657364373a7a6f6e655f69646931306565656531303a7075626c69635f6b657936353a0446115b0131baccf94a5856ede871295f6f3d352e6847cda9c03e89fe09f732808711ec97af6e341f110a326da1bdb81f5ae3badf76a90b22c8c491aed3aaa296393a726563697069656e7432303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc363a73656e64657232303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc393a7369676e617475726537303a304402203a3ff2e174c64e91fb98fd8ddd7b4fa85fef7ec43483ed4085b213fca9ae73e80220401cae21a65451280e7bb389074231fe4b78861ab47417fe9a5ae0dbb2c0a7d4393a74696d657374616d7032373a323031382d31312d32315430303a30303a30302e3030303030305a65");
-            PublicKey publicKey = PrivateKey.FromBytes(
+            PublicKey publicKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
@@ -187,7 +187,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanValidate()
         {
-            PrivateKey privateKey = PrivateKey.FromBytes(
+            PrivateKey privateKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
@@ -231,7 +231,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanConvertToRaw()
         {
-            PrivateKey privateKey = PrivateKey.FromBytes(
+            PrivateKey privateKey = new PrivateKey(
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -20,6 +20,17 @@ namespace Libplanet.Crypto
         [Uno.EqualityKey]
         private readonly ECPrivateKeyParameters keyParam;
 
+        public PrivateKey(byte[] bs)
+            : this(
+                new ECPrivateKeyParameters(
+                    "ECDSA",
+                    new BigInteger(1, bs),
+                    GetECParameters()
+                )
+            )
+        {
+        }
+
         private PrivateKey(ECPrivateKeyParameters keyParam)
         {
             this.keyParam = keyParam;
@@ -37,15 +48,6 @@ namespace Libplanet.Crypto
         }
 
         public byte[] Bytes => keyParam.D.ToByteArrayUnsigned();
-
-        public static PrivateKey FromBytes(byte[] bs)
-        {
-            ECDomainParameters ecParams = GetECParameters();
-            var keyParam = new ECPrivateKeyParameters(
-                "ECDSA", new BigInteger(1, bs), ecParams);
-
-            return new PrivateKey(keyParam);
-        }
 
         public static PrivateKey Generate()
         {
@@ -92,7 +94,7 @@ namespace Libplanet.Crypto
 
         public byte[] Decrypt(byte[] payload)
         {
-            PublicKey pubKey = PublicKey.FromBytes(payload.Take(33).ToArray());
+            PublicKey pubKey = new PublicKey(payload.Take(33).ToArray());
             byte[] aesKey = ECDH(pubKey);
             var aes = new Aesgcm(aesKey);
 

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -11,6 +11,11 @@ namespace Libplanet.Crypto
         [Uno.EqualityKey]
         private readonly ECPublicKeyParameters _keyParam;
 
+        public PublicKey(byte[] bs)
+            : this(GetECPublicKeyParameters(bs))
+        {
+        }
+
         internal PublicKey(ECPublicKeyParameters keyParam)
         {
             _keyParam = keyParam;
@@ -22,18 +27,6 @@ namespace Libplanet.Crypto
             {
                 return _keyParam;
             }
-        }
-
-        public static PublicKey FromBytes(byte[] bs)
-        {
-            var ecParams = PrivateKey.GetECParameters();
-            var keyParam = new ECPublicKeyParameters(
-                "ECDSA",
-                ecParams.Curve.DecodePoint(bs),
-                ecParams
-            );
-
-            return new PublicKey(keyParam);
         }
 
         public byte[] Format(bool compress)
@@ -62,6 +55,16 @@ namespace Libplanet.Crypto
             return aes.Encrypt(
                 payload,
                 disposablePrivateKey.PublicKey.Format(true)
+            );
+        }
+
+        private static ECPublicKeyParameters GetECPublicKeyParameters(byte[] bs)
+        {
+            var ecParams = PrivateKey.GetECParameters();
+            return new ECPublicKeyParameters(
+                "ECDSA",
+                ecParams.Curve.DecodePoint(bs),
+                ecParams
             );
         }
     }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Tx
         public Transaction(RawTransaction rawTx)
         {
             Sender = new Address(rawTx.Sender);
-            PublicKey = PublicKey.FromBytes(rawTx.PublicKey);
+            PublicKey = new PublicKey(rawTx.PublicKey);
             Recipient = new Address(rawTx.Recipient);
             Timestamp = DateTime.ParseExact(
                 rawTx.Timestamp,


### PR DESCRIPTION
First of all, in the same reason to <https://github.com/planetarium/libplanet.net/pull/16>, the changes made by <https://github.com/planetarium/libplanet.net/pull/9> were rolled back.  `PrivateKey` and `PublicKey` types were reverted from a value type to a reference type again to avoid *default states* of these types.

Similar to <https://github.com/planetarium/libplanet.net/pull/12>, now there are no hand-coded equality predicates and these became generated by Uno.CodeGen.  As key types are not a value type anymore, it's relatively simpler to apply Uno.CodeGen.  Things like `#pragma warning` are unnecessary here.

Lastly, I replaced `.FromBytes()` static methods with normal constructors that takes a `byte[]`.  I believe it's closer to what people expect from library APIs.