### PR TITLE
Add Miner property to IActionContext

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,7 @@ To be released.
  -  Made `Swarm` possible to configure its network `appProtocolVersion` and,
     to ignore peers if their version is different.  [[#167]], [[#170]]
  -  Added `IActionContext.Miner` property.  [[#173]], [[#174]]
+ -  Renamed `Block<T>.RewardBeneficiary` to `Block<T>.Miner`.  [[#174]]
 
 [#28]: https://github.com/planetarium/libplanet/issues/28
 [#98]: https://github.com/planetarium/libplanet/issues/98

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -178,6 +178,7 @@ To be released.
  -  `BencodexFormatter` became able to serialize `BigInteger`.  [[#159]]
  -  Made `Swarm` possible to configure its network `appProtocolVersion` and,
     to ignore peers if their version is different.  [[#167]], [[#170]]
+ -  Added `IActionContext.Miner` property.  [[#173]], [[#174]]
 
 [#28]: https://github.com/planetarium/libplanet/issues/28
 [#98]: https://github.com/planetarium/libplanet/issues/98
@@ -201,6 +202,8 @@ To be released.
 [#167]: https://github.com/planetarium/libplanet/issues/167
 [#169]: https://github.com/planetarium/libplanet/pull/169
 [#170]: https://github.com/planetarium/libplanet/pull/170
+[#173]: https://github.com/planetarium/libplanet/issues/173
+[#174]: https://github.com/planetarium/libplanet/pull/174
 [RFC 5389]: https://tools.ietf.org/html/rfc5389
 [RFC 5766]: https://tools.ietf.org/html/rfc5766
 

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Explorer.Controllers
                 Difficulty = block.Difficulty,
                 Nonce = block.Nonce.ToString(),
                 PreviousHash = block.PreviousHash.ToString(),
-                RewardBeneficiary = block.RewardBeneficiary?.ToHex(),
+                Miner = block.Miner?.ToHex(),
                 Timestamp = block.Timestamp.ToString(TimestampFormat),
                 TxIds = (block.Transactions
                     .OrderByDescending(tx => tx.Timestamp)

--- a/Libplanet.Explorer/ViewModels/BlockViewModel.cs
+++ b/Libplanet.Explorer/ViewModels/BlockViewModel.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Explorer.ViewModels
         public long Index { get; set; }
         public int Difficulty { get; set; }
         public string Nonce { get; set; }
-        public string RewardBeneficiary { get; set; }
+        public string Miner { get; set; }
         public string PreviousHash { get; set; }
         public string Timestamp { get; set; }
         public List<Dictionary<string, string>> TxIds { get; set; }

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -14,10 +14,12 @@ namespace Libplanet.Tests.Action
                 (0, 1559595546),
                 (1, 534011718),
             };
+            var address = new Address("21744f4f08db23e044178dafb8273aeb5ebe6644");
             foreach (var (seed, expected) in testCases)
             {
                 var context = new ActionContext(
-                    signer: new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
+                    signer: address,
+                    miner: address,
                     blockIndex: 1,
                     previousStates: new DumbAccountStateDelta(),
                     randomSeed: seed

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -250,6 +250,7 @@ namespace Libplanet.Tests.Blockchain
             var states = chain.GetStates(new[]
             {
                 TestEvaluateAction.SignerKey,
+                TestEvaluateAction.MinerKey,
                 TestEvaluateAction.BlockIndexKey,
             });
 
@@ -257,12 +258,18 @@ namespace Libplanet.Tests.Blockchain
                 states[TestEvaluateAction.SignerKey],
                 fromAddress.ToHex()
             );
+            Assert.Equal(
+                states[TestEvaluateAction.MinerKey],
+                _fx.Address1.ToHex());
             Assert.Equal(states[TestEvaluateAction.BlockIndexKey], blockIndex);
         }
 
         private sealed class TestEvaluateAction : IAction
         {
             public static readonly Address SignerKey =
+                new PrivateKey().PublicKey.ToAddress();
+
+            public static readonly Address MinerKey =
                 new PrivateKey().PublicKey.ToAddress();
 
             public static readonly Address BlockIndexKey =
@@ -284,6 +291,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 return context.PreviousStates
                     .SetState(SignerKey, context.Signer.ToHex())
+                    .SetState(MinerKey, context.Miner.ToHex())
                     .SetState(BlockIndexKey, context.BlockIndex);
             }
         }

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero), _fx.Genesis.Timestamp);
             Assert.Equal(
                 new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
-                _fx.Genesis.RewardBeneficiary);
+                _fx.Genesis.Miner);
             Assert.Equal(new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }), _fx.Genesis.Nonce);
             AssertBytesEqual(
                 new HashDigest<SHA256>(
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(new DateTimeOffset(2018, 11, 30, 0, 0, 0, TimeSpan.Zero), _fx.Next.Timestamp);
             Assert.Equal(
                 new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
-                _fx.Next.RewardBeneficiary);
+                _fx.Next.Miner);
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace Libplanet.Tests.Blocks
             var block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
                 _fx.Next.Difficulty,
-                _fx.Next.RewardBeneficiary.Value,
+                _fx.Next.Miner.Value,
                 _fx.Genesis.Hash,
                 now + TimeSpan.FromSeconds(901),
                 new Transaction<DumbAction>[] { }
@@ -395,7 +395,7 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: _fx.Next.Difficulty,
                 nonce: new Nonce(new byte[] { 0x00 }),
-                rewardBeneficiary: _fx.Next.RewardBeneficiary,
+                miner: _fx.Next.Miner,
                 previousHash: _fx.Next.PreviousHash,
                 timestamp: _fx.Next.Timestamp,
                 transactions: _fx.Next.Transactions
@@ -413,7 +413,7 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Genesis.Index,
                 difficulty: 1, // invalid
                 nonce: _fx.Genesis.Nonce,
-                rewardBeneficiary: _fx.Genesis.RewardBeneficiary,
+                miner: _fx.Genesis.Miner,
                 previousHash: _fx.Genesis.PreviousHash,
                 timestamp: _fx.Genesis.Timestamp,
                 transactions: MineGenesis<DumbAction>().Transactions
@@ -426,7 +426,7 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: 0, // invalid
                 nonce: _fx.Next.Nonce,
-                rewardBeneficiary: _fx.Next.RewardBeneficiary,
+                miner: _fx.Next.Miner,
                 previousHash: _fx.Next.PreviousHash,
                 timestamp: _fx.Next.Timestamp,
                 transactions: _fx.Next.Transactions
@@ -443,7 +443,7 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Genesis.Index,
                 difficulty: _fx.Genesis.Difficulty,
                 nonce: _fx.Genesis.Nonce,
-                rewardBeneficiary: _fx.Genesis.RewardBeneficiary,
+                miner: _fx.Genesis.Miner,
                 previousHash: new HashDigest<SHA256>(GetRandomBytes(32)), // invalid
                 timestamp: _fx.Genesis.Timestamp,
                 transactions: MineGenesis<DumbAction>().Transactions
@@ -457,7 +457,7 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: _fx.Next.Difficulty,
                 nonce: _fx.Next.Nonce,
-                rewardBeneficiary: _fx.Next.RewardBeneficiary,
+                miner: _fx.Next.Miner,
                 previousHash: null,
                 timestamp: _fx.Next.Timestamp,
                 transactions: _fx.Next.Transactions
@@ -478,7 +478,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal("2018-11-29T00:00:00.000000Z", rawGenesis.Timestamp);
             Assert.Equal(
                 ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644"),
-                rawGenesis.RewardBeneficiary
+                rawGenesis.Miner
             );
             Assert.Equal(
                 new byte[] { 0x01, 0x00, 0x00, 0x00 },
@@ -503,7 +503,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal("2018-11-30T00:00:00.000000Z", rawNext.Timestamp);
             Assert.Equal(
                 ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644"),
-                rawNext.RewardBeneficiary
+                rawNext.Miner
              );
         }
 
@@ -515,7 +515,7 @@ namespace Libplanet.Tests.Blocks
                 index: sameBlock1.Index,
                 difficulty: sameBlock1.Difficulty,
                 nonce: sameBlock1.Nonce,
-                rewardBeneficiary: sameBlock1.RewardBeneficiary,
+                miner: sameBlock1.Miner,
                 previousHash: null,
                 timestamp: sameBlock1.Timestamp,
                 transactions: sameBlock1.Transactions

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -78,7 +78,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         internal static Block<T> MineGenesis<T>()
             where T : IAction, new()
         {
-            var rewardBeneficiary = new Address(
+            var miner = new Address(
                 "21744f4f08db23e044178dafb8273aeb5ebe6644"
             );
             var timestamp = new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero);
@@ -86,7 +86,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 index: 0,
                 difficulty: 0,
                 nonce: new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }),
-                rewardBeneficiary: rewardBeneficiary,
+                miner: miner,
                 previousHash: null,
                 timestamp: timestamp,
                 transactions: new List<Transaction<T>>()
@@ -109,14 +109,14 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             const int difficulty = 1;
             HashDigest<SHA256> previousHash = previousBlock.Hash;
             DateTimeOffset timestamp = previousBlock.Timestamp.AddDays(1);
-            Address rewardBeneficiary = previousBlock.RewardBeneficiary.Value;
+            Address miner = previousBlock.Miner.Value;
 
             if (nonce == null)
             {
                 return Block<T>.Mine(
                     index: index,
                     difficulty: difficulty,
-                    rewardBeneficiary: rewardBeneficiary,
+                    miner: miner,
                     previousHash: previousHash,
                     timestamp: timestamp,
                     transactions: txs
@@ -127,7 +127,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 index: index,
                 difficulty: difficulty,
                 nonce: new Nonce(nonce),
-                rewardBeneficiary: rewardBeneficiary,
+                miner: miner,
                 previousHash: previousHash,
                 timestamp: timestamp,
                 transactions: txs

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -613,6 +613,7 @@ namespace Libplanet.Tests.Tx
                     default,
                     1,
                     new AccountStateDeltaImpl(address => null),
+                    addresses[0],
                     rehearsal: rehearsal
                 );
                 Assert.Equal(

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -4,6 +4,7 @@ namespace Libplanet.Action
     {
         public ActionContext(
             Address signer,
+            Address miner,
             long blockIndex,
             IAccountStateDelta previousStates,
             int randomSeed,
@@ -11,6 +12,7 @@ namespace Libplanet.Action
         )
         {
             Signer = signer;
+            Miner = miner;
             BlockIndex = blockIndex;
             Rehearsal = rehearsal;
             PreviousStates = previousStates;
@@ -18,6 +20,8 @@ namespace Libplanet.Action
         }
 
         public Address Signer { get; }
+
+        public Address Miner { get; }
 
         public long BlockIndex { get; }
 

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -13,6 +13,11 @@ namespace Libplanet.Action
         Address Signer { get; }
 
         /// <summary>
+        /// <see cref="Address"/> of a block miner account.
+        /// </summary>
+        Address Miner { get; }
+
+        /// <summary>
         /// Block index of a transaction that an executed <see cref="IAction"/>
         /// belongs to.
         /// </summary>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -230,7 +230,7 @@ namespace Libplanet.Blockchain
         }
 
         public Block<T> MineBlock(
-            Address rewardBeneficiary,
+            Address miner,
             DateTimeOffset currentTime
         )
         {
@@ -254,7 +254,7 @@ namespace Libplanet.Blockchain
                 Block<T> block = Block<T>.Mine(
                     index: index,
                     difficulty: difficulty,
-                    rewardBeneficiary: rewardBeneficiary,
+                    miner: miner,
                     previousHash: prevHash,
                     timestamp: currentTime,
                     transactions: transactions
@@ -269,8 +269,8 @@ namespace Libplanet.Blockchain
             }
         }
 
-        public Block<T> MineBlock(Address rewardBeneficiary) =>
-            MineBlock(rewardBeneficiary, DateTimeOffset.UtcNow);
+        public Block<T> MineBlock(Address miner) =>
+            MineBlock(miner, DateTimeOffset.UtcNow);
 
         internal HashDigest<SHA256> FindBranchPoint(BlockLocator locator)
         {

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -173,7 +173,8 @@ namespace Libplanet.Blocks
                 );
             foreach (Transaction<T> tx in Transactions)
             {
-                delta = tx.EvaluateActions(Hash, Index, delta);
+                delta = tx.EvaluateActions(
+                    Hash, Index, delta, RewardBeneficiary.Value);
                 yield return delta;
                 delta = new AccountStateDeltaImpl(delta.GetState);
             }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Blocks
             long index,
             int difficulty,
             Nonce nonce,
-            Address? rewardBeneficiary,
+            Address? miner,
             HashDigest<SHA256>? previousHash,
             DateTimeOffset timestamp,
             IEnumerable<Transaction<T>> transactions)
@@ -35,7 +35,7 @@ namespace Libplanet.Blocks
             Index = index;
             Difficulty = difficulty;
             Nonce = nonce;
-            RewardBeneficiary = rewardBeneficiary;
+            Miner = miner;
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions;
@@ -51,8 +51,8 @@ namespace Libplanet.Blocks
             Index = rawBlock.Index;
             Difficulty = rawBlock.Difficulty;
             Nonce = new Nonce(rawBlock.Nonce);
-            RewardBeneficiary = (rawBlock.RewardBeneficiary != null)
-                ? new Address(rawBlock.RewardBeneficiary)
+            Miner = (rawBlock.Miner != null)
+                ? new Address(rawBlock.Miner)
                 : default(Address?);
             PreviousHash = (rawBlock.PreviousHash != null)
                 ? new HashDigest<SHA256>(rawBlock.PreviousHash)
@@ -90,7 +90,7 @@ namespace Libplanet.Blocks
         public Nonce Nonce { get; }
 
         [Uno.EqualityIgnore]
-        public Address? RewardBeneficiary { get; }
+        public Address? Miner { get; }
 
         [Uno.EqualityIgnore]
         public HashDigest<SHA256>? PreviousHash { get; }
@@ -104,7 +104,7 @@ namespace Libplanet.Blocks
         public static Block<T> Mine(
             long index,
             int difficulty,
-            Address rewardBeneficiary,
+            Address miner,
             HashDigest<SHA256>? previousHash,
             DateTimeOffset timestamp,
             IEnumerable<Transaction<T>> transactions)
@@ -113,7 +113,7 @@ namespace Libplanet.Blocks
                 index,
                 difficulty,
                 n,
-                rewardBeneficiary,
+                miner,
                 previousHash,
                 timestamp,
                 transactions
@@ -174,7 +174,7 @@ namespace Libplanet.Blocks
             foreach (Transaction<T> tx in Transactions)
             {
                 delta = tx.EvaluateActions(
-                    Hash, Index, delta, RewardBeneficiary.Value);
+                    Hash, Index, delta, Miner.Value);
                 yield return delta;
                 delta = new AccountStateDeltaImpl(delta.GetState);
             }
@@ -374,7 +374,7 @@ namespace Libplanet.Blocks
                 index: Index,
                 timestamp: Timestamp.ToString(TimestampFormat),
                 nonce: Nonce.ToByteArray(),
-                rewardBeneficiary: RewardBeneficiary?.ToByteArray(),
+                miner: Miner?.ToByteArray(),
                 difficulty: Difficulty,
                 transactions: transactions,
                 previousHash: PreviousHash?.ToByteArray()

--- a/Libplanet/Blocks/RawBlock.cs
+++ b/Libplanet/Blocks/RawBlock.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Blocks
             long index,
             string timestamp,
             byte[] nonce,
-            byte[] rewardBeneficiary,
+            byte[] miner,
             int difficulty,
             byte[] previousHash,
             IEnumerable transactions)
@@ -18,7 +18,7 @@ namespace Libplanet.Blocks
                 index,
                 timestamp,
                 nonce,
-                rewardBeneficiary,
+                miner,
                 difficulty,
                 previousHash,
                 transactions,
@@ -31,7 +31,7 @@ namespace Libplanet.Blocks
             long index,
             string timestamp,
             byte[] nonce,
-            byte[] rewardBeneficiary,
+            byte[] miner,
             int difficulty,
             byte[] previousHash,
             IEnumerable transactions,
@@ -40,7 +40,7 @@ namespace Libplanet.Blocks
             Index = index;
             Timestamp = timestamp;
             Nonce = nonce;
-            RewardBeneficiary = rewardBeneficiary;
+            Miner = miner;
             Difficulty = difficulty;
             PreviousHash = previousHash;
             Transactions = transactions;
@@ -52,7 +52,7 @@ namespace Libplanet.Blocks
                 index: info.GetInt64("index"),
                 timestamp: info.GetString("timestamp"),
                 nonce: info.GetValue<byte[]>("nonce"),
-                rewardBeneficiary: info.GetValue<byte[]>("reward_beneficiary"),
+                miner: info.GetValue<byte[]>("reward_beneficiary"),
                 difficulty: info.GetInt32("difficulty"),
                 previousHash: info.GetValueOrDefault<byte[]>(
                     "previous_hash",
@@ -70,7 +70,7 @@ namespace Libplanet.Blocks
 
         public byte[] Nonce { get; }
 
-        public byte[] RewardBeneficiary { get; }
+        public byte[] Miner { get; }
 
         public int Difficulty { get; }
 
@@ -87,7 +87,7 @@ namespace Libplanet.Blocks
         {
             info.AddValue("index", Index);
             info.AddValue("timestamp", Timestamp);
-            info.AddValue("reward_beneficiary", RewardBeneficiary);
+            info.AddValue("reward_beneficiary", Miner);
             info.AddValue("difficulty", Difficulty);
             info.AddValue("transactions", Transactions);
             info.AddValue("nonce", Nonce);
@@ -108,7 +108,7 @@ namespace Libplanet.Blocks
             return new RawBlock(
                 index: Index,
                 timestamp: Timestamp,
-                rewardBeneficiary: RewardBeneficiary,
+                miner: Miner,
                 difficulty: Difficulty,
                 nonce: Nonce,
                 previousHash: PreviousHash,

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -248,7 +248,7 @@ namespace Libplanet.Store
                     index: rawBlock.Index,
                     difficulty: rawBlock.Difficulty,
                     nonce: new Nonce(rawBlock.Nonce),
-                    rewardBeneficiary: new Address(rawBlock.RewardBeneficiary),
+                    miner: new Address(rawBlock.Miner),
                     previousHash: previousHash,
                     timestamp: DateTimeOffset.ParseExact(
                         rawBlock.Timestamp,

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -367,6 +367,7 @@ namespace Libplanet.Tx
                     default(HashDigest<SHA256>),
                     0,
                     new AccountStateDeltaImpl(_ => null),
+                    signer,
                     rehearsal: true
                 );
                 if (!updatedAddresses.IsSupersetOf(delta.UpdatedAddresses))
@@ -442,6 +443,7 @@ namespace Libplanet.Tx
         /// <see cref="Actions"/> being executed.  Note that its
         /// <see cref="IAccountStateDelta.UpdatedAddresses"/> are remained
         /// to the returned next states.</param>
+        /// <param name="minerAddress">An address of block miner.</param>
         /// <param name="rehearsal">Pass <c>true</c> if it is intended
         /// to be dry-run (i.e., the returned result will be never used).
         /// The default value is <c>false</c>.</param>
@@ -462,6 +464,7 @@ namespace Libplanet.Tx
             HashDigest<SHA256> blockHash,
             long blockIndex,
             IAccountStateDelta previousStates,
+            Address minerAddress,
             bool rehearsal = false
         )
         {
@@ -473,6 +476,7 @@ namespace Libplanet.Tx
             {
                 var context = new ActionContext(
                     signer: Signer,
+                    miner: minerAddress,
                     blockIndex: blockIndex,
                     previousStates: states,
                     randomSeed: unchecked(seed++),


### PR DESCRIPTION
- Added `Miner` property to `IActionContext`.
- Renamed `Block<T>.RewardBeneficiary` to `Block<T>.Miner`
Resolves #173