### PR TITLE
Prevent multiple transactions of the same signer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@ To be released.
     parameter.  This purposes to determine how long to wait for pending
     messages when a `Swarm` instance is requested to terminate.
  -  Added `NamespaceNotFoundException` class.  [[#232]]
+ -  Added `SimultaneousTxsException` class.  [[#242]]
 
 ### Behavioral changes
 
@@ -94,6 +95,8 @@ To be released.
  -  `Transaction<T>.EvaluateActionsGradually()` became to record
     `IAccountStateDelta.SetState()` calls even if its argument is the same
     to the previous state. [[#241]]
+ -  A signer became to allowed to have only one transaction at most in 
+    `Block<T>.Transactions`. [[#125]], [[#242]]
 
 ### Bug fixes
 
@@ -125,6 +128,7 @@ To be released.
 
 [Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md
 [#31]: https://github.com/planetarium/libplanet/issues/31
+[#125]: https://github.com/planetarium/libplanet/issues/125
 [#185]: https://github.com/planetarium/libplanet/pull/185
 [#187]: https://github.com/planetarium/libplanet/issues/187
 [#190]: https://github.com/planetarium/libplanet/pull/190
@@ -151,6 +155,7 @@ To be released.
 [#236]: https://github.com/planetarium/libplanet/pull/236
 [#240]: https://github.com/planetarium/libplanet/pull/240
 [#241]: https://github.com/planetarium/libplanet/pull/241
+[#242]: https://github.com/planetarium/libplanet/pull/242
 
 
 Version 0.2.2

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -446,6 +446,26 @@ namespace Libplanet.Tests.Blocks
         }
 
         [Fact]
+        public void ValidateSignersHaveOnlyOneTransactions()
+        {
+            var privateKey = new PrivateKey();
+
+            var tx1 = Transaction<PolymorphicAction<BaseAction>>.Create(
+                privateKey,
+                new PolymorphicAction<BaseAction>[0]);
+            var tx2 = Transaction<PolymorphicAction<BaseAction>>.Create(
+                privateKey,
+                new PolymorphicAction<BaseAction>[0]);
+
+            Block<PolymorphicAction<BaseAction>> invalidBlock = MineNext(
+                _fx.Genesis,
+                new[] { tx1, tx2 });
+
+            Assert.Throws<SimultaneousTxsException>(() =>
+                invalidBlock.Validate(DateTimeOffset.UtcNow, _ => null));
+        }
+
+        [Fact]
         public void CanDetectInvalidTimestamp()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;

--- a/Libplanet/Blocks/SimultaneousTxsException.cs
+++ b/Libplanet/Blocks/SimultaneousTxsException.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Libplanet.Blocks
+{
+    /// <summary>
+    /// The exception that is thrown when a signer has more than one
+    /// transactions in <see cref="Block{T}.Transactions"/>.
+    /// </summary>
+    [Serializable]
+    public sealed class SimultaneousTxsException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="SimultaneousTxsException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="signers">Addresses of signers who have more than one
+        /// transactions in <see cref="Block{T}.Transactions"/>.</param>
+        public SimultaneousTxsException(
+            string message,
+            IEnumerable<Address> signers)
+            : base($"{message}: Signers: {string.Join(", ", signers)}")
+        {
+            Signers = signers;
+        }
+
+        /// <summary>
+        /// Gets the addresses of signers who have more than one transactions
+        /// in <see cref="Block{T}.Transactions"/>.
+        /// </summary>
+        public IEnumerable<Address> Signers { get; }
+    }
+}


### PR DESCRIPTION
This patch prevents multiple transactions of the same signer from being stored in one block to prevent transaction replay.  #125 