### PR TITLE
Move namespace Libplanet.Tests.Stun to Libplanet.Stun.Tests

### DIFF
--- a/Libplanet.Stun.Tests/Stun/Crc32Test.cs
+++ b/Libplanet.Stun.Tests/Stun/Crc32Test.cs
@@ -3,7 +3,7 @@ using System.Text;
 using Libplanet.Stun;
 using Xunit;
 
-namespace Libplanet.Tests.Stun
+namespace Libplanet.Stun.Tests
 {
     public class Crc32Test
     {


### PR DESCRIPTION
In #315, `Libplanet.Tests.Stun` namespace was moved to `Libplanet.Stun.Tests.`, but not testcode of `Libplanet.Stun.Crc32`.
