### PR TITLE
Fix unexpected access during disposing FileStoreFixture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,8 @@ To be released.
     [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
  -  `Swarm` now ignores the blocks that are same index as tip it have, but
     processes only the longer blocks.
+ -  Fixed a bug that occured when `Swarm` was handling multiple responses at the
+    same time.
  -  Added `IStore.ListNamespaces()` method.
  -  `Transaction<T>` now throws an `InvalidActionTypeException` if an action type
     is not annotated with `ActionTypeAttribute`.  [#144]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,8 @@ To be released.
     `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed
     from `IImmutableList<Uri>` to `IPEndPoint`.
     [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
+ -  `Swarm` now ignores the blocks that are same index as tip it have, but
+    processes only the longer blocks.
  -  Added `IStore.ListNamespaces()` method.
  -  `Transaction<T>` now throws an `InvalidActionTypeException` if an action type
     is not annotated with `ActionTypeAttribute`.  [#144]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,8 +98,8 @@ To be released.
     `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed
     from `IImmutableList<Uri>` to `IPEndPoint`.
     [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
- -  `Swarm` now ignores the blocks that are same index as tip it have, but
-    processes only the longer blocks.
+ -  `Swarm` became to ignore tip blocks of the same height (`Index`) that it
+    already has and deal with only longer (higher) blocks.
  -  Fixed a bug that occured when `Swarm` was handling multiple responses at the
     same time.
  -  Added `IStore.ListNamespaces()` method.

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -140,7 +140,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
-        public async Task CanBroadcastWhileMining()
+        public async Task BroadcastWhileMining()
         {
             Swarm a = _swarms[0];
             Swarm b = _swarms[1];

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -140,7 +140,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
-        public async Task CanBroadcastWhlieMining()
+        public async Task CanBroadcastWhileMining()
         {
             Swarm a = _swarms[0];
             Swarm b = _swarms[1];

--- a/Libplanet.Tests/Store/FileStoreFixture.cs
+++ b/Libplanet.Tests/Store/FileStoreFixture.cs
@@ -118,24 +118,7 @@ namespace Libplanet.Tests.Store
         {
             if (Directory.Exists(Path))
             {
-                try
-                {
-                    Directory.Delete(Path, true);
-                }
-                catch (IOException e)
-                {
-                    if (e.Message.Contains("being used by another process"))
-                    {
-                        /*
-                        FIXME: This is an ad-hoc workaround to
-                        <https://github.com/planetarium/libplanet/issues/148>.
-                        This should be properly fixed.
-                        */
-                        return;
-                    }
-
-                    throw;
-                }
+                Directory.Delete(Path, true);
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -904,7 +904,7 @@ namespace Libplanet.Net
             Block<T> latest = blocks.Last();
             Block<T> tip = blockChain.Tip;
 
-            if (tip == null || latest.Index >= tip.Index)
+            if (tip == null || latest.Index > tip.Index)
             {
                 using (await _blockSyncMutex.LockAsync())
                 {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -585,8 +585,10 @@ namespace Libplanet.Net
                         cancellationToken: token);
 
                     int hashCount = blockHashes.Count();
+                    _logger.Debug($"Required block count: {hashCount}.");
                     while (hashCount > 0)
                     {
+                        _logger.Debug("Receiving block...");
                         NetMQMessage response =
                         await socket.ReceiveMultipartMessageAsync(
                             cancellationToken: token);
@@ -633,8 +635,10 @@ namespace Libplanet.Net
                         cancellationToken: cancellationToken);
 
                     int hashCount = txIds.Count();
+                    _logger.Debug($"Required tx count: {hashCount}.");
                     while (hashCount > 0)
                     {
+                        _logger.Debug("Receiving tx...");
                         NetMQMessage response =
                         await socket.ReceiveMultipartMessageAsync(
                             cancellationToken: cancellationToken);
@@ -866,7 +870,7 @@ namespace Libplanet.Net
 
             _logger.Debug(
                 $"Trying to GetBlocksAsync() " +
-                $"(using {message.Hashes.Count()} hashes");
+                $"(using {message.Hashes.Count()} hashes)");
             IAsyncEnumerable<Block<T>> fetched = GetBlocksAsync<T>(
                 peer, message.Hashes, cancellationToken);
 
@@ -906,6 +910,7 @@ namespace Libplanet.Net
                 {
                     _logger.Debug("Trying to find branchpoint...");
                     BlockLocator locator = blockChain.GetBlockLocator();
+                    _logger.Debug($"Locator's count: {locator.Count()}");
                     IEnumerable<HashDigest<SHA256>> hashes =
                         await GetBlockHashesAsync(
                             peer, locator, oldest.Hash, cancellationToken);
@@ -1020,7 +1025,7 @@ namespace Libplanet.Net
                 }
 
                 _logger.Debug(
-                    $"Required hashes are {string.Join(",", hashes)}. " +
+                    $"Required hashes (count: {hashes.Count()}). " +
                     $"(tip: {blockChain.Tip?.Hash})"
                 );
 
@@ -1030,7 +1035,9 @@ namespace Libplanet.Net
                     cancellationToken
                 ).ForEachAsync(block =>
                 {
+                    _logger.Debug($"Trying to append block[{block.Hash}]...");
                     blockChain.Append(block);
+                    _logger.Debug($"Block[{block.Hash}] is appended.");
                 });
             }
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1324,7 +1324,6 @@ namespace Libplanet.Net
         private async Task<Peer> DialPeerAsync(
             Peer peer, CancellationToken cancellationToken)
         {
-            Peer original = peer;
             var dealer = new DealerSocket();
             dealer.Options.Identity =
                 _privateKey.PublicKey.ToAddress().ToByteArray();


### PR DESCRIPTION
This PR fixes #148. more precisely, it bypassed the problem by letting ignore blocks that we no longer need to synchronize.

It also fixed a bug in the process of handling multiple responses at the same time. This solves the problem that certain test cases do not terminate.