### PR TITLE
Integrate Block<T>.Validate() and .EvaluateActions()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ To be released.
     [[#232]]
  -  Added `IStore.ForkStateReferences<T>(string, string, Block<T>,
     IImmutableSet<Address>` method.  [[#232]]
+ -  Removed `Block<T>.Validate()` and `Block<T>.EvaluateActions()` method.  [[#243]]
 
 ### Added interfaces
 
@@ -74,6 +75,7 @@ To be released.
     messages when a `Swarm` instance is requested to terminate.
  -  Added `NamespaceNotFoundException` class.  [[#232]]
  -  Added `SimultaneousTxsException` class.  [[#242]]
+ -  Added `Block<T>.Evaluate()` method.  [[#243]]
 
 ### Behavioral changes
 
@@ -97,7 +99,11 @@ To be released.
     to the previous state. [[#241]]
  -  A signer became to allowed to have only one transaction at most in 
     `Block<T>.Transactions`. [[#125]], [[#242]]
-
+ -  `Block<T>.Validate()` and `Block<T>.EvaluateActions()` are integrated into
+    `Block<T>.Evaluate()`.  [[#243]]
+ -  `BlockChain<T>.Append()` became to execute `Action.Execute()` only once per
+    actions in the `Block<T>`.  [[#243]]
+ 
 ### Bug fixes
 
  -  Fixed a bug that TURN relay had been disconnected when being connected for
@@ -156,6 +162,7 @@ To be released.
 [#240]: https://github.com/planetarium/libplanet/pull/240
 [#241]: https://github.com/planetarium/libplanet/pull/241
 [#242]: https://github.com/planetarium/libplanet/pull/242
+[#243]: https://github.com/planetarium/libplanet/pull/243
 
 
 Version 0.2.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,7 +102,7 @@ To be released.
  -  `Block<T>.Validate()` and `Block<T>.EvaluateActions()` are integrated into
     `Block<T>.Evaluate()`.  [[#243]]
  -  `BlockChain<T>.Append()` became to execute `Action.Execute()` only once per
-    actions in the `Block<T>`.  [[#243]]
+    action in the `Block<T>`.  [[#243]]
  
 ### Bug fixes
 

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -203,9 +203,9 @@ namespace Libplanet.Tests.Blocks
             int randomValue = 0;
             (int, int, string[], Address)[] expectations =
             {
-                (0, 0, new[] { "A", null, null, null, null }, _fx.TxFixture.PrivateKey1.PublicKey.ToAddress()),
-                (0, 1, new[] { "A", "B", null, null, null }, _fx.TxFixture.PrivateKey1.PublicKey.ToAddress()),
-                (1, 0, new[] { "A", "B", "C", null, null }, _fx.TxFixture.PrivateKey2.PublicKey.ToAddress()),
+                (0, 0, new[] { "A", null, null, null, null }, _fx.TxFixture.Address1),
+                (0, 1, new[] { "A", "B", null, null, null }, _fx.TxFixture.Address1),
+                (1, 0, new[] { "A", "B", "C", null, null }, _fx.TxFixture.Address2),
             };
             Assert.Equal(expectations.Length, pairs.Length);
             foreach (
@@ -282,9 +282,9 @@ namespace Libplanet.Tests.Blocks
                 .ToImmutableArray();
             expectations = new[]
             {
-                (0, 0, new[] { "A,D", "B", "C", null, null }, _fx.TxFixture.PrivateKey1.PublicKey.ToAddress()),
-                (1, 0, new[] { "A,D", "B", "C", "E", null }, _fx.TxFixture.PrivateKey2.PublicKey.ToAddress()),
-                (2, 0, new[] { "A,D", "B", "C", "E", "RecordRehearsal:False" }, _fx.TxFixture.PrivateKey3.PublicKey.ToAddress()),
+                (0, 0, new[] { "A,D", "B", "C", null, null }, _fx.TxFixture.Address1),
+                (1, 0, new[] { "A,D", "B", "C", "E", null }, _fx.TxFixture.Address2),
+                (2, 0, new[] { "A,D", "B", "C", "E", "RecordRehearsal:False" }, _fx.TxFixture.Address3),
             };
             Assert.Equal(expectations.Length, pairs.Length);
             foreach (
@@ -336,9 +336,9 @@ namespace Libplanet.Tests.Blocks
         public void EvaluateInvalidTxSignature()
         {
             RawTransaction rawTx = new RawTransaction(
-                _fx.TxFixture.Address.ToByteArray(),
+                _fx.TxFixture.Address1.ToByteArray(),
                 new byte[][] { },
-                _fx.TxFixture.PublicKey.Format(false),
+                _fx.TxFixture.PublicKey1.Format(false),
                 DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
                 new IDictionary<string, object>[0],
                 new byte[10]
@@ -359,7 +359,7 @@ namespace Libplanet.Tests.Blocks
             RawTransaction rawTxWithoutSig = new RawTransaction(
                 new PrivateKey().PublicKey.ToAddress().ToByteArray(),
                 new byte[][] { },
-                _fx.TxFixture.PublicKey.Format(false),
+                _fx.TxFixture.PublicKey1.Format(false),
                 DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
                 new IDictionary<string, object>[0],
                 new byte[0]
@@ -393,9 +393,9 @@ namespace Libplanet.Tests.Blocks
                 _fx.TxFixture.TxWithActions
                     .ToRawTransaction(false).Actions.ToImmutableArray();
             RawTransaction rawTxWithoutSig = new RawTransaction(
-                _fx.TxFixture.Address.ToByteArray(),
+                _fx.TxFixture.Address1.ToByteArray(),
                 new byte[][] { },
-                _fx.TxFixture.PublicKey.Format(false),
+                _fx.TxFixture.PublicKey1.Format(false),
                 DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
                 rawActions,
                 new byte[0]

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -107,7 +107,7 @@ namespace Libplanet.Tests.Tx
                 _fx.TxWithActions.Actions
             );
             Assert.Equal(
-                new[] { _fx.Address }.ToImmutableHashSet(),
+                new[] { _fx.Address1 }.ToImmutableHashSet(),
                 tx.UpdatedAddresses
             );
 
@@ -118,7 +118,7 @@ namespace Libplanet.Tests.Tx
                 new[] { additionalAddr }.ToImmutableHashSet()
             );
             Assert.Equal(
-                new[] { _fx.Address, additionalAddr }.ToHashSet(),
+                new[] { _fx.Address1, additionalAddr }.ToHashSet(),
                 txWithAddr.UpdatedAddresses.ToHashSet()
             );
         }
@@ -628,7 +628,7 @@ namespace Libplanet.Tests.Tx
                 {
                     ActionEvaluation<DumbAction> eval = evaluations[i];
                     Assert.Equal(actions[i], eval.Action);
-                    Assert.Equal(_fx.Address, eval.InputContext.Signer);
+                    Assert.Equal(_fx.Address1, eval.InputContext.Signer);
                     Assert.Equal(addresses[0], eval.InputContext.Miner);
                     Assert.Equal(1, eval.InputContext.BlockIndex);
                     Assert.Equal(rehearsal, eval.InputContext.Rehearsal);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -97,13 +97,13 @@ namespace Libplanet.Tests.Tx
         public void CreateWithDefaultUpdatedAddresses()
         {
             Transaction<DumbAction> emptyTx = Transaction<DumbAction>.Create(
-                _fx.PrivateKey,
+                _fx.PrivateKey1,
                 new DumbAction[0]
             );
             Assert.Empty(emptyTx.UpdatedAddresses);
 
             var tx = Transaction<PolymorphicAction<BaseAction>>.Create(
-                _fx.PrivateKey,
+                _fx.PrivateKey1,
                 _fx.TxWithActions.Actions
             );
             Assert.Equal(
@@ -113,7 +113,7 @@ namespace Libplanet.Tests.Tx
 
             Address additionalAddr = new PrivateKey().PublicKey.ToAddress();
             var txWithAddr = Transaction<PolymorphicAction<BaseAction>>.Create(
-                _fx.PrivateKey,
+                _fx.PrivateKey1,
                 _fx.TxWithActions.Actions,
                 new[] { additionalAddr }.ToImmutableHashSet()
             );
@@ -128,7 +128,7 @@ namespace Libplanet.Tests.Tx
         {
             DateTimeOffset rightBefore = DateTimeOffset.UtcNow;
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
-                _fx.PrivateKey,
+                _fx.PrivateKey1,
                 new DumbAction[0],
                 ImmutableHashSet<Address>.Empty
             );
@@ -153,7 +153,7 @@ namespace Libplanet.Tests.Tx
             // The actions parameter cannot be null.
             Assert.Throws<ArgumentNullException>(() =>
                 Transaction<DumbAction>.Create(
-                    _fx.PrivateKey,
+                    _fx.PrivateKey1,
                     null,
                     ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow
@@ -167,7 +167,7 @@ namespace Libplanet.Tests.Tx
             var action = new ThrowException { Throw = true };
             Assert.Throws<UnexpectedlyTerminatedTxRehearsalException>(() =>
                 Transaction<ThrowException>.Create(
-                    _fx.PrivateKey,
+                    _fx.PrivateKey1,
                     new[] { action },
                     ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow
@@ -602,7 +602,7 @@ namespace Libplanet.Tests.Tx
                 new DumbAction(addresses[2], "R", true, recordRandom: true),
             };
             Transaction<DumbAction> tx =
-                Transaction<DumbAction>.Create(_fx.PrivateKey, actions);
+                Transaction<DumbAction>.Create(_fx.PrivateKey1, actions);
             foreach (bool rehearsal in new[] { false, true })
             {
                 DumbAction.RehearsalRecords.Value =
@@ -843,12 +843,12 @@ namespace Libplanet.Tests.Tx
         {
             var actions = new List<DumbAction>();
             Transaction<DumbAction> t1 = Transaction<DumbAction>.Create(
-                _fx.PrivateKey,
+                _fx.PrivateKey1,
                 actions
             );
             var t2 = new Transaction<DumbAction>(
-                _fx.PrivateKey.PublicKey.ToAddress(),
-                _fx.PrivateKey.PublicKey,
+                _fx.PrivateKey1.PublicKey.ToAddress(),
+                _fx.PrivateKey1.PublicKey,
                 ImmutableHashSet<Address>.Empty,
                 t1.Timestamp,
                 actions,

--- a/Libplanet.Tests/Tx/TxFixture.cs
+++ b/Libplanet.Tests/Tx/TxFixture.cs
@@ -71,9 +71,17 @@ namespace Libplanet.Tests.Tx
 
         public PrivateKey PrivateKey3 { get; }
 
-        public PublicKey PublicKey => PrivateKey1.PublicKey;
+        public PublicKey PublicKey1 => PrivateKey1.PublicKey;
 
-        public Address Address => PublicKey.ToAddress();
+        public PublicKey PublicKey2 => PrivateKey2.PublicKey;
+
+        public PublicKey PublicKey3 => PrivateKey3.PublicKey;
+
+        public Address Address1 => PublicKey1.ToAddress();
+
+        public Address Address2 => PublicKey2.ToAddress();
+
+        public Address Address3 => PublicKey3.ToAddress();
 
         public Transaction<PolymorphicAction<BaseAction>> Tx { get; }
 

--- a/Libplanet.Tests/Tx/TxFixture.cs
+++ b/Libplanet.Tests/Tx/TxFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
@@ -11,7 +10,7 @@ namespace Libplanet.Tests.Tx
     {
         public TxFixture()
         {
-            PrivateKey = new PrivateKey(
+            PrivateKey1 = new PrivateKey(
                 new byte[]
                 {
                     0xcf, 0x36, 0xec, 0xf9, 0xe4, 0x7c, 0x87, 0x9a, 0x0d, 0xbf,
@@ -20,11 +19,29 @@ namespace Libplanet.Tests.Tx
                     0x7b, 0x76,
                 }
             );
-            var recipient = new Address(PrivateKey.PublicKey);
+            PrivateKey2 = new PrivateKey(
+                new byte[]
+                {
+                    0xa8, 0x69, 0xfd, 0xac, 0xed, 0x45, 0x18, 0xd5, 0x36, 0x30,
+                    0x25, 0xe5, 0xfa, 0x15, 0x26, 0x10, 0x88, 0x39, 0x78, 0x0e,
+                    0xac, 0x98, 0x73, 0x5c, 0x3f, 0x3f, 0x42, 0xec, 0xd3, 0xd2,
+                    0x42, 0x46,
+                }
+            );
+            PrivateKey3 = new PrivateKey(
+                new byte[]
+                {
+                    0x92, 0x7e, 0xed, 0x40, 0x7f, 0x15, 0x0f, 0x50, 0xc5, 0x60,
+                    0x50, 0x15, 0x54, 0x0d, 0xe7, 0xaa, 0x4d, 0x0e, 0xa3, 0x34,
+                    0x31, 0x9b, 0x4e, 0xa8, 0x91, 0xab, 0xcd, 0x02, 0xdb, 0x14,
+                    0x9f, 0x5f,
+                }
+            );
+            var recipient = new Address(PrivateKey1.PublicKey);
             var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
 
             Tx = Transaction<PolymorphicAction<BaseAction>>.Create(
-                PrivateKey,
+                PrivateKey1,
                 new PolymorphicAction<BaseAction>[0],
                 timestamp: timestamp
             );
@@ -42,15 +59,19 @@ namespace Libplanet.Tests.Tx
                 },
             };
             TxWithActions = Transaction<PolymorphicAction<BaseAction>>.Create(
-                PrivateKey,
+                PrivateKey1,
                 actions,
                 timestamp: timestamp
             );
         }
 
-        public PrivateKey PrivateKey { get; }
+        public PrivateKey PrivateKey1 { get; }
 
-        public PublicKey PublicKey => PrivateKey.PublicKey;
+        public PrivateKey PrivateKey2 { get; }
+
+        public PrivateKey PrivateKey3 { get; }
+
+        public PublicKey PublicKey => PrivateKey1.PublicKey;
 
         public Address Address => PublicKey.ToAddress();
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -171,13 +171,13 @@ namespace Libplanet.Blocks
                 );
             foreach (Transaction<T> tx in Transactions)
             {
-                IEnumerable<ActionEvaluation<T>> triples =
+                IEnumerable<ActionEvaluation<T>> evaluations =
                     tx.EvaluateActionsGradually(
                         Hash,
                         Index,
                         delta,
                         Miner.Value);
-                foreach (var evaluation in triples)
+                foreach (var evaluation in evaluations)
                 {
                     yield return (tx, evaluation);
                     delta = evaluation.OutputStates;
@@ -194,16 +194,16 @@ namespace Libplanet.Blocks
         /// <para>It throws an <see cref="InvalidBlockException"/> or
         /// an <see cref="InvalidTxException"/> if there is any
         /// integrity error.</para>
-        /// <para>Otherwise it returns an <see cref="ActionEvaluation{T}"/>
-        /// for each steps.</para>
+        /// <para>Otherwise it enumerates an <see cref="ActionEvaluation{T}"/>
+        /// for each <see cref="IAction"/>.</para>
         /// </summary>
         /// <param name="currentTime">The current time to validate
         /// time-wise conditions.</param>
         /// <param name="accountStateGetter">The getter of previous states.
         /// This affects the execution of <see cref="Transaction{T}.Actions"/>.
         /// </param>
-        /// <returns>An <see cref="ActionEvaluation{T}"/> for each steps.
-        /// </returns>
+        /// <returns>An <see cref="ActionEvaluation{T}"/> for each
+        /// <see cref="IAction"/>.</returns>
         /// <exception cref="InvalidBlockTimestampException">Thrown when
         /// the <see cref="Timestamp"/> is invalid, for example, it is the far
         /// future than the given <paramref name="currentTime"/>.</exception>


### PR DESCRIPTION
This PR integrates `Block<T>.Validate()` and `Block<T>.EvaluateActions()` into `Block<T>.Evaluate()` to reduce `Action.Execute()` during `BlockChain<T>.Append()`.
