### PR TITLE
Fix errors during unittest on Mono

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,7 @@ To be released.
  -  `BlockSet<T>[int]` changed so as not to validate a block.  [[#231]]
  -  Improved read performance of `Block<T>.Hash` and `Transaction<T>.Id`. [[#228],
     [#234]]
+ -  `Swarm.StartAsync()` doesn't call `Swarm.StopAsync()` anymore.
 
 # Bug fixes
 

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -83,7 +83,12 @@ namespace Libplanet.Tests.Net
                 s.StopAsync().Wait();
             }
 
-            NetMQConfig.Cleanup(false);
+            // FIXME NetMQConfig.Cleanup stucks in macOS + .NET Core now...
+            //       so we clean netmq related resources only in Mono runtime.
+            if (Type.GetType("Mono.Runtime") is Type)
+            {
+                NetMQConfig.Cleanup(false);
+            }
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -418,7 +418,6 @@ namespace Libplanet.Tests.Net
 
             cts.Cancel();
             await task;
-            Assert.False(swarm.Running);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -16,6 +16,7 @@ using Libplanet.Net;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
+using NetMQ;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -81,6 +82,8 @@ namespace Libplanet.Tests.Net
             {
                 s.StopAsync().Wait();
             }
+
+            NetMQConfig.Cleanup(false);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -524,10 +524,6 @@ namespace Libplanet.Net
                     "An unexpected exception occured during StartAsync()");
                 throw;
             }
-            finally
-            {
-                await StopAsync();
-            }
         }
 
         public void BroadcastBlocks<T>(IEnumerable<Block<T>> blocks)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -390,10 +390,12 @@ namespace Libplanet.Net
                         await Task.Delay(_linger, cancellationToken);
                     }
 
-                    if (_queuePoller.IsRunning)
-                    {
-                        _queuePoller.Stop();
-                    }
+                    _broadcastQueue.ReceiveReady -= DoBroadcast;
+                    _replyQueue.ReceiveReady -= DoReply;
+
+                    _queuePoller.Dispose();
+                    _broadcastQueue.Dispose();
+                    _replyQueue.Dispose();
 
                     foreach (DealerSocket s in _dealers.Values)
                     {


### PR DESCRIPTION
This PR aids some unittest errors on Mono runtime.

- Made `Swarm.StopAsync()` closes internal resources(e.g. `_broadcastQueue`) to avoid too many open files error.
  - Also, `SwarmTest` now cleans NetMQ resources at the end of each test case.
- Bump .netframework version of `Libplanet.Tests` used by Mono to avoid missing method exception.

I omitted changelog because there is no difference from previous version. 