### PR TITLE
Made BlockChain<T>.GetNonce() to refer staged transactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,10 @@ To be released.
 
 ### Added interfaces
 
--  `BlockChain<T>.GetNonce()` became to receive an optional parameter
-   `includeStage` to refer staged transactions during nonce computation. [[#270]]
-
 ### Behavioral changes
+
+-  `BlockChain<T>.GetNonce()` became to refer staged transactions during nonce
+   computation. [[#270]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,14 @@ To be released.
 
 ### Added interfaces
 
+-  `BlockChain<T>.GetNonce()` became to receive an optional parameter
+   `includeStage` to refer staged transactions during nonce computation. [[#270]]
+
 ### Behavioral changes
 
 ### Bug fixes
+
+[#270]: https://github.com/planetarium/libplanet/pull/270
 
 
 Version 0.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ To be released.
 
 ### Behavioral changes
 
--  `BlockChain<T>.GetNonce()` became to refer staged transactions during nonce
+-  `BlockChain<T>.GetNonce()` became to count staged transactions too during nonce
    computation. [[#270]]
 
 ### Bug fixes

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -802,8 +802,7 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.StageTransactions(txsB.ToHashSet());
 
-            Assert.Equal(1, _blockChain.GetNonce(address));
-            Assert.Equal(3, _blockChain.GetNonce(address, true));
+            Assert.Equal(3, _blockChain.GetNonce(address));
 
             Transaction<DumbAction>[] txsC =
             {
@@ -812,7 +811,7 @@ namespace Libplanet.Tests.Blockchain
             };
             _blockChain.StageTransactions(txsC.ToHashSet());
 
-            Assert.Equal(4, _blockChain.GetNonce(address, true));
+            Assert.Equal(4, _blockChain.GetNonce(address));
         }
 
         private sealed class NullPolicy<T> : IBlockPolicy<T>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -766,6 +766,55 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(states[TestEvaluateAction.BlockIndexKey], blockIndex);
         }
 
+        [Fact]
+        public void GetNonce()
+        {
+            var privateKey = new PrivateKey();
+            Address address = privateKey.PublicKey.ToAddress();
+            var actions = new[] { new DumbAction(_fx.Address1, "foo") };
+
+            Assert.Equal(0, _blockChain.GetNonce(address));
+
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>();
+            _blockChain.Append(genesis);
+
+            Assert.Equal(0, _blockChain.GetNonce(address));
+
+            Transaction<DumbAction>[] txsA =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
+            };
+
+            Block<DumbAction> b1 = TestUtils.MineNext(
+                genesis,
+                txsA,
+                null,
+                _blockChain.Policy.GetNextBlockDifficulty(_blockChain));
+            _blockChain.Append(b1);
+
+            Assert.Equal(1, _blockChain.GetNonce(address));
+
+            Transaction<DumbAction>[] txsB =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 2),
+            };
+
+            _blockChain.StageTransactions(txsB.ToHashSet());
+
+            Assert.Equal(1, _blockChain.GetNonce(address));
+            Assert.Equal(3, _blockChain.GetNonce(address, true));
+
+            Transaction<DumbAction>[] txsC =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 3),
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 3),
+            };
+            _blockChain.StageTransactions(txsC.ToHashSet());
+
+            Assert.Equal(4, _blockChain.GetNonce(address, true));
+        }
+
         private sealed class NullPolicy<T> : IBlockPolicy<T>
             where T : IAction, new()
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -290,23 +290,20 @@ namespace Libplanet.Blockchain
                 transactions.Select(tx => tx.Id).ToImmutableHashSet());
         }
 
-        public long GetNonce(Address address, bool includeStage = false)
+        public long GetNonce(Address address)
         {
             long nonce = Store.GetTxNonce(Id.ToString(), address);
 
-            if (includeStage)
-            {
-                IEnumerable<Transaction<T>> stagedTxs = Store
-                    .IterateStagedTransactionIds()
-                    .Select(Store.GetTransaction<T>)
-                    .Where(tx => tx.Signer.Equals(address));
+            IEnumerable<Transaction<T>> stagedTxs = Store
+                .IterateStagedTransactionIds()
+                .Select(Store.GetTransaction<T>)
+                .Where(tx => tx.Signer.Equals(address));
 
-                foreach (Transaction<T> tx in stagedTxs)
+            foreach (Transaction<T> tx in stagedTxs)
+            {
+                if (nonce <= tx.Nonce)
                 {
-                    if (nonce <= tx.Nonce)
-                    {
-                        nonce = tx.Nonce + 1;
-                    }
+                    nonce = tx.Nonce + 1;
                 }
             }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -290,9 +290,27 @@ namespace Libplanet.Blockchain
                 transactions.Select(tx => tx.Id).ToImmutableHashSet());
         }
 
-        public long GetNonce(Address address)
+        public long GetNonce(Address address, bool includeStage = false)
         {
-            return Store.GetTxNonce(Id.ToString(), address);
+            long nonce = Store.GetTxNonce(Id.ToString(), address);
+
+            if (includeStage)
+            {
+                IEnumerable<Transaction<T>> stagedTxs = Store
+                    .IterateStagedTransactionIds()
+                    .Select(Store.GetTransaction<T>)
+                    .Where(tx => tx.Signer.Equals(address));
+
+                foreach (Transaction<T> tx in stagedTxs)
+                {
+                    if (nonce <= tx.Nonce)
+                    {
+                        nonce = tx.Nonce + 1;
+                    }
+                }
+            }
+
+            return nonce;
         }
 
         public Block<T> MineBlock(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -328,7 +328,7 @@ namespace Libplanet.Blockchain
             List<Transaction<T>> transactions = Store
                 .IterateStagedTransactionIds()
                 .Select(Store.GetTransaction<T>)
-                .OfType<Transaction<T>>()
+                .OrderBy(tx => tx.Nonce)
                 .ToList();
 
             Block<T> block = Block<T>.Mine(


### PR DESCRIPTION
~This PR adds `includeStage` to `BlockChain<T>.GetNonce()` to refer staged transactions during nonce computation.~

I've changed `BlockChain<T>.GetNonce()` to refer staged transactions without any other options.