### PR TITLE
Fix _blockSyncMutex timing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,8 @@ To be released.
  -  Block/tx-related methods in `IStore` and `BaseIndex<T>` no longer
     accepts `@namespace` parameter.  It means that even if a forking occurs, the
     same block/tx files are shared.
+ -  Fixed a bug that made unnecessary fork when receiving blocks from other
+    peer.
  -  `Transaction<T>` now throws an `InvalidActionTypeException` if an action type
     is not annotated with `ActionTypeAttribute`.  [[#144]]
  -  Turn into parameter in `BlockPolicy`'s constructor to milliseconds. [[#151]]


### PR DESCRIPTION
This PR adjusts the timing of `_blockSyncMutex` when receiving blocks from other peers to avoid unnecessary forking.

At this time, block exchange related bug fixes are not affected by the specification change, so the changelog was skipped.