### PR TITLE
Adjust how IStore deals with state references and tx nonce

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "editor.rulers": [80]
+  "editor.rulers": [80, 100]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,12 @@ To be released.
      -  Removed `IStore.ForkTxNonce()` method.
      -  `FileStore` became to occupy fewer bytes for storing tx nonces.
         This change broke file-level backward compatibility.
+ -  `IStore` became possible to look up multiple state references in a stack.
+    [[#272], [#307]]
+     -  Removed `IStore.LookupStateReference<T>()` method.
+        Instead, a newly added static class `StoreExtension` provides
+        an extension method of the same name.
+     -  Added `IStore.IterateStateReferences()` method.
 
 ### Added interfaces
 
@@ -44,6 +50,7 @@ To be released.
     IImmutableSet<Address>, DateTimeOffset?)` method.  [[#294]]
  -  Added `BlockChain<T>.GetNextTxNonce()` method which counts staged
     transactions too during nonce computation.  [[#270], [#294]]
+ -  Added `StoreExtension` static class.  [[#272], [#307]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,13 @@ To be released.
     broadcast.  [[#274], [#297]]
  -  `Swarm.StartAsync()` method became to receive `broadcastTxInterval`
     (or `millisecondsBroadcastTxInterval`) parameter.  [[#274], [#297]]
+ -  `IStore` became to treat a "tx nonce" mere a `long` integer instead of
+    a stack of block hashes.  [[#272], [#307]]
+     -  `IStore.IncreaseTxNonce<T>(string, Block<T>)` method was replaced by
+        `IStore.IncreaseTxNonce(string, Address, long)` method.
+     -  Removed `IStore.ForkTxNonce()` method.
+     -  `FileStore` became to occupy fewer bytes for storing tx nonces.
+        This change broke file-level backward compatibility.
 
 ### Added interfaces
 
@@ -93,6 +100,7 @@ To be released.
 [#294]: https://github.com/planetarium/libplanet/pull/294
 [#297]: https://github.com/planetarium/libplanet/pull/297
 [#303]: https://github.com/planetarium/libplanet/issues/303
+[#307]: https://github.com/planetarium/libplanet/pull/307
 [#308]: https://github.com/planetarium/libplanet/pull/308
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ You can build these assemblies using `msbuild -r` Mono or .NET Framework
 provide.
 *You can't build them using `dotnet build` command or `dotnet msbuild`,*
 because the Unity runtime is not based on .NET Core but Mono,
-which is compatible to .NET Framework 4.6.
+which is compatible with .NET Framework 4.6.
 Please be sure that Mono's *bin* directory is prior to .NET Core's one
 (or it's okay too if .NET Core is not installed at all).  Mono or .NET
 Framework's `msbuild` could try to use .NET Core's version of several
@@ -139,7 +139,7 @@ The way to execute the runner binary depend on the platform.  For details,
 please read [xunit-unity-runner]'s README.  FYI you can use `-h`/`--help`
 option as well.
 
-To sum up, the instruction is like below (the example is assumming Linux):
+To sum up, the instruction is like below (the example is assuming Linux):
 
     msbuild -r
     xunit-unity-runner/StandaloneLinux64 \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/s
 -----
 
 We write as complete tests as possible to the corresponding implementation code.
-Going near to the [code coverage][2] 100% is one of our goals.
+Going near to the [code coverage][3] 100% is one of our goals.
 
 The *Libplanet* solution consists of 4 projects.  *Libplanet* and
 *Libplanet.Stun* are actual implementations.  These are built to *Libplanet.dll*
@@ -89,7 +89,7 @@ To build and run unit tests at a time execute the below command:
     dotnet test
 
 [Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build/latest?definitionId=1&branchName=master
-[2]: https://codecov.io/gh/planetarium/libplanet
+[3]: https://codecov.io/gh/planetarium/libplanet
 [Xunit]: https://xunit.github.io/
 
 
@@ -105,6 +105,48 @@ or cloud offers like [Xirsys].
 [Coturn]: https://github.com/coturn/coturn
 [gortc/turn]: https://github.com/gortc/turn
 [Xirsys]: https://xirsys.com/
+
+
+### [xunit-unity-runner]
+
+Unity is one of our platforms we primarily target to support, so we've been
+testing Libplanet on the actual Unity runtime, and you could see whether it's
+passed on [Azure Pipelines].
+
+However, if it fails and it does not fail on other platforms but only Unity,
+you need to run Unity tests on your own machine so that you rapidily and
+repeatedly tinker things, make a try, and immediately get feedback from them.
+
+Here's how to run Unity tests on your machine.  We've made and used
+[xunit-unity-runner] to run [Xunit] tests on the actual Unity runtime,
+and our build jobs on Azure Pipelines also use this.  This test runner
+is actually a Unity app, though it's not a game app.  As of June 2019,
+there are [executable binaries][4] for Linux, macOS, and Windows.
+Its usage is simple.  It's a CLI app that takes *absolute* paths to
+.NET assemblies (*.dll*) that consist of test classes (based on Xunit).
+
+You can build these assemblies using `msbuild -r` Mono or .NET Framework
+provide.
+*You can't build them using `dotnet build` command or `dotnet msbuild`,*
+because the Unity runtime is not based on .NET Core but Mono,
+which is compatible to .NET Framework 4.6.
+Please be sure that Mono's *bin* directory is prior to .NET Core's one
+(or it's okay too if .NET Core is not installed at all).  Mono or .NET
+Framework's `msbuild` could try to use .NET Core's version of several
+utilities during build, and this could cause some errors.
+
+The way to execute the runner binary depend on the platform.  For details,
+please read [xunit-unity-runner]'s README.  FYI you can use `-h`/`--help`
+option as well.
+
+To sum up, the instruction is like below (the example is assumming Linux):
+
+    msbuild -r
+    xunit-unity-runner/StandaloneLinux64 \
+      "`pwd`"/*.Tests/bin/Debug/net461/*.Tests.dll
+
+[xunit-unity-runner]: https://github.com/planetarium/xunit-unity-runner
+[4]: https://github.com/planetarium/xunit-unity-runner/releases/latest
 
 
 Style convention

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1026,11 +1026,21 @@ namespace Libplanet.Tests.Blockchain
                     (x, y) => x.SetItems(y.GetUpdatedStates())
                 );
 
+            void BuildIndex(Guid id, Block<DumbAction> block)
+            {
+                string idString = id.ToString();
+                foreach (Transaction<DumbAction> tx in block.Transactions)
+                {
+                    store.IncreaseTxNonce(idString, tx.Signer);
+                }
+
+                store.AppendIndex(idString, block.Hash);
+            }
+
             // Build the store has incomplete states
             Block<DumbAction> b = TestUtils.MineGenesis<DumbAction>();
             chain.Blocks[b.Hash] = b;
-            store.IncreaseTxNonce(chainId.ToString(), b);
-            store.AppendIndex(chainId.ToString(), b.Hash);
+            BuildIndex(chainId, b);
             IImmutableDictionary<Address, object> dirty =
                 GetDirty(b.Evaluate(DateTimeOffset.UtcNow, _ => null));
             const int accountsCount = 5;
@@ -1061,8 +1071,7 @@ namespace Libplanet.Tests.Blockchain
                         dirty.Keys.ToImmutableHashSet(),
                         b
                     );
-                    store.IncreaseTxNonce(chainId.ToString(), b);
-                    store.AppendIndex(chainId.ToString(), b.Hash);
+                    BuildIndex(chainId, b);
                 }
             }
 

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
+
+using static Libplanet.Store.StoreExtension;
+
+namespace Libplanet.Tests.Store
+{
+    public class StoreExtensionTest
+    {
+        public static IEnumerable<object[]> StoreFixtures
+        {
+            get
+            {
+                yield return new object[] { new FileStoreFixture() };
+                yield return new object[] { new LiteDBStoreFixture() };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StoreFixtures))]
+        public void LookupStateReference(StoreFixture fx)
+        {
+            Address address = fx.Address1;
+
+            Transaction<DumbAction> tx4 = fx.MakeTransaction(
+                new DumbAction[] { new DumbAction(address, "foo") }
+            );
+            Block<DumbAction> block4 = TestUtils.MineNext(fx.Block3, new[] { tx4 });
+
+            Transaction<DumbAction> tx5 = fx.MakeTransaction(
+                new DumbAction[] { new DumbAction(address, "bar") }
+            );
+            Block<DumbAction> block5 = TestUtils.MineNext(block4, new[] { tx5 });
+
+            Block<DumbAction> block6 = TestUtils.MineNext(block5, new Transaction<DumbAction>[0]);
+
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, block4));
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, block5));
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, block6));
+
+            fx.Store.StoreStateReference(fx.StoreNamespace, tx4.UpdatedAddresses, block4);
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
+            Assert.Equal(
+                block4.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
+            );
+            Assert.Equal(
+                block4.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
+            );
+            Assert.Equal(
+                block4.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
+            );
+
+            fx.Store.StoreStateReference(fx.StoreNamespace, tx5.UpdatedAddresses, block5);
+            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
+            Assert.Equal(
+                block4.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
+            );
+            Assert.Equal(
+                block5.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
+            );
+            Assert.Equal(
+                block5.Hash,
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -248,13 +249,17 @@ namespace Libplanet.Tests.Store
 
             Fx.Store.StoreStateReference(Fx.StoreNamespace, tx4.UpdatedAddresses, block4);
             Assert.Equal(
-                new[] { (block4.Hash, block4.Index) },
+                new[] { Tuple.Create(block4.Hash, block4.Index) },
                 this.Fx.Store.IterateStateReferences(this.Fx.StoreNamespace, address)
             );
 
             Fx.Store.StoreStateReference(Fx.StoreNamespace, tx5.UpdatedAddresses, block5);
             Assert.Equal(
-                new[] { (block5.Hash, block5.Index), (block4.Hash, block4.Index) },
+                new[]
+                {
+                    Tuple.Create(block5.Hash, block5.Index),
+                    Tuple.Create(block4.Hash, block4.Index),
+                },
                 this.Fx.Store.IterateStateReferences(this.Fx.StoreNamespace, address)
             );
         }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -426,75 +426,17 @@ namespace Libplanet.Tests.Store
             Assert.Equal(0, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
             Assert.Equal(0, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
 
-            Block<DumbAction> block1 = TestUtils.MineNext(
-                TestUtils.MineGenesis<DumbAction>(),
-                new[] { Fx.Transaction1 });
-            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, block1);
-
+            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer);
             Assert.Equal(1, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
             Assert.Equal(0, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
 
-            Block<DumbAction> block2 = TestUtils.MineNext(
-                block1,
-                new[] { Fx.Transaction2 });
-            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, block2);
-
+            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer, 5);
             Assert.Equal(1, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
-            Assert.Equal(1, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
-        }
+            Assert.Equal(5, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
 
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [Theory]
-        public void ForkTxNonce(int branchPointIndex)
-        {
-            var privateKey1 = new PrivateKey();
-            var privateKey2 = new PrivateKey();
-            Address address1 = privateKey1.PublicKey.ToAddress();
-            Address address2 = privateKey2.PublicKey.ToAddress();
-            Block<DumbAction> prevBlock = Fx.Block3;
-            const string targetNamespace = "dummy";
-
-            var blocks = new List<Block<DumbAction>>
-            {
-                TestUtils.MineNext(
-                    prevBlock,
-                    new[] { Fx.MakeTransaction(privateKey: privateKey1) }),
-            };
-            blocks.Add(
-                TestUtils.MineNext(
-                    blocks[0],
-                    new[] { Fx.MakeTransaction(privateKey: privateKey1) }));
-            blocks.Add(
-                TestUtils.MineNext(
-                    blocks[1],
-                    new[] { Fx.MakeTransaction(privateKey: privateKey1) }));
-            blocks.Add(
-                TestUtils.MineNext(
-                    blocks[2],
-                    new[] { Fx.MakeTransaction(privateKey: privateKey2) }));
-
-            foreach (Block<DumbAction> block in blocks)
-            {
-                Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, block);
-            }
-
-            var branchPoint = blocks[branchPointIndex];
-            Fx.Store.ForkTxNonce(
-                Fx.StoreNamespace,
-                targetNamespace,
-                branchPoint,
-                new[] { address1, address2 }.ToImmutableHashSet());
-            Assert.Equal(
-                3,
-                Fx.Store.GetTxNonce(Fx.StoreNamespace, address1));
-            Assert.Equal(
-                branchPointIndex + 1,
-                Fx.Store.GetTxNonce(targetNamespace, address1));
-            Assert.Equal(
-                0,
-                Fx.Store.GetTxNonce(targetNamespace, address2));
+            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer, 2);
+            Assert.Equal(3, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
+            Assert.Equal(5, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -152,14 +152,13 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
-        public HashDigest<SHA256>? LookupStateReference<T>(
+        public IEnumerable<(HashDigest<SHA256>, long)> IterateStateReferences(
             string @namespace,
-            Address address,
-            Block<T> lookupUntil)
-            where T : IAction, new()
+            Address address
+        )
         {
-            _logs.Add((nameof(LookupStateReference), address, null));
-            return _store.LookupStateReference(@namespace, address, lookupUntil);
+            _logs.Add((nameof(IterateStateReferences), @namespace, address));
+            return _store.IterateStateReferences(@namespace, address);
         }
 
         public void StoreStateReference<T>(
@@ -168,6 +167,7 @@ namespace Libplanet.Tests.Store
             Block<T> block)
             where T : IAction, new()
         {
+            // FIXME: Log arguments properly (including @namespace).
             _logs.Add((nameof(StoreStateReference), block.Hash, null));
             _store.StoreStateReference(@namespace, addresses, block);
         }
@@ -179,6 +179,7 @@ namespace Libplanet.Tests.Store
             IImmutableSet<Address> addressesToStrip)
             where T : IAction, new()
         {
+            // FIXME: Log arguments properly.
             _logs.Add((nameof(ForkStateReferences), null, null));
             _store.ForkStateReferences(
                 sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
@@ -186,12 +187,13 @@ namespace Libplanet.Tests.Store
 
         public long GetTxNonce(string @namespace, Address address)
         {
-            _logs.Add((nameof(GetTxNonce), address, null));
+            _logs.Add((nameof(GetTxNonce), @namespace, address));
             return _store.GetTxNonce(@namespace, address);
         }
 
         public void IncreaseTxNonce(string @namespace, Address address, long delta = 1)
         {
+            // FIXME: Log arguments properly (including @namespace).
             _logs.Add((nameof(IncreaseTxNonce), address, delta));
             _store.IncreaseTxNonce(@namespace, address, delta);
         }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
@@ -152,10 +153,9 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
-        public IEnumerable<(HashDigest<SHA256>, long)> IterateStateReferences(
+        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,
-            Address address
-        )
+            Address address)
         {
             _logs.Add((nameof(IterateStateReferences), @namespace, address));
             return _store.IterateStateReferences(@namespace, address);

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -190,23 +190,10 @@ namespace Libplanet.Tests.Store
             return _store.GetTxNonce(@namespace, address);
         }
 
-        public void IncreaseTxNonce<T>(string @namespace, Block<T> block)
-            where T : IAction, new()
+        public void IncreaseTxNonce(string @namespace, Address address, long delta = 1)
         {
-            _logs.Add((nameof(IncreaseTxNonce), block.Hash, null));
-            _store.IncreaseTxNonce(@namespace, block);
-        }
-
-        public void ForkTxNonce<T>(
-            string sourceNamespace,
-            string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
-            where T : IAction, new()
-        {
-            _logs.Add((nameof(ForkTxNonce), null, null));
-            _store.ForkTxNonce(
-                sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
+            _logs.Add((nameof(IncreaseTxNonce), address, delta));
+            _store.IncreaseTxNonce(@namespace, address, delta);
         }
 
         public void StageTransactionIds(IDictionary<TxId, bool> txids)

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -75,8 +76,8 @@ namespace Libplanet.Store
         );
 
         /// <inheritdoc />
-        public abstract IEnumerable<(HashDigest<SHA256>, long)>
-        IterateStateReferences(string @namespace, Address address);
+        public abstract IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
+            string @namespace, Address address);
 
         /// <inheritdoc />
         public abstract void StoreStateReference<T>(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -75,11 +75,8 @@ namespace Libplanet.Store
         );
 
         /// <inheritdoc />
-        public abstract HashDigest<SHA256>? LookupStateReference<T>(
-            string @namespace,
-            Address address,
-            Block<T> lookupUntil)
-            where T : IAction, new();
+        public abstract IEnumerable<(HashDigest<SHA256>, long)>
+        IterateStateReferences(string @namespace, Address address);
 
         /// <inheritdoc />
         public abstract void StoreStateReference<T>(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -100,18 +100,7 @@ namespace Libplanet.Store
         public abstract long GetTxNonce(string @namespace, Address address);
 
         /// <inheritdoc/>
-        public abstract void IncreaseTxNonce<T>(
-            string @namespace,
-            Block<T> block)
-            where T : IAction, new();
-
-        /// <inheritdoc/>
-        public abstract void ForkTxNonce<T>(
-            string sourceNamespace,
-            string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
-            where T : IAction, new();
+        public abstract void IncreaseTxNonce(string @namespace, Address signer, long delta = 1);
 
         public long CountTransactions()
         {

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -709,78 +709,30 @@ namespace Libplanet.Store
                 return 0;
             }
 
-            int hashSize = HashDigest<SHA256>.Size;
-            int blockIndexSize = sizeof(long);
-            int nonceSize = sizeof(long);
-            int nonceEntrySize = hashSize + blockIndexSize + nonceSize;
-
             using (Stream stream = nonceFile.OpenRead())
             {
-                if (stream.Length % nonceEntrySize != 0)
-                {
-                    throw new FileLoadException(
-                        $"Nonce file size {stream.Length} should be " +
-                        $"a multiple of nonce entry size {nonceEntrySize}");
-                }
-
-                var buffer = new byte[nonceEntrySize];
-
-                stream.Seek(-buffer.Length, SeekOrigin.End);
+                var buffer = new byte[sizeof(long)];
                 stream.Read(buffer, 0, buffer.Length);
-
-                return BitConverter.ToInt64(buffer, hashSize + blockIndexSize);
+                return BitConverter.ToInt64(buffer, 0);
             }
         }
 
         /// <inheritdoc/>
-        public override void IncreaseTxNonce<T>(
-            string @namespace,
-            Block<T> block)
+        public override void IncreaseTxNonce(string @namespace, Address signer, long delta = 1)
         {
-            IEnumerable<Address> signers = block
-                .Transactions
-                .Select(tx => tx.Signer);
-            int hashSize = HashDigest<SHA256>.Size;
-            long blockIndex = block.Index;
+            long nextNonce = GetTxNonce(@namespace, signer) + delta;
+            var nonceFile = new FileInfo(GetTxNoncePath(@namespace, signer));
 
-            foreach (Address signer in signers)
+            if (!nonceFile.Directory.Exists)
             {
-                long nextNonce = GetTxNonce(@namespace, signer) + 1;
-                var nonceFile = new FileInfo(
-                    GetTxNoncePath(@namespace, signer));
-
-                if (!nonceFile.Directory.Exists)
-                {
-                    nonceFile.Directory.Create();
-                }
-
-                using (Stream stream = nonceFile.Open(
-                    FileMode.Append, FileAccess.Write))
-                {
-                    stream.Write(block.Hash.ToByteArray(), 0, hashSize);
-                    stream.Write(
-                        BitConverter.GetBytes(blockIndex), 0, sizeof(long));
-                    stream.Write(
-                        BitConverter.GetBytes(nextNonce), 0, sizeof(long));
-                }
+                nonceFile.Directory.Create();
             }
-        }
 
-        /// <inheritdoc/>
-        public override void ForkTxNonce<T>(
-            string sourceNamespace,
-            string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
-        {
-            ForkIndexedStack(
-                sourceNamespace,
-                destinationNamespace,
-                branchPoint.Index,
-                addressesToStrip,
-                GetTxNoncePath,
-                GetTxNoncePath,
-                s => GetTxNonces(s).Select(t => t.Item2));
+            using (Stream stream = nonceFile.OpenWrite())
+            {
+                byte[] nonceBytes = BitConverter.GetBytes(nextNonce);
+                stream.Write(nonceBytes, 0, nonceBytes.Length);
+            }
         }
 
         private void ForkIndexedStack(

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -611,8 +611,8 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<(HashDigest<SHA256>, long)>
-        IterateStateReferences(string @namespace, Address address)
+        public override IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
+            string @namespace, Address address)
         {
             var addrFile = new FileInfo(
                 GetStateReferencePath(@namespace, address));
@@ -635,7 +635,10 @@ namespace Libplanet.Store
             {
                 foreach (var (hashBytes, index) in GetStateReferences(stream))
                 {
-                    yield return (new HashDigest<SHA256>(hashBytes), index);
+                    yield return Tuple.Create(
+                        new HashDigest<SHA256>(hashBytes),
+                        index
+                    );
                 }
             }
         }

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
@@ -117,10 +118,9 @@ namespace Libplanet.Store
         /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) go last,
         /// and the lowest index (i.e., the closest to the genesis) go first.</returns>
         /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
-        IEnumerable<(HashDigest<SHA256>, long)> IterateStateReferences(
+        IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,
-            Address address
-        );
+            Address address);
 
         /// <summary>
         /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -193,53 +193,20 @@ namespace Libplanet.Store
         /// </param>
         /// <returns>A <see cref="Transaction{T}"/> nonce. If there is no
         /// previous <see cref="Transaction{T}"/>, return 0.</returns>
-        /// <seealso cref="IncreaseTxNonce{T}"/>
+        /// <seealso cref="IncreaseTxNonce(string, Address, long)"/>
         long GetTxNonce(string @namespace, Address address);
 
         /// <summary>
-        /// Increases <see cref="Transaction{T}"/> of
-        /// <see cref="Transaction{T}.Signer"/> in the <paramref name="block"/>.
+        /// Increases (or decreases if a negative <paramref name="delta"/> is given)
+        /// the tx nonce counter for <paramref name="signer"/>.
         /// </summary>
         /// <param name="namespace">The namespace to increase
         /// <see cref="Transaction{T}"/> nonce.</param>
-        /// <param name="block">The <see cref="Block{T}"/> which has the
-        /// <see cref="Transaction{T}"/>s.</param>
-        /// <typeparam name="T">An <see cref="IAction"/> class used with
-        /// <paramref name="block"/>.</typeparam>
-        /// <seealso cref="GetTxNonce"/>
-        void IncreaseTxNonce<T>(string @namespace, Block<T> block)
-            where T : IAction, new();
-
-        /// <summary>
-        /// Forks <see cref="Transaction{T}"/> nonces from
-        /// <paramref name="sourceNamespace"/> to
-        /// <paramref name="destinationNamespace"/>.
-        /// <para>This method copies <see cref="Transaction{T}"/> nonces from
-        /// <paramref name="sourceNamespace"/> to
-        /// <paramref name="destinationNamespace"/> and strips
-        /// <paramref name="addressesToStrip"/> of nonces after
-        /// <paramref name="branchPoint"/>.</para>
-        /// </summary>
-        /// <param name="sourceNamespace">The namespace of
-        /// <see cref="Transaction{T}"/> nonces to fork.</param>
-        /// <param name="destinationNamespace">The namespace of destination
-        /// <see cref="Transaction{T}"/> nonces.</param>
-        /// <param name="branchPoint">The branch point <see cref="Block{T}"/>
-        /// to fork.</param>
-        /// <param name="addressesToStrip">The set of <see cref="Address"/>es
-        /// to strip <see cref="Transaction{T}"/> nonces after forking.</param>
-        /// <typeparam name="T">An <see cref="IAction"/> class used with
-        /// <paramref name="branchPoint"/>.</typeparam>
-        /// <exception cref="NamespaceNotFoundException">Thrown when the given
-        /// <paramref name="sourceNamespace"/> does not exist.</exception>
-        /// <seealso cref="GetTxNonce"/>
-        /// <seealso cref="IncreaseTxNonce{T}"/>
-        void ForkTxNonce<T>(
-            string sourceNamespace,
-            string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
-            where T : IAction, new();
+        /// <param name="signer">The address of the account to increase tx nonce.</param>
+        /// <param name="delta">How many to incrase the counter.  A negative number decreases
+        /// the counter.  1 by default.</param>
+        /// <seealso cref="GetTxNonce(string, Address)"/>
+        void IncreaseTxNonce(string @namespace, Address signer, long delta = 1);
 
         long CountTransactions();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -108,26 +108,19 @@ namespace Libplanet.Store
         );
 
         /// <summary>
-        /// Looks up a state reference, which is a <see cref="Block{T}.Hash"/>
-        /// that has the state of the <paramref name="address"/>.
+        /// Gets pairs of a state reference and a corresponding <see cref="Block{T}.Index"/> of
+        /// the requested <paramref name="address"/> in the specified <paramref name="namespace"/>.
         /// </summary>
-        /// <param name="namespace">The namespace to look up a state reference.
-        /// </param>
-        /// <param name="address">The <see cref="Address"/> to look up.
-        /// </param>
-        /// <param name="lookupUntil">The upper bound (i.e., the latest block)
-        /// of the search range. <see cref="Block{T}"/>s after
-        /// <paramref name="lookupUntil"/> are ignored.</param>
-        /// <returns>A <see cref="Block{T}.Hash"/> which has the state of the
-        /// <paramref name="address"/>.</returns>
-        /// <typeparam name="T">An <see cref="IAction"/> class used with
-        /// <paramref name="lookupUntil"/>.</typeparam>
-        /// <seealso cref="StoreStateReference{T}"/>
-        HashDigest<SHA256>? LookupStateReference<T>(
+        /// <param name="namespace">The chain namespace.</param>
+        /// <param name="address">The <see cref="Address"/> to get state references.</param>
+        /// <returns><em>Ordered</em> pairs of a state reference and a corresponding
+        /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) go last,
+        /// and the lowest index (i.e., the closest to the genesis) go first.</returns>
+        /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
+        IEnumerable<(HashDigest<SHA256>, long)> IterateStateReferences(
             string @namespace,
-            Address address,
-            Block<T> lookupUntil)
-            where T : IAction, new();
+            Address address
+        );
 
         /// <summary>
         /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>
@@ -142,7 +135,7 @@ namespace Libplanet.Store
         /// of the <see cref="Address"/>.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="block"/>.</typeparam>
-        /// <seealso cref="LookupStateReference{T}"/>
+        /// <seealso cref="IterateStateReferences(string, Address)"/>
         void StoreStateReference<T>(
             string @namespace,
             IImmutableSet<Address> addresses,
@@ -172,8 +165,8 @@ namespace Libplanet.Store
         /// <paramref name="branchPoint"/>.</typeparam>
         /// <exception cref="NamespaceNotFoundException">Thrown when the given
         /// <paramref name="sourceNamespace"/> does not exist.</exception>
-        /// <seealso cref="LookupStateReference{T}"/>
-        /// <seealso cref="StoreStateReference{T}"/>
+        /// <seealso cref="IterateStateReferences(string, Address)"/>
+        /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
         void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -354,10 +354,9 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IEnumerable<(HashDigest<SHA256>, long)> IterateStateReferences(
+        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,
-            Address address
-        )
+            Address address)
         {
             var fileId = $"{StateRefIdPrefix}{@namespace}/{address.ToHex()}";
             LiteFileInfo file = _db.FileStorage.FindById(fileId);
@@ -393,7 +392,10 @@ namespace Libplanet.Store
                     stream.Read(buffer, 0, buffer.Length);
                     byte[] hashBytes = buffer.Take(hashSize).ToArray();
                     long index = BitConverter.ToInt64(buffer, hashSize);
-                    yield return (new HashDigest<SHA256>(hashBytes), index);
+                    yield return Tuple.Create(
+                        new HashDigest<SHA256>(hashBytes),
+                        index
+                    );
                 }
             }
         }

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -519,136 +519,39 @@ namespace Libplanet.Store
                 return 0;
             }
 
-            int hashSize = HashDigest<SHA256>.Size;
-            int blockIndexSize = sizeof(long);
-            int nonceSize = sizeof(long);
-            int nonceEntrySize = hashSize + blockIndexSize + nonceSize;
-
-            using (var stream = new MemoryStream())
+            using (var stream = file.OpenRead())
             {
-                file.CopyTo(stream);
-
-                if (stream.Length % nonceEntrySize != 0)
-                {
-                    throw new FileLoadException(
-                        $"Nonce file size {stream.Length} should be " +
-                        $"a multiple of nonce entry size {nonceEntrySize}");
-                }
-
-                var buffer = new byte[nonceEntrySize];
-                stream.Seek(stream.Length - buffer.Length, SeekOrigin.Begin);
+                var buffer = new byte[sizeof(long)];
                 stream.Read(buffer, 0, buffer.Length);
-
-                return BitConverter.ToInt64(buffer, hashSize + blockIndexSize);
+                return BitConverter.ToInt64(buffer, 0);
             }
         }
 
         /// <inheritdoc/>
-        public void IncreaseTxNonce<T>(string @namespace, Block<T> block)
-            where T : IAction, new()
+        public void IncreaseTxNonce(string @namespace, Address signer, long delta = 1)
         {
-            IEnumerable<Address> signers = block
-                .Transactions
-                .Select(tx => tx.Signer);
-            int hashSize = HashDigest<SHA256>.Size;
-            long blockIndex = block.Index;
+            var fileId = $"{NonceIdPrefix}{@namespace}/{signer.ToHex()}";
+            long nextNonce = GetTxNonce(@namespace, signer) + delta;
 
-            foreach (Address signer in signers)
+            if (!_db.FileStorage.Exists(fileId))
             {
-                var fileId = $"{NonceIdPrefix}{@namespace}/{signer.ToHex()}";
-                long nextNonce = GetTxNonce(@namespace, signer) + 1;
-
-                if (!_db.FileStorage.Exists(fileId))
-                {
-                    _db.FileStorage.Upload(
-                        fileId,
-                        signer.ToHex(),
-                        new MemoryStream());
-                }
-
-                LiteFileInfo file = _db.FileStorage.FindById(fileId);
-                using (var temp = new MemoryStream())
-                {
-                    file.CopyTo(temp);
-                    temp.Seek(0, SeekOrigin.Begin);
-                    byte[] prev = temp.ToArray();
-
-                    using (LiteFileStream stream = file.OpenWrite())
-                    {
-                        stream.Write(prev, 0, prev.Length);
-                        stream.Write(block.Hash.ToByteArray(), 0, hashSize);
-                        stream.Write(
-                            BitConverter.GetBytes(blockIndex), 0, sizeof(long));
-                        stream.Write(
-                            BitConverter.GetBytes(nextNonce), 0, sizeof(long));
-                    }
-                }
-            }
-        }
-
-        /// <inheritdoc/>
-        public void ForkTxNonce<T>(
-            string sourceNamespace,
-            string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
-            where T : IAction, new()
-        {
-            long branchPointIndex = branchPoint.Index;
-            List<LiteFileInfo> files =
-                _db.FileStorage
-                    .Find($"{NonceIdPrefix}{sourceNamespace}")
-                    .ToList();
-
-            if (!files.Any() && addressesToStrip.Any())
-            {
-                throw new NamespaceNotFoundException(
-                    sourceNamespace,
-                    "The source namespace to be forked does not exist.");
-            }
-
-            foreach (LiteFileInfo srcFile in files)
-            {
-                string destId =
-                    $"{NonceIdPrefix}{destinationNamespace}/{srcFile.Filename}";
                 _db.FileStorage.Upload(
-                    destId,
-                    srcFile.Filename,
+                    fileId,
+                    signer.ToHex(),
                     new MemoryStream());
+            }
 
-                LiteFileInfo destFile = _db.FileStorage.FindById(destId);
-                using (LiteFileStream srcStream = srcFile.OpenRead())
-                using (LiteFileStream destStream = destFile.OpenWrite())
+            LiteFileInfo file = _db.FileStorage.FindById(fileId);
+            using (var temp = new MemoryStream())
+            {
+                file.CopyTo(temp);
+                temp.Seek(0, SeekOrigin.Begin);
+                byte[] prev = temp.ToArray();
+
+                using (LiteFileStream stream = file.OpenWrite())
                 {
-                    while (srcStream.Position < srcStream.Length)
-                    {
-                        var hashBytes = new byte[HashDigest<SHA256>.Size];
-                        var indexBytes = new byte[sizeof(long)];
-                        var nonceBytes = new byte[sizeof(long)];
-
-                        srcStream.Read(hashBytes, 0, hashBytes.Length);
-                        srcStream.Read(indexBytes, 0, indexBytes.Length);
-                        srcStream.Read(nonceBytes, 0, nonceBytes.Length);
-
-                        long currentIndex =
-                            BitConverter.ToInt64(indexBytes, 0);
-
-                        if (currentIndex <= branchPointIndex)
-                        {
-                            destStream.Write(hashBytes, 0, hashBytes.Length);
-                            destStream.Write(indexBytes, 0, indexBytes.Length);
-                            destStream.Write(nonceBytes, 0, nonceBytes.Length);
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (destFile.Length == 0)
-                {
-                    _db.FileStorage.Delete(destId);
+                    byte[] nonceBytes = BitConverter.GetBytes(nextNonce);
+                    stream.Write(nonceBytes, 0, nonceBytes.Length);
                 }
             }
         }

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
-using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 
@@ -38,13 +37,13 @@ namespace Libplanet.Store
                 throw new ArgumentNullException(nameof(lookupUntil));
             }
 
-            IEnumerable<(HashDigest<SHA256>, long)> stateRefs =
+            IEnumerable<Tuple<HashDigest<SHA256>, long>> stateRefs =
                 store.IterateStateReferences(@namespace, address);
-            foreach ((HashDigest<SHA256> refHash, long refIndex) in stateRefs)
+            foreach (Tuple<HashDigest<SHA256>, long> pair in stateRefs)
             {
-                if (refIndex <= lookupUntil.Index)
+                if (pair.Item2 <= lookupUntil.Index)
                 {
-                    return refHash;
+                    return pair.Item1;
                 }
             }
 

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Store
+{
+    public static class StoreExtension
+    {
+        /// <summary>
+        /// Looks up a state reference, which is a block's <see cref="Block{T}.Hash"/> that contains
+        /// an action mutating the <paramref name="address"/>' state.
+        /// </summary>
+        /// <param name="store">The store object expected to contain the state reference.</param>
+        /// <param name="namespace">The namespace to look up a state reference.</param>
+        /// <param name="address">The <see cref="Address"/> to look up.</param>
+        /// <param name="lookupUntil">The upper bound (i.e., the latest block) of the search range.
+        /// <see cref="Block{T}"/>s after <paramref name="lookupUntil"/> are ignored.</param>
+        /// <returns>A <see cref="Block{T}.Hash"/> which has the state of
+        /// the <paramref name="address"/>.</returns>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="lookupUntil"/>.</typeparam>
+        /// <seealso
+        /// cref="IStore.StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
+        /// <seealso cref="IStore.IterateStateReferences(string, Address)"/>
+        public static HashDigest<SHA256>? LookupStateReference<T>(
+            this IStore store,
+            string @namespace,
+            Address address,
+            Block<T> lookupUntil)
+            where T : IAction, new()
+        {
+            if (lookupUntil is null)
+            {
+                throw new ArgumentNullException(nameof(lookupUntil));
+            }
+
+            IEnumerable<(HashDigest<SHA256>, long)> stateRefs =
+                store.IterateStateReferences(@namespace, address);
+            foreach ((HashDigest<SHA256> refHash, long refIndex) in stateRefs)
+            {
+                if (refIndex <= lookupUntil.Index)
+                {
+                    return refHash;
+                }
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This consists of two changes on the `IStore` interface and its implementations:

- Tx nonces is no more stacked but encoded as a single 64-bit integer instead.
- Multiple state references for an address can be fetched at a time, without multiple method calls.

These changes are needed for implementing #272.