### PR TITLE
Rename IBlockPolicyExtension to BlockPolicyExtension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,8 +20,6 @@ To be released.
     `IBlockPolicy<T>.ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)`
     method.  [[#210]]
  -  Removed `IBlockPolicy<T>.ValidateBlocks()` method.  [[#210]]
- -  Added `IBlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
-    IReadOnlyList<Block<T>>, DateTimeOffset)` method.  [[#210]]
  -  `BlockChain<T>[int]` became to throw `ArgumentOutOfRangeException` instead
     of `IndexOutOfRangeException`.  [[#210]]
  -  Added `GetAddressesMask(HashDigest<SHA256>)` method to `IStore` interface
@@ -49,6 +47,8 @@ To be released.
     [[#204]], [[#206]]
  -  Added `BlockDownloadState` class to represent a block downloading state.
     [[#204]], [[#206]]
+ -  Added `BlockPolicyExtension.ValidateBlocks<T>(IBlockPolicy<T>,
+    IReadOnlyList<Block<T>>, DateTimeOffset)` method.  [[#210]]
  -  Added `Transaction<T>.EvaluateActionsGradually(HashDigest<SHA256>, long,
     IAccountStateDelta, Address, bool)` method.  [[#31], [#212]]
  -  Added `Block<T>.EvaluateActionsPerTx(AccountStateGetter)` method.

--- a/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Blockchain.Policies
     /// the most part) to deal with <see cref="IBlockPolicy{T}"/>.
     /// </summary>
     /// <seealso cref="IBlockPolicy{T}"/>
-    public static class IBlockPolicyExtension
+    public static class BlockPolicyExtension
     {
         /// <summary>
         /// Checks if <paramref name="blocks"/> are invalid, and if that

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Blockchain.Policies
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
-    /// <seealso cref="IBlockPolicyExtension"/>
+    /// <seealso cref="BlockPolicyExtension"/>
     public interface IBlockPolicy<T>
         where T : IAction, new()
     {
@@ -28,7 +28,7 @@ namespace Libplanet.Blockchain.Policies
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
-        /// <seealso cref="IBlockPolicyExtension.ValidateBlocks{T}"/>
+        /// <seealso cref="BlockPolicyExtension.ValidateBlocks{T}"/>
         InvalidBlockException ValidateNextBlock(
             IReadOnlyList<Block<T>> blocks,
             Block<T> nextBlock);


### PR DESCRIPTION
- Renamed `IBlockPolicyExtension` to `BlockPolicyExtension` to fit naming convention.