### PR TITLE
Adjust difficulty gradually

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,12 @@ To be released.
  -  `Swarm` class now does not implement `IEquatable<Swarm>` anymore and
     its `Equals(object)` method and `GetHashCode()` method became to have
     default behavior of `object` class.
+ -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and
+    related classes method parameters and field types have changed accordingly.
+ -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]
+ -  Added `HashDigest.LessThanTarget()` method.  [[#213]]
+ -  `BlockPolicy<T>` constructor became to receive the minimum difficulty and
+    the mining difficulty bound divisor.  [[#213]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
@@ -58,6 +64,8 @@ To be released.
     became to validate only the next block to be appended.  [[#210]]
  -  Improved `BlockChain<T>.Fork()` performance by avoiding double validation
     of already validated blocks.  [[#215]]
+ -  The calculation algorithm of `BlockPolicy<T>.GetNextBlockDifficulty()`
+    method is changed.  [[#213]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
@@ -67,6 +75,7 @@ To be released.
 [#205]: https://github.com/planetarium/libplanet/pull/205
 [#206]: https://github.com/planetarium/libplanet/pull/206
 [#210]: https://github.com/planetarium/libplanet/pull/210
+[#213]: https://github.com/planetarium/libplanet/pull/213
 [#215]: https://github.com/planetarium/libplanet/pull/215
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,9 +38,9 @@ To be released.
  -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and
     related classes method parameters and field types have changed accordingly.
  -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]
- -  Added `HashDigest.LessThanTarget()` method.  [[#213]]
- -  `BlockPolicy<T>` constructor became to receive the minimum difficulty and
-    the mining difficulty bound divisor.  [[#213]]
+ -  Added `HashDigest.Satisfies()` method.  [[#213]]
+ -  `BlockPolicy<T>` constructor became to receive the `minimumDifficulty`
+    and the mining `difficultyBoundDivisor`.  [[#213]]
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN
@@ -65,7 +65,11 @@ To be released.
  -  Improved `BlockChain<T>.Fork()` performance by avoiding double validation
     of already validated blocks.  [[#215]]
  -  The calculation algorithm of `BlockPolicy<T>.GetNextBlockDifficulty()`
-    method is changed.  [[#213]]
+    method was changed to the [Ethereum Homestead algorithm] except for the
+    difficulty bomb.  [[#213]]
+ -  The difficulty was changed from representing the number of leading zeros of
+    target number to representing a divisor to obtain the target number.
+    [[#213]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
@@ -77,6 +81,7 @@ To be released.
 [#210]: https://github.com/planetarium/libplanet/pull/210
 [#213]: https://github.com/planetarium/libplanet/pull/213
 [#215]: https://github.com/planetarium/libplanet/pull/215
+[Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md
 
 
 Version 0.2.2

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -370,7 +370,7 @@ namespace Libplanet.Tests.Blockchain
                 _exceptionToThrow = exceptionToThrow;
             }
 
-            public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
+            public long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
                 blocks.Any() ? 1 : 0;
 
             public InvalidBlockException ValidateNextBlock(

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -352,9 +352,9 @@ namespace Libplanet.Tests.Blockchain.Policies
             var miner = default(Address);
             long i = 0;
             HashDigest<SHA256>? previousHash = null;
-            foreach ((int timestampHour, int d) in blockArgs)
+            foreach ((int timestampHour, long d) in blockArgs)
             {
-                int difficulty = d;
+                long difficulty = d;
                 var timestamp =
                     FixtureEpoch + TimeSpan.FromHours(timestampHour);
                 if (interprocess != null)
@@ -398,7 +398,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         private struct BlockFields
         {
             internal long Index;
-            internal int Difficulty;
+            internal long Difficulty;
             internal HashDigest<SHA256>? PreviousHash;
             internal DateTimeOffset Timestamp;
         }

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -391,19 +391,18 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void DetectInvalidNonce()
         {
+            const int easyDifficulty = 4;
             var invalidBlock = new Block<PolymorphicAction<BaseAction>>(
                 index: _fx.Next.Index,
-                difficulty: _fx.Next.Difficulty,
+                difficulty: easyDifficulty,
                 nonce: new Nonce(new byte[] { 0x00 }),
                 miner: _fx.Next.Miner,
                 previousHash: _fx.Next.PreviousHash,
                 timestamp: _fx.Next.Timestamp,
-                transactions: _fx.Next.Transactions
-            );
+                transactions: _fx.Next.Transactions);
 
             Assert.Throws<InvalidBlockNonceException>(() =>
-                invalidBlock.Validate(DateTimeOffset.UtcNow)
-            );
+                invalidBlock.Validate(DateTimeOffset.UtcNow));
         }
 
         [Fact]

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -11,34 +11,34 @@ namespace Libplanet.Tests
     {
         [Theory]
         [ClassData(typeof(HashcashTestData))]
-        public void AnswerLessThanTarget(byte[] challenge, long difficulty)
+        public void AnswerSatisfiesDifficulty(byte[] challenge, long difficulty)
         {
             byte[] Stamp(Nonce nonce) => challenge.Concat(nonce.ToByteArray()).ToArray();
             var answer = Hashcash.Answer(Stamp, difficulty);
             var digest = Hashcash.Hash(Stamp(answer));
-            Assert.True(digest.LessThanTarget(difficulty));
+            Assert.True(digest.Satisfies(difficulty));
         }
 
         [Fact]
         public void TestBytesWithDifficulty()
         {
-            Assert.True(LessThanTarget(new byte[1] { 0x80 }, 0));
-            Assert.False(LessThanTarget(new byte[1] { 0x80 }, 2));
+            Assert.True(Satisfies(new byte[1] { 0x80 }, 0));
+            Assert.False(Satisfies(new byte[1] { 0x80 }, 2));
             long[] difficulties = Enumerable.Range(1, 8)
                 .Select(x => (long)Math.Pow(2, x)).ToArray();
 
             foreach (long difficulty in difficulties)
             {
-                Assert.True(LessThanTarget(new byte[2] { 0x00, 0x80 }, difficulty));
+                Assert.True(Satisfies(new byte[2] { 0x00, 0x80 }, difficulty));
             }
 
-            Assert.False(LessThanTarget(new byte[2] { 0x00, 0x80 }, 512));
-            Assert.True(LessThanTarget(new byte[2] { 0x00, 0x7f },  512));
-            Assert.False(LessThanTarget(new byte[2] { 0x00, 0x7f }, 1024));
-            Assert.True(LessThanTarget(new byte[2] { 0x00, 0x20 }, 1024));
+            Assert.False(Satisfies(new byte[2] { 0x00, 0x80 }, 512));
+            Assert.True(Satisfies(new byte[2] { 0x00, 0x7f },  512));
+            Assert.False(Satisfies(new byte[2] { 0x00, 0x7f }, 1024));
+            Assert.True(Satisfies(new byte[2] { 0x00, 0x20 }, 1024));
         }
 
-        private bool LessThanTarget(byte[] bytes, long difficulty)
+        private bool Satisfies(byte[] bytes, long difficulty)
         {
             byte[] digest;
             if (bytes.Length < HashDigest<SHA256>.Size)
@@ -54,7 +54,7 @@ namespace Libplanet.Tests
                 digest = bytes;
             }
 
-            return new HashDigest<SHA256>(digest).LessThanTarget(difficulty);
+            return new HashDigest<SHA256>(digest).Satisfies(difficulty);
         }
     }
 

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Tests
     {
         [Theory]
         [ClassData(typeof(HashcashTestData))]
-        public void AnswerLessThanTarget(byte[] challenge, int difficulty)
+        public void AnswerLessThanTarget(byte[] challenge, long difficulty)
         {
             byte[] Stamp(Nonce nonce) => challenge.Concat(nonce.ToByteArray()).ToArray();
             var answer = Hashcash.Answer(Stamp, difficulty);
@@ -24,10 +24,10 @@ namespace Libplanet.Tests
         {
             Assert.True(LessThanTarget(new byte[1] { 0x80 }, 0));
             Assert.False(LessThanTarget(new byte[1] { 0x80 }, 2));
-            int[] difficulties = Enumerable.Range(1, 8)
-                .Select(x => (int)Math.Pow(2, x)).ToArray();
+            long[] difficulties = Enumerable.Range(1, 8)
+                .Select(x => (long)Math.Pow(2, x)).ToArray();
 
-            foreach (int difficulty in difficulties)
+            foreach (long difficulty in difficulties)
             {
                 Assert.True(LessThanTarget(new byte[2] { 0x00, 0x80 }, difficulty));
             }
@@ -38,7 +38,7 @@ namespace Libplanet.Tests
             Assert.True(LessThanTarget(new byte[2] { 0x00, 0x20 }, 1024));
         }
 
-        private bool LessThanTarget(byte[] bytes, int difficulty)
+        private bool LessThanTarget(byte[] bytes, long difficulty)
         {
             byte[] digest;
             if (bytes.Length < HashDigest<SHA256>.Size)

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -107,7 +107,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             }
 
             const long index = 1;
-            const int difficulty = 1;
+            const long difficulty = 1;
             HashDigest<SHA256> previousHash = previousBlock.Hash;
             DateTimeOffset timestamp = previousBlock.Timestamp.AddDays(1);
             Address miner = previousBlock.Miner.Value;

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -306,7 +306,7 @@ namespace Libplanet.Blockchain
         {
             string @namespace = Id.ToString();
             long index = Store.CountIndex(@namespace);
-            int difficulty = Policy.GetNextBlockDifficulty(this);
+            long difficulty = Policy.GetNextBlockDifficulty(this);
             HashDigest<SHA256>? prevHash = Store.IndexBlockHash(
                 @namespace,
                 index - 1

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -25,9 +25,9 @@ namespace Libplanet.Blockchain.Policies
         /// 5000 milliseconds by default.
         /// </param>
         /// <param name="minimumDifficulty">Configures
-        /// <see cref="MinimumDifficulty"/> 1024 by default.</param>
+        /// <see cref="MinimumDifficulty"/>. 1024 by default.</param>
         /// <param name="difficultyBoundDivisor">Configures
-        /// <see cref="DifficultyBoundDivisor"/> 128 by default.</param>
+        /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         public BlockPolicy(
             int blockIntervalMilliseconds = 5000,
             long minimumDifficulty = 1024,
@@ -66,14 +66,14 @@ namespace Libplanet.Blockchain.Policies
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(minimumDifficulty),
-                    "Minimum difficulty must be greater than 0");
+                    "Minimum difficulty must be greater than 0.");
             }
 
             if (minimumDifficulty <= difficultyBoundDivisor)
             {
                 const string message =
                     "Difficulty bound divisor must be less than " +
-                    "minimum difficulty";
+                    "the minimum difficulty.";
 
                 throw new ArgumentOutOfRangeException(
                     nameof(difficultyBoundDivisor),

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -175,10 +175,10 @@ namespace Libplanet.Blockchain.Policies
             DateTimeOffset prevTimestamp = prevBlock.Timestamp;
             TimeSpan timeDiff = prevTimestamp - prevPrevTimestamp;
             long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
-            long multiplier = Math.Max(
-                1 - (timeDiffMilliseconds /
-                     (long)BlockInterval.TotalMilliseconds),
-                -99);
+            const long minimumMultiplier = -99;
+            long multiplier = 1 - (timeDiffMilliseconds /
+                                   (long)BlockInterval.TotalMilliseconds);
+            multiplier = Math.Max(multiplier, minimumMultiplier);
 
             var prevDifficulty = prevBlock.Difficulty;
             var offset = prevDifficulty / DifficultyBoundDivisor;

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -158,6 +158,12 @@ namespace Libplanet.Blockchain.Policies
         {
             int index = blocks.Count;
 
+            if (index < 0)
+            {
+                throw new InvalidBlockIndexException(
+                    $"index must be 0 or more, but its index is {index}.");
+            }
+
             if (index <= 1)
             {
                 return index == 0 ? 0 : MinimumDifficulty;

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -64,7 +64,7 @@ namespace Libplanet.Blockchain.Policies
             Block<T> nextBlock)
         {
             int index = blocks.Count;
-            int difficulty = GetNextBlockDifficulty(blocks);
+            long difficulty = GetNextBlockDifficulty(blocks);
 
             Block<T> lastBlock = index >= 1 ? blocks[index - 1] : null;
             HashDigest<SHA256>? prevHash = lastBlock?.Hash;
@@ -113,9 +113,9 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc />
-        public int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks)
+        public long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks)
         {
-            const int minDifficulty = 1024;
+            const long minDifficulty = 1024;
             const int difficultyBoundDivisor = 512;
 
             int index = blocks.Count;
@@ -130,15 +130,15 @@ namespace Libplanet.Blockchain.Policies
             DateTimeOffset prevPrevTimestamp = blocks[index - 2].Timestamp;
             DateTimeOffset prevTimestamp = prevBlock.Timestamp;
             TimeSpan timeDiff = prevTimestamp - prevPrevTimestamp;
-            int timeDiffMilliseconds = (int)timeDiff.TotalMilliseconds;
-            int multiplier = Math.Max(
+            long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
+            long multiplier = Math.Max(
                 1 - (timeDiffMilliseconds /
-                     (int)BlockInterval.TotalMilliseconds),
+                     (long)BlockInterval.TotalMilliseconds),
                 -99);
 
             var prevDifficulty = prevBlock.Difficulty;
             var offset = prevDifficulty / difficultyBoundDivisor;
-            int nextDifficulty = prevDifficulty + (offset * multiplier);
+            long nextDifficulty = prevDifficulty + (offset * multiplier);
 
             return Math.Max(nextDifficulty, minDifficulty);
         }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -42,6 +42,6 @@ namespace Libplanet.Blockchain.Policies
         /// followed by a new <see cref="Block{T}"/> to be mined.</param>
         /// <returns>A right <see cref="Block{T}.Difficulty"/>
         /// for a new <see cref="Block{T}"/> to be mined.</returns>
-        int GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks);
+        long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks);
     }
 }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -344,7 +344,7 @@ namespace Libplanet.Blocks
                 }
             }
 
-            if (!Hash.HasLeadingZeroBits(Difficulty))
+            if (!Hash.LessThanTarget(Difficulty))
             {
                 throw new InvalidBlockNonceException(
                     $"hash ({Hash}) with the nonce ({Nonce}) does not " +

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Blocks
 
         public Block(
             long index,
-            int difficulty,
+            long difficulty,
             Nonce nonce,
             Address? miner,
             HashDigest<SHA256>? previousHash,
@@ -83,7 +83,7 @@ namespace Libplanet.Blocks
         public long Index { get; }
 
         [IgnoreDuringEquals]
-        public int Difficulty { get; }
+        public long Difficulty { get; }
 
         [IgnoreDuringEquals]
         public Nonce Nonce { get; }
@@ -102,7 +102,7 @@ namespace Libplanet.Blocks
 
         public static Block<T> Mine(
             long index,
-            int difficulty,
+            long difficulty,
             Address miner,
             HashDigest<SHA256>? previousHash,
             DateTimeOffset timestamp,

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -344,7 +344,7 @@ namespace Libplanet.Blocks
                 }
             }
 
-            if (!Hash.LessThanTarget(Difficulty))
+            if (!Hash.Satisfies(Difficulty))
             {
                 throw new InvalidBlockNonceException(
                     $"hash ({Hash}) with the nonce ({Nonce}) does not " +

--- a/Libplanet/Blocks/RawBlock.cs
+++ b/Libplanet/Blocks/RawBlock.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Blocks
             string timestamp,
             byte[] nonce,
             byte[] miner,
-            int difficulty,
+            long difficulty,
             byte[] previousHash,
             IEnumerable transactions)
             : this(
@@ -32,7 +32,7 @@ namespace Libplanet.Blocks
             string timestamp,
             byte[] nonce,
             byte[] miner,
-            int difficulty,
+            long difficulty,
             byte[] previousHash,
             IEnumerable transactions,
             byte[] hash)
@@ -72,7 +72,7 @@ namespace Libplanet.Blocks
 
         public byte[] Miner { get; }
 
-        public int Difficulty { get; }
+        public long Difficulty { get; }
 
         public byte[] PreviousHash { get; }
 

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Numerics;
 using System.Security.Cryptography;
 
 namespace Libplanet
@@ -132,42 +133,31 @@ namespace Libplanet
         }
 
         /// <summary>
-        /// Tests if a digest starts with the given number
-        /// (i.e., <paramref name="bits"/>) of zero bits.
-        /// <para>Note that it is bitwise, not bytes.</para>
+        /// Tests if a digest is less than the target computed for the given
+        /// <paramref name="difficulty"/>).
         /// </summary>
-        /// <param name="bits">The number of leading zero bits to test.</param>
-        /// <returns><c>true</c> only if a digest has leading zero bits of
-        /// the given number (i.e., <paramref name="bits"/>), or more than that.
-        /// If <paramref name="bits"/> is <c>0</c> it always returns
-        /// <c>true</c>.   Otherwise, it returns <c>false</c>.
+        /// <param name="difficulty">The difficulty to compute target number.
+        /// </param>
+        /// <returns><c>true</c> only if a digest is less than the target
+        /// computed for the given <paramref name="difficulty"/>).
+        /// If <paramref name="difficulty"/> is <c>0</c> it always returns
+        /// <c>true</c>.
         /// </returns>
         [Pure]
-        public bool HasLeadingZeroBits(int bits)
+        public bool LessThanTarget(int difficulty)
         {
-            int leadingBytes = bits / 8;
-            int trailingBits = (int)bits % 8;
-
-            if (ByteArray.Length < (bits / 8) + 1)
+            if (difficulty == 0)
             {
-                return false;
+                return true;
             }
 
-            for (int i = 0; i < leadingBytes; i++)
-            {
-                if (ByteArray[i] != 0)
-                {
-                    return false;
-                }
-            }
+            BigInteger target = new BigInteger(
+                Math.Pow(2, 256) / difficulty);
 
-            if (trailingBits != 0)
-            {
-                var mask = 0xff << (8 - trailingBits) & 0xff;
-                return (ByteArray[(int)leadingBytes] & mask) == 0;
-            }
+            // Add zero to convert unsigned BigInteger
+            BigInteger result = new BigInteger(ByteArray.Add(0).ToArray());
 
-            return true;
+            return result < target;
         }
 
         /// <summary>

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -151,8 +151,8 @@ namespace Libplanet
                 return true;
             }
 
-            var target = new BigInteger(
-                Math.Pow(2, 256) / difficulty);
+            double maxTarget = Math.Pow(2, 256);
+            var target = new BigInteger(maxTarget / difficulty);
 
             // Add zero to convert unsigned BigInteger
             var result = new BigInteger(ByteArray.Add(0).ToArray());

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -151,11 +151,11 @@ namespace Libplanet
                 return true;
             }
 
-            BigInteger target = new BigInteger(
+            var target = new BigInteger(
                 Math.Pow(2, 256) / difficulty);
 
             // Add zero to convert unsigned BigInteger
-            BigInteger result = new BigInteger(ByteArray.Add(0).ToArray());
+            var result = new BigInteger(ByteArray.Add(0).ToArray());
 
             return result < target;
         }

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -144,7 +144,7 @@ namespace Libplanet
         /// <c>true</c>.
         /// </returns>
         [Pure]
-        public bool LessThanTarget(long difficulty)
+        public bool Satisfies(long difficulty)
         {
             if (difficulty == 0)
             {

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -144,7 +144,7 @@ namespace Libplanet
         /// <c>true</c>.
         /// </returns>
         [Pure]
-        public bool LessThanTarget(int difficulty)
+        public bool LessThanTarget(long difficulty)
         {
             if (difficulty == 0)
             {

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -21,12 +21,12 @@ namespace Libplanet
         /// should not vary for different <paramref name="nonce"/>s.</para>
         /// </summary>
         /// <param name="nonce">An arbitrary nonce for an attempt, provided
-        /// by <see cref="Hashcash.Answer(Stamp, int)"/> method.</param>
+        /// by <see cref="Hashcash.Answer(Stamp, long)"/> method.</param>
         /// <returns>A <see cref="byte"/> array determined from the given
         /// <paramref name="nonce"/>.  It should return consistently
         /// an equivalent array for equivalent <paramref name="nonce"/>
         /// values.</returns>
-        /// <seealso cref="Hashcash.Answer(Stamp, int)"/>
+        /// <seealso cref="Hashcash.Answer(Stamp, long)"/>
         /// <seealso cref="Nonce"/>
         public delegate byte[] Stamp(Nonce nonce);
 
@@ -45,7 +45,7 @@ namespace Libplanet
         /// <returns>A <see cref="Nonce"/> value which satisfies the given
         /// <paramref name="difficulty"/>.</returns>
         /// <seealso cref="Stamp"/>
-        public static Nonce Answer(Stamp stamp, int difficulty)
+        public static Nonce Answer(Stamp stamp, long difficulty)
         {
             var nonceBytes = new byte[10];
             var random = new Random();

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -59,7 +59,7 @@ namespace Libplanet
                     return nonce;
                 }
 
-                if (digest.LessThanTarget(difficulty))
+                if (digest.Satisfies(difficulty))
                 {
                     return nonce;
                 }

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -40,8 +40,8 @@ namespace Libplanet
         /// <param name="stamp">A callback to get a &#x0201c;stamp&#x0201d;
         /// which is a <see cref="byte"/> array determined from a given
         /// <see cref="Nonce"/> value.</param>
-        /// <param name="difficulty">The minimum required number of
-        /// leading zero bits that a returned answer needs to have.</param>
+        /// <param name="difficulty">A number to calculate the target number
+        /// for which the returned answer should be less than.</param>
         /// <returns>A <see cref="Nonce"/> value which satisfies the given
         /// <paramref name="difficulty"/>.</returns>
         /// <seealso cref="Stamp"/>
@@ -54,7 +54,12 @@ namespace Libplanet
                 random.NextBytes(nonceBytes);
                 var nonce = new Nonce(nonceBytes);
                 var digest = Hash(stamp(nonce));
-                if (digest.HasLeadingZeroBits(difficulty))
+                if (difficulty == 0)
+                {
+                    return nonce;
+                }
+
+                if (digest.LessThanTarget(difficulty))
                 {
                     return nonce;
                 }


### PR DESCRIPTION
- Changed the difficulty calculation algorithm to gradually adjust the difficulty.
- Removed `HashDigest.HasLeadingZeroBits()` method and added `HashDigest.LessThanTarget()` mtehod.
- Changed difficulty type to `long` from `int`.
- Changed `BlockPolicy` interface to receive the minimum difficulty and difficulty bound divisor.
