### PR TITLE
Run unit tests on Unity player

### DIFF
--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -1,6 +1,7 @@
 parameters:
   configuration: Debug
-  testArguments: ""
+  testDisplayName: xunit.console.exe *.Tests.dll
+  testCommand: "mono xunit.runner.console.*/tools/net461/xunit.console.exe"
 
 steps:
 
@@ -25,11 +26,11 @@ steps:
         /p:Configuration=${{ parameters.configuration }}
 
 - task: CmdLine@2
-  displayName: xunit.console.exe *.Tests.dll
+  displayName: ${{ parameters.testDisplayName }}
   inputs:
     script: |
-      mono xunit.runner.console.*/tools/net461/xunit.console.exe \
-        *.Tests/bin/${{ parameters.configuration }}/net*/*.Tests.dll
+      ${{ parameters.testCommand }} \
+        "$(pwd)"/*.Tests/bin/${{ parameters.configuration }}/net*/*.Tests.dll
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
   timeoutInMinutes: 10

--- a/.azure-pipelines/windows-net461.yml
+++ b/.azure-pipelines/windows-net461.yml
@@ -16,7 +16,11 @@ steps:
     script: |
       foreach ($path in gci *.Tests/*.Tests.csproj) {
         [xml]$csproj = Get-Content $path
-        $csproj.Project.PropertyGroup[0].TargetFramework = "net461"
+        foreach ($pg in $csproj.Project.PropertyGroup) {
+          if ($pg.TargetFramework -ne $null) {
+            $pg.TargetFramework = "net461"
+          }
+        }
         $csproj.Save($path)
       }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,33 @@ jobs:
       testArguments: -appdomains denied
   timeoutInMinutes: 30
 
+- job: macOS_Unity
+  pool:
+    vmImage: macOS-10.14
+  steps:
+  - task: CmdLine@2
+    displayName: Download xunit-unity-runner
+    inputs:
+      script: |
+        pushd /tmp
+        curl -L -O \
+          https://github.com/planetarium/xunit-unity-runner/releases/download/0.2.0/xunit-unity-runner-0.2.0-StandaloneOSX.tar.bz2
+        tar xvfj xunit-unity-runner-*.tar.bz2
+        popd
+  - template: .azure-pipelines/mono.yml
+    parameters:
+      configuration: $(configuration)
+      turnServerUrl: $(turnServerUrl)
+      testDisplayName: StandaloneOSX *.Tests.dll
+      testCommand: |-
+        /tmp/StandaloneOSX.app/Contents/MacOS/StandaloneOSX \
+          --exclude-method Libplanet.Tests.Blocks.BlockTest.EvaluateActionsPerTx
+      # FIXME: For unknown reason, on Unity methods returning ValueTuple<...>
+      #        cause MissingMethodException exception.  We should diagnose
+      #        this and make Unity builds to run these tests too.
+      #        See also: https://git.io/fjBDY
+  timeoutInMinutes: 30
+
 - job: Linux_NETCore
   pool:
     vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
This adds a CI job that runs unit tests on Unity player.  In order to run xUnit.net tests on Unity player, I made [xunit-unity-runner][1] as well.

Note that I temporarily disabled `Libplanet.Tests.Blocks.BlockTest.EvaluateActionsPerTx` test, because it causes `MissingMethodException` and I haven't found how to fix this yet.  I guess it's related to this: <https://github.com/dotnet/standard/issues/476#issuecomment-326726613>.

[1]: https://github.com/planetarium/xunit-unity-runner