### PR TITLE
Check changelog using Changelog Check instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,20 +122,7 @@ script:
   if [[ "$TRAVIS_OS_NAME" = "linux" && "$TRAVIS_TAG" != "" ]]; then
     changes="$(submark -i --h2 "Version $TRAVIS_TAG" CHANGES.md | egrep '\S')"
     [[ "$changes" != "" ]]
-  fi
-
-# Check changelog
-- |
-  commit_sha="${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_TAG:-${TRAVIS_COMMIT}}}"
-  if [[ "$(git tag -l)" = "" ]]; then
-    echo "Skip changelog chekcer because there has been no release yet."
-  elif git show --format=%B --quiet "$commit_sha" \
-     | egrep '\[(skip changelog|changelog skip)\]' > /dev/null; then
-    echo "Skip changelog checker..."
-  elif [[ "$TRAVIS_TAG" != "" ]]; then
     ! grep -i "to be released" CHANGES.md
-  else
-    [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.md)" != "" ]]
   fi
 
 # Check coding styles

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@ Libplanet changelog
 Version 0.1.1
 -------------
 
-- Improved stability of `Swarm` and `SwarmTest`.
+To be released.
+
+ -  Improved stability of `Swarm` and `SwarmTest`.
 
 
 Version 0.1.0


### PR DESCRIPTION
As I made a GitHub App called [Changelog Check][] (code is [here][1]), remove the equivalent check from the Travis CI build script.

Note that this looks like:

![](https://user-images.githubusercontent.com/12431/53788843-434f5f00-3f66-11e9-9767-f527a29d04a2.png)

[Changelog Check]: https://github.com/apps/changelog-check
[1]: https://github.com/planetarium/changelog-check