### PR TITLE
Option to reuse states calculated by trusted peers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,7 +66,7 @@ Released on July 8, 2019.
  -  `BlockChain<T>.StageTransactions` became to receive
     `IDictionary<Transaction<T>, bool>` instead of `ISet<Transaction<T>>`.
     [[#274], [#297]]
--  `IStore.StageTransactionIds()` method became to receive
+ -  `IStore.StageTransactionIds()` method became to receive
     `IDictionary<TxId, bool>` instead of `ISet<TxId>`.  [[#274], [#297]]
  -  `IStore.IterateStagedTransactionIds()` method became to receive
     `bool toBroadcast` which is whether to iterate only the TxId set to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,7 +113,7 @@ Released on July 8, 2019.
  -  Added `BlockChain<T>.GetNextTxNonce()` method which counts staged
     transactions too during nonce computation.  [[#270], [#294]]
  -  Added `StoreExtension` static class.  [[#272], [#307]]
- -  Added `Swarm<T>.BlockChain` property.
+ -  Added `Swarm<T>.BlockChain` property.  [[#272], [#343]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,20 @@ To be released.
 
 ### Added interfaces
 
+ -  Added `trustedStateValidators` option to `Swarm<T>.PreloadAsync()` method.
+    If any peer in this set is reachable and there is no built up blockchain
+    in a current node, `Swarm<T>` receives the latest states of the major
+    blockchain from that trusted peer, which is also calculated by that peer,
+    instead of autonomously calculating the states from scratch.
+    Note that this option is intended to be exposed to end users through
+    a feasible user interface so that they can decide whom to trust
+    for themselves.
+    [[#272], [#343]]
+
 ### Behavioral changes
 
+ -  `BlockChain<T>.PreloadAsync()` method became to omit rendering of
+    `IAction`s in the preloaded behind blocks.  [[#272], [#343]]
  -  `Swarm<T>` became to have two more message types: `GetRecentStates` (`0x0b`)
     and `RecentStates` (`0x0c`).  [[#272], [#343]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,7 @@ Released on July 8, 2019.
  -  Added `BlockChain<T>.GetNextTxNonce()` method which counts staged
     transactions too during nonce computation.  [[#270], [#294]]
  -  Added `StoreExtension` static class.  [[#272], [#307]]
+ -  Added `Swarm<T>.BlockChain` property.
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,9 +16,13 @@ To be released.
 
 ### Behavioral changes
 
+ -  `Swarm<T>` became to have two more message types: `GetRecentStates` (`0x0b`)
+    and `RecentStates` (`0x0c`).  [[#272], [#343]]
+
 ### Bug fixes
 
 
+[#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350
 
 

--- a/Docs/publish.sh
+++ b/Docs/publish.sh
@@ -73,6 +73,7 @@ for _ in 1 2 3; do
   git -C /tmp/gh-pages add "/tmp/gh-pages/$slug"
 
   latest_version="$(git tag --sort -v:refname | head -n1)"
+  commit_hash="$(git log -n1 --pretty=%H)"
   tag="$(echo -n "$GITHUB_REF" | sed -e 's/^refs\/tags\///g')"
   if [ "$(git tag -l)" = "" ] || [ "$latest_version" = "$tag" ]; then
     index="$(cat "/tmp/gh-pages/$slug/index.html")"
@@ -87,7 +88,7 @@ for _ in 1 2 3; do
 
   git -C /tmp/gh-pages commit \
     --allow-empty \
-    -m "Publish docs from $GITHUB_SHA"
+    -m "Publish docs from $commit_hash"
 
   if git -C /tmp/gh-pages push origin gh-pages; then
     break

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
-    <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet
+  Name="Rules for Libplanet.Tests"
+  Description="Code analysis rules for Libplanet.Tests.csproj."
+  ToolsVersion="10.0">
+
+  <Rules
+    AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis"
+    RuleNamespace="Microsoft.Rules.Managed">
+
+    <!-- Single line comment should begin with a space. -->
+    <Rule Id="SA1005" Action="None" />
+    <!-- Closing parenthesis should be on line of opening parenthesis -->
+    <Rule Id="SA1112" Action="None" />
+    <!-- Single-line comment should be preceded by blank line. -->
+    <Rule Id="SA1515" Action="None" />
+    <!-- TODO: Write copyright -->
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+    <!-- Allow field name to begin with an underscore. -->
+    <Rule Id="SA1309" Action="None" />
+    <!-- Allow an expression not to declare parenthese. -->
+    <Rule Id="SA1407" Action="None" />
+    <!-- Allow a rich text in a XML doc comment's <summary>. -->
+    <Rule Id="SA1462" Action="None" />
+    <Rule Id="SA1642" Action="None" />
+    <!-- Every property's docs doesn't have to start with "Gets", because
+    it's ridiculous. -->
+    <Rule Id="SA1623" Action="None" />
+    <!--Allow to call an instance member of the local class or a base class is
+    not prefixed with 'this.'. -->
+    <Rule Id="SA1101" Action="None" />
+    <!--Allow closing parenthesis to be placed in new line. -->
+    <Rule Id="SA1009" Action="None" />
+    <Rule Id="SA1111" Action="None" />
+    <!-- TODO: Documentation -->
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA0001" Action="None" />
+  </Rules>
+
+  <Rules AnalyzerId="Menees.Analyzers" RuleNamespace="Menees.Analyzers">
+    <Rule Id="MEN002" Action="Warning" />
+    <Rule Id="MEN007" Action="None" />
+    <Rule Id="MEN009" Action="Warning" />
+    <Rule Id="MEN010" Action="None" />
+    <Rule Id="MEN011" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -989,7 +989,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void ValidateNonce()
+        public void ValidateTxNonces()
         {
             var privateKey = new PrivateKey();
             var actions = new[] { new DumbAction() };
@@ -1003,7 +1003,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
             };
             Block<DumbAction> b1 = TestUtils.MineNext(genesis, txsA);
-            _blockChain.ValidateNonce(b1);
+            _blockChain.ValidateTxNonces(b1);
 
             Transaction<DumbAction>[] txsB =
             {
@@ -1011,7 +1011,7 @@ namespace Libplanet.Tests.Blockchain
             };
             Block<DumbAction> b2 = TestUtils.MineNext(genesis, txsB);
             Assert.Throws<InvalidTxNonceException>(() =>
-                _blockChain.ValidateNonce(b2));
+                _blockChain.ValidateTxNonces(b2));
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1002,16 +1002,31 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
             };
-            Block<DumbAction> b1 = TestUtils.MineNext(genesis, txsA);
-            _blockChain.ValidateTxNonces(b1);
+            Block<DumbAction> b1 = TestUtils.MineNext(genesis, txsA, difficulty: 1024);
+            _blockChain.Append(b1);
 
             Transaction<DumbAction>[] txsB =
             {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 2),
+            };
+            Block<DumbAction> b2 = TestUtils.MineNext(b1, txsB, difficulty: 1024);
+            _blockChain.Append(b2);
+
+            // Invalid if nonce is too low
+            Transaction<DumbAction>[] txsC =
+            {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
             };
-            Block<DumbAction> b2 = TestUtils.MineNext(genesis, txsB);
-            Assert.Throws<InvalidTxNonceException>(() =>
-                _blockChain.ValidateTxNonces(b2));
+            Block<DumbAction> b3a = TestUtils.MineNext(b2, txsC, difficulty: 1024);
+            Assert.Throws<InvalidTxNonceException>(() => _blockChain.Append(b3a));
+
+            // Invalid if nonce is too high
+            Transaction<DumbAction>[] txsD =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 4),
+            };
+            Block<DumbAction> b3b = TestUtils.MineNext(b2, txsD, difficulty: 1024);
+            Assert.Throws<InvalidTxNonceException>(() => _blockChain.Append(b3b));
         }
 
         [Fact]

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -67,9 +67,5 @@
       <Link>xunit.runner.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 </Project>

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -45,11 +45,6 @@ namespace Libplanet.Tests.Net.Messages
                     null
                 )
             );
-            Address a = new PrivateKey().PublicKey.ToAddress();
-            var blockStates = emptyBlockStates.Add(
-                default,
-                ImmutableDictionary<Address, object>.Empty
-            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
-using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using NetMQ;

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -50,6 +50,8 @@ namespace Libplanet.Tests.Net.Messages
         [Fact]
         public void DataFrames()
         {
+            // This test lengthens long... Please read the brief description of the entire payload
+            // structure from the comment in the RecentStates.DataFrames property code.
             ISet<Address> accounts = Enumerable.Repeat(0, 5).Select(_ =>
                 new PrivateKey().PublicKey.ToAddress()
             ).ToHashSet();

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using Libplanet.Action;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using NetMQ;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Messages
+{
+    public class RecentStatesTest
+    {
+        [Fact]
+        public void Constructor()
+        {
+            var emptyBlockStates = ImmutableDictionary<
+                HashDigest<SHA256>,
+                IImmutableDictionary<Address, object>
+            >.Empty;
+            Assert.Throws<ArgumentNullException>(() =>
+                new RecentStates(
+                    default,
+                    null,
+                    ImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>.Empty,
+                    ImmutableDictionary<Address, long>.Empty
+                )
+            );
+            Assert.Throws<ArgumentNullException>(() =>
+                new RecentStates(
+                    default,
+                    emptyBlockStates,
+                    null,
+                    ImmutableDictionary<Address, long>.Empty
+                )
+            );
+            Assert.Throws<ArgumentNullException>(() =>
+                new RecentStates(
+                    default,
+                    emptyBlockStates,
+                    ImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>.Empty,
+                    null
+                )
+            );
+            Address a = new PrivateKey().PublicKey.ToAddress();
+            var blockStates = emptyBlockStates.Add(
+                default,
+                ImmutableDictionary<Address, object>.Empty
+            );
+        }
+
+        [Fact]
+        public void DataFrames()
+        {
+            ISet<Address> accounts = Enumerable.Repeat(0, 5).Select(_ =>
+                new PrivateKey().PublicKey.ToAddress()
+            ).ToHashSet();
+            int accountsCount = accounts.Count;
+            ISet<Address> signers = Enumerable.Repeat(0, 10).Select(_ =>
+                new PrivateKey().PublicKey.ToAddress()
+            ).ToHashSet();
+            int signersCount = signers.Count;
+            var privKey = new PrivateKey();
+
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            var randomBytesBuffer = new byte[HashDigest<SHA256>.Size];
+            (HashDigest<SHA256>, IImmutableDictionary<Address, object>)[] blockStates =
+                accounts.SelectMany(address =>
+                {
+                    rng.GetNonZeroBytes(randomBytesBuffer);
+                    var blockHash1 = new HashDigest<SHA256>(randomBytesBuffer);
+                    rng.GetNonZeroBytes(randomBytesBuffer);
+                    var blockHash2 = new HashDigest<SHA256>(randomBytesBuffer);
+                    IImmutableDictionary<Address, object> emptyState =
+                        ImmutableDictionary<Address, object>.Empty;
+                    return new[]
+                    {
+                        (blockHash1, emptyState.Add(address, $"A:{blockHash1}:{address}")),
+                        (blockHash2, emptyState.Add(address, $"B:{blockHash2}:{address}")),
+                    };
+                }).ToArray();
+            IImmutableDictionary<HashDigest<SHA256>, IImmutableDictionary<Address, object>>
+                compressedBlockStates = blockStates.Where(
+                    (_, i) => i % 2 == 1
+                ).ToImmutableDictionary(p => p.Item1, p => p.Item2);
+            HashDigest<SHA256> blockHash = blockStates.Last().Item1;
+
+            IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> stateRefs =
+                accounts.Select(a =>
+                {
+                    var states = blockStates
+                        .Where(pair => pair.Item2.ContainsKey(a))
+                        .Select(pair => pair.Item1)
+                        .ToImmutableList();
+                    return new KeyValuePair<Address, IImmutableList<HashDigest<SHA256>>>(a, states);
+                }).ToImmutableDictionary();
+            IImmutableDictionary<Address, long> txNonces = signers.Select(a =>
+                new KeyValuePair<Address, long>(a, 1)
+            ).ToImmutableDictionary();
+
+            RecentStates reply = new RecentStates(
+                blockHash,
+                compressedBlockStates,
+                stateRefs,
+                txNonces
+            );
+            NetMQMessage msg = reply.ToNetMQMessage(privKey);
+            const int headerSize = 3;  // type, pubkey, sig
+            int stateRefsOffset = headerSize + 1;
+            int txNoncesOffset = stateRefsOffset + 1 + (accountsCount * 4);
+            int blockStatesOffset = txNoncesOffset + 1 + (signersCount * 2);
+            Assert.Equal(
+               blockStatesOffset + 1 + (compressedBlockStates.Count * 4),
+               msg.FrameCount
+            );
+            Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
+            Assert.Equal(accountsCount, BitConverter.ToInt32(msg[headerSize + 1].Buffer));
+            for (int i = 0; i < accountsCount; i++)
+            {
+                int offset = stateRefsOffset + 1 + (i * 4);
+                Assert.Equal(Address.Size, msg[offset].BufferSize);
+                Address address = new Address(msg[offset].Buffer);
+                Assert.Contains(address, accounts);
+
+                Assert.Equal(4, msg[offset + 1].BufferSize);
+                Assert.Equal(2, BitConverter.ToInt32(msg[offset + 1].Buffer));
+
+                Assert.Equal(HashDigest<SHA256>.Size, msg[offset + 2].BufferSize);
+                Assert.Equal(stateRefs[address][0], new HashDigest<SHA256>(msg[offset + 2].Buffer));
+                Assert.Equal(HashDigest<SHA256>.Size, msg[offset + 3].BufferSize);
+                Assert.Equal(stateRefs[address][1], new HashDigest<SHA256>(msg[offset + 3].Buffer));
+
+                accounts.Remove(address);
+            }
+
+            Assert.Empty(accounts);
+            Assert.Equal(signersCount, BitConverter.ToInt32(msg[txNoncesOffset].Buffer));
+
+            for (int i = 0; i < signersCount; i++)
+            {
+                int offset = txNoncesOffset + 1 + (i * 2);
+                Assert.Equal(Address.Size, msg[offset].BufferSize);
+                Address address = new Address(msg[offset].Buffer);
+                Assert.Contains(address, signers);
+
+                Assert.Equal(8, msg[offset + 1].BufferSize);
+                Assert.Equal(txNonces[address], BitConverter.ToInt64(msg[offset + 1].Buffer));
+
+                signers.Remove(address);
+            }
+
+            Assert.Empty(signers);
+            Assert.Equal(
+                compressedBlockStates.Count,
+                BitConverter.ToInt32(msg[blockStatesOffset].Buffer)
+            );
+
+            var formatter = new BinaryFormatter();
+            for (int i = 0; i < compressedBlockStates.Count; i++)
+            {
+                int offset = blockStatesOffset + 1 + (i * 4);
+
+                var hash = new HashDigest<SHA256>(msg[offset].Buffer);
+                Assert.Contains(hash, compressedBlockStates);
+                Assert.Equal(1, BitConverter.ToInt32(msg[offset + 1].Buffer));
+
+                var addr = new Address(msg[offset + 2].Buffer);
+                Assert.Equal(compressedBlockStates[hash].Keys.First(), addr);
+
+                using (var stream = new MemoryStream())
+                {
+                    stream.Write(msg[offset + 3].Buffer, 0, msg[offset + 3].BufferSize);
+                    stream.Seek(0, SeekOrigin.Begin);
+                    string state = (string)formatter.Deserialize(stream);
+                    Assert.Equal($"B:{hash}:{addr}", state);
+                }
+            }
+
+            msg = reply.ToNetMQMessage(privKey);
+            var parsed = new RecentStates(msg.Skip(headerSize).ToArray());
+            Assert.Equal(blockHash, parsed.BlockHash);
+            Assert.False(parsed.Missing);
+            Assert.Equal(compressedBlockStates, parsed.BlockStates);
+            Assert.Equal(stateRefs, parsed.StateReferences);
+            Assert.Equal(txNonces, parsed.TxNonces);
+
+            RecentStates missing = new RecentStates(blockHash, null, null, null);
+            msg = missing.ToNetMQMessage(privKey);
+            Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
+            Assert.Equal(-1, BitConverter.ToInt32(msg[headerSize + 1].Buffer));
+
+            parsed = new RecentStates(missing.ToNetMQMessage(privKey).Skip(headerSize).ToArray());
+            Assert.Equal(blockHash, parsed.BlockHash);
+            Assert.True(parsed.Missing);
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -118,7 +118,7 @@ namespace Libplanet.Tests.Net.Messages
                msg.FrameCount
             );
             Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
-            Assert.Equal(accountsCount, BitConverter.ToInt32(msg[headerSize + 1].Buffer));
+            Assert.Equal(accountsCount, BitConverter.ToInt32(msg[headerSize + 1].Buffer, 0));
             for (int i = 0; i < accountsCount; i++)
             {
                 int offset = stateRefsOffset + 1 + (i * 4);
@@ -127,7 +127,7 @@ namespace Libplanet.Tests.Net.Messages
                 Assert.Contains(address, accounts);
 
                 Assert.Equal(4, msg[offset + 1].BufferSize);
-                Assert.Equal(2, BitConverter.ToInt32(msg[offset + 1].Buffer));
+                Assert.Equal(2, BitConverter.ToInt32(msg[offset + 1].Buffer, 0));
 
                 Assert.Equal(HashDigest<SHA256>.Size, msg[offset + 2].BufferSize);
                 Assert.Equal(stateRefs[address][0], new HashDigest<SHA256>(msg[offset + 2].Buffer));
@@ -138,7 +138,7 @@ namespace Libplanet.Tests.Net.Messages
             }
 
             Assert.Empty(accounts);
-            Assert.Equal(signersCount, BitConverter.ToInt32(msg[txNoncesOffset].Buffer));
+            Assert.Equal(signersCount, BitConverter.ToInt32(msg[txNoncesOffset].Buffer, 0));
 
             for (int i = 0; i < signersCount; i++)
             {
@@ -148,7 +148,7 @@ namespace Libplanet.Tests.Net.Messages
                 Assert.Contains(address, signers);
 
                 Assert.Equal(8, msg[offset + 1].BufferSize);
-                Assert.Equal(txNonces[address], BitConverter.ToInt64(msg[offset + 1].Buffer));
+                Assert.Equal(txNonces[address], BitConverter.ToInt64(msg[offset + 1].Buffer, 0));
 
                 signers.Remove(address);
             }
@@ -156,7 +156,7 @@ namespace Libplanet.Tests.Net.Messages
             Assert.Empty(signers);
             Assert.Equal(
                 compressedBlockStates.Count,
-                BitConverter.ToInt32(msg[blockStatesOffset].Buffer)
+                BitConverter.ToInt32(msg[blockStatesOffset].Buffer, 0)
             );
 
             var formatter = new BinaryFormatter();
@@ -166,7 +166,7 @@ namespace Libplanet.Tests.Net.Messages
 
                 var hash = new HashDigest<SHA256>(msg[offset].Buffer);
                 Assert.Contains(hash, compressedBlockStates);
-                Assert.Equal(1, BitConverter.ToInt32(msg[offset + 1].Buffer));
+                Assert.Equal(1, BitConverter.ToInt32(msg[offset + 1].Buffer, 0));
 
                 var addr = new Address(msg[offset + 2].Buffer);
                 Assert.Equal(compressedBlockStates[hash].Keys.First(), addr);
@@ -191,7 +191,7 @@ namespace Libplanet.Tests.Net.Messages
             RecentStates missing = new RecentStates(blockHash, null, null, null);
             msg = missing.ToNetMQMessage(privKey);
             Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
-            Assert.Equal(-1, BitConverter.ToInt32(msg[headerSize + 1].Buffer));
+            Assert.Equal(-1, BitConverter.ToInt32(msg[headerSize + 1].Buffer, 0));
 
             parsed = new RecentStates(missing.ToNetMQMessage(privKey).Skip(headerSize).ToArray());
             Assert.Equal(blockHash, parsed.BlockHash);

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -112,7 +112,7 @@ namespace Libplanet.Tests.Net.Messages
                msg.FrameCount
             );
             Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
-            Assert.Equal(accountsCount, BitConverter.ToInt32(msg[headerSize + 1].Buffer, 0));
+            Assert.Equal(accountsCount, msg[headerSize + 1].ConvertToInt32());
             for (int i = 0; i < accountsCount; i++)
             {
                 int offset = stateRefsOffset + 1 + (i * 4);
@@ -121,7 +121,7 @@ namespace Libplanet.Tests.Net.Messages
                 Assert.Contains(address, accounts);
 
                 Assert.Equal(4, msg[offset + 1].BufferSize);
-                Assert.Equal(2, BitConverter.ToInt32(msg[offset + 1].Buffer, 0));
+                Assert.Equal(2, msg[offset + 1].ConvertToInt32());
 
                 Assert.Equal(HashDigest<SHA256>.Size, msg[offset + 2].BufferSize);
                 Assert.Equal(stateRefs[address][0], new HashDigest<SHA256>(msg[offset + 2].Buffer));
@@ -132,7 +132,7 @@ namespace Libplanet.Tests.Net.Messages
             }
 
             Assert.Empty(accounts);
-            Assert.Equal(signersCount, BitConverter.ToInt32(msg[txNoncesOffset].Buffer, 0));
+            Assert.Equal(signersCount, msg[txNoncesOffset].ConvertToInt32());
 
             for (int i = 0; i < signersCount; i++)
             {
@@ -142,16 +142,13 @@ namespace Libplanet.Tests.Net.Messages
                 Assert.Contains(address, signers);
 
                 Assert.Equal(8, msg[offset + 1].BufferSize);
-                Assert.Equal(txNonces[address], BitConverter.ToInt64(msg[offset + 1].Buffer, 0));
+                Assert.Equal(txNonces[address], msg[offset + 1].ConvertToInt64());
 
                 signers.Remove(address);
             }
 
             Assert.Empty(signers);
-            Assert.Equal(
-                compressedBlockStates.Count,
-                BitConverter.ToInt32(msg[blockStatesOffset].Buffer, 0)
-            );
+            Assert.Equal(compressedBlockStates.Count, msg[blockStatesOffset].ConvertToInt32());
 
             var formatter = new BinaryFormatter();
             for (int i = 0; i < compressedBlockStates.Count; i++)
@@ -160,7 +157,7 @@ namespace Libplanet.Tests.Net.Messages
 
                 var hash = new HashDigest<SHA256>(msg[offset].Buffer);
                 Assert.Contains(hash, compressedBlockStates);
-                Assert.Equal(1, BitConverter.ToInt32(msg[offset + 1].Buffer, 0));
+                Assert.Equal(1, msg[offset + 1].ConvertToInt32());
 
                 var addr = new Address(msg[offset + 2].Buffer);
                 Assert.Equal(compressedBlockStates[hash].Keys.First(), addr);
@@ -185,7 +182,7 @@ namespace Libplanet.Tests.Net.Messages
             RecentStates missing = new RecentStates(blockHash, null, null, null);
             msg = missing.ToNetMQMessage(privKey);
             Assert.Equal(blockHash, new HashDigest<SHA256>(msg[headerSize].Buffer));
-            Assert.Equal(-1, BitConverter.ToInt32(msg[headerSize + 1].Buffer, 0));
+            Assert.Equal(-1, msg[headerSize + 1].ConvertToInt32());
 
             parsed = new RecentStates(missing.ToNetMQMessage(privKey).Skip(headerSize).ToArray());
             Assert.Equal(blockHash, parsed.BlockHash);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -96,6 +96,14 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [Fact]
+        public void BlockChain()
+        {
+            Assert.Same(_blockchains[0], _swarms[0].BlockChain);
+            Assert.Same(_blockchains[1], _swarms[1].BlockChain);
+            Assert.Same(_blockchains[2], _swarms[2].BlockChain);
+        }
+
         [Fact(Timeout = Timeout)]
         public async Task CanNotStartTwice()
         {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -934,17 +934,13 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarm);
                 await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
-                await StartAsync(receiverSwarm);
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
+                await receiverSwarm.PreloadAsync(receiverChain);
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
             }
             finally
             {
-                await Task.WhenAll(
-                    minerSwarm.StopAsync(),
-                    receiverSwarm.StopAsync());
+                await minerSwarm.StopAsync();
             }
         }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -321,7 +321,7 @@ namespace Libplanet.Blockchain
         /// <see cref="GetNextTxNonce"/> result of the
         /// <see cref="Transaction{T}.Signer"/>.</exception>
         public void Append(Block<T> block, DateTimeOffset currentTime) =>
-            Append(block, currentTime, render: true);
+            Append(block, currentTime, evaluateActions: true, renderActions: true);
 
         /// <summary>
         /// Adds <paramref name="transactions"/> to the pending list so that
@@ -489,11 +489,21 @@ namespace Libplanet.Blockchain
         internal void Append(
             Block<T> block,
             DateTimeOffset currentTime,
-            bool render
+            bool evaluateActions,
+            bool renderActions
         )
         {
+            if (!evaluateActions && renderActions)
+            {
+                throw new ArgumentException(
+                    $"{nameof(renderActions)} option requires {nameof(evaluateActions)} " +
+                    "to be turned on.",
+                    nameof(renderActions)
+                );
+            }
+
             _rwlock.EnterUpgradeableReadLock();
-            ActionEvaluation<T>[] evaluations;
+            ActionEvaluation<T>[] evaluations = null;
             try
             {
                 InvalidBlockException e =
@@ -507,18 +517,23 @@ namespace Libplanet.Blockchain
                 HashDigest<SHA256>? tip =
                     Store.IndexBlockHash(Id.ToString(), -1);
 
-                ValidateNonce(block);
-
-                evaluations = block.Evaluate(
-                    currentTime,
-                    a => GetStates(new[] { a }, tip).GetValueOrDefault(a)
-                ).ToArray();
+                if (evaluateActions)
+                {
+                    ValidateNonce(block);
+                    evaluations = block.Evaluate(
+                        currentTime,
+                        a => GetStates(new[] { a }, tip).GetValueOrDefault(a)
+                    ).ToArray();
+                }
 
                 _rwlock.EnterWriteLock();
                 try
                 {
                     Blocks[block.Hash] = block;
-                    SetStates(block, evaluations, buildIndices: true);
+                    if (!(evaluations is null))
+                    {
+                        SetStates(block, evaluations, buildIndices: true);
+                    }
 
                     Store.AppendIndex(Id.ToString(), block.Hash);
                     ISet<TxId> txIds = block.Transactions
@@ -537,7 +552,7 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitUpgradeableReadLock();
             }
 
-            if (render)
+            if (!(evaluations is null) && renderActions)
             {
                 foreach (var evaluation in evaluations)
                 {
@@ -800,7 +815,7 @@ namespace Libplanet.Blockchain
         // FIXME it's very dangerous because replacing Id means
         // ALL blocks (referenced by MineBlock(), etc.) will be changed.
         // we need to add a synchronization mechanism to handle this correctly.
-        internal void Swap(BlockChain<T> other)
+        internal void Swap(BlockChain<T> other, bool render)
         {
             // Finds the branch point.
             Block<T> topmostCommon = null;
@@ -820,23 +835,26 @@ namespace Libplanet.Blockchain
                 }
             }
 
-            // Unrender stale actions.
-            for (
-                Block<T> b = Tip;
-                !(b is null) && b.Index > (topmostCommon?.Index ?? -1) &&
-                    b.PreviousHash is HashDigest<SHA256> ph;
-                b = Blocks[ph]
-            )
+            if (render)
             {
-                var actions = b.EvaluateActionsPerTx(a =>
-                    GetStates(new[] { a }, b.PreviousHash).GetValueOrDefault(a)
-                ).Reverse();
-                foreach (var (_, evaluation) in actions)
+                // Unrender stale actions.
+                for (
+                    Block<T> b = Tip;
+                    !(b is null) && b.Index > (topmostCommon?.Index ?? -1) &&
+                        b.PreviousHash is HashDigest<SHA256> ph;
+                    b = Blocks[ph]
+                )
                 {
-                    evaluation.Action.Unrender(
-                        evaluation.InputContext,
-                        evaluation.OutputStates
-                    );
+                    var actions = b.EvaluateActionsPerTx(a =>
+                        GetStates(new[] { a }, b.PreviousHash).GetValueOrDefault(a)
+                    ).Reverse();
+                    foreach (var (_, evaluation) in actions)
+                    {
+                        evaluation.Action.Unrender(
+                            evaluation.InputContext,
+                            evaluation.OutputStates
+                        );
+                    }
                 }
             }
 
@@ -854,22 +872,25 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitWriteLock();
             }
 
-            // Render actions that had been behind.
-            IEnumerable<Block<T>> blocksToRender =
-                topmostCommon is Block<T> branchPoint
-                    ? this.SkipWhile(b => b.Index <= branchPoint.Index)
-                    : this;
-            foreach (Block<T> b in blocksToRender)
+            if (render)
             {
-                var actions = b.EvaluateActionsPerTx(a =>
-                    GetStates(new[] { a }, b.PreviousHash).GetValueOrDefault(a)
-                );
-                foreach (var (_, evaluation) in actions)
+                // Render actions that had been behind.
+                IEnumerable<Block<T>> blocksToRender =
+                    topmostCommon is Block<T> branchPoint
+                        ? this.SkipWhile(b => b.Index <= branchPoint.Index)
+                        : this;
+                foreach (Block<T> b in blocksToRender)
                 {
-                    evaluation.Action.Render(
-                        evaluation.InputContext,
-                        evaluation.OutputStates
+                    var actions = b.EvaluateActionsPerTx(a =>
+                        GetStates(new[] { a }, b.PreviousHash).GetValueOrDefault(a)
                     );
+                    foreach (var (_, evaluation) in actions)
+                    {
+                        evaluation.Action.Render(
+                            evaluation.InputContext,
+                            evaluation.OutputStates
+                        );
+                    }
                 }
             }
         }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -519,7 +519,7 @@ namespace Libplanet.Blockchain
 
                 if (evaluateActions)
                 {
-                    ValidateNonce(block);
+                    ValidateTxNonces(block);
                     evaluations = block.Evaluate(
                         currentTime,
                         a => GetStates(new[] { a }, tip).GetValueOrDefault(a)
@@ -564,7 +564,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal void ValidateNonce(Block<T> block)
+        internal void ValidateTxNonces(Block<T> block)
         {
             var nonces = new Dictionary<Address, long>();
             foreach (Transaction<T> tx in block.Transactions)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -909,7 +909,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        private void SetStates(
+        internal void SetStates(
             Block<T> block,
             IReadOnlyList<ActionEvaluation<T>> actionEvaluations,
             bool buildStateReferences

--- a/Libplanet/Net/Messages/GetRecentStates.cs
+++ b/Libplanet/Net/Messages/GetRecentStates.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class GetRecentStates : Message
+    {
+        public GetRecentStates(HashDigest<SHA256> blockHash)
+        {
+            BlockHash = blockHash;
+        }
+
+        public GetRecentStates(NetMQFrame[] frames)
+            : this(new HashDigest<SHA256>(frames[0].Buffer))
+        {
+        }
+
+        public HashDigest<SHA256> BlockHash { get; }
+
+        protected override MessageType Type => MessageType.GetRecentStates;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(BlockHash.ToByteArray());
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -67,7 +67,7 @@ namespace Libplanet.Net.Messages
 
             /// <summary>
             /// A reply to <see cref="GetRecentStates"/>.
-            /// Contains the calculated recent states, transaction nonces, and state references.
+            /// Contains the calculated recent states and state references.
             /// </summary>
             RecentStates = 0x0c,
         }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Net.Messages
             Ping = 0x01,
 
             /// <summary>
-            /// Reply of `Ping`.
+            /// A reply to <see cref="Ping"/>.
             /// </summary>
             Pong = 0x02,
 
@@ -59,6 +59,17 @@ namespace Libplanet.Net.Messages
             /// Message containing serialized transaction.
             /// </summary>
             Tx = 0x10,
+
+            /// <summary>
+            /// Request to query calculated states.
+            /// </summary>
+            GetRecentStates = 0x0b,
+
+            /// <summary>
+            /// A reply to <see cref="GetRecentStates"/>.
+            /// Contains the calculated recent states, transaction nonces, and state references.
+            /// </summary>
+            RecentStates = 0x0c,
         }
 
         public byte[] Identity { get; set; }
@@ -102,6 +113,8 @@ namespace Libplanet.Net.Messages
                 { MessageType.GetTxs, typeof(GetTxs) },
                 { MessageType.Blocks, typeof(Blocks) },
                 { MessageType.Tx, typeof(Tx) },
+                { MessageType.GetRecentStates, typeof(GetRecentStates) },
+                { MessageType.RecentStates, typeof(RecentStates) },
             };
 
             if (!types.TryGetValue(rawType, out Type type))

--- a/Libplanet/Net/Messages/RecentStates.cs
+++ b/Libplanet/Net/Messages/RecentStates.cs
@@ -163,6 +163,56 @@ namespace Libplanet.Net.Messages
 
         protected override IEnumerable<NetMQFrame> DataFrames
         {
+            /*
+            Note that the data frames this property returns omit the very first three frames
+            of (message type, public key, signature).  See also Message.ToNetMQMessage() method.
+
+            | 1. BlockHash (32 bytes; SHA-256 digest)
+            |   The requested block hash which corresponds to
+            |   the given GetRecentStates.BlockHash value.
+            +
+            | 2. StateReferences.Count (4 bytes; 32-bit integer in big endian)
+            |   The number of the accounts of the following state references (3) in the payload.
+            |   When Missing = true, this contains -1 and no data frames follow at all.
+            +
+            | 3. StateReferences [unordered]
+            | | 3.1. Key (20 bytes; account address)
+            | |   The account address of the following state references (3.3).
+            | +
+            | | 3.2. Value.Count (4 bytes; 32-bit integer in big endian)
+            | |   The length of the following state references (3.3).
+            | +
+            | | 3.3. Value [descending order; the recent block goes first & the oldest goes last]
+            | | | 3.3.1. (32 bytes; SHA-256 digest)
+            | | |   A state reference of the account (3.1).
+            +
+            | 4. TxNonces.Count (4 bytes; 32-bit integer in big endian)
+            |   The number of the following tx nonces (5) in the payload.
+            +
+            | 5. TxNonces [unordered]
+            | | 5.1. Key (20 bytes; account address)
+            | |   An account address that corresponds to the following tx nonce (5.2).
+            | +
+            | | 5.2. Value (8 bytes; 64-bit integer in big endian)
+            | |   The current tx nonce of the above account (5.1).
+            +
+            | 6. BlockStates.Count (4 bytes; 32-bit integer in big endian)
+            |   The number of the following block states (7) in the payload.
+            +
+            | 7. BlockStates [unordered]
+            | | 7.1. Key (32 bytes; SHA-256 digest)
+            | |   A block hash having the following states delta (7.3).
+            | +
+            | | 7.2. Value.Count (4 bytes; 32-bit integer in big endian)
+            | |   The number of accounts whose states changed in the following delta (7.3).
+            | +
+            | | 7.3. Value [unordered]
+            | | | 7.3.1. Key (20 bytes; account address)
+            | | |   An account address having the following updated state (7.3.2).
+            | | +
+            | | | 7.3.2. Value (varying bytes; .NET binary serialization format)
+            | | |   An updated state of the account (7.3.1).
+            */
             get
             {
                 yield return new NetMQFrame(BlockHash.ToByteArray());

--- a/Libplanet/Net/Messages/RecentStates.cs
+++ b/Libplanet/Net/Messages/RecentStates.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class RecentStates : Message
+    {
+        public RecentStates(
+            HashDigest<SHA256> blockHash,
+            IImmutableDictionary<
+                HashDigest<SHA256>,
+                IImmutableDictionary<Address, object>
+            > blockStates,
+            IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> stateReferences,
+            IImmutableDictionary<Address, long> txNonces
+        )
+        {
+            BlockHash = blockHash;
+
+            if (blockStates is null && stateReferences is null && txNonces is null)
+            {
+                BlockStates = null;
+                StateReferences = null;
+                TxNonces = null;
+                return;
+            }
+
+            if (blockStates is null)
+            {
+                throw new ArgumentNullException(nameof(blockStates));
+            }
+            else if (stateReferences is null)
+            {
+                throw new ArgumentNullException(nameof(stateReferences));
+            }
+            else if (txNonces is null)
+            {
+                throw new ArgumentNullException(nameof(txNonces));
+            }
+
+            BlockStates = blockStates;
+            StateReferences = stateReferences;
+            TxNonces = txNonces;
+        }
+
+        public RecentStates(NetMQFrame[] frames)
+        {
+            IEnumerator<NetMQFrame> it = ((IEnumerable<NetMQFrame>)frames).GetEnumerator();
+
+            it.MoveNext();
+            BlockHash = new HashDigest<SHA256>(it.Current.Buffer);
+
+            it.MoveNext();
+            int accountsCount = BitConverter.ToInt32(it.Current.Buffer, 0);
+
+            if (accountsCount < 0)
+            {
+                BlockStates = null;
+                StateReferences = null;
+                TxNonces = null;
+                return;
+            }
+
+            var stateRefs =
+                new Dictionary<Address, IImmutableList<HashDigest<SHA256>>>(accountsCount);
+
+            for (int j = 0; j < accountsCount; j++)
+            {
+                it.MoveNext();
+                var address = new Address(it.Current.Buffer);
+
+                it.MoveNext();
+                int stateRefsLength = BitConverter.ToInt32(it.Current.Buffer, 0);
+                List<HashDigest<SHA256>> refs = new List<HashDigest<SHA256>>(stateRefsLength);
+
+                for (int k = 0; k < stateRefsLength; k++)
+                {
+                    it.MoveNext();
+                    refs.Add(new HashDigest<SHA256>(it.Current.Buffer));
+                }
+
+                stateRefs[address] = refs.ToImmutableList();
+            }
+
+            it.MoveNext();
+            int signersCount = BitConverter.ToInt32(it.Current.Buffer, 0);
+
+            var txNonces = new Dictionary<Address, long>(accountsCount);
+
+            for (int j = 0; j < signersCount; j++)
+            {
+                it.MoveNext();
+                var address = new Address(it.Current.Buffer);
+
+                it.MoveNext();
+                txNonces[address] = BitConverter.ToInt64(it.Current.Buffer, 0);
+            }
+
+            it.MoveNext();
+            int blocksLength = BitConverter.ToInt32(it.Current.Buffer, 0);  // This is not height!
+
+            var blockStates =
+                new Dictionary<HashDigest<SHA256>, IImmutableDictionary<Address, object>>(
+                    blocksLength);
+            var formatter = new BinaryFormatter();
+
+            for (int j = 0; j < blocksLength; j++)
+            {
+                it.MoveNext();
+                var blockHash = new HashDigest<SHA256>(it.Current.Buffer);
+
+                it.MoveNext();
+                int statesLength = BitConverter.ToInt32(it.Current.Buffer, 0);
+
+                var states = new Dictionary<Address, object>(statesLength);
+                for (int k = 0; k < statesLength; k++)
+                {
+                    it.MoveNext();
+                    var address = new Address(it.Current.Buffer);
+
+                    it.MoveNext();
+                    using (var stream = new MemoryStream(it.Current.Buffer))
+                    {
+                        states[address] = formatter.Deserialize(stream);
+                    }
+                }
+
+                blockStates[blockHash] = states.ToImmutableDictionary();
+            }
+
+            BlockStates = blockStates.ToImmutableDictionary();
+            StateReferences = stateRefs.ToImmutableDictionary();
+            TxNonces = txNonces.ToImmutableDictionary();
+        }
+
+        public HashDigest<SHA256> BlockHash { get; }
+
+        public bool Missing => BlockStates is null;
+
+        public IImmutableDictionary<
+            HashDigest<SHA256>,
+            IImmutableDictionary<Address, object>
+        > BlockStates { get; }
+
+        /// <summary>
+        /// State references of all available accounts.  Each value has a list of
+        /// state references in ascending order; the closest to the genesis block
+        /// goes first, and the closest to the tip goes last.
+        /// </summary>
+        public IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> StateReferences
+        {
+            get;
+        }
+
+        public IImmutableDictionary<Address, long> TxNonces { get; }
+
+        protected override MessageType Type => MessageType.RecentStates;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(BlockHash.ToByteArray());
+                if (Missing)
+                {
+                    yield return new NetMQFrame(BitConverter.GetBytes(-1));
+                    yield break;
+                }
+
+                yield return new NetMQFrame(BitConverter.GetBytes(StateReferences.Count));
+
+                foreach (var pair in StateReferences)
+                {
+                    yield return new NetMQFrame(pair.Key.ToByteArray());
+
+                    IImmutableList<HashDigest<SHA256>> stateRefs = pair.Value;
+                    yield return new NetMQFrame(BitConverter.GetBytes(stateRefs.Count));
+
+                    foreach (HashDigest<SHA256> blockHash in stateRefs)
+                    {
+                        yield return new NetMQFrame(blockHash.ToByteArray());
+                    }
+                }
+
+                yield return new NetMQFrame(BitConverter.GetBytes(TxNonces.Count));
+
+                foreach (var pair in TxNonces)
+                {
+                    yield return new NetMQFrame(pair.Key.ToByteArray());
+                    yield return new NetMQFrame(BitConverter.GetBytes(pair.Value));
+                }
+
+                yield return new NetMQFrame(BitConverter.GetBytes(BlockStates.Count));
+                var formatter = new BinaryFormatter();
+                foreach (var blockState in BlockStates)
+                {
+                    yield return new NetMQFrame(blockState.Key.ToByteArray());
+
+                    IImmutableDictionary<Address, object> states = blockState.Value;
+                    yield return new NetMQFrame(BitConverter.GetBytes(states.Count));
+
+                    foreach (var addressState in states)
+                    {
+                        yield return new NetMQFrame(addressState.Key.ToByteArray());
+
+                        using (var stream = new MemoryStream())
+                        {
+                            formatter.Serialize(stream, addressState.Value);
+                            yield return new NetMQFrame(stream.GetBuffer());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/RecentStates.cs
+++ b/Libplanet/Net/Messages/RecentStates.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using NetMQ;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -225,6 +225,12 @@ namespace Libplanet.Net
         }
 
         /// <summary>
+        /// The <see cref="BlockChain{T}"/> instance this <see cref="Swarm{T}"/> instance
+        /// synchronizes with.
+        /// </summary>
+        public BlockChain<T> BlockChain => _blockChain;
+
+        /// <summary>
         /// Whether this <see cref="Swarm{T}"/> instance is running.
         /// </summary>
         public bool Running

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1453,10 +1453,7 @@ namespace Libplanet.Net
                 IStore store = _blockChain.Store;
                 string ns = _blockChain.Id.ToString();
 
-                IImmutableSet<Address> addresses =
-                    store.ListAddresses(ns).ToImmutableHashSet();
-
-                stateRefs = addresses.Select(address =>
+                stateRefs = store.ListAddresses(ns).Select(address =>
                 {
                     ImmutableList<HashDigest<SHA256>> refs =
                         store.IterateStateReferences(ns, address).Select(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1462,6 +1462,7 @@ namespace Libplanet.Net
 
                 blockStates = stateRefs.Values
                     .Select(refs => refs.Last())
+                    .ToImmutableHashSet()
                     .Select(bh =>
                         new KeyValuePair<
                             HashDigest<SHA256>,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -898,6 +898,60 @@ namespace Libplanet.Net
                         break;
                     }
 
+                case GetRecentStates getRecentStates:
+                    {
+                        HashDigest<SHA256> blockHash = getRecentStates.BlockHash;
+                        IImmutableDictionary<HashDigest<SHA256>,
+                            IImmutableDictionary<Address, object>
+                        > blockStates = null;
+                        IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+                            stateRefs = null;
+                        IImmutableDictionary<Address, long> txNonces = null;
+
+                        if (_blockChain.Blocks.ContainsKey(blockHash))
+                        {
+                            // FIXME: Swarm should not directly access to the IStore instance,
+                            // but BlockChain<T> should have an indirect interface to its underlying
+                            // store.
+                            IStore store = _blockChain.Store;
+                            string ns = _blockChain.Id.ToString();
+
+                            IImmutableSet<Address> addresses =
+                                store.ListAddresses(ns).ToImmutableHashSet();
+
+                            stateRefs = addresses.Select(address =>
+                            {
+                                ImmutableList<HashDigest<SHA256>> refs =
+                                    store.IterateStateReferences(ns, address).Select(
+                                        p => p.Item1
+                                    ).Reverse().ToImmutableList();
+                                return
+                                    new KeyValuePair<Address, IImmutableList<HashDigest<SHA256>>>(
+                                        address, refs
+                                    );
+                            }).ToImmutableDictionary();
+                            txNonces = store.ListTxNonces(ns).ToImmutableDictionary();
+
+                            blockStates = stateRefs.Values
+                                .Select(refs => refs.Last())
+                                .Select(bh =>
+                                    new KeyValuePair<
+                                        HashDigest<SHA256>,
+                                        IImmutableDictionary<Address, object>
+                                    >(bh, store.GetBlockStates(bh))
+                                )
+                                .ToImmutableDictionary();
+                        }
+
+                        var reply = new RecentStates(blockHash, blockStates, stateRefs, txNonces)
+                        {
+                            Identity = getRecentStates.Identity,
+                        };
+                        _replyQueue.Enqueue(reply);
+
+                        break;
+                    }
+
                 case GetBlocks getBlocks:
                     {
                         TransferBlocks(getBlocks);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -919,10 +919,6 @@ namespace Libplanet.Net
                         // store.
                         IStore store = BlockChain.Store;
                         string ns = BlockChain.Id.ToString();
-                        foreach (KeyValuePair<Address, long> pair in recentStates.TxNonces)
-                        {
-                            store.IncreaseTxNonce(ns, pair.Key, pair.Value);
-                        }
 
                         foreach (var pair in recentStates.StateReferences)
                         {
@@ -1443,7 +1439,6 @@ namespace Libplanet.Net
             > blockStates = null;
             IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
                 stateRefs = null;
-            IImmutableDictionary<Address, long> txNonces = null;
 
             if (_blockChain.Blocks.ContainsKey(blockHash))
             {
@@ -1464,7 +1459,6 @@ namespace Libplanet.Net
                             address, refs
                         );
                 }).ToImmutableDictionary();
-                txNonces = store.ListTxNonces(ns).ToImmutableDictionary();
 
                 blockStates = stateRefs.Values
                     .Select(refs => refs.Last())
@@ -1477,7 +1471,7 @@ namespace Libplanet.Net
                     .ToImmutableDictionary();
             }
 
-            var reply = new RecentStates(blockHash, blockStates, stateRefs, txNonces)
+            var reply = new RecentStates(blockHash, blockStates, stateRefs)
             {
                 Identity = getRecentStates.Identity,
             };

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -406,7 +406,7 @@ namespace Libplanet.Net
         /// <exception cref="SwarmException">Thrown when this <see cref="Swarm{T}"/> instance is
         /// already <see cref="Running"/>.</exception>
         /// <remarks>If the <see cref="BlockChain"/> has no blocks at all or there are long behind
-        /// blocks to caught in the network this method could lead unexpected behaviors, because
+        /// blocks to caught in the network this method could lead to unexpected behaviors, because
         /// this tries to <see cref="IAction.Render"/> <em>all</em> actions in the behind blocks
         /// so that there are a lot of calls to <see cref="IAction.Render"/> method in a short
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
@@ -534,7 +534,7 @@ namespace Libplanet.Net
         /// An instance that receives progress updates for block downloads.
         /// </param>
         /// <param name="trustedStateValidators">
-        /// If any peer in this set is reachable and there is no built up
+        /// If any peer in this set is reachable and there are no built-up
         /// blocks in a current node, <see cref="Swarm{T}"/> receives the latest
         /// states of the major blockchain from that trusted peer,
         /// which is also calculated by that peer, instead of autonomously

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -875,8 +875,8 @@ namespace Libplanet.Net
                     longestPeerWithLength?.Item1,
                     null,
                     progress,
-                    cancellationToken,
-                    evaluateActions: render
+                    evaluateActions: render,
+                    cancellationToken: cancellationToken
                 );
                 if (!synced.Id.Equals(_blockChain.Id))
                 {
@@ -1130,8 +1130,8 @@ namespace Libplanet.Net
             Peer peer,
             HashDigest<SHA256>? stop,
             IProgress<BlockDownloadState> progress,
-            CancellationToken cancellationToken,
-            bool evaluateActions
+            bool evaluateActions,
+            CancellationToken cancellationToken
         )
         {
             // Fix the tip here because it may change while receiving the block
@@ -1197,8 +1197,8 @@ namespace Libplanet.Net
                         synced,
                         stop,
                         progress,
-                        cancellationToken,
-                        evaluateActions
+                        evaluateActions,
+                        cancellationToken
                     );
                     break;
                 }
@@ -1251,8 +1251,8 @@ namespace Libplanet.Net
                     peer,
                     oldest.PreviousHash,
                     null,
-                    cancellationToken,
-                    evaluateActions: true
+                    evaluateActions: true,
+                    cancellationToken: cancellationToken
                 );
                 _logger.Debug("Filled up. trying to concatenation...");
 
@@ -1284,8 +1284,8 @@ namespace Libplanet.Net
             BlockChain<T> blockChain,
             HashDigest<SHA256>? stop,
             IProgress<BlockDownloadState> progress,
-            CancellationToken cancellationToken,
-            bool evaluateActions
+            bool evaluateActions,
+            CancellationToken cancellationToken
         )
         {
             while (!cancellationToken.IsCancellationRequested)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -230,7 +230,7 @@ namespace Libplanet.Store
         /// <param name="namespace">The namespace to increase
         /// <see cref="Transaction{T}"/> nonce.</param>
         /// <param name="signer">The address of the account to increase tx nonce.</param>
-        /// <param name="delta">How many to incrase the counter.  A negative number decreases
+        /// <param name="delta">How many to increase the counter.  A negative number decreases
         /// the counter.  1 by default.</param>
         /// <seealso cref="GetTxNonce(string, Address)"/>
         void IncreaseTxNonce(string @namespace, Address signer, long delta = 1);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -134,8 +134,8 @@ namespace Libplanet.Store
         /// <param name="namespace">The chain namespace.</param>
         /// <param name="address">The <see cref="Address"/> to get state references.</param>
         /// <returns><em>Ordered</em> pairs of a state reference and a corresponding
-        /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) go last,
-        /// and the lowest index (i.e., the closest to the genesis) go first.</returns>
+        /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) go
+        /// first and the lowest index (i.e., the closest to the genesis) go last.</returns>
         /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
         IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -156,7 +156,7 @@ namespace Libplanet.Store
         /// <paramref name="block"/>.</typeparam>
         /// <remarks>State reference must be stored in the same order as the blocks. For now,
         /// it is assumed that this is only called by
-        /// <see cref="BlockChain{T}.Append(Block{T}, DateTimeOffset, bool)"/> method.</remarks>
+        /// <see cref="BlockChain{T}.Append(Block{T})"/> method.</remarks>
         /// <seealso cref="IterateStateReferences(string, Address)"/>
         void StoreStateReference<T>(
             string @namespace,

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,4 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
+  <MaxFileLines>2050</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
This patch implements (in a quick-and-dirty way) the idea suggested from #272.  There are direct accesses to `IStore` from `Swarm<T>`; these should be fixed in the near future, as they have possibility to cause unexpected behaviors on race conditions.

Closes #272.