### PR TITLE
Change type of Peer.EndPoint to DnsEndPoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,8 +149,8 @@ To be released.
  -  Since we decided to depend on TURN ([RFC 5766]) and STUN ([RFC 5389]) to
     work around NAT so that `Peer`'s endpoints don't have to be multiple,
     `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed
-    from `IImmutableList<Uri>` to `IPEndPoint`.
-    [[#120], [#123] by Yang Chun Ung, [#126], [#127]]
+    from `IImmutableList<Uri>` to `DnsEndPoint`.
+    [[#120], [#123] by Yang Chun Ung, [#126], [#127], [#165]]
  -  `Swarm` became to ignore tip blocks of the same height (`Index`) that it
     already has and deal with only longer (higher) blocks.
  -  Fixed a bug that occured when `Swarm` was handling multiple responses at the
@@ -181,7 +181,6 @@ To be released.
 [#98]: https://github.com/planetarium/libplanet/issues/98
 [#99]: https://github.com/planetarium/libplanet/issues/99
 [#120]: https://github.com/planetarium/libplanet/issues/120
-[#167]: https://github.com/planetarium/libplanet/issues/167
 [#121]: https://github.com/planetarium/libplanet/pull/121
 [#123]: https://github.com/planetarium/libplanet/pull/123
 [#124]: https://github.com/planetarium/libplanet/pull/124
@@ -196,6 +195,8 @@ To be released.
 [#144]: https://github.com/planetarium/libplanet/pull/144
 [#151]: https://github.com/planetarium/libplanet/pull/151
 [#159]: https://github.com/planetarium/libplanet/pull/159
+[#165]: https://github.com/planetarium/libplanet/issues/165
+[#167]: https://github.com/planetarium/libplanet/issues/167
 [#169]: https://github.com/planetarium/libplanet/pull/169
 [#170]: https://github.com/planetarium/libplanet/pull/170
 [RFC 5389]: https://tools.ietf.org/html/rfc5389

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,11 +150,13 @@ To be released.
     work around NAT so that `Peer`'s endpoints don't have to be multiple,
     `Peer.Urls` was renamed to `Peer.EndPoint` and its type also was changed
     from `IImmutableList<Uri>` to `DnsEndPoint`.
-    [[#120], [#123] by Yang Chun Ung, [#126], [#127], [#165]]
+    [[#120], [#123] by Yang Chun Ung, [#126], [#127], [#165], [#166]]
  -  `Swarm` became to ignore tip blocks of the same height (`Index`) that it
     already has and deal with only longer (higher) blocks.
  -  Fixed a bug that occured when `Swarm` was handling multiple responses at the
     same time.
+ -  Fixed a bug that the `Swarm` constructor had hanged in certain runtimes
+    like Unity engine.
  -  Removed `AddressTransactionSet` which handles handle `Address` to
     `IEnumerable<TxId>` indices, and the following methods in `IStore`:
      -  `IStore.IterateAddresses()`

--- a/Libplanet.Tests/Net/PeerSetDeltaTest.cs
+++ b/Libplanet.Tests/Net/PeerSetDeltaTest.cs
@@ -17,20 +17,20 @@ namespace Libplanet.Tests.Net
             var peerSetDelta = new PeerSetDelta(
                 new Peer(
                     new PrivateKey().PublicKey,
-                    new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234)
+                    new DnsEndPoint("0.0.0.0", 1234)
                 ),
                 DateTimeOffset.UtcNow,
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234)),
+                        new DnsEndPoint("1.2.3.4", 1234)),
                 }.ToImmutableHashSet(),
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new IPEndPoint(IPAddress.Parse("2.3.4.5"), 1234)),
+                        new DnsEndPoint("2.3.4.5", 1234)),
                 }.ToImmutableHashSet(),
                 null
             );

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Tests.Net
                     "038f92e8098c897c2a9ae3226eb6337eb" +
                     "7ca8dbad5e1c8c9b130a9d39171a44134"
                     ));
-            var endPoint = new IPEndPoint(IPAddress.Parse("0.0.0.0"), 1234);
+            var endPoint = new DnsEndPoint("0.0.0.0", 1234);
             var peer = new Peer(key, endPoint);
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -56,16 +56,16 @@ namespace Libplanet.Tests.Net
             {
                 new Swarm(
                     new PrivateKey(),
-                    1,
-                    ipAddress: IPAddress.Loopback),
+                    appProtocolVersion: 1,
+                    host: IPAddress.Loopback.ToString()),
                 new Swarm(
                     new PrivateKey(),
-                    1,
-                    ipAddress: IPAddress.Loopback),
+                    appProtocolVersion: 1,
+                    host: IPAddress.Loopback.ToString()),
                 new Swarm(
                     new PrivateKey(),
-                    1,
-                    ipAddress: IPAddress.Loopback),
+                    appProtocolVersion: 1,
+                    host: IPAddress.Loopback.ToString()),
             };
         }
 
@@ -313,20 +313,20 @@ namespace Libplanet.Tests.Net
         {
             var a = new Swarm(
                 new PrivateKey(),
-                ipAddress: IPAddress.Loopback,
+                host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2);
             var b = new Swarm(
                 new PrivateKey(),
-                ipAddress: IPAddress.Loopback,
+                host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
 
             var c = new Swarm(
                 new PrivateKey(),
-                ipAddress: IPAddress.Loopback,
+                host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2);
             var d = new Swarm(
                 new PrivateKey(),
-                ipAddress: IPAddress.Loopback,
+                host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
 
             BlockChain<DumbAction> chain = _blockchains[0];
@@ -364,18 +364,18 @@ namespace Libplanet.Tests.Net
             var a = new Swarm(
                 pk1,
                 1,
-                ipAddress: IPAddress.Parse("0.0.0.0"),
+                host: "0.0.0.0",
                 listenPort: 5555);
             var b = new Swarm(
                 pk1,
                 1,
-                ipAddress: IPAddress.Parse("0.0.0.0"),
+                host: "0.0.0.0",
                 listenPort: 5555,
                 createdAt: a.LastDistributed);
             var c = new Swarm(
                 pk2,
                 1,
-                ipAddress: IPAddress.Parse("0.0.0.0"),
+                host: "0.0.0.0",
                 listenPort: 5555);
 
             Assert.Equal(a, b);
@@ -638,11 +638,11 @@ namespace Libplanet.Tests.Net
         [Fact]
         public void CanResolveEndPoint()
         {
-            var expected = new IPEndPoint(IPAddress.Parse("1.2.3.4"), 5678);
+            var expected = new DnsEndPoint("1.2.3.4", 5678);
             Swarm s = new Swarm(
                 new PrivateKey(),
                 1,
-                ipAddress: IPAddress.Parse("1.2.3.4"),
+                host: "1.2.3.4",
                 listenPort: 5678);
 
             Assert.Equal(expected, s.EndPoint);
@@ -665,8 +665,11 @@ namespace Libplanet.Tests.Net
         [Fact]
         public async Task AsPeerThrowSwarmExceptionWhenUnbound()
         {
-            Swarm swarm =
-                new Swarm(new PrivateKey(), 1, ipAddress: IPAddress.Loopback);
+            Swarm swarm = new Swarm(
+                new PrivateKey(),
+                1,
+                host: IPAddress.Loopback.ToString()
+            );
             Assert.Throws<SwarmException>(() => swarm.AsPeer);
 
             await StartAsync(swarm, _blockchains[0]);
@@ -688,10 +691,7 @@ namespace Libplanet.Tests.Net
                     credential: password),
             };
 
-            var seed = new Swarm(
-                new PrivateKey(),
-                1,
-                ipAddress: IPAddress.Loopback);
+            var seed = new Swarm(new PrivateKey(), 1, host: "localhost");
             var swarmA = new Swarm(new PrivateKey(), 1, iceServers: iceServers);
             var swarmB = new Swarm(new PrivateKey(), 1, iceServers: iceServers);
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -627,11 +627,26 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
-        public void CanDenyNullParams()
+        public void ThrowArgumentExceptionInConstructor()
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
                 new Swarm(null, 1);
+            });
+
+            // Swarm needs host or iceServers.
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new Swarm(new PrivateKey(), 1);
+            });
+
+            // Swarm needs host or iceServers.
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new Swarm(
+                    new PrivateKey(),
+                    1,
+                    iceServers: new IceServer[] { });
             });
         }
 

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Net;
 using System.Runtime.Serialization;
 using Libplanet.Crypto;
@@ -15,7 +12,7 @@ namespace Libplanet.Net
     [GeneratedEquality]
     public partial class Peer : ISerializable
     {
-        public Peer(PublicKey publicKey, IPEndPoint endPoint)
+        public Peer(PublicKey publicKey, DnsEndPoint endPoint)
         {
             if (publicKey == null)
             {
@@ -33,7 +30,9 @@ namespace Libplanet.Net
         protected Peer(SerializationInfo info, StreamingContext context)
         {
             PublicKey = new PublicKey(info.GetValue<byte[]>("public_key"));
-            EndPoint = info.GetValue<IPEndPoint>("end_point");
+            EndPoint = new DnsEndPoint(
+                info.GetString("end_point_host"),
+                info.GetInt32("end_point_port"));
         }
 
         [EqualityKey]
@@ -42,7 +41,7 @@ namespace Libplanet.Net
 
         [EqualityKey]
         [Pure]
-        public IPEndPoint EndPoint { get; }
+        public DnsEndPoint EndPoint { get; }
 
         [Pure]
         public Address Address => new Address(PublicKey);
@@ -53,7 +52,8 @@ namespace Libplanet.Net
         )
         {
             info.AddValue("public_key", PublicKey.Format(true));
-            info.AddValue("end_point", EndPoint);
+            info.AddValue("end_point_host", EndPoint.Host);
+            info.AddValue("end_point_port", EndPoint.Port);
         }
 
         public override string ToString()


### PR DESCRIPTION
This PR changes `Peer.EndPoint`'s type to `DnsEndPoint` to resolve #165.

In this process, I've found a problem that the node behind the NAT can't connect properly, but I will treat it as a separate issue.
