### PR TITLE
Force dotnet if running on mono

### DIFF
--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -28,7 +28,7 @@ steps:
   displayName: xunit.console.exe *.Tests.dll
   inputs:
     script: |
-      mono xunit.runner.console.*/tools/net472/xunit.console.exe \
+      mono xunit.runner.console.*/tools/net461/xunit.console.exe \
         *.Tests/bin/${{ parameters.configuration }}/net*/*.Tests.dll
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}

--- a/.azure-pipelines/windows-net461.yml
+++ b/.azure-pipelines/windows-net461.yml
@@ -36,12 +36,6 @@ steps:
         xunit.runner.console.*/tools/net472/xunit.console.exe \
           *.Tests/bin/$(configuration)/net*/*.Tests.dll \
           ${{ parameters.testArguments }}
-    # FIXME: For unknown reason, on Windows tests depending on TURN_SERVER_URL
-    #        seems to never end or to take too long time.  We should diagnose
-    #        this and make Windows builds to run these tests too.
-    # FIXME: For unknown reason, on Windows + Mono SwarmTests seem never end.
-    #        We should diagnose this and make Windows builds to run these
-    #        tests too.
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
   timeoutInMinutes: 10

--- a/.azure-pipelines/windows-net461.yml
+++ b/.azure-pipelines/windows-net461.yml
@@ -33,7 +33,7 @@ steps:
     targetType: inline
     script: |
       ${{ parameters.testPrefix }} \
-        xunit.runner.console.*/tools/net472/xunit.console.exe \
+        xunit.runner.console.*/tools/net461/xunit.console.exe \
           *.Tests/bin/$(configuration)/net*/*.Tests.dll \
           ${{ parameters.testArguments }}
   env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,7 +112,9 @@ To be released.
  -  `BlockChain<T>.Append()` method became to throw `InvalidTxNonceException`
     when the `Transaction<T>.Nonce` does not correspond to its `Signer`'s
     current nonce.  [[#246]]
-
+ -  `Swarm` became to enforce `ForceDotNet.Force()` in [AsyncIO] while it's running on
+    Mono runtime.  [[#247]]
+ 
 ### Bug fixes
 
  -  Fixed a bug that TURN relay had been disconnected when being connected for
@@ -141,6 +143,7 @@ To be released.
  -  Fixed a bug that `Swarm` could not properly communicate with `Peer` behind
     NAT. [[#240]]
 
+[AsyncIO]: https://github.com/somdoron/AsyncIO
 [Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md
 [#31]: https://github.com/planetarium/libplanet/issues/31
 [#133]: https://github.com/planetarium/libplanet/issues/133
@@ -171,6 +174,8 @@ To be released.
 [#240]: https://github.com/planetarium/libplanet/pull/240
 [#241]: https://github.com/planetarium/libplanet/pull/241
 [#243]: https://github.com/planetarium/libplanet/pull/243
+[#246]: https://github.com/planetarium/libplanet/pull/246
+[#247]: https://github.com/planetarium/libplanet/pull/247
 [#251]: https://github.com/planetarium/libplanet/pull/251
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,8 @@ To be released.
     unnecessary race conditions. [[#217]]
  -  Fixed a bug that `Swarm` could not properly communicate with `Peer` behind
     NAT. [[#240]]
+ -  Fixed a bug that `BlockChain<T>.FindNextHashes()` throws
+    `ArgumentOutOfRangeException` when chain is empty.
 
 [AsyncIO]: https://github.com/somdoron/AsyncIO
 [Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -300,8 +301,11 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanFindNextHashes()
+        public void FindNextHashes()
         {
+            Assert.Empty(_blockChain.FindNextHashes(
+                new BlockLocator(new HashDigest<SHA256>[] { })
+                ));
             _blockChain.Append(_fx.Block1);
             var block0 = _fx.Block1;
             var block1 = _blockChain.MineBlock(_fx.Address1);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -275,51 +275,6 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task WorksAsCollection()
-        {
-            Swarm a = _swarms[0];
-            Swarm b = _swarms[1];
-            Swarm c = _swarms[2];
-
-            // Obtaining swarm's endpoint...
-            await Task.WhenAll(
-                StartAsync(a, _blockchains[0]),
-                StartAsync(b, _blockchains[1]),
-                StartAsync(c, _blockchains[2]));
-
-            Assert.Empty(a);
-            Assert.Empty(b);
-            Assert.Empty(c);
-
-            a.Add(b.AsPeer);
-            a.Add(c.AsPeer);
-            Assert.Contains(b.AsPeer, a);
-            Assert.Contains(c.AsPeer, a);
-
-            Peer[] peers = null;
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                a.CopyTo(peers, 0);
-            });
-
-            peers = new Peer[3];
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                a.CopyTo(peers, -1);
-            });
-            Assert.Throws<ArgumentException>(() =>
-            {
-                a.CopyTo(peers, 2);
-            });
-
-            a.CopyTo(peers, 1);
-
-            Assert.Equal(
-                new HashSet<Peer> { null, b.AsPeer, c.AsPeer },
-                peers.ToHashSet());
-        }
-
-        [Fact(Timeout = Timeout)]
         public async Task DetectAppProtocolVersion()
         {
             var a = new Swarm(
@@ -353,8 +308,8 @@ namespace Libplanet.Tests.Net
 
                 foreach (var peer in peers)
                 {
-                    a.Add(peer);
-                    b.Add(peer);
+                    await a.AddPeersAsync(new[] { peer });
+                    await b.AddPeersAsync(new[] { peer });
                 }
 
                 Assert.Equal(new[] { c.AsPeer }, a.ToArray());
@@ -396,7 +351,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(a, chain);
                 await StartAsync(b, chain);
 
-                a.Add(b.AsPeer);
+                await a.AddPeersAsync(new[] { b.AsPeer });
 
                 Assert.True(isCalled);
             }
@@ -773,7 +728,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm, minerChain);
-                receiverSwarm.Add(minerSwarm.AsPeer);
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
                 await StartAsync(receiverSwarm, receiverChain);
 
@@ -815,7 +770,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm, minerChain);
-                receiverSwarm.Add(minerSwarm.AsPeer);
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
                 await receiverSwarm.PreloadAsync(receiverChain, progress);
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -83,6 +83,11 @@ namespace Libplanet.Tests.Net
             {
                 s.StopAsync().Wait(DisposeTimeout);
             }
+
+            if (!(Type.GetType("Mono.Runtime") is null))
+            {
+                NetMQConfig.Cleanup(false);
+            }
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -445,6 +445,11 @@ namespace Libplanet.Blockchain
 
                 HashDigest<SHA256>? tip = Store.IndexBlockHash(
                     Id.ToString(), -1);
+                if (tip is null)
+                {
+                    yield break;
+                }
+
                 HashDigest<SHA256>? currentHash = FindBranchPoint(locator);
 
                 while (currentHash != null && count > 0)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1092,9 +1092,19 @@ namespace Libplanet.Net
             _logger.Debug("Trying to find branchpoint...");
             BlockLocator locator = blockChain.GetBlockLocator();
             _logger.Debug($"Locator's count: {locator.Count()}");
-            IEnumerable<HashDigest<SHA256>> hashes =
+            IEnumerable<HashDigest<SHA256>> hashes = (
                 await GetBlockHashesAsync(
-                    peer, locator, stop, cancellationToken);
+                    peer, locator, stop, cancellationToken)
+            ).ToArray();
+
+            if (!hashes.Any())
+            {
+                _logger.Debug(
+                    $"Peer[{peer}] didn't return any hashes. " +
+                    $"ignored.");
+                return blockChain;
+            }
+
             HashDigest<SHA256> branchPoint = hashes.First();
 
             _logger.Debug(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -252,7 +252,7 @@ namespace Libplanet.Net
             DateTimeOffset? timestamp = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (timestamp == null)
+            if (timestamp is null)
             {
                 timestamp = DateTimeOffset.UtcNow;
             }
@@ -314,6 +314,10 @@ namespace Libplanet.Net
                             $"DialPeerAsync({peer}) failed. ignored."
                         );
                     }
+                }
+                else
+                {
+                    _peers[peer] = timestamp.Value;
                 }
             }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -12,6 +12,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using AsyncIO;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -64,6 +65,14 @@ namespace Libplanet.Net
         private TurnClient _turnClient;
         private CancellationTokenSource _workerCancellationTokenSource;
         private IPAddress _publicIPAddress;
+
+        static Swarm()
+        {
+            if (!(Type.GetType("Mono.Runtime") is null))
+            {
+                ForceDotNet.Force();
+            }
+        }
 
         public Swarm(
             PrivateKey privateKey,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,12 +98,7 @@ jobs:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
       testPrefix: '"$PROGRAMFILES/Mono/bin/mono.exe"'
-      testArguments: |
-        -appdomains denied \
-        -noclass Libplanet.Tests.Net.SwarmTest
-      # FIXME: For unknown reason, on Windows + Mono SwarmTests seem never end.
-      #        We should diagnose this and make Windows builds to run these
-      #        tests too.
+      testArguments: -appdomains denied
   timeoutInMinutes: 30
 
 - job: Linux_NETCore


### PR DESCRIPTION
- This PR mainly aids hanging unit tests running on Mono in Windows by calling `AsyncIO.ForceDotNet.Force()` to enforce using sockets in .NET, not Windows native.
- It's also prevents some other possible hanging unit tests by eliminating `Swarm.Add()` usages.
- It's also fixes `ArgumentOutOfRangeException` that occurred when requesting a hash when `BlockChain <T>` was empty.