### PR TITLE
Fix Swarm.DialPeerAsync()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ To be released.
  - Since we decided to depend on TURN ([RFC 5766]) and STUN ([RFC 5389]) to work around NAT so that `Peer`'s endpoints don't have to be multiple,
 `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed from `IImmutableList<Uri>` to `IPEndPoint`. (See also [#120], [#126])
  - `Address` and `TxId` are now serializable.
+ - `Swarm.AddPeersAsync()` was fixed to ignore unreachable peers.
 
 
 Version 0.1.1

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -641,11 +641,10 @@ namespace Libplanet.Tests.Net
 
         private async Task EnsureRecvAsync(Swarm swarm, Peer peer = null, DateTimeOffset? lastReceived = null)
         {
+            Log.Debug($"Waiting to ensure recv... [{swarm.AsPeer}]");
             while (true)
             {
-                Log.Debug($"Waiting for receive event... [{swarm.AsPeer}]");
                 await swarm.DeltaReceived.WaitAsync();
-                Log.Debug($"Event received. [{swarm.AsPeer}]");
 
                 if (lastReceived == null)
                 {
@@ -681,6 +680,8 @@ namespace Libplanet.Tests.Net
                     break;
                 }
             }
+
+            Log.Debug($"Received. [{swarm.AsPeer}]");
         }
 
         private async Task EnsureExchange(Swarm a, Swarm b)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1319,7 +1319,8 @@ namespace Libplanet.Net
             );
 
             _logger.Debug(
-                $"Trying to distribute own delta ({delta.AddedPeers.Count})..."
+                $"Trying to distribute own delta " +
+                $"(+{delta.AddedPeers.Count}, -{delta.RemovedPeers.Count})..."
             );
             if (delta.AddedPeers.Any() || delta.RemovedPeers.Any() || all)
             {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -217,7 +217,6 @@ namespace Libplanet.Net
 
             foreach (Peer peer in peers)
             {
-                Peer addedPeer = peer;
                 if (peer.PublicKey == publicKey)
                 {
                     continue;
@@ -234,24 +233,29 @@ namespace Libplanet.Net
                     try
                     {
                         _logger.Debug($"Trying to DialPeerAsync({peer})...");
-                        addedPeer = await DialPeerAsync(
-                            peer,
-                            cancellationToken
-                        );
+                        await DialPeerAsync(peer, cancellationToken);
                         _logger.Debug($"DialPeerAsync({peer}) is complete.");
+
+                        _peers[peer] = timestamp.Value;
+                        addedPeers.Add(peer);
                     }
                     catch (IOException e)
                     {
                         _logger.Error(
                             e,
-                            $"IOException occured in DialPeerAsync ({peer})."
+                            $"DialPeerAsync({peer}) failed. ignored."
+                        );
+                        continue;
+                    }
+                    catch (TimeoutException e)
+                    {
+                        _logger.Error(
+                            e,
+                            $"DialPeerAsync({peer}) failed. ignored."
                         );
                         continue;
                     }
                 }
-
-                _peers[addedPeer] = timestamp.Value;
-                addedPeers.Add(addedPeer);
             }
 
             return addedPeers;
@@ -1276,18 +1280,13 @@ namespace Libplanet.Net
             }
             catch (IOException e)
             {
-                _logger.Error(
-                    e,
-                    $"IOException occured in DialAsync ({peer.EndPoint}).");
                 dealer.Dispose();
+                throw e;
             }
             catch (TimeoutException e)
             {
-                _logger.Error(
-                    e,
-                    $"TimeoutException occured in DialAsync ({peer.EndPoint})."
-                );
                 dealer.Dispose();
+                throw e;
             }
 
             return peer;


### PR DESCRIPTION
In [failed test](https://api.travis-ci.com/v3/job/184409651/log.txt), `Swarm.DialPeerAsync()` seems to add unreachable peer. 

```
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][13] - TimeoutException occured in DialAsync (127.0.0.1:50040).
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][13] - DialPeerAsync(0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040) is complete.
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][13] - 3/13/2019 5:59:30 AM +00:00 0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040 > +0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][13] - 3/13/2019 5:59:30 AM +00:00 0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040 > -0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][12] - Trying to apply the delta[[Sender: 0x43056260567c13B4Dce2b3ac6F6F6a86ecE5EB8E.127.0.0.1:50040, +: 2, -: 0]]...
        05:59:47[@8eFB6385bAB28Fc189D4692333b8926AFb23Fa3c][12] - Trying to add peers...
```

this PR fixed `Swarm.DialPeerAsync()` to ignore properly.