### PR TITLE
Tune `Block<T>.Hash` and `Transaction<T>.Id`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@ To be released.
  -  Removed `HashDigest.HasLeadingZeroBits()` method.  [[#213]]
  -  The signature of `IStore.PutBlock<T>(Block<T>)` method was changed to
     `PutBlock<T>(Block<T>, Address)`.  [[#189], [#197]]
+ -  `Block<T>.Hash` is no longer calculated using the full data of the
+    `Transaction<T>`, but is calculated using only the `Transaction<T>.Id`. [[#234]]
 
 ### Added interfaces
 
@@ -81,6 +83,8 @@ To be released.
     target number to representing a divisor to obtain the target number.
     [[#213]]
  -  `BlockSet<T>[int]` changed so as not to validate a block.  [[#231]]
+ -  Improved read performance of `Block<T>.Hash` and `Transaction<T>.Id`. [[#228],
+    [#234]]
 
 # Bug fixes
 
@@ -129,7 +133,9 @@ To be released.
 [#217]: https://github.com/planetarium/libplanet/pull/217
 [#218]: https://github.com/planetarium/libplanet/pull/218
 [#223]: https://github.com/planetarium/libplanet/pull/223
+[#228]: https://github.com/planetarium/libplanet/issues/228
 [#231]: https://github.com/planetarium/libplanet/pull/231
+[#234]: https://github.com/planetarium/libplanet/pull/234
 
 
 Version 0.2.2

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -46,25 +46,25 @@ namespace Libplanet.Blocks
         {
         }
 
-        private Block(RawBlock rawBlock)
+        private Block(RawBlock rb)
+            : this(
+                rb.Index,
+                rb.Difficulty,
+                new Nonce(rb.Nonce),
+                rb.Miner is null ? (Address?)null : new Address(rb.Miner),
+#pragma warning disable MEN002 // Line is too long
+                rb.PreviousHash is null ? (HashDigest<SHA256>?)null : new HashDigest<SHA256>(rb.PreviousHash),
+#pragma warning restore MEN002 // Line is too long
+                DateTimeOffset.ParseExact(
+                    rb.Timestamp,
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture).ToUniversalTime(),
+                rb.Transactions
+                    .Cast<Dictionary<string, object>>()
+                    .Select(d => new Transaction<T>(new RawTransaction(d)))
+                    .ToList()
+                )
         {
-            Index = rawBlock.Index;
-            Difficulty = rawBlock.Difficulty;
-            Nonce = new Nonce(rawBlock.Nonce);
-            Miner = (rawBlock.Miner != null)
-                ? new Address(rawBlock.Miner)
-                : default(Address?);
-            PreviousHash = (rawBlock.PreviousHash != null)
-                ? new HashDigest<SHA256>(rawBlock.PreviousHash)
-                : default(HashDigest<SHA256>?);
-            Timestamp = DateTimeOffset.ParseExact(
-                rawBlock.Timestamp,
-                TimestampFormat,
-                CultureInfo.InvariantCulture).ToUniversalTime();
-            Transactions = rawBlock.Transactions
-                .Cast<Dictionary<string, object>>()
-                .Select(d => new Transaction<T>(new RawTransaction(d)))
-                .ToList();
         }
 
         public HashDigest<SHA256> Hash

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -39,6 +39,7 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions;
+            Hash = Hashcash.Hash(ToBencodex(false, true));
         }
 
         protected Block(SerializationInfo info, StreamingContext context)
@@ -67,17 +68,7 @@ namespace Libplanet.Blocks
         {
         }
 
-        public HashDigest<SHA256> Hash
-        {
-            get
-            {
-                byte[] bencoded = ToBencodex(
-                    hash: false,
-                    transactionData: true
-                );
-                return Hashcash.Hash(bencoded);
-            }
-        }
+        public HashDigest<SHA256> Hash { get; }
 
         [IgnoreDuringEquals]
         public long Index { get; }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions;
-            Hash = Hashcash.Hash(ToBencodex(false, true));
+            Hash = Hashcash.Hash(ToBencodex(false, false));
         }
 
         protected Block(SerializationInfo info, StreamingContext context)
@@ -109,7 +109,7 @@ namespace Libplanet.Blocks
                 transactions
             );
             Nonce nonce = Hashcash.Answer(
-                n => MakeBlock(n).ToBencodex(false, true),
+                n => MakeBlock(n).ToBencodex(false, false),
                 difficulty
             );
             return MakeBlock(nonce);

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -157,6 +157,12 @@ namespace Libplanet.Tx
             PublicKey = publicKey ??
                         throw new ArgumentNullException(nameof(publicKey));
 
+            using (var hasher = SHA256.Create())
+            {
+                byte[] payload = ToBencodex(true);
+                Id = new TxId(hasher.ComputeHash(payload));
+            }
+
             if (validate)
             {
                 Validate();
@@ -169,17 +175,7 @@ namespace Libplanet.Tx
         /// <para>For more characteristics, see <see cref="TxId"/> type.</para>
         /// </summary>
         /// <seealso cref="TxId"/>
-        public TxId Id
-        {
-            get
-            {
-                using (var hasher = SHA256.Create())
-                {
-                    byte[] payload = ToBencodex(true);
-                    return new TxId(hasher.ComputeHash(payload));
-                }
-            }
-        }
+        public TxId Id { get; }
 
         /// <summary>
         /// A <see cref="PublicKey"/> of the account who signs this transaction.


### PR DESCRIPTION
This PR adjusts `Block<T>.Hash` and `Transaction<T>.Id` as below to stabilize mining performance irrespective of the number of transactions.

- `Block<T>.Hash` and `Transaction<T>.Id`  determined in their constructor instead of dynamically generated each time.
- `Block<T>.Hash` is no longer calculated using the full data of the `Transaction<T>`, but is calculated using only the `Transaction<T>.Id`.