### PR TITLE
Fix transaction sort order in ValidateNonce

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -814,6 +814,33 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(4, _blockChain.GetNonce(address));
         }
 
+        [Fact]
+        public void ValidateNonce()
+        {
+            var privateKey = new PrivateKey();
+            Address address = privateKey.PublicKey.ToAddress();
+            var actions = new[] { new DumbAction(_fx.Address1, "foo") };
+
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>();
+            _blockChain.Append(genesis);
+
+            Transaction<DumbAction>[] txsA =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
+            };
+            Block<DumbAction> b1 = TestUtils.MineNext(genesis, txsA);
+            _blockChain.ValidateNonce(b1);
+
+            Transaction<DumbAction>[] txsB =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
+            };
+            Block<DumbAction> b2 = TestUtils.MineNext(genesis, txsB);
+            Assert.Throws<InvalidTxNonceException>(() =>
+                _blockChain.ValidateNonce(b2));
+        }
+
         private sealed class NullPolicy<T> : IBlockPolicy<T>
             where T : IAction, new()
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -410,7 +410,9 @@ namespace Libplanet.Blockchain
         internal void ValidateNonce(Block<T> block)
         {
             var nonces = new Dictionary<Address, long>();
-            foreach (Transaction<T> tx in block.Transactions)
+            IEnumerable<Transaction<T>> transactions =
+                block.Transactions.OrderBy(tx => tx.Nonce);
+            foreach (Transaction<T> tx in transactions)
             {
                 Address signer = tx.Signer;
                 if (!nonces.TryGetValue(signer, out long nonce))


### PR DESCRIPTION
This fixes transaction sort order in `ValidateNonce`.
This bug was introduced in 0.4.0-dev, so I omitted the changelog.