### PR TITLE
Fix SwarmTest.EnsureRecvAsync()

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -687,11 +687,6 @@ namespace Libplanet.Tests.Net
             {
                 await swarm.DeltaReceived.WaitAsync();
 
-                if (lastReceived == null)
-                {
-                    break;
-                }
-
                 DateTimeOffset? lastSeen = null;
                 if (peer == null)
                 {
@@ -716,7 +711,10 @@ namespace Libplanet.Tests.Net
                     }
                 }
 
-                if ((lastSeen != null) && (lastSeen >= lastReceived))
+                bool seenLater =
+                    (lastReceived is null) || (lastSeen >= lastReceived);
+
+                if (!(lastSeen is null) && seenLater)
                 {
                     break;
                 }


### PR DESCRIPTION
This PR fixes `SwarmTest.EnsureRecvAsync()` to check target `swarm` really has received peer. 

In previous implementations, when `swarm.DeltaReceived` was set more than once with `lastReceived` is null, it passed even if it didn't have `peer`.

it also closes #137.