### PR TITLE
Fix tx nonces being missed during fork

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ To be released.
  -  `Swarm.StartAsync()` method became to receive `broadcastTxInterval`
     (or `millisecondsBroadcastTxInterval`) parameter.  [[#274], [#297]]
  -  `IStore` became to treat a "tx nonce" mere a `long` integer instead of
-    a stack of block hashes.  [[#272], [#307]]
+    a stack of block hashes.  [[#272], [#307], [#309], [#310]]
      -  `IStore.IncreaseTxNonce<T>(string, Block<T>)` method was replaced by
         `IStore.IncreaseTxNonce(string, Address, long)` method.
      -  Removed `IStore.ForkTxNonce()` method.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ To be released.
  -  `Peer.AppProtocolVersion` became nullable to represent `Peer` whose version
     is unknown.  [[#280]]
  -  Added `IStore.ListAddresses()` method.  [[#272], [#285]]
+ -  Added `IStore.ListTxNonces()` method. [[#272], [#309], [#310]]
  -  Removed `BlockChain<T>.GetNonce()` method.  [[#294]]
  -  `BlockChain<T>.StageTransactions` became to receive
     `IDictionary<Transaction<T>, bool>` instead of `ISet<Transaction<T>>`.
@@ -109,6 +110,8 @@ To be released.
 [#303]: https://github.com/planetarium/libplanet/issues/303
 [#307]: https://github.com/planetarium/libplanet/pull/307
 [#308]: https://github.com/planetarium/libplanet/pull/308
+[#309]: https://github.com/planetarium/libplanet/issues/309
+[#310]: https://github.com/planetarium/libplanet/pull/310
 
 
 Version 0.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,7 +100,7 @@ To be released.
 [#275]: https://github.com/planetarium/libplanet/pull/275
 [#276]: https://github.com/planetarium/libplanet/pull/276
 [#277]: https://github.com/planetarium/libplanet/pull/277
-[#281]: https://github.com/planetarium/libplanet/pull/280
+[#280]: https://github.com/planetarium/libplanet/pull/280
 [#281]: https://github.com/planetarium/libplanet/pull/281
 [#285]: https://github.com/planetarium/libplanet/pull/285
 [#287]: https://github.com/planetarium/libplanet/pull/287

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -480,8 +480,15 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void ForkTxNonce()
         {
+            // An active account, so that its some recent transactions became "stale" due to a fork.
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.PublicKey.ToAddress();
+
+            // An inactive account, so that it has no recent transactions but only an old
+            // transaction, so that its all transactions are stale-proof (stale-resistant).
+            var lessActivePrivateKey = new PrivateKey();
+            Address lessActiveAddress = lessActivePrivateKey.PublicKey.ToAddress();
+
             var actions = new[] { new DumbAction(address, "foo") };
 
             Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>();
@@ -490,6 +497,7 @@ namespace Libplanet.Tests.Blockchain
             Transaction<DumbAction>[] txsA =
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey),
+                _fx.MakeTransaction(privateKey: lessActivePrivateKey),
             };
 
             Assert.Equal(0, _blockChain.GetNextTxNonce(address));
@@ -521,6 +529,7 @@ namespace Libplanet.Tests.Blockchain
 
             BlockChain<DumbAction> forked = _blockChain.Fork(b1.Hash);
             Assert.Equal(1, forked.GetNextTxNonce(address));
+            Assert.Equal(1, forked.GetNextTxNonce(lessActiveAddress));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -438,14 +438,37 @@ namespace Libplanet.Tests.Store
             Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer);
             Assert.Equal(1, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
             Assert.Equal(0, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
+            Assert.Equal(
+                new Dictionary<Address, long>
+                {
+                    [Fx.Transaction1.Signer] = 1,
+                },
+                Fx.Store.ListTxNonces(Fx.StoreNamespace).ToDictionary(p => p.Key, p => p.Value)
+            );
 
             Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer, 5);
             Assert.Equal(1, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
             Assert.Equal(5, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
+            Assert.Equal(
+                new Dictionary<Address, long>
+                {
+                    [Fx.Transaction1.Signer] = 1,
+                    [Fx.Transaction2.Signer] = 5,
+                },
+                Fx.Store.ListTxNonces(Fx.StoreNamespace).ToDictionary(p => p.Key, p => p.Value)
+            );
 
             Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer, 2);
             Assert.Equal(3, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
             Assert.Equal(5, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction2.Signer));
+            Assert.Equal(
+                new Dictionary<Address, long>
+                {
+                    [Fx.Transaction1.Signer] = 3,
+                    [Fx.Transaction2.Signer] = 5,
+                },
+                Fx.Store.ListTxNonces(Fx.StoreNamespace).ToDictionary(p => p.Key, p => p.Value)
+            );
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -185,6 +185,12 @@ namespace Libplanet.Tests.Store
                 sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
         }
 
+        public IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace)
+        {
+            _logs.Add((nameof(ListTxNonces), @namespace, null));
+            return _store.ListTxNonces(@namespace);
+        }
+
         public long GetTxNonce(string @namespace, Address address)
         {
             _logs.Add((nameof(GetTxNonce), @namespace, address));

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -95,6 +95,9 @@ namespace Libplanet.Store
             where T : IAction, new();
 
         /// <inheritdoc/>
+        public abstract IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace);
+
+        /// <inheritdoc/>
         public abstract long GetTxNonce(string @namespace, Address address);
 
         /// <inheritdoc/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -181,7 +181,7 @@ namespace Libplanet.Store
         /// <param name="namespace">The namespace to list <see cref="Address"/>es and their
         /// <see cref="Transaction{T}"/> nonces.</param>
         /// <returns>Pairs of an <see cref="Address"/> and its tx nonce.  All nonces are greater
-        /// than 0.  (If there are underlying entries having zero nonce these must be hidden.)
+        /// than 0.  (If there are underlying entries having zero nonces these must be hidden.)
         /// </returns>
         /// <seealso cref="GetTxNonce(string, Address)"/>
         IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -175,6 +175,18 @@ namespace Libplanet.Store
             where T : IAction, new();
 
         /// <summary>
+        /// Lists all <see cref="Address"/>es that have ever signed <see cref="Transaction{T}"/>,
+        /// and their corresponding <see cref="Transaction{T}"/> nonces.
+        /// </summary>
+        /// <param name="namespace">The namespace to list <see cref="Address"/>es and their
+        /// <see cref="Transaction{T}"/> nonces.</param>
+        /// <returns>Pairs of an <see cref="Address"/> and its tx nonce.  All nonces are greater
+        /// than 0.  (If there are underlying entries having zero nonce these must be hidden.)
+        /// </returns>
+        /// <seealso cref="GetTxNonce(string, Address)"/>
+        IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace);
+
+        /// <summary>
         /// Gets <see cref="Transaction{T}"/> nonce of the
         /// <paramref name="address"/>.
         /// </summary>

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -505,6 +505,27 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace)
+        {
+            var collectionId = $"{NonceIdPrefix}{@namespace}";
+            LiteCollection<BsonDocument> collection = _db.GetCollection<BsonDocument>(collectionId);
+            foreach (BsonDocument doc in collection.FindAll())
+            {
+                if (doc.TryGetValue("_id", out BsonValue id) && id.IsBinary)
+                {
+                    var address = new Address(id.AsBinary);
+                    if (doc.TryGetValue("v", out BsonValue v) && v.IsInt64)
+                    {
+                        if (v.AsInt64 > 0)
+                        {
+                            yield return new KeyValuePair<Address, long>(address, v.AsInt64);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc/>
         public long GetTxNonce(string @namespace, Address address)
         {
             var collectionId = $"{NonceIdPrefix}{@namespace}";


### PR DESCRIPTION
This fixes the bug #309 that tx nonces being missed during fork, because addresses that aren't *stale* are missing.  To correctly fix this, I've needed `IStore.ListTxNonces()` as well (note that `IStore.ListAddresses()` could miss addresses that have never had any states but ever signed some transactions).