### PR TITLE
Fix GetStates bug when there are multiple addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ To be released.
 
 ### Bug fixes
 
- -  Fixed a bug where the GetStates method does not return the latest state
-    when there are multiple addresses.  [[#346]]
+ -  Fixed a bug where the `BlockChain<T>.GetStates()` method had not returned
+    the latest state when there are multiple addresses.  [[#346]]
 
 [#346]: https://github.com/planetarium/libplanet/pull/346
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.4.1
 
 To be released.
 
+### Bug fixes
+
+ -  Fixed a bug where the GetStates method does not return the latest state
+    when there are multiple addresses.  [[#346]]
+
+[#346]: https://github.com/planetarium/libplanet/pull/346
 
 Version 0.4.0
 -------------

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
@@ -46,31 +46,32 @@ namespace Libplanet.Tests.Store
             fx.Store.StoreStateReference(fx.StoreNamespace, tx4.UpdatedAddresses, block4);
             Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(
-                block4.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
+                Tuple.Create(block4.Hash, block4.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block4)
             );
             Assert.Equal(
-                block4.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
+                Tuple.Create(block4.Hash, block4.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block5)
             );
             Assert.Equal(
-                block4.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
+                Tuple.Create(block4.Hash, block4.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block6)
             );
 
             fx.Store.StoreStateReference(fx.StoreNamespace, tx5.UpdatedAddresses, block5);
-            Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
+            Assert.Null(fx.Store.LookupStateReferenceWithIndex(
+                fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(
-                block4.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
+                Tuple.Create(block4.Hash, block4.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block4)
             );
             Assert.Equal(
-                block5.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
+                Tuple.Create(block5.Hash, block5.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block5)
             );
             Assert.Equal(
-                block5.Hash,
-                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
+                Tuple.Create(block5.Hash, block5.Index),
+                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block6)
             );
         }
     }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -349,14 +349,14 @@ namespace Libplanet.Tests.Store
                 blocks[3]);
 
             Assert.Equal(
-                blocks[2].Hash,
-                Fx.Store.LookupStateReference(Fx.StoreNamespace, address1, blocks[3]));
+                Tuple.Create(blocks[2].Hash, blocks[2].Index),
+                Fx.Store.LookupStateReferenceWithIndex(Fx.StoreNamespace, address1, blocks[3]));
             Assert.Equal(
-                blocks[3].Hash,
-                Fx.Store.LookupStateReference(Fx.StoreNamespace, address2, blocks[3]));
+                Tuple.Create(blocks[3].Hash, blocks[3].Index),
+                Fx.Store.LookupStateReferenceWithIndex(Fx.StoreNamespace, address2, blocks[3]));
             Assert.Equal(
-                    blocks[branchPointIndex].Hash,
-                    Fx.Store.LookupStateReference(targetNamespace, address1, blocks[3]));
+                    Tuple.Create(blocks[branchPointIndex].Hash, blocks[branchPointIndex].Index),
+                    Fx.Store.LookupStateReferenceWithIndex(targetNamespace, address1, blocks[3]));
             Assert.Null(
                     Fx.Store.LookupStateReference(targetNamespace, address2, blocks[3]));
         }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -216,17 +216,21 @@ namespace Libplanet.Blockchain
 
             ImmutableHashSet<Address> requestedAddresses =
                 addresses.ToImmutableHashSet();
-            var hashValues = new HashSet<HashDigest<SHA256>>();
+            var stateReferences = new HashSet<Tuple<HashDigest<SHA256>, long>>();
 
             foreach (var address in requestedAddresses)
             {
-                var hashDigest = Store.LookupStateReference(
+                Tuple<HashDigest<SHA256>, long> sr = Store.LookupStateReferenceWithIndex(
                     Id.ToString(), address, block);
-                if (!(hashDigest is null))
+                if (!(sr is null))
                 {
-                    hashValues.Add(hashDigest.Value);
+                    stateReferences.Add(sr);
                 }
             }
+
+            IEnumerable<HashDigest<SHA256>> hashValues = stateReferences
+                .OrderByDescending(sr => sr.Item2)
+                .Select(sr => sr.Item1);
 
             foreach (var hashValue in hashValues)
             {

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -32,6 +32,19 @@ namespace Libplanet.Store
             Block<T> lookupUntil)
             where T : IAction, new()
         {
+            Tuple<HashDigest<SHA256>, long> sr = store.
+                LookupStateReferenceWithIndex(@namespace, address, lookupUntil);
+
+            return sr?.Item1;
+        }
+
+        internal static Tuple<HashDigest<SHA256>, long> LookupStateReferenceWithIndex<T>(
+            this IStore store,
+            string @namespace,
+            Address address,
+            Block<T> lookupUntil)
+            where T : IAction, new()
+        {
             if (lookupUntil is null)
             {
                 throw new ArgumentNullException(nameof(lookupUntil));
@@ -43,7 +56,7 @@ namespace Libplanet.Store
             {
                 if (pair.Item2 <= lookupUntil.Index)
                 {
-                    return pair.Item1;
+                    return Tuple.Create(pair.Item1, pair.Item2);
                 }
             }
 


### PR DESCRIPTION
This fixes a bug where `GetStates` method does not return the latest state when there are multiple addresses. And also this changes the return value of `LookupStateReference()` method to fix the bug.