### PR TITLE
Turn int parameter in BlockPolicy's constructor to milliseconds #104

### DIFF
--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -28,19 +28,19 @@ namespace Libplanet.Tests.Blockchain.Policies
         [Fact]
         public void Constructors()
         {
-            var tenSec = new TimeSpan(0, 0, 10);
-            var a = new BlockPolicy<BaseAction>(tenSec);
-            Assert.Equal(tenSec, a.BlockInterval);
+            var tenMilliSec = new TimeSpan(0, 0, 10000);
+            var a = new BlockPolicy<BaseAction>(tenMilliSec);
+            Assert.Equal(tenMilliSec, a.BlockInterval);
 
             var b = new BlockPolicy<BaseAction>(65);
             Assert.Equal(
-                new TimeSpan(0, 1, 5),
+                new TimeSpan(0, 1000, 5000),
                 b.BlockInterval
             );
 
             var c = new BlockPolicy<BaseAction>();
             Assert.Equal(
-                new TimeSpan(0, 0, 5),
+                new TimeSpan(0, 0, 5000),
                 c.BlockInterval
             );
 
@@ -48,14 +48,14 @@ namespace Libplanet.Tests.Blockchain.Policies
                 () => new BlockPolicy<BaseAction>(tenSec.Negate())
             );
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<BaseAction>(-5)
+                () => new BlockPolicy<BaseAction>(-5000)
             );
         }
 
         [Fact]
         public void GetNextBlockDifficulty()
         {
-            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3, 0, 0));
+            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3000, 0, 0));
             Block<BaseAction>[] blocks = MineBlocks(
                 new[] { (0, 0), (1, 1), (3, 2), (7, 3), (9, 2), (13, 3) }
             ).ToArray();
@@ -93,7 +93,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         [Fact]
         public void ValidateBlocks()
         {
-            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3, 0, 0));
+            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3000, 0, 0));
 
             // The genesis block must has the index #0.
             Assert.IsType<InvalidBlockIndexException>(

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -18,14 +18,14 @@ namespace Libplanet.Blockchain.Policies
     {
         /// <summary>
         /// Creates a <see cref="BlockPolicy{T}"/> with configuring
-        /// <see cref="BlockInterval"/> in seconds.
+        /// <see cref="BlockInterval"/> in milliseconds.
         /// </summary>
-        /// <param name="blockIntervalSeconds">Configures
-        /// <see cref="BlockInterval"/> in seconds.  5 seconds by default.
+        /// <param name="blockIntervalMilliseconds">Configures
+        /// <see cref="BlockInterval"/> in milleseconds.  5000 ms by default.
         /// </param>
-        public BlockPolicy(int blockIntervalSeconds = 5)
+        public BlockPolicy(int blockIntervalMilliseconds = 5000)
             : this(
-                TimeSpan.FromSeconds(blockIntervalSeconds)
+                TimeSpan.FromMilliseconds(blockIntervalMilliseconds)
             )
         {
         }
@@ -94,7 +94,7 @@ namespace Libplanet.Blockchain.Policies
                     );
                 }
 
-                if (block.PreviousHash != prevHash)
+                if (!block.PreviousHash.Equals(prevHash))
                 {
                     if (prevHash == null)
                     {


### PR DESCRIPTION
### Checklist

- [x] Fixed Libplanet/Blockchain/Policies/BlockPolicy.cs  Constructor
     - [x] BlockPolicy(int blockIntervalMilliseconds = 5000)
     - [x] TimeSpan.FromMilliseconds(blockIntervalMilliseconds)
     - [x] Modified Summary Comments to reflect milliseconds.
- [x] Fixed if logic in Libplanet/Blockchain/Policies/BlockPolicy.cs on line 97
     - [x] Changed if (block.PreviousHash != prevHash) to if (!block.PreviousHash.Equals(prevHash))
- [x] Modified  Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs to use milliseconds instead of seconds.