### PR TITLE
Bump netmq version to 4.0.0.207-pre

### DIFF
--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -38,7 +38,7 @@ https://docs.libplanet.io/</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5104</NoWarn>
     <!-- FIXME: CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
@@ -67,7 +67,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NetMQ" Version="4.0.0.1" />
+    <PackageReference Include="NetMQ" Version="4.0.0.207-pre" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -393,7 +393,11 @@ namespace Libplanet.Net
                     _broadcastQueue.ReceiveReady -= DoBroadcast;
                     _replyQueue.ReceiveReady -= DoReply;
 
-                    _queuePoller.Dispose();
+                    if (_queuePoller.IsRunning)
+                    {
+                        _queuePoller.Dispose();
+                    }
+
                     _broadcastQueue.Dispose();
                     _replyQueue.Dispose();
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
         --collect "Code coverage"
   - task: Bash@3
     displayName: codecov
-    condition: "ne('', variables['codecovToken'])"
     inputs:
       targetType: inline
       script: |


### PR DESCRIPTION
This PR bumps the netmq version to [4.0.0.207-pre](https://www.nuget.org/packages/NetMQ/4.0.0.207-pre) to avoid unexpected errors on macOS. 

I omitted change log because it doesn't change behavior.