### PR TITLE
Make BlockChain<T>.GetStates() returns early for nonexistent addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ To be released.
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
     nonce is stale.  [[#193]]
+ -  Fixed `BlockChain<T>.GetStates()` had descended to the bottom
+    (i.e., the genesis block) where a given `Address` referes to
+    a nonexistent account (i.e., never used before).  [[#189]]
  -  Added `GetAddressesMask(HashDigest<SHA256>)` method to `IStore` interface
     and its all implementations.  [[#189]]
  -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,19 +6,22 @@ Version 0.3.0
 
 To be released.
 
- - Added `Swarm.DifferentVersionPeerEncountered` event handler that can handle
-   events when a different version of a peer is discovered.  [[#167]], [[#185]]
- - Added `Peer.AppProtocolVersion` property.  [[#185]]
- - `Swarm.StartAsync()` now receives the height of blocks (tip `Index`) from
-   other known peers and synchronizes the blocks if necessary
-   before propagating/receiving pinpointed recent blocks to prevent inefficient
-   round-trips.  [[#187], [#190]]
- - Improved the read throughput of `BlockChain<T>` while mining through
-   `BlockChain<T>.MineBlock()`
+ -  Added `Swarm.DifferentVersionPeerEncountered` event handler that can handle
+    events when a different version of a peer is discovered.  [[#167]], [[#185]]
+ -  Added `Peer.AppProtocolVersion` property.  [[#185]]
+ -  `Swarm.StartAsync()` now receives the height of blocks (tip `Index`) from
+    other known peers and synchronizes the blocks if necessary
+    before propagating/receiving pinpointed recent blocks to prevent inefficient
+    round-trips.  [[#187], [#190]]
+ -  Improved overall read throughput of `BlockChain<T>` while blocks are being
+    mined by `BlockChain<T>.MineBlock()`.
+ -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
+    nonce is stale.  [[#193]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
 [#190]: https://github.com/planetarium/libplanet/pull/190
+[#193]: https://github.com/planetarium/libplanet/pull/193
 
 
 Version 0.2.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ To be released.
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
     nonce is stale.  [[#193]]
+ -  Added `GetAddressesMask(HashDigest<SHA256>)` method to `IStore` interface
+    and its all implementations.  [[#189]]
+ -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to
+    `PutBlock<T>(Block<T>, Address)`.  [[#189]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -26,7 +27,7 @@ namespace Libplanet.Tests.Store
         {
             Assert.Empty(_fx.Store.ListNamespaces());
 
-            _fx.Store.PutBlock(_fx.Block1);
+            _fx.Store.PutBlock(_fx.Block1, default);
             _fx.Store.AppendIndex(_ns, _fx.Block1.Hash);
             Assert.Equal(
                 new[] { _ns }.ToImmutableHashSet(),
@@ -92,7 +93,8 @@ namespace Libplanet.Tests.Store
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
             Assert.False(_fx.Store.DeleteBlock(_fx.Block1.Hash));
 
-            _fx.Store.PutBlock(_fx.Block1);
+            Address arbitraryMask = new PrivateKey().PublicKey.ToAddress();
+            _fx.Store.PutBlock(_fx.Block1, arbitraryMask);
             Assert.Equal(1, _fx.Store.CountBlocks());
             Assert.Equal(
                 new HashSet<HashDigest<SHA256>>
@@ -103,10 +105,17 @@ namespace Libplanet.Tests.Store
             Assert.Equal(
                 _fx.Block1,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block1.Hash));
+            Assert.Equal(
+                arbitraryMask,
+                _fx.Store.GetAddressesMask(_fx.Block1.Hash)
+            );
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block2.Hash));
+            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block2.Hash));
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
+            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block3.Hash));
 
-            _fx.Store.PutBlock(_fx.Block2);
+            Address arbitraryMask2 = new PrivateKey().PublicKey.ToAddress();
+            _fx.Store.PutBlock(_fx.Block2, arbitraryMask2);
             Assert.Equal(2, _fx.Store.CountBlocks());
             Assert.Equal(
                 new HashSet<HashDigest<SHA256>>
@@ -119,9 +128,18 @@ namespace Libplanet.Tests.Store
                 _fx.Block1,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block1.Hash));
             Assert.Equal(
+                arbitraryMask,
+                _fx.Store.GetAddressesMask(_fx.Block1.Hash)
+            );
+            Assert.Equal(
                 _fx.Block2,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block2.Hash));
+            Assert.Equal(
+                arbitraryMask2,
+                _fx.Store.GetAddressesMask(_fx.Block2.Hash)
+            );
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
+            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block3.Hash));
 
             Assert.True(_fx.Store.DeleteBlock(_fx.Block1.Hash));
             Assert.Equal(1, _fx.Store.CountBlocks());

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -74,6 +74,12 @@ namespace Libplanet.Tests.Store
             return _store.GetBlock<T>(blockHash);
         }
 
+        public Address? GetAddressesMask(HashDigest<SHA256> blockHash)
+        {
+            _logs.Add((nameof(GetAddressesMask), blockHash, null));
+            return _store.GetAddressesMask(blockHash);
+        }
+
         public AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
         {
             _logs.Add((nameof(GetBlockStates), blockHash, null));
@@ -123,11 +129,11 @@ namespace Libplanet.Tests.Store
             return _store.ListNamespaces();
         }
 
-        public void PutBlock<T>(Block<T> block)
+        public void PutBlock<T>(Block<T> block, Address addressesMask)
             where T : IAction, new()
         {
-            _logs.Add((nameof(PutBlock), block, null));
-            _store.PutBlock<T>(block);
+            _logs.Add((nameof(PutBlock), block, addressesMask));
+            _store.PutBlock<T>(block, addressesMask);
         }
 
         public void PutTransaction<T>(Transaction<T> tx)

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -131,6 +132,13 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 previousHash: previousHash,
                 timestamp: timestamp,
                 transactions: txs
+            );
+        }
+
+        internal static string ToString(BitArray bitArray)
+        {
+            return new string(
+                bitArray.OfType<bool>().Select(b => b ? '1' : '0').ToArray()
             );
         }
     }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -165,19 +165,56 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitReadLock();
             }
 
-            ImmutableHashSet<Address> requestedAddresses =
-                addresses.ToImmutableHashSet();
+            ImmutableDictionary<Address, BitArray> requestedAddresses =
+                addresses.Select(addr =>
+                    new KeyValuePair<Address, BitArray>(
+                        addr,
+                        new BitArray(addr.ToByteArray())
+                    )
+                ).ToImmutableDictionary();
+            ImmutableHashSet<Address> requestedAddressSet =
+                requestedAddresses.Keys.ToImmutableHashSet();
+
+            bool IsPossiblyIn(BitArray addr, BitArray maskPattern)
+            {
+                var match = (BitArray)maskPattern.Clone();
+                match.And(addr);
+                return match.OfType<bool>().Any(bit => bit);
+            }
+
+            var coveredAddresses = new HashSet<Address>();
             var states = new AddressStateMap();
+
             while (offset != null)
             {
                 states = (AddressStateMap)states.SetItems(
                     Store.GetBlockStates(offset.Value)
                     .Where(
-                        kv => requestedAddresses.Contains(kv.Key) &&
+                        kv => requestedAddresses.ContainsKey(kv.Key) &&
                         !states.ContainsKey(kv.Key))
                     );
 
-                if (requestedAddresses.SetEquals(states.Keys))
+                // If there is no mask for the offset (the store made in
+                // the older versions of Libplanet may lack mask files),
+                // make the mask to match to all possible addresses.
+                var mask = new BitArray(
+                    offset is HashDigest<SHA256> hash &&
+                        Store.GetAddressesMask(hash) is Address a
+                        ? a.ToByteArray()
+                        : Enumerable.Repeat((byte)0xff, Address.Size).ToArray()
+                );
+
+                // Addresses that are definitely not existent.
+                coveredAddresses.UnionWith(
+                    requestedAddresses.Where(
+                        pair => !IsPossiblyIn(pair.Value, mask)
+                    ).Select(pair => pair.Key)
+                );
+
+                // Already gethered addresses.
+                coveredAddresses.UnionWith(states.Keys);
+
+                if (requestedAddressSet.SetEquals(coveredAddresses))
                 {
                     break;
                 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -201,7 +201,7 @@ namespace Libplanet.Blockchain
                     offset is HashDigest<SHA256> hash &&
                         Store.GetAddressesMask(hash) is Address a
                         ? a.ToByteArray()
-                        : Enumerable.Repeat((byte)0xff, Address.Size).ToArray()
+                        : BlockSet<T>.WildcardMask
                 );
 
                 // Addresses that are definitely not existent.

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -52,7 +52,11 @@ namespace Libplanet.Store
         public abstract Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
             where T : IAction, new();
 
-        public abstract void PutBlock<T>(Block<T> block)
+        /// <inheritdoc />
+        public abstract Address? GetAddressesMask(HashDigest<SHA256> blockHash);
+
+        /// <inheritdoc />
+        public abstract void PutBlock<T>(Block<T> block, Address addressesMask)
             where T : IAction, new();
 
         public abstract bool DeleteBlock(HashDigest<SHA256> blockHash);

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -13,6 +13,10 @@ namespace Libplanet.Store
     public class BlockSet<T> : BaseIndex<HashDigest<SHA256>, Block<T>>
         where T : IAction, new()
     {
+        // TODO: We should have a distinct type like AddressMask in the future.
+        internal static readonly byte[] WildcardMask =
+            Enumerable.Repeat((byte)0xff, Address.Size).ToArray();
+
         public BlockSet(IStore store)
             : base(store)
         {
@@ -79,8 +83,7 @@ namespace Libplanet.Store
                         // (the store made in the older versions of Libplanet
                         // may lack mask files), make the mask to match to
                         // all possible addresses.
-                        prevMask = Enumerable.Repeat((byte)0xff, Address.Size)
-                            .ToArray();
+                        prevMask = WildcardMask;
                     }
                 }
                 else

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -63,7 +63,9 @@ namespace Libplanet.Store
                 }
 
                 value.Validate(DateTimeOffset.UtcNow);
-                Store.PutBlock(value);
+
+                // FIXME: A proper mask should be passed.
+                Store.PutBlock(value, default(Address));
             }
         }
 

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -51,14 +51,14 @@ namespace Libplanet.Store
                     throw new KeyNotFoundException();
                 }
 
-                Trace.Assert(block.Hash == key);
+                Trace.Assert(block.Hash.Equals(key));
                 block.Validate(DateTimeOffset.UtcNow);
                 return block;
             }
 
             set
             {
-                if (value.Hash != key)
+                if (!value.Hash.Equals(key))
                 {
                     throw new InvalidBlockHashException(
                         $"{value}.hash does not match to {key}");

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -45,7 +45,35 @@ namespace Libplanet.Store
         Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
             where T : IAction, new();
 
-        void PutBlock<T>(Block<T> block)
+        /// <summary>
+        /// Gets the bitmask of all addresses ever used until the block
+        /// of the given <paramref name="blockHash"/>.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of
+        /// the topmost <see cref="Block{T}"/> of the <see cref="Block{T}"/>
+        /// sequence that updated the <see cref="Address"/> set to which
+        /// the bit mask you want to obtain approximates.</param>
+        /// <returns>A bitmask in the <see cref="Address"/> type
+        /// (so this is probably not a valid address).  It can be
+        /// <c>null</c> if the given <paramref name="blockHash"/> refers to
+        /// a <see cref="Block{T}"/> that is not in the store.</returns>
+        Address? GetAddressesMask(HashDigest<SHA256> blockHash);
+
+        /// <summary>
+        /// Puts the given <paramref name="block"/> in to the store,
+        /// with a bit mask which approximates the <see cref="Address"/> set
+        /// updated by the <paramref name="block"/> and its all previous
+        /// <see cref="Block{T}"/>s.
+        /// </summary>
+        /// <param name="block">A <see cref="Block{T}"/> to put into the store.
+        /// </param>
+        /// <param name="addressesMask">A bit mask, in the <see cref="Address"/>
+        /// type (so this is probably not a valid address), which approximates
+        /// the <see cref="Address"/> set updated by the <paramref name="block"
+        /// /> and its all previous <see cref="Block{T}"/>s.</param>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="block"/>.</typeparam>
+        void PutBlock<T>(Block<T> block, Address addressesMask)
             where T : IAction, new();
 
         bool DeleteBlock(HashDigest<SHA256> blockHash);


### PR DESCRIPTION
This patch completely fixes the bug #189.  Besides the patch #192, this deals with nonexistent addresses.

This involves a mask-based index to approximates a set of `Addresses`.  The key idea is that if a certain address had been ever used and included into the mask, the mask ensures to have only non-zero bits (i.e., trues) for the same positions that the address has non-zero bits.  You can also think of it as a kind of bloom filter but no hash functions.  The point is that although a mask cannot ensure if an address is in it but can ensure an address is definitely not in it.

To store a mask for each block, I added a new parameter `Address addressesMask` to `IStore.PutBlock<T>()` method, and a new method named `IStore.GetAddressesMask()` to query this.  I wrote XML comments on these methods.  Please read comments for API details.

Although I added a mask as an ad-hoc field of `IStore` at this stage, I suggest put this information into `Block<T>` type for the future so that mask is also validated within block's cryptographic hash.  (More detailed proposal is in the commit message of e01da78a4d13b9a9c3c3d05a54412e31cb9385ec.)