### PR TITLE
Fix concurrency error in TurnClient.AcceptRelayedStreamAsync()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,8 @@ To be released.
     NAT. [[#240]]
  -  Fixed a bug that `BlockChain<T>.FindNextHashes()` throws
     `ArgumentOutOfRangeException` when chain is empty.
+ -  Fixed a bug that `TurnClient.AcceptRelayedStreamAsync()`didn't handle
+    concurrent connections correctly. [[#256]]
 
 [AsyncIO]: https://github.com/somdoron/AsyncIO
 [Ethereum Homestead algorithm]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md
@@ -179,6 +181,7 @@ To be released.
 [#246]: https://github.com/planetarium/libplanet/pull/246
 [#247]: https://github.com/planetarium/libplanet/pull/247
 [#251]: https://github.com/planetarium/libplanet/pull/251
+[#256]: https://github.com/planetarium/libplanet/pull/256
 
 
 Version 0.2.2

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <AdditionalFiles Include="..\stylecop.json" />
     <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <AdditionalFiles Include="..\stylecop.json" />
     <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
+using Nito.AsyncEx;
 using Serilog;
 
 [assembly: InternalsVisibleTo("Libplanet.Stun.Tests")]
@@ -22,9 +23,11 @@ namespace Libplanet.Stun
         private readonly IDictionary<byte[], TaskCompletionSource<StunMessage>>
             _responses;
 
+        private readonly AsyncProducerConsumerQueue<ConnectionAttempt>
+            _connectionAttempts;
+
         private readonly Task _messageProcessor;
         private TcpClient _control;
-        private TaskCompletionSource<ConnectionAttempt> _connectAttempted;
 
         public TurnClient(
             string host,
@@ -41,6 +44,9 @@ namespace Libplanet.Stun
 
             _control = new TcpClient();
             _control.Connect(_host, _port);
+
+            _connectionAttempts =
+                new AsyncProducerConsumerQueue<ConnectionAttempt>();
 
             _responses =
                 new Dictionary<byte[], TaskCompletionSource<StunMessage>>(
@@ -105,12 +111,10 @@ namespace Libplanet.Stun
 
         public async Task<NetworkStream> AcceptRelayedStreamAsync()
         {
-            NetworkStream stream = _control.GetStream();
             while (true)
             {
-                _connectAttempted =
-                    new TaskCompletionSource<ConnectionAttempt>();
-                ConnectionAttempt attempt = await _connectAttempted.Task;
+                ConnectionAttempt attempt =
+                    await _connectionAttempts.DequeueAsync();
 
                 byte[] id = attempt.ConnectionId;
                 var relayedClient = new TcpClient(_host, _port);
@@ -217,10 +221,9 @@ namespace Libplanet.Stun
                 {
                     StunMessage message = await StunMessage.Parse(stream);
 
-                    if (_connectAttempted != null &&
-                        message is ConnectionAttempt attempt)
+                    if (message is ConnectionAttempt attempt)
                     {
-                        _connectAttempted.SetResult(attempt);
+                        await _connectionAttempts.EnqueueAsync(attempt);
                     }
                     else if (_responses.TryGetValue(
                         message.TransactionId,

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
+using Serilog;
 
 [assembly: InternalsVisibleTo("Libplanet.Stun.Tests")]
 namespace Libplanet.Stun
@@ -230,10 +230,12 @@ namespace Libplanet.Stun
                         _responses.Remove(message.TransactionId);
                     }
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    // Ignore the exception and retry.
-                    // FIXME add logging framework and a proper log message.
+                    Log.Error(
+                        e,
+                        $"An unexpected exception occured during parsing."
+                    );
                 }
             }
         }

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -71,7 +71,7 @@ https://docs.libplanet.io/</Description>
     </PackageReference>
     <PackageReference Include="NetMQ" Version="4.0.0.207-pre" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
#248 occurs when two or more nodes simultaneously request a TURN relay for one node. this patch fixes it.

Also in this process, I let `Libplanet.Stun` use [Serilog](https://serilog.net/), and upgrade the version used by `Libplanet`.