### PR TITLE
Use msbuild -t:pack again and update outdated docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
       - $HOME/AppData/Local/NuGet/v3-cache
     filter_secrets: false  # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
 
+env:
+  - PROJECTS="Libplanet.Stun Libplanet"
+
 solution: Libplanet.sln
 install:
 - |
@@ -129,10 +132,16 @@ script:
 - hooks/check-bom
 
 # Build the whole solution
-- msbuild -p:Configuration=Release -r Libplanet
+- |
+  for project in $PROJECTS; do
+    msbuild -p:Configuration=Release -r $project
+  done
 
 # Run unit tests
-- msbuild -p:Configuration=Release -t:XunitTest Libplanet.Tests
+- |
+  for project in $PROJECTS; do
+    msbuild -p:Configuration=Release -t:build,XunitTest $project.Tests
+  done
 
 # Run unit tests with coverage report
 - cat codecov.yml | curl --data-binary @- https://codecov.io/validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ script:
 - hooks/check-bom
 
 # Build the whole solution
-- msbuild -p:Configuration=Release -r
+- msbuild -p:Configuration=Release -r Libplanet
 
 # Run unit tests
 - msbuild -p:Configuration=Release -t:XunitTest Libplanet.Tests
@@ -154,7 +154,7 @@ script:
 # Build Libplanet.*.nupkg
 - |
   rm -f "Libplanet/bin/Release/Libplanet.$version.nupkg"
-  nuget_props=('Configuration=Release')
+  msbuild_props=('Configuration=Release')
   if [[ "$TRAVIS_TAG" = "" && "$version" = *-dev ]]; then
     # Append "+buildno" to the package version (e.g., 0.1.2-dev+34)
     # if it's not a tag push.
@@ -165,19 +165,14 @@ script:
       nupkg_version="$version.$TRAVIS_BUILD_NUMBER"
       appended_version="$nupkg_version+$(date +%Y%m%d)"
     fi
-    nuget_props+=("PackageVersion=$appended_version")
-    nuget_props+=('NoPackageAnalysis=true')
-    msbuild -r "${nuget_props[@]/#/-p:}"
+    msbuild_props+=("PackageVersion=$appended_version")
+    msbuild_props+=('NoPackageAnalysis=true')
+    msbuild -r "${msbuild_props[@]/#/-p:}" Libplanet
   else
     nupkg_version="$version"
     appended_version="$version"
   fi
-  nuget pack Libplanet/Libplanet.csproj \
-    -Verbosity detailed \
-    -IncludeReferencedProjects \
-    -OutputDirectory Libplanet/bin/Release \
-    -Properties "$(IFS=';'; echo "${nuget_props[*]}")" \
-    -Version "$appended_version"
+  msbuild -t:pack "${msbuild_props[@]/#/-p:}" Libplanet
   unzip -l "Libplanet/bin/Release/Libplanet.$nupkg_version.nupkg" \
     > /tmp/nupkgfiles
   cat /tmp/nupkgfiles

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,9 @@ Build
 -----
 
 The following command installs dependencies (required library packages) and
-builds the whole Libplanet solution:
+builds the *Libplanet* project:
 
-    msbuild -r
+    msbuild -r Libplanet
 
 
 Tests [![Build Status](https://travis-ci.com/planetarium/libplanet.svg?branch=master)][Travis CI] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][2]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,23 +75,21 @@ Tests [![Build Status](https://travis-ci.com/planetarium/libplanet.svg?branch=ma
 We write as complete tests as possible to the corresponding implementation code.
 Going near to the [code coverage][2] 100% is one of our goals.
 
-The *Libplanet* solution consists of two projects.  *Libplanet* is an actual
-implementation.  It is built to a *Libplanet.dll* assembly and packed as
-a NuGet package.
+The *Libplanet* solution consists of 4 projects.  *Libplanet* and
+*Libplanet.Stun* are actual implementations.  These are built to *Libplanet.dll*
+and *Libplanet.Stun.dll* assemblies and packed into one NuGet package.
 
-*Libplanet.Tests* is a test suite for the *Libplanet.dll* assembly.
-It depends on [Xunit], and every namespace and class in it corresponds to
-one in *Libplanet* project.  If there's *Libplanet.Foo.Bar* class there also
-should be *Libplanet.Tests.Foo.BarTest* to test it.
+*Libplanet.Tests* is a test suite for the *Libplanet.dll* assembly, and
+*Libplanet.Stun.Tests* is a test suite for the *Libplanet.Stun.dll* assembly.
+Both depend on [Xunit], and every namespace and class in it corresponds to
+one in *Libplanet* and *Libplanet.Stun* projects.
+If there's *Libplanet.Foo.Bar* class there also should be
+*Libplanet.Tests.Foo.BarTest* to test it.
 
-To build and run unit tests at a time execute the below command:
+To build and run unit tests at a time execute the below commands:
 
-    msbuild -r -t:'Build;XunitTest' Libplanet.Tests
-
-It's okay to omit `-r` and `Build` task if you've already run `msbuild -r`
-right before:
-
-    msbuild -t:XunitTest Libplanet.Tests
+    msbuild -r -t:Build,XunitTest Libplanet.Tests
+    msbuild -r -t:Build,XunitTest Libplanet.Stun.Tests
 
 [Travis CI]: https://travis-ci.com/planetarium/libplanet
 [2]: https://codecov.io/gh/planetarium/libplanet

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,11 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -16,4 +24,14 @@
     <ProjectReference Include="..\Libplanet.Stun\Libplanet.Stun.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
+    <!--
+    As Mono has no proper AppDomain, we prevent it on Mono.
+    This works around Xunit's fatal error on Mono.
+    -->
+    <Content Include="xunit.runner.mono.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Libplanet.Stun.Tests/xunit.runner.mono.json
+++ b/Libplanet.Stun.Tests/xunit.runner.mono.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
+  "appDomain": "denied"
+}

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Libplanet.Stun\Libplanet.Stun.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -3,15 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun", "Libplanet.Stun\Libplanet.Stun.csproj", "{4F5DB8F5-D0F4-454C-95A7-87F53E5D5E36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun.Tests", "Libplanet.Stun.Tests\Libplanet.Stun.Tests.csproj", "{5C2B23E2-C286-412D-ADE1-F6796B7083DE}"
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet", "Libplanet\Libplanet.csproj", "{50E14C9A-3C2F-4A51-971F-6143952D0F1C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Tests", "Libplanet.Tests\Libplanet.Tests.csproj", "{3BA7D9BE-EBBF-432E-9880-0E2D2C17FCF8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Explorer", "Libplanet.Explorer\Libplanet.Explorer.csproj", "{CC035C07-8D2B-4608-BA09-3FBB290A3EA6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun", "Libplanet.Stun\Libplanet.Stun.csproj", "{4F5DB8F5-D0F4-454C-95A7-87F53E5D5E36}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun.Tests", "Libplanet.Stun.Tests\Libplanet.Stun.Tests.csproj", "{5C2B23E2-C286-412D-ADE1-F6796B7083DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -88,7 +88,23 @@ https://docs.libplanet.io/</Description>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <!-- The above hacky trick is borrowed from the following Stack Overflow
+  answer: https://stackoverflow.com/a/45004898/383405 (see #2). -->
   <ItemGroup>
-    <ProjectReference Include="..\Libplanet.Stun\Libplanet.Stun.csproj" />
+    <ProjectReference
+      Include="..\Libplanet.Stun\Libplanet.Stun.csproj"
+      PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>
+      $(TargetsForTfmSpecificBuildOutput);IncludeP2PAssets
+    </TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="IncludeP2PAssets">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)Libplanet.Stun.dll" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -69,7 +69,7 @@ https://docs.libplanet.io/</Description>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Uno.SourceGenerationTasks" Version="1.29.0-dev.195">
+    <PackageReference Include="Uno.SourceGenerationTasks" Version="1.29.0">
       <!-- Note that this is actually not necessarily a direct dependency,
       but an indirect dependency of Uno.CodeGen.  This item purposes to merely
       ignore NU1701 warnings during restoring Uno.CodeGen package.
@@ -79,8 +79,9 @@ https://docs.libplanet.io/</Description>
       <NoWarn>NU1701</NoWarn>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Uno.CodeGen" Version="1.30.0-dev.102" />
-    <PackageReference Include="Uno.Core" Version="1.25.0" />
+    <PackageReference Include="Uno.CodeGen" Version="1.30.0" />
+    <PackageReference Include="Uno.Core" Version="1.26.0" />
+    <PackageReference Include="Uno.Equality" Version="1.30.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This addresses the following problems:

- *Libplanet* uses *Uno.Equality* package but its package metadata hadn't had a dependency on *Uno.Equality*.
- *Libplanet.Stun.Tests* hadn't run for a while, and not been able to run with `msbuild`.
- NuGet metadata had been missing on the NuGet Gallery page (#153).  It's due to `nuget pack` command which is outdated, so I replaced it with `msbuild -t:pack` task again.
- Docs had been outdated so that it hadn't reflected the project separation done by PR #130.