### PR TITLE
Adjsut _rwlock to improve write throughput

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@ To be released.
  -  Added `Address.Size` constant, which is fixed to the `Int32` 20.
  -  Fixed a bug that `Block<T>.Validate()` had not thrown `InvalidTxException`
     even if there is any integrity error on its `Transactions`.
+ -  Improved the write throughput of `BlockChain<T>` while polling
+    `BlockChain<T>.GetStates()`
  -  `Swarm.AddPeersAsync()` was fixed so that unreachable `Peer`s are ignored.
     [[#128]]
  -  `Swarm` became able to relay their connection via TURN ([RFC 5766])


### PR DESCRIPTION
This PR adjusts the timing of `_rwlock.ExitReadLock()` to improve write throughput of the `BlockChain<T>`. 

The idea is that - if all blocks are to be added, and they are not changed or deleted , we don't have to lock the entire `GetStates()`, only need to synchronize the part that gets the first block.