### PR TITLE
Replace links to the old repository name with the new name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ builds the whole Libplanet solution:
     msbuild -r
 
 
-Tests [![Build Status](https://travis-ci.com/planetarium/libplanet.net.svg?branch=master)][Travis CI] [![Codecov](https://codecov.io/gh/planetarium/libplanet.net/branch/master/graph/badge.svg)][2]
+Tests [![Build Status](https://travis-ci.com/planetarium/libplanet.svg?branch=master)][Travis CI] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][2]
 -----
 
 We write as complete tests as possible to the corresponding implementation code.
@@ -93,8 +93,8 @@ right before:
 
     msbuild -t:XunitTest Libplanet.Tests
 
-[Travis CI]: https://travis-ci.com/planetarium/libplanet.net
-[2]: https://codecov.io/gh/planetarium/libplanet.net
+[Travis CI]: https://travis-ci.com/planetarium/libplanet
+[2]: https://codecov.io/gh/planetarium/libplanet
 [Xunit]: https://xunit.github.io/
 
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -6,18 +6,18 @@
     <Summary>A .NET library for creating multiplayer online game in decentralized fashion.</Summary>
     <Description>A .NET library for creating multiplayer online game in decentralized fashion.
 See also the docs for details:
-http://planetarium.github.io/libplanet.net/</Description>
+https://docs.libplanet.io/</Description>
     <!-- FIXME: The above summary/description should be rewritten. -->
-    <PackageProjectUrl>https://github.com/planetarium/libplanet.net</PackageProjectUrl>
+    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/47222188?s=64</PackageIconUrl>
     <PackageDocumentationFile>README.md</PackageDocumentationFile>
     <Authors>Hong Minhee; Swen Mun</Authors>
     <Company>Planetarium</Company>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <PackageReleaseNotes>https://github.com/planetarium/libplanet.net/blob/master/CHANGES.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/master/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>
-    <RepositoryUrl>git://github.com/planetarium/libplanet.net.git</RepositoryUrl>
+    <RepositoryUrl>git://github.com/planetarium/libplanet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Libplanet</RootNamespace>
     <AssemblyName>Libplanet</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Libplanet
 =========
 
 [![Discord](https://img.shields.io/discord/539405872346955788.svg?color=7289da&logo=discord&logoColor=white)][Discord]
-[![Build Status](https://travis-ci.com/planetarium/libplanet.net.svg?branch=master)][Travis CI]
-[![Codecov](https://codecov.io/gh/planetarium/libplanet.net/branch/master/graph/badge.svg)][Codecov]
+[![Build Status](https://travis-ci.com/planetarium/libplanet.svg?branch=master)][Travis CI]
+[![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][Codecov]
 [![NuGet](https://img.shields.io/nuget/v/Libplanet.svg?style=flat)][NuGet]
 [![NuGet (prerelease)](https://img.shields.io/nuget/vpre/Libplanet.svg?style=flat)][NuGet]
 
@@ -14,8 +14,8 @@ server.  Under the hood, it incorporates many features (e.g.,
 [digital signature], [BFT] consensus, data replication) of a [blockchain].
 
 [Discord]: https://discord.gg/ue9fgc3
-[Travis CI]: https://travis-ci.com/planetarium/libplanet.net
-[Codecov]: https://codecov.io/gh/planetarium/libplanet.net
+[Travis CI]: https://travis-ci.com/planetarium/libplanet
+[Codecov]: https://codecov.io/gh/planetarium/libplanet
 [NuGet]: https://www.nuget.org/packages/Libplanet/
 [digital signature]: https://en.wikipedia.org/wiki/Digital_signature
 [BFT]: https://en.wikipedia.org/wiki/Byzantine_fault_tolerance


### PR DESCRIPTION
As we discussed in #105, I renamed the repository from planetarium/libplanet.net to planetarium/libplanet.  Although GitHub maintains the old links and redirects them to the new links, the redirection does not work for GitHub Pages.  With this situation, I gave the new domain docs.libplanet.net to the docs, and replaced all old links to the docs with the new domain.

This fixes #95 and #105.