### PR TITLE
Use upstream Equals.Fody & fix CI issues

### DIFF
--- a/.travis.dotCover.xml
+++ b/.travis.dotCover.xml
@@ -4,7 +4,12 @@ Travis CI executes dotCover.  $SOLUTION is a placeholder
 to be replaced using sed. -->
 <CoverageParams>
   <TargetExecutable>C:\Program Files\dotnet\dotnet.exe</TargetExecutable>
-  <TargetArguments>test -c Debug -v n $SOLUTION</TargetArguments>
+  <TargetArguments>test -c Debug -v n $SOLUTION --filter RequireTurnServer!=true</TargetArguments>
+  <!--
+  FIXME: For unknown reason, on Travis CI tests depending on TURN_SERVER_URL
+         seems not terminated or to take too long time.  We should diagnose
+         this and make the CI to run these tests too.
+  -->
   <TargetWorkingDir></TargetWorkingDir>
   <ReportType>DetailedXML</ReportType>
   <Output>Libplanet.cov.xml</Output>

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       directories:
       - $HOME/.nuget/packages
       - $HOME/AppData/Local/NuGet/v3-cache
+      - $HOME/.ChocoCache
     filter_secrets: false  # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
 
 solution: Libplanet.sln
@@ -60,6 +61,8 @@ install:
     brew update
     brew cask install powershell
   elif [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
+    choco config set cacheLocation "$(cygpath -w "$HOME/.ChocoCache")"
+
     # .NET Core SDK 2.2+
     choco install dotnetcore-sdk
     dotnet --info

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,8 +162,11 @@ script:
       -c Release
   fi
 
-# Run unit tests
-- travis_wait dotnet test -c Release -v n
+# Run unit tests (without TURN server)
+- dotnet test -c Release -v n --filter "RequireTurnServer!=true"
+# FIXME: For unknown reason, on Travis CI tests depending on TURN_SERVER_URL
+#        seems not terminated or to take too long time.  We should diagnose
+#        this and make the CI to run these tests too.
 
 # Run unit tests with coverage report
 - |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,20 @@ To build and run unit tests at a time execute the below command:
 [Xunit]: https://xunit.github.io/
 
 
+### `TURN_SERVER_URL`
+
+Some tests depend on a TURN server.  If `TURN_SERVER_URL` environment variable
+is set (the value looks like `turn://user:password@host:3478/`)
+these tests also run.  Otherwise, these tests are skipped.
+
+FYI there are several TURN implementations like [Coturn] and [gortc/turn],
+or cloud offers like [Xirsys].
+
+[Coturn]: https://github.com/coturn/coturn
+[gortc/turn]: https://github.com/gortc/turn
+[Xirsys]: https://xirsys.com/
+
+
 Style convention
 ----------------
 

--- a/Libplanet.Tests/Net/IceServerTest.cs
+++ b/Libplanet.Tests/Net/IceServerTest.cs
@@ -8,6 +8,7 @@ namespace Libplanet.Tests.Net
 {
     public class IceServerTest
     {
+        [Trait("RequireTurnServer", "true")]
         [FactOnlyTurnAvailable]
         public async Task CreateTurnClient()
         {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -701,6 +701,7 @@ namespace Libplanet.Tests.Net
             Assert.Equal(swarm.EndPoint, swarm.AsPeer.EndPoint);
         }
 
+        [Trait("RequireTurnServer", "true")]
         [FactOnlyTurnAvailable]
         public async Task ExchangeWithIceServer()
         {

--- a/Libplanet/FodyWeavers.xml
+++ b/Libplanet/FodyWeavers.xml
@@ -3,5 +3,5 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
 
-  <Equals4 />
+  <Equals />
 </Weavers>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -60,9 +60,8 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="AsyncEnumerator" Version="2.2.1" />
     <PackageReference Include="Bencodex" Version="0.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
-    <PackageReference Include="Equals4.Fody" Version="1.9.6" />
-    <PackageReference Include="Fody" Version="4.2.1">
-      <!-- Fody 5.0.0 dropped MSBuild 15 support. -->
+    <PackageReference Include="Equals.Fody" Version="1.9.6" />
+    <PackageReference Include="Fody" Version="5.0.1-beta.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">


### PR DESCRIPTION
- [As the upstream Fody 5.0.1-beta.2 started to support MSBuild 15 again][1], I changed Libplanet to use it instead of our local fork (see also the previous patch #219).
- As Chocolatey packages are installed for every build on Travis CI, I made them cached.
- For unknown reason, tests that depend on `TURN_SERVER_URL` take strangely long time (currently the master builds fails due to timeout), so I temporarily made them skipped on Travis CI.  However, we should turn on these tests again eventually.

[1]: https://github.com/Fody/Equals/issues/81#issuecomment-486672975