### PR TITLE
Denote build metadata only to VersionSuffix

### DIFF
--- a/.github/bin/dist-version.ps1
+++ b/.github/bin/dist-version.ps1
@@ -24,8 +24,9 @@ $HeadCommit = `
 
 if ($env:GITHUB_EVENT_NAME.StartsWith("schedule")) {
   $date = (Get-Date).ToUniversalTime().ToString("yyyyMMdd")
-  $VersionSuffix = "nightly.$date+$HeadCommit"
+  $VersionSuffix = "nightly.$date"
   $PackageVersion = "$VersionPrefix-$VersionSuffix"
+  $VersionSuffix = "$VersionSuffix+$HeadCommit"
 } elseif ($env:GITHUB_REF.StartsWith("refs/tags/")) {
   $tag = $env:GITHUB_REF.Substring(10)
   if ("$tag" -ne "$VersionPrefix") {
@@ -36,15 +37,16 @@ if ($env:GITHUB_EVENT_NAME.StartsWith("schedule")) {
 } else {
   $event = Get-Content $env:GITHUB_EVENT_PATH | ConvertFrom-Json
   $timestamp = $event.head_commit.timestamp
-  if ($event.head_commit.id -ne $null) {
-    $HeadCommit = $event.head_commit.id.Substring(0, 7)
-  }
   if ($timestamp -eq $null) {
     $timestamp = Get-Date
   }
   $timestamp = $timestamp.ToUniversalTime()
-  $VersionSuffix = "dev.$($timestamp.ToString("yyyyMMddHHmmss"))+$HeadCommit"
+  $VersionSuffix = "dev.$($timestamp.ToString("yyyyMMddHHmmss"))"
   $PackageVersion = "$VersionPrefix-$VersionSuffix"
+  if ($event.head_commit.id -ne $null) {
+    $HeadCommit = $event.head_commit.id.Substring(0, 7)
+  }
+  $VersionSuffix = "$VersionSuffix+$HeadCommit"
 }
 
 if ($VersionSuffix -eq $null) {


### PR DESCRIPTION
This is also a bugfix of my previous patches #253 & #254. 🙄

As NuGet doesn't append build metadata to a filename, denote a commit hash to only a VersionSuffix, not a full package version string.