### PR TITLE
Delete an index, tx nonces and state references during chain swapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,8 +82,8 @@ To be released.
     an empty `TxIds` from peers, and it had made the network waste bandwidth for
     unnecessary messages.  `Swam` became to no more send such empty `GetTxs`.
     [[#297]]
- -  `BlockChain<T>.Swap()` became to delete an index, tx nonces and state
-    references in the previous chain. [[#329]]
+ -  `BlockChain<T>.Swap()` became to delete an index, tx nonces, and state
+    references in the replaced chain. [[#329]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,8 @@ To be released.
     an empty `TxIds` from peers, and it had made the network waste bandwidth for
     unnecessary messages.  `Swam` became to no more send such empty `GetTxs`.
     [[#297]]
+ -  `BlockChain<T>.Swap()` became to delete an index, tx nonces and state
+    references in the previous chain. [[#329]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@ To be released.
     became to neither longer take `BlockChain<T>` nor a generic method.
     Because the `Swarm` constructor takes it instead.  [[#324]]
  -  `Swarm` does not implement `ICollection<Peer>` anymore.  [[#326]]
+ -  Added `IStore.DeleteNamespace()` method. [[#329]]
 
 ### Added interfaces
 
@@ -129,6 +130,7 @@ To be released.
 [#317]: https://github.com/planetarium/libplanet/pull/317
 [#324]: https://github.com/planetarium/libplanet/pull/324
 [#326]: https://github.com/planetarium/libplanet/pull/326
+[#329]: https://github.com/planetarium/libplanet/pull/329
 
 Version 0.3.0
 -------------

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -629,7 +629,12 @@ namespace Libplanet.Tests.Blockchain
                 );
                 fork.Append(forkTip, DateTimeOffset.UtcNow, render: false);
 
+                string previousNamespace = _blockChain.Id.ToString();
                 _blockChain.Swap(fork);
+
+                Assert.Empty(_blockChain.Store.IterateIndex(previousNamespace));
+                Assert.Empty(_blockChain.Store.ListAddresses(previousNamespace));
+
                 var renders = DumbAction.RenderRecords.Value;
 
                 int actionsCountA = txsA.Sum(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -634,6 +634,7 @@ namespace Libplanet.Tests.Blockchain
 
                 Assert.Empty(_blockChain.Store.IterateIndex(previousNamespace));
                 Assert.Empty(_blockChain.Store.ListAddresses(previousNamespace));
+                Assert.Empty(_blockChain.Store.ListTxNonces(previousNamespace));
 
                 var renders = DumbAction.RenderRecords.Value;
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;

--- a/Libplanet.Tests/Store/LiteDBStoreTest.cs
+++ b/Libplanet.Tests/Store/LiteDBStoreTest.cs
@@ -1,13 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Security.Cryptography;
-using Libplanet.Action;
-using Libplanet.Blocks;
-using Libplanet.Tests.Common.Action;
-using Libplanet.Tx;
-using Org.BouncyCastle.Crypto;
-using Xunit;
 
 namespace Libplanet.Tests.Store
 {

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -37,6 +37,34 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
+        public void DeleteNamespace()
+        {
+            Block<DumbAction> block1 = TestUtils.MineNext(
+                TestUtils.MineGenesis<DumbAction>(),
+                new[] { Fx.Transaction1 });
+            Fx.Store.AppendIndex(Fx.StoreNamespace, block1.Hash);
+            Fx.Store.AppendIndex("asdf", block1.Hash);
+            Address[] addresses = Enumerable.Repeat<object>(null, 8)
+                .Select(_ => new PrivateKey().PublicKey.ToAddress())
+                .ToArray();
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                addresses.Take(3).ToImmutableHashSet(),
+                block1
+            );
+            Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer);
+
+            Fx.Store.DeleteNamespace(Fx.StoreNamespace);
+
+            Assert.Equal(
+                new[] { "asdf" }.ToImmutableHashSet(),
+                Fx.Store.ListNamespaces().ToImmutableHashSet()
+            );
+            Assert.Empty(Fx.Store.ListAddresses(Fx.StoreNamespace).ToArray());
+            Assert.Equal(0, Fx.Store.GetTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer));
+        }
+
+        [Fact]
         public void ListAddresses()
         {
             Assert.Empty(Fx.Store.ListAddresses(Fx.StoreNamespace).ToArray());

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -68,6 +68,12 @@ namespace Libplanet.Tests.Store
             return _store.ListAddresses(@namespace);
         }
 
+        public void DeleteNamespace(string @namespace)
+        {
+            _logs.Add((nameof(DeleteNamespace), @namespace, null));
+            _store.DeleteNamespace(@namespace);
+        }
+
         public bool DeleteTransaction(TxId txid)
         {
             _logs.Add((nameof(DeleteTransaction), txid, null));

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -807,6 +807,7 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterWriteLock();
 
+                Store.DeleteNamespace(Id.ToString());
                 Id = other.Id;
                 Blocks = new BlockSet<T>(Store);
                 Transactions = new TransactionSet<T>(Store);

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -117,5 +117,8 @@ namespace Libplanet.Store
             string @namespace,
             HashDigest<SHA256> hash
         );
+
+        /// <inheritdoc/>
+        public abstract void DeleteNamespace(string @namespace);
     }
 }

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -178,6 +178,29 @@ namespace Libplanet.Store
             }
         }
 
+        /// <inheritdoc/>
+        public override void DeleteNamespace(string @namespace)
+        {
+            var indexFile = new FileInfo(GetIndexPath(@namespace));
+            var txNonceDir = new DirectoryInfo(GetTxNoncePath(@namespace));
+            var stateRefsDir = new DirectoryInfo(GetStateReferencePath(@namespace));
+
+            if (indexFile.Exists)
+            {
+                indexFile.Delete();
+            }
+
+            if (txNonceDir.Exists)
+            {
+                txNonceDir.Delete(true);
+            }
+
+            if (stateRefsDir.Exists)
+            {
+                stateRefsDir.Delete(true);
+            }
+        }
+
         public override long AppendIndex(
             string @namespace,
             HashDigest<SHA256> hash

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -28,9 +28,9 @@ namespace Libplanet.Store
         bool DeleteIndex(string @namespace, HashDigest<SHA256> hash);
 
         /// <summary>
-        /// Deletes an index, tx nonce and state references in the given
+        /// Deletes an index, tx nonces, and state references in the given
         /// <paramref name="namespace"/>.
-        /// it also deletes namespace itself.
+        /// It also deletes namespace itself.
         /// </summary>
         /// <param name="namespace">The namespace to delete.</param>
         /// <remarks>This does not delete blocks or transactions that belong to

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -28,6 +28,13 @@ namespace Libplanet.Store
         bool DeleteIndex(string @namespace, HashDigest<SHA256> hash);
 
         /// <summary>
+        /// Delete index, tx nonce and state references on given namespace.
+        /// it also deletes namespace itself.
+        /// </summary>
+        /// <param name="namespace">The namespace to delete.</param>
+        void DeleteNamespace(string @namespace);
+
+        /// <summary>
         /// Lists all addresses that have ever had states.
         /// </summary>
         /// <param name="namespace">The namespace to list addresses.</param>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -28,10 +28,14 @@ namespace Libplanet.Store
         bool DeleteIndex(string @namespace, HashDigest<SHA256> hash);
 
         /// <summary>
-        /// Delete index, tx nonce and state references on given namespace.
+        /// Deletes an index, tx nonce and state references in the given
+        /// <paramref name="namespace"/>.
         /// it also deletes namespace itself.
         /// </summary>
         /// <param name="namespace">The namespace to delete.</param>
+        /// <remarks>This does not delete blocks or transactions that belong to
+        /// the index of the <paramref name="namespace"/>, but only the index,
+        /// tx nonces, and state references.</remarks>
         void DeleteNamespace(string @namespace);
 
         /// <summary>

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -85,6 +85,18 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public void DeleteNamespace(string @namespace)
+        {
+            _db.DropCollection(IndexCollection(@namespace).Name);
+            _db.DropCollection($"{NonceIdPrefix}{@namespace}");
+
+            foreach (LiteFileInfo file in _db.FileStorage.Find($"{StateRefIdPrefix}{@namespace}"))
+            {
+                _db.FileStorage.Delete(file.Id);
+            }
+        }
+
+        /// <inheritdoc/>
         public long CountIndex(string @namespace)
         {
             return IndexCollection(@namespace).Count();


### PR DESCRIPTION
This PR enables `BlockChain<T>` to clean up data(index, tx nonces, staterefs) in the previous chain during `.Swap()`. (resolves #322) To accomplish, it also adds `IStore.DeleteNamespace()` and `LiteDBStore` / `FileStore` implementation.