### PR TITLE
Fix “Invalid IL code” runtime error on Mono (hence also on Unity)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ script:
   fi
 
 # Run unit tests
-- dotnet test -c Release -v n
+- travis_wait dotnet test -c Release -v n
 
 # Run unit tests with coverage report
 - |
@@ -170,7 +170,7 @@ script:
     dotCover_config="$(cat .travis.dotCover.xml)"
     echo "${dotCover_config//\$SOLUTION/$solution_abspath}" \
       > dotCover.xml
-    dotCover.exe cover dotCover.xml
+    travis_wait dotCover.exe cover dotCover.xml
     # Upload report to Codecov.io
     codecov.exe -f Libplanet.cov.xml -t "$CODECOV_TOKEN"
   fi

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,11 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' ">
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,11 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' ">
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Libplanet/FodyWeavers.xml
+++ b/Libplanet/FodyWeavers.xml
@@ -3,5 +3,5 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
 
-  <Equals />
+  <Equals4 />
 </Weavers>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -60,7 +60,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="AsyncEnumerator" Version="2.2.1" />
     <PackageReference Include="Bencodex" Version="0.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
-    <PackageReference Include="Equals.Fody" Version="1.9.3" />
+    <PackageReference Include="Equals4.Fody" Version="1.9.6" />
     <PackageReference Include="Fody" Version="4.2.1">
       <!-- Fody 5.0.0 dropped MSBuild 15 support. -->
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This patch fixes <q>Invalid IL code</q> runtime error on Mono (hence also on Unity).

The bug in itself was already fixed in upstream Equals.Fody (see Fody/Equals#81).  However, the fixed version (1.9.6) depends on Fody 5 which dropped MSBuild 15 support (see also Fody/Fody#679).  Our problem is that MSBuild 15 is not widely adopted yet (the latest stable release of .NET Core 2.2 for macOS lacks MSBuild 16, for instance).

So I forked Equals.Fody and make the fork (named [Equals4.Fody][1]) to cherry-pick the recent bug fixes without upgrading Fody to 5.

This patch also makes the tests to run on Mono besides .NET Core.

[1]: https://github.com/planetarium/Equals4.Foldy