### PR TITLE
Typo on version string: +, not .

### DIFF
--- a/.github/bin/dist-version.ps1
+++ b/.github/bin/dist-version.ps1
@@ -43,7 +43,7 @@ if ($env:GITHUB_EVENT_NAME.StartsWith("schedule")) {
     $timestamp = Get-Date
   }
   $timestamp = $timestamp.ToUniversalTime()
-  $VersionSuffix = "dev.$($timestamp.ToString("yyyyMMddHHmmss")).$HeadCommit"
+  $VersionSuffix = "dev.$($timestamp.ToString("yyyyMMddHHmmss"))+$HeadCommit"
   $PackageVersion = "$VersionPrefix-$VersionSuffix"
 }
 


### PR DESCRIPTION
This is a bugfix of my previous patch #253. 🙄 