### PR TITLE
Automatically publish docs for every push

### DIFF
--- a/Docs/build.ps1
+++ b/Docs/build.ps1
@@ -56,9 +56,11 @@ if (Get-Command mono -errorAction SilentlyContinue) {
   $unix = [System.PlatformId]::Unix;
   $macos = [System.PlatformId]::MacOSX;
   if (@($unix, $macos).Contains($platform)) {
-    Write-Error "Failed to find the command: mono"
-    Write-Error "You need to install Mono on your system."
-    Write-Error "See also: https://www.mono-project.com/"
+    Write-Error @"
+Failed to find the command: mono
+You need to install Mono on your system.
+See also: https://www.mono-project.com/
+"@
     exit 127
   } else {
     docfx/docfx.exe docfx.json @args

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,3 +83,71 @@ jobs:
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)
       artifactName: $(Build.BuildId)_$(Build.BuildNumber)
+  - task: PowerShell@2
+    displayName: 'Publish docs to GitHub Pages'
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+    inputs:
+      targetType: inline
+      failOnStderr: false
+      script: |
+        Set-PSDebug -Trace 1
+
+        if ("${env:GITHUB_TOKEN}" -eq "") {
+          Write-Error @'
+        The environment variable GITHUB_TOKEN is not defined.
+        You can create an access token from GitHub's settings:
+          https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+        You can define secret variables from Azure Pipelines' settings.
+          https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=vsts&tabs=yaml%2Cbatch#secret-variables
+        '@
+          exit 1
+        }
+
+        $repoUrl = $env:BUILD_REPOSITORY_URI -replace `
+          "^https://","https://${env:GITHUB_TOKEN}@"
+        $buildPath = "${env:BUILD_REPOSITORY_LOCALPATH}/Docs/_site"
+        $commit = "${env:BUILD_SOURCEVERSION}"
+        $dirName = if ($env:BUILD_REASON -eq "PullRequest") {
+          "pulls/${env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}"
+        } else {
+          $env:BUILD_SOURCEBRANCHNAME
+        };
+
+        $authorName = $(git show -s --format='%ce' "$commit")
+        $authorEmail = $(git show -s --format='%ce' "$commit")
+
+        $tmpGitdir = New-TemporaryFile
+        rm "$tmpGitDir"
+        git clone -b gh-pages --single-branch --depth 5 "$repoUrl" "$tmpGitDir"
+
+        cd "$tmpGitDir"
+        git config user.name "$authorName"
+        git config user.email "$authorEmail"
+
+        if (Test-Path "$dirName") {
+          git rm -rf "$dirName"
+        }
+
+        if (-not (Test-Path pulls)) {
+          mkdir pulls
+        }
+
+        Copy-Item -Path $buildPath -Recurse -Destination $dirName
+        git add "$dirName"
+
+        # The below code updates the root index.html so that it's equivalent
+        # to the actual index.html in the docs directory.  It should be adjusted
+        # later so that the root index.html is update only when a new tag is
+        # made.
+        $addedTags = @"
+        <meta http-equiv="refresh" content="0;$dirName/">
+        <base href="$dirName/">
+        "@
+        Get-Content "$dirName/index.html" `
+          | %{$_ -replace "</title>","</title>$addedTags"} `
+          > index.html
+        git add index.html
+
+        git commit --allow-empty -m "Triggered by $commit"
+        git push origin gh-pages


### PR DESCRIPTION
This patch adds a new task to Azure Pipeline settings so that it automatically publishes an updated version of docs to GitHub Pages every time we push commits to the Git repository.  Built docs are going to <https://planetarium.github.io/libplanet.net/>.

Every pull request becomes to have its own docs as well.  For example, this pull request has <https://planetarium.github.io/libplanet.net/pulls/37/>.

Postscript: Azure Pipeline currently does not trigger a build when a new tag is pushed.  This makes release automation difficult.  AppVayor might be better fit for our project.