### PR TITLE
Validate only the next block to be appended when append a block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,10 @@ To be released.
  -  `IBlockPolicy<T>.ValidateBlocks()` and
     `IBlockPolicy<T>.GetNextBlockDifficulty()` became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
+ -  Added `ValidateBlockToAppend(IReadOnlyList<Block<T>>, Block<T>)` to
+    `IBlockPolicy<T>`.  [[#210]]
+ -  Instead of validating the entire blocks, `BlockChain<T>.Append()` became
+    to validate only the next block to be appended.  [[#210]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
@@ -48,6 +52,7 @@ To be released.
 [#204]: https://github.com/planetarium/libplanet/issues/204
 [#205]: https://github.com/planetarium/libplanet/pull/205
 [#206]: https://github.com/planetarium/libplanet/pull/206
+[#210]: https://github.com/planetarium/libplanet/pull/210
 
 
 Version 0.2.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,15 +37,18 @@ To be released.
  -  `BlockChain<T>` became to implement `IReadOnlyList<Block<T>>`.  [[#205]]
  -  `BlockChain<T>.Validate()` became to receive `IReadOnlyList<Block<<T>>`
     instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  `IBlockPolicy<T>.GetNextBlockDifficulty()` became to receive
+ -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  Added `ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)` to
-    `IBlockPolicy<T>`.  [[#210]]
- -  `IBlockPolicy<T>.ValidateBlocks()` is removed.  [[#210]]
+ -  Added
+    `IBlockPolicy<T>.ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)`
+    method.  [[#210]]
+ -  Removed `IBlockPolicy<T>.ValidateBlocks()` method.  [[#210]]
  -  Added `IBlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
-    IReadOnlyList<Block<T>>, DateTimeOffset)`.  [[#210]]
- -  Instead of validating the entire blocks, `BlockChain<T>.Append()` became
-    to validate only the next block to be appended.  [[#210]]
+    IReadOnlyList<Block<T>>, DateTimeOffset)` method.  [[#210]]
+ -  `BlockChain<T>[int]` became to throw `ArgumentOutOfRangeException` instead
+    of `IndexOutOfRangeException`.  [[#210]]
+ -  Instead of validating the entire blocks, `BlockChain<T>.Append()` method
+    became to validate only the next block to be appended.  [[#210]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,19 @@ Version 0.3.0
 
 To be released.
 
+ -  `BlockChain<T>` became to implement `IReadOnlyList<Block<T>>`.  [[#205]]
+ -  `BlockChain<T>.Validate()` method became to receive 
+    `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
+ -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
+    `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
+ -  Added
+    `IBlockPolicy<T>.ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)`
+    method.  [[#210]]
+ -  Removed `IBlockPolicy<T>.ValidateBlocks()` method.  [[#210]]
+ -  Added `IBlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
+    IReadOnlyList<Block<T>>, DateTimeOffset)` method.  [[#210]]
+ -  `BlockChain<T>[int]` became to throw `ArgumentOutOfRangeException` instead
+    of `IndexOutOfRangeException`.  [[#210]]
  -  Added `Swarm.DifferentVersionPeerEncountered` event handler that can handle
     events when a different version of a peer is discovered.  [[#167]], [[#185]]
  -  Added `Peer.AppProtocolVersion` property.  [[#185]]
@@ -34,19 +47,6 @@ To be released.
     given.
  -  Fixed a bug that TURN relay had been disconnected when being connected for longer than 5
     minutes.
- -  `BlockChain<T>` became to implement `IReadOnlyList<Block<T>>`.  [[#205]]
- -  `BlockChain<T>.Validate()` became to receive `IReadOnlyList<Block<<T>>`
-    instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
-    `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  Added
-    `IBlockPolicy<T>.ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)`
-    method.  [[#210]]
- -  Removed `IBlockPolicy<T>.ValidateBlocks()` method.  [[#210]]
- -  Added `IBlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
-    IReadOnlyList<Block<T>>, DateTimeOffset)` method.  [[#210]]
- -  `BlockChain<T>[int]` became to throw `ArgumentOutOfRangeException` instead
-    of `IndexOutOfRangeException`.  [[#210]]
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` method
     became to validate only the next block to be appended.  [[#210]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ To be released.
  -  `IBlockPolicy<T>.ValidateBlocks()` and
     `IBlockPolicy<T>.GetNextBlockDifficulty()` became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  Added `ValidateBlockToAppend(IReadOnlyList<Block<T>>, Block<T>)` to
+ -  Added `ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)` to
     `IBlockPolicy<T>`.  [[#210]]
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` became
     to validate only the next block to be appended.  [[#210]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,11 +37,13 @@ To be released.
  -  `BlockChain<T>` became to implement `IReadOnlyList<Block<T>>`.  [[#205]]
  -  `BlockChain<T>.Validate()` became to receive `IReadOnlyList<Block<<T>>`
     instead of `IEnumerable<Block<T>>`.  [[#205]]
- -  `IBlockPolicy<T>.ValidateBlocks()` and
-    `IBlockPolicy<T>.GetNextBlockDifficulty()` became to receive
+ -  `IBlockPolicy<T>.GetNextBlockDifficulty()` became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
  -  Added `ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)` to
     `IBlockPolicy<T>`.  [[#210]]
+ -  `IBlockPolicy<T>.ValidateBlocks()` is removed.  [[#210]]
+ -  Added `IBlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
+    IReadOnlyList<Block<T>>, DateTimeOffset)`.  [[#210]]
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` became
     to validate only the next block to be appended.  [[#210]]
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Tests.Blockchain
         public void CanFindBlockByIndex()
         {
             // use assignment to snooze compiler error (CS0201)
-            Assert.Throws<IndexOutOfRangeException>(() => { var x = _blockChain[0]; });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = _blockChain[0]; });
             Block<DumbAction> block = _blockChain.MineBlock(_fx.Address1);
             Assert.Equal(block, _blockChain[0]);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Xml.Schema;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -356,11 +354,6 @@ namespace Libplanet.Tests.Blockchain
         {
             public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
                 blocks.Any() ? 1 : 0;
-
-            public InvalidBlockException ValidateBlocks(
-                IReadOnlyList<Block<T>> blocks,
-                DateTimeOffset currentTime
-            ) => null;
 
             public InvalidBlockException ValidateNextBlock(
                 IReadOnlyList<Block<T>> blocks, Block<T> nextBlock) => null;

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -362,8 +362,8 @@ namespace Libplanet.Tests.Blockchain
                 DateTimeOffset currentTime
             ) => null;
 
-            public InvalidBlockException ValidateBlockToAppend(
-                IReadOnlyList<Block<T>> blocks, Block<T> blockToAppend) => null;
+            public InvalidBlockException ValidateNextBlock(
+                IReadOnlyList<Block<T>> blocks, Block<T> nextBlock) => null;
         }
 
         private sealed class TestEvaluateAction : IAction

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -164,6 +164,17 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void AppendValidatesBlock()
+        {
+            var blockChain = new BlockChain<DumbAction>(
+                new NullPolicy<DumbAction>(
+                    new InvalidBlockDifficultyException(string.Empty)),
+                _fx.Store);
+            Assert.Throws<InvalidBlockDifficultyException>(
+                () => blockChain.Append(_fx.Block1));
+        }
+
+        [Fact]
         public void CanFindNextHashes()
         {
             _blockChain.Append(_fx.Block1);
@@ -352,11 +363,19 @@ namespace Libplanet.Tests.Blockchain
         private sealed class NullPolicy<T> : IBlockPolicy<T>
             where T : IAction, new()
         {
+            private readonly InvalidBlockException _exceptionToThrow;
+
+            public NullPolicy(InvalidBlockException exceptionToThrow = null)
+            {
+                _exceptionToThrow = exceptionToThrow;
+            }
+
             public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
                 blocks.Any() ? 1 : 0;
 
             public InvalidBlockException ValidateNextBlock(
-                IReadOnlyList<Block<T>> blocks, Block<T> nextBlock) => null;
+                IReadOnlyList<Block<T>> blocks, Block<T> nextBlock) =>
+                _exceptionToThrow;
         }
 
         private sealed class TestEvaluateAction : IAction

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -361,6 +361,9 @@ namespace Libplanet.Tests.Blockchain
                 IReadOnlyList<Block<T>> blocks,
                 DateTimeOffset currentTime
             ) => null;
+
+            public InvalidBlockException ValidateBlockToAppend(
+                IReadOnlyList<Block<T>> blocks, Block<T> blockToAppend) => null;
         }
 
         private sealed class TestEvaluateAction : IAction

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -113,7 +113,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         }
 
         [Fact]
-        public void ValidateBlockToAppend()
+        public void ValidateNextBlock()
         {
             _blockChain.Append(_genesis);
 
@@ -124,22 +124,22 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _genesis.Hash,
                 _genesis.Timestamp.AddDays(1),
                 _emptyTransaction);
-            _policy.ValidateBlockToAppend(_blockChain, validNextBlock);
+            _policy.ValidateNextBlock(_blockChain, validNextBlock);
             _blockChain.Append(validNextBlock);
         }
 
         [Fact]
-        public void ValidateBlockToAppendGenesis()
+        public void ValidateNextBlockGenesis()
         {
             var policy = _blockChain.Policy;
 
             var validGenesis = TestUtils.MineGenesis<DumbAction>();
             Assert.Null(
-                policy.ValidateBlockToAppend(_blockChain, validGenesis));
+                policy.ValidateNextBlock(_blockChain, validGenesis));
 
             var invalidIndexGenesis = TestUtils.MineNext(validGenesis);
             Assert.IsType<InvalidBlockIndexException>(
-                policy.ValidateBlockToAppend(_blockChain, invalidIndexGenesis));
+                policy.ValidateNextBlock(_blockChain, invalidIndexGenesis));
 
             var invalidPreviousHashGenesis = new Block<DumbAction>(
                  0,
@@ -150,13 +150,13 @@ namespace Libplanet.Tests.Blockchain.Policies
                  _genesis.Timestamp,
                  _emptyTransaction);
             Assert.IsType<InvalidBlockPreviousHashException>(
-                policy.ValidateBlockToAppend(
+                policy.ValidateNextBlock(
                     _blockChain,
                     invalidPreviousHashGenesis));
         }
 
         [Fact]
-        public void ValidateBlockToAppendInvalidIndex()
+        public void ValidateNextBlockInvalidIndex()
         {
             _blockChain.Append(_genesis);
             _blockChain.Append(_validNext);
@@ -169,11 +169,11 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction);
             Assert.IsType<InvalidBlockIndexException>(
-                _policy.ValidateBlockToAppend(_blockChain, invalidIndexBlock));
+                _policy.ValidateNextBlock(_blockChain, invalidIndexBlock));
         }
 
         [Fact]
-        public void ValidateBlockToAppendInvalidDifficulty()
+        public void ValidateNextBlockInvalidDifficulty()
         {
             _blockChain.Append(_genesis);
             _blockChain.Append(_validNext);
@@ -186,13 +186,13 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction);
             Assert.IsType<InvalidBlockDifficultyException>(
-                _policy.ValidateBlockToAppend(
+                _policy.ValidateNextBlock(
                     _blockChain,
                     invalidDifficultyBlock));
         }
 
         [Fact]
-        public void ValidateBlockToAppendInvalidPreviousHash()
+        public void ValidateNextBlockInvalidPreviousHash()
         {
             _blockChain.Append(_genesis);
             _blockChain.Append(_validNext);
@@ -205,13 +205,13 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction);
             Assert.IsType<InvalidBlockPreviousHashException>(
-                _policy.ValidateBlockToAppend(
+                _policy.ValidateNextBlock(
                     _blockChain,
                     invalidPreviousHashBlock));
         }
 
         [Fact]
-        public void ValidateBlockToAppendInvalidTimestamp()
+        public void ValidateNextBlockInvalidTimestamp()
         {
             _blockChain.Append(_genesis);
             _blockChain.Append(_validNext);
@@ -224,7 +224,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _validNext.Timestamp.Subtract(TimeSpan.FromSeconds(1)),
                 _emptyTransaction);
             Assert.IsType<InvalidBlockTimestampException>(
-                _policy.ValidateBlockToAppend(
+                _policy.ValidateNextBlock(
                     _blockChain,
                     invalidPreviousTimestamp));
         }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -243,7 +243,7 @@ namespace Libplanet.Blockchain
                 block.Validate(
                     currentTime,
                     a => GetStates(new[] { a }, tip).GetValueOrDefault(a));
-                Policy.ValidateBlockToAppend(this, block);
+                Policy.ValidateNextBlock(this, block);
 
                 Enumerable.Append(this, block);
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -245,8 +245,6 @@ namespace Libplanet.Blockchain
                     a => GetStates(new[] { a }, tip).GetValueOrDefault(a));
                 Policy.ValidateNextBlock(this, block);
 
-                Enumerable.Append(this, block);
-
                 _rwlock.EnterWriteLock();
                 try
                 {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Blockchain
                 {
                     return this[-1];
                 }
-                catch (IndexOutOfRangeException)
+                catch (ArgumentOutOfRangeException)
                 {
                     return null;
                 }
@@ -105,7 +105,7 @@ namespace Libplanet.Blockchain
                     );
                     if (blockHash == null)
                     {
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException();
                     }
 
                     return Blocks[blockHash.Value];

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -243,9 +243,10 @@ namespace Libplanet.Blockchain
                 block.Validate(
                     currentTime,
                     a => GetStates(new[] { a }, tip).GetValueOrDefault(a));
+                Policy.ValidateBlockToAppend(this, block);
+
                 Enumerable.Append(this, block);
 
-                Validate(this, currentTime);
                 _rwlock.EnterWriteLock();
                 try
                 {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -243,7 +243,13 @@ namespace Libplanet.Blockchain
                 block.Validate(
                     currentTime,
                     a => GetStates(new[] { a }, tip).GetValueOrDefault(a));
-                Policy.ValidateNextBlock(this, block);
+                InvalidBlockException e =
+                    Policy.ValidateNextBlock(this, block);
+
+                if (!(e is null))
+                {
+                    throw e;
+                }
 
                 _rwlock.EnterWriteLock();
                 try

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -58,33 +58,6 @@ namespace Libplanet.Blockchain.Policies
         /// </summary>
         public TimeSpan BlockInterval { get; }
 
-        /// <inheritdoc />
-        public InvalidBlockException ValidateBlocks(
-            IReadOnlyList<Block<T>> blocks,
-            DateTimeOffset currentTime
-        )
-        {
-            Block<T> secondLastBlock = null;
-            Block<T> lastBlock = null;
-
-            for (var i = 0; i < blocks.Count; i++)
-            {
-                Block<T> block = blocks[i];
-                InvalidBlockException exception = ValidateNextBlock(
-                    i, secondLastBlock, lastBlock, block);
-
-                if (!(exception is null))
-                {
-                    return exception;
-                }
-
-                secondLastBlock = lastBlock;
-                lastBlock = block;
-            }
-
-            return null;
-        }
-
         /// <inheritdoc/>
         public InvalidBlockException ValidateNextBlock(
             IReadOnlyList<Block<T>> blocks,

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -64,15 +64,7 @@ namespace Libplanet.Blockchain.Policies
             Block<T> nextBlock)
         {
             int index = blocks.Count;
-            int difficulty = 0;
-
-            if (index >= 2)
-            {
-                difficulty = GetNextDifficultyFromPrevTimestamp(
-                    blocks[index - 2].Timestamp,
-                    blocks[index - 1].Timestamp,
-                    blocks[index - 1].Difficulty);
-            }
+            int difficulty = index < 2 ? index : GetNextBlockDifficulty(blocks);
 
             Block<T> lastBlock = index >= 1 ? blocks[index - 1] : null;
             HashDigest<SHA256>? prevHash = lastBlock?.Hash;
@@ -123,28 +115,19 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc />
         public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks)
         {
-            int blockCount = blocks.Count;
+            int index = blocks.Count;
 
-            if (blockCount <= 1)
+            if (index <= 1)
             {
-                return blockCount;
+                return index;
             }
 
-            Block<T> prevPrevBlock = blocks[blockCount - 2];
-            Block<T> prevBlock = blocks[blockCount - 1];
+            DateTimeOffset prevPrevTimestamp = blocks[index - 2].Timestamp;
+            DateTimeOffset prevTimestamp = blocks[index - 1].Timestamp;
+            int prevDifficulty = blocks[index - 1].Difficulty;
 
-            return GetNextDifficultyFromPrevTimestamp(
-                prevPrevBlock.Timestamp,
-                prevBlock.Timestamp,
-                prevBlock.Difficulty);
-        }
-
-        private int GetNextDifficultyFromPrevTimestamp(
-            DateTimeOffset? prevPrevTimestamp,
-            DateTimeOffset? prevTimestamp,
-            int prevDifficulty)
-        {
             bool needMore = prevTimestamp - prevPrevTimestamp < BlockInterval;
+
             return Math.Max(
                 needMore ? prevDifficulty + 1 : prevDifficulty - 1,
                 1);

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Blockchain.Policies
             for (var i = 0; i < blocks.Count; i++)
             {
                 Block<T> block = blocks[i];
-                InvalidBlockException exception = ValidateBlockToAppend(
+                InvalidBlockException exception = ValidateNextBlock(
                     i, secondLastBlock, lastBlock, block);
 
                 if (!(exception is null))
@@ -86,9 +86,9 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc/>
-        public InvalidBlockException ValidateBlockToAppend(
+        public InvalidBlockException ValidateNextBlock(
             IReadOnlyList<Block<T>> blocks,
-            Block<T> blockToAppend)
+            Block<T> nextBlock)
         {
             int blockCount = blocks.Count;
             Block<T> secondLastBlock = blockCount >= 2
@@ -98,11 +98,11 @@ namespace Libplanet.Blockchain.Policies
                 ? blocks[blockCount - 1]
                 : null;
 
-            return ValidateBlockToAppend(
+            return ValidateNextBlock(
                 blocks.Count,
                 secondLastBlock,
                 lastBlock,
-                blockToAppend);
+                nextBlock);
         }
 
         /// <inheritdoc />
@@ -124,7 +124,7 @@ namespace Libplanet.Blockchain.Policies
                 prevBlock.Difficulty);
         }
 
-        private InvalidBlockException ValidateBlockToAppend(
+        private InvalidBlockException ValidateNextBlock(
             int blockCount,
             Block<T> secondLastBlock,
             Block<T> lastBlock,

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -131,9 +131,20 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc />
         public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks)
         {
-            return ExpectDifficulties(blocks, yieldNext: true)
-                .First(t => t.Block == null)
-                .Difficulty;
+            int blockCount = blocks.Count;
+
+            if (blockCount <= 1)
+            {
+                return blockCount;
+            }
+
+            Block<T> prevPrevBlock = blocks[blockCount - 2];
+            Block<T> prevBlock = blocks[blockCount - 1];
+
+            return GetNextDifficultyFromPrevTimestamp(
+                prevPrevBlock.Timestamp,
+                prevBlock.Timestamp,
+                prevBlock.Difficulty);
         }
 
         private IEnumerable<DifficultyExpectation> ExpectDifficulties(
@@ -165,16 +176,9 @@ namespace Libplanet.Blockchain.Policies
                     continue;
                 }
 
-                bool needMore =
-                    prevPrevTimestamp != null &&
-                    (
-                        prevPrevTimestamp == null ||
-                        prevTimestamp - prevPrevTimestamp < BlockInterval
-                    );
-                difficulty = Math.Max(
-                    needMore ? difficulty + 1 : difficulty - 1,
-                    1
-                );
+                difficulty = GetNextDifficultyFromPrevTimestamp(
+                    prevPrevTimestamp, prevTimestamp, difficulty);
+
                 yield return new DifficultyExpectation
                 {
                     Difficulty = difficulty,
@@ -187,6 +191,17 @@ namespace Libplanet.Blockchain.Policies
                     prevTimestamp = block.Timestamp;
                 }
             }
+        }
+
+        private int GetNextDifficultyFromPrevTimestamp(
+            DateTimeOffset? prevPrevTimestamp,
+            DateTimeOffset? prevTimestamp,
+            int prevDifficulty)
+        {
+            bool needMore = prevTimestamp - prevPrevTimestamp < BlockInterval;
+            return Math.Max(
+                needMore ? prevDifficulty + 1 : prevDifficulty - 1,
+                1);
         }
 
         private struct DifficultyExpectation

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -133,16 +133,16 @@ namespace Libplanet.Blockchain.Policies
             int index = blockCount;
             int difficulty = 0;
 
-            if (lastBlock is Block<T> block)
+            if (lastBlock is null)
             {
-                difficulty = GetNextDifficultyFromPrevTimestamp(
-                    secondLastBlock?.Timestamp,
-                    block.Timestamp,
-                    block.Difficulty);
+                difficulty = 0;
             }
             else
             {
-                difficulty = 0;
+                difficulty = GetNextDifficultyFromPrevTimestamp(
+                    secondLastBlock?.Timestamp,
+                    lastBlock.Timestamp,
+                    lastBlock.Difficulty);
             }
 
             HashDigest<SHA256>? prevHash = lastBlock?.Hash;
@@ -165,7 +165,7 @@ namespace Libplanet.Blockchain.Policies
 
             if (!blockToAppend.PreviousHash.Equals(prevHash))
             {
-                if (prevHash == null)
+                if (prevHash is null)
                 {
                     return new InvalidBlockPreviousHashException(
                         "the genesis block must have not previous block");

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -12,28 +11,10 @@ namespace Libplanet.Blockchain.Policies
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    /// <seealso cref="IBlockPolicyExtension"/>
     public interface IBlockPolicy<T>
         where T : IAction, new()
     {
-        /// <summary>
-        /// Checks if <paramref name="blocks"/> are invalid, and if that
-        /// returns the reason.
-        /// <para>Note that it returns <c>null</c> when blocks are
-        /// <em>valid</em>.</para>
-        /// </summary>
-        /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
-        /// validate.</param>
-        /// <param name="currentTime">The current time to be used to validate
-        /// of <see cref="Block{T}.Timestamp"/>s.
-        /// Usually <see cref="DateTimeOffset.UtcNow"/> is used.</param>
-        /// <returns>The reason why the given <paramref name="blocks"/> are
-        /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
-        /// <em>valid</em>.</returns>
-        InvalidBlockException ValidateBlocks(
-            IReadOnlyList<Block<T>> blocks,
-            DateTimeOffset currentTime
-        );
-
         /// <summary>
         /// Checks if <paramref name="nextBlock"/> is invalid, and if that
         /// returns the reason.
@@ -47,6 +28,7 @@ namespace Libplanet.Blockchain.Policies
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
+        /// <seealso cref="IBlockPolicyExtension.ValidateBlocks{T}"/>
         InvalidBlockException ValidateNextBlock(
             IReadOnlyList<Block<T>> blocks,
             Block<T> nextBlock);

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -35,6 +35,23 @@ namespace Libplanet.Blockchain.Policies
         );
 
         /// <summary>
+        /// Checks if <paramref name="blockToAppend"/> is invalid, and if that
+        /// returns the reason.
+        /// <para>Note that it returns <c>null</c> when
+        /// <paramref name="blockToAppend"/> is <em>valid</em>.</para>
+        /// </summary>
+        /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
+        /// append <paramref name="blockToAppend"/>.</param>
+        /// <param name="blockToAppend">The next block to append to
+        /// <paramref name="blocks"/>.</param>
+        /// <returns>The reason why the given <paramref name="blocks"/> are
+        /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
+        /// <em>valid</em>.</returns>
+        InvalidBlockException ValidateBlockToAppend(
+            IReadOnlyList<Block<T>> blocks,
+            Block<T> blockToAppend);
+
+        /// <summary>
         /// Determines a right <see cref="Block{T}.Difficulty"/>
         /// for a new <see cref="Block{T}"/> to be mined
         /// right after the given <paramref name="blocks"/>.

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -35,21 +35,21 @@ namespace Libplanet.Blockchain.Policies
         );
 
         /// <summary>
-        /// Checks if <paramref name="blockToAppend"/> is invalid, and if that
+        /// Checks if <paramref name="nextBlock"/> is invalid, and if that
         /// returns the reason.
         /// <para>Note that it returns <c>null</c> when
-        /// <paramref name="blockToAppend"/> is <em>valid</em>.</para>
+        /// <paramref name="nextBlock"/> is <em>valid</em>.</para>
         /// </summary>
         /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
-        /// append <paramref name="blockToAppend"/>.</param>
-        /// <param name="blockToAppend">The next block to append to
+        /// append <paramref name="nextBlock"/>.</param>
+        /// <param name="nextBlock">The next block to append to
         /// <paramref name="blocks"/>.</param>
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
-        InvalidBlockException ValidateBlockToAppend(
+        InvalidBlockException ValidateNextBlock(
             IReadOnlyList<Block<T>> blocks,
-            Block<T> blockToAppend);
+            Block<T> nextBlock);
 
         /// <summary>
         /// Determines a right <see cref="Block{T}.Difficulty"/>

--- a/Libplanet/Blockchain/Policies/IBlockPolicyExtension.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicyExtension.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain.Policies
+{
+    /// <summary>
+    /// This extension class enables some convenient methods (sugar for
+    /// the most part) to deal with <see cref="IBlockPolicy{T}"/>.
+    /// </summary>
+    /// <seealso cref="IBlockPolicy{T}"/>
+    public static class IBlockPolicyExtension
+    {
+        /// <summary>
+        /// Checks if <paramref name="blocks"/> are invalid, and if that
+        /// returns the reason.
+        /// <para>Note that it returns <c>null</c> when blocks are
+        /// <em>valid</em>.</para>
+        /// </summary>
+        /// <param name="policy"><see cref="IBlockPolicy{T}"/> to used for
+        /// validation <paramref name="blocks"/>.</param>
+        /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
+        /// validate.</param>
+        /// <param name="currentTime">The current time to be used to validate
+        /// of <see cref="Block{T}.Timestamp"/>s.
+        /// Usually <see cref="DateTimeOffset.UtcNow"/> is used.</param>
+        /// <returns>The reason why the given <paramref name="blocks"/> are
+        /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
+        /// <em>valid</em>.</returns>
+        /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+        /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+        /// <seealso cref="IBlockPolicy{T}"/>
+        /// <seealso cref="IBlockPolicy{T}.ValidateNextBlock"/>
+        public static InvalidBlockException ValidateBlocks<T>(
+            this IBlockPolicy<T> policy,
+            IReadOnlyList<Block<T>> blocks,
+            DateTimeOffset currentTime)
+            where T : IAction, new()
+        {
+            var tempBlocks = new List<Block<T>>();
+            foreach (Block<T> block in blocks)
+            {
+                InvalidBlockException exception =
+                    policy.ValidateNextBlock(tempBlocks, block);
+                if (!(exception is null))
+                {
+                    return exception;
+                }
+
+                tempBlocks.Add(block);
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Added `ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)` to `IBlockPolicy`.
- Changed `BlockChain<T>.Append()` to validate only the next block to be appended.
- Removed `ExpectDifficulties()`.
- Changed `IndexOutOfRangeException` in `BlockChain<T>` to `ArgumentOutOfRangeException`.
- Moved `IBlockPolicy<T>.ValidateBlocks()` to `IBlockPolicyExtension.ValidateBlocks<T>()`.