### PR TITLE
Remove state comparison in EvaluateActionsGradually

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@ To be released.
     [[#228], [#234]]
  -  `Swarm.StartAsync()` now does not call `Swarm.StopAsync()` anymore,
     therefore `Swarm.StopAsync()` should be explicitly called.  [[#236]]
+ -  `Transaction<T>.EvaluateActionsGradually()` became to record
+    `IAccountStateDelta.SetState()` calls even if its argument is the same
+    to the previous state. [[#241]]
 
 ### Bug fixes
 
@@ -147,6 +150,7 @@ To be released.
 [#234]: https://github.com/planetarium/libplanet/pull/234
 [#236]: https://github.com/planetarium/libplanet/pull/236
 [#240]: https://github.com/planetarium/libplanet/pull/240
+[#241]: https://github.com/planetarium/libplanet/pull/241
 
 
 Version 0.2.2

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -73,7 +73,6 @@ namespace Libplanet.Tests.Action
             IAccountStateDelta c = b.SetState(_addr[0], "a");
             Assert.Equal("a", c.GetState(_addr[0]));
             Assert.Equal("z", b.GetState(_addr[0]));
-            Assert.Empty(c.UpdatedAddresses);
             Assert.Empty(init.UpdatedAddresses);
         }
 

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -46,21 +46,9 @@ namespace Libplanet.Action
             object state
         )
         {
-            IImmutableDictionary<Address, object> newState =
-                _updatedStates.SetItem(address, state);
-            foreach (Address addr in newState.Keys)
-            {
-                object epochState = _accountStateGetter(addr);
-                if (ReferenceEquals(epochState, state) ||
-                    Equals(epochState, state))
-                {
-                    newState = newState.Remove(addr);
-                }
-            }
-
             return new AccountStateDeltaImpl(_accountStateGetter)
             {
-                _updatedStates = newState,
+                _updatedStates = _updatedStates.SetItem(address, state),
             };
         }
     }


### PR DESCRIPTION
This PR removes state comparison in `AccountStateDeltaImpl.SetState()` (used by `IAction.Execute()`) to improve performance of action evaluation.