### PR TITLE
Network polishing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ To be released.
     given.
  -  Fixed a bug that TURN relay had been disconnected when being connected for longer than 5
     minutes.
+ -  Improved connection stability of TURN relay.
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` method
     became to validate only the next block to be appended.  [[#210]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@ To be released.
  -  Improved connection stability of TURN relay.
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` method
     became to validate only the next block to be appended.  [[#210]]
+ -  Improved `BlockChain<T>.Fork()` performance by omitting unnecessary validation.
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,10 +47,13 @@ To be released.
     given.
  -  Fixed a bug that TURN relay had been disconnected when being connected for longer than 5
     minutes.
- -  Improved connection stability of TURN relay.
+ -  Fixed a bug that a TURN connection had turned unavailable after
+    it once failed to parse a message (due to a corrupted packet).
+    [[#215]]
  -  Instead of validating the entire blocks, `BlockChain<T>.Append()` method
     became to validate only the next block to be appended.  [[#210]]
- -  Improved `BlockChain<T>.Fork()` performance by omitting unnecessary validation.
+ -  Improved `BlockChain<T>.Fork()` performance by avoiding double validation
+    of already validated blocks.  [[#215]]
 
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
@@ -60,6 +63,7 @@ To be released.
 [#205]: https://github.com/planetarium/libplanet/pull/205
 [#206]: https://github.com/planetarium/libplanet/pull/206
 [#210]: https://github.com/planetarium/libplanet/pull/210
+[#215]: https://github.com/planetarium/libplanet/pull/215
 
 
 Version 0.2.2

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -421,7 +421,6 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitReadLock();
             }
 
-            forked.Validate(forked, currentTime);
             return forked;
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -737,20 +737,32 @@ namespace Libplanet.Net
         {
             while (Running)
             {
-                NetworkStream stream =
-                    await _turnClient.AcceptRelayedStreamAsync();
-
-                #pragma warning disable CS4014
-                Task.Run(async () =>
+                try
                 {
-                    using (var proxy = new NetworkStreamProxy(stream))
+                    NetworkStream stream =
+                        await _turnClient.AcceptRelayedStreamAsync();
+
+                    // TODO We should expose the interface so that library users
+                    // can limit / manage the task.
+#pragma warning disable CS4014
+                    Task.Run(async () =>
                     {
-                        await proxy.StartAsync(
-                            IPAddress.Loopback,
-                            _listenPort.Value);
-                    }
-                });
-                #pragma warning restore CS4014
+                        using (var proxy = new NetworkStreamProxy(stream))
+                        {
+                            await proxy.StartAsync(
+                                IPAddress.Loopback,
+                                _listenPort.Value);
+                        }
+                    });
+#pragma warning restore CS4014
+                }
+                catch (Exception e)
+                {
+                    _logger.Error(
+                        e,
+                        $"Unexpected exception occured. try again"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes two problems.

1. Current TURN client and relay implementations are vulnerable to packet corruption because they do not retry if parsing fails. To fix this, I modified to ignore exceptions and retry.
2. When forking to apply a chain from another node, use `BlockChain<T>.Fork()` to rewind the current chain to the branch point. I improved performance by eliminating unnecessary validation at this time.