### PR TITLE
Different protocol version of peer handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.3.0
 
 To be released.
 
+ - Added `Swarm.DifferentVersionPeerEncountered` event handler that can handle
+   events when a different version of a peer is discovered.  [[#167]], [[#185]]
+ - Added `Peer.AppProtocolVersion` property.  [[#185]]
+
+[#185]: https://github.com/planetarium/libplanet/pull/185
+
 
 Version 0.2.1
 -------------

--- a/Libplanet.Tests/Net/PeerSetDeltaTest.cs
+++ b/Libplanet.Tests/Net/PeerSetDeltaTest.cs
@@ -17,20 +17,23 @@ namespace Libplanet.Tests.Net
             var peerSetDelta = new PeerSetDelta(
                 new Peer(
                     new PrivateKey().PublicKey,
-                    new DnsEndPoint("0.0.0.0", 1234)
+                    new DnsEndPoint("0.0.0.0", 1234),
+                    1
                 ),
                 DateTimeOffset.UtcNow,
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new DnsEndPoint("1.2.3.4", 1234)),
+                        new DnsEndPoint("1.2.3.4", 1234),
+                        1),
                 }.ToImmutableHashSet(),
                 new[]
                 {
                     new Peer(
                         new PrivateKey().PublicKey,
-                        new DnsEndPoint("2.3.4.5", 1234)),
+                        new DnsEndPoint("2.3.4.5", 1234),
+                        1),
                 }.ToImmutableHashSet(),
                 null
             );

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tests.Net
                     "7ca8dbad5e1c8c9b130a9d39171a44134"
                     ));
             var endPoint = new DnsEndPoint("0.0.0.0", 1234);
-            var peer = new Peer(key, endPoint);
+            var peer = new Peer(key, endPoint, 1);
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -359,6 +359,45 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
+        public async Task HandleDifferentAppProtocolVersion()
+        {
+            var isCalled = false;
+
+            void GameHandler(object sender, DifferentProtocolVersionEventArgs e)
+            {
+                isCalled = true;
+            }
+
+            var a = new Swarm(
+                new PrivateKey(),
+                host: IPAddress.Loopback.ToString(),
+                appProtocolVersion: 2);
+            var b = new Swarm(
+                new PrivateKey(),
+                host: IPAddress.Loopback.ToString(),
+                appProtocolVersion: 3);
+
+            a.DifferentVersionPeerEncountered += GameHandler;
+
+            BlockChain<DumbAction> chain = _blockchains[0];
+
+            try
+            {
+                await StartAsync(a, chain);
+                await StartAsync(b, chain);
+
+                a.Add(b.AsPeer);
+
+                Assert.True(isCalled);
+            }
+            finally
+            {
+                await a.StopAsync();
+                await b.StopAsync();
+            }
+        }
+
+        [Fact]
         public void BeComparedProperly()
         {
             var pk1 = new PrivateKey();

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -353,6 +353,8 @@ namespace Libplanet.Tests.Net
             {
                 await a.StopAsync();
                 await b.StopAsync();
+                await c.StopAsync();
+                await d.StopAsync();
             }
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -371,13 +371,12 @@ namespace Libplanet.Tests.Net
             var a = new Swarm(
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
-                appProtocolVersion: 2);
+                appProtocolVersion: 2,
+                differentVersionPeerEncountered: GameHandler);
             var b = new Swarm(
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
-
-            a.DifferentVersionPeerEncountered += GameHandler;
 
             BlockChain<DumbAction> chain = _blockchains[0];
 

--- a/Libplanet/Net/DifferentProtocolVersionEventArgs.cs
+++ b/Libplanet/Net/DifferentProtocolVersionEventArgs.cs
@@ -1,0 +1,20 @@
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// The event data that provides a value when
+    /// <see cref="Swarm.DifferentVersionPeerEncountered" /> is occured.
+    /// </summary>
+    public class DifferentProtocolVersionEventArgs
+    {
+        /// <summary>
+        /// The protocol version of the current <see cref="Swarm"/>.
+        /// </summary>
+        public int ExpectedVersion { get; set; }
+
+        /// <summary>
+        /// The protocol version of the <see cref="Peer"/> that the
+        /// <see cref="Swarm" /> is trying to connect to.
+        /// </summary>
+        public int ActualVersion { get; set; }
+    }
+}

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -8,10 +8,23 @@ using Uno;
 
 namespace Libplanet.Net
 {
+    /// <summary>
+    /// A representation of peer node.
+    /// </summary>
+    /// <seealso cref="Swarm"/>
     [Serializable]
     [GeneratedEquality]
     public partial class Peer : ISerializable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Peer"/> class.
+        /// </summary>
+        /// <param name="publicKey">A <see cref="PublicKey"/> of the
+        /// <see cref="Peer"/>.</param>
+        /// <param name="endPoint">A <see cref="DnsEndPoint"/> consisting of the
+        /// host and port of the <see cref="Peer"/>.</param>
+        /// <param name="appProtocolVersion">An application protocol version
+        /// that the <see cref="Peer"/> is using.</param>
         public Peer(
             PublicKey publicKey, DnsEndPoint endPoint, int appProtocolVersion)
         {
@@ -38,20 +51,32 @@ namespace Libplanet.Net
             AppProtocolVersion = info.GetInt32("app_protocol_version");
         }
 
+        /// <summary>
+        /// The corresponding <see cref="Libplanet.Crypto.PublicKey"/> of
+        /// this peer.
+        /// </summary>
         [EqualityKey]
         [Pure]
         public PublicKey PublicKey { get; }
 
+        /// <summary>
+        /// The corresponding <see cref="DnsEndPoint"/> of this peer.
+        /// </summary>
         [EqualityKey]
         [Pure]
         public DnsEndPoint EndPoint { get; }
 
+        /// <summary>
+        /// The corresponding application protocol version of this peer.
+        /// </summary>
+        /// <seealso cref="Swarm.DifferentVersionPeerEncountered"/>
         [Pure]
         public int AppProtocolVersion { get; }
 
         [Pure]
         public Address Address => new Address(PublicKey);
 
+        /// <inheritdoc/>
         public void GetObjectData(
             SerializationInfo info,
             StreamingContext context
@@ -63,6 +88,7 @@ namespace Libplanet.Net
             info.AddValue("app_protocol_version", AppProtocolVersion);
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"{Address}.{EndPoint}.{AppProtocolVersion}";

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -12,7 +12,8 @@ namespace Libplanet.Net
     [GeneratedEquality]
     public partial class Peer : ISerializable
     {
-        public Peer(PublicKey publicKey, DnsEndPoint endPoint)
+        public Peer(
+            PublicKey publicKey, DnsEndPoint endPoint, int appProtocolVersion)
         {
             if (publicKey == null)
             {
@@ -25,6 +26,7 @@ namespace Libplanet.Net
 
             PublicKey = publicKey;
             EndPoint = endPoint;
+            AppProtocolVersion = appProtocolVersion;
         }
 
         protected Peer(SerializationInfo info, StreamingContext context)
@@ -33,6 +35,7 @@ namespace Libplanet.Net
             EndPoint = new DnsEndPoint(
                 info.GetString("end_point_host"),
                 info.GetInt32("end_point_port"));
+            AppProtocolVersion = info.GetInt32("app_protocol_version");
         }
 
         [EqualityKey]
@@ -42,6 +45,9 @@ namespace Libplanet.Net
         [EqualityKey]
         [Pure]
         public DnsEndPoint EndPoint { get; }
+
+        [Pure]
+        public int AppProtocolVersion { get; }
 
         [Pure]
         public Address Address => new Address(PublicKey);
@@ -54,11 +60,12 @@ namespace Libplanet.Net
             info.AddValue("public_key", PublicKey.Format(true));
             info.AddValue("end_point_host", EndPoint.Host);
             info.AddValue("end_point_port", EndPoint.Port);
+            info.AddValue("app_protocol_version", AppProtocolVersion);
         }
 
         public override string ToString()
         {
-            return $"{Address}.{EndPoint}";
+            return $"{Address}.{EndPoint}.{AppProtocolVersion}";
         }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1161,6 +1161,11 @@ namespace Libplanet.Net
 
             if (IsUnknownPeer(sender))
             {
+                if (IsDifferentProtocolVersion(sender))
+                {
+                    return;
+                }
+
                 delta = new PeerSetDelta(
                     delta.Sender,
                     delta.Timestamp,
@@ -1168,6 +1173,16 @@ namespace Libplanet.Net
                     delta.RemovedPeers,
                     delta.ExistingPeers
                 );
+            }
+
+            if (IsDifferentProtocolVersion(sender))
+            {
+                delta = new PeerSetDelta(
+                    delta.Sender,
+                    delta.Timestamp,
+                    new Peer[] { }.ToImmutableHashSet(),
+                    delta.RemovedPeers,
+                    new Peer[] { }.ToImmutableHashSet());
             }
 
             _logger.Debug($"Received the delta[{delta}].");
@@ -1199,6 +1214,11 @@ namespace Libplanet.Net
             }
 
             return false;
+        }
+
+        private bool IsDifferentProtocolVersion(Peer sender)
+        {
+            return sender.AppProtocolVersion != _appProtocolVersion;
         }
 
         private async Task ApplyDelta(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -64,7 +64,9 @@ namespace Libplanet.Net
             string host = null,
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
-            IEnumerable<IceServer> iceServers = null)
+            IEnumerable<IceServer> iceServers = null,
+            EventHandler<DifferentProtocolVersionEventArgs>
+                differentVersionPeerEncountered = null)
             : this(
                   privateKey,
                   appProtocolVersion,
@@ -72,7 +74,8 @@ namespace Libplanet.Net
                   host,
                   listenPort,
                   createdAt,
-                  iceServers)
+                  iceServers,
+                  differentVersionPeerEncountered)
         {
         }
 
@@ -83,7 +86,9 @@ namespace Libplanet.Net
             string host = null,
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
-            IEnumerable<IceServer> iceServers = null)
+            IEnumerable<IceServer> iceServers = null,
+            EventHandler<DifferentProtocolVersionEventArgs>
+                differentVersionPeerEncountered = null)
         {
             Running = false;
 
@@ -102,6 +107,7 @@ namespace Libplanet.Net
             DeltaReceived = new AsyncAutoResetEvent();
             TxReceived = new AsyncAutoResetEvent();
             BlockReceived = new AsyncAutoResetEvent();
+            DifferentVersionPeerEncountered = differentVersionPeerEncountered;
 
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
             _router = new RouterSocket();

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -145,6 +145,13 @@ namespace Libplanet.Net
             }
         }
 
+        /// <summary>
+        /// The <see cref="EventHandler" /> called when the different version of
+        /// <see cref="Peer" /> is discovered.
+        /// </summary>
+        public event EventHandler<DifferentProtocolVersionEventArgs>
+            DifferentVersionPeerEncountered;
+
         public int Count => _peers.Count;
 
         public bool IsReadOnly => false;
@@ -1163,6 +1170,12 @@ namespace Libplanet.Net
             {
                 if (IsDifferentProtocolVersion(sender))
                 {
+                    var args = new DifferentProtocolVersionEventArgs
+                        {
+                            ExpectedVersion = _appProtocolVersion,
+                            ActualVersion = sender.AppProtocolVersion,
+                        };
+                    DifferentVersionPeerEncountered?.Invoke(this, args);
                     return;
                 }
 
@@ -1401,6 +1414,16 @@ namespace Libplanet.Net
                 if (pong.AppProtocolVersion != _appProtocolVersion)
                 {
                     dealer.Dispose();
+
+                    DifferentProtocolVersionEventArgs args =
+                        new DifferentProtocolVersionEventArgs
+                        {
+                            ExpectedVersion = _appProtocolVersion,
+                            ActualVersion = pong.AppProtocolVersion,
+                        };
+
+                    DifferentVersionPeerEncountered?.Invoke(this, args);
+
                     throw new DifferentAppProtocolVersionException(
                         $"Peer protocol version is different.",
                         _appProtocolVersion,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -156,7 +156,7 @@ namespace Libplanet.Net
 
         public Peer AsPeer =>
             EndPoint != null
-            ? new Peer(_privateKey.PublicKey, EndPoint)
+            ? new Peer(_privateKey.PublicKey, EndPoint, _appProtocolVersion)
             : throw new SwarmException(
                 "Can't translate unbound Swarm to Peer.");
 


### PR DESCRIPTION
- Added `appProtocolVersion` to `Peer`.
- Made ignore or remove `Peer` if the `appProtocolVersion` is different.
- Added EventHandler to handle different version of Peer.

Please review the name of classes as well. I'm not sure they are appropriate.