### PR TITLE
Fix the issue that the document's "View Source" link was broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,20 @@ script:
 # Check coding styles
 - hooks/check-bom
 
+# Build docs using DocFX
+- |
+  if [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
+    powershell -Command "Set-ExecutionPolicy Unrestricted"
+    pwsh=powershell
+  else
+    pwsh=pwsh
+  fi
+  $pwsh \
+    -File Docs/build.ps1 \
+    -WorkingDirectory Docs/ \
+    -ExecutionPolicy Bypass
+- '[[ -f Docs/_site/index.html ]]'
+
 # Build the whole solution
 - |
   for project in $PROJECTS; do
@@ -188,20 +202,6 @@ script:
   grep -i Libplanet.dll /tmp/nupkgfiles
   grep -i Libplanet.Stun.dll /tmp/nupkgfiles
   rm -f "Libplanet/bin/Release/Libplanet.$version.nupkg"
-
-# Build docs using DocFX
-- |
-  if [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
-    powershell -Command "Set-ExecutionPolicy Unrestricted"
-    pwsh=powershell
-  else
-    pwsh=pwsh
-  fi
-  $pwsh \
-    -File Docs/build.ps1 \
-    -WorkingDirectory Docs/ \
-    -ExecutionPolicy Bypass
-- '[[ -f Docs/_site/index.html ]]'
 
 # Turn off "set -e" option
 - set +e


### PR DESCRIPTION
This patch fixes planetarium/libplanet#82. While building the code, [Uno.CodeGen][] generates [separated files][^1] so that [DocFX][] catches another automatically generated code. That's why **View Source** link was broken. I changed the `Docs`'s build order to solve this issue.

[Uno.CodeGen]: https://github.com/nventive/Uno.CodeGen
[DocFX]: https://dotnet.github.io/docfx/
[^1]: https://github.com/nventive/Uno.CodeGen/blob/master/doc/Equality%20Generation.md