### PR TITLE
Upgrade NuGet to 5.0.0-preview4

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -35,7 +35,7 @@ fi
 set -ev
 
 curl -o /tmp/nuget.exe \
-  https://dist.nuget.org/win-x86-commandline/v5.0.0-preview2/nuget.exe
+  https://dist.nuget.org/win-x86-commandline/v5.0.0-preview4/nuget.exe
 
 if compgen -G "Libplanet/bin/Release/Libplanet.*.nupkg" > /dev/null; then
   for f in Libplanet/bin/Release/Libplanet.*.nupkg; do


### PR DESCRIPTION
I hope that this makes our NuGet page can show the content of *README.md*.  (It currently seems to ignore `<PackageDocumentationFile>` tag in *Libplanet.csproj*.)