### PR TITLE
Peer.EndPoints to Peer.EndPoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ Version 0.2.0
 
 To be released.
 
- -  The type of `Peer.Urls` property is changed from `Uri` to `IPEndPoint`.
+ - Since we decided to depend on TURN ([RFC 5766]) and STUN ([RFC 5389]) to work around NAT so that `Peer`'s endpoints don't have to be multiple,
+`Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed from `IImmutableList<Uri>` to `IPEndPoint`. (See also [#120], [#126])
  - `Address` and `TxId` are now serializable.
 
 
@@ -22,3 +23,9 @@ Version 0.1.0
 -------------
 
 Initial release.  Released on February 26, 2019.
+
+
+[#120]: https://github.com/planetarium/libplanet/issues/120
+[#126]: https://github.com/planetarium/libplanet/issues/126
+[RFC 5389]: https://tools.ietf.org/html/rfc5389
+[RFC 5766]: https://tools.ietf.org/html/rfc5766

--- a/Libplanet.Tests/Net/PeerSetDeltaTest.cs
+++ b/Libplanet.Tests/Net/PeerSetDeltaTest.cs
@@ -12,25 +12,25 @@ namespace Libplanet.Tests.Net
     public class PeerSetDeltaTest
     {
         [Fact]
-        public void CanBeSerialized()
+        public void Serialize()
         {
             var peerSetDelta = new PeerSetDelta(
                 new Peer(
                     new PrivateKey().PublicKey,
-                    new[] { new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234) }
+                    new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234)
                 ),
                 DateTimeOffset.UtcNow,
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new[] { new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234) }),
+                        new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234)),
                 }.ToImmutableHashSet(),
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new[] { new IPEndPoint(IPAddress.Parse("2.3.4.5"), 1234) }),
+                        new IPEndPoint(IPAddress.Parse("2.3.4.5"), 1234)),
                 }.ToImmutableHashSet(),
                 null
             );

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -1,81 +1,24 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
 using Libplanet.Net;
-using Libplanet.Serialization;
 using Xunit;
 
 namespace Libplanet.Tests.Net
 {
     public class PeerTest
     {
-        private static PublicKey _samplePublicKey = new PublicKey(
-            ByteUtil.ParseHex(
-                "038f92e8098c897c2a9ae3226eb6337eb" +
-                "7ca8dbad5e1c8c9b130a9d39171a44134"
-            )
-        );
-
-        private static IPEndPoint[] _sampleEndPoints = new IPEndPoint[]
-        {
-            new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234),
-            new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234),
-            new IPEndPoint(IPAddress.Parse("2.3.4.5"), 1234),
-        };
-
         [Fact]
-        public void ConstructorWithImmutableList()
+        public void Serialize()
         {
-            Assert.Throws<ArgumentNullException>(
-                () => new Peer(_samplePublicKey, null)
-            );
-            var peer = new Peer(
-                _samplePublicKey,
-                _sampleEndPoints.ToImmutableList()
-            );
-            Assert.Equal(_samplePublicKey, peer.PublicKey);
-            Assert.Equal(_sampleEndPoints, peer.EndPoints);
-        }
-
-        [Fact]
-        public void ConstructorWithEnumerable()
-        {
-            Assert.Throws<ArgumentNullException>(
-                () => new Peer(_samplePublicKey, (IEnumerable<IPEndPoint>)null)
-            );
-            var peer = new Peer(_samplePublicKey, _sampleEndPoints);
-            Assert.Equal(_samplePublicKey, peer.PublicKey);
-            Assert.Equal(_sampleEndPoints, peer.EndPoints);
-        }
-
-        [Fact]
-        public void AddUrl()
-        {
-            var peer = new Peer(_samplePublicKey, _sampleEndPoints);
-            Assert.Equal(_samplePublicKey, peer.PublicKey);
-            Assert.Equal(
-                new IPEndPoint[]
-                {
-                    new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234),
-                    new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234),
-                    new IPEndPoint(IPAddress.Parse("2.3.4.5"), 1234),
-                    new IPEndPoint(IPAddress.Parse("3.4.5.6"), 1234),
-                },
-                peer.AddEndPoint(new IPEndPoint(IPAddress.Parse("3.4.5.6"), 1234)).EndPoints
-            );
-        }
-
-        [Fact]
-        public void CanBeSerialized()
-        {
-            var peer = new Peer(
-                _samplePublicKey,
-                _sampleEndPoints.ToImmutableList()
-            );
+            var key = new PublicKey(
+                ByteUtil.ParseHex(
+                    "038f92e8098c897c2a9ae3226eb6337eb" +
+                    "7ca8dbad5e1c8c9b130a9d39171a44134"
+                    ));
+            var endPoint = new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234);
+            var peer = new Peer(key, endPoint);
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {


### PR DESCRIPTION
This PR replaces `Peer.EndPoints` with `Peer.EndPoint`. (as suggested in #126)