### PR TITLE
Remove `id` from BlockChain<T> constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ To be released.
     Because the `Swarm<T>` constructor takes it instead.  [[#324]]
  -  `Swarm<T>` does not implement `ICollection<Peer>` anymore.  [[#326]]
  -  Added `IStore.DeleteNamespace()` method. [[#329]]
+ -  Removed the `id` parameter from the `BlockChain<T>` constructor, and it
+    became to automatically detect an appropriate `BlockChain<T>.Id`.
+    [[#279], [#332]]
 
 ### Added interfaces
 
@@ -121,6 +124,7 @@ To be released.
 [#275]: https://github.com/planetarium/libplanet/pull/275
 [#276]: https://github.com/planetarium/libplanet/pull/276
 [#277]: https://github.com/planetarium/libplanet/pull/277
+[#279]: https://github.com/planetarium/libplanet/issues/279
 [#280]: https://github.com/planetarium/libplanet/pull/280
 [#281]: https://github.com/planetarium/libplanet/pull/281
 [#282]: https://github.com/planetarium/libplanet/issues/282
@@ -141,6 +145,7 @@ To be released.
 [#326]: https://github.com/planetarium/libplanet/pull/326
 [#327]: https://github.com/planetarium/libplanet/pull/327
 [#329]: https://github.com/planetarium/libplanet/pull/329
+[#332]: https://github.com/planetarium/libplanet/pull/332
 
 Version 0.3.0
 -------------

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -987,6 +987,34 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(actions, transaction.Actions);
         }
 
+        [Fact]
+        public void GetCanonicalChain()
+        {
+            Assert.Null(BlockChain<DumbAction>.GetCanonicalChain(_fx.Store));
+
+            Block<DumbAction> block1 = TestUtils.MineGenesis<DumbAction>();
+            Block<DumbAction> block2 = TestUtils.MineNext(block1);
+            Block<DumbAction> block3 = TestUtils.MineNext(block2);
+            Guid id1 = Guid.NewGuid();
+            Guid id2 = Guid.NewGuid();
+
+            foreach (Block<DumbAction> b in new[] { block1 })
+            {
+                _fx.Store.AppendIndex(id1.ToString(), b.Hash);
+                _fx.Store.PutBlock(b);
+            }
+
+            Assert.Equal(id1, BlockChain<DumbAction>.GetCanonicalChain(_fx.Store));
+
+            foreach (Block<DumbAction> b in new[] { block2, block3 })
+            {
+                _fx.Store.AppendIndex(id2.ToString(), b.Hash);
+                _fx.Store.PutBlock(b);
+            }
+
+            Assert.Equal(id2, BlockChain<DumbAction>.GetCanonicalChain(_fx.Store));
+        }
+
         /// <summary>
         /// Builds a fixture that has incomplete states for blocks other
         /// than the tip, to test <c>GetStates()</c> method's

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1014,9 +1014,9 @@ namespace Libplanet.Net
             // same genesis block...
             else if (!_blockChain.Blocks.ContainsKey(branchPoint))
             {
-                synced = new BlockChain<T>(
-                    _blockChain.Policy,
-                    _blockChain.Store);
+                // Create a whole new chain because the branch point doesn't exist on
+                // the current chain.
+                synced = new BlockChain<T>(_blockChain.Policy, _blockChain.Store, Guid.NewGuid());
             }
             else
             {


### PR DESCRIPTION
This PR resolves #279 by removing the `id` parameter from `BlockChain<T>` constructor. it also made `BlockChain<T>.Id` to be automatically determined by chain height.