### PR TITLE
Fix broken release script

### DIFF
--- a/.github/bin/dist-version.ps1
+++ b/.github/bin/dist-version.ps1
@@ -8,9 +8,11 @@ if ((Get-ChildItem env:GITHUB_*).Count -lt 1) {
   exit 1
 }
 
+$Namespace = @{m = "http://schemas.microsoft.com/developer/msbuild/2003"}
 $VersionPrefix = (Select-Xml `
   -Path Libplanet/Libplanet.csproj `
-  -XPath './Project/PropertyGroup/VersionPrefix/text()').Node.Value
+  -Namespace $Namespace `
+  -XPath './m:Project/m:PropertyGroup/m:VersionPrefix/text()').Node.Value
 
 New-Item -ItemType directory -Path obj -ErrorAction SilentlyContinue
 [Console]::Error.Write("VersionPrefix: ")

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "push" {
 
 workflow "pull request" {
   on = "pull_request"
-  resolves = ["docs:status"]
+  resolves = ["docs:status", "dist:pack"]
 }
 
 workflow "everyday" {
@@ -60,13 +60,14 @@ action "docs:status" {
   ]
 }
 
-action "dist:version" {
-  uses = "docker://mcr.microsoft.com/powershell:latest"
-  args = [".github/bin/dist-version.ps1"]
-}
-
 action "dist:git-checkout" {
   uses = "dahlia/actions/checkout-pull-request@master"
+}
+
+action "dist:version" {
+  uses = "docker://mcr.microsoft.com/powershell:latest"
+  needs = ["dist:git-checkout"]
+  args = [".github/bin/dist-version.ps1"]
 }
 
 action "dist:pack" {


### PR DESCRIPTION
This fixes the broken release script run by GitHub Actions.  My previous patch #245 assigned the MSBuild 2003 XML namespace to *\*.csproj* files, and it broke the XPath used by `dist:version` action.

In order to be warned before a pull request is merged, I also made `dist:pack` action run for `pull_request` events.