### PR TITLE
Build docs using GitHub Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,26 @@
+workflow "on push" {
+  on = "push"
+  resolves = ["docs:publish"]
+}
+
+action "docs:build" {
+  uses = "dahlia/actions/docfx@master"
+  env = {
+    MSBUILD_PROJECT = "Libplanet"
+  }
+  args = ["Docs/docfx.json"]
+}
+
+action "docs:publish" {
+  uses = "docker://alpine/git:latest"
+  needs = "docs:build"
+  secrets = [
+    # GHPAGES_SSH_KEY has to contain a base64-encoded private key without
+    # new lines:
+    #   base64 -w0 < ssh_key_file
+    # The key has to be also registered as a deploy key of the repository,
+    # and be allowed write access.
+    "GHPAGES_SSH_KEY"
+  ]
+  runs = ["Docs/publish.sh"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -203,32 +203,6 @@ script:
     rm -f "Libplanet/bin/Release/Libplanet.$version_prefix.nupkg"
   fi
 
-# Build docs using DocFX
-- |
-  if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
-    # As installing Mono on macOS build takes too long time and Travis CI
-    # does not support Docker on macOS build, we skip docs build on macOS.
-    exit 0
-  elif [[ "$TRAVIS_OS_NAME" = "windows" ]]; then
-    powershell -Command "Set-ExecutionPolicy Unrestricted"
-    pwsh=powershell
-  else
-    pwsh=pwsh
-  fi
-  # TODO: Currently DocFX requires .NET Framework 4.6 which means incompatible
-  # with .NET Core but compatible with Mono.  We disabled Mono on Travis CI
-  # to prevent slow build startup (installing Mono on Travis Linux takes longer
-  # than minutes), so here we invoke DocFX using Docker instead.
-  # The current setup makes DocFX unable to resolve types in the framework
-  # as we need to invoke `dotnet recover` first inside the Docker.
-  # FIXME: We'd better have a separate build process for docs other than
-  # Travis CI, e.g., GitHub Actions.
-  $pwsh \
-    -File Docs/build.ps1 \
-    -WorkingDirectory Docs/ \
-    -ExecutionPolicy Bypass
-- '[[ -f Docs/_site/index.html ]]'
-
 # Turn off "set -e" option
 - set +e
 
@@ -250,12 +224,12 @@ deploy:
   file: Libplanet/bin/Release/Libplanet.*.nupkg
   name: "Libplanet $TRAVIS_TAG"
 
-# Upload a .nupkg file to NuGet and publish docs to GitHub Pages
+# Upload a .nupkg file to NuGet
 - provider: script
   on:
     all_branches: true
   skip_cleanup: true
-  script: bash publish.sh && bash Docs/publish.sh
+  script: bash publish.sh
 
 # Adjust the release note on GitHub releases
 after_deploy: |

--- a/Docs/build.ps1
+++ b/Docs/build.ps1
@@ -64,8 +64,8 @@ if (-not (Test-Path "$BaseDir/docfx")) {
 # the native way on Windows, it should be interpreted by Mono VM on other POSIX
 # systems.
 Set-Location $BaseDir
-if (Get-Command mono1 -ErrorAction SilentlyContinue) {
-  mono1 "$BaseDir/docfx/docfx.exe" "$BaseDir/docfx.json" @args
+if (Get-Command mono -ErrorAction SilentlyContinue) {
+  mono "$BaseDir/docfx/docfx.exe" "$BaseDir/docfx.json" @args
 } else {
   $platform = [System.Environment]::OSVersion.Platform;
   $unix = [System.PlatformId]::Unix;

--- a/Docs/publish.sh
+++ b/Docs/publish.sh
@@ -1,8 +1,12 @@
-#!/bin/bash
+#!/bin/ash
 # Publish docs to GitHub Pages.
-# Note that this script is intended to be run by Travis CI.
-if ! (env | grep '^TRAVIS_'); then
-  echo "This script is intended to be run by Travis CI." > /dev/stderr
+# Note that this script is intended to be run by GitHub Actions.
+if ! (env | grep '^GITHUB_'); then
+  {
+    echo "This script is intended to be run by GitHub Actions."
+    echo "You can run GitHub Actions locally using \`act':"
+    echo "  https://github.com/nektos/act"
+  } > /dev/stderr
   exit 1
 fi
 
@@ -12,51 +16,39 @@ b64d() {
   if command -v python > /dev/null; then
     python -m base64 -d
   else
-    base64 --decode
+    base64 -d
   fi
 }
 
-if [[ "$TRAVIS_JOB_NUMBER" != *.1 ]]; then
-  echo "This script is executed by only the first job so that" \
-       "it is run only once." > /dev/stderr
-  exit 0
-fi
-
-if [[ "$TRAVIS_SECURE_ENV_VARS" = "false" ]]; then
-  echo "The secure envrionment variables are disallowed or not configured." \
-    > /dev/stderr
-  exit 0
-fi
-
-if [[ "$GITHUB_SSH_KEY" = "" ]]; then
+if [ "$GHPAGES_SSH_KEY" = "" ]; then
   {
-    echo "The environment variable GITHUB_SSH_KEY is not configured."
-    echo "Configure the secure variable from Travis CI repository settings."
-    echo "https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings"
-    echo "GITHUB_SSH_KEY has to contain a base64-encoded private key without" \
+    echo "The environment variable GHPAGES_SSH_KEY is not configured."
+    echo "Configure GITHUB_TOKEN from GitHub Actions web page."
+    echo "The key has to be also registered as a deploy key of the repository" \
+         ", and be allowed write access."
+    echo "GHPAGES_SSH_KEY has to contain a base64-encoded private key without" \
          "new lines."
   } > /dev/stderr
   exit 0
 fi
 
-echo "$GITHUB_SSH_KEY" | b64d > /tmp/github_id
-if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
-  chmod 600 /tmp/github_id
-fi
+echo "$GHPAGES_SSH_KEY" | b64d > /tmp/github_id
+chmod 600 /tmp/github_id
 export GIT_SSH_COMMAND='ssh -i /tmp/github_id -o "StrictHostKeyChecking no"'
 
-git clone -b gh-pages "git@github.com:$TRAVIS_REPO_SLUG.git" /tmp/gh-pages
+git clone -b gh-pages "git@github.com:$GITHUB_REPOSITORY.git" /tmp/gh-pages
 git -C /tmp/gh-pages config user.name "$(git log -n1 --format=%cn)"
 git -C /tmp/gh-pages config user.email "$(git log -n1 --format=%ce)"
 
-slug="${TRAVIS_TAG:-${TRAVIS_BRANCH}}"
-[[ "$slug" != "" ]]
+slug="$(echo -n "$GITHUB_REF" | sed -e 's/^refs\/\(heads\|tags\)\///g')"
+[ "$slug" != "" ]
 rm -rf "/tmp/gh-pages/$slug"
 cp -r Docs/_site "/tmp/gh-pages/$slug"
 git -C /tmp/gh-pages add "/tmp/gh-pages/$slug"
 
 latest_version="$(git tag --sort -v:refname | head -n1)"
-if [[ "$(git tag -l)" = "" || "$latest_version" = "$TRAVIS_TAG" ]]; then
+tag="$(echo -n "$GITHUB_REF" | sed -e 's/^refs\/tags\///g')"
+if [ "$(git tag -l)" = "" ] || [ "$latest_version" = "$tag" ]; then
   index="$(cat "/tmp/gh-pages/$slug/index.html")"
   {
     echo -n "${index%</title>*}</title>"
@@ -69,7 +61,7 @@ fi
 
 git -C /tmp/gh-pages commit \
   --allow-empty \
-  -m "Publish docs from $TRAVIS_COMMIT"
+  -m "Publish docs from $GITHUB_SHA"
 git -C /tmp/gh-pages push origin gh-pages
 
 rm /tmp/github_id


### PR DESCRIPTION
As currently Mono has not been installed in Travis CI builds, DocFX (which is based on .NET Framework/Mono) has not resolved types in the standard library.  So I removed a process to build docs from Travis CI, and added a GitHub Actions workflow to build docs using DocFX with Mono.