### PR TITLE
Move namespace Libplanet.Tests.Stun to Libplanet.Stun.Tests

### DIFF
--- a/Libplanet.Stun.Tests/Stun/Attributes/ErrorCodeTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/ErrorCodeTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class ErrorCodeTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/LifetimeTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/LifetimeTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class LifetimeTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/MessageIntegrityTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/MessageIntegrityTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class MessageIntegrityTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/NonceTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/NonceTest.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class NonceTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/RealmTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/RealmTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class RealmTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/RequestedTransportTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/RequestedTransportTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class RequestedTransportTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/StunAddressExtensionTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/StunAddressExtensionTest.cs
@@ -3,7 +3,7 @@ using System.Net;
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class StunAddressExtensionTest
     {

--- a/Libplanet.Stun.Tests/Stun/Attributes/UserNameTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/UserNameTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Attributes;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Attributes
+namespace Libplanet.Stun.Tests.Attributes
 {
     public class UserNameTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/AllocateErrorResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/AllocateErrorResponseTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class AllocateErrorResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/AllocateRequestTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/AllocateRequestTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class AllocateRequestTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/AllocateSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/AllocateSuccessResponseTest.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class AllocateSuccessResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSucessTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSucessTest.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class BindingRequestSucessTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/BindingRequestTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/BindingRequestTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class BindingRequestTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/ConnectionAttemptTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/ConnectionAttemptTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class ConnectionAttemptTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindRequestTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindRequestTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class ConnectionBindRequestTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindSuccessResponseTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class ConnectionBindSuccessResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionRequestTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionRequestTest.cs
@@ -2,7 +2,7 @@ using System.Net;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class CreatePermissionRequestTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionSuccessResponseTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class CreatePermissionSuccessResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class RefreshErrorResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshRequestTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshRequestTest.cs
@@ -1,7 +1,7 @@
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class RefreshRequestTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshSuccessResponseTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class RefreshSuccessResponseTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/StunMessageTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/StunMessageTest.cs
@@ -4,7 +4,7 @@ using Libplanet.Stun.Attributes;
 using Libplanet.Stun.Messages;
 using Xunit;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     public class StunMessageTest
     {

--- a/Libplanet.Stun.Tests/Stun/Messages/TestStunContext.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/TestStunContext.cs
@@ -1,6 +1,6 @@
 using Libplanet.Stun;
 
-namespace Libplanet.Tests.Stun.Messages
+namespace Libplanet.Stun.Tests.Messages
 {
     internal class TestStunContext : IStunContext
     {


### PR DESCRIPTION
Libplanet.Tests.Stun namespace is outdated. move to Libplanet.Stun.Tests.