### PR TITLE
Add block hash index which has address states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,10 +22,6 @@ To be released.
  -  Removed `IBlockPolicy<T>.ValidateBlocks()` method.  [[#210]]
  -  `BlockChain<T>[int]` became to throw `ArgumentOutOfRangeException` instead
     of `IndexOutOfRangeException`.  [[#210]]
- -  Added `GetAddressesMask(HashDigest<SHA256>)` method to `IStore` interface
-    and its all implementations.  [[#189], [#197]]
- -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to
-    `PutBlock<T>(Block<T>, Address)`.  [[#189], [#197]]
  -  Removed `KeyEquals()` methods from all classes and structs.  [[#216]]
  -  `Swarm` class now does not implement `IEquatable<Swarm>` anymore and
     its `Equals(object)` method and `GetHashCode()` method became to have

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@ To be released.
  -  `Swarm` constructor became to receive a `linger` (or `millisecondsLinger`)
     parameter.  This purposes to determine how long to wait for pending
     messages when a `Swarm` instance is requested to terminate.
+ -  Added `NamespaceNotFoundException` class.  [[#232]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,12 @@ To be released.
     `PutBlock<T>(Block<T>, Address)`.  [[#189], [#197]]
  -  `Block<T>.Hash` is no longer calculated using the full data of the
     `Transaction<T>`, but is calculated using only the `Transaction<T>.Id`. [[#234]]
+ -  Added `IStore.GetAddressStateBlockHash(string, Address, long)` method.
+    [[#232]]
+ -  Added `IStore.SetAddressStateBlockHash<T>(string, Block<T>)` method.
+    [[#232]]
+ -  Added `IStore.ForkAddressStateBlockHash(string, string, long,
+    IImmutableSet<Address>` method.  [[#232]]
 
 ### Added interfaces
 
@@ -132,6 +138,7 @@ To be released.
 [#223]: https://github.com/planetarium/libplanet/pull/223
 [#228]: https://github.com/planetarium/libplanet/issues/228
 [#231]: https://github.com/planetarium/libplanet/pull/231
+[#232]: https://github.com/planetarium/libplanet/pull/232
 [#234]: https://github.com/planetarium/libplanet/pull/234
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,11 +40,11 @@ To be released.
     `PutBlock<T>(Block<T>, Address)`.  [[#189], [#197]]
  -  `Block<T>.Hash` is no longer calculated using the full data of the
     `Transaction<T>`, but is calculated using only the `Transaction<T>.Id`. [[#234]]
- -  Added `IStore.GetAddressStateBlockHash(string, Address, long)` method.
+ -  Added `IStore.LookupStateReference<T>(string, Address, Block<T>)` method.
     [[#232]]
- -  Added `IStore.SetAddressStateBlockHash<T>(string, Block<T>)` method.
+ -  Added `IStore.StoreStateReference<T>(string, Block<T>)` method.
     [[#232]]
- -  Added `IStore.ForkAddressStateBlockHash(string, string, long,
+ -  Added `IStore.ForkStateReferences<T>(string, string, Block<T>,
     IImmutableSet<Address>` method.  [[#232]]
 
 ### Added interfaces

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -171,6 +171,26 @@ namespace Libplanet.Tests.Blockchain
             states = chain.GetStates(new List<Address> { _fx.Address1 });
             result = (BattleResult)states[_fx.Address1];
             Assert.Contains("bow", result.UsedWeapons);
+
+            var tx3 = Transaction<PolymorphicAction<BaseAction>>.Create(
+                new PrivateKey(),
+                new List<PolymorphicAction<BaseAction>>
+                {
+                    new Attack
+                    {
+                        Weapon = "sword",
+                        Target = "orc",
+                        TargetAddress = _fx.Address1,
+                    },
+                }
+            );
+            chain.StageTransactions(
+                new HashSet<Transaction<PolymorphicAction<BaseAction>>> { tx3 }
+            );
+            chain.MineBlock(_fx.Address1);
+            states = chain.GetStates(new List<Address> { _fx.Address1 });
+
+            Assert.NotEmpty(states);
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -319,7 +319,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void ForkAddressStateBlockHash()
+        public void ForkStateReferences()
         {
             Address address = new PrivateKey().PublicKey.ToAddress();
 
@@ -357,7 +357,7 @@ namespace Libplanet.Tests.Blockchain
 
             BlockChain<DumbAction> forked = _blockChain.Fork(b1.Hash);
 
-            var hash = forked.Store.GetAddressStateBlockHash(
+            var hash = forked.Store.LookupStateReference(
                 forked.Id.ToString(),
                 address,
                 _blockChain.Tip.Index);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -360,7 +360,7 @@ namespace Libplanet.Tests.Blockchain
             var hash = forked.Store.LookupStateReference(
                 forked.Id.ToString(),
                 address,
-                _blockChain.Tip.Index);
+                _blockChain.Tip);
 
             Assert.Equal(b1.Hash, hash);
         }

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -439,6 +439,26 @@ namespace Libplanet.Tests.Store
                     _fx.Store.GetAddressStateBlockHash(targetNamespace, address, blocks[2].Index));
         }
 
+        [Fact]
+        public void ForkAddressStateBlockHashDirectoryNotFound()
+        {
+            var targetNamespace = "dummy";
+            Address address = _fx.Address1;
+
+            _fx.Store.ForkAddressStateBlockHash(
+                _ns,
+                targetNamespace,
+                0,
+                ImmutableHashSet<Address>.Empty);
+
+            Assert.Throws<DirectoryNotFoundException>(() =>
+                _fx.Store.ForkAddressStateBlockHash(
+                    _ns,
+                    targetNamespace,
+                    0,
+                    new HashSet<Address> { address }.ToImmutableHashSet()));
+        }
+
         public void Dispose()
         {
             _fx.Dispose();

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -419,7 +419,7 @@ namespace Libplanet.Tests.Store
             }
 
             var branchPoint = blocks[0];
-            var toUpdateAddresses = blocks
+            var addressesToStrip = blocks
                 .SkipWhile(b => b.Index <= branchPoint.Index)
                 .SelectMany(b => b.Transactions)
                 .SelectMany(tx => tx.UpdatedAddresses)
@@ -429,7 +429,7 @@ namespace Libplanet.Tests.Store
                 _ns,
                 targetNamespace,
                 branchPoint.Index,
-                toUpdateAddresses);
+                addressesToStrip);
 
             Assert.Equal(
                 blocks[2].Hash,

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -91,9 +91,12 @@ namespace Libplanet.Tests.Store
             string expected = Path.Combine(
                 _fx.Path,
                 "addr_state_block",
+                _ns,
                 "45a2",
                 "2187e2D8850bb357886958bC3E8560929ccc");
-            string actual = _fx.Store.GetAddressStateBlockHashPath(_fx.Address1);
+            string actual = _fx.Store.GetAddressStateBlockHashPath(
+                _ns,
+                _fx.Address1);
 
             Assert.Equal(expected, actual);
         }
@@ -330,13 +333,13 @@ namespace Libplanet.Tests.Store
             };
             blocks.Add(TestUtils.MineNext(blocks[0], txs));
 
-            string path = _fx.Store.GetAddressStateBlockHashPath(address);
+            string path = _fx.Store.GetAddressStateBlockHashPath(_ns, address);
             var addressStateBlockFile = new FileInfo(path);
             Assert.False(addressStateBlockFile.Exists);
 
             foreach (Block<DumbAction> block in blocks)
             {
-                _fx.Store.SetAddressStateBlockHash(block);
+                _fx.Store.SetAddressStateBlockHash(_ns, block);
             }
 
             addressStateBlockFile = new FileInfo(path);
@@ -367,7 +370,7 @@ namespace Libplanet.Tests.Store
             Address address = _fx.Address1;
             Block<DumbAction> prevBlock = _fx.Block3;
 
-            Assert.Null(_fx.Store.GetAddressStateBlockHash(address, 0));
+            Assert.Null(_fx.Store.GetAddressStateBlockHash(_ns, address, 0));
 
             Transaction<DumbAction> transaction = _fx.MakeTransaction(
                 new List<DumbAction>(),
@@ -377,12 +380,12 @@ namespace Libplanet.Tests.Store
                 prevBlock,
                 new[] { transaction });
 
-            _fx.Store.SetAddressStateBlockHash(block);
+            _fx.Store.SetAddressStateBlockHash(_ns, block);
 
             Assert.Equal(
                 block.Hash,
-                _fx.Store.GetAddressStateBlockHash(address, block.Index));
-            Assert.Null(_fx.Store.GetAddressStateBlockHash(address, block.Index - 1));
+                _fx.Store.GetAddressStateBlockHash(_ns, address, block.Index));
+            Assert.Null(_fx.Store.GetAddressStateBlockHash(_ns, address, block.Index - 1));
         }
 
         public void Dispose()

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -420,11 +420,7 @@ namespace Libplanet.Tests.Store
             }
 
             var branchPoint = blocks[0];
-            var addressesToStrip = blocks
-                .SkipWhile(b => b.Index <= branchPoint.Index)
-                .SelectMany(b => b.Transactions)
-                .SelectMany(tx => tx.UpdatedAddresses)
-                .ToImmutableHashSet();
+            var addressesToStrip = new[] { address }.ToImmutableHashSet();
 
             _fx.Store.ForkStateReferences(
                 _ns,

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -372,7 +372,7 @@ namespace Libplanet.Tests.Store
             Address address = _fx.Address1;
             Block<DumbAction> prevBlock = _fx.Block3;
 
-            Assert.Null(_fx.Store.LookupStateReference(_ns, address, 0));
+            Assert.Null(_fx.Store.LookupStateReference(_ns, address, prevBlock));
 
             Transaction<DumbAction> transaction = _fx.MakeTransaction(
                 new List<DumbAction>(),
@@ -388,8 +388,8 @@ namespace Libplanet.Tests.Store
 
             Assert.Equal(
                 block.Hash,
-                _fx.Store.LookupStateReference(_ns, address, block.Index));
-            Assert.Null(_fx.Store.LookupStateReference(_ns, address, block.Index - 1));
+                _fx.Store.LookupStateReference(_ns, address, block));
+            Assert.Null(_fx.Store.LookupStateReference(_ns, address, prevBlock));
         }
 
         [Fact]
@@ -428,15 +428,15 @@ namespace Libplanet.Tests.Store
             _fx.Store.ForkStateReferences(
                 _ns,
                 targetNamespace,
-                branchPoint.Index,
+                branchPoint,
                 addressesToStrip);
 
             Assert.Equal(
                 blocks[2].Hash,
-                _fx.Store.LookupStateReference(_ns, address, blocks[2].Index));
+                _fx.Store.LookupStateReference(_ns, address, blocks[2]));
             Assert.Equal(
                     blocks[0].Hash,
-                    _fx.Store.LookupStateReference(targetNamespace, address, blocks[2].Index));
+                    _fx.Store.LookupStateReference(targetNamespace, address, blocks[2]));
         }
 
         [Fact]
@@ -448,14 +448,14 @@ namespace Libplanet.Tests.Store
             _fx.Store.ForkStateReferences(
                 _ns,
                 targetNamespace,
-                0,
+                _fx.Block1,
                 ImmutableHashSet<Address>.Empty);
 
             Assert.Throws<DirectoryNotFoundException>(() =>
                 _fx.Store.ForkStateReferences(
                     _ns,
                     targetNamespace,
-                    0,
+                    _fx.Block1,
                     new HashSet<Address> { address }.ToImmutableHashSet()));
         }
 

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Security.Cryptography;
 using Libplanet.Action;
-using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -27,7 +26,7 @@ namespace Libplanet.Tests.Store
         {
             Assert.Empty(_fx.Store.ListNamespaces());
 
-            _fx.Store.PutBlock(_fx.Block1, default);
+            _fx.Store.PutBlock(_fx.Block1);
             _fx.Store.AppendIndex(_ns, _fx.Block1.Hash);
             Assert.Equal(
                 new[] { _ns }.ToImmutableHashSet(),
@@ -93,8 +92,7 @@ namespace Libplanet.Tests.Store
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
             Assert.False(_fx.Store.DeleteBlock(_fx.Block1.Hash));
 
-            Address arbitraryMask = new PrivateKey().PublicKey.ToAddress();
-            _fx.Store.PutBlock(_fx.Block1, arbitraryMask);
+            _fx.Store.PutBlock(_fx.Block1);
             Assert.Equal(1, _fx.Store.CountBlocks());
             Assert.Equal(
                 new HashSet<HashDigest<SHA256>>
@@ -105,17 +103,10 @@ namespace Libplanet.Tests.Store
             Assert.Equal(
                 _fx.Block1,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block1.Hash));
-            Assert.Equal(
-                arbitraryMask,
-                _fx.Store.GetAddressesMask(_fx.Block1.Hash)
-            );
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block2.Hash));
-            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block2.Hash));
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
-            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block3.Hash));
 
-            Address arbitraryMask2 = new PrivateKey().PublicKey.ToAddress();
-            _fx.Store.PutBlock(_fx.Block2, arbitraryMask2);
+            _fx.Store.PutBlock(_fx.Block2);
             Assert.Equal(2, _fx.Store.CountBlocks());
             Assert.Equal(
                 new HashSet<HashDigest<SHA256>>
@@ -128,18 +119,9 @@ namespace Libplanet.Tests.Store
                 _fx.Block1,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block1.Hash));
             Assert.Equal(
-                arbitraryMask,
-                _fx.Store.GetAddressesMask(_fx.Block1.Hash)
-            );
-            Assert.Equal(
                 _fx.Block2,
                 _fx.Store.GetBlock<DumbAction>(_fx.Block2.Hash));
-            Assert.Equal(
-                arbitraryMask2,
-                _fx.Store.GetAddressesMask(_fx.Block2.Hash)
-            );
             Assert.Null(_fx.Store.GetBlock<DumbAction>(_fx.Block3.Hash));
-            Assert.Null(_fx.Store.GetAddressesMask(_fx.Block3.Hash));
 
             Assert.True(_fx.Store.DeleteBlock(_fx.Block1.Hash));
             Assert.Equal(1, _fx.Store.CountBlocks());

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -361,6 +361,30 @@ namespace Libplanet.Tests.Store
             }
         }
 
+        [Fact]
+        public void GetAddressStateBlockHash()
+        {
+            Address address = _fx.Address1;
+            Block<DumbAction> prevBlock = _fx.Block3;
+
+            Assert.Null(_fx.Store.GetAddressStateBlockHash(address, 0));
+
+            Transaction<DumbAction> transaction = _fx.MakeTransaction(
+                new List<DumbAction>(),
+                new HashSet<Address> { address }.ToImmutableHashSet());
+
+            Block<DumbAction> block = TestUtils.MineNext(
+                prevBlock,
+                new[] { transaction });
+
+            _fx.Store.SetAddressStateBlockHash(block);
+
+            Assert.Equal(
+                block.Hash,
+                _fx.Store.GetAddressStateBlockHash(address, block.Index));
+            Assert.Null(_fx.Store.GetAddressStateBlockHash(address, block.Index - 1));
+        }
+
         public void Dispose()
         {
             _fx.Dispose();

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -339,7 +339,9 @@ namespace Libplanet.Tests.Store
 
             foreach (Block<DumbAction> block in blocks)
             {
-                _fx.Store.SetAddressStateBlockHash(_ns, block);
+                var updatedAddresses = new HashSet<Address> { address };
+                _fx.Store.SetAddressStateBlockHash(
+                    _ns, block, updatedAddresses.ToImmutableHashSet());
             }
 
             addressStateBlockFile = new FileInfo(path);
@@ -380,7 +382,9 @@ namespace Libplanet.Tests.Store
                 prevBlock,
                 new[] { transaction });
 
-            _fx.Store.SetAddressStateBlockHash(_ns, block);
+            var updatedAddresses = new HashSet<Address> { address };
+            _fx.Store.SetAddressStateBlockHash(
+                _ns, block, updatedAddresses.ToImmutableHashSet());
 
             Assert.Equal(
                 block.Hash,
@@ -409,7 +413,9 @@ namespace Libplanet.Tests.Store
 
             foreach (Block<DumbAction> block in blocks)
             {
-                _fx.Store.SetAddressStateBlockHash(_ns, block);
+                var updatedAddresses = new HashSet<Address> { address };
+                _fx.Store.SetAddressStateBlockHash(
+                    _ns, block, updatedAddresses.ToImmutableHashSet());
             }
 
             var branchPoint = blocks[0];

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Store;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -451,7 +452,7 @@ namespace Libplanet.Tests.Store
                 _fx.Block1,
                 ImmutableHashSet<Address>.Empty);
 
-            Assert.Throws<DirectoryNotFoundException>(() =>
+            Assert.Throws<NamespaceNotFoundException>(() =>
                 _fx.Store.ForkStateReferences(
                     _ns,
                     targetNamespace,

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -146,13 +146,14 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
-        public HashDigest<SHA256>? LookupStateReference(
+        public HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            long offsetIndex)
+            Block<T> lookupFrom)
+            where T : IAction, new()
         {
             _logs.Add((nameof(LookupStateReference), address, null));
-            return _store.LookupStateReference(@namespace, address, offsetIndex);
+            return _store.LookupStateReference(@namespace, address, lookupFrom);
         }
 
         public void StoreStateReference<T>(
@@ -165,15 +166,16 @@ namespace Libplanet.Tests.Store
             _store.StoreStateReference(@namespace, addresses, block);
         }
 
-        public void ForkStateReferences(
+        public void ForkStateReferences<T>(
             string sourceNamespace,
             string destNamespace,
-            long branchPointIndex,
+            Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
+            where T : IAction, new()
         {
             _logs.Add((nameof(ForkStateReferences), null, null));
             _store.ForkStateReferences(
-                sourceNamespace, destNamespace, branchPointIndex, addressesToStrip);
+                sourceNamespace, destNamespace, branchPoint, addressesToStrip);
         }
 
         public void StageTransactionIds(ISet<TxId> txids)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -164,6 +164,17 @@ namespace Libplanet.Tests.Store
             _store.SetAddressStateBlockHash(@namespace, block);
         }
 
+        public void ForkAddressStateBlockHash(
+            string sourceNamespace,
+            string targetNamespace,
+            long branchPointIndex,
+            IImmutableSet<Address> toUpdateAddresses)
+        {
+            _logs.Add((nameof(ForkAddressStateBlockHash), null, null));
+            _store.ForkAddressStateBlockHash(
+                sourceNamespace, targetNamespace, branchPointIndex, toUpdateAddresses);
+        }
+
         public void StageTransactionIds(ISet<TxId> txids)
         {
             _logs.Add((nameof(StageTransactionIds), txids, null));

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -149,11 +149,11 @@ namespace Libplanet.Tests.Store
         public HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            Block<T> lookupFrom)
+            Block<T> lookupUntil)
             where T : IAction, new()
         {
             _logs.Add((nameof(LookupStateReference), address, null));
-            return _store.LookupStateReference(@namespace, address, lookupFrom);
+            return _store.LookupStateReference(@namespace, address, lookupUntil);
         }
 
         public void StoreStateReference<T>(
@@ -168,14 +168,14 @@ namespace Libplanet.Tests.Store
 
         public void ForkStateReferences<T>(
             string sourceNamespace,
-            string destNamespace,
+            string destinationNamespace,
             Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
             where T : IAction, new()
         {
             _logs.Add((nameof(ForkStateReferences), null, null));
             _store.ForkStateReferences(
-                sourceNamespace, destNamespace, branchPoint, addressesToStrip);
+                sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
         }
 
         public void StageTransactionIds(ISet<TxId> txids)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -147,18 +147,21 @@ namespace Libplanet.Tests.Store
         }
 
         public HashDigest<SHA256>? GetAddressStateBlockHash(
+            string @namespace,
             Address address,
             long offsetIndex)
         {
             _logs.Add((nameof(GetAddressStateBlockHash), address, null));
-            return _store.GetAddressStateBlockHash(address, offsetIndex);
+            return _store.GetAddressStateBlockHash(@namespace, address, offsetIndex);
         }
 
-        public void SetAddressStateBlockHash<T>(Block<T> block)
+        public void SetAddressStateBlockHash<T>(
+            string @namespace,
+            Block<T> block)
             where T : IAction, new()
         {
             _logs.Add((nameof(SetAddressStateBlockHash), block.Hash, null));
-            _store.SetAddressStateBlockHash(block);
+            _store.SetAddressStateBlockHash(@namespace, block);
         }
 
         public void StageTransactionIds(ISet<TxId> txids)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -146,6 +146,13 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
+        public void SetAddressStateBlockHash<T>(Block<T> block)
+            where T : IAction, new()
+        {
+            _logs.Add((nameof(SetAddressStateBlockHash), block.Hash, null));
+            _store.SetAddressStateBlockHash(block);
+        }
+
         public void StageTransactionIds(ISet<TxId> txids)
         {
             _logs.Add((nameof(StageTransactionIds), txids, null));

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -157,11 +157,12 @@ namespace Libplanet.Tests.Store
 
         public void SetAddressStateBlockHash<T>(
             string @namespace,
-            Block<T> block)
+            Block<T> block,
+            IImmutableSet<Address> updatedAddresses)
             where T : IAction, new()
         {
             _logs.Add((nameof(SetAddressStateBlockHash), block.Hash, null));
-            _store.SetAddressStateBlockHash(@namespace, block);
+            _store.SetAddressStateBlockHash(@namespace, block, updatedAddresses);
         }
 
         public void ForkAddressStateBlockHash(

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -74,12 +74,6 @@ namespace Libplanet.Tests.Store
             return _store.GetBlock<T>(blockHash);
         }
 
-        public Address? GetAddressesMask(HashDigest<SHA256> blockHash)
-        {
-            _logs.Add((nameof(GetAddressesMask), blockHash, null));
-            return _store.GetAddressesMask(blockHash);
-        }
-
         public AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
         {
             _logs.Add((nameof(GetBlockStates), blockHash, null));
@@ -129,11 +123,11 @@ namespace Libplanet.Tests.Store
             return _store.ListNamespaces();
         }
 
-        public void PutBlock<T>(Block<T> block, Address addressesMask)
+        public void PutBlock<T>(Block<T> block)
             where T : IAction, new()
         {
-            _logs.Add((nameof(PutBlock), block, addressesMask));
-            _store.PutBlock<T>(block, addressesMask);
+            _logs.Add((nameof(PutBlock), block, null));
+            _store.PutBlock<T>(block);
         }
 
         public void PutTransaction<T>(Transaction<T> tx)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -169,11 +169,11 @@ namespace Libplanet.Tests.Store
             string sourceNamespace,
             string targetNamespace,
             long branchPointIndex,
-            IImmutableSet<Address> toUpdateAddresses)
+            IImmutableSet<Address> addressesToStrip)
         {
             _logs.Add((nameof(ForkAddressStateBlockHash), null, null));
             _store.ForkAddressStateBlockHash(
-                sourceNamespace, targetNamespace, branchPointIndex, toUpdateAddresses);
+                sourceNamespace, targetNamespace, branchPointIndex, addressesToStrip);
         }
 
         public void StageTransactionIds(ISet<TxId> txids)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -146,34 +146,34 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
-        public HashDigest<SHA256>? GetAddressStateBlockHash(
+        public HashDigest<SHA256>? LookupStateReference(
             string @namespace,
             Address address,
             long offsetIndex)
         {
-            _logs.Add((nameof(GetAddressStateBlockHash), address, null));
-            return _store.GetAddressStateBlockHash(@namespace, address, offsetIndex);
+            _logs.Add((nameof(LookupStateReference), address, null));
+            return _store.LookupStateReference(@namespace, address, offsetIndex);
         }
 
-        public void SetAddressStateBlockHash<T>(
+        public void StoreStateReference<T>(
             string @namespace,
-            Block<T> block,
-            IImmutableSet<Address> updatedAddresses)
+            IImmutableSet<Address> addresses,
+            Block<T> block)
             where T : IAction, new()
         {
-            _logs.Add((nameof(SetAddressStateBlockHash), block.Hash, null));
-            _store.SetAddressStateBlockHash(@namespace, block, updatedAddresses);
+            _logs.Add((nameof(StoreStateReference), block.Hash, null));
+            _store.StoreStateReference(@namespace, addresses, block);
         }
 
-        public void ForkAddressStateBlockHash(
+        public void ForkStateReferences(
             string sourceNamespace,
-            string targetNamespace,
+            string destNamespace,
             long branchPointIndex,
             IImmutableSet<Address> addressesToStrip)
         {
-            _logs.Add((nameof(ForkAddressStateBlockHash), null, null));
-            _store.ForkAddressStateBlockHash(
-                sourceNamespace, targetNamespace, branchPointIndex, addressesToStrip);
+            _logs.Add((nameof(ForkStateReferences), null, null));
+            _store.ForkStateReferences(
+                sourceNamespace, destNamespace, branchPointIndex, addressesToStrip);
         }
 
         public void StageTransactionIds(ISet<TxId> txids)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -146,6 +146,14 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
+        public HashDigest<SHA256>? GetAddressStateBlockHash(
+            Address address,
+            long offsetIndex)
+        {
+            _logs.Add((nameof(GetAddressStateBlockHash), address, null));
+            return _store.GetAddressStateBlockHash(address, offsetIndex);
+        }
+
         public void SetAddressStateBlockHash<T>(Block<T> block)
             where T : IAction, new()
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -354,7 +354,14 @@ namespace Libplanet.Blockchain
                         .ToImmutableHashSet();
 
                     Store.UnstageTransactionIds(txIds);
-                    Store.SetAddressStateBlockHash(Id.ToString(), block);
+
+                    ImmutableHashSet<Address> updatedAddresses =
+                        block.Transactions
+                        .SelectMany(tx => tx.UpdatedAddresses)
+                        .ToImmutableHashSet();
+
+                    Store.SetAddressStateBlockHash(
+                        Id.ToString(), block, updatedAddresses);
                 }
                 finally
                 {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -471,9 +471,12 @@ namespace Libplanet.Blockchain
 
                 var toUpdateAddresses = new HashSet<Address>();
 
-                for (var i = pointBlock.Index + 1; i <= Tip.Index; i++)
+                for (
+                    Block<T> block = Tip;
+                    block.PreviousHash is HashDigest<SHA256> hash
+                    && !block.Hash.Equals(point);
+                    block = Blocks[hash])
                 {
-                    Block<T> block = this[i];
                     toUpdateAddresses.UnionWith(
                         block.Transactions
                             .SelectMany(tx => tx.UpdatedAddresses)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -188,8 +188,8 @@ namespace Libplanet.Blockchain
 
             foreach (var address in requestedAddresses)
             {
-                var hashDigest =
-                    Store.GetAddressStateBlockHash(address, blockIndex);
+                var hashDigest = Store.GetAddressStateBlockHash(
+                    Id.ToString(), address, blockIndex);
                 if (!(hashDigest is null))
                 {
                     hashValues.Add(hashDigest.Value);
@@ -343,7 +343,7 @@ namespace Libplanet.Blockchain
                         .ToImmutableHashSet();
 
                     Store.UnstageTransactionIds(txIds);
-                    Store.SetAddressStateBlockHash(block);
+                    Store.SetAddressStateBlockHash(Id.ToString(), block);
                 }
                 finally
                 {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -199,7 +199,7 @@ namespace Libplanet.Blockchain
 
             foreach (var address in requestedAddresses)
             {
-                var hashDigest = Store.GetAddressStateBlockHash(
+                var hashDigest = Store.LookupStateReference(
                     Id.ToString(), address, blockIndex);
                 if (!(hashDigest is null))
                 {
@@ -360,8 +360,8 @@ namespace Libplanet.Blockchain
                         .SelectMany(tx => tx.UpdatedAddresses)
                         .ToImmutableHashSet();
 
-                    Store.SetAddressStateBlockHash(
-                        Id.ToString(), block, updatedAddresses);
+                    Store.StoreStateReference(
+                        Id.ToString(), updatedAddresses, block);
                 }
                 finally
                 {
@@ -481,7 +481,7 @@ namespace Libplanet.Blockchain
                             .ToImmutableHashSet());
                 }
 
-                Store.ForkAddressStateBlockHash(
+                Store.ForkStateReferences(
                     Id.ToString(),
                     forked.Id.ToString(),
                     pointBlock.Index,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -191,7 +191,6 @@ namespace Libplanet.Blockchain
             }
 
             Block<T> block = Blocks[offset.Value];
-            long blockIndex = block.Index;
 
             ImmutableHashSet<Address> requestedAddresses =
                 addresses.ToImmutableHashSet();
@@ -200,7 +199,7 @@ namespace Libplanet.Blockchain
             foreach (var address in requestedAddresses)
             {
                 var hashDigest = Store.LookupStateReference(
-                    Id.ToString(), address, blockIndex);
+                    Id.ToString(), address, block);
                 if (!(hashDigest is null))
                 {
                     hashValues.Add(hashDigest.Value);
@@ -484,7 +483,7 @@ namespace Libplanet.Blockchain
                 Store.ForkStateReferences(
                     Id.ToString(),
                     forked.Id.ToString(),
-                    pointBlock.Index,
+                    pointBlock,
                     toUpdateAddresses.ToImmutableHashSet());
             }
             finally

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -449,6 +449,25 @@ namespace Libplanet.Blockchain
                         break;
                     }
                 }
+
+                Block<T> pointBlock = Blocks[point];
+
+                var toUpdateAddresses = new HashSet<Address>();
+
+                for (var i = pointBlock.Index + 1; i <= Tip.Index; i++)
+                {
+                    Block<T> block = this[i];
+                    toUpdateAddresses.UnionWith(
+                        block.Transactions
+                            .SelectMany(tx => tx.UpdatedAddresses)
+                            .ToImmutableHashSet());
+                }
+
+                Store.ForkAddressStateBlockHash(
+                    Id.ToString(),
+                    forked.Id.ToString(),
+                    pointBlock.Index,
+                    toUpdateAddresses.ToImmutableHashSet());
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -156,6 +156,17 @@ namespace Libplanet.Blockchain
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Gets the state of the given <paramref name="addresses"/> in the
+        /// <see cref="BlockChain{T}"/> from <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="addresses">The list of <see cref="Address"/>es to get
+        /// their states.</param>
+        /// <param name="offset">The <see cref="HashDigest{T}"/> of the block to
+        /// start finding the state. It will be The tip of the
+        /// <see cref="BlockChain{T}"/> if it is <c>null</c>.</param>
+        /// <returns>The <see cref="AddressStateMap"/> of given
+        /// <paramref name="addresses"/>.</returns>
         public AddressStateMap GetStates(
             IEnumerable<Address> addresses, HashDigest<SHA256>? offset = null)
         {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -66,6 +66,9 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        public abstract HashDigest<SHA256>? GetAddressStateBlockHash(
+            Address address, long offsetIndex);
+
         public abstract void SetAddressStateBlockHash<T>(Block<T> block)
             where T : IAction, new();
 

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -52,11 +52,7 @@ namespace Libplanet.Store
         public abstract Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
             where T : IAction, new();
 
-        /// <inheritdoc />
-        public abstract Address? GetAddressesMask(HashDigest<SHA256> blockHash);
-
-        /// <inheritdoc />
-        public abstract void PutBlock<T>(Block<T> block, Address addressesMask)
+        public abstract void PutBlock<T>(Block<T> block)
             where T : IAction, new();
 
         public abstract bool DeleteBlock(HashDigest<SHA256> blockHash);

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Store
         public abstract HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            Block<T> lookupFrom)
+            Block<T> lookupUntil)
             where T : IAction, new();
 
         public abstract void StoreStateReference<T>(
@@ -81,7 +81,7 @@ namespace Libplanet.Store
 
         public abstract void ForkStateReferences<T>(
             string sourceNamespace,
-            string destNamespace,
+            string destinationNamespace,
             Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
             where T : IAction, new();

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -67,20 +67,20 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
-        public abstract HashDigest<SHA256>? GetAddressStateBlockHash(
+        public abstract HashDigest<SHA256>? LookupStateReference(
             string @namespace,
             Address address,
             long offsetIndex);
 
-        public abstract void SetAddressStateBlockHash<T>(
+        public abstract void StoreStateReference<T>(
             string @namespace,
-            Block<T> block,
-            IImmutableSet<Address> updatedAddresses)
+            IImmutableSet<Address> addresses,
+            Block<T> block)
             where T : IAction, new();
 
-        public abstract void ForkAddressStateBlockHash(
+        public abstract void ForkStateReferences(
             string sourceNamespace,
-            string targetNamespace,
+            string destNamespace,
             long branchPointIndex,
             IImmutableSet<Address> addressesToStrip);
 

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -67,10 +67,11 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
-        public abstract HashDigest<SHA256>? LookupStateReference(
+        public abstract HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            long offsetIndex);
+            Block<T> lookupFrom)
+            where T : IAction, new();
 
         public abstract void StoreStateReference<T>(
             string @namespace,
@@ -78,11 +79,12 @@ namespace Libplanet.Store
             Block<T> block)
             where T : IAction, new();
 
-        public abstract void ForkStateReferences(
+        public abstract void ForkStateReferences<T>(
             string sourceNamespace,
             string destNamespace,
-            long branchPointIndex,
-            IImmutableSet<Address> addressesToStrip);
+            Block<T> branchPoint,
+            IImmutableSet<Address> addressesToStrip)
+            where T : IAction, new();
 
         public long CountTransactions()
         {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
@@ -75,6 +76,12 @@ namespace Libplanet.Store
             string @namespace,
             Block<T> block)
             where T : IAction, new();
+
+        public abstract void ForkAddressStateBlockHash(
+            string sourceNamespace,
+            string targetNamespace,
+            long branchPointIndex,
+            IImmutableSet<Address> toUpdateAddresses);
 
         public long CountTransactions()
         {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -66,6 +66,9 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        public abstract void SetAddressStateBlockHash<T>(Block<T> block)
+            where T : IAction, new();
+
         public long CountTransactions()
         {
             return IterateTransactionIds().LongCount();

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -10,6 +10,7 @@ namespace Libplanet.Store
 {
     public abstract class BaseStore : IStore
     {
+        /// <inheritdoc />
         public abstract IEnumerable<string> ListNamespaces();
 
         public abstract long CountIndex(string @namespace);
@@ -53,6 +54,7 @@ namespace Libplanet.Store
         public abstract Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
             where T : IAction, new();
 
+        /// <inheritdoc />
         public abstract void PutBlock<T>(Block<T> block)
             where T : IAction, new();
 
@@ -67,18 +69,21 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        /// <inheritdoc />
         public abstract HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
             Block<T> lookupUntil)
             where T : IAction, new();
 
+        /// <inheritdoc />
         public abstract void StoreStateReference<T>(
             string @namespace,
             IImmutableSet<Address> addresses,
             Block<T> block)
             where T : IAction, new();
 
+        /// <inheritdoc />
         public abstract void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -82,7 +82,7 @@ namespace Libplanet.Store
             string sourceNamespace,
             string targetNamespace,
             long branchPointIndex,
-            IImmutableSet<Address> toUpdateAddresses);
+            IImmutableSet<Address> addressesToStrip);
 
         public long CountTransactions()
         {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -74,7 +74,8 @@ namespace Libplanet.Store
 
         public abstract void SetAddressStateBlockHash<T>(
             string @namespace,
-            Block<T> block)
+            Block<T> block,
+            IImmutableSet<Address> updatedAddresses)
             where T : IAction, new();
 
         public abstract void ForkAddressStateBlockHash(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -67,9 +67,13 @@ namespace Libplanet.Store
         );
 
         public abstract HashDigest<SHA256>? GetAddressStateBlockHash(
-            Address address, long offsetIndex);
+            string @namespace,
+            Address address,
+            long offsetIndex);
 
-        public abstract void SetAddressStateBlockHash<T>(Block<T> block)
+        public abstract void SetAddressStateBlockHash<T>(
+            string @namespace,
+            Block<T> block)
             where T : IAction, new();
 
         public long CountTransactions()

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -570,8 +570,6 @@ namespace Libplanet.Store
             HashDigest<SHA256> blockHash = block.Hash;
             long blockIndex = block.Index;
             int hashSize = HashDigest<SHA256>.Size;
-            int blockInfoSize = hashSize + sizeof(long);
-            var buffer = new byte[blockInfoSize];
 
             ImmutableHashSet<Address> updatedAddresses = block.Transactions
                 .SelectMany(tx => tx.UpdatedAddresses)
@@ -590,9 +588,9 @@ namespace Libplanet.Store
                 using (Stream stream = addressStateBlockFile.Open(
                     FileMode.Append, FileAccess.Write))
                 {
-                    blockHash.ToByteArray().CopyTo(buffer, 0);
-                    BitConverter.GetBytes(blockIndex).CopyTo(buffer, hashSize);
-                    stream.Write(buffer, 0, buffer.Length);
+                    stream.Write(blockHash.ToByteArray(), 0, hashSize);
+                    stream.Write(
+                        BitConverter.GetBytes(blockIndex), 0, sizeof(long));
                 }
             }
         }

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -547,9 +547,10 @@ namespace Libplanet.Store
             {
                 long position = stream.Seek(0, SeekOrigin.End);
 
-                while (position - buffer.Length >= 0)
+                for (var i = 1; position - buffer.Length >= 0; i++)
                 {
-                    position = stream.Seek(-buffer.Length, SeekOrigin.Current);
+                    position = stream.Seek(
+                        -buffer.Length * i, SeekOrigin.End);
                     stream.Read(buffer, 0, buffer.Length);
                     byte[] hashBytes = buffer.Take(hashSize).ToArray();
                     long index = BitConverter.ToInt64(buffer, hashSize);

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -532,6 +532,7 @@ namespace Libplanet.Store
             }
         }
 
+        /// <inheritdoc/>
         public override HashDigest<SHA256>? GetAddressStateBlockHash(
             string @namespace,
             Address address,
@@ -561,6 +562,7 @@ namespace Libplanet.Store
             return null;
         }
 
+        /// <inheritdoc/>
         public override void SetAddressStateBlockHash<T>(
             string @namespace,
             Block<T> block)
@@ -595,6 +597,7 @@ namespace Libplanet.Store
             }
         }
 
+        /// <inheritdoc/>
         public override void ForkAddressStateBlockHash(
             string sourceNamespace,
             string targetNamespace,

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -536,11 +536,11 @@ namespace Libplanet.Store
         public override HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            Block<T> lookupFrom)
+            Block<T> lookupUntil)
         {
             var addrFile = new FileInfo(
                 GetStateReferencePath(@namespace, address));
-            long lookupFromIndex = lookupFrom.Index;
+            long lookupUntilIndex = lookupUntil.Index;
 
             if (!addrFile.Exists)
             {
@@ -553,7 +553,7 @@ namespace Libplanet.Store
                     var (hashBytes, index)
                     in GetStateReferences(stream))
                 {
-                    if (index <= lookupFromIndex)
+                    if (index <= lookupUntilIndex)
                     {
                         return new HashDigest<SHA256>(hashBytes);
                     }
@@ -596,12 +596,12 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public override void ForkStateReferences<T>(
             string sourceNamespace,
-            string destNamespace,
+            string destinationNamespace,
             Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
         {
             string sourceDir = GetStateReferencePath(sourceNamespace);
-            string targetDir = GetStateReferencePath(destNamespace);
+            string targetDir = GetStateReferencePath(destinationNamespace);
             bool copied = CopyDirectory(sourceDir, targetDir);
 
             if (!copied && addressesToStrip.Any())
@@ -614,7 +614,7 @@ namespace Libplanet.Store
             foreach (Address address in addressesToStrip)
             {
                 StripStateReference(
-                    destNamespace,
+                    destinationNamespace,
                     address,
                     branchPoint.Index);
             }

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -667,6 +667,8 @@ namespace Libplanet.Store
 
                 yield return (hashBytes, index);
             }
+
+            stream.Seek(position, SeekOrigin.Begin);
         }
 
         private FileStream IndexFileStream(string @namespace)

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -445,6 +445,7 @@ namespace Libplanet.Store
             }
         }
 
+        /// <inheritdoc />
         public override void PutBlock<T>(Block<T> block)
         {
             foreach (var tx in block.Transactions)

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -127,18 +127,21 @@ namespace Libplanet.Store
             );
         }
 
-        public string GetAddressStateBlockHashPath()
+        public string GetAddressStateBlockHashPath(string @namespace)
         {
             return Path.Combine(
                 _path,
-                _addressStateBlockDir);
+                _addressStateBlockDir,
+                @namespace);
         }
 
-        public string GetAddressStateBlockHashPath(Address address)
+        public string GetAddressStateBlockHashPath(
+            string @namespace,
+            Address address)
         {
             string addressHex = address.ToHex();
             return Path.Combine(
-                GetAddressStateBlockHashPath(),
+                GetAddressStateBlockHashPath(@namespace),
                 addressHex.Substring(0, 4),
                 addressHex.Substring(4));
         }
@@ -530,9 +533,12 @@ namespace Libplanet.Store
         }
 
         public override HashDigest<SHA256>? GetAddressStateBlockHash(
-            Address address, long offsetIndex)
+            string @namespace,
+            Address address,
+            long offsetIndex)
         {
-            var addrFile = new FileInfo(GetAddressStateBlockHashPath(address));
+            var addrFile = new FileInfo(
+                GetAddressStateBlockHashPath(@namespace, address));
 
             if (!addrFile.Exists)
             {
@@ -565,7 +571,9 @@ namespace Libplanet.Store
             return null;
         }
 
-        public override void SetAddressStateBlockHash<T>(Block<T> block)
+        public override void SetAddressStateBlockHash<T>(
+            string @namespace,
+            Block<T> block)
         {
             HashDigest<SHA256> blockHash = block.Hash;
             long blockIndex = block.Index;
@@ -580,7 +588,7 @@ namespace Libplanet.Store
             foreach (Address address in updatedAddresses)
             {
                 var addressStateBlockFile = new FileInfo(
-                    GetAddressStateBlockHashPath(address));
+                    GetAddressStateBlockHashPath(@namespace, address));
 
                 if (!addressStateBlockFile.Directory.Exists)
                 {

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -533,13 +533,14 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override HashDigest<SHA256>? LookupStateReference(
+        public override HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            long offsetIndex)
+            Block<T> lookupFrom)
         {
             var addrFile = new FileInfo(
                 GetStateReferencePath(@namespace, address));
+            long lookupFromIndex = lookupFrom.Index;
 
             if (!addrFile.Exists)
             {
@@ -552,7 +553,7 @@ namespace Libplanet.Store
                     var (hashBytes, index)
                     in GetStateReferences(stream))
                 {
-                    if (index <= offsetIndex)
+                    if (index <= lookupFromIndex)
                     {
                         return new HashDigest<SHA256>(hashBytes);
                     }
@@ -593,10 +594,10 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override void ForkStateReferences(
+        public override void ForkStateReferences<T>(
             string sourceNamespace,
             string destNamespace,
-            long branchPointIndex,
+            Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
         {
             string sourceDir = GetStateReferencePath(sourceNamespace);
@@ -614,7 +615,7 @@ namespace Libplanet.Store
                 StripStateReference(
                     destNamespace,
                     address,
-                    branchPointIndex);
+                    branchPoint.Index);
             }
         }
 

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -565,15 +565,12 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public override void SetAddressStateBlockHash<T>(
             string @namespace,
-            Block<T> block)
+            Block<T> block,
+            IImmutableSet<Address> updatedAddresses)
         {
             HashDigest<SHA256> blockHash = block.Hash;
             long blockIndex = block.Index;
             int hashSize = HashDigest<SHA256>.Size;
-
-            ImmutableHashSet<Address> updatedAddresses = block.Transactions
-                .SelectMany(tx => tx.UpdatedAddresses)
-                .ToImmutableHashSet();
 
             foreach (Address address in updatedAddresses)
             {

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -606,8 +606,9 @@ namespace Libplanet.Store
 
             if (!copied && addressesToStrip.Any())
             {
-                throw new DirectoryNotFoundException(
-                    $"{sourceDir} to be forked does not exist.");
+                throw new NamespaceNotFoundException(
+                    sourceNamespace,
+                    "The source namespace to be forked does not exist.");
             }
 
             foreach (Address address in addressesToStrip)

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -22,7 +22,6 @@ namespace Libplanet.Store
         private const string _stagedTransactionsDir = "stage";
         private const string _statesDir = "states";
         private const string _indicesDir = "indices";
-        private const string _addressesMaskDir = "masks";
 
         private static readonly string[] BuiltinDirs =
         {
@@ -83,16 +82,6 @@ namespace Libplanet.Store
             return Path.Combine(
                 _path,
                 _blocksDir);
-        }
-
-        public string GetAddressesMaskPath(HashDigest<SHA256> blockHash)
-        {
-            var keyHex = blockHash.ToString();
-            return Path.Combine(
-                _path,
-                _addressesMaskDir,
-                keyHex.Substring(0, 4),
-                keyHex.Substring(4));
         }
 
         public string GetStagedTransactionPath(TxId txid)
@@ -271,22 +260,6 @@ namespace Libplanet.Store
             }
         }
 
-        public override Address? GetAddressesMask(HashDigest<SHA256> blockHash)
-        {
-            var blockFile = new FileInfo(GetAddressesMaskPath(blockHash));
-            if (!blockFile.Exists)
-            {
-                return null;
-            }
-
-            using (Stream stream = blockFile.OpenRead())
-            {
-                var buffer = new byte[Address.Size];
-                stream.Read(buffer, 0, buffer.Length);
-                return new Address(buffer);
-            }
-        }
-
         public override Transaction<T> GetTransaction<T>(TxId txid)
         {
             var txFile = new FileInfo(GetTransactionPath(txid));
@@ -450,7 +423,7 @@ namespace Libplanet.Store
             }
         }
 
-        public override void PutBlock<T>(Block<T> block, Address addressesMask)
+        public override void PutBlock<T>(Block<T> block)
         {
             foreach (var tx in block.Transactions)
             {
@@ -467,14 +440,6 @@ namespace Libplanet.Store
                     transactionData: false
                 );
                 stream.Write(blockBytes, 0, blockBytes.Length);
-            }
-
-            var maskFile = new FileInfo(GetAddressesMaskPath(block.Hash));
-            maskFile.Directory.Create();
-            using (Stream stream = maskFile.Open(
-                FileMode.OpenOrCreate, FileAccess.Write))
-            {
-                stream.Write(addressesMask.ToByteArray(), 0, Address.Size);
             }
         }
 

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -601,11 +601,12 @@ namespace Libplanet.Store
         {
             string sourceDir = GetAddressStateBlockHashPath(sourceNamespace);
             string targetDir = GetAddressStateBlockHashPath(targetNamespace);
-            var copied = CopyDirectory(sourceDir, targetDir);
+            bool copied = CopyDirectory(sourceDir, targetDir);
 
-            if (!copied)
+            if (!copied && addressesToStrip.Any())
             {
-                return;
+                throw new DirectoryNotFoundException(
+                    $"{sourceDir} to be forked does not exist.");
             }
 
             foreach (Address address in addressesToStrip)

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -597,7 +597,7 @@ namespace Libplanet.Store
             string sourceNamespace,
             string targetNamespace,
             long branchPointIndex,
-            IImmutableSet<Address> toUpdateAddresses)
+            IImmutableSet<Address> addressesToStrip)
         {
             string sourceDir = GetAddressStateBlockHashPath(sourceNamespace);
             string targetDir = GetAddressStateBlockHashPath(targetNamespace);
@@ -608,7 +608,7 @@ namespace Libplanet.Store
                 return;
             }
 
-            foreach (Address address in toUpdateAddresses)
+            foreach (Address address in addressesToStrip)
             {
                 RemoveAddressStateBlockHashAfterPoint(
                     targetNamespace,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -114,14 +114,13 @@ namespace Libplanet.Store
         /// <see cref="Block{T}.Hash"/> will be stored.</param>
         /// <param name="branchPointIndex">The index of branch point to fork.
         /// </param>
-        /// <param name="toUpdateAddresses">The set of <see cref="Address"/>es
-        /// to be updated by fork in the <paramref name="targetNamespace"/>.
-        /// </param>
+        /// <param name="addressesToStrip">The set of <see cref="Address"/>es
+        /// to strip <see cref="Block{T}.Hash"/> after forking.</param>
         void ForkAddressStateBlockHash(
             string sourceNamespace,
             string targetNamespace,
             long branchPointIndex,
-            IImmutableSet<Address> toUpdateAddresses);
+            IImmutableSet<Address> addressesToStrip);
 
         long CountTransactions();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -64,6 +64,9 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        void SetAddressStateBlockHash<T>(Block<T> block)
+            where T : IAction, new();
+
         long CountTransactions();
 
         long CountBlocks();

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -64,6 +64,10 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        HashDigest<SHA256>? GetAddressStateBlockHash(
+            Address address,
+            long offsetIndex);
+
         void SetAddressStateBlockHash<T>(Block<T> block)
             where T : IAction, new();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -128,6 +128,8 @@ namespace Libplanet.Store
         ///     to strip <see cref="Block{T}.Hash"/> after forking.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="branchPoint"/>.</typeparam>
+        /// <exception cref="NamespaceNotFoundException">Thrown when the given
+        /// <paramref name="sourceNamespace"/> does not exist.</exception>
         /// <seealso cref="LookupStateReference{T}"/>
         /// <seealso cref="StoreStateReference{T}"/>
         void ForkStateReferences<T>(

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -66,59 +66,67 @@ namespace Libplanet.Store
         );
 
         /// <summary>
-        /// Gets a <see cref="Block{T}.Hash"/> which has the state of the
-        /// <paramref name="address"/>.
+        /// Lookup a state reference, which is a <see cref="Block{T}.Hash"/>
+        /// that has the state of the <paramref name="address"/>.
         /// </summary>
-        /// <param name="namespace">The namespace to get
-        /// <see cref="Block{T}.Hash"/>.</param>
-        /// <param name="address">The <see cref="Address"/> to find the
-        /// <see cref="Block{T}.Hash"/>.</param>
+        /// <param name="namespace">The namespace to lookup a state reference.
+        /// </param>
+        /// <param name="address">The <see cref="Address"/> to find lookup.
+        /// </param>
         /// <param name="offsetIndex">The offset at which to begin looking for
         /// a block hash.</param>
         /// <returns>A <see cref="Block{T}.Hash"/> which has the state of the
         /// <paramref name="address"/>.</returns>
-        /// <seealso cref="SetAddressStateBlockHash{T}"/>
-        HashDigest<SHA256>? GetAddressStateBlockHash(
+        /// <seealso cref="StoreStateReference{T}"/>
+        HashDigest<SHA256>? LookupStateReference(
             string @namespace,
             Address address,
             long offsetIndex);
 
         /// <summary>
-        /// Stores a <see cref="Block{T}.Hash"/> which has the state of the
-        /// <see cref="Address"/> for each updated <see cref="Address"/>es by
-        /// the <paramref name="block"/>.
-        /// </summary>
-        /// <param name="namespace">The namespace to store
-        /// <see cref="Block{T}.Hash"/>.</param>
+        /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>
+        /// that has the state of the <see cref="Address"/> for each updated
+        /// <see cref="Address"/>es by the <see cref="Transaction{T}"/>s in the
+        /// <paramref name="block"/>.</summary>
+        /// <param name="namespace">The namespace to store a state reference.
+        /// </param>
+        /// <param name="addresses">The <see cref="Address"/>es to store state
+        /// reference.</param>
         /// <param name="block">The <see cref="Block{T}"/> which has the state
         /// of the <see cref="Address"/>.</param>
-        /// <param name="updatedAddresses">The <see cref="Address"/>es updated
-        /// by the <paramref name="block"/>.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="block"/>.</typeparam>
-        /// <seealso cref="GetAddressStateBlockHash"/>
-        void SetAddressStateBlockHash<T>(
+        /// <seealso cref="LookupStateReference"/>
+        void StoreStateReference<T>(
             string @namespace,
-            Block<T> block,
-            IImmutableSet<Address> updatedAddresses)
+            IImmutableSet<Address> addresses,
+            Block<T> block)
             where T : IAction, new();
 
         /// <summary>
-        /// Forks <see cref="Block{T}.Hash"/>es which has the state of the
-        /// <see cref="Address"/>es from <paramref name="sourceNamespace"/> to
-        /// <paramref name="targetNamespace"/>.
+        /// Forks state references, which are <see cref="Block{T}.Hash"/>es that
+        /// have the state of the <see cref="Address"/>es, from
+        /// <paramref name="sourceNamespace"/> to
+        /// <paramref name="destNamespace"/>.
+        /// <para>This method copies state references from
+        /// <paramref name="sourceNamespace"/> to
+        /// <paramref name="destNamespace"/> and strips
+        /// <paramref name="addressesToStrip"/> of state references after
+        /// <paramref name="branchPointIndex"/>.</para>
         /// </summary>
-        /// <param name="sourceNamespace">The namespace to fork
-        /// <see cref="Block{T}.Hash"/>es.</param>
-        /// <param name="targetNamespace">The namespace where the forked
-        /// <see cref="Block{T}.Hash"/> will be stored.</param>
+        /// <param name="sourceNamespace">The namespace of state references to
+        /// fork.</param>
+        /// <param name="destNamespace">The namespace of destination state
+        /// references.</param>
         /// <param name="branchPointIndex">The index of branch point to fork.
         /// </param>
         /// <param name="addressesToStrip">The set of <see cref="Address"/>es
         /// to strip <see cref="Block{T}.Hash"/> after forking.</param>
-        void ForkAddressStateBlockHash(
+        /// <seealso cref="LookupStateReference"/>
+        /// <seealso cref="StoreStateReference{T}"/>
+        void ForkStateReferences(
             string sourceNamespace,
-            string targetNamespace,
+            string destNamespace,
             long branchPointIndex,
             IImmutableSet<Address> addressesToStrip);
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -92,10 +92,15 @@ namespace Libplanet.Store
         /// <see cref="Block{T}.Hash"/>.</param>
         /// <param name="block">The <see cref="Block{T}"/> which has the state
         /// of the <see cref="Address"/>.</param>
+        /// <param name="updatedAddresses">The <see cref="Address"/>es updated
+        /// by the <paramref name="block"/>.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="block"/>.</typeparam>
         /// <seealso cref="GetAddressStateBlockHash"/>
-        void SetAddressStateBlockHash<T>(string @namespace, Block<T> block)
+        void SetAddressStateBlockHash<T>(
+            string @namespace,
+            Block<T> block,
+            IImmutableSet<Address> updatedAddresses)
             where T : IAction, new();
 
         /// <summary>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -46,34 +46,13 @@ namespace Libplanet.Store
             where T : IAction, new();
 
         /// <summary>
-        /// Gets the bitmask of all addresses ever used until the block
-        /// of the given <paramref name="blockHash"/>.
-        /// </summary>
-        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of
-        /// the topmost <see cref="Block{T}"/> of the <see cref="Block{T}"/>
-        /// sequence that updated the <see cref="Address"/> set to which
-        /// the bit mask you want to obtain approximates.</param>
-        /// <returns>A bitmask in the <see cref="Address"/> type
-        /// (so this is probably not a valid address).  It can be
-        /// <c>null</c> if the given <paramref name="blockHash"/> refers to
-        /// a <see cref="Block{T}"/> that is not in the store.</returns>
-        Address? GetAddressesMask(HashDigest<SHA256> blockHash);
-
-        /// <summary>
-        /// Puts the given <paramref name="block"/> in to the store,
-        /// with a bit mask which approximates the <see cref="Address"/> set
-        /// updated by the <paramref name="block"/> and its all previous
-        /// <see cref="Block{T}"/>s.
+        /// Puts the given <paramref name="block"/> in to the store.
         /// </summary>
         /// <param name="block">A <see cref="Block{T}"/> to put into the store.
         /// </param>
-        /// <param name="addressesMask">A bit mask, in the <see cref="Address"/>
-        /// type (so this is probably not a valid address), which approximates
-        /// the <see cref="Address"/> set updated by the <paramref name="block"
-        /// /> and its all previous <see cref="Block{T}"/>s.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="block"/>.</typeparam>
-        void PutBlock<T>(Block<T> block, Address addressesMask)
+        void PutBlock<T>(Block<T> block)
             where T : IAction, new();
 
         bool DeleteBlock(HashDigest<SHA256> blockHash);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -73,15 +73,19 @@ namespace Libplanet.Store
         /// </param>
         /// <param name="address">The <see cref="Address"/> to find lookup.
         /// </param>
-        /// <param name="offsetIndex">The offset at which to begin looking for
-        /// a block hash.</param>
+        /// <param name="lookupFrom">The starting point to lookup a state
+        /// reference. Blocks after <paramref name="lookupFrom"/> are ignored.
+        /// </param>
         /// <returns>A <see cref="Block{T}.Hash"/> which has the state of the
         /// <paramref name="address"/>.</returns>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="lookupFrom"/>.</typeparam>
         /// <seealso cref="StoreStateReference{T}"/>
-        HashDigest<SHA256>? LookupStateReference(
+        HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            long offsetIndex);
+            Block<T> lookupFrom)
+            where T : IAction, new();
 
         /// <summary>
         /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>
@@ -96,7 +100,7 @@ namespace Libplanet.Store
         /// of the <see cref="Address"/>.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="block"/>.</typeparam>
-        /// <seealso cref="LookupStateReference"/>
+        /// <seealso cref="LookupStateReference{T}"/>
         void StoreStateReference<T>(
             string @namespace,
             IImmutableSet<Address> addresses,
@@ -112,23 +116,26 @@ namespace Libplanet.Store
         /// <paramref name="sourceNamespace"/> to
         /// <paramref name="destNamespace"/> and strips
         /// <paramref name="addressesToStrip"/> of state references after
-        /// <paramref name="branchPointIndex"/>.</para>
+        /// <paramref name="branchPoint"/>.</para>
         /// </summary>
         /// <param name="sourceNamespace">The namespace of state references to
-        /// fork.</param>
+        ///     fork.</param>
         /// <param name="destNamespace">The namespace of destination state
-        /// references.</param>
-        /// <param name="branchPointIndex">The index of branch point to fork.
+        ///     references.</param>
+        /// <param name="branchPoint">The index of branch point to fork.
         /// </param>
         /// <param name="addressesToStrip">The set of <see cref="Address"/>es
-        /// to strip <see cref="Block{T}.Hash"/> after forking.</param>
-        /// <seealso cref="LookupStateReference"/>
+        ///     to strip <see cref="Block{T}.Hash"/> after forking.</param>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="branchPoint"/>.</typeparam>
+        /// <seealso cref="LookupStateReference{T}"/>
         /// <seealso cref="StoreStateReference{T}"/>
-        void ForkStateReferences(
+        void ForkStateReferences<T>(
             string sourceNamespace,
             string destNamespace,
-            long branchPointIndex,
-            IImmutableSet<Address> addressesToStrip);
+            Block<T> branchPoint,
+            IImmutableSet<Address> addressesToStrip)
+            where T : IAction, new();
 
         long CountTransactions();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -71,6 +72,12 @@ namespace Libplanet.Store
 
         void SetAddressStateBlockHash<T>(string @namespace, Block<T> block)
             where T : IAction, new();
+
+        void ForkAddressStateBlockHash(
+            string sourceNamespace,
+            string targetNamespace,
+            long branchPointIndex,
+            IImmutableSet<Address> toUpdateAddresses);
 
         long CountTransactions();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Store
             long offsetIndex);
 
         /// <summary>
-        /// Store a <see cref="Block{T}.Hash"/> which has the state of the
+        /// Stores a <see cref="Block{T}.Hash"/> which has the state of the
         /// <see cref="Address"/> for each updated <see cref="Address"/>es by
         /// the <paramref name="block"/>.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Libplanet.Store
             where T : IAction, new();
 
         /// <summary>
-        /// Fork <see cref="Block{T}.Hash"/>es which has the state of the
+        /// Forks <see cref="Block{T}.Hash"/>es which has the state of the
         /// <see cref="Address"/>es from <paramref name="sourceNamespace"/> to
         /// <paramref name="targetNamespace"/>.
         /// </summary>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -65,14 +65,53 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        /// <summary>
+        /// Gets a <see cref="Block{T}.Hash"/> which has the state of the
+        /// <paramref name="address"/>.
+        /// </summary>
+        /// <param name="namespace">The namespace to get
+        /// <see cref="Block{T}.Hash"/>.</param>
+        /// <param name="address">The <see cref="Address"/> to find the
+        /// <see cref="Block{T}.Hash"/>.</param>
+        /// <param name="offsetIndex">The offset at which to begin looking for
+        /// a block hash.</param>
+        /// <returns>A <see cref="Block{T}.Hash"/> which has the state of the
+        /// <paramref name="address"/>.</returns>
+        /// <seealso cref="SetAddressStateBlockHash{T}"/>
         HashDigest<SHA256>? GetAddressStateBlockHash(
             string @namespace,
             Address address,
             long offsetIndex);
 
+        /// <summary>
+        /// Store a <see cref="Block{T}.Hash"/> which has the state of the
+        /// <see cref="Address"/> for each updated <see cref="Address"/>es by
+        /// the <paramref name="block"/>.
+        /// </summary>
+        /// <param name="namespace">The namespace to store
+        /// <see cref="Block{T}.Hash"/>.</param>
+        /// <param name="block">The <see cref="Block{T}"/> which has the state
+        /// of the <see cref="Address"/>.</param>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="block"/>.</typeparam>
+        /// <seealso cref="GetAddressStateBlockHash"/>
         void SetAddressStateBlockHash<T>(string @namespace, Block<T> block)
             where T : IAction, new();
 
+        /// <summary>
+        /// Fork <see cref="Block{T}.Hash"/>es which has the state of the
+        /// <see cref="Address"/>es from <paramref name="sourceNamespace"/> to
+        /// <paramref name="targetNamespace"/>.
+        /// </summary>
+        /// <param name="sourceNamespace">The namespace to fork
+        /// <see cref="Block{T}.Hash"/>es.</param>
+        /// <param name="targetNamespace">The namespace where the forked
+        /// <see cref="Block{T}.Hash"/> will be stored.</param>
+        /// <param name="branchPointIndex">The index of branch point to fork.
+        /// </param>
+        /// <param name="toUpdateAddresses">The set of <see cref="Address"/>es
+        /// to be updated by fork in the <paramref name="targetNamespace"/>.
+        /// </param>
         void ForkAddressStateBlockHash(
             string sourceNamespace,
             string targetNamespace,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -65,10 +65,11 @@ namespace Libplanet.Store
         );
 
         HashDigest<SHA256>? GetAddressStateBlockHash(
+            string @namespace,
             Address address,
             long offsetIndex);
 
-        void SetAddressStateBlockHash<T>(Block<T> block)
+        void SetAddressStateBlockHash<T>(string @namespace, Block<T> block)
             where T : IAction, new();
 
         long CountTransactions();

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -73,18 +73,18 @@ namespace Libplanet.Store
         /// </param>
         /// <param name="address">The <see cref="Address"/> to find lookup.
         /// </param>
-        /// <param name="lookupFrom">The starting point to lookup a state
-        /// reference. Blocks after <paramref name="lookupFrom"/> are ignored.
-        /// </param>
+        /// <param name="lookupUntil">The upper bound (i.e., the latest block)
+        /// of the search range. <see cref="Block{T}"/>s after
+        /// <paramref name="lookupUntil"/> are ignored.</param>
         /// <returns>A <see cref="Block{T}.Hash"/> which has the state of the
         /// <paramref name="address"/>.</returns>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
-        /// <paramref name="lookupFrom"/>.</typeparam>
+        /// <paramref name="lookupUntil"/>.</typeparam>
         /// <seealso cref="StoreStateReference{T}"/>
         HashDigest<SHA256>? LookupStateReference<T>(
             string @namespace,
             Address address,
-            Block<T> lookupFrom)
+            Block<T> lookupUntil)
             where T : IAction, new();
 
         /// <summary>
@@ -111,21 +111,21 @@ namespace Libplanet.Store
         /// Forks state references, which are <see cref="Block{T}.Hash"/>es that
         /// have the state of the <see cref="Address"/>es, from
         /// <paramref name="sourceNamespace"/> to
-        /// <paramref name="destNamespace"/>.
+        /// <paramref name="destinationNamespace"/>.
         /// <para>This method copies state references from
         /// <paramref name="sourceNamespace"/> to
-        /// <paramref name="destNamespace"/> and strips
+        /// <paramref name="destinationNamespace"/> and strips
         /// <paramref name="addressesToStrip"/> of state references after
         /// <paramref name="branchPoint"/>.</para>
         /// </summary>
         /// <param name="sourceNamespace">The namespace of state references to
-        ///     fork.</param>
-        /// <param name="destNamespace">The namespace of destination state
-        ///     references.</param>
+        /// fork.</param>
+        /// <param name="destinationNamespace">The namespace of destination
+        /// state references.</param>
         /// <param name="branchPoint">The index of branch point to fork.
         /// </param>
         /// <param name="addressesToStrip">The set of <see cref="Address"/>es
-        ///     to strip <see cref="Block{T}.Hash"/> after forking.</param>
+        /// to strip <see cref="Block{T}.Hash"/> after forking.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="branchPoint"/>.</typeparam>
         /// <exception cref="NamespaceNotFoundException">Thrown when the given
@@ -134,7 +134,7 @@ namespace Libplanet.Store
         /// <seealso cref="StoreStateReference{T}"/>
         void ForkStateReferences<T>(
             string sourceNamespace,
-            string destNamespace,
+            string destinationNamespace,
             Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
             where T : IAction, new();

--- a/Libplanet/Store/NamespaceNotFoundException.cs
+++ b/Libplanet/Store/NamespaceNotFoundException.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Libplanet.Store
+{
+    /// <summary>
+    /// The exception that is thrown when the namespace of
+    /// <see cref="Libplanet.Store"/> does not exist.
+    /// </summary>
+    [Serializable]
+    public sealed class NamespaceNotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="NamespaceNotFoundException"/> class.
+        /// </summary>
+        /// <param name="namespace">The namespace not found.</param>
+        /// <param name="message">The message that describes the error.</param>
+        public NamespaceNotFoundException(string @namespace, string message)
+            : base($"{@namespace}: {message}")
+        {
+            Namespace = @namespace;
+        }
+
+        /// <summary>
+        /// Gets the namespace not found.
+        /// </summary>
+        public string Namespace { get; }
+    }
+}


### PR DESCRIPTION
- Added `IStore.LookupStateReference<T>()` method.
- Added `IStore.StoreStateReference<T>()` method.
- Added `IStore.ForkStateReferences<T>()` method.
- Changed `BlockChain<T>.GetStates()` to use a state reference, which is a `Block<T>.Hash` that has the state of the `Address`.
- Added documentation of `BlockChain<T>.GetStates()`.
