### PR TITLE
Avoid publishing packages/docs unless a branch is for releases

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -19,7 +19,12 @@ if [ "$NUGET_API_KEY" = "" ]; then
   exit 1
 fi
 
-if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ]; then
+# Publish a package only if the repository is upstream (planetarium/libplanet)
+# and the branch is for releases (master or maintenance-*).
+# shellcheck disable=SC2235
+if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ] || (
+    [ "$GITHUB_REF" != refs/heads/master ] &&
+    [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ] ); then
   alias dotnet="echo DRY-RUN: dotnet"
 fi
 

--- a/Docs/publish.sh
+++ b/Docs/publish.sh
@@ -41,6 +41,13 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
   pr_number="$(jq '.pull_request.number' "$GITHUB_EVENT_PATH")"
   slug="pulls/$pr_number"
 else
+  if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && \
+     [ "$GITHUB_REF" != refs/heads/master ] && \
+     [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ]; then
+    echo "This branch is not for releases, so docs won't be published." \
+      > /dev/stderr
+    exit 0
+  fi
   slug="$(echo -n "$GITHUB_REF" | sed -e 's/^refs\/\(heads\|tags\)\///g')"
 fi
 [ "$slug" != "" ]


### PR DESCRIPTION
This patch prevents the GitHub Actions process publishing packages/docs a non-release branch by accident.  Without this patch, for example, temporary branches made by the [autorebase] bot are published to NuGet.

<img width="603" alt="Screen Shot 2019-06-25 at 3 38 11 PM" src="https://user-images.githubusercontent.com/12431/60074995-42ce1480-975f-11e9-9068-a86dda675fbb.png">

[autorebase]: https://github.com/apps/autorebase