### PR TITLE
Remove writelock to improve the read throughput.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ To be released.
    other known peers and synchronizes the blocks if necessary
    before propagating/receiving pinpointed recent blocks to prevent inefficient
    round-trips.  [[#187], [#190]]
+ - Improved the read throughput of `BlockChain<T>` while mining through
+   `BlockChain<T>.MineBlock()`
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187


### PR DESCRIPTION
This PR removes the write lock on `BlockChain<T>.MineBlock()` to increase the read throughput. Since `BlockChain<T>.Append()` already has the write lock, it can be assumed that minimal consistency is guaranteed.