### PR TITLE
.NET Framework 4.6 & Uno.CodeGen → .NET Core 2.2 & Equals.Fody

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 _UpgradeReport_Files/
 [Pp]ackages/
 mono_crash.*.json
+FodyWeavers.xsd
 
 Thumbs.db
 Desktop.ini

--- a/.travis.dotCover.xml
+++ b/.travis.dotCover.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Configuration for dotCover.  It is intended to be used when
-Travis CI executes dotCover.  $ASSEMBLY is a placeholder
+Travis CI executes dotCover.  $SOLUTION is a placeholder
 to be replaced using sed. -->
 <CoverageParams>
-  <TargetExecutable>C:\ProgramData\chocolatey\bin\xunit.console.exe</TargetExecutable>
-  <TargetArguments>$ASSEMBLY -diagnostics</TargetArguments>
+  <TargetExecutable>C:\Program Files\dotnet\dotnet.exe</TargetExecutable>
+  <TargetArguments>test -c Debug -v n $SOLUTION</TargetArguments>
   <TargetWorkingDir></TargetWorkingDir>
   <ReportType>DetailedXML</ReportType>
-  <Output>$ASSEMBLY.cov.xml</Output>
+  <Output>Libplanet.cov.xml</Output>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
         <ModuleMask>Libplanet</ModuleMask>
-        <ModuleMask>Libplanet.Stun</ModuleMask>
       </FilterEntry>
     </IncludeFilters>
     <ExcludeFilters>

--- a/.travis.dotCover.xml
+++ b/.travis.dotCover.xml
@@ -12,11 +12,13 @@ to be replaced using sed. -->
     <IncludeFilters>
       <FilterEntry>
         <ModuleMask>Libplanet</ModuleMask>
+        <ModuleMask>Libplanet.Stun</ModuleMask>
       </FilterEntry>
     </IncludeFilters>
     <ExcludeFilters>
       <FilterEntry>
         <ModuleMask>Libplanet.Tests</ModuleMask>
+        <ModuleMask>Libplanet.Stun.Tests</ModuleMask>
       </FilterEntry>
     </ExcludeFilters>
   </Filters>

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     language: csharp
     dotnet: 2.2.203
     mono: none
+    services: [docker]
     addons:
       apt:
         packages:
@@ -21,6 +22,7 @@ matrix:
     osx_image: xcode10.1
     language: csharp
     dotnet: 2.2.106
+    mono: none
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -201,12 +203,24 @@ script:
 
 # Build docs using DocFX
 - |
-  if [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
+  if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
+    # As installing Mono on macOS build takes too long time and Travis CI
+    # does not support Docker on macOS build, we skip docs build on macOS.
+    exit 0
+  elif [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
     powershell -Command "Set-ExecutionPolicy Unrestricted"
     pwsh=powershell
   else
     pwsh=pwsh
   fi
+  # TODO: Currently DocFX requires .NET Framework 4.6 which means incompatible
+  # with .NET Core but compatible with Mono.  We disabled Mono on Travis CI
+  # to prevent slow build startup (installing Mono on Travis Linux takes longer
+  # than minutes), so here we invoke DocFX using Docker instead.
+  # The current setup makes DocFX unable to resolve types in the framework
+  # as we need to invoke `dotnet recover` first inside the Docker.
+  # FIXME: We'd better have a separate build process for docs other than
+  # Travis CI, e.g., GitHub Actions.
   $pwsh \
     -File Docs/build.ps1 \
     -WorkingDirectory Docs/ \

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,20 +131,6 @@ script:
 # Check coding styles
 - hooks/check-bom
 
-# Build docs using DocFX
-- |
-  if [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
-    powershell -Command "Set-ExecutionPolicy Unrestricted"
-    pwsh=powershell
-  else
-    pwsh=pwsh
-  fi
-  $pwsh \
-    -File Docs/build.ps1 \
-    -WorkingDirectory Docs/ \
-    -ExecutionPolicy Bypass
-- '[[ -f Docs/_site/index.html ]]'
-
 # Build the whole solution
 - |
   for project in $PROJECTS; do
@@ -204,6 +190,20 @@ script:
   if [[ "$nupkg_version" != "$version" ]]; then
     rm -f "Libplanet/bin/Release/Libplanet.$version.nupkg"
   fi
+
+# Build docs using DocFX
+- |
+  if [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
+    powershell -Command "Set-ExecutionPolicy Unrestricted"
+    pwsh=powershell
+  else
+    pwsh=pwsh
+  fi
+  $pwsh \
+    -File Docs/build.ps1 \
+    -WorkingDirectory Docs/ \
+    -ExecutionPolicy Bypass
+- '[[ -f Docs/_site/index.html ]]'
 
 # Turn off "set -e" option
 - set +e

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,6 @@ script:
 - dotnet test -c Release -v n
 
 # Run unit tests with coverage report
-- cat codecov.yml | curl --data-binary @- https://codecov.io/validate
 - |
   if [[ "$TRAVIS_OS_NAME" = "windows" && "$CODECOV_TOKEN" != "" ]]; then
     dotnet build -c Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ matrix:
   - os: linux
     dist: xenial
     language: csharp
+    dotnet: 2.2.203
+    mono: none
     addons:
       apt:
         packages:
@@ -18,6 +20,7 @@ matrix:
   - os: osx
     osx_image: xcode10.1
     language: csharp
+    dotnet: 2.2.106
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -30,9 +33,6 @@ matrix:
       - $HOME/.nuget/packages
       - $HOME/AppData/Local/NuGet/v3-cache
     filter_secrets: false  # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
-
-env:
-  - PROJECTS="Libplanet.Stun Libplanet"
 
 solution: Libplanet.sln
 install:
@@ -58,17 +58,9 @@ install:
     brew update
     brew cask install powershell
   elif [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
-    # MSBuild
-    {
-      echo "#!/bin/bash"
-      echo "'/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe'" '"$@"'
-    } > /usr/bin/msbuild
-    chmod +x /usr/bin/msbuild
-
-    # NuGet
-    curl -o /usr/bin/nuget.exe \
-      https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-    chmod +x /usr/bin/nuget.exe
+    # .NET Core SDK 2.2+
+    choco install dotnetcore-sdk
+    dotnet --info
 
     # xmllint
     mkdir /tmp/libxml2
@@ -93,7 +85,7 @@ install:
       mkdir /tmp/dotcover
       pushd /tmp
       wget \
-        https://download.jetbrains.com/resharper/ReSharperUltimate.2018.3.3/JetBrains.dotCover.CommandLineTools.2018.3.3.zip
+        https://download.jetbrains.com/resharper/ReSharperUltimate.2018.3.4/JetBrains.dotCover.CommandLineTools.2018.3.4.zip
       pushd dotcover
       7z x ../JetBrains.dotCover.CommandLineTools.*.zip
       popd
@@ -105,20 +97,26 @@ install:
     fi
   fi
   set +ev
-- nuget restore Libplanet.sln
+
+# Restore NuGet packages (dependencies)
+- |
+  for i in 1 2 3; do
+    # Retry up to 3 times
+    dotnet restore -s https://api.nuget.org/v3/index.json && break
+  done
 
 script:
 # Fail fast if anything in below commands fails
 - set -e
 
 # If a tag is pushed, the NuGet package version has to be the same to
-# the tag name.
+# the tag name, without any suffix.
 - |
-  version="$(xmllint \
-    --xpath './Project/PropertyGroup/Version/text()' \
+  version_prefix="$(xmllint \
+    --xpath './Project/PropertyGroup/VersionPrefix/text()' \
     Libplanet/Libplanet.csproj)"
-- 'echo "NuGet package version: $version"'
-- '[[ "$TRAVIS_TAG" = "" || "$version" = "$TRAVIS_TAG" ]]'
+- 'echo "VersionPrefix: $version_prefix"'
+- '[[ "$TRAVIS_TAG" = "" || "$version_prefix" = "$TRAVIS_TAG" ]]'
 
 # If a tag is pushed, there has to be an entry in CHANGES.md for the version.
 - |
@@ -131,24 +129,43 @@ script:
 # Check coding styles
 - hooks/check-bom
 
+# Append suffix to the package version if it's not a tag push:
+# - "dev.BUILDNO+DATE" (e.g., 0.1.2-dev.34+20190423)
+# - "nightly.DATE" (e.g., 0.1.2-nightly.20190423)
+- |
+  if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
+    version_suffix="nightly.$(date +%Y%m%d)"
+    nupkg_version="$version_prefix-$version_suffix"
+  elif [[ "$TRAVIS_TAG" = "" ]]; then
+    version_suffix="dev.$TRAVIS_BUILD_NUMBER"
+    nupkg_version="$version_prefix-$version_suffix"
+    commit_date="$(git log -n1 --pretty=%cd --date=format:%Y%m%d)"
+    version_suffix="$version_suffix+$commit_date"
+  else
+    nupkg_version="$TRAVIS_TAG"
+  fi
+
 # Build the whole solution
 - |
-  for project in $PROJECTS; do
-    msbuild -p:Configuration=Release -r $project
-  done
+  if [[ "$TRAVIS_TAG" = "" ]]; then
+    dotnet build \
+      -c Release \
+      --version-suffix "$version_suffix" \
+      -p:NoPackageAnalysis=true
+  else
+    dotnet build \
+      -c Release
+  fi
 
 # Run unit tests
-- |
-  for project in $PROJECTS; do
-    msbuild -p:Configuration=Release -t:build,XunitTest $project.Tests
-  done
+- dotnet test -c Release -v n
 
 # Run unit tests with coverage report
 - cat codecov.yml | curl --data-binary @- https://codecov.io/validate
 - |
   if [[ "$TRAVIS_OS_NAME" = "windows" && "$CODECOV_TOKEN" != "" ]]; then
-    msbuild -p:Configuration=Debug -p:DebugType=full -r
-    for assembly in Libplanet.Tests/bin/Debug/*/Libplanet.Tests.dll; do
+    dotnet build -c Debug
+    for assembly in *.Tests/bin/Debug/*/*.Tests.dll; do
       echo "$assembly:"
       dotCover_config="$(cat .travis.dotCover.xml)"
       assembly_abspath="$(cygpath -w "$(pwd)/$assembly")"
@@ -162,33 +179,24 @@ script:
 
 # Build Libplanet.*.nupkg
 - |
-  rm -f "Libplanet/bin/Release/Libplanet.$version.nupkg"
-  msbuild_props=('Configuration=Release')
-  if [[ "$TRAVIS_TAG" = "" && "$version" = *-dev ]]; then
-    # Append "+buildno" to the package version (e.g., 0.1.2-dev+34)
-    # if it's not a tag push.
-    if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
-      appended_version="${version/-dev/-nightly}.$(date +%Y%m%d)"
-      nupkg_version="$appended_version"
-    else
-      nupkg_version="$version.$TRAVIS_BUILD_NUMBER"
-      appended_version="$nupkg_version+$(date +%Y%m%d)"
-    fi
-    msbuild_props+=("PackageVersion=$appended_version")
-    msbuild_props+=('NoPackageAnalysis=true')
-    msbuild -r "${msbuild_props[@]/#/-p:}" Libplanet
+  if [[ "$TRAVIS_TAG" = "" ]]; then
+    echo "Version suffix: $version_suffix"
+    dotnet pack Libplanet \
+      -c Release \
+      --version-suffix "$version_suffix" \
+      -p:NoPackageAnalysis=true
   else
-    nupkg_version="$version"
-    appended_version="$version"
+    dotnet pack Libplanet \
+      -c Release
   fi
-  msbuild -t:pack "${msbuild_props[@]/#/-p:}" Libplanet
+  ls -al Libplanet/bin/Release/
   unzip -l "Libplanet/bin/Release/Libplanet.$nupkg_version.nupkg" \
     > /tmp/nupkgfiles
   cat /tmp/nupkgfiles
   grep -i Libplanet.dll /tmp/nupkgfiles
   grep -i Libplanet.Stun.dll /tmp/nupkgfiles
-  if [[ "$nupkg_version" != "$version" ]]; then
-    rm -f "Libplanet/bin/Release/Libplanet.$version.nupkg"
+  if [[ "$nupkg_version" != "$version_prefix" ]]; then
+    rm -f "Libplanet/bin/Release/Libplanet.$version_prefix.nupkg"
   fi
 
 # Build docs using DocFX

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
     mv */*.exe */*.dll /c/Windows/
     popd
 
-    # Tools for test coverage (dotcover-clt, codecov-exe, xunit)
+    # Tools for test coverage (dotcover-clt, codecov-exe)
     if [[ "$CODECOV_TOKEN" != "" ]]; then
       mkdir /tmp/dotcover
       pushd /tmp
@@ -95,7 +95,7 @@ install:
       rm JetBrains.dotCover.CommandLineTools.*.zip
       popd
 
-      choco install codecov xunit
+      choco install codecov
     fi
   fi
   set +ev
@@ -166,16 +166,13 @@ script:
 - |
   if [[ "$TRAVIS_OS_NAME" = "windows" && "$CODECOV_TOKEN" != "" ]]; then
     dotnet build -c Debug
-    for assembly in *.Tests/bin/Debug/*/*.Tests.dll; do
-      echo "$assembly:"
-      dotCover_config="$(cat .travis.dotCover.xml)"
-      assembly_abspath="$(cygpath -w "$(pwd)/$assembly")"
-      echo "${dotCover_config//\$ASSEMBLY/$assembly_abspath}" \
-        > "$assembly.dotCover.xml"
-      dotCover.exe cover "$assembly.dotCover.xml"
-      # Upload report to Codecov.io
-      codecov.exe -f "$assembly.cov.xml" -t "$CODECOV_TOKEN"
-    done
+    solution_abspath="$(cygpath -w "$(pwd)"/Libplanet.sln)"
+    dotCover_config="$(cat .travis.dotCover.xml)"
+    echo "${dotCover_config//\$SOLUTION/$solution_abspath}" \
+      > dotCover.xml
+    dotCover.exe cover dotCover.xml
+    # Upload report to Codecov.io
+    codecov.exe -f Libplanet.cov.xml -t "$CODECOV_TOKEN"
   fi
 
 # Build Libplanet.*.nupkg

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,11 +4,8 @@
     {
       "label": "Build",
       "type": "shell",
-      "command": "msbuild",
-      "args": [
-        "-r",
-        "-p:GenerateFullPaths=true"
-      ],
+      "command": "dotnet",
+      "args": ["build"],
       "group": "build",
       "presentation": {
         "reveal": "silent"
@@ -18,14 +15,8 @@
     {
       "label": "Test",
       "type": "shell",
-      "command": "msbuild",
-      "args": [
-        "-r",
-        "-p:GenerateFullPaths=true",
-        "-t:Build",
-        "-t:XunitTest",
-        "Libplanet.Tests"
-      ],
+      "command": "dotnet",
+      "args": ["test"],
       "group": "build",
       "presentation": {
         "reveal": "always",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Version 0.3.0
 To be released.
 
  -  `BlockChain<T>` became to implement `IReadOnlyList<Block<T>>`.  [[#205]]
- -  `BlockChain<T>.Validate()` method became to receive 
+ -  `BlockChain<T>.Validate()` method became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
  -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
     `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
@@ -31,6 +31,10 @@ To be released.
     [[#204]], [[#206]]
  -  Added `BlockDownloadState` class to represent a block downloading state.
     [[#204]], [[#206]]
+ -  Removed `KeyEquals()` methods from all classes and structs.
+ -  `Swarm` class now does not implement `IEquatable<Swarm>` anymore and
+    its `Equals(object)` method and `GetHashCode()` method became to have
+    default behavior of `object` class.
  -  Improved overall read throughput of `BlockChain<T>` while blocks are being
     mined by `BlockChain<T>.MineBlock()`.
  -  Fixed a bug that `TurnClientException` had been thrown by Swarm when a STUN

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,22 +25,20 @@ for purposes:
 Prerequisites
 -------------
 
-If you use Linux or macOS you need [Mono], which provides C# compiler and
-.NET VM.  You could install it by `sudo apt install mono-devel` command
-if you use Ubuntu Linux.  If you use macOS and [Homebrew], you can install
-it by `brew cask install mono-mdk` command.
+You need [.NET Core] SDK 2.2+ which provides the latest C# compiler and .NET VM.
+Read and follow the instruction to install .NET Core SDK on
+the [.NET Core downloads page][1].
+FYI if you use macOS and [Homebrew] you can install it by
+`brew cask install dotnet-sdk` command.
 
-If you are on Windows you need things like C# compiler included in
-[Build Tools for Visual Studio 2017][1].  Choose the following workloads
-during installation:
+Make sure that your .NET Core SDK is 2.2 or higher.  You could show
+the version you are using by `dotnet --info` command.
 
- -  <q>Windows</q> → <q>.NET desktop build tools</q>
- -  <q>Other Toolsets</q> → <q>.NET Core build tools</q>
-
-These tools should bring MSBuild, the Libplanet project uses to build, as well.
-Check if `msbuild` is available on the shell or Command Prompt.  If it fails
-to find command named `msbuild` it might be not installed correctly or its
-directory might be missing in the `PATH` environment.
+If it's Windows please check if the environment variable named
+`MSBuildSDKsPath` refers to the proper version of .NET Core SDK.
+If you use Visual Studio 2017 (not 2019) you can only use .NET Core 2.2.105
+at the highest.  .NET Core SDK higher than the version 2.2.105 is not
+recognized Visual Studio 2017.
 
 Although it is not necessary, you should install a proper IDE for .NET
 (or an [OmniSharp] extension for your favorite editor — except it takes
@@ -52,11 +50,11 @@ Unless you already have your favorite setup, we recommend you to use
 made .NET as well.  So Visual Studio Code has a [first-party C# extension][2]
 which works well together.
 
-[Mono]: https://www.mono-project.com/
+[.NET Core]: https://dot.net/
 [Homebrew]: https://brew.sh/
 [OmniSharp]: http://www.omnisharp.net/
 [Visual Studio Code]: https://code.visualstudio.com/
-[1]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017
+[1]: https://dotnet.microsoft.com/download
 [2]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp
 
 
@@ -64,9 +62,9 @@ Build
 -----
 
 The following command installs dependencies (required library packages) and
-builds the *Libplanet* project:
+builds the entire *Libplanet* solution:
 
-    msbuild -r Libplanet
+    dotnet build
 
 
 Tests [![Build Status](https://travis-ci.com/planetarium/libplanet.svg?branch=master)][Travis CI] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][2]
@@ -86,10 +84,9 @@ one in *Libplanet* or *Libplanet.Stun* projects.
 If there's *Libplanet.Foo.Bar* class there also should be
 *Libplanet.Tests.Foo.BarTest* to test it.
 
-To build and run unit tests at a time execute the below commands:
+To build and run unit tests at a time execute the below command:
 
-    msbuild -r -t:Build,XunitTest Libplanet.Tests
-    msbuild -r -t:Build,XunitTest Libplanet.Stun.Tests
+    dotnet test
 
 [Travis CI]: https://travis-ci.com/planetarium/libplanet
 [2]: https://codecov.io/gh/planetarium/libplanet

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Crypto;
-using Uno.Extensions;
 using Xunit;
 
 namespace Libplanet.Tests.Action

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -525,11 +525,8 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(sameBlock1, sameBlock2);
             Assert.NotEqual(sameBlock2, differentBlock);
 
-            Assert.True(sameBlock1 == sameBlock2);
-            Assert.False(sameBlock2 == differentBlock);
-
-            Assert.False(sameBlock1 != sameBlock2);
-            Assert.True(sameBlock2 != differentBlock);
+            Assert.True(sameBlock1.Equals(sameBlock2));
+            Assert.False(sameBlock2.Equals(differentBlock));
         }
     }
 }

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -397,36 +397,6 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
-        public void BeComparedProperly()
-        {
-            var pk1 = new PrivateKey();
-            var pk2 = new PrivateKey();
-            var a = new Swarm(
-                pk1,
-                1,
-                host: "0.0.0.0",
-                listenPort: 5555);
-            var b = new Swarm(
-                pk1,
-                1,
-                host: "0.0.0.0",
-                listenPort: 5555,
-                createdAt: a.LastDistributed);
-            var c = new Swarm(
-                pk2,
-                1,
-                host: "0.0.0.0",
-                listenPort: 5555);
-
-            Assert.Equal(a, b);
-            Assert.NotEqual(a, c);
-            a.Add(c.AsPeer);
-
-            Assert.NotEqual(a, b);
-            Assert.True(a.KeyEquals(b));
-        }
-
-        [Fact]
         public async Task CanBeCancelled()
         {
             Swarm swarm = _swarms[0];

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -7,7 +7,6 @@ using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
-using Uno.Disposables;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -37,11 +37,9 @@ namespace Libplanet
     /// </summary>
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
-    #pragma warning disable CS0282
     [Serializable]
-    [Uno.GeneratedEquality]
-    public partial struct Address : ISerializable
-    #pragma warning restore CS0282
+    [Equals]
+    public struct Address : ISerializable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="Address"/> takes.
@@ -79,14 +77,6 @@ namespace Libplanet
             }
 
             _byteArray = address.ToImmutableArray();
-
-            #pragma warning disable CS0103
-            /* Suppress CS0171.
-            See also https://github.com/nventive/Uno.CodeGen/pull/91
-            */
-            _computedHashCode = null;
-            _computedKeyHashCode = null;
-            #pragma warning restore CS0103
         }
 
         public Address(
@@ -141,7 +131,6 @@ namespace Libplanet
         /// <remarks>This is immutable.  For a mutable array, call <see
         /// cref="ToByteArray()"/> method.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        [Uno.EqualityKey]
         public ImmutableArray<byte> ByteArray
         {
             get

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -379,7 +379,7 @@ namespace Libplanet.Blockchain
                 {
                     yield return currentHash.Value;
 
-                    if (currentHash == stop || currentHash == tip)
+                    if (currentHash.Equals(stop) || currentHash.Equals(tip))
                     {
                         break;
                     }
@@ -410,7 +410,7 @@ namespace Libplanet.Blockchain
                 foreach (var index in Store.IterateIndex(Id.ToString()))
                 {
                     Store.AppendIndex(forked.Id.ToString(), index);
-                    if (index == point)
+                    if (index.Equals(point))
                     {
                         break;
                     }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -14,8 +14,8 @@ using Libplanet.Tx;
 
 namespace Libplanet.Blocks
 {
-    [Uno.GeneratedEquality]
-    public partial class Block<T> : ISerializable
+    [Equals]
+    public class Block<T> : ISerializable
         where T : IAction, new()
     {
         internal const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
@@ -67,7 +67,6 @@ namespace Libplanet.Blocks
                 .ToList();
         }
 
-        [Uno.EqualityKey]
         public HashDigest<SHA256> Hash
         {
             get
@@ -80,25 +79,25 @@ namespace Libplanet.Blocks
             }
         }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public long Index { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public int Difficulty { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public Nonce Nonce { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public Address? Miner { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public HashDigest<SHA256>? PreviousHash { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public DateTimeOffset Timestamp { get; }
 
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public IEnumerable<Transaction<T>> Transactions { get; }
 
         public static Block<T> Mine(

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -37,8 +37,8 @@ namespace Libplanet.Crypto
     /// <para>Every <see cref="PrivateKey"/> object is immutable.</para>
     /// </remarks>
     /// <seealso cref="Libplanet.Crypto.PublicKey"/>
-    [Uno.GeneratedEquality]
-    public partial class PrivateKey
+    [Equals]
+    public class PrivateKey
     {
         private readonly ECPrivateKeyParameters keyParam;
 
@@ -88,7 +88,7 @@ namespace Libplanet.Crypto
         /// this private key.
         /// </summary>
         [Pure]
-        [Uno.EqualityIgnore]
+        [IgnoreDuringEquals]
         public PublicKey PublicKey
         {
             get
@@ -121,7 +121,6 @@ namespace Libplanet.Crypto
         /// </remarks>
         /// <seealso cref="PrivateKey(byte[])"/>
         [Pure]
-        [Uno.EqualityKey]
         public byte[] ByteArray => keyParam.D.ToByteArrayUnsigned();
 
         /// <summary>

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -24,8 +24,8 @@ namespace Libplanet.Crypto
     /// <remarks>Every <see cref="PublicKey"/> object is immutable.</remarks>
     /// <seealso cref="PrivateKey"/>
     /// <seealso cref="Address"/>
-    [Uno.GeneratedEquality]
-    public partial class PublicKey
+    [Equals]
+    public class PublicKey
     {
         /// <summary>
         /// Creates a <see cref="PublicKey"/> instance from the given
@@ -51,7 +51,6 @@ namespace Libplanet.Crypto
             KeyParam = keyParam;
         }
 
-        [Uno.EqualityKey]
         internal ECPublicKeyParameters KeyParam { get; }
 
         /// <summary>

--- a/Libplanet/Crypto/SymmetricKey.cs
+++ b/Libplanet/Crypto/SymmetricKey.cs
@@ -20,17 +20,15 @@ namespace Libplanet.Crypto
     /// cryptography, it uses the same <see cref="SymmetricKey"/> for both
     /// encrypting a plaintext and decrypting a ciphertext.
     /// </summary>
-    [Uno.GeneratedEquality]
-    public partial class SymmetricKey
+    [Equals]
+    public class SymmetricKey
     {
         private const int KeyBitSize = 256;
         private const int MacBitSize = 128;
         private const int NonceBitSize = 128;
 
-        [Uno.EqualityIgnore]
         private readonly SecureRandom _secureRandom;
 
-        [Uno.EqualityIgnore]
         private readonly byte[] _key;
 
         /// <summary>
@@ -71,7 +69,6 @@ namespace Libplanet.Crypto
         /// <remarks>This is immutable.  For a mutable array, call
         /// <see cref="ToByteArray()"/> method.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        [Uno.EqualityKey]
         [Pure]
         public ImmutableArray<byte> ByteArray => _key.ToImmutableArray();
 

--- a/Libplanet/FodyWeavers.xml
+++ b/Libplanet/FodyWeavers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+
+  <Equals />
+</Weavers>

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -15,11 +15,9 @@ namespace Libplanet
     /// <typeparam name="T">A <see cref="HashAlgorithm"/> which corresponds to
     /// a digest.  This determines <see cref="Size"/> of a digest.</typeparam>
     /// <seealso cref="HashAlgorithm"/>
-    #pragma warning disable CS0282
-    [Uno.GeneratedEquality]
-    public partial struct HashDigest<T>
+    [Equals]
+    public struct HashDigest<T>
         where T : HashAlgorithm
-    #pragma warning restore CS0282
     {
         /// <summary>
         /// The fixed, and valid <see cref="Array.Length"/> of
@@ -73,14 +71,6 @@ namespace Libplanet
             }
 
             _byteArray = hashDigest.ToImmutableArray();
-
-            #pragma warning disable CS0103
-            /* Suppress CS0171.
-            See also https://github.com/nventive/Uno.CodeGen/pull/91
-            */
-            _computedHashCode = null;
-            _computedKeyHashCode = null;
-            #pragma warning restore CS0103
         }
 
         /// <summary>
@@ -89,7 +79,6 @@ namespace Libplanet
         /// <remarks>It is immutable.  For a mutable array, use
         /// <see cref="ToByteArray()"/> method instead.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        [Uno.EqualityKey]
         public ImmutableArray<byte> ByteArray
         {
             get

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -15,8 +15,7 @@ namespace Libplanet
     /// <typeparam name="T">A <see cref="HashAlgorithm"/> which corresponds to
     /// a digest.  This determines <see cref="Size"/> of a digest.</typeparam>
     /// <seealso cref="HashAlgorithm"/>
-    [Equals]
-    public struct HashDigest<T>
+    public struct HashDigest<T> : IEquatable<HashDigest<T>>
         where T : HashAlgorithm
     {
         /// <summary>
@@ -193,6 +192,43 @@ namespace Libplanet
         public override string ToString()
         {
             return ByteUtil.Hex(ToByteArray());
+        }
+
+        [Pure]
+        public override bool Equals(object obj)
+        {
+            return obj is IEquatable<HashDigest<T>> other
+                ? other.Equals(this)
+                : false;
+        }
+
+        [Pure]
+        public override int GetHashCode()
+        {
+            int code = 0;
+            unchecked
+            {
+                foreach (byte b in ByteArray)
+                {
+                    code = (code * 397) ^ b.GetHashCode();
+                }
+            }
+
+            return code;
+        }
+
+        [Pure]
+        bool IEquatable<HashDigest<T>>.Equals(HashDigest<T> other)
+        {
+            for (int i = 0; i < Size; i++)
+            {
+                if (!ByteArray[i].Equals(other.ByteArray[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -2,7 +2,18 @@
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
-    <Version>0.3.0-dev</Version>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <!-- Note: don't be confused by the word "prefix" here.  It's merely a
+    version without suffix like "-dev.123".  See the following examples:
+      Version: 1.2.3-dev.456
+      VersionPrefix: 1.2.3
+      VersionSuffix: dev.456
+    If it's a stable release the version becomes like:
+      Version: 1.2.3
+      VersionPrefix: 1.2.3
+      VersionSuffix: (N/A)
+    Note that the version suffix is filled through CLI option of dotnet command.
+    -->
     <Summary>A .NET library for creating multiplayer online game in decentralized fashion.</Summary>
     <Description>A .NET library for creating multiplayer online game in decentralized fashion.
 See also the docs for details:

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -34,10 +34,12 @@ https://docs.libplanet.io/</Description>
     <AssemblyName>Libplanet</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>CS1591</NoWarn> <!-- FIXME: This should be turned on eventually. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- FIXME: CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -28,7 +28,6 @@ https://docs.libplanet.io/</Description>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn> <!-- FIXME: This should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
-    <UnoSourceGeneratorUseGenerationHost>true</UnoSourceGeneratorUseGenerationHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -48,14 +47,9 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="AsyncEnumerator" Version="2.2.1" />
     <PackageReference Include="Bencodex" Version="0.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
-    <PackageReference Include="CommonServiceLocator" Version="1.3.0">
-      <!-- Note that this is actually not necessarily a direct dependency,
-      but an indirect dependency of Uno.Core.  This item purposes to merely
-      ignore NU1701 warnings during restoring Uno.CodeGen package.
-      See also:
-      https://github.com/nventive/Uno/blob/master/doc/articles/faq.md#warning-package-unouisourcegenerationtasks-was-restored-using-netframeworkversion461
-      -->
-      <NoWarn>NU1701</NoWarn>
+    <PackageReference Include="Equals.Fody" Version="1.9.3" />
+    <PackageReference Include="Fody" Version="4.2.1">
+      <!-- Fody 5.0.0 dropped MSBuild 15 support. -->
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
@@ -69,19 +63,6 @@ https://docs.libplanet.io/</Description>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Uno.SourceGenerationTasks" Version="1.29.0">
-      <!-- Note that this is actually not necessarily a direct dependency,
-      but an indirect dependency of Uno.CodeGen.  This item purposes to merely
-      ignore NU1701 warnings during restoring Uno.CodeGen package.
-      See also:
-      https://github.com/nventive/Uno/blob/master/doc/articles/faq.md#warning-package-unouisourcegenerationtasks-was-restored-using-netframeworkversion461
-      -->
-      <NoWarn>NU1701</NoWarn>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Uno.CodeGen" Version="1.30.0" />
-    <PackageReference Include="Uno.Core" Version="1.26.0" />
-    <PackageReference Include="Uno.Equality" Version="1.30.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -5,25 +5,22 @@ namespace Libplanet.Net
     /// <summary>
     /// A container that indicates the progress of a block download.
     /// </summary>
-    [Uno.GeneratedEquality]
-    public partial class BlockDownloadState
+    [Equals]
+    public class BlockDownloadState
     {
         /// <summary>
         /// Total number of blocks to receive in the current batch.
         /// </summary>
-        [Uno.EqualityHash]
         public int TotalBlockCount { get; internal set; }
 
         /// <summary>
         /// The number of currently received blocks.
         /// </summary>
-        [Uno.EqualityHash]
         public int ReceivedBlockCount { get; internal set; }
 
         /// <summary>
         /// The hash digest of the block just received.
         /// </summary>
-        [Uno.EqualityHash]
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
     }
 }

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Runtime.Serialization;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
-using Uno;
 
 namespace Libplanet.Net
 {
@@ -13,8 +12,8 @@ namespace Libplanet.Net
     /// </summary>
     /// <seealso cref="Swarm"/>
     [Serializable]
-    [GeneratedEquality]
-    public partial class Peer : ISerializable
+    [Equals]
+    public class Peer : ISerializable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Peer"/> class.
@@ -55,14 +54,12 @@ namespace Libplanet.Net
         /// The corresponding <see cref="Libplanet.Crypto.PublicKey"/> of
         /// this peer.
         /// </summary>
-        [EqualityKey]
         [Pure]
         public PublicKey PublicKey { get; }
 
         /// <summary>
         /// The corresponding <see cref="DnsEndPoint"/> of this peer.
         /// </summary>
-        [EqualityKey]
         [Pure]
         public DnsEndPoint EndPoint { get; }
 
@@ -70,9 +67,15 @@ namespace Libplanet.Net
         /// The corresponding application protocol version of this peer.
         /// </summary>
         /// <seealso cref="Swarm.DifferentVersionPeerEncountered"/>
+        [IgnoreDuringEquals]
         [Pure]
         public int AppProtocolVersion { get; }
 
+        /// <summary>The peer's address which is derviced from
+        /// its <see cref="PublicKey"/>.
+        /// </summary>
+        /// <seealso cref="PublicKey"/>
+        [IgnoreDuringEquals]
         [Pure]
         public Address Address => new Address(PublicKey);
 

--- a/Libplanet/Net/PeerSetDelta.cs
+++ b/Libplanet/Net/PeerSetDelta.cs
@@ -7,8 +7,8 @@ using Libplanet.Serialization;
 namespace Libplanet.Net
 {
     [Serializable]
-    [Uno.GeneratedEquality]
-    public partial class PeerSetDelta : ISerializable
+    [Equals]
+    public class PeerSetDelta : ISerializable
     {
         public PeerSetDelta(
             Peer sender,
@@ -36,21 +36,14 @@ namespace Libplanet.Net
                 .ToImmutableHashSet();
         }
 
-        [Uno.EqualityHash]
-        [Uno.EqualityKey]
         public Peer Sender { get; }
 
-        [Uno.EqualityHash]
-        [Uno.EqualityKey]
         public DateTimeOffset Timestamp { get; }
 
-        [Uno.EqualityHash]
         public IImmutableSet<Peer> AddedPeers { get; }
 
-        [Uno.EqualityHash]
         public IImmutableSet<Peer> RemovedPeers { get; }
 
-        [Uno.EqualityHash]
         public IImmutableSet<Peer> ExistingPeers { get; }
 
         public void GetObjectData(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -27,8 +27,7 @@ using Serilog.Events;
 
 namespace Libplanet.Net
 {
-    [Uno.GeneratedEquality]
-    public partial class Swarm : ICollection<Peer>, IDisposable
+    public class Swarm : ICollection<Peer>, IDisposable
     {
         private static readonly TimeSpan TurnAllocationLifetime =
             TimeSpan.FromSeconds(777);
@@ -169,7 +168,6 @@ namespace Libplanet.Net
 
         public DnsEndPoint EndPoint { get; private set; }
 
-        [Uno.EqualityKey]
         public Address Address => _privateKey.PublicKey.ToAddress();
 
         public Peer AsPeer =>
@@ -178,16 +176,12 @@ namespace Libplanet.Net
             : throw new SwarmException(
                 "Can't translate unbound Swarm to Peer.");
 
-        [Uno.EqualityIgnore]
         public AsyncAutoResetEvent DeltaReceived { get; }
 
-        [Uno.EqualityIgnore]
         public AsyncAutoResetEvent DeltaDistributed { get; }
 
-        [Uno.EqualityIgnore]
         public AsyncAutoResetEvent TxReceived { get; }
 
-        [Uno.EqualityIgnore]
         public AsyncAutoResetEvent BlockReceived { get; }
 
         public DateTimeOffset LastReceived { get; private set; }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -253,7 +253,7 @@ namespace Libplanet.Net
 
             foreach (Peer peer in peers)
             {
-                if (peer.PublicKey == publicKey)
+                if (peer.PublicKey.Equals(publicKey))
                 {
                     continue;
                 }
@@ -1000,7 +1000,7 @@ namespace Libplanet.Net
                     "BlockHashes doesn't have sender address.");
             }
 
-            Peer peer = _peers.Keys.FirstOrDefault(p => p.Address == from);
+            Peer peer = _peers.Keys.FirstOrDefault(p => p.Address.Equals(from));
             if (peer == null)
             {
                 _logger.Information(
@@ -1060,7 +1060,7 @@ namespace Libplanet.Net
             );
 
             BlockChain<T> synced;
-            if (tip is null || branchPoint == tip.Hash)
+            if (tip is null || branchPoint.Equals(tip.Hash))
             {
                 _logger.Debug("it doesn't need fork.");
                 synced = blockChain;
@@ -1247,7 +1247,7 @@ namespace Libplanet.Net
                     "TxIds doesn't have sender address.");
             }
 
-            Peer peer = _peers.Keys.FirstOrDefault(p => p.Address == from);
+            Peer peer = _peers.Keys.FirstOrDefault(p => p.Address.Equals(from));
             if (peer == null)
             {
                 _logger.Information(
@@ -1343,12 +1343,12 @@ namespace Libplanet.Net
 
         private bool IsUnknownPeer(Peer sender)
         {
-            if (_peers.Keys.All(p => sender.PublicKey != p.PublicKey))
+            if (_peers.Keys.All(p => !sender.PublicKey.Equals(p.PublicKey)))
             {
                 return true;
             }
 
-            if (_dealers.Keys.All(a => sender.Address != a))
+            if (_dealers.Keys.All(a => !sender.Address.Equals(a)))
             {
                 return true;
             }

--- a/Libplanet/Nonce.cs
+++ b/Libplanet/Nonce.cs
@@ -9,10 +9,8 @@ namespace Libplanet
     /// An arbitrary <see cref="byte"/>s that determines a
     /// <see cref="Hashcash.Stamp"/>.
     /// </summary>
-    #pragma warning disable CS0282
-    [Uno.GeneratedEquality]
-    public partial struct Nonce
-    #pragma warning restore CS0282
+    [Equals]
+    public struct Nonce
     {
         private ImmutableArray<byte> _byteArray;
 
@@ -35,14 +33,6 @@ namespace Libplanet
             }
 
             _byteArray = nonce.ToImmutableArray();
-
-            #pragma warning disable CS0103
-            /* Suppress CS0171.
-            See also https://github.com/nventive/Uno.CodeGen/pull/91
-            */
-            _computedHashCode = null;
-            _computedKeyHashCode = null;
-            #pragma warning restore CS0103
         }
 
         /// <summary>
@@ -51,7 +41,6 @@ namespace Libplanet
         /// <remarks>It is immutable.  For a mutable array, use
         /// <see cref="ToByteArray()"/> method instead.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        [Uno.EqualityKey]
         public ImmutableArray<byte> ByteArray
         {
             get

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -172,7 +172,7 @@ namespace Libplanet.Store
             {
                 foreach (var idx in IterateIndex(@namespace))
                 {
-                    if (!found && idx == hash)
+                    if (!found && idx.Equals(hash))
                     {
                         found = true;
                     }

--- a/Libplanet/Store/TransactionSet.cs
+++ b/Libplanet/Store/TransactionSet.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Store
                     throw new KeyNotFoundException();
                 }
 
-                Trace.Assert(tx?.Id == key);
+                Trace.Assert(key.Equals(tx?.Id));
                 tx?.Validate();
 
                 return tx;
@@ -56,7 +56,7 @@ namespace Libplanet.Store
 
             set
             {
-                if (value.Id != key)
+                if (!key.Equals(value.Id))
                 {
                     throw new InvalidTxIdException(
                         value.Id,

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -11,7 +11,6 @@ using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
-using Uno.Extensions;
 
 namespace Libplanet.Tx
 {
@@ -470,7 +469,7 @@ namespace Libplanet.Tx
         {
             int seed =
                 BitConverter.ToInt32(blockHash.ToByteArray(), 0) ^
-                (Signature.Empty() ? 0 : BitConverter.ToInt32(Signature, 0));
+                (Signature.Any() ? BitConverter.ToInt32(Signature, 0) : 0);
             IAccountStateDelta states = previousStates;
             foreach (T action in Actions)
             {

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -16,11 +16,9 @@ namespace Libplanet.Tx
     /// (See also <see cref="Size"/> constant.)</para>
     /// </summary>
     /// <seealso cref="Transaction{T}.Id"/>
-    #pragma warning disable CS0282
     [Serializable]
-    [Uno.GeneratedEquality]
-    public partial struct TxId : ISerializable
-    #pragma warning restore CS0282
+    [Equals]
+    public struct TxId : ISerializable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="TxId"/> takes.
@@ -59,14 +57,6 @@ namespace Libplanet.Tx
             }
 
             _byteArray = txid.ToImmutableArray();
-
-            #pragma warning disable CS0103
-            /* Suppress CS0171.
-            See also https://github.com/nventive/Uno.CodeGen/pull/91
-            */
-            _computedHashCode = null;
-            _computedKeyHashCode = null;
-            #pragma warning restore CS0103
         }
 
         public TxId(
@@ -83,7 +73,6 @@ namespace Libplanet.Tx
         /// <remarks>It is immutable.  For a mutable array, use
         /// <see cref="ToByteArray()"/> method instead.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        [Uno.EqualityKey]
         public ImmutableArray<byte> ByteArray
         {
             get

--- a/README.md
+++ b/README.md
@@ -66,17 +66,19 @@ In the near future, we are going to submit it to [Unity Asset Store] too.
 Build
 -----
 
-You could build a *Libplanet.dll* assembly from the source code.
+You could build a *Libplanet.dll* and *Libplanet.Stun.dll* assemblies
+from the source code.
 
 The following command installs dependencies (required library packages) and
 builds the whole Libplanet solution:
 
 ~~~~~~~~ bash
-msbuild -r
+dotnet build
 ~~~~~~~~
 
-Note that `msbuild` is distributed together with Mono framework or
-Visual Studio.
+Note that `dotnet` command is distributed together with [.NET Core] SDK.
 
 If you'd like to contribute code to the Libplanet project in earnest,
 please read our [contributor guide](CONTRIBUTING.md).
+
+[.NET Core]: https://dot.net/

--- a/hooks/validate-release
+++ b/hooks/validate-release
@@ -16,9 +16,9 @@ fi
 
 version="$1"
 
-if [[ "$version" = *-dev ]]; then
+if [[ "$version" = *-* ]]; then
   {
-    echo "$0: error: the version number must not end with -dev suffix:"
+    echo "$0: error: the version number must not end with any suffix:"
     echo "  $version"
   } > /dev/stderr
   exit 1
@@ -27,15 +27,15 @@ fi
 csproj="$root/Libplanet/Libplanet.csproj"
 if command -v xmllint > /dev/null; then
   csproj_version="$(xmllint \
-    --xpath './Project/PropertyGroup/Version/text()' \
+    --xpath './Project/PropertyGroup/VersionPrefix/text()' \
     "$csproj")"
 else
-  version_regex='<Version>([0-9]+\.[0-9]+\.[0-9]+)</Version>'
-  if [[ "$(grep '<Version>[^>]*</Version>' "$csproj")" =~ $version_regex ]]
+  regex='<VersionPrefix>([0-9]+\.[0-9]+\.[0-9]+)</VersionPrefix>'
+  if [[ "$(grep '<VersionPrefix>[^>]*</VersionPrefix>' "$csproj")" =~ $regex ]]
   then
     csproj_version="${BASH_REMATCH[1]}"
   else
-    echo "$0: error: failed to find <Version> tag from $csproj file" \
+    echo "$0: error: failed to find <VersionPrefix> tag from $csproj file" \
       > /dev/stderr
     exit 1
   fi


### PR DESCRIPTION
This patch replaces Uno.CodeGen, a barrier to adopting .NET Core, with [Equals.Fody], and makes the build process depends on `dotnet` CLI instead of `msbuild`.  (Of course, `msbuild` also still works.)

Pros of .NET Core are:

 -  Behaviors across platforms are more consistent than .NET Framework v. Mono.
 -  Both tests (`Libplanet.Tests` & `Libplanet.Stun.Tests`) can be run at a time on CLI (`dotnet test`).
 -  Tests can be `--filter`ed on CLI as well (whereas xunit.runner.msbuild is only able to run the whole tests.)

Pros of Equals.Fody:

 -  As it rewrites code at IL level, types don't have to be `partial`.
     -  So it's entirely free from the bug #82 without any tricks.
     -  We don't need to add lines of preprocessor directives to suppress warnings.
 -  Works with .NET Framework, Mono, and .NET Core.

Also note that there are some limitations on Equals.Fody when it's compared to Uno.CodeGen:

 -  It doesn't work with generic `struct`s (and generic `class`es?  Not sure).  See `HashDigest<T>` as well; its equality methods are written by hand.
 -  Fields to compare are opt-in by default and can be opt-out by annotating `[IgnoreDuringEquals]` attribute.  This leads types with one identity property and other many properties to look dirty.  See `Block<T>`for example; its properties all have an `[IgnoreDuringEquals]` attribute except for the `Hash` property.
 -  Apparently `operator ==` and `operator !=` are not generated.

[Equals.Fody]: https://github.com/Fody/Equals