### PR TITLE
Add Swarm.PreloadAsync()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ To be released.
     round-trips.  [[#187], [#190]]
  -  Added `Swarm.PreloadAsync()` method to explicitly and preemptively download
     initial blocks before `Swarm.StartAsync<T>()` being called.
-    [[#204]] [[#206]]
+    [[#204]], [[#206]]
  -  Added `BlockDownloadState` class to represents a block downloading state.
     [[#204]], [[#206]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ To be released.
     round-trips.  [[#187], [#190]]
  -  Added `Swarm.PreloadAsync()` that explicitly synchronizes the blocks before
     starting and `BlockDownloadState` that represents downloading states.
-    [[#204]] [[#206]]
+    [[#204]], [[#206]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,10 @@ To be released.
     other known peers and synchronizes the blocks if necessary
     before propagating/receiving pinpointed recent blocks to prevent inefficient
     round-trips.  [[#187], [#190]]
- -  Added `Swarm.PreloadAsync()` that explicitly synchronizes the blocks before
-    starting and `BlockDownloadState` that represents downloading states.
+ -  Added `Swarm.PreloadAsync()` method to explicitly and preemptively download
+    initial blocks before `Swarm.StartAsync<T>()` being called.
+    [[#204]] [[#206]]
+ -  Added `BlockDownloadState` class to represents a block downloading state.
     [[#204]], [[#206]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ To be released.
  -  Added `Swarm.PreloadAsync()` method to explicitly and preemptively download
     initial blocks before `Swarm.StartAsync<T>()` being called.
     [[#204]], [[#206]]
- -  Added `BlockDownloadState` class to represents a block downloading state.
+ -  Added `BlockDownloadState` class to represent a block downloading state.
     [[#204]], [[#206]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ To be released.
     other known peers and synchronizes the blocks if necessary
     before propagating/receiving pinpointed recent blocks to prevent inefficient
     round-trips.  [[#187], [#190]]
+ -  Added `Swarm.PreloadAsync()` that explicitly synchronizes the blocks before
+    starting and `BlockDownloadState` that represents downloading states.
+    [[#204]] [[#206]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
@@ -40,7 +43,9 @@ To be released.
 [#187]: https://github.com/planetarium/libplanet/issues/187
 [#190]: https://github.com/planetarium/libplanet/pull/190
 [#193]: https://github.com/planetarium/libplanet/pull/193
+[#204]: https://github.com/planetarium/libplanet/issues/204
 [#205]: https://github.com/planetarium/libplanet/pull/205
+[#206]: https://github.com/planetarium/libplanet/pull/206
 
 
 Version 0.2.2

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// A container that indicates the progress of a block download.
+    /// </summary>
+    [Uno.GeneratedEquality]
+    public partial class BlockDownloadState
+    {
+        /// <summary>
+        /// Total number of blocks to receive in the current batch.
+        /// </summary>
+        [Uno.EqualityHash]
+        public int TotalBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The number of currently received blocks.
+        /// </summary>
+        [Uno.EqualityHash]
+        public int ReceivedBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The hash digest of the block just received.
+        /// </summary>
+        [Uno.EqualityHash]
+        public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
+    }
+}

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -478,13 +478,9 @@ namespace Libplanet.Net
                 using (await _runningMutex.LockAsync())
                 {
                     Running = true;
-                    IAsyncEnumerable<(Peer, long?)> peersWithLength =
-                        DialToExistingPeers(cancellationToken).Select(
-                            pp => (pp.Item1, pp.Item2.TipIndex));
-                    await SyncBehindsBlocksFromPeersAsync(
+                    await PreloadAsync(
                         blockChain,
-                        peersWithLength,
-                        cancellationToken);
+                        cancellationToken: cancellationToken);
                 }
 
                 var tasks = new List<Task>
@@ -545,6 +541,40 @@ namespace Libplanet.Net
                 cancellationToken);
         }
 
+        /// <summary>
+        /// Synchronizes the blocks with other registerd <see cref="Peer"/>s.
+        /// </summary>
+        /// <param name="blockChain">
+        /// A <see cref="BlockChain{T}"/> instance to synchronize.
+        /// </param>
+        /// <param name="progress">
+        /// An instance that receives progress updates for block downloads.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.
+        /// </param>
+        /// <typeparam name="T">An <see cref="IAction"/> type. It should match
+        /// to <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+        /// <returns>
+        /// No object or value is returned by this method when it completes.
+        /// </returns>
+        public async Task PreloadAsync<T>(
+            BlockChain<T> blockChain,
+            IProgress<BlockDownloadState> progress = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where T : IAction, new()
+        {
+            IAsyncEnumerable<(Peer, long?)> peersWithLength =
+                DialToExistingPeers(cancellationToken).Select(
+                    pp => (pp.Item1, pp.Item2.TipIndex));
+            await SyncBehindsBlocksFromPeersAsync(
+                blockChain,
+                peersWithLength,
+                progress,
+                cancellationToken);
+        }
+
         internal async Task<IEnumerable<HashDigest<SHA256>>>
             GetBlockHashesAsync(
                 Peer peer,
@@ -553,8 +583,6 @@ namespace Libplanet.Net
                 CancellationToken token = default(CancellationToken)
             )
         {
-            CheckStarted();
-
             if (!_peers.ContainsKey(peer))
             {
                 throw new PeerNotFoundException(
@@ -589,8 +617,6 @@ namespace Libplanet.Net
             CancellationToken token = default(CancellationToken))
             where T : IAction, new()
         {
-            CheckStarted();
-
             if (!_peers.ContainsKey(peer))
             {
                 throw new PeerNotFoundException(
@@ -639,8 +665,6 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken))
             where T : IAction, new()
         {
-            CheckStarted();
-
             if (!_peers.ContainsKey(peer))
             {
                 throw new PeerNotFoundException(
@@ -771,6 +795,7 @@ namespace Libplanet.Net
         private async Task SyncBehindsBlocksFromPeersAsync<T>(
             BlockChain<T> blockChain,
             IAsyncEnumerable<(Peer, long?)> peersWithLength,
+            IProgress<BlockDownloadState> progress,
             CancellationToken cancellationToken)
             where T : IAction, new()
         {
@@ -789,6 +814,7 @@ namespace Libplanet.Net
                     blockChain,
                     longestPeerWithLength?.Item1,
                     null,
+                    progress,
                     cancellationToken);
                 if (!synced.Id.Equals(blockChain.Id))
                 {
@@ -999,6 +1025,7 @@ namespace Libplanet.Net
             BlockChain<T> blockChain,
             Peer peer,
             HashDigest<SHA256>? stop,
+            IProgress<BlockDownloadState> progress,
             CancellationToken cancellationToken)
             where T : IAction, new()
         {
@@ -1051,7 +1078,7 @@ namespace Libplanet.Net
                 try
                 {
                     await FillBlocksAsync(
-                        peer, synced, stop, cancellationToken);
+                        peer, synced, stop, progress, cancellationToken);
                     break;
                 }
                 catch (Exception e)
@@ -1094,6 +1121,7 @@ namespace Libplanet.Net
                     blockChain,
                     peer,
                     oldest.PreviousHash,
+                    null,
                     cancellationToken);
                 _logger.Debug("Filled up. trying to concatenation...");
 
@@ -1124,6 +1152,7 @@ namespace Libplanet.Net
             Peer peer,
             BlockChain<T> blockChain,
             HashDigest<SHA256>? stop,
+            IProgress<BlockDownloadState> progress,
             CancellationToken cancellationToken)
             where T : IAction, new()
         {
@@ -1144,8 +1173,10 @@ namespace Libplanet.Net
                     break;
                 }
 
+                int hashCount = hashes.Count();
+                int received = 0;
                 _logger.Debug(
-                    $"Required hashes (count: {hashes.Count()}). " +
+                    $"Required hashes (count: {hashCount}). " +
                     $"(tip: {blockChain.Tip?.Hash})"
                 );
 
@@ -1157,6 +1188,13 @@ namespace Libplanet.Net
                 {
                     _logger.Debug($"Trying to append block[{block.Hash}]...");
                     blockChain.Append(block);
+                    received++;
+                    progress?.Report(new BlockDownloadState()
+                    {
+                        TotalBlockCount = hashCount,
+                        ReceivedBlockCount = received,
+                        ReceivedBlockHash = block.Hash,
+                    });
                     _logger.Debug($"Block[{block.Hash}] is appended.");
                 });
             }
@@ -1445,8 +1483,6 @@ namespace Libplanet.Net
             CancellationToken cancellationToken
         )
         {
-            CheckStarted();
-
             dealer.Connect(address);
 
             _logger.Debug($"Trying to Ping to [{address}]...");

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -542,7 +542,7 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Synchronizes the blocks with other registerd <see cref="Peer"/>s.
+        /// Preemptively downloads blocks from registered <see cref="Peer"/>s.
         /// </summary>
         /// <param name="blockChain">
         /// A <see cref="BlockChain{T}"/> instance to synchronize.

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -557,7 +557,8 @@ namespace Libplanet.Net
         /// <typeparam name="T">An <see cref="IAction"/> type. It should match
         /// to <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
         /// <returns>
-        /// No object or value is returned by this method when it completes.
+        /// A task without value.
+        /// You only can <c>await</c> until the method is completed.
         /// </returns>
         public async Task PreloadAsync<T>(
             BlockChain<T> blockChain,


### PR DESCRIPTION
This PR adds `Swarm.PreloadAsync()` to explicitly downloads the blocks before starting. and, it also adds `BlockDownloadState` to provide current download state to caller(game).