### PR TITLE
Retry refreshing when stale nonce error occurred

### DIFF
--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Stun.Messages
 
             using (var stream = new MemoryStream(bytes))
             {
-                var response = await StunMessage.Parse(stream);
+                var response = (RefreshErrorResponse) await StunMessage.Parse(stream);
                 Assert.Equal(
                     new byte[]
                     {
@@ -31,7 +31,7 @@ namespace Libplanet.Tests.Stun.Messages
                         0x0b, 0xad,
                     },
                     response.TransactionId);
-                Assert.IsType<RefreshErrorResponse>(response);
+                Assert.Equal(437, response.ErrorCode);
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/RefreshErrorResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/RefreshErrorResponse.cs
@@ -1,3 +1,5 @@
+using Libplanet.Stun.Attributes;
+
 namespace Libplanet.Stun.Messages
 {
     public class RefreshErrorResponse : StunMessage
@@ -5,5 +7,23 @@ namespace Libplanet.Stun.Messages
         public override MessageClass Class => MessageClass.ErrorResponse;
 
         public override MessageMethod Method => MessageMethod.Refresh;
+
+        public int ErrorCode
+        {
+            get
+            {
+                ErrorCode attr = GetAttribute<ErrorCode>();
+                return attr.Code;
+            }
+        }
+
+        public byte[] Nonce
+        {
+            get
+            {
+                Nonce attr = GetAttribute<Nonce>();
+                return attr.Value;
+            }
+        }
     }
 }

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -163,6 +163,14 @@ namespace Libplanet.Stun
             {
                 return TimeSpan.FromSeconds(success.Lifetime);
             }
+            else if (
+                response is RefreshErrorResponse error &&
+                error.ErrorCode == 438)
+            {
+                // Retry refreshing when stale nonce error(438) occured.
+                Nonce = error.Nonce;
+                return await RefreshAllocationAsync(lifetime);
+            }
 
             throw new TurnClientException("RefreshRequest failed.", response);
         }


### PR DESCRIPTION
This PR fixes `TurnClient` to retry `RefreshAllocation` when stale nonce error occurred.