### PR TITLE
Version bump & fix a double uploading bug for stable version numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Libplanet changelog
 ===================
 
+Version 0.1.2
+-------------
+
+To be released.
+
+
 Version 0.1.1
 -------------
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
-    <Version>0.1.1</Version>
+    <Version>0.1.2-dev</Version>
     <Summary>A .NET library for creating multiplayer online game in decentralized fashion.</Summary>
     <Description>A .NET library for creating multiplayer online game in decentralized fashion.
 See also the docs for details:

--- a/publish.sh
+++ b/publish.sh
@@ -12,6 +12,20 @@ if [[ "$TRAVIS_JOB_NUMBER" != *.1 ]]; then
   exit 0
 fi
 
+version="$(xmllint \
+ --xpath './Project/PropertyGroup/Version/text()' \
+ Libplanet/Libplanet.csproj)"
+if [[ "$TRAVIS_TAG" = "" && "$version" != *-dev ]]; then
+  # If we prepare a RC, at that time a package version does not end with
+  # "-dev" suffix, and Travis CI builds try to build a .nupkg file of
+  # a stable versionn number twice, because two builds for one commit
+  # are made: one for push to a branch, and another one is a tag push.
+  # So we need to avoid publishing .nupkg to NuGet for stable version numbers
+  # when it is not a tag push.
+  echo "Publishing to NuGet will be done at a tag build." > /dev/stderr
+  exit 0
+fi
+
 if [[ "$NUGET_API_KEY" = "" ]]; then
   echo "This script is skipped if NUGET_API_KEY envrionment variable is not" \
        "present." > /dev/stderr


### PR DESCRIPTION
As we've just released 0.1.1, I bumped the version to 0.1.2-dev, and fixed a bug that *.nupkg* file had been uploaded to NuGet twice for stable version numbers (i.e., no `-dev` suffix).