### PR TITLE
Fixed bug that staged tx disappears

### DIFF
--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -124,5 +124,22 @@ namespace Libplanet.Tests
             _blockchain.Append(_fx.Block1);
             Assert.Contains(_fx.Block1, _blockchain);
         }
+
+        [Fact]
+        public void CanStoreAddresses()
+        {
+            Assert.Empty(_blockchain.Addresses);
+            var txs = new HashSet<Transaction<BaseAction>>()
+            {
+                _fx.Transaction1,
+                _fx.Transaction2
+            };
+            _blockchain.StageTransactions(txs);
+            _blockchain.MineBlock(_fx.Address1);
+
+            Assert.NotEmpty(_blockchain.Addresses);
+            Assert.Contains(_fx.Transaction1, _blockchain.Addresses[_fx.Transaction1.Recipient]);
+            Assert.DoesNotContain(_fx.Transaction2, _blockchain.Addresses[_fx.Transaction1.Recipient]);
+        }
     }
 }

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -208,6 +208,7 @@ namespace Libplanet
                 transactions: Store.IterateStagedTransactionIds()
                 .Select(txId => Store.GetTransaction<T>(txId))
                 .OfType<Transaction<T>>()
+                .ToList()
             );
             Append(block);
 


### PR DESCRIPTION
Staged transactions doesn't contain properly in `Blockchain.Append()` since it's LINQ expression that can be affected by other function (e.g. `Store.UnstageTransactionIds()`) , not a fixed value. So, I fixed to freeze transactions on block creation.