### PR TITLE
Bump xunit-unity-runner's version to 0.2.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
       script: |
         pushd /tmp
         curl -L -O \
-          https://github.com/planetarium/xunit-unity-runner/releases/download/0.2.0/xunit-unity-runner-0.2.0-StandaloneOSX.tar.bz2
+          https://github.com/planetarium/xunit-unity-runner/releases/download/0.2.2/xunit-unity-runner-0.2.2-StandaloneOSX.tar.bz2
         tar xvfj xunit-unity-runner-*.tar.bz2
         popd
   - template: .azure-pipelines/mono.yml


### PR DESCRIPTION
This PR bumps xunit-unity-runner version to [0.2.2](https://github.com/planetarium/xunit-unity-runner/releases/tag/0.2.2) to apply [this patch](https://github.com/planetarium/xunit-unity-runner/pull/1).