### PR TITLE
Throw exception when action type is not annotated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,8 @@ To be released.
     from `IImmutableList<Uri>` to `IPEndPoint`.
     [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
  -  Added `IStore.ListNamespaces()` method.
+ -  `Transaction<T>` now throws an `InvalidActionTypeException` if an action type
+    is not annotated with `ActionTypeAttribute`.  [#144]
 
 [#98]: https://github.com/planetarium/libplanet/issues/98
 [#99]: https://github.com/planetarium/libplanet/issues/99
@@ -113,6 +115,7 @@ To be released.
 [#132]: https://github.com/planetarium/libplanet/issues/132
 [#135]: https://github.com/planetarium/libplanet/pull/135
 [#136]: https://github.com/planetarium/libplanet/pull/136
+[#144]: https://github.com/planetarium/libplanet/pull/144
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -279,6 +279,17 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(states[TestEvaluateAction.BlockIndexKey], blockIndex);
         }
 
+        [Fact]
+        public void DetectInvalidActionType()
+        {
+            var privateKey = new PrivateKey();
+            var action = new ActionNotAttributeAnnotated();
+
+            Assert.Throws<InvalidActionTypeException>(
+                () => Transaction<BaseAction>.Create(
+                privateKey, new[] { action }));
+        }
+
         [ActionType("test")]
         private class TestEvaluateAction : BaseAction
         {
@@ -301,6 +312,22 @@ namespace Libplanet.Tests.Blockchain
                 return context.PreviousStates
                     .SetState(SignerKey, context.Signer.ToHex())
                     .SetState(BlockIndexKey, context.BlockIndex);
+            }
+        }
+
+        private class ActionNotAttributeAnnotated : BaseAction
+        {
+            public override IImmutableDictionary<string, object> PlainValue =>
+                new Dictionary<string, object>().ToImmutableDictionary();
+
+            public override void LoadPlainValue(
+                IImmutableDictionary<string, object> plainValue)
+            {
+            }
+
+            public override IAccountStateDelta Execute(IActionContext context)
+            {
+                return context.PreviousStates;
             }
         }
     }

--- a/Libplanet/Action/ActionTypeAttribute.cs
+++ b/Libplanet/Action/ActionTypeAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Libplanet.Tx;
 
 namespace Libplanet.Action
 {
@@ -40,11 +41,20 @@ namespace Libplanet.Action
         /// <c>null</c>.</returns>
         public static string ValueOf(Type actionType)
         {
-            return actionType
+            string typeIdentifier = actionType
                 .GetCustomAttributes()
                 .OfType<ActionTypeAttribute>()
                 .Select(attr => attr.TypeIdentifier)
                 .FirstOrDefault();
+
+            if (typeIdentifier is null)
+            {
+                throw new InvalidActionTypeException(
+                    "Action type should be annotated with ActionTypeAttribute."
+                );
+            }
+
+            return typeIdentifier;
         }
     }
 }

--- a/Libplanet/Tx/InvalidActionTypeException.cs
+++ b/Libplanet/Tx/InvalidActionTypeException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Tx
+{
+    [Serializable]
+    public sealed class InvalidActionTypeException : Exception
+    {
+        public InvalidActionTypeException()
+        {
+        }
+
+        public InvalidActionTypeException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidActionTypeException(
+            string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- Made threw an `InvalidActionTypeException` if an action type is not annotated with `actionTypeAttribute`. #28 