### PR TITLE
Improve branch point finding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ To be released.
     round trips on the network are now much reduced.  [[#273], [#276]]
  -  `Message.Block` has been replaced by `Message.Blocks` and the magic number
     has been changed to `0x0a`.  [[#276]]
+ -  Improved performance of `Swarm`'s response time to `GetBlockHashes`
+    request messages.  [[#277]]
 
 ### Bug fixes
 
@@ -30,6 +32,7 @@ To be released.
 [#273]: https://github.com/planetarium/libplanet/issues/273
 [#275]: https://github.com/planetarium/libplanet/pull/275
 [#276]: https://github.com/planetarium/libplanet/pull/276
+[#277]: https://github.com/planetarium/libplanet/pull/277
 
 
 Version 0.3.0

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -471,12 +471,6 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
-                HashDigest<SHA256>? Next(HashDigest<SHA256> hash)
-                {
-                    long nextIndex = Blocks[hash].Index + 1;
-                    return Store.IndexBlockHash(Id.ToString(), nextIndex);
-                }
-
                 HashDigest<SHA256>? tip = Store.IndexBlockHash(
                     Id.ToString(), -1);
                 if (tip is null)
@@ -484,18 +478,26 @@ namespace Libplanet.Blockchain
                     yield break;
                 }
 
-                HashDigest<SHA256>? currentHash = FindBranchPoint(locator);
+                HashDigest<SHA256> branchPoint = FindBranchPoint(locator);
+                var branchPointIndex = (int)Blocks[branchPoint].Index;
+                IEnumerable<HashDigest<SHA256>> hashes = Store
+                    .IterateIndex(Id.ToString())
+                    .Skip(branchPointIndex);
 
-                while (currentHash != null && count > 0)
+                foreach (HashDigest<SHA256> hash in hashes)
                 {
-                    yield return currentHash.Value;
-
-                    if (currentHash.Equals(stop) || currentHash.Equals(tip))
+                    if (count == 0)
                     {
-                        break;
+                        yield break;
                     }
 
-                    currentHash = Next(currentHash.Value);
+                    yield return hash;
+
+                    if (hash.Equals(stop))
+                    {
+                        yield break;
+                    }
+
                     count--;
                 }
             }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -438,12 +438,19 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
+                // FIXME Depending on the amount of Index stored in the `Store`,
+                //       it can use the memory excessively.
+                //       we should find alternative approach.
+                ImmutableHashSet<HashDigest<SHA256>> indices = Store
+                    .IterateIndex(Id.ToString())
+                    .ToImmutableHashSet();
+
                 // Assume locator is sorted descending by height.
                 foreach (HashDigest<SHA256> hash in locator)
                 {
-                    if (Blocks.ContainsKey(hash))
+                    if (indices.Contains(hash))
                     {
-                        return Blocks[hash].Hash;
+                        return hash;
                     }
                 }
 

--- a/Libplanet/Store/BaseIndex.cs
+++ b/Libplanet/Store/BaseIndex.cs
@@ -44,10 +44,7 @@ namespace Libplanet.Store
             }
         }
 
-        public bool Contains(KeyValuePair<TKey, TVal> item)
-        {
-            return Enumerable.Contains(this, item);
-        }
+        public abstract bool Contains(KeyValuePair<TKey, TVal> item);
 
         public bool ContainsKey(TKey key)
         {

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -55,6 +55,12 @@ namespace Libplanet.Store
             }
         }
 
+        public override bool Contains(
+            KeyValuePair<HashDigest<SHA256>, Block<T>> item)
+        {
+            return Store.IterateBlockHashes().Contains(item.Key);
+        }
+
         public override bool Remove(HashDigest<SHA256> key)
         {
             return Store.DeleteBlock(key);

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -16,24 +16,13 @@ namespace Libplanet.Store
         {
         }
 
-        public override ICollection<HashDigest<SHA256>> Keys
-        {
-            get
-            {
-                return Store.IterateBlockHashes().ToList();
-            }
-        }
+        public override ICollection<HashDigest<SHA256>> Keys =>
+            Store.IterateBlockHashes().ToList();
 
-        public override ICollection<Block<T>> Values
-        {
-            get
-            {
-                return Store.IterateBlockHashes()
-                    .Select(Store.GetBlock<T>)
-                    .OfType<Block<T>>()
-                    .ToList();
-            }
-        }
+        public override ICollection<Block<T>> Values =>
+            Store.IterateBlockHashes()
+                .Select(Store.GetBlock<T>)
+                .ToList();
 
         public override int Count => (int)Store.CountBlocks();
 

--- a/Libplanet/Store/TransactionSet.cs
+++ b/Libplanet/Store/TransactionSet.cs
@@ -63,6 +63,11 @@ namespace Libplanet.Store
             }
         }
 
+        public override bool Contains(KeyValuePair<TxId, Transaction<T>> item)
+        {
+            return Store.IterateTransactionIds().Contains(item.Key);
+        }
+
         public override bool Remove(TxId key)
         {
             return Store.DeleteTransaction(key);

--- a/Libplanet/Store/TransactionSet.cs
+++ b/Libplanet/Store/TransactionSet.cs
@@ -14,13 +14,8 @@ namespace Libplanet.Store
         {
         }
 
-        public override ICollection<TxId> Keys
-        {
-            get
-            {
-                return Store.IterateTransactionIds().ToList();
-            }
-        }
+        public override ICollection<TxId> Keys =>
+            Store.IterateTransactionIds().ToList();
 
         public override ICollection<Transaction<T>> Values
         {
@@ -28,7 +23,6 @@ namespace Libplanet.Store
             {
                 return Keys
                     .Select(k => Store.GetTransaction<T>(k))
-                    .OfType<Transaction<T>>()
                     .ToList();
             }
         }


### PR DESCRIPTION
This PR improves performance of `BlockChain<T>.Blocks.Contains()`, `BlockChain<T>.FindBranchPoint()` and `BlockChain<T>.FindNextHashes()` to reduce response time for block hashes query.