### PR TITLE
Fix bug related Action.Excute().

### DIFF
--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -79,7 +79,7 @@ namespace Libplanet.Tests
         [Fact]
         public void CanProcessActions()
         {
-            var actions = new List<BaseAction>()
+            var actions1 = new List<BaseAction>()
             {
                 new Attack()
                 {
@@ -97,14 +97,14 @@ namespace Libplanet.Tests
                     Target = "goblin",
                 },
             };
-            Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
+            Transaction<BaseAction> tx1 = Transaction<BaseAction>.Make(
                 new PrivateKey(),
                 _fx.Address1,
-                actions,
+                actions1,
                 DateTime.UtcNow
             );
 
-            _blockchain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx });
+            _blockchain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx1 });
             _blockchain.MineBlock(_fx.Address1);
 
             AddressStateMap states = _blockchain.GetStates(new List<Address> { _fx.Address1 });
@@ -115,6 +115,28 @@ namespace Libplanet.Tests
             Assert.Contains("staff", result.UsedWeapons);
             Assert.Contains("orc", result.Targets);
             Assert.Contains("goblin", result.Targets);
+
+            var actions2 = new List<BaseAction>()
+            {
+                new Attack()
+                {
+                    Weapon = "bow",
+                    Target = "goblin",
+                },
+            };
+            Transaction<BaseAction> tx2 = Transaction<BaseAction>.Make(
+                new PrivateKey(),
+                _fx.Address1,
+                actions2,
+                DateTime.UtcNow
+            );
+
+            _blockchain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx2 });
+            _blockchain.MineBlock(_fx.Address1);
+
+            states = _blockchain.GetStates(new List<Address> { _fx.Address1 });
+            result = (BattleResult)states[_fx.Address1];
+            Assert.Contains("bow", result.UsedWeapons);
         }
 
         [Fact]

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -29,11 +29,13 @@ namespace Libplanet.Tests.Common.Action
 
         public override AddressStateMap Execute(Address from, Address to, AddressStateMap states)
         {
-            var result = (BattleResult)states.GetValueOrDefault(to);
+            var result = new BattleResult();
 
-            if (result == null)
+            if (states.TryGetValue(to, out object value))
             {
-                result = new BattleResult();
+                var previousResult = (BattleResult)value;
+                result.UsedWeapons = previousResult.UsedWeapons;
+                result.Targets = previousResult.Targets;
             }
 
             result.UsedWeapons.Add(Weapon);

--- a/Libplanet.Tests/Common/Action/BattleResult.cs
+++ b/Libplanet.Tests/Common/Action/BattleResult.cs
@@ -12,8 +12,8 @@ namespace Libplanet.Tests.Common.Action
             Targets = new HashSet<string>();
         }
 
-        public HashSet<string> UsedWeapons { get; }
+        public HashSet<string> UsedWeapons { get; internal set; }
 
-        public HashSet<string> Targets { get; }
+        public HashSet<string> Targets { get; internal set; }
     }
 }


### PR DESCRIPTION
When Action.Execute() treats `state` as an immutable object, `ImmutableDictionary.AddRange()` throws an `ArgumentException` because a new object is created for the same key each time.