### PR TITLE
Add BlockChain<T>.UnstageTransactions()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@ To be released.
  -  Added `HashDigest.Satisfies()` method.  [[#213]]
  -  `BlockPolicy<T>` constructor became to receive the `minimumDifficulty`
     and the mining `difficultyBoundDivisor`.  [[#213]]
+ -  Added `BlockChain<T>.UnstageTransactions()` method.  [[#223]]
 
 ### Behavioral changes
 
@@ -115,6 +116,7 @@ To be released.
 [#215]: https://github.com/planetarium/libplanet/pull/215
 [#216]: https://github.com/planetarium/libplanet/pull/216
 [#217]: https://github.com/planetarium/libplanet/pull/217
+[#223]: https://github.com/planetarium/libplanet/pull/223
 
 
 Version 0.2.2

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -67,7 +67,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanStateTransactions()
+        public void StageTransactions()
         {
             Assert.Empty(_blockChain.Transactions);
             var txs = new HashSet<Transaction<DumbAction>>()
@@ -80,6 +80,23 @@ namespace Libplanet.Tests.Blockchain
                 txs,
                 _blockChain.Transactions.Values.ToHashSet()
             );
+        }
+
+        [Fact]
+        public void UnstageTransactions()
+        {
+            Assert.Empty(_blockChain.Transactions);
+            var txs = new HashSet<Transaction<DumbAction>>()
+            {
+                _fx.Transaction1,
+                _fx.Transaction2,
+            };
+            _blockChain.StageTransactions(txs);
+            Assert.Equal(
+                txs.Select(tx => tx.Id).ToList(),
+                _blockChain.Store.IterateStagedTransactionIds());
+            _blockChain.UnstageTransactions(txs);
+            Assert.Empty(_blockChain.Store.IterateStagedTransactionIds());
         }
 
         [Fact]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -265,16 +265,35 @@ namespace Libplanet.Blockchain
         public void Append(Block<T> block, DateTimeOffset currentTime) =>
             Append(block, currentTime, render: true);
 
-        public void StageTransactions(ISet<Transaction<T>> txs)
+        /// <summary>
+        /// Adds <paramref name="transactions"/> to the pending list so that
+        /// a next <see cref="Block{T}"/> to be mined contains these
+        /// <paramref name="transactions"/>.
+        /// </summary>
+        /// <param name="transactions">
+        /// <see cref="Transaction{T}"/>s to add to the pending list.</param>
+        public void StageTransactions(ISet<Transaction<T>> transactions)
         {
-            foreach (Transaction<T> tx in txs)
+            foreach (Transaction<T> tx in transactions)
             {
                 Transactions[tx.Id] = tx;
             }
 
             Store.StageTransactionIds(
-                txs.Select(tx => tx.Id).ToImmutableHashSet()
+                transactions.Select(tx => tx.Id).ToImmutableHashSet()
             );
+        }
+
+        /// <summary>
+        /// Removes <paramref name="transactions"/> from the pending list.
+        /// </summary>
+        /// <param name="transactions"><see cref="Transaction{T}"/>s
+        /// to remove from the pending list.</param>
+        /// <seealso cref="StageTransactions"/>
+        public void UnstageTransactions(ISet<Transaction<T>> transactions)
+        {
+            Store.UnstageTransactionIds(
+                transactions.Select(tx => tx.Id).ToImmutableHashSet());
         }
 
         public Block<T> MineBlock(


### PR DESCRIPTION
This patch adds `BlockChain<T>.UnstageTransactions()` method.