### PR TITLE
Allow BlockChain<T> to have incomplete states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,15 @@ To be released.
     `cancellationToken` option.  [[#287]]
  -  Added a `Peer` constructor omitting `appProtocolVersion` parameter
     to create a `Peer` whose version is unknown.
+ -  Added `IncompleteBlockStatesException` class.  [[#272], [#285]]
 
 ### Behavioral changes
 
  -  `BlockChain<T>.GetNonce()` became to count staged transactions too during
     nonce computation.  [[#270]]
+ -  `BlockChain<T>.GetStates()` method became to throw
+    `IncompleteBlockStatesException` if its `Store` lacks the states of a block
+    that a requested address lastly updated.  [[#272], [#285]]
  -  A message `Swarm` makes became to have multiple blocks within it, which
     means round trips on the network are now much reduced.  [[#273], [#276]]
  -  `Message.Block` has been replaced by `Message.Blocks` and the magic number
@@ -50,11 +54,13 @@ To be released.
 [#269]: https://github.com/planetarium/libplanet/pull/269
 [#270]: https://github.com/planetarium/libplanet/pull/270
 [#271]: https://github.com/planetarium/libplanet/pull/271
+[#272]: https://github.com/planetarium/libplanet/issues/272
 [#273]: https://github.com/planetarium/libplanet/issues/273
 [#275]: https://github.com/planetarium/libplanet/pull/275
 [#276]: https://github.com/planetarium/libplanet/pull/276
 [#277]: https://github.com/planetarium/libplanet/pull/277
 [#281]: https://github.com/planetarium/libplanet/pull/281
+[#285]: https://github.com/planetarium/libplanet/pull/285
 [#287]: https://github.com/planetarium/libplanet/pull/287
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ To be released.
  -  Improved performance of `Swarm`'s response time to `GetBlockHashes`
     request messages.  [[#277]]
  -  Added IPv6 support to `Libplanet.Stun.StunAddress`. [[#267], [#271]]
+ -  `IStore.GetStates()` became able to return `null` to represent an absence
+    of states (i.e., incomplete states).  [[#272], [#285]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ To be released.
 
  -  `Peer.AppProtocolVersion` became nullable to represent `Peer` whose version
     is unknown.
+ -  Added `IStore.ListAddresses()` method.  [[#272], [#285]]
 
 ### Added interfaces
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ To be released.
  -  Added a `Peer` constructor omitting `appProtocolVersion` parameter
     to create a `Peer` whose version is unknown.
  -  Added `IncompleteBlockStatesException` class.  [[#272], [#285]]
+ -  Added `completeStates` option to `BlockChain<T>.GetStates()` method.
+    [[#272], [#285]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@ To be released.
  -  Improved performance of `Swarm`'s response time to `GetBlockHashes`
     request messages.  [[#277]]
  -  Added IPv6 support to `Libplanet.Stun.StunAddress`. [[#267], [#271]]
- -  `IStore.GetStates()` became able to return `null` to represent an absence
+ -  `IStore.GetBlockStates()` became able to return `null` to represent an absence
     of states (i.e., incomplete states).  [[#272], [#285]]
 
 ### Bug fixes

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -743,7 +743,7 @@ namespace Libplanet.Tests.Blockchain
 
             // As the store lacks the states for blocks other than the tip,
             // the following GetStates() calls should throw an exception.
-            foreach (Address addr in addresses.SkipLast(1))
+            foreach (Address addr in addresses.Take(addresses.Length - 1))
             {
                 Assert.Throws<IncompleteBlockStatesException>(() =>
                     chain.GetStates(new[] { addr })
@@ -759,7 +759,7 @@ namespace Libplanet.Tests.Blockchain
             IStore store = chain.Store;
 
             chain.GetStates(new[] { addresses.Last() }, completeStates: true);
-            foreach (Block<DumbAction> block in chain.SkipLast(1))
+            foreach (Block<DumbAction> block in chain.Take(chain.Count() - 1))
             {
                 Assert.Null(store.GetBlockStates(block.Hash));
             }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -731,7 +731,7 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void GetStatesThrowsIncompleteBlockStatesException()
         {
-            (Address[] addresses, BlockChain<DumbAction> chain) =
+            (_, Address[] addresses, BlockChain<DumbAction> chain) =
                 MakeIncompleteBlockStates();
 
             // As the store has the states for the tip (latest block),
@@ -739,7 +739,7 @@ namespace Libplanet.Tests.Blockchain
             Address lastAddress = addresses.Last();
             AddressStateMap states = chain.GetStates(new[] { lastAddress });
             Assert.NotEmpty(states);
-            Assert.Equal("4", states[lastAddress]);
+            Assert.Equal("9", states[lastAddress]);
 
             // As the store lacks the states for blocks other than the tip,
             // the following GetStates() calls should throw an exception.
@@ -754,20 +754,72 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void GetStatesWithCompletingStates()
         {
-            (Address[] addresses, BlockChain<DumbAction> chain) =
-                MakeIncompleteBlockStates();
-            IStore store = chain.Store;
+            (Address signer, Address[] addresses, BlockChain<DumbAction> chain)
+                = MakeIncompleteBlockStates();
+            string @namespace = chain.Id.ToString();
+            Block<DumbAction>[] blocks = chain.ToArray();
+            StoreTracker store = (StoreTracker)chain.Store;
 
+            HashDigest<SHA256>[] ListStateReferences(Address address)
+            {
+                Block<DumbAction> block = chain.Tip;
+                List<HashDigest<SHA256>> refs = new List<HashDigest<SHA256>>();
+
+                while (true)
+                {
+                    HashDigest<SHA256>? sr =
+                        store.LookupStateReference(@namespace, address, block);
+                    if (sr is HashDigest<SHA256> reference)
+                    {
+                        refs.Add(reference);
+                        block = chain.Blocks[reference];
+                        if (block.PreviousHash is HashDigest<SHA256> prev)
+                        {
+                            block = chain.Blocks[prev];
+                            continue;
+                        }
+                    }
+
+                    break;
+                }
+
+                return refs.ToArray();
+            }
+
+            IImmutableDictionary<Address, HashDigest<SHA256>[]> stateRefs =
+                addresses.Select(a =>
+                    new KeyValuePair<Address, HashDigest<SHA256>[]>(
+                        a,
+                        ListStateReferences(a)
+                    )
+                ).ToImmutableDictionary();
+            long txNonce = store.GetTxNonce(@namespace, signer);
+
+            store.ClearLogs();
             chain.GetStates(new[] { addresses.Last() }, completeStates: true);
-            foreach (Block<DumbAction> block in chain.Take(chain.Count() - 1))
+
+            Assert.Empty(
+                store.Logs.Where(l => l.Item1 == "StoreStateReference")
+            );
+            foreach (Block<DumbAction> block in blocks.Take(blocks.Length - 1))
             {
                 Assert.Null(store.GetBlockStates(block.Hash));
             }
 
+            store.ClearLogs();
             chain.GetStates(new[] { addresses[0] }, completeStates: true);
-            foreach (Block<DumbAction> block in chain)
+
+            foreach (Block<DumbAction> block in blocks)
             {
                 Assert.NotNull(store.GetBlockStates(block.Hash));
+            }
+
+            // Calculating and filling states should not affect state references
+            // or tx nonce.
+            Assert.Equal(txNonce, store.GetTxNonce(@namespace, signer));
+            foreach (Address address in addresses)
+            {
+                Assert.Equal(stateRefs[address], ListStateReferences(address));
             }
         }
 
@@ -860,13 +912,40 @@ namespace Libplanet.Tests.Blockchain
 
         /// <summary>
         /// Builds a fixture that has incomplete states for blocks other
-        /// than the tip, to test GetStates() method's completeStates: true
-        /// option and IncompleteBlockStatesException.
+        /// than the tip, to test <c>GetStates()</c> method's
+        /// <c>completeStates: true</c> option and
+        /// <see cref="IncompleteBlockStatesException"/>.
+        ///
+        /// <para>The fixture this makes has total 5 addresses (i.e., accounts;
+        /// these go to the second item of the returned triple) and 11 blocks
+        /// (these go to the third item of the returned triple). Every block
+        /// contains a transaction within an action that mutates one account
+        /// state except of the genesis block.  All transactions in the fixture
+        /// are signed by one private key (its address goes to the first item
+        /// of the returned triple).  The most important thing is that
+        /// these blocks all lack its states except of the last block (tip).
+        /// Overall blocks in the fixture look like:</para>
+        ///
+        /// <code>
+        ///  Index   UpdatedAddresses   States in Store
+        /// ------- ------------------ -----------------
+        ///      0                      Absent
+        ///      1   addresses[0]       Absent
+        ///      2   addresses[1]       Absent
+        ///      3   addresses[2]       Absent
+        ///      4   addresses[3]       Absent
+        ///      5   addresses[4]       Absent
+        ///      6   addresses[0]       Absent
+        ///      7   addresses[1]       Absent
+        ///      8   addresses[2]       Absent
+        ///      9   addresses[3]       Absent
+        ///     10   addresses[4]       Present
+        /// </code>
         /// </summary>
-        private (Address[] addresses, BlockChain<DumbAction> chain)
+        private (Address, Address[] addresses, BlockChain<DumbAction> chain)
             MakeIncompleteBlockStates()
         {
-            IStore store = _fx.Store;
+            IStore store = new StoreTracker(_fx.Store);
             Guid chainId = Guid.NewGuid();
             var chain = new BlockChain<DumbAction>(
                 new NullPolicy<DumbAction>(),
@@ -874,7 +953,7 @@ namespace Libplanet.Tests.Blockchain
                 chainId
             );
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            Address signer = privateKey.PublicKey.ToAddress();
 
             IImmutableDictionary<Address, object> GetDirty(
                 IEnumerable<ActionEvaluation<DumbAction>> evaluations) =>
@@ -892,35 +971,42 @@ namespace Libplanet.Tests.Blockchain
             store.AppendIndex(chainId.ToString(), b.Hash);
             IImmutableDictionary<Address, object> dirty =
                 GetDirty(b.Evaluate(DateTimeOffset.UtcNow, _ => null));
-            const int blocksCount = 5;
-            Address[] addresses = Enumerable.Repeat<object>(null, blocksCount)
+            const int accountsCount = 5;
+            Address[] addresses = Enumerable.Repeat<object>(null, accountsCount)
                 .Select(_ => new PrivateKey().PublicKey.ToAddress())
                 .ToArray();
-            for (int i = 0; i < blocksCount; ++i)
+            for (int i = 0; i < 2; ++i)
             {
-                Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
-                    store.GetTxNonce(chainId.ToString(), address),
-                    privateKey,
-                    new[] { new DumbAction(addresses[i], i.ToString()) }
-                );
-                b = TestUtils.MineNext(b, new Transaction<DumbAction>[] { tx });
-                dirty = GetDirty(
-                    b.Evaluate(DateTimeOffset.UtcNow, dirty.GetValueOrDefault)
-                );
-                Assert.NotEmpty(dirty);
-                chain.Blocks[b.Hash] = b;
-                store.StoreStateReference(
-                    chainId.ToString(),
-                    dirty.Keys.ToImmutableHashSet(),
-                    b
-                );
-                store.IncreaseTxNonce(chainId.ToString(), b);
-                store.AppendIndex(chainId.ToString(), b.Hash);
+                for (int j = 0; j < accountsCount; ++j)
+                {
+                    int index = i * accountsCount + j;
+                    Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
+                        store.GetTxNonce(chainId.ToString(), signer),
+                        privateKey,
+                        new[] { new DumbAction(addresses[j], index.ToString()) }
+                    );
+                    b = TestUtils.MineNext(b, new[] { tx });
+                    dirty = GetDirty(
+                        b.Evaluate(
+                            DateTimeOffset.UtcNow,
+                            dirty.GetValueOrDefault
+                        )
+                    );
+                    Assert.NotEmpty(dirty);
+                    chain.Blocks[b.Hash] = b;
+                    store.StoreStateReference(
+                        chainId.ToString(),
+                        dirty.Keys.ToImmutableHashSet(),
+                        b
+                    );
+                    store.IncreaseTxNonce(chainId.ToString(), b);
+                    store.AppendIndex(chainId.ToString(), b.Hash);
+                }
             }
 
             store.SetBlockStates(b.Hash, new AddressStateMap(dirty));
 
-            return (addresses, chain);
+            return (signer, addresses, chain);
         }
 
         private sealed class NullPolicy<T> : IBlockPolicy<T>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -920,10 +920,10 @@ namespace Libplanet.Tests.Blockchain
         /// these go to the second item of the returned triple) and 11 blocks
         /// (these go to the third item of the returned triple). Every block
         /// contains a transaction within an action that mutates one account
-        /// state except of the genesis block.  All transactions in the fixture
+        /// state except for the genesis block.  All transactions in the fixture
         /// are signed by one private key (its address goes to the first item
         /// of the returned triple).  The most important thing is that
-        /// these blocks all lack its states except of the last block (tip).
+        /// these blocks all lack its states except for the last block (tip).
         /// Overall blocks in the fixture look like:</para>
         ///
         /// <code>

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -31,6 +32,43 @@ namespace Libplanet.Tests.Store
             Assert.Equal(
                 new[] { Fx.StoreNamespace, "asdf" }.ToImmutableHashSet(),
                 Fx.Store.ListNamespaces().ToImmutableHashSet()
+            );
+        }
+
+        [Fact]
+        public void ListAddresses()
+        {
+            Assert.Empty(Fx.Store.ListAddresses(Fx.StoreNamespace).ToArray());
+
+            Address[] addresses = Enumerable.Repeat<object>(null, 8)
+                .Select(_ => new PrivateKey().PublicKey.ToAddress())
+                .ToArray();
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                addresses.Take(3).ToImmutableHashSet(),
+                Fx.Block1
+            );
+            Assert.Equal(
+                addresses.Take(3).ToImmutableHashSet(),
+                Fx.Store.ListAddresses(Fx.StoreNamespace).ToImmutableHashSet()
+            );
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                addresses.Skip(2).Take(3).ToImmutableHashSet(),
+                Fx.Block2
+            );
+            Assert.Equal(
+                addresses.Take(5).ToImmutableHashSet(),
+                Fx.Store.ListAddresses(Fx.StoreNamespace).ToImmutableHashSet()
+            );
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                addresses.Skip(5).Take(3).ToImmutableHashSet(),
+                Fx.Block3
+            );
+            Assert.Equal(
+                addresses.ToImmutableHashSet(),
+                Fx.Store.ListAddresses(Fx.StoreNamespace).ToImmutableHashSet()
             );
         }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -335,9 +335,9 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
-        public void StoreBlockState()
+        public void BlockState()
         {
-            Assert.Empty(Fx.Store.GetBlockStates(Fx.Hash1));
+            Assert.Null(Fx.Store.GetBlockStates(Fx.Hash1));
             AddressStateMap states = new AddressStateMap(
                 new Dictionary<Address, object>()
                 {

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -61,6 +61,12 @@ namespace Libplanet.Tests.Store
             return _store.DeleteIndex(@namespace, hash);
         }
 
+        public IEnumerable<Address> ListAddresses(string @namespace)
+        {
+            _logs.Add((nameof(ListAddresses), @namespace, null));
+            return _store.ListAddresses(@namespace);
+        }
+
         public bool DeleteTransaction(TxId txid)
         {
             _logs.Add((nameof(DeleteTransaction), txid, null));

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -253,7 +253,8 @@ namespace Libplanet
             if (hex.Length != 40)
             {
                 throw new ArgumentException(
-                    "address hex must be 40 bytes",
+                    "Address hex must be 40 bytes, but " +
+                    $"{hex.Length} bytes were passed.",
                     nameof(hex)
                 );
             }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -250,7 +250,7 @@ namespace Libplanet.Blockchain
                                         b.PreviousHash
                                     ).GetValueOrDefault(a)
                                 ).ToArray();
-                            SetStates(b, evaluations);
+                            SetStates(b, evaluations, buildIndices: false);
                         }
 
                         blockStates = Store.GetBlockStates(hashValue);
@@ -434,7 +434,7 @@ namespace Libplanet.Blockchain
                 try
                 {
                     Blocks[block.Hash] = block;
-                    SetStates(block, evaluations);
+                    SetStates(block, evaluations, buildIndices: true);
 
                     Store.AppendIndex(Id.ToString(), block.Hash);
                     ISet<TxId> txIds = block.Transactions
@@ -747,7 +747,9 @@ namespace Libplanet.Blockchain
 
         private void SetStates(
             Block<T> block,
-            IReadOnlyList<ActionEvaluation<T>> actionEvaluations)
+            IReadOnlyList<ActionEvaluation<T>> actionEvaluations,
+            bool buildIndices
+        )
         {
             HashDigest<SHA256> blockHash = block.Hash;
             IAccountStateDelta lastStates = actionEvaluations.Count > 0
@@ -773,9 +775,12 @@ namespace Libplanet.Blockchain
                 new AddressStateMap(totalDelta)
             );
 
-            var chainId = Id.ToString();
-            Store.StoreStateReference(chainId, updatedAddresses, block);
-            Store.IncreaseTxNonce(chainId, block);
+            if (buildIndices)
+            {
+                string chainId = Id.ToString();
+                Store.StoreStateReference(chainId, updatedAddresses, block);
+                Store.IncreaseTxNonce(chainId, block);
+            }
         }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -172,14 +172,14 @@ namespace Libplanet.Blockchain
         /// If this option is turned off (which is default) this method throws
         /// <see cref="IncompleteBlockStatesException"/> instead
         /// for the same situation.
-        /// Just-in-time calculation of states could take long time so that
-        /// overall latency of an application may rise.</param>
+        /// Just-in-time calculation of states could take a long time so that
+        /// the overall latency of an application may rise.</param>
         /// <returns>The <see cref="AddressStateMap"/> of given
         /// <paramref name="addresses"/>.</returns>
         /// <exception cref="IncompleteBlockStatesException">Thrown when
         /// the <see cref="BlockChain{T}"/> instance does not contain
         /// states dirty of the block which lastly updated states of a requested
-        /// address, because actions in the block has never been executed.
+        /// address, because actions in the block have never been executed.
         /// If <paramref name="completeStates"/> option is turned on
         /// this exception is not thrown and incomplete states are calculated
         /// and filled on the fly instead.

--- a/Libplanet/Blockchain/IncompleteBlockStatesException.cs
+++ b/Libplanet/Blockchain/IncompleteBlockStatesException.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// The exception that is thrown when a <see cref="BlockChain{T}"/> have
+    /// not calculated the complete states for all blocks, but an operation
+    /// that needs some lacked states is requested.
+    /// </summary>
+    public class IncompleteBlockStatesException : Exception
+    {
+        /// <summary>
+        /// Creates a new <see cref="IncompleteBlockStatesException"/> object.
+        /// </summary>
+        /// <param name="blockHash">Specifies <see cref="BlockHash"/>.
+        /// It is automatically included to the <see cref="Exception.Message"/>
+        /// string.</param>
+        /// <param name="message">Specifies the <see cref="Exception.Message"/>.
+        /// </param>
+        public IncompleteBlockStatesException(
+            HashDigest<SHA256> blockHash,
+            string message = null)
+            : base(
+                message is null
+                    ? $"{blockHash} lacks states"
+                    : $"{message}\nBlock that lacks states: {blockHash}")
+        {
+            BlockHash = blockHash;
+        }
+
+        /// <summary>
+        /// The <see cref="Block{T}.Hash"/> of <see cref="Block{T}"/> that
+        /// a <see cref="BlockChain{T}"/> lacks the states.
+        /// </summary>
+        public HashDigest<SHA256> BlockHash { get; }
+    }
+}

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -29,6 +29,9 @@ namespace Libplanet.Store
             HashDigest<SHA256> hash
         );
 
+        /// <inheritdoc />
+        public abstract IEnumerable<Address> ListAddresses(string @namespace);
+
         public abstract void StageTransactionIds(
             ISet<TxId> txids
         );

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -242,6 +242,36 @@ namespace Libplanet.Store
             return 0;
         }
 
+        /// <inheritdoc/>
+        public override IEnumerable<Address> ListAddresses(string @namespace)
+        {
+            string dirPath = GetStateReferencePath(@namespace);
+            var dir = new DirectoryInfo(dirPath);
+            if (!dir.Exists)
+            {
+                yield break;
+            }
+
+            foreach (DirectoryInfo upper in dir.EnumerateDirectories())
+            {
+                foreach (FileInfo lower in upper.EnumerateFiles())
+                {
+                    string hex = upper.Name + lower.Name;
+                    Address address;
+                    try
+                    {
+                        address = new Address(hex);
+                    }
+                    catch (ArgumentException)
+                    {
+                        continue;
+                    }
+
+                    yield return address;
+                }
+            }
+        }
+
         public override bool DeleteBlock(HashDigest<SHA256> blockHash)
         {
             var blockFile = new FileInfo(GetBlockPath(blockHash));

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -526,7 +526,7 @@ namespace Libplanet.Store
 
             if (!statesFile.Exists)
             {
-                return new AddressStateMap();
+                return null;
             }
 
             using (Stream stream = statesFile.OpenRead())

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -25,6 +25,14 @@ namespace Libplanet.Store
 
         bool DeleteIndex(string @namespace, HashDigest<SHA256> hash);
 
+        /// <summary>
+        /// Lists all addresses that have ever had states.
+        /// </summary>
+        /// <param name="namespace">The namespace to list addresses.</param>
+        /// <returns>All addresses in an arbitrary order.  The order might
+        /// be vary for each call.</returns>
+        IEnumerable<Address> ListAddresses(string @namespace);
+
         void StageTransactionIds(ISet<TxId> txids);
 
         void UnstageTransactionIds(ISet<TxId> txids);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -58,6 +58,27 @@ namespace Libplanet.Store
 
         bool DeleteBlock(HashDigest<SHA256> blockHash);
 
+        /// <summary>
+        /// Gets the states updated by actions in the inquired block.
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to query.
+        /// </param>
+        /// <returns>The states updated by actions in the inquired block.
+        /// If actions definitely do not update any addresses it returns
+        /// an empty map.  If there is no record for the inquired block
+        /// (because actions in it have never been evaluated yet) it returns
+        /// <c>null</c> instead.
+        /// </returns>
+        /// <remarks>It does not return all states built up from the genesis
+        /// block nor delta, but only dirty states by actions the inquired
+        /// block.
+        /// <para>For example, if actions in the genesis block do
+        /// <c>a++; b++</c>, /// and actions in the second block do
+        /// <c>b++; c++</c>, this method /// for the second block returns
+        /// <c>b = 2; c = 1</c> (dirty), not
+        /// <c>a = 1; b = 2; c = 1</c> (all states) nor
+        /// <c>b = 1; c = 1</c> (delta).</para>
+        /// </remarks>
         AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash);
 
         void SetBlockStates(

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -270,7 +270,7 @@ namespace Libplanet.Store
                 _db.FileStorage.FindById(BlockStateFileId(blockHash));
             if (file is null)
             {
-                return new AddressStateMap();
+                return null;
             }
 
             using (var stream = new MemoryStream())

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -118,6 +118,39 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public IEnumerable<Address> ListAddresses(string @namespace)
+        {
+            var prefix = $"{StateRefIdPrefix}{@namespace}/";
+            foreach (LiteFileInfo fileInfo in _db.FileStorage.Find(prefix))
+            {
+                string fileId = fileInfo.Id;
+                int slashIndex = fileId.LastIndexOf('/');
+                if (slashIndex < 0)
+                {
+                    continue;
+                }
+
+                string addressHex = fileId.Substring(slashIndex + 1);
+                if (addressHex.Length < Address.Size * 2)
+                {
+                    continue;
+                }
+
+                Address address;
+                try
+                {
+                    address = new Address(addressHex);
+                }
+                catch (ArgumentException)
+                {
+                    continue;
+                }
+
+                yield return address;
+            }
+        }
+
+        /// <inheritdoc/>
         public void StageTransactionIds(ISet<TxId> txids)
         {
             StagedTxIds.InsertBulk(

--- a/Libplanet/Tx/InvalidTxUpdatedAddressesException.cs
+++ b/Libplanet/Tx/InvalidTxUpdatedAddressesException.cs
@@ -26,9 +26,9 @@ namespace Libplanet.Tx
         /// the <see cref="Exception.Message"/> string.</param>
         /// <param name="updatableAddresses">Specifies the
         /// <see cref="UpdatableAddresses"/>.</param>
-        /// <param name="updatedAddresses">Specified the
+        /// <param name="updatedAddresses">Specifies the
         /// <see cref="UpdatedAddresses"/>.</param>
-        /// <param name="message">Specifies a <see cref="Exception.Message"/>.
+        /// <param name="message">Specifies the <see cref="Exception.Message"/>.
         /// </param>
         [SuppressMessage(
             "Microsoft.StyleCop.CSharp.ReadabilityRules",


### PR DESCRIPTION
This patch makes `BlockChain<T>` to have incomplete states so that we can implement #272 on this.  Where a `BlockChain<T>` does not have complete states and a query to states that it lacks is required, there are two options:

- Throwing `IncompleteBlockStatesException` (which is default).
- Evaluating actions preceding the requested states and filling the states on the fly (`completeStates: true`).

See also *CHANGES.md* as well.