### PR TITLE
Do not avoid publishing packages/docs for tag pushes

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -23,6 +23,7 @@ fi
 # and the branch is for releases (master or maintenance-*).
 # shellcheck disable=SC2235
 if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ] || (
+    [ "$GITHUB_REF" = "${GITHUB_REF#refs/tags/}" ] &&
     [ "$GITHUB_REF" != refs/heads/master ] &&
     [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ] ); then
   alias dotnet="echo DRY-RUN: dotnet"

--- a/Docs/publish.sh
+++ b/Docs/publish.sh
@@ -42,6 +42,7 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
   slug="pulls/$pr_number"
 else
   if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && \
+     [ "$GITHUB_REF" = "${GITHUB_REF#refs/tags/}" ] &&
      [ "$GITHUB_REF" != refs/heads/master ] && \
      [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ]; then
     echo "This branch is not for releases, so docs won't be published." \


### PR DESCRIPTION
This fixes a bug made by the patch #305.