### PR TITLE
Allow null to Peer.AppProtocolVersion for easy configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ indent_style = space
 continuation_indent_size = 4
 
 [*.{cs,md,xml}]
-max_line_length = 80
+max_line_length = 100
 
 [*.{cs,md}]
 indent_size = 4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ To be released.
 
 ### Backward-incompatible interface changes
 
+ -  `Peer.AppProtocolVersion` became nullable to represent `Peer` whose version
+    is unknown.
+
 ### Added interfaces
 
  -  Added `LiteDBStore` backend that uses [LiteDB] under the hood.  [[#269]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,8 @@ To be released.
  -  Added `LiteDBStore` backend that uses [LiteDB] under the hood.  [[#269]]
  -  All `*Async()` methods belonging to `TurnClient` class became to have
     `cancellationToken` option.  [[#287]]
- -  Added a version-less `Peer` constructor to create a `Peer` whose version
-    is unknown.
+ -  Added a `Peer` constructor omitting `appProtocolVersion` parameter
+    to create a `Peer` whose version is unknown.
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ To be released.
  -  Added `LiteDBStore` backend that uses [LiteDB] under the hood.  [[#269]]
  -  All `*Async()` methods belonging to `TurnClient` class became to have
     `cancellationToken` option.  [[#287]]
+ -  Added a version-less `Peer` constructor to create a `Peer` whose version
+    is unknown.
 
 ### Behavioral changes
 

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -9,16 +10,62 @@ namespace Libplanet.Tests.Net
 {
     public class PeerTest
     {
-        [Fact]
-        public void Serialize()
+        public static IEnumerable<object[]> GetPeers()
         {
-            var key = new PublicKey(
-                ByteUtil.ParseHex(
-                    "038f92e8098c897c2a9ae3226eb6337eb" +
-                    "7ca8dbad5e1c8c9b130a9d39171a44134"
-                    ));
-            var endPoint = new DnsEndPoint("0.0.0.0", 1234);
-            var peer = new Peer(key, endPoint, 1, IPAddress.IPv6Loopback);
+            yield return new object[]
+            {
+                new Peer(
+                    new PublicKey(new byte[]
+                    {
+                        0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20, 0x42, 0x3b,
+                        0xad, 0x39, 0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b,
+                        0x33, 0xe3, 0x48, 0x7c, 0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96,
+                        0xf8, 0xa5, 0x48, 0x34, 0x40, 0xef, 0xbb, 0xef, 0x06, 0x57,
+                        0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45,
+                        0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
+                        0x1a, 0x3d, 0x3c, 0x76, 0xdb,
+                    }),
+                    new DnsEndPoint("0.0.0.0", 1234),
+                    1,
+                    IPAddress.IPv6Loopback),
+            };
+            yield return new object[]
+            {
+                new Peer(
+                    new PublicKey(new byte[]
+                    {
+                        0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20, 0x42, 0x3b,
+                        0xad, 0x39, 0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b,
+                        0x33, 0xe3, 0x48, 0x7c, 0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96,
+                        0xf8, 0xa5, 0x48, 0x34, 0x40, 0xef, 0xbb, 0xef, 0x06, 0x57,
+                        0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45,
+                        0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
+                        0x1a, 0x3d, 0x3c, 0x76, 0xdb,
+                    }),
+                    new DnsEndPoint("0.0.0.0", 1234),
+                    1),
+            };
+            yield return new object[]
+            {
+                new Peer(
+                    new PublicKey(new byte[]
+                    {
+                        0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20, 0x42, 0x3b,
+                        0xad, 0x39, 0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b,
+                        0x33, 0xe3, 0x48, 0x7c, 0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96,
+                        0xf8, 0xa5, 0x48, 0x34, 0x40, 0xef, 0xbb, 0xef, 0x06, 0x57,
+                        0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45,
+                        0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
+                        0x1a, 0x3d, 0x3c, 0x76, 0xdb,
+                    }),
+                    new DnsEndPoint("0.0.0.0", 1234)),
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPeers))]
+        public void Serialize(Peer peer)
+        {
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
             {
@@ -28,6 +75,21 @@ namespace Libplanet.Tests.Net
                 Peer deserialized = (Peer)formatter.Deserialize(stream);
                 Assert.Equal(peer, deserialized);
             }
+        }
+
+        [Fact]
+        public void WithAppProtocolVersion()
+        {
+            var peerWithoutVersion = new Peer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            Peer peerWithVersion = peerWithoutVersion.WithAppProtocolVersion(42);
+            var expected = new Peer(
+                peerWithoutVersion.PublicKey,
+                peerWithoutVersion.EndPoint,
+                42
+                );
+            Assert.Equal(expected, peerWithVersion);
         }
     }
 }

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -16,7 +16,8 @@ namespace Libplanet.Net
     public class Peer : ISerializable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Peer"/> class.
+        /// Initializes a new instance of the <see cref="Peer"/> class
+        /// with omitting <see cref="AppProtocolVersion"/>.
         /// </summary>
         /// <param name="publicKey">A <see cref="PublicKey"/> of the
         /// <see cref="Peer"/>.</param>

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -22,12 +22,26 @@ namespace Libplanet.Net
         /// <see cref="Peer"/>.</param>
         /// <param name="endPoint">A <see cref="DnsEndPoint"/> consisting of the
         /// host and port of the <see cref="Peer"/>.</param>
+        public Peer(
+            PublicKey publicKey,
+            DnsEndPoint endPoint)
+            : this(publicKey, endPoint, default(int?), null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Peer"/> class.
+        /// </summary>
+        /// <param name="publicKey">A <see cref="PublicKey"/> of the
+        /// <see cref="Peer"/>.</param>
+        /// <param name="endPoint">A <see cref="DnsEndPoint"/> consisting of the
+        /// host and port of the <see cref="Peer"/>.</param>
         /// <param name="appProtocolVersion">An application protocol version
         /// that the <see cref="Peer"/> is using.</param>
         public Peer(
             PublicKey publicKey,
             DnsEndPoint endPoint,
-            int appProtocolVersion)
+            int? appProtocolVersion)
         : this(publicKey, endPoint, appProtocolVersion, null)
         {
         }
@@ -35,7 +49,7 @@ namespace Libplanet.Net
         internal Peer(
             PublicKey publicKey,
             DnsEndPoint endPoint,
-            int appProtocolVersion,
+            int? appProtocolVersion,
             IPAddress publicIPAddress)
         {
             PublicKey = publicKey ??
@@ -52,7 +66,8 @@ namespace Libplanet.Net
             EndPoint = new DnsEndPoint(
                 info.GetString("end_point_host"),
                 info.GetInt32("end_point_port"));
-            AppProtocolVersion = info.GetInt32("app_protocol_version");
+            AppProtocolVersion =
+                info.GetValueOrDefault<int?>("app_protocol_version", null);
             string addressStr = info.GetString("public_ip_address");
             if (addressStr != null)
             {
@@ -79,7 +94,7 @@ namespace Libplanet.Net
         /// <seealso cref="Swarm.DifferentVersionPeerEncountered"/>
         [IgnoreDuringEquals]
         [Pure]
-        public int AppProtocolVersion { get; }
+        public int? AppProtocolVersion { get; }
 
         /// <summary>The peer's address which is derived from
         /// its <see cref="PublicKey"/>.
@@ -109,6 +124,15 @@ namespace Libplanet.Net
         public override string ToString()
         {
             return $"{Address}.{EndPoint}.{AppProtocolVersion}";
+        }
+
+        internal Peer WithAppProtocolVersion(int appProtocolVersion)
+        {
+            return new Peer(
+                PublicKey,
+                EndPoint,
+                appProtocolVersion,
+                PublicIPAddress);
         }
     }
 }

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Menees.Analyzers.Settings>
-  <MaxLineColumns>80</MaxLineColumns>
+  <MaxLineColumns>100</MaxLineColumns>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
This patch allows null value to `Peer.AppProtocolVersion`. so this adds version-less `Peer` constructor and `Peer.WithAppProtocolVersion()`.

Also, this PR widens the line length limit to 100 (as #222).