### PR TITLE
Fix relaying bug with NAT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,8 @@ To be released.
     [[#217]]
  -  Improved concurrency of `BlockChain<T>.Append()` method by removing
     unnecessary race conditions. [[#217]]
+ -  Fixed a bug that `Swarm` could not properly communicate with `Peer` behind
+    NAT. [[#240]]
 
 [Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md
 [#31]: https://github.com/planetarium/libplanet/issues/31
@@ -144,6 +146,7 @@ To be released.
 [#232]: https://github.com/planetarium/libplanet/pull/232
 [#234]: https://github.com/planetarium/libplanet/pull/234
 [#236]: https://github.com/planetarium/libplanet/pull/236
+[#240]: https://github.com/planetarium/libplanet/pull/240
 
 
 Version 0.2.2

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tests.Net
                     "7ca8dbad5e1c8c9b130a9d39171a44134"
                     ));
             var endPoint = new DnsEndPoint("0.0.0.0", 1234);
-            var peer = new Peer(key, endPoint, 1);
+            var peer = new Peer(key, endPoint, 1, IPAddress.IPv6Loopback);
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -713,7 +713,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Trait("RequireTurnServer", "true")]
-        [FactOnlyTurnAvailable]
+        [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task ExchangeWithIceServer()
         {
             Uri turnUrl = FactOnlyTurnAvailable.TurnUri;

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Net
         [Pure]
         public int AppProtocolVersion { get; }
 
-        /// <summary>The peer's address which is derviced from
+        /// <summary>The peer's address which is derived from
         /// its <see cref="PublicKey"/>.
         /// </summary>
         /// <seealso cref="PublicKey"/>

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -25,20 +25,25 @@ namespace Libplanet.Net
         /// <param name="appProtocolVersion">An application protocol version
         /// that the <see cref="Peer"/> is using.</param>
         public Peer(
-            PublicKey publicKey, DnsEndPoint endPoint, int appProtocolVersion)
+            PublicKey publicKey,
+            DnsEndPoint endPoint,
+            int appProtocolVersion)
+        : this(publicKey, endPoint, appProtocolVersion, null)
         {
-            if (publicKey == null)
-            {
-                throw new ArgumentNullException(nameof(publicKey));
-            }
-            else if (endPoint == null)
-            {
-                throw new ArgumentNullException(nameof(endPoint));
-            }
+        }
 
-            PublicKey = publicKey;
-            EndPoint = endPoint;
+        internal Peer(
+            PublicKey publicKey,
+            DnsEndPoint endPoint,
+            int appProtocolVersion,
+            IPAddress publicIPAddress)
+        {
+            PublicKey = publicKey ??
+                        throw new ArgumentNullException(nameof(publicKey));
+            EndPoint = endPoint ??
+                       throw new ArgumentNullException(nameof(endPoint));
             AppProtocolVersion = appProtocolVersion;
+            PublicIPAddress = publicIPAddress;
         }
 
         protected Peer(SerializationInfo info, StreamingContext context)
@@ -48,6 +53,11 @@ namespace Libplanet.Net
                 info.GetString("end_point_host"),
                 info.GetInt32("end_point_port"));
             AppProtocolVersion = info.GetInt32("app_protocol_version");
+            string addressStr = info.GetString("public_ip_address");
+            if (addressStr != null)
+            {
+                PublicIPAddress = IPAddress.Parse(addressStr);
+            }
         }
 
         /// <summary>
@@ -79,6 +89,9 @@ namespace Libplanet.Net
         [Pure]
         public Address Address => new Address(PublicKey);
 
+        [Pure]
+        internal IPAddress PublicIPAddress { get; }
+
         /// <inheritdoc/>
         public void GetObjectData(
             SerializationInfo info,
@@ -89,6 +102,7 @@ namespace Libplanet.Net
             info.AddValue("end_point_host", EndPoint.Host);
             info.AddValue("end_point_port", EndPoint.Port);
             info.AddValue("app_protocol_version", AppProtocolVersion);
+            info.AddValue("public_ip_address", PublicIPAddress?.ToString());
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR fixes a bug that `Swarm` could not properly communicate with `Peer` behind NAT. to accomplish that, it made changes as belows.

- Added `Peer.PublicIPAddress` which indicates the IP address to be used when the peer connects to another peer.
  - it's `internal` and does not affect public interface.
- Made `Swarm.CreatePermission()` uses `Peer.PublicIPAddress` instead of `Peer.Endpoint` if available.