### PR TITLE
Throw exception when ciphertext is invalid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Version 0.2.0
 
 To be released.
 
+ -  `PrivateKey.Decrypt()` now throws an `InvalidCiphertextException`
+    instead of returning `null` when `cipherText` is invalid.  [[#140]]
  -  `Transaction<T>`'s `Sender`–`Recipient` model was replaced by
     `Signer`–`UpdatedAddresses` model.   Unlike cryptocurrencies,
     transactions in games are not necessarily a transfer of assets,

--- a/Libplanet.Tests/Crypto/PrivateKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PrivateKeyTest.cs
@@ -150,6 +150,34 @@ namespace Libplanet.Tests.Crypto
         }
 
         [Fact]
+        public void DecryptDetectInvalidCipherText()
+        {
+            var key1 = new PrivateKey(
+                new byte[]
+                {
+                    0xfb, 0xc2, 0x00, 0x42, 0xb3, 0xa7, 0x07, 0xa7, 0xd5, 0xa1,
+                    0xfa, 0x57, 0x71, 0x71, 0xf4, 0x9c, 0xd3, 0xa9, 0xe6, 0x7a,
+                    0xb9, 0x29, 0x57, 0x57, 0xc7, 0x14, 0xe3, 0xf2, 0xf8, 0xc2,
+                    0xd5, 0x73,
+                }
+            );
+            var key2 = new PrivateKey(
+                new byte[]
+                {
+                    0xfb, 0xc2, 0x00, 0x42, 0xb3, 0xa7, 0x07, 0xa7, 0xd5, 0xa1,
+                    0xfa, 0x57, 0x71, 0x71, 0xf4, 0x9c, 0xd3, 0xa9, 0xe6, 0x7a,
+                    0xb9, 0x29, 0x57, 0x57, 0xc7, 0x14, 0xe3, 0xf2, 0xf8, 0xc2,
+                    0xd5, 0x37,
+                }
+            );
+            var message = Encoding.ASCII.GetBytes("test message");
+            var cipherText = key1.PublicKey.Encrypt(message);
+
+            Assert.Throws<InvalidCiphertextException>(
+                () => key2.Decrypt(cipherText));
+        }
+
+        [Fact]
         public void EqualsTest()
         {
             var key1 = new PrivateKey(

--- a/Libplanet/Crypto/InvalidCiphertextException.cs
+++ b/Libplanet/Crypto/InvalidCiphertextException.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Crypto
+{
+    [Serializable]
+    public class InvalidCiphertextException : Exception
+    {
+        public InvalidCiphertextException()
+        {
+        }
+
+        public InvalidCiphertextException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidCiphertextException(
+            string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected InvalidCiphertextException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -190,9 +190,9 @@ namespace Libplanet.Crypto
         /// </summary>
         /// <param name="ciphertext">The encrypted data.</param>
         /// <returns>The plain data the <paramref name="ciphertext"/> encrypted.
-        /// It returns <c>null</c> if the <paramref name="ciphertext"/> is
-        /// invalid (this behavior will be eventually changed in the future to
-        /// throw an exception instead).</returns>
+        /// </returns>
+        /// <exception cref="InvalidCiphertextException">Thrown when the given
+        /// <paramref name="ciphertext"/> is invalid.</exception>
         /// <remarks>
         /// Although the parameter name <paramref name="ciphertext"/> has the
         /// word &#x201c;text&#x201d;, both a <paramref name="ciphertext"/>
@@ -206,11 +206,6 @@ namespace Libplanet.Crypto
             PublicKey pubKey = new PublicKey(ciphertext.Take(33).ToArray());
             SymmetricKey aes = ExchangeKey(pubKey);
 
-            // FIXME: This merely returns null when the given ciphertext is
-            // invalid (which means it is not encrypted with the corresponding
-            // public key for the most part).  This should become to throw
-            // an appropriate exception instead and also reflected to docs
-            // comment (to add <exception> tag) as well.
             return aes.Decrypt(ciphertext, 33);
         }
 

--- a/Libplanet/Crypto/SymmetricKey.cs
+++ b/Libplanet/Crypto/SymmetricKey.cs
@@ -184,8 +184,10 @@ namespace Libplanet.Crypto
                 }
                 catch (InvalidCipherTextException)
                 {
-                    // FIXME
-                    return null;
+                    throw new InvalidCiphertextException(
+                        "The ciphertext is invalid. " +
+                        "Ciphertext may not have been encrypted with " +
+                        "the corresponding public key");
                 }
             }
         }


### PR DESCRIPTION
- Made threw an `InvalidCiphertextException` when ciphertext is invalid.