### PR TITLE
Fix Swarm broadcasting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   - os: osx
     osx_image: xcode10.1
     language: csharp
-    dotnet: 2.2.106
+    dotnet: 2.2.203
     mono: none
     cache:
       directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,11 +172,12 @@ script:
 - |
   if [[ "$TRAVIS_OS_NAME" = "windows" && "$CODECOV_TOKEN" != "" ]]; then
     dotnet build -c Debug
+    dotnet build-server shutdown
     solution_abspath="$(cygpath -w "$(pwd)"/Libplanet.sln)"
     dotCover_config="$(cat .travis.dotCover.xml)"
     echo "${dotCover_config//\$SOLUTION/$solution_abspath}" \
       > dotCover.xml
-    travis_wait dotCover.exe cover dotCover.xml
+    travis_wait 60 dotCover.exe cover dotCover.xml /p:UseSharedCompilation=false
     # Upload report to Codecov.io
     codecov.exe -f Libplanet.cov.xml -t "$CODECOV_TOKEN"
   fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,14 +32,11 @@ To be released.
     default behavior of `object` class.  [[#216]]
  -  Also, `Swarm` class now does not implement `IDisposable` too. Thus
     `Swarm.Dispose()` was removed too. [[#218]]
- -  `Swarm` became to use a queue to broadcast own message. [[#218]]
-     - The methods that broadcast message now aren't async. So they are renamed
-       as below.
-       - `Swarm.BroadcastBlocksAsync()` → `Swarm.BroadcastBlocks()`
-       - `Swarm.BroadcastTxsAsync()` → `Swarm.BroadcastTxs()`
-     - `Swarm` became to receive a `linger` on its constructor. The linger is
-       used to determine how long to wait for a pending message when stopping
-       the swarm.
+ -  `Swarm` became to use a queue to maintain internal messages.  [[#218]]
+     -  The broadcasting methods are no more `async`, so they are renamed
+        as below.
+        -  `Swarm.BroadcastBlocksAsync()` → `Swarm.BroadcastBlocks()`
+        -  `Swarm.BroadcastTxsAsync()` → `Swarm.BroadcastTxs()`
  -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and
     related classes method parameters and field types have changed accordingly.
  -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]
@@ -67,6 +64,9 @@ To be released.
  -  `BlockPolicy<T>` constructor became to receive the `minimumDifficulty`
     and the mining `difficultyBoundDivisor`.  [[#213]]
  -  Added `BlockChain<T>.UnstageTransactions()` method.  [[#223]]
+ -  `Swarm` constructor became to receive a `linger` (or `millisecondsLinger`)
+    parameter.  This purposes to determine how long to wait for pending
+    messages when a `Swarm` instance is requested to terminate.
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ To be released.
  -  `Swarm` class now does not implement `IEquatable<Swarm>` anymore and
     its `Equals(object)` method and `GetHashCode()` method became to have
     default behavior of `object` class.  [[#216]]
+ -  also, `Swarm` class now does not implement `IDisposable` too. thus
+    `Swarm.Dispose()` was removed too.
  -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and
     related classes method parameters and field types have changed accordingly.
  -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ To be released.
     default behavior of `object` class.  [[#216]]
  -  Also, `Swarm` class now does not implement `IDisposable` too. Thus
     `Swarm.Dispose()` was removed too. [[#218]]
- -  `Swarm` became to use queue to broadcast own message. [[#218]]
+ -  `Swarm` became to use a queue to broadcast own message. [[#218]]
      - The methods that broadcast message now aren't async. So they are renamed
        as below.
        - `Swarm.BroadcastBlocksAsync()` → `Swarm.BroadcastBlocks()`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,14 +30,14 @@ To be released.
  -  `Swarm` class now does not implement `IEquatable<Swarm>` anymore and
     its `Equals(object)` method and `GetHashCode()` method became to have
     default behavior of `object` class.  [[#216]]
- -  also, `Swarm` class now does not implement `IDisposable` too. thus
+ -  Also, `Swarm` class now does not implement `IDisposable` too. Thus
     `Swarm.Dispose()` was removed too. [[#218]]
  -  `Swarm` became to use queue to broadcast own message. [[#218]]
-     - The methods that broadcast message now aren't async. so they are renamed
+     - The methods that broadcast message now aren't async. So they are renamed
        as below.
        - `Swarm.BroadcastBlocksAsync()` → `Swarm.BroadcastBlocks()`
        - `Swarm.BroadcastTxsAsync()` → `Swarm.BroadcastTxs()`
-     - `Swarm` became to receive a `linger` on its constructor. the linger is
+     - `Swarm` became to receive a `linger` on its constructor. The linger is
        used to determine how long to wait for a pending message when stopping
        the swarm.
  -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,15 @@ To be released.
     its `Equals(object)` method and `GetHashCode()` method became to have
     default behavior of `object` class.  [[#216]]
  -  also, `Swarm` class now does not implement `IDisposable` too. thus
-    `Swarm.Dispose()` was removed too.
+    `Swarm.Dispose()` was removed too. [[#218]]
+ -  `Swarm` became to use queue to broadcast own message. [[#218]]
+     - The methods that broadcast message now aren't async. so they are renamed
+       as below.
+       - `Swarm.BroadcastBlocksAsync()` → `Swarm.BroadcastBlocks()`
+       - `Swarm.BroadcastTxsAsync()` → `Swarm.BroadcastTxs()`
+     - `Swarm` became to receive a `linger` on its constructor. the linger is
+       used to determine how long to wait for a pending message when stopping
+       the swarm.
  -  The type of `Block<T>.Difficulty` is changed to `long` instead of `int`, and
     related classes method parameters and field types have changed accordingly.
  -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]
@@ -119,6 +127,7 @@ To be released.
 [#215]: https://github.com/planetarium/libplanet/pull/215
 [#216]: https://github.com/planetarium/libplanet/pull/216
 [#217]: https://github.com/planetarium/libplanet/pull/217
+[#218]: https://github.com/planetarium/libplanet/pull/218
 [#223]: https://github.com/planetarium/libplanet/pull/223
 [#231]: https://github.com/planetarium/libplanet/pull/231
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -166,11 +166,11 @@ namespace Libplanet.Tests.Net
                         Log.Debug(
                             $"Block mined. " +
                             $"[Swarm: {swarm.Address}, Block: {block.Hash}]");
-                        await swarm.BroadcastBlocksAsync(new[] { block });
+                        swarm.BroadcastBlocks(new[] { block });
                         await Task.Delay(delay);
                     }
 
-                    await swarm.BroadcastBlocksAsync(new[] { chain.Last() });
+                    swarm.BroadcastBlocks(new[] { chain.Last() });
                     Log.Debug("Mining complete.");
                 });
             }
@@ -550,7 +550,7 @@ namespace Libplanet.Tests.Net
                 await EnsureExchange(swarmA, swarmC);
                 await EnsureExchange(swarmB, swarmC);
 
-                await swarmA.BroadcastTxsAsync(new[] { tx });
+                swarmA.BroadcastTxs(new[] { tx });
 
                 await swarmC.TxReceived.WaitAsync();
                 await swarmB.TxReceived.WaitAsync();
@@ -608,7 +608,7 @@ namespace Libplanet.Tests.Net
                 await EnsureExchange(swarmA, swarmC);
                 await EnsureExchange(swarmB, swarmC);
 
-                await swarmB.BroadcastBlocksAsync(new[] { chainB.Last() });
+                swarmB.BroadcastBlocks(new[] { chainB.Last() });
 
                 await swarmC.BlockReceived.WaitAsync();
                 await swarmA.BlockReceived.WaitAsync();
@@ -619,7 +619,7 @@ namespace Libplanet.Tests.Net
                 // than chainA
                 Assert.NotEqual(chainB.AsEnumerable(), chainA);
 
-                await swarmA.BroadcastBlocksAsync(new[] { chainA.Last() });
+                swarmA.BroadcastBlocks(new[] { chainA.Last() });
 
                 await swarmB.BlockReceived.WaitAsync();
                 await swarmC.BlockReceived.WaitAsync();

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -305,7 +305,9 @@ namespace Libplanet.Tests.Net
 
             a.CopyTo(peers, 1);
 
-            Assert.Equal(new Peer[] { null, b.AsPeer, c.AsPeer }, peers);
+            Assert.Equal(
+                new HashSet<Peer> { null, b.AsPeer, c.AsPeer },
+                peers.ToHashSet());
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -401,7 +401,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task CanBeCancelled()
+        public async Task Cancel()
         {
             Swarm swarm = _swarms[0];
             BlockChain<DumbAction> chain = _blockchains[0];
@@ -414,7 +414,7 @@ namespace Libplanet.Tests.Net
             );
 
             cts.Cancel();
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+            await task;
             Assert.False(swarm.Running);
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -798,7 +798,10 @@ namespace Libplanet.Tests.Net
             var actualStates = new List<BlockDownloadState>();
             var progress = new Progress<BlockDownloadState>(state =>
             {
-                actualStates.Add(state);
+                lock (actualStates)
+                {
+                    actualStates.Add(state);
+                }
             });
 
             try

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -77,7 +77,7 @@ namespace Libplanet.Tests.Net
 
             foreach (Swarm s in _swarms)
             {
-                s.Dispose();
+                s.StopAsync().Wait();
             }
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -24,6 +24,8 @@ namespace Libplanet.Tests.Net
 {
     public class SwarmTest : IDisposable
     {
+        private const int Timeout = 60 * 1000;
+
         private readonly FileStoreFixture _fx1;
         private readonly FileStoreFixture _fx2;
         private readonly FileStoreFixture _fx3;
@@ -81,7 +83,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanNotStartTwice()
         {
             Swarm swarm = _swarms[0];
@@ -98,7 +100,7 @@ namespace Libplanet.Tests.Net
             await swarm.StopAsync();
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanStop()
         {
             Swarm swarm = _swarms[0];
@@ -114,7 +116,7 @@ namespace Libplanet.Tests.Net
             await task;
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanWaitForRunning()
         {
             Swarm swarm = _swarms[0];
@@ -142,7 +144,7 @@ namespace Libplanet.Tests.Net
             Assert.False(swarm.Running);
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task BroadcastWhileMining()
         {
             Swarm a = _swarms[0];
@@ -208,7 +210,7 @@ namespace Libplanet.Tests.Net
                 chainB.AsEnumerable().ToHashSet());
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanExchangePeer()
         {
             Swarm a = _swarms[0];
@@ -265,7 +267,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task WorksAsCollection()
         {
             Swarm a = _swarms[0];
@@ -310,7 +312,7 @@ namespace Libplanet.Tests.Net
                 peers.ToHashSet());
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task DetectAppProtocolVersion()
         {
             var a = new Swarm(
@@ -360,7 +362,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task HandleDifferentAppProtocolVersion()
         {
             var isCalled = false;
@@ -398,7 +400,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanBeCancelled()
         {
             Swarm swarm = _swarms[0];
@@ -416,7 +418,7 @@ namespace Libplanet.Tests.Net
             Assert.False(swarm.Running);
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanGetBlock()
         {
             Swarm swarmA = _swarms[0];
@@ -478,7 +480,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task GetTx()
         {
             Swarm swarmA = _swarms[0];
@@ -520,7 +522,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task BroadcastTx()
         {
             Swarm swarmA = _swarms[0];
@@ -569,7 +571,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanBroadcastBlock()
         {
             Swarm swarmA = _swarms[0];
@@ -638,7 +640,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public void ThrowArgumentExceptionInConstructor()
         {
             Assert.Throws<ArgumentNullException>(() =>
@@ -662,7 +664,7 @@ namespace Libplanet.Tests.Net
             });
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public void CanResolveEndPoint()
         {
             var expected = new DnsEndPoint("1.2.3.4", 5678);
@@ -676,7 +678,7 @@ namespace Libplanet.Tests.Net
             Assert.Equal(expected, s.AsPeer.EndPoint);
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task CanStopGracefullyWhileStarting()
         {
             Swarm a = _swarms[0];
@@ -689,7 +691,7 @@ namespace Libplanet.Tests.Net
             await Task.WhenAll(a.StopAsync(), t);
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task AsPeerThrowSwarmExceptionWhenUnbound()
         {
             Swarm swarm = new Swarm(
@@ -746,7 +748,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task InitialBlockDownload()
         {
             Swarm minerSwarm = _swarms[0];
@@ -779,7 +781,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task Preload()
         {
             Swarm minerSwarm = _swarms[0];

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -519,7 +519,9 @@ namespace Libplanet.Net
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Unexpected exception occured.");
+                _logger.Error(
+                    e,
+                    "An unexpected exception occured during StartAsync()");
                 throw;
             }
             finally
@@ -774,7 +776,7 @@ namespace Libplanet.Net
                 {
                     _logger.Error(
                         e,
-                        $"Unexpected exception occured. try again"
+                        "An unexpected exception occured. try again..."
                     );
                 }
             }
@@ -919,7 +921,12 @@ namespace Libplanet.Net
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Unexpected exception occured.");
+                    _logger.Error(
+                        e,
+#pragma warning disable MEN002 // Line is too long
+                        "An unexpected exception occured during ReceiveMessageAsync()"
+#pragma warning restore MEN002 // Line is too long
+                    );
                     throw;
                 }
             }
@@ -1684,7 +1691,10 @@ namespace Libplanet.Net
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "An unexpected exception occured.");
+                _logger.Error(
+                    ex,
+                    "An unexpected exception occured during DoBroadcast()"
+                );
             }
 
             _logger.Debug($"broadcasted: {msg}");

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -106,9 +106,10 @@ namespace Libplanet.Net
             _privateKey = privateKey
                 ?? throw new ArgumentNullException(nameof(privateKey));
             _dialTimeout = dialTimeout;
-            _peers = new Dictionary<Peer, DateTimeOffset>();
-            _removedPeers = new Dictionary<Peer, DateTimeOffset>();
-            LastSeenTimestamps = new Dictionary<Peer, DateTimeOffset>();
+            _peers = new ConcurrentDictionary<Peer, DateTimeOffset>();
+            _removedPeers = new ConcurrentDictionary<Peer, DateTimeOffset>();
+            LastSeenTimestamps =
+                new ConcurrentDictionary<Peer, DateTimeOffset>();
 
             DateTimeOffset now = createdAt.GetValueOrDefault(
                 DateTimeOffset.UtcNow);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1362,8 +1362,17 @@ namespace Libplanet.Net
                 _logger.Debug($"Trying to apply the delta[{delta}]...");
                 await ApplyDelta(delta, cancellationToken);
 
-                LastReceived = delta.Timestamp;
-                LastSeenTimestamps[delta.Sender] = delta.Timestamp;
+                bool alreadyReceived =
+                    LastSeenTimestamps.TryGetValue(
+                        delta.Sender,
+                        out DateTimeOffset existingTimestamp) &&
+                    existingTimestamp > delta.Timestamp;
+
+                if (!alreadyReceived)
+                {
+                    LastReceived = delta.Timestamp;
+                    LastSeenTimestamps[delta.Sender] = delta.Timestamp;
+                }
 
                 DeltaReceived.Set();
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -515,7 +515,7 @@ namespace Libplanet.Net
                     tasks.Add(RefreshPermissions(workerCancellationToken));
                 }
 
-                await Task.WhenAll(tasks);
+                await Task.WhenAny(tasks);
             }
             catch (Exception e)
             {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -27,7 +27,7 @@ using Serilog.Events;
 
 namespace Libplanet.Net
 {
-    public class Swarm : ICollection<Peer>, IDisposable
+    public class Swarm : ICollection<Peer>
     {
         private static readonly TimeSpan TurnAllocationLifetime =
             TimeSpan.FromSeconds(777);
@@ -389,11 +389,6 @@ namespace Libplanet.Net
             }
 
             _logger.Debug("Stopped.");
-        }
-
-        public void Dispose()
-        {
-            StopAsync().Wait();
         }
 
         public IEnumerator<Peer> GetEnumerator()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1333,13 +1333,16 @@ namespace Libplanet.Net
                     return;
                 }
 
-                delta = new PeerSetDelta(
-                    delta.Sender,
-                    delta.Timestamp,
-                    delta.AddedPeers.Add(sender),
-                    delta.RemovedPeers,
-                    delta.ExistingPeers
-                );
+                if (!delta.RemovedPeers.Contains(delta.Sender))
+                {
+                    delta = new PeerSetDelta(
+                        delta.Sender,
+                        delta.Timestamp,
+                        delta.AddedPeers.Add(sender),
+                        delta.RemovedPeers,
+                        delta.ExistingPeers
+                    );
+                }
             }
 
             if (IsDifferentProtocolVersion(sender))


### PR DESCRIPTION
This PR changes the broadcasting mechanism from TAP to `NetMQPoller` based to prevent unexpected behavior on multi threading environment. to accomplish it, it made some interface changes that convert some asynchronous methods to sync methods.

Also, it adds time out on the unit tests to investigate the test freezing and fixes some problems in CI environment.