### PR TITLE
Turn into parameter in BlockPolicy's constructor to milliseconds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,7 @@ To be released.
  -  Added `IStore.ListNamespaces()` method.
  -  `Transaction<T>` now throws an `InvalidActionTypeException` if an action type
     is not annotated with `ActionTypeAttribute`.  [#144]
+ - Turn into parameter in `BlockPolicy`'s constructor to milliseconds. [#151]
 
 [#98]: https://github.com/planetarium/libplanet/issues/98
 [#99]: https://github.com/planetarium/libplanet/issues/99
@@ -116,6 +117,7 @@ To be released.
 [#135]: https://github.com/planetarium/libplanet/pull/135
 [#136]: https://github.com/planetarium/libplanet/pull/136
 [#144]: https://github.com/planetarium/libplanet/pull/144
+[#151]: https://github.com/planetarium/libplanet/pull/151
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766
 

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Blockchain.Policies
             var a = new BlockPolicy<BaseAction>(tenSec);
             Assert.Equal(tenSec, a.BlockInterval);
 
-            var b = new BlockPolicy<BaseAction>(65);
+            var b = new BlockPolicy<BaseAction>(65000);
             Assert.Equal(
                 new TimeSpan(0, 1, 5),
                 b.BlockInterval

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -18,14 +18,15 @@ namespace Libplanet.Blockchain.Policies
     {
         /// <summary>
         /// Creates a <see cref="BlockPolicy{T}"/> with configuring
-        /// <see cref="BlockInterval"/> in seconds.
+        /// <see cref="BlockInterval"/> in milliseconds.
         /// </summary>
-        /// <param name="blockIntervalSeconds">Configures
-        /// <see cref="BlockInterval"/> in seconds.  5 seconds by default.
+        /// <param name="blockIntervalMilliseconds">Configures
+        /// <see cref="BlockInterval"/> in milliseconds.
+        /// 5000 milliseconds by default.
         /// </param>
-        public BlockPolicy(int blockIntervalSeconds = 5)
+        public BlockPolicy(int blockIntervalMilliseconds = 5000)
             : this(
-                TimeSpan.FromSeconds(blockIntervalSeconds)
+                TimeSpan.FromMilliseconds(blockIntervalMilliseconds)
             )
         {
         }


### PR DESCRIPTION
This PR turns `BlockPolicy`'s constructor parameter into milliseconds.
(closes #104)