### PR TITLE
Change return value of LookupStateReference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,18 @@ To be released.
 
 ### Backward-incompatible interface changes
 
+ -  `StoreExtension.LookupStateReference<T>()` method became to return
+    `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
+    and `Block<T>.Index`.  [[#350]]
+
 ### Added interfaces
 
 ### Behavioral changes
 
 ### Bug fixes
+
+
+[#350]: https://github.com/planetarium/libplanet/pull/350
 
 
 Version 0.4.1

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -417,9 +417,9 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(
                 Tuple.Create(b1.Hash, b1.Index),
-                forked.Store.LookupStateReferenceWithIndex(fId, addr1, forked.Tip));
+                forked.Store.LookupStateReference(fId, addr1, forked.Tip));
             Assert.Null(
-                forked.Store.LookupStateReferenceWithIndex(fId, addr2, forked.Tip));
+                forked.Store.LookupStateReference(fId, addr2, forked.Tip));
 
             // Fork from b2.
             forked = _blockChain.Fork(b2.Hash);
@@ -427,10 +427,10 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(
                 Tuple.Create(b1.Hash, b1.Index),
-                forked.Store.LookupStateReferenceWithIndex(fId, addr1, forked.Tip));
+                forked.Store.LookupStateReference(fId, addr1, forked.Tip));
             Assert.Equal(
                 Tuple.Create(b2.Hash, b2.Index),
-                forked.Store.LookupStateReferenceWithIndex(fId, addr2, forked.Tip));
+                forked.Store.LookupStateReference(fId, addr2, forked.Tip));
         }
 
         [Fact]
@@ -787,7 +787,7 @@ namespace Libplanet.Tests.Blockchain
                 while (true)
                 {
                     Tuple<HashDigest<SHA256>, long> sr =
-                        store.LookupStateReferenceWithIndex(@namespace, address, block);
+                        store.LookupStateReference(@namespace, address, block);
                     if (sr?.Item1 is HashDigest<SHA256> reference)
                     {
                         refs.Add(reference);

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -47,31 +47,31 @@ namespace Libplanet.Tests.Store
             Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(
                 Tuple.Create(block4.Hash, block4.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block4)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
             );
             Assert.Equal(
                 Tuple.Create(block4.Hash, block4.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block5)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
             );
             Assert.Equal(
                 Tuple.Create(block4.Hash, block4.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block6)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
             );
 
             fx.Store.StoreStateReference(fx.StoreNamespace, tx5.UpdatedAddresses, block5);
-            Assert.Null(fx.Store.LookupStateReferenceWithIndex(
+            Assert.Null(fx.Store.LookupStateReference(
                 fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(
                 Tuple.Create(block4.Hash, block4.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block4)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block4)
             );
             Assert.Equal(
                 Tuple.Create(block5.Hash, block5.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block5)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block5)
             );
             Assert.Equal(
                 Tuple.Create(block5.Hash, block5.Index),
-                fx.Store.LookupStateReferenceWithIndex(fx.StoreNamespace, address, block6)
+                fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
             );
         }
     }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -350,13 +350,13 @@ namespace Libplanet.Tests.Store
 
             Assert.Equal(
                 Tuple.Create(blocks[2].Hash, blocks[2].Index),
-                Fx.Store.LookupStateReferenceWithIndex(Fx.StoreNamespace, address1, blocks[3]));
+                Fx.Store.LookupStateReference(Fx.StoreNamespace, address1, blocks[3]));
             Assert.Equal(
                 Tuple.Create(blocks[3].Hash, blocks[3].Index),
-                Fx.Store.LookupStateReferenceWithIndex(Fx.StoreNamespace, address2, blocks[3]));
+                Fx.Store.LookupStateReference(Fx.StoreNamespace, address2, blocks[3]));
             Assert.Equal(
                     Tuple.Create(blocks[branchPointIndex].Hash, blocks[branchPointIndex].Index),
-                    Fx.Store.LookupStateReferenceWithIndex(targetNamespace, address1, blocks[3]));
+                    Fx.Store.LookupStateReference(targetNamespace, address1, blocks[3]));
             Assert.Null(
                     Fx.Store.LookupStateReference(targetNamespace, address2, blocks[3]));
         }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -220,7 +220,7 @@ namespace Libplanet.Blockchain
 
             foreach (var address in requestedAddresses)
             {
-                Tuple<HashDigest<SHA256>, long> sr = Store.LookupStateReferenceWithIndex(
+                Tuple<HashDigest<SHA256>, long> sr = Store.LookupStateReference(
                     Id.ToString(), address, block);
                 if (!(sr is null))
                 {

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -18,27 +18,15 @@ namespace Libplanet.Store
         /// <param name="address">The <see cref="Address"/> to look up.</param>
         /// <param name="lookupUntil">The upper bound (i.e., the latest block) of the search range.
         /// <see cref="Block{T}"/>s after <paramref name="lookupUntil"/> are ignored.</param>
-        /// <returns>A <see cref="Block{T}.Hash"/> which has the state of
-        /// the <paramref name="address"/>.</returns>
+        /// <returns>Returns a nullable tuple consisting of <see cref="Block{T}.Hash"/> and
+        /// <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/> with the state of the
+        /// address.</returns>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="lookupUntil"/>.</typeparam>
         /// <seealso
         /// cref="IStore.StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
         /// <seealso cref="IStore.IterateStateReferences(string, Address)"/>
-        public static HashDigest<SHA256>? LookupStateReference<T>(
-            this IStore store,
-            string @namespace,
-            Address address,
-            Block<T> lookupUntil)
-            where T : IAction, new()
-        {
-            Tuple<HashDigest<SHA256>, long> sr = store.
-                LookupStateReferenceWithIndex(@namespace, address, lookupUntil);
-
-            return sr?.Item1;
-        }
-
-        internal static Tuple<HashDigest<SHA256>, long> LookupStateReferenceWithIndex<T>(
+        public static Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             this IStore store,
             string @namespace,
             Address address,


### PR DESCRIPTION
This removes `LookupStateReferenceWithIndex()`, a temporary method to ensure backward compatibility with 0.4.1, and changes the return value of `LookupStateReference()`.