### PR TITLE
Fix disconnecting on TURN relay session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ To be released.
     `PutBlock<T>(Block<T>, Address)`.  [[#189]]
  -  Improved the read throughput of `BlockChain<T>` when calling
     `BlockChain<T>.Append()`.
+ -  Fixed a bug that `Swarm` attempted to use TURN relay even though `_host` was
+    given.
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ To be released.
     and its all implementations.  [[#189]]
  -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to
     `PutBlock<T>(Block<T>, Address)`.  [[#189]]
+ -  Improved the read throughput of `BlockChain<T>` when calling
+    `BlockChain<T>.Append()`.
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
     `BlockChain<T>.Append()`.
  -  Fixed a bug that `Swarm` attempted to use TURN relay even though `_host` was
     given.
+ -  Fixed a bug that TURN relay was disconnected when connecting for more than 5
+    minutes.
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,11 +24,10 @@ To be released.
     and its all implementations.  [[#189]]
  -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to
     `PutBlock<T>(Block<T>, Address)`.  [[#189]]
- -  Improved the read throughput of `BlockChain<T>` when calling
-    `BlockChain<T>.Append()`.
- -  Fixed a bug that `Swarm` attempted to use TURN relay even though `_host` was
+ -  Improved the read throughput of `BlockChain<T>.Append()`.
+ -  Fixed a bug that `Swarm` had attempted to use TURN relay even if the `host` argument was
     given.
- -  Fixed a bug that TURN relay was disconnected when connecting for more than 5
+ -  Fixed a bug that TURN relay had been disconnected when being connected for longer than 5
     minutes.
 
 [#185]: https://github.com/planetarium/libplanet/pull/185

--- a/Libplanet/Net/NetworkStreamProxy.cs
+++ b/Libplanet/Net/NetworkStreamProxy.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net
 
         private async Task Proxy(NetworkStream source, NetworkStream target)
         {
-            while (true)
+            while (source.CanRead && target.CanWrite)
             {
                 var buf = new byte[_bufferSize];
                 int read = await source.ReadAsync(buf, 0, buf.Length);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -441,7 +441,7 @@ namespace Libplanet.Net
                 throw new SwarmException("Swarm is already running.");
             }
 
-            if (_host is null && _iceServers != null)
+            if (_host is null && !(_iceServers is null))
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
             }
@@ -814,7 +814,7 @@ namespace Libplanet.Net
             {
                 await Task.Delay(lifetime - TimeSpan.FromMinutes(1));
                 await Task.WhenAll(
-                    _peers.Keys.Select(p => CreatePermission(p)));
+                    _peers.Keys.Select(CreatePermission));
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -436,7 +436,7 @@ namespace Libplanet.Net
                 throw new SwarmException("Swarm is already running.");
             }
 
-            if (_iceServers != null)
+            if (_host is null && _iceServers != null)
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
             }


### PR DESCRIPTION
This PR aids problem the problem of TURN relay session being disconnected. if the TURN server doesn't receive `CreatePermission` on time, it deletes the registered peer and rejects any request from that. to prevent this, I added a task that iterates `CreatePermission`.

It also fixes the following issues:

- Fixed a bug that `Swarm `attempted to use TURN relay even though `_host` was given.
- Adjusted a lock in `Append()` to increase parallelism.