### PR TITLE
Network polishing

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -202,18 +202,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanDeleteAfter()
-        {
-            var block1 = _blockChain.MineBlock(_fx.Address1);
-            var block2 = _blockChain.MineBlock(_fx.Address1);
-            var block3 = _blockChain.MineBlock(_fx.Address1);
-
-            _blockChain.DeleteAfter(block2.Hash);
-
-            Assert.Equal(new[] { block1, block2 }, _blockChain);
-        }
-
-        [Fact]
         public void CanFork()
         {
             var block1 = _blockChain.MineBlock(_fx.Address1);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -135,7 +135,73 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
-        public async Task WorksAsExpected()
+        public async Task CanBroadcastWhlieMining()
+        {
+            Swarm a = _swarms[0];
+            Swarm b = _swarms[1];
+
+            BlockChain<BaseAction> chainA = _blockchains[0];
+            BlockChain<BaseAction> chainB = _blockchains[1];
+
+            Task CreateMiner(
+                Swarm swarm,
+                BlockChain<BaseAction> chain,
+                int delay,
+                CancellationToken cancellationToken
+            )
+            {
+                return Task.Run(async () =>
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        var block = chain.MineBlock(_fx1.Address1);
+                        Log.Debug(
+                            $"Block mined. " +
+                            $"[Swarm: {swarm.Address}, Block: {block.Hash}]");
+                        await swarm.BroadcastBlocksAsync(new[] { block });
+                        await Task.Delay(delay);
+                    }
+
+                    await swarm.BroadcastBlocksAsync(new[] { chain.Last() });
+                    Log.Debug("Mining complete.");
+                });
+            }
+
+            var minerCanceller = new CancellationTokenSource();
+            Task miningA = CreateMiner(a, chainA, 5000, minerCanceller.Token);
+            Task miningB = CreateMiner(b, chainB, 8000, minerCanceller.Token);
+
+            try
+            {
+                await StartAsync(a, chainA);
+                await StartAsync(b, chainB);
+
+                await b.AddPeersAsync(new[] { a.AsPeer });
+                await EnsureExchange(a, b);
+
+                await Task.Delay(10000);
+                minerCanceller.Cancel();
+
+                await Task.WhenAll(miningA, miningB);
+
+                await Task.Delay(5000);
+            }
+            finally
+            {
+                await a.StopAsync();
+                await b.StopAsync();
+            }
+
+            Log.Debug($"chainA: {string.Join(",", chainA)}");
+            Log.Debug($"chainB: {string.Join(",", chainB)}");
+
+            Assert.Subset(
+                chainA.AsEnumerable().ToHashSet(),
+                chainB.AsEnumerable().ToHashSet());
+        }
+
+        [Fact]
+        public async Task CanExchangePeer()
         {
             Swarm a = _swarms[0];
             Swarm b = _swarms[1];

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -498,6 +498,19 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [Fact]
+        public void CanDenyNullParams()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                new Swarm(null, new Uri("inproc://illegal_swarm"));
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                new Swarm(new PrivateKey(), null);
+            });
+        }
+
         private async Task<Task> StartAsync<T>(
             Swarm swarm,
             BlockChain<T> blockChain,

--- a/Libplanet.Tests/Store/FileStoreFixture.cs
+++ b/Libplanet.Tests/Store/FileStoreFixture.cs
@@ -19,7 +19,6 @@ namespace Libplanet.Tests.Store
                 System.IO.Path.GetTempPath(), $"filestore_test_{postfix}");
             Store = new FileStore(Path);
             StoreNamespace = Guid.NewGuid().ToString();
-            Store.InitNamespace(StoreNamespace);
 
             Address1 = new Address(new byte[]
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -268,22 +268,6 @@ namespace Libplanet.Blockchain
             return forked;
         }
 
-        internal void DeleteAfter(HashDigest<SHA256> point)
-        {
-            HashDigest<SHA256>? current = Store.IndexBlockHash(
-                Id.ToString(), -1
-            );
-
-            while (current is HashDigest<SHA256> hash && hash != point)
-            {
-                HashDigest<SHA256>? previous = Blocks[hash].PreviousHash;
-                Store.DeleteBlock(Id.ToString(), hash);
-                Store.DeleteIndex(Id.ToString(), hash);
-
-                current = previous;
-            }
-        }
-
         internal BlockLocator GetBlockLocator(int threshold = 10)
         {
             HashDigest<SHA256>? current = Store.IndexBlockHash(
@@ -312,6 +296,17 @@ namespace Libplanet.Blockchain
             }
 
             return new BlockLocator(hashes);
+        }
+
+        // FIXME it's very dangerous because replacing Id means
+        // ALL blocks (referenced by MineBlock(), etc.) will be changed.
+        // we need to add a synchronization mechanism to handle this correctly.
+        internal void Swap(BlockChain<T> other)
+        {
+            Id = other.Id;
+            Blocks = new BlockSet<T>(Store, Id.ToString());
+            Transactions = new TransactionSet<T>(Store, Id.ToString());
+            Addresses = new AddressTransactionSet<T>(Store, Id.ToString());
         }
 
         private void EvaluateActions(Block<T> block)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -5,18 +5,22 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using System.Threading;
 using Libplanet.Action;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Store;
 using Libplanet.Tx;
 
+[assembly: InternalsVisibleTo("Libplanet.Explorer")]
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
 namespace Libplanet.Blockchain
 {
     public class BlockChain<T> : IEnumerable<Block<T>>
         where T : IAction
     {
+        private readonly ReaderWriterLockSlim _rwlock;
+
         public BlockChain(IBlockPolicy<T> policy, IStore store)
             : this(policy, store, Guid.NewGuid())
         {
@@ -30,26 +34,17 @@ namespace Libplanet.Blockchain
             Blocks = new BlockSet<T>(store, Id.ToString());
             Transactions = new TransactionSet<T>(store, Id.ToString());
             Addresses = new AddressTransactionSet<T>(store, Id.ToString());
+
+            _rwlock = new ReaderWriterLockSlim(
+                LockRecursionPolicy.SupportsRecursion);
+        }
+
+        ~BlockChain()
+        {
+            _rwlock?.Dispose();
         }
 
         public IBlockPolicy<T> Policy { get; }
-
-        public IDictionary<HashDigest<SHA256>, Block<T>> Blocks
-        {
-            get; private set;
-        }
-
-        public IDictionary<TxId, Transaction<T>> Transactions
-        {
-            get; private set;
-        }
-
-        public IDictionary<Address, IEnumerable<Transaction<T>>> Addresses
-        {
-            get; private set;
-        }
-
-        public IStore Store { get; }
 
         public Block<T> Tip
         {
@@ -68,19 +63,45 @@ namespace Libplanet.Blockchain
 
         public Guid Id { get; private set; }
 
+        internal IDictionary<HashDigest<SHA256>, Block<T>> Blocks
+        {
+            get; private set;
+        }
+
+        internal IDictionary<TxId, Transaction<T>> Transactions
+        {
+            get; private set;
+        }
+
+        internal IDictionary<Address, IEnumerable<Transaction<T>>> Addresses
+        {
+            get; private set;
+        }
+
+        internal IStore Store { get; }
+
         public Block<T> this[long index]
         {
             get
             {
-                HashDigest<SHA256>? blockHash = Store.IndexBlockHash(
-                    Id.ToString(), index
-                );
-                if (blockHash == null)
+                try
                 {
-                    throw new IndexOutOfRangeException();
-                }
+                    _rwlock.EnterReadLock();
 
-                return Blocks[blockHash.Value];
+                    HashDigest<SHA256>? blockHash = Store.IndexBlockHash(
+                        Id.ToString(), index
+                    );
+                    if (blockHash == null)
+                    {
+                        throw new IndexOutOfRangeException();
+                    }
+
+                    return Blocks[blockHash.Value];
+                }
+                finally
+                {
+                    _rwlock.ExitReadLock();
+                }
             }
         }
 
@@ -103,12 +124,21 @@ namespace Libplanet.Blockchain
 
         public IEnumerator<Block<T>> GetEnumerator()
         {
-            IEnumerable<HashDigest<SHA256>> indexes = Store.IterateIndex(
-                Id.ToString()
-            );
-            foreach (HashDigest<SHA256> hash in indexes)
+            try
             {
-                yield return Blocks[hash];
+                _rwlock.EnterReadLock();
+
+                IEnumerable<HashDigest<SHA256>> indexes = Store.IterateIndex(
+                    Id.ToString()
+                );
+                foreach (HashDigest<SHA256> hash in indexes)
+                {
+                    yield return Blocks[hash];
+                }
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
             }
         }
 
@@ -120,48 +150,65 @@ namespace Libplanet.Blockchain
         public AddressStateMap GetStates(
             IEnumerable<Address> addresses, HashDigest<SHA256>? offset = null)
         {
-            if (offset == null)
+            try
             {
-                offset = Store.IndexBlockHash(Id.ToString(), -1);
-            }
-
-            var states = new AddressStateMap();
-            while (offset != null)
-            {
-                states = (AddressStateMap)states.SetItems(
-                    Store.GetBlockStates(Id.ToString(), offset.Value)
-                    .Where(
-                        kv => addresses.Contains(kv.Key) &&
-                        !states.ContainsKey(kv.Key))
-                );
-                if (states.Keys.SequenceEqual(addresses))
+                _rwlock.EnterReadLock();
+                if (offset == null)
                 {
-                    break;
+                    offset = Store.IndexBlockHash(Id.ToString(), -1);
                 }
 
-                offset = Blocks[offset.Value].PreviousHash;
-            }
+                var states = new AddressStateMap();
+                while (offset != null)
+                {
+                    states = (AddressStateMap)states.SetItems(
+                        Store.GetBlockStates(Id.ToString(), offset.Value)
+                        .Where(
+                            kv => addresses.Contains(kv.Key) &&
+                            !states.ContainsKey(kv.Key))
+                     );
+                    if (states.Keys.SequenceEqual(addresses))
+                    {
+                        break;
+                    }
 
-            return states;
+                    offset = Blocks[offset.Value].PreviousHash;
+                }
+
+                return states;
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
         }
 
         public void Append(Block<T> block, DateTimeOffset currentTime)
         {
-            Validate(Enumerable.Append(this, block), currentTime);
-            Blocks[block.Hash] = block;
-            EvaluateActions(block);
-
-            long index = Store.AppendIndex(Id.ToString(), block.Hash);
-            ISet<TxId> txIds = block.Transactions
-                .Select(t => t.Id)
-                .ToImmutableHashSet();
-
-            Store.UnstageTransactionIds(Id.ToString(), txIds);
-            foreach (Transaction<T> tx in block.Transactions)
+            try
             {
-                Store.AppendAddressTransactionId(
-                    Id.ToString(), tx.Recipient, tx.Id
-                );
+                _rwlock.EnterWriteLock();
+
+                Validate(Enumerable.Append(this, block), currentTime);
+                Blocks[block.Hash] = block;
+                EvaluateActions(block);
+
+                long index = Store.AppendIndex(Id.ToString(), block.Hash);
+                ISet<TxId> txIds = block.Transactions
+                    .Select(t => t.Id)
+                    .ToImmutableHashSet();
+
+                Store.UnstageTransactionIds(Id.ToString(), txIds);
+                foreach (Transaction<T> tx in block.Transactions)
+                {
+                    Store.AppendAddressTransactionId(
+                        Id.ToString(), tx.Recipient, tx.Id
+                    );
+                }
+            }
+            finally
+            {
+                _rwlock.ExitWriteLock();
             }
         }
 
@@ -170,15 +217,24 @@ namespace Libplanet.Blockchain
 
         public void StageTransactions(ISet<Transaction<T>> txs)
         {
-            foreach (Transaction<T> tx in txs)
+            try
             {
-                Transactions[tx.Id] = tx;
-            }
+                _rwlock.EnterWriteLock();
 
-            Store.StageTransactionIds(
-                Id.ToString(),
-                txs.Select(tx => tx.Id).ToImmutableHashSet()
-            );
+                foreach (Transaction<T> tx in txs)
+                {
+                    Transactions[tx.Id] = tx;
+                }
+
+                Store.StageTransactionIds(
+                    Id.ToString(),
+                    txs.Select(tx => tx.Id).ToImmutableHashSet()
+                );
+            }
+            finally
+            {
+                _rwlock.ExitWriteLock();
+            }
         }
 
         public Block<T> MineBlock(
@@ -186,23 +242,39 @@ namespace Libplanet.Blockchain
             DateTimeOffset currentTime
         )
         {
-            long index = Store.CountIndex(Id.ToString());
-            int difficulty = Policy.GetNextBlockDifficulty(this);
+            try
+            {
+                _rwlock.EnterWriteLock();
 
-            Block<T> block = Block<T>.Mine(
-                index: index,
-                difficulty: difficulty,
-                rewardBeneficiary: rewardBeneficiary,
-                previousHash: Store.IndexBlockHash(Id.ToString(), index - 1),
-                timestamp: currentTime,
-                transactions: Store.IterateStagedTransactionIds(Id.ToString())
-                .Select(txId => Store.GetTransaction<T>(Id.ToString(), txId))
-                .OfType<Transaction<T>>()
-                .ToList()
-            );
-            Append(block, currentTime);
+                string @namespace = Id.ToString();
+                long index = Store.CountIndex(@namespace);
+                int difficulty = Policy.GetNextBlockDifficulty(this);
+                HashDigest<SHA256>? prevHash = Store.IndexBlockHash(
+                    @namespace,
+                    index - 1
+                );
+                List<Transaction<T>> transactions = Store
+                    .IterateStagedTransactionIds(@namespace)
+                    .Select(txId => Store.GetTransaction<T>(@namespace, txId))
+                    .OfType<Transaction<T>>()
+                    .ToList();
 
-            return block;
+                Block<T> block = Block<T>.Mine(
+                    index: index,
+                    difficulty: difficulty,
+                    rewardBeneficiary: rewardBeneficiary,
+                    previousHash: prevHash,
+                    timestamp: currentTime,
+                    transactions: transactions
+                );
+                Append(block, currentTime);
+
+                return block;
+            }
+            finally
+            {
+                _rwlock.ExitWriteLock();
+            }
         }
 
         public Block<T> MineBlock(Address rewardBeneficiary) =>
@@ -210,16 +282,25 @@ namespace Libplanet.Blockchain
 
         internal HashDigest<SHA256> FindBranchPoint(BlockLocator locator)
         {
-            // Assume locator is sorted descending by height.
-            foreach (HashDigest<SHA256> hash in locator)
+            try
             {
-                if (Blocks.ContainsKey(hash))
-                {
-                    return Blocks[hash].Hash;
-                }
-            }
+                _rwlock.EnterReadLock();
 
-            return this[0].Hash;
+                // Assume locator is sorted descending by height.
+                foreach (HashDigest<SHA256> hash in locator)
+                {
+                    if (Blocks.ContainsKey(hash))
+                    {
+                        return Blocks[hash].Hash;
+                    }
+                }
+
+                return this[0].Hash;
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
         }
 
         internal IEnumerable<HashDigest<SHA256>> FindNextHashes(
@@ -227,73 +308,99 @@ namespace Libplanet.Blockchain
             HashDigest<SHA256>? stop = null,
             int count = 500)
         {
-            HashDigest<SHA256>? Next(HashDigest<SHA256> hash)
+            try
             {
-                long nextIndex = Blocks[hash].Index + 1;
-                return Store.IndexBlockHash(Id.ToString(), nextIndex);
-            }
+                _rwlock.EnterReadLock();
 
-            HashDigest<SHA256>? tip = Store.IndexBlockHash(Id.ToString(), -1);
-            HashDigest<SHA256>? currentHash = FindBranchPoint(locator);
-
-            while (currentHash != null && count > 0)
-            {
-                yield return currentHash.Value;
-
-                if (currentHash == stop || currentHash == tip)
+                HashDigest<SHA256>? Next(HashDigest<SHA256> hash)
                 {
-                    break;
+                    long nextIndex = Blocks[hash].Index + 1;
+                    return Store.IndexBlockHash(Id.ToString(), nextIndex);
                 }
 
-                currentHash = Next(currentHash.Value);
-                count--;
+                HashDigest<SHA256>? tip = Store.IndexBlockHash(
+                    Id.ToString(), -1);
+                HashDigest<SHA256>? currentHash = FindBranchPoint(locator);
+
+                while (currentHash != null && count > 0)
+                {
+                    yield return currentHash.Value;
+
+                    if (currentHash == stop || currentHash == tip)
+                    {
+                        break;
+                    }
+
+                    currentHash = Next(currentHash.Value);
+                    count--;
+                }
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
             }
         }
 
         internal BlockChain<T> Fork(HashDigest<SHA256> point)
         {
             var forked = new BlockChain<T>(Policy, Store, Guid.NewGuid());
-            foreach (var index in Store.IterateIndex(Id.ToString()))
+            try
             {
-                forked.Append(Blocks[index]);
-
-                if (index == point)
+                _rwlock.EnterReadLock();
+                foreach (var index in Store.IterateIndex(Id.ToString()))
                 {
-                    break;
-                }
-            }
+                    forked.Append(Blocks[index]);
 
-            return forked;
+                    if (index == point)
+                    {
+                        break;
+                    }
+                }
+
+                return forked;
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
         }
 
         internal BlockLocator GetBlockLocator(int threshold = 10)
         {
-            HashDigest<SHA256>? current = Store.IndexBlockHash(
-                Id.ToString(), -1
-            );
-            long step = 1;
-            var hashes = new List<HashDigest<SHA256>>();
-
-            while (current is HashDigest<SHA256> hash)
+            try
             {
-                hashes.Add(hash);
-                Block<T> currentBlock = Blocks[hash];
+                _rwlock.EnterReadLock();
 
-                if (currentBlock.Index == 0)
+                HashDigest<SHA256>? current = Store.IndexBlockHash(
+                    Id.ToString(), -1);
+                long step = 1;
+                var hashes = new List<HashDigest<SHA256>>();
+
+                while (current is HashDigest<SHA256> hash)
                 {
-                    break;
+                    hashes.Add(hash);
+                    Block<T> currentBlock = Blocks[hash];
+
+                    if (currentBlock.Index == 0)
+                    {
+                        break;
+                    }
+
+                    long nextIndex = Math.Max(currentBlock.Index - step, 0);
+                    current = Store.IndexBlockHash(Id.ToString(), nextIndex);
+
+                    if (hashes.Count > threshold)
+                    {
+                        step *= 2;
+                    }
                 }
 
-                long nextIndex = Math.Max(currentBlock.Index - step, 0);
-                current = Store.IndexBlockHash(Id.ToString(), nextIndex);
-
-                if (hashes.Count > threshold)
-                {
-                    step *= 2;
-                }
+                return new BlockLocator(hashes);
             }
-
-            return new BlockLocator(hashes);
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
         }
 
         // FIXME it's very dangerous because replacing Id means
@@ -301,10 +408,19 @@ namespace Libplanet.Blockchain
         // we need to add a synchronization mechanism to handle this correctly.
         internal void Swap(BlockChain<T> other)
         {
-            Id = other.Id;
-            Blocks = new BlockSet<T>(Store, Id.ToString());
-            Transactions = new TransactionSet<T>(Store, Id.ToString());
-            Addresses = new AddressTransactionSet<T>(Store, Id.ToString());
+            try
+            {
+                _rwlock.EnterWriteLock();
+
+                Id = other.Id;
+                Blocks = new BlockSet<T>(Store, Id.ToString());
+                Transactions = new TransactionSet<T>(Store, Id.ToString());
+                Addresses = new AddressTransactionSet<T>(Store, Id.ToString());
+            }
+            finally
+            {
+                _rwlock.ExitWriteLock();
+            }
         }
 
         private void EvaluateActions(Block<T> block)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -30,8 +30,6 @@ namespace Libplanet.Blockchain
             Blocks = new BlockSet<T>(store, Id.ToString());
             Transactions = new TransactionSet<T>(store, Id.ToString());
             Addresses = new AddressTransactionSet<T>(store, Id.ToString());
-
-            Store.InitNamespace(Id.ToString());
         }
 
         public IBlockPolicy<T> Policy { get; }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Net.Messages
             Tx = 0x10,
         }
 
-        public Address? Identity { get; set; }
+        public byte[] Identity { get; set; }
 
         protected abstract MessageType Type { get; }
 
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Messages
 
             if (!reply)
             {
-                message.Identity = new Address(raw[0].Buffer);
+                message.Identity = raw[0].Buffer.ToArray();
             }
 
             return message;
@@ -136,9 +136,9 @@ namespace Libplanet.Net.Messages
             message.Push(key.PublicKey.Format(true));
             message.Push((byte)Type);
 
-            if (Identity is Address to)
+            if (Identity is byte[] to)
             {
-                message.Push(to.ToByteArray());
+                message.Push(to);
             }
 
             return message;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1213,6 +1213,9 @@ namespace Libplanet.Net
             Peer original = peer;
             var connected = false;
 
+            // Peer can have more than 2 Url due to NAT and so on.
+            // Therefore, DialPeerAsync () checks the accessible URLs
+            // and puts them at the front.
             foreach (var (url, i) in peer.Urls.Select((url, i) => (url, i)))
             {
                 var dealer = new DealerSocket();
@@ -1362,6 +1365,7 @@ namespace Libplanet.Net
                 throw new ArgumentNullException(nameof(peer));
             }
 
+            // See DialPeerAsync().
             Uri url = peer.Urls.FirstOrDefault();
             return url?.ToString().TrimEnd('/');
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -68,6 +68,8 @@ namespace Libplanet.Net
             int? listenPort = null,
             DateTimeOffset? createdAt = null)
         {
+            Running = false;
+
             _privateKey = privateKey
                 ?? throw new ArgumentNullException(nameof(privateKey));
             _dialTimeout = dialTimeout;
@@ -96,8 +98,6 @@ namespace Libplanet.Net
             string loggerId = _privateKey.PublicKey.ToAddress().ToHex();
             _logger = Log.ForContext<Swarm>()
                 .ForContext("SwarmId", loggerId);
-
-            Running = false;
         }
 
         ~Swarm()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -427,6 +427,32 @@ namespace Libplanet.Net
             }
         }
 
+        public async Task BroadcastBlocksAsync<T>(
+            IEnumerable<Block<T>> blocks,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where T : IAction
+        {
+            _logger.Debug("Broadcast Blocks.");
+            var message = new BlockHashes(blocks.Select(b => b.Hash));
+            await BroadcastMessage(
+                message.ToNetMQMessage(_privateKey),
+                TimeSpan.FromMilliseconds(300),
+                cancellationToken);
+        }
+
+        public async Task BroadcastTxsAsync<T>(
+            IEnumerable<Transaction<T>> txs,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where T : IAction
+        {
+            _logger.Debug("Broadcast Txs.");
+            var message = new TxIds(txs.Select(tx => tx.Id));
+            await BroadcastMessage(
+                message.ToNetMQMessage(_privateKey),
+                TimeSpan.FromMilliseconds(300),
+                cancellationToken);
+        }
+
         internal async Task<IEnumerable<HashDigest<SHA256>>>
             GetBlockHashesAsync(
                 Peer peer,
@@ -577,32 +603,6 @@ namespace Libplanet.Net
                     }
                 }
             });
-        }
-
-        internal async Task BroadcastBlocksAsync<T>(
-            IEnumerable<Block<T>> blocks,
-            CancellationToken cancellationToken = default(CancellationToken))
-            where T : IAction
-        {
-            _logger.Debug("Broadcast Blocks.");
-            var message = new BlockHashes(blocks.Select(b => b.Hash));
-            await BroadcastMessage(
-                message.ToNetMQMessage(_privateKey),
-                TimeSpan.FromMilliseconds(300),
-                cancellationToken);
-        }
-
-        internal async Task BroadcastTxsAsync<T>(
-            IEnumerable<Transaction<T>> txs,
-            CancellationToken cancellationToken = default(CancellationToken))
-            where T : IAction
-        {
-            _logger.Debug("Broadcast Txs.");
-            var message = new TxIds(txs.Select(tx => tx.Id));
-            await BroadcastMessage(
-                message.ToNetMQMessage(_privateKey),
-                TimeSpan.FromMilliseconds(300),
-                cancellationToken);
         }
 
         private static IPAddress GetLocalIPAddress()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -84,6 +84,7 @@ namespace Libplanet.Net
             DeltaDistributed = new AsyncAutoResetEvent();
             DeltaReceived = new AsyncAutoResetEvent();
             TxReceived = new AsyncAutoResetEvent();
+            BlockReceived = new AsyncAutoResetEvent();
 
             _dealers = new Dictionary<Address, DealerSocket>();
             _router = new RouterSocket();
@@ -150,6 +151,9 @@ namespace Libplanet.Net
 
         [Uno.EqualityIgnore]
         public AsyncAutoResetEvent TxReceived { get; }
+
+        [Uno.EqualityIgnore]
+        public AsyncAutoResetEvent BlockReceived { get; }
 
         public DateTimeOffset LastReceived { get; private set; }
 
@@ -806,7 +810,7 @@ namespace Libplanet.Net
                 Block<T> latest = blocks.Last();
                 Block<T> tip = blockChain.Tip;
 
-                if (tip == null || latest.Index > tip.Index)
+                if (tip == null || latest.Index >= tip.Index)
                 {
                     using (await _blockSyncMutex.LockAsync())
                     {
@@ -874,6 +878,7 @@ namespace Libplanet.Net
                         " ignored.");
                 }
 
+                BlockReceived.Set();
                 _logger.Debug("Append complete.");
             }
             catch (Exception e)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -61,8 +61,10 @@ namespace Libplanet.Net
             TimeSpan dialTimeout,
             DateTimeOffset? createdAt = null)
         {
-            _privateKey = privateKey;
-            _listenUrl = listenUrl;
+            _privateKey = privateKey
+                ?? throw new ArgumentNullException(nameof(privateKey));
+            _listenUrl = listenUrl
+                ?? throw new ArgumentNullException(nameof(listenUrl));
             _dialTimeout = dialTimeout;
             _peers = new Dictionary<Peer, DateTimeOffset>();
             _removedPeers = new Dictionary<Peer, DateTimeOffset>();
@@ -105,7 +107,8 @@ namespace Libplanet.Net
         [Uno.EqualityKey]
         public Peer AsPeer => new Peer(
             _privateKey.PublicKey,
-            (_listenUrl != null) ? new[] { _listenUrl } : new Uri[] { });
+            new[] { _listenUrl }
+        );
 
         [Uno.EqualityIgnore]
         public AsyncAutoResetEvent DeltaReceived { get; }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Net
         public Swarm(
             PrivateKey privateKey,
             Uri listenUrl,
-            int millisecondsDialTimeout,
+            int millisecondsDialTimeout = 15000,
             DateTimeOffset? createdAt = null)
             : this(
                   privateKey,
@@ -58,12 +58,12 @@ namespace Libplanet.Net
         public Swarm(
             PrivateKey privateKey,
             Uri listenUrl,
-            TimeSpan? dialTimeout = null,
+            TimeSpan dialTimeout,
             DateTimeOffset? createdAt = null)
         {
             _privateKey = privateKey;
             _listenUrl = listenUrl;
-            _dialTimeout = dialTimeout ?? TimeSpan.FromMilliseconds(15000);
+            _dialTimeout = dialTimeout;
             _peers = new Dictionary<Peer, DateTimeOffset>();
             _removedPeers = new Dictionary<Peer, DateTimeOffset>();
             LastSeenTimestamps = new Dictionary<Peer, DateTimeOffset>();

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -9,8 +9,6 @@ namespace Libplanet.Store
 {
     public abstract class BaseStore : IStore
     {
-        public abstract void InitNamespace(string @namespace);
-
         public abstract long CountIndex(string @namespace);
 
         public abstract IEnumerable<HashDigest<SHA256>> IterateIndex(

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -8,8 +8,6 @@ namespace Libplanet.Store
 {
     public interface IStore
     {
-        void InitNamespace(string @namespace);
-
         long CountIndex(string @namespace);
 
         IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace);


### PR DESCRIPTION
This PR contains some enhancements / bug fixes that occured while testing on Unity3d as below.

- Replaced `Swarm._listenUrl` with `_ipAddress` (optional) and `_listenPort`(also optional) for easy configuration.
- Added some log messages for debugging.
- Exposed broadcast related methods (`Swarm.BroadcastBlocksAsync()` / `Swarm.BroadcastTxsAsync()`)
- Made to create a new DealerSocket for each request to avoid response overlapping.
- Fixed an issue where `Swarm` does not correctly respond to peer that are registered but never actually connected.
- Fixed `ProcessBlockHash()`