### PR TITLE
Minor fixes for Rider IDE

### DIFF
--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -10,7 +10,8 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
+                             '$(BuildingByReSharper)'!='true'">
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
@@ -23,7 +24,9 @@
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Libplanet.Stun</AssemblyName>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);MEN001</NoWarn>
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -10,7 +10,8 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
+                             '$(BuildingByReSharper)'!='true'">
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
@@ -24,7 +25,9 @@
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -40,7 +40,7 @@ https://docs.libplanet.io/</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591;NU5104</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5104;MEN001</NoWarn>
     <!-- FIXME: CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
FYI `MEN001` is a rule to enforce use only hard tabs instead soft tabs (i.e., spaces), which contradicts StyleCop's [`SA1027`][1].

[1]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md