### PR TITLE
Fix Swarm.StopAsync()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,12 @@ To be released.
 
 ### Bug fixes
 
+-  Fixed a bug that `Swarm` reported `TaskCanceledException` as an unknown
+   exception while stopping. [[#275]]
+
 [#270]: https://github.com/planetarium/libplanet/pull/270
 [#273]: https://github.com/planetarium/libplanet/issues/273
+[#275]: https://github.com/planetarium/libplanet/pull/275
 [#276]: https://github.com/planetarium/libplanet/pull/276
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,9 +21,9 @@ To be released.
 
 ### Bug fixes
 
--  Fixed a bug that `Swarm` reported `TaskCanceledException` as an unknown
+ -  Fixed a bug that `Swarm` reported `TaskCanceledException` as an unknown
    exception while stopping. [[#275]]
--  Fixed a bug that `Swarm` didn't stop properly during `Swarm.Preload()`.
+ -  Fixed a bug that `Swarm` didn't stop properly during `Swarm.Preload()`.
    [[#275]]
 
 [#270]: https://github.com/planetarium/libplanet/pull/270

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ To be released.
 
 -  Fixed a bug that `Swarm` reported `TaskCanceledException` as an unknown
    exception while stopping. [[#275]]
+-  Fixed a bug that `Swarm` didn't stop properly during `Swarm.Preload()`.
+   [[#275]]
 
 [#270]: https://github.com/planetarium/libplanet/pull/270
 [#273]: https://github.com/planetarium/libplanet/issues/273

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -110,19 +110,20 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task CanStop()
+        public async Task StopAsync()
         {
             Swarm swarm = _swarms[0];
             BlockChain<DumbAction> chain = _blockchains[0];
 
             await swarm.StopAsync();
-            Task task = await StartAsync(swarm, chain);
+            var task = await StartAsync(swarm, chain);
 
             Assert.True(swarm.Running);
             await swarm.StopAsync();
 
             Assert.False(swarm.Running);
-            await task;
+
+            Assert.False(task.IsFaulted);
         }
 
         [Fact(Timeout = Timeout)]
@@ -867,12 +868,10 @@ namespace Libplanet.Tests.Net
         )
             where T : IAction, new()
         {
-            Task task = Task.Run(
-                async () => await swarm.StartAsync(
-                    blockChain,
-                    200,
-                    cancellationToken
-                )
+            Task task = swarm.StartAsync(
+                blockChain,
+                200,
+                cancellationToken
             );
             await swarm.WaitForRunningAsync();
             return task;

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -59,7 +59,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncEnumerator" Version="2.2.1" />
+    <PackageReference Include="AsyncEnumerator" Version="2.2.2" />
     <PackageReference Include="Bencodex" Version="0.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
     <PackageReference Include="Equals.Fody" Version="1.9.6" />

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1170,6 +1170,13 @@ namespace Libplanet.Net
                         peer, synced, stop, progress, cancellationToken);
                     break;
                 }
+
+                // We can't recover with TaskCanceledException and
+                // ObjectDisposedException. so just re-throw them.
+                catch (ObjectDisposedException)
+                {
+                    throw;
+                }
                 catch (TaskCanceledException)
                 {
                     throw;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -549,6 +549,10 @@ namespace Libplanet.Net
 
                 await Task.WhenAny(tasks);
             }
+            catch (TaskCanceledException e)
+            {
+                _logger.Information(e, "Task was canceled.");
+            }
             catch (Exception e)
             {
                 _logger.Error(
@@ -949,6 +953,10 @@ namespace Libplanet.Net
                         "Could not parse NetMQMessage properly; ignore."
                     );
                 }
+                catch (TaskCanceledException e)
+                {
+                    _logger.Information(e, "Task was canceled.");
+                }
                 catch (Exception e)
                 {
                     _logger.Error(
@@ -1152,6 +1160,10 @@ namespace Libplanet.Net
                     await FillBlocksAsync(
                         peer, synced, stop, progress, cancellationToken);
                     break;
+                }
+                catch (TaskCanceledException)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -548,7 +548,7 @@ namespace Libplanet.Net
                     tasks.Add(RefreshPermissions(workerCancellationToken));
                 }
 
-                await Task.WhenAny(tasks);
+                await await Task.WhenAny(tasks);
             }
             catch (TaskCanceledException e)
             {


### PR DESCRIPTION
This PR fixes issues as below.

- Fixed a bug that `Swarm.StopAsync()` didn't stop properly during `Swarm.Preload()`
- Filled up cancellation support with `CancellationToken` on TAP methods.