### PR TITLE
IStore.ListNamespaces() method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@ To be released.
     `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed
     from `IImmutableList<Uri>` to `IPEndPoint`.
     [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
+ -  Added `IStore.ListNamespaces()` method.
 
 [#98]: https://github.com/planetarium/libplanet/issues/98
 [#99]: https://github.com/planetarium/libplanet/issues/99

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -22,6 +22,24 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
+        public void ListNamespaces()
+        {
+            Assert.Empty(_fx.Store.ListNamespaces());
+
+            _fx.Store.PutBlock(_ns, _fx.Block1);
+            Assert.Equal(
+                new[] { _ns }.ToImmutableHashSet(),
+                _fx.Store.ListNamespaces().ToImmutableHashSet()
+            );
+
+            _fx.Store.PutBlock("asdf", _fx.Block1);
+            Assert.Equal(
+                new[] { _ns, "asdf" }.ToImmutableHashSet(),
+                _fx.Store.ListNamespaces().ToImmutableHashSet()
+            );
+        }
+
+        [Fact]
         public void CanReturnTransactionPath()
         {
             Assert.Equal(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -9,6 +9,8 @@ namespace Libplanet.Store
 {
     public abstract class BaseStore : IStore
     {
+        public abstract IEnumerable<string> ListNamespaces();
+
         public abstract long CountIndex(string @namespace);
 
         public abstract IEnumerable<HashDigest<SHA256>> IterateIndex(

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -15,7 +15,7 @@ using Libplanet.Tx;
 
 namespace Libplanet.Store
 {
-    public class FileStore : BaseStore, IStore
+    public class FileStore : BaseStore
     {
         private const string _transactionsDir = "tx";
         private const string _blocksDir = "blocks";
@@ -151,6 +151,18 @@ namespace Libplanet.Store
                 @namespace,
                 _indexFile
             );
+        }
+
+        /// <inheritdoc/>
+        public override IEnumerable<string> ListNamespaces()
+        {
+            if (Directory.Exists(_path))
+            {
+                foreach (string p in Directory.EnumerateDirectories(_path))
+                {
+                    yield return Path.GetFileName(p);
+                }
+            }
         }
 
         public override long AppendAddressTransactionId(

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -8,6 +8,12 @@ namespace Libplanet.Store
 {
     public interface IStore
     {
+        /// <summary>
+        /// Lists existing namespaces.
+        /// </summary>
+        /// <returns>Existing namespaces.</returns>
+        IEnumerable<string> ListNamespaces();
+
         long CountIndex(string @namespace);
 
         IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace);


### PR DESCRIPTION
Although I frankly am not sure if it's really necessary, I added a new method `ListNamespaces()` to `IStore` and implemented `FileSystem.ListNamespaces()` too.  I am going to use this to make an ad-hoc solution to #96.
