### PR TITLE
Make dist:nuget to fail if dist:github-release fails

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -88,7 +88,7 @@ action "dist:release-note" {
 
 action "dist:nuget" {
   uses = "docker://mcr.microsoft.com/dotnet/core/sdk:2.2"
-  needs = ["dist:pack", "dist:release-note"]
+  needs = ["dist:pack", "dist:release-note", "dist:github-release"]
   runs = [".github/bin/dist-nuget.sh"]
   secrets = [
     "NUGET_API_KEY"


### PR DESCRIPTION
As NuGet does not allow to remove an once uploaded package, making `dist:nuget` to depend on `dist:github-release` seems more robust.