### PR TITLE
Implement Block Actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ To be released.
     `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
     and `Block<T>.Index`.  [[#350]]
  -  The `IBlockPolicy<T>` became to `IBlockPolicy<TTxAction, TBlockAction>`
-    to add `IBlockPolicy.BlockActions` property. Accordingly, `BlockChain<T>`
+    to add `IBlockPolicy.BlockAction` property. Accordingly, `BlockChain<T>`
     and `Swarm<T>` became `BlockChain<TTxAction, TBlockAction>`, and
     `Swarm<TTxAction, TBlockAction>`, respectively.  [[#319], [#357]]
 
@@ -21,8 +21,8 @@ To be released.
 ### Behavioral changes
 
  - `BlockChain<TTxAction, TBlockAction>` became to evaluate
-   `IBlockPolicy<TTxAction, TBlockAction>.BlockActions` and set the
-   state when a mined block is appended to the chain.  [[#319], [#357]]
+   `IBlockPolicy<TTxAction, TBlockAction>.BlockAction` and set the
+   state when a block is appended to the chain.  [[#319], [#357]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,15 +11,25 @@ To be released.
  -  `StoreExtension.LookupStateReference<T>()` method became to return
     `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
     and `Block<T>.Index`.  [[#350]]
+ -  The `IBlockPolicy<T>` became to `IBlockPolicy<TTxAction, TBlockAction>`
+    to add `IBlockPolicy.BlockActions` property. Accordingly, `BlockChain<T>`
+    and `Swarm<T>` became `BlockChain<TTxAction, TBlockAction>`, and
+    `Swarm<TTxAction, TBlockAction>`, respectively.  [[#319], [#357]]
 
 ### Added interfaces
 
 ### Behavioral changes
 
+ - `BlockChain<TTxAction, TBlockAction>` became to evaluate
+   `IBlockPolicy<TTxAction, TBlockAction>.BlockActions` and set the
+   state when a mined block is appended to the chain.  [[#319], [#357]]
+
 ### Bug fixes
 
 
+[#319]: https://github.com/planetarium/libplanet/issues/319
 [#350]: https://github.com/planetarium/libplanet/pull/350
+[#357]: https://github.com/planetarium/libplanet/pull/357
 
 
 Version 0.4.1

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -207,8 +207,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void Append()
         {
-            DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
-            MinerReward.RenderRecords.Value = ImmutableList<MinerReward.RenderRecord>.Empty;
+            DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+            MinerReward.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
             Address[] addresses = Enumerable.Repeat(0, 4)
                 .Select(_ => new PrivateKey().PublicKey.ToAddress())
@@ -247,9 +247,10 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Contains(b1, _blockChain);
                 Assert.Equal(new[] { b0, b1 }, _blockChain.ToArray());
                 var renders = DumbAction.RenderRecords.Value;
+                var renderActions = renders.Select(r => (DumbAction)r.Action).ToArray();
                 Assert.Equal(4, renders.Count);
                 Assert.True(renders.All(r => r.Render));
-                Assert.Equal("foo", renders[0].Action.Item);
+                Assert.Equal("foo", renderActions[0].Item);
                 Assert.Equal(1, renders[0].Context.BlockIndex);
                 Assert.Equal(
                     new string[] { null, null, null, null },
@@ -259,7 +260,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", null, null, null },
                     addresses.Select(renders[0].NextStates.GetState)
                 );
-                Assert.Equal("bar", renders[1].Action.Item);
+                Assert.Equal("bar", renderActions[1].Item);
                 Assert.Equal(1, renders[1].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[0].NextStates.GetState),
@@ -269,7 +270,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", "bar", null, null },
                     addresses.Select(renders[1].NextStates.GetState)
                 );
-                Assert.Equal("baz", renders[2].Action.Item);
+                Assert.Equal("baz", renderActions[2].Item);
                 Assert.Equal(1, renders[2].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[1].NextStates.GetState),
@@ -279,7 +280,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", "bar", "baz", null },
                     addresses.Select(renders[2].NextStates.GetState)
                 );
-                Assert.Equal("qux", renders[3].Action.Item);
+                Assert.Equal("qux", renderActions[3].Item);
                 Assert.Equal(1, renders[3].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[2].NextStates.GetState),
@@ -310,8 +311,8 @@ namespace Libplanet.Tests.Blockchain
             }
             finally
             {
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
-                MinerReward.RenderRecords.Value = ImmutableList<MinerReward.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+                MinerReward.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 
@@ -638,8 +639,8 @@ namespace Libplanet.Tests.Blockchain
 
             try
             {
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
-                MinerReward.RenderRecords.Value = ImmutableList<MinerReward.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+                MinerReward.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
                 Block<DumbAction> forkTip = TestUtils.MineNext(
                     fork.Tip,
@@ -657,6 +658,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Empty(_blockChain.Store.ListTxNonces(previousNamespace));
 
                 var renders = DumbAction.RenderRecords.Value;
+                var renderActions = renders.Select(r => (DumbAction)r.Action).ToArray();
 
                 int actionsCountA = txsA.Sum(
                     a => a.Sum(tx => tx.Actions.Count)
@@ -667,13 +669,13 @@ namespace Libplanet.Tests.Blockchain
                 Assert.True(renders.Take(actionsCountA).All(r => r.Unrender));
                 Assert.True(renders.Skip(actionsCountA).All(r => r.Render));
 
-                Assert.Equal("qux", renders[0].Action.Item);
-                Assert.Equal("baz", renders[1].Action.Item);
-                Assert.Equal("bar", renders[2].Action.Item);
-                Assert.Equal("foo", renders[3].Action.Item);
-                Assert.Equal("fork-foo", renders[4].Action.Item);
-                Assert.Equal("fork-bar", renders[5].Action.Item);
-                Assert.Equal("fork-baz", renders[6].Action.Item);
+                Assert.Equal("qux", renderActions[0].Item);
+                Assert.Equal("baz", renderActions[1].Item);
+                Assert.Equal("bar", renderActions[2].Item);
+                Assert.Equal("foo", renderActions[3].Item);
+                Assert.Equal("fork-foo", renderActions[4].Item);
+                Assert.Equal("fork-bar", renderActions[5].Item);
+                Assert.Equal("fork-baz", renderActions[6].Item);
 
                 var minerAddress = TestUtils.GenesisMinerAddress;
                 var blockRenders = MinerReward.RenderRecords.Value;
@@ -685,8 +687,8 @@ namespace Libplanet.Tests.Blockchain
             }
             finally
             {
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
-                MinerReward.RenderRecords.Value = ImmutableList<MinerReward.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+                MinerReward.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 
@@ -1349,23 +1351,6 @@ namespace Libplanet.Tests.Blockchain
                     Context = context,
                     NextStates = nextStates,
                 });
-            }
-
-            public struct RenderRecord
-            {
-                public bool Render { get; set; }
-
-                public bool Unrender
-                {
-                    get => !Render;
-                    set => Render = !value;
-                }
-
-                public IAction Action { get; set; }
-
-                public IActionContext Context { get; set; }
-
-                public IAccountStateDelta NextStates { get; set; }
             }
         }
     }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Blockchain
         {
             _fx = new FileStoreFixture();
             _blockChain = new BlockChain<DumbAction, MinerReward>(
-                new BlockPolicy<DumbAction, MinerReward>(new[] { new MinerReward(1) }),
+                new BlockPolicy<DumbAction, MinerReward>(new MinerReward(1)),
                 _fx.Store
             );
         }
@@ -1083,9 +1083,9 @@ namespace Libplanet.Tests.Blockchain
             var privateKey2 = new PrivateKey();
             var address2 = privateKey2.PublicKey.ToAddress();
 
-            var blockActions = new[] { new DumbAction(address1, "foo"),  };
+            var blockAction = new DumbAction(address1, "foo");
             BlockPolicy<DumbAction, DumbAction> policy =
-                new BlockPolicy<DumbAction, DumbAction>(blockActions);
+                new BlockPolicy<DumbAction, DumbAction>(blockAction);
 
             var blockChain = new BlockChain<DumbAction, DumbAction>(policy, _fx.Store);
 
@@ -1229,7 +1229,7 @@ namespace Libplanet.Tests.Blockchain
                 _exceptionToThrow = exceptionToThrow;
             }
 
-            public IList<TBlockAction> BlockActions => new List<TBlockAction>();
+            public TBlockAction BlockAction => default(TBlockAction);
 
             public long GetNextBlockDifficulty(IReadOnlyList<Block<TTxAction>> blocks) =>
                 blocks.Any() ? 1 : 0;

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Threading;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -1281,76 +1280,6 @@ namespace Libplanet.Tests.Blockchain
                 IActionContext context,
                 IAccountStateDelta nextStates)
             {
-            }
-        }
-
-        private sealed class MinerReward : IAction
-        {
-            public MinerReward()
-            {
-            }
-
-            public MinerReward(int reward)
-            {
-                Reward = reward;
-            }
-
-            public static AsyncLocal<ImmutableList<RenderRecord>>
-                RenderRecords { get; } = new AsyncLocal<ImmutableList<RenderRecord>>();
-
-            public int Reward { get; private set; }
-
-            public IImmutableDictionary<string, object> PlainValue =>
-                new Dictionary<string, object>
-                {
-                    ["reward"] = Reward,
-                }.ToImmutableDictionary();
-
-            public void LoadPlainValue(IImmutableDictionary<string, object> plainValue)
-            {
-                Reward = (int)plainValue["reward"];
-            }
-
-            public IAccountStateDelta Execute(IActionContext ctx)
-            {
-                IAccountStateDelta states = ctx.PreviousStates;
-
-                int previousReward = (int?)states?.GetState(ctx.Miner) ?? 0;
-                int reward = previousReward + Reward;
-
-                return states.SetState(ctx.Miner, reward);
-            }
-
-            public void Render(IActionContext context, IAccountStateDelta nextStates)
-            {
-                if (RenderRecords.Value is null)
-                {
-                    RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
-                }
-
-                RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
-                {
-                    Render = true,
-                    Action = this,
-                    Context = context,
-                    NextStates = nextStates,
-                });
-            }
-
-            public void Unrender(IActionContext context, IAccountStateDelta nextStates)
-            {
-                if (RenderRecords.Value is null)
-                {
-                    RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
-                }
-
-                RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
-                {
-                    Unrender = true,
-                    Action = this,
-                    Context = context,
-                    NextStates = nextStates,
-                });
             }
         }
     }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -138,7 +138,7 @@ namespace Libplanet.Tests.Blockchain
 
             var chain =
                 new BlockChain<PolymorphicAction<BaseAction>, PolymorphicAction<BaseAction>>(
-                new BlockPolicy<PolymorphicAction<BaseAction>, PolymorphicAction<BaseAction>>(),
+                new BlockPolicy<PolymorphicAction<BaseAction>, PolymorphicAction<BaseAction>>(null),
                 _fx.Store
             );
             chain.StageTransactions(
@@ -916,7 +916,7 @@ namespace Libplanet.Tests.Blockchain
             );
 
             var chain = new BlockChain<TestEvaluateAction, TestEvaluateAction>(
-                new BlockPolicy<TestEvaluateAction, TestEvaluateAction>(),
+                new BlockPolicy<TestEvaluateAction, TestEvaluateAction>(null),
                 _fx.Store
             );
             chain.StageTransactions(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1166,6 +1166,8 @@ namespace Libplanet.Tests.Blockchain
                 _exceptionToThrow = exceptionToThrow;
             }
 
+            public IList<TBlockAction> BlockActions => new List<TBlockAction>();
+
             public long GetNextBlockDifficulty(IReadOnlyList<Block<TTxAction>> blocks) =>
                 blocks.Any() ? 1 : 0;
 

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -58,7 +58,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new TimeSpan(0, 1, 5),
                 b.BlockInterval);
 
-            var c = new BlockPolicy<DumbAction, DumbAction>();
+            var c = new BlockPolicy<DumbAction, DumbAction>(null);
             Assert.Equal(
                 new TimeSpan(0, 0, 5),
                 c.BlockInterval);

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -31,6 +31,7 @@ namespace Libplanet.Tests.Blockchain.Policies
             _output = output;
             _blocks = new List<Block<DumbAction>>();
             _policy = new BlockPolicy<DumbAction, DumbAction>(
+                null,
                 TimeSpan.FromMilliseconds(5000),
                 1024,
                 128);
@@ -49,10 +50,10 @@ namespace Libplanet.Tests.Blockchain.Policies
         public void Constructors()
         {
             var tenSec = new TimeSpan(0, 0, 10);
-            var a = new BlockPolicy<DumbAction, DumbAction>(tenSec, 1024, 128);
+            var a = new BlockPolicy<DumbAction, DumbAction>(null, tenSec, 1024, 128);
             Assert.Equal(tenSec, a.BlockInterval);
 
-            var b = new BlockPolicy<DumbAction, DumbAction>(65000);
+            var b = new BlockPolicy<DumbAction, DumbAction>(null, 65000);
             Assert.Equal(
                 new TimeSpan(0, 1, 5),
                 b.BlockInterval);
@@ -63,20 +64,21 @@ namespace Libplanet.Tests.Blockchain.Policies
                 c.BlockInterval);
 
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction, DumbAction>(tenSec.Negate(), 1024, 128));
+                () => new BlockPolicy<DumbAction, DumbAction>(null, tenSec.Negate(), 1024, 128));
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction, DumbAction>(-5));
+                () => new BlockPolicy<DumbAction, DumbAction>(null, -5));
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction, DumbAction>(tenSec, 0, 128));
+                new BlockPolicy<DumbAction, DumbAction>(null, tenSec, 0, 128));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction, DumbAction>(tenSec, 1024, 1024));
+                new BlockPolicy<DumbAction, DumbAction>(null, tenSec, 1024, 1024));
         }
 
         [Fact]
         public void GetNextBlockDifficulty()
         {
-            var policy = new BlockPolicy<DumbAction, DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction, DumbAction>(
+                null, new TimeSpan(3, 0, 0), 1024, 128);
             Block<DumbAction>[] blocks = MineBlocks(
                 new[] { (0, 0), (1, 1024), (3, 1032), (7, 1040), (9, 1040), (13, 1048) }
             ).ToArray();
@@ -229,7 +231,8 @@ namespace Libplanet.Tests.Blockchain.Policies
         [Fact]
         public void ValidateBlocks()
         {
-            var policy = new BlockPolicy<DumbAction, DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction, DumbAction>(
+                null, new TimeSpan(3, 0, 0), 1024, 128);
 
             // The genesis block must has the index #0.
             Assert.IsType<InvalidBlockIndexException>(

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         private readonly ITestOutputHelper _output;
 
         private List<Block<DumbAction>> _blocks;
-        private IBlockPolicy<DumbAction> _policy;
+        private IBlockPolicy<DumbAction, DumbAction> _policy;
         private List<Transaction<DumbAction>> _emptyTransaction;
         private Block<DumbAction> _genesis;
         private Block<DumbAction> _validNext;
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         {
             _output = output;
             _blocks = new List<Block<DumbAction>>();
-            _policy = new BlockPolicy<DumbAction>(
+            _policy = new BlockPolicy<DumbAction, DumbAction>(
                 TimeSpan.FromMilliseconds(5000),
                 1024,
                 128);
@@ -49,34 +49,34 @@ namespace Libplanet.Tests.Blockchain.Policies
         public void Constructors()
         {
             var tenSec = new TimeSpan(0, 0, 10);
-            var a = new BlockPolicy<DumbAction>(tenSec, 1024, 128);
+            var a = new BlockPolicy<DumbAction, DumbAction>(tenSec, 1024, 128);
             Assert.Equal(tenSec, a.BlockInterval);
 
-            var b = new BlockPolicy<DumbAction>(65000);
+            var b = new BlockPolicy<DumbAction, DumbAction>(65000);
             Assert.Equal(
                 new TimeSpan(0, 1, 5),
                 b.BlockInterval);
 
-            var c = new BlockPolicy<DumbAction>();
+            var c = new BlockPolicy<DumbAction, DumbAction>();
             Assert.Equal(
                 new TimeSpan(0, 0, 5),
                 c.BlockInterval);
 
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction>(tenSec.Negate(), 1024, 128));
+                () => new BlockPolicy<DumbAction, DumbAction>(tenSec.Negate(), 1024, 128));
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction>(-5));
+                () => new BlockPolicy<DumbAction, DumbAction>(-5));
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(tenSec, 0, 128));
+                new BlockPolicy<DumbAction, DumbAction>(tenSec, 0, 128));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(tenSec, 1024, 1024));
+                new BlockPolicy<DumbAction, DumbAction>(tenSec, 1024, 1024));
         }
 
         [Fact]
         public void GetNextBlockDifficulty()
         {
-            var policy = new BlockPolicy<DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction, DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
             Block<DumbAction>[] blocks = MineBlocks(
                 new[] { (0, 0), (1, 1024), (3, 1032), (7, 1040), (9, 1040), (13, 1048) }
             ).ToArray();
@@ -229,7 +229,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         [Fact]
         public void ValidateBlocks()
         {
-            var policy = new BlockPolicy<DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction, DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
 
             // The genesis block must has the index #0.
             Assert.IsType<InvalidBlockIndexException>(

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using Libplanet.Action;
 
@@ -177,23 +176,6 @@ namespace Libplanet.Tests.Common.Action
                 hashCode = (hashCode * 397) ^ RecordRehearsal.GetHashCode();
                 return hashCode;
             }
-        }
-
-        public struct RenderRecord
-        {
-            public bool Render { get; set; }
-
-            public bool Unrender
-            {
-                get => !Render;
-                set => Render = !value;
-            }
-
-            public DumbAction Action { get; set; }
-
-            public IActionContext Context { get; set; }
-
-            public IAccountStateDelta NextStates { get; set; }
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/MinerReward.cs
+++ b/Libplanet.Tests/Common/Action/MinerReward.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public sealed class MinerReward : IAction
+    {
+        public MinerReward()
+        {
+        }
+
+        public MinerReward(int reward)
+        {
+            Reward = reward;
+        }
+
+        public static AsyncLocal<ImmutableList<RenderRecord>>
+            RenderRecords { get; } = new AsyncLocal<ImmutableList<RenderRecord>>();
+
+        public int Reward { get; private set; }
+
+        public IImmutableDictionary<string, object> PlainValue =>
+            new Dictionary<string, object>
+            {
+                ["reward"] = Reward,
+            }.ToImmutableDictionary();
+
+        public void LoadPlainValue(IImmutableDictionary<string, object> plainValue)
+        {
+            Reward = (int)plainValue["reward"];
+        }
+
+        public IAccountStateDelta Execute(IActionContext ctx)
+        {
+            IAccountStateDelta states = ctx.PreviousStates;
+
+            int previousReward = (int?)states?.GetState(ctx.Miner) ?? 0;
+            int reward = previousReward + Reward;
+
+            return states.SetState(ctx.Miner, reward);
+        }
+
+        public void Render(IActionContext context, IAccountStateDelta nextStates)
+        {
+            if (RenderRecords.Value is null)
+            {
+                RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+            }
+
+            RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
+            {
+                Render = true,
+                Action = this,
+                Context = context,
+                NextStates = nextStates,
+            });
+        }
+
+        public void Unrender(IActionContext context, IAccountStateDelta nextStates)
+        {
+            if (RenderRecords.Value is null)
+            {
+                RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+            }
+
+            RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
+            {
+                Unrender = true,
+                Action = this,
+                Context = context,
+                NextStates = nextStates,
+            });
+        }
+    }
+}

--- a/Libplanet.Tests/Common/Action/RenderRecord.cs
+++ b/Libplanet.Tests/Common/Action/RenderRecord.cs
@@ -1,0 +1,21 @@
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public struct RenderRecord
+    {
+        public bool Render { get; set; }
+
+        public bool Unrender
+        {
+            get => !Render;
+            set => Render = !value;
+        }
+
+        public IAction Action { get; set; }
+
+        public IActionContext Context { get; set; }
+
+        public IAccountStateDelta NextStates { get; set; }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Net
                 .CreateLogger()
                 .ForContext<SwarmTest>();
 
-            var policy = new BlockPolicy<DumbAction, DumbAction>();
+            var policy = new BlockPolicy<DumbAction, DumbAction>(null);
             _fx1 = new FileStoreFixture();
             _fx2 = new FileStoreFixture();
             _fx3 = new FileStoreFixture();

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -33,8 +33,8 @@ namespace Libplanet.Tests.Net
         private readonly FileStoreFixture _fx2;
         private readonly FileStoreFixture _fx3;
 
-        private readonly List<BlockChain<DumbAction>> _blockchains;
-        private readonly List<Swarm<DumbAction>> _swarms;
+        private readonly List<BlockChain<DumbAction, DumbAction>> _blockchains;
+        private readonly List<Swarm<DumbAction, DumbAction>> _swarms;
 
         public SwarmTest(ITestOutputHelper output)
         {
@@ -47,31 +47,31 @@ namespace Libplanet.Tests.Net
                 .CreateLogger()
                 .ForContext<SwarmTest>();
 
-            var policy = new BlockPolicy<DumbAction>();
+            var policy = new BlockPolicy<DumbAction, DumbAction>();
             _fx1 = new FileStoreFixture();
             _fx2 = new FileStoreFixture();
             _fx3 = new FileStoreFixture();
 
-            _blockchains = new List<BlockChain<DumbAction>>
+            _blockchains = new List<BlockChain<DumbAction, DumbAction>>
             {
-                new BlockChain<DumbAction>(policy, _fx1.Store),
-                new BlockChain<DumbAction>(policy, _fx2.Store),
-                new BlockChain<DumbAction>(policy, _fx3.Store),
+                new BlockChain<DumbAction, DumbAction>(policy, _fx1.Store),
+                new BlockChain<DumbAction, DumbAction>(policy, _fx2.Store),
+                new BlockChain<DumbAction, DumbAction>(policy, _fx3.Store),
             };
 
-            _swarms = new List<Swarm<DumbAction>>
+            _swarms = new List<Swarm<DumbAction, DumbAction>>
             {
-                new Swarm<DumbAction>(
+                new Swarm<DumbAction, DumbAction>(
                     _blockchains[0],
                     new PrivateKey(),
                     appProtocolVersion: 1,
                     host: IPAddress.Loopback.ToString()),
-                new Swarm<DumbAction>(
+                new Swarm<DumbAction, DumbAction>(
                     _blockchains[1],
                     new PrivateKey(),
                     appProtocolVersion: 1,
                     host: IPAddress.Loopback.ToString()),
-                new Swarm<DumbAction>(
+                new Swarm<DumbAction, DumbAction>(
                     _blockchains[2],
                     new PrivateKey(),
                     appProtocolVersion: 1,
@@ -85,7 +85,7 @@ namespace Libplanet.Tests.Net
             _fx2.Dispose();
             _fx3.Dispose();
 
-            foreach (Swarm<DumbAction> s in _swarms)
+            foreach (Swarm<DumbAction, DumbAction> s in _swarms)
             {
                 s.StopAsync().Wait(DisposeTimeout);
             }
@@ -99,7 +99,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanNotStartTwice()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarm = _swarms[0];
 
             Task t = await Task.WhenAny(
                 swarm.StartAsync(),
@@ -115,8 +115,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task StopAsync()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
-            BlockChain<DumbAction> chain = _blockchains[0];
+            Swarm<DumbAction, DumbAction> swarm = _swarms[0];
+            BlockChain<DumbAction, DumbAction> chain = _blockchains[0];
 
             await swarm.StopAsync();
             var task = await StartAsync(swarm);
@@ -132,8 +132,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanWaitForRunning()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
-            BlockChain<DumbAction> chain = _blockchains[0];
+            Swarm<DumbAction, DumbAction> swarm = _swarms[0];
+            BlockChain<DumbAction, DumbAction> chain = _blockchains[0];
 
             Assert.False(swarm.Running);
 
@@ -160,15 +160,15 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastWhileMining()
         {
-            Swarm<DumbAction> a = _swarms[0];
-            Swarm<DumbAction> b = _swarms[1];
+            Swarm<DumbAction, DumbAction> a = _swarms[0];
+            Swarm<DumbAction, DumbAction> b = _swarms[1];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
 
             Task CreateMiner(
-                Swarm<DumbAction> swarm,
-                BlockChain<DumbAction> chain,
+                Swarm<DumbAction, DumbAction> swarm,
+                BlockChain<DumbAction, DumbAction> chain,
                 int delay,
                 CancellationToken cancellationToken
             )
@@ -226,19 +226,19 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanExchangePeer()
         {
-            BlockChain<DumbAction> chain = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chain = _blockchains[0];
 
-            var a = new Swarm<DumbAction>(
+            var a = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 1,
                 host: IPAddress.Loopback.ToString());
-            var b = new Swarm<DumbAction>(
+            var b = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 1,
                 host: IPAddress.Loopback.ToString());
-            var c = new Swarm<DumbAction>(
+            var c = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 1,
@@ -308,25 +308,25 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task DetectAppProtocolVersion()
         {
-            BlockChain<DumbAction> chain = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chain = _blockchains[0];
 
-            var a = new Swarm<DumbAction>(
+            var a = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2);
-            var b = new Swarm<DumbAction>(
+            var b = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
 
-            var c = new Swarm<DumbAction>(
+            var c = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2);
-            var d = new Swarm<DumbAction>(
+            var d = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
@@ -369,15 +369,15 @@ namespace Libplanet.Tests.Net
                 isCalled = true;
             }
 
-            BlockChain<DumbAction> chain = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chain = _blockchains[0];
 
-            var a = new Swarm<DumbAction>(
+            var a = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2,
                 differentVersionPeerEncountered: GameHandler);
-            var b = new Swarm<DumbAction>(
+            var b = new Swarm<DumbAction, DumbAction>(
                 chain,
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
@@ -402,7 +402,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task Cancel()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarm = _swarms[0];
             var cts = new CancellationTokenSource();
 
             Task task = await StartAsync(
@@ -417,11 +417,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanGetBlock()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
 
             Block<DumbAction> genesis = chainA.MineBlock(_fx1.Address1);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
@@ -481,11 +481,11 @@ namespace Libplanet.Tests.Net
         {
             var privateKey = new PrivateKey();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
 
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = new Swarm<DumbAction>(
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = new Swarm<DumbAction, DumbAction>(
                 chainB,
                 privateKey,
                 1,
@@ -543,11 +543,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetTx()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -587,13 +587,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastTx()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmC = _swarms[2];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainC = _blockchains[2];
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -638,11 +638,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task TxStagedNotToBroadcast()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
 
             Transaction<DumbAction> txA = chainA.MakeTransaction(
                 new PrivateKey(),
@@ -674,13 +674,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastTxAsync()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmC = _swarms[2];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainC = _blockchains[2];
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -721,13 +721,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanBroadcastBlock()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction, DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction, DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction, DumbAction> swarmC = _swarms[2];
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction, DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> chainC = _blockchains[2];
 
             // chainA, chainB and chainC shares genesis block.
             Block<DumbAction> genesis = chainA.MineBlock(_fx1.Address1);
@@ -792,24 +792,24 @@ namespace Libplanet.Tests.Net
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(null, new PrivateKey(), 1);
+                new Swarm<DumbAction, DumbAction>(null, new PrivateKey(), 1);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(_blockchains[0], null, 1);
+                new Swarm<DumbAction, DumbAction>(_blockchains[0], null, 1);
             });
 
-            // Swarm<DumbAction> needs host or iceServers.
+            // Swarm<DumbAction, DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(_blockchains[0], new PrivateKey(), 1);
+                new Swarm<DumbAction, DumbAction>(_blockchains[0], new PrivateKey(), 1);
             });
 
-            // Swarm<DumbAction> needs host or iceServers.
+            // Swarm<DumbAction, DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(
+                new Swarm<DumbAction, DumbAction>(
                     _blockchains[0],
                     new PrivateKey(),
                     1,
@@ -821,7 +821,7 @@ namespace Libplanet.Tests.Net
         public void CanResolveEndPoint()
         {
             var expected = new DnsEndPoint("1.2.3.4", 5678);
-            Swarm<DumbAction> s = new Swarm<DumbAction>(
+            Swarm<DumbAction, DumbAction> s = new Swarm<DumbAction, DumbAction>(
                 _blockchains[0],
                 new PrivateKey(),
                 1,
@@ -835,8 +835,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanStopGracefullyWhileStarting()
         {
-            Swarm<DumbAction> a = _swarms[0];
-            Swarm<DumbAction> b = _swarms[1];
+            Swarm<DumbAction, DumbAction> a = _swarms[0];
+            Swarm<DumbAction, DumbAction> b = _swarms[1];
 
             await StartAsync(b);
             await a.AddPeersAsync(new[] { b.AsPeer });
@@ -848,7 +848,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task AsPeerThrowSwarmExceptionWhenUnbound()
         {
-            Swarm<DumbAction> swarm = new Swarm<DumbAction>(
+            Swarm<DumbAction, DumbAction> swarm = new Swarm<DumbAction, DumbAction>(
                 _blockchains[0],
                 new PrivateKey(),
                 1,
@@ -876,17 +876,17 @@ namespace Libplanet.Tests.Net
                     credential: password),
             };
 
-            var seed = new Swarm<DumbAction>(
+            var seed = new Swarm<DumbAction, DumbAction>(
                 _blockchains[0],
                 new PrivateKey(),
                 1,
                 host: "localhost");
-            var swarmA = new Swarm<DumbAction>(
+            var swarmA = new Swarm<DumbAction, DumbAction>(
                 _blockchains[1],
                 new PrivateKey(),
                 1,
                 iceServers: iceServers);
-            var swarmB = new Swarm<DumbAction>(
+            var swarmB = new Swarm<DumbAction, DumbAction>(
                 _blockchains[2],
                 new PrivateKey(),
                 1,
@@ -918,11 +918,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task InitialBlockDownload()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction, DumbAction> minerSwarm = _swarms[0];
+            Swarm<DumbAction, DumbAction> receiverSwarm = _swarms[1];
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> minerChain = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> receiverChain = _blockchains[1];
 
             foreach (int i in Enumerable.Range(0, 10))
             {
@@ -951,11 +951,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task Preload()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction, DumbAction> minerSwarm = _swarms[0];
+            Swarm<DumbAction, DumbAction> receiverSwarm = _swarms[1];
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction, DumbAction> minerChain = _blockchains[0];
+            BlockChain<DumbAction, DumbAction> receiverChain = _blockchains[1];
 
             foreach (int i in Enumerable.Range(0, 10))
             {
@@ -1001,7 +1001,7 @@ namespace Libplanet.Tests.Net
         }
 
         private async Task<Task> StartAsync(
-            Swarm<DumbAction> swarm,
+            Swarm<DumbAction, DumbAction> swarm,
             CancellationToken cancellationToken = default
         )
         {
@@ -1015,7 +1015,7 @@ namespace Libplanet.Tests.Net
         }
 
         private async Task EnsureRecvAsync(
-            Swarm<DumbAction> swarm,
+            Swarm<DumbAction, DumbAction> swarm,
             Peer peer = null,
             DateTimeOffset? lastReceived = null)
         {
@@ -1062,7 +1062,9 @@ namespace Libplanet.Tests.Net
             Log.Debug($"Received. [{swarm.AsPeer}]");
         }
 
-        private async Task EnsureExchange(Swarm<DumbAction> a, Swarm<DumbAction> b)
+        private async Task EnsureExchange(
+            Swarm<DumbAction, DumbAction> a,
+            Swarm<DumbAction, DumbAction> b)
         {
             await a.WaitForRunningAsync();
             await b.WaitForRunningAsync();

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -16,24 +16,25 @@ using Libplanet.Tx;
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
 namespace Libplanet.Blockchain
 {
-    public class BlockChain<T> : IReadOnlyList<Block<T>>
-        where T : IAction, new()
+    public class BlockChain<TTxAction, TBlockAction> : IReadOnlyList<Block<TTxAction>>
+        where TTxAction : IAction, new()
+        where TBlockAction : IAction, new()
     {
         private readonly ReaderWriterLockSlim _rwlock;
         private readonly object _txLock;
 
-        public BlockChain(IBlockPolicy<T> policy, IStore store)
+        public BlockChain(IBlockPolicy<TTxAction, TBlockAction> policy, IStore store)
             : this(policy, store, GetCanonicalChain(store) ?? Guid.NewGuid())
         {
         }
 
-        internal BlockChain(IBlockPolicy<T> policy, IStore store, Guid id)
+        internal BlockChain(IBlockPolicy<TTxAction, TBlockAction> policy, IStore store, Guid id)
         {
             Id = id;
             Policy = policy;
             Store = store;
-            Blocks = new BlockSet<T>(store);
-            Transactions = new TransactionSet<T>(store);
+            Blocks = new BlockSet<TTxAction>(store);
+            Transactions = new TransactionSet<TTxAction>(store);
 
             _rwlock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             _txLock = new object();
@@ -44,9 +45,9 @@ namespace Libplanet.Blockchain
             _rwlock?.Dispose();
         }
 
-        public IBlockPolicy<T> Policy { get; }
+        public IBlockPolicy<TTxAction, TBlockAction> Policy { get; }
 
-        public Block<T> Tip
+        public Block<TTxAction> Tip
         {
             get
             {
@@ -64,37 +65,39 @@ namespace Libplanet.Blockchain
         public Guid Id { get; private set; }
 
         /// <summary>
-        /// All <see cref="Block{T}"/>s in the <see cref="BlockChain{T}"/>
-        /// storage, including orphan <see cref="Block{T}"/>s.
-        /// Keys are <see cref="Block{T}.Hash"/>es and values are
-        /// their corresponding <see cref="Block{T}"/>s.
+        /// All <see cref="Block{TTxaction}"/>s in the
+        /// <see cref="BlockChain{TTxaction, TBlockAction}"/>
+        /// storage, including orphan <see cref="Block{TTxaction}"/>s.
+        /// Keys are <see cref="Block{TTxaction}.Hash"/>es and values are
+        /// their corresponding <see cref="Block{TTxaction}"/>s.
         /// </summary>
-        public IDictionary<HashDigest<SHA256>, Block<T>> Blocks
+        public IDictionary<HashDigest<SHA256>, Block<TTxAction>> Blocks
         {
             get; private set;
         }
 
         /// <summary>
-        /// All <see cref="Transaction{T}"/>s in the <see cref="BlockChain{T}"/>
-        /// storage, including orphan <see cref="Transaction{T}"/>s.
-        /// Keys are <see cref="Transaction{T}.Id"/>s and values are
-        /// their corresponding <see cref="Transaction{T}"/>s.
+        /// All <see cref="Transaction{TTxaction}"/>s in the
+        /// <see cref="BlockChain{TTxaction, TBlockAction}"/>
+        /// storage, including orphan <see cref="Transaction{TTxaction}"/>s.
+        /// Keys are <see cref="Transaction{TTxaction}.Id"/>s and values are
+        /// their corresponding <see cref="Transaction{TTxaction}"/>s.
         /// </summary>
-        public IDictionary<TxId, Transaction<T>> Transactions
+        public IDictionary<TxId, Transaction<TTxAction>> Transactions
         {
             get; private set;
         }
 
         /// <inheritdoc/>
-        int IReadOnlyCollection<Block<T>>.Count =>
+        int IReadOnlyCollection<Block<TTxAction>>.Count =>
             checked((int)Store.CountIndex(Id.ToString()));
 
         internal IStore Store { get; }
 
         /// <inheritdoc/>
-        public Block<T> this[int index] => this[(long)index];
+        public Block<TTxAction> this[int index] => this[(long)index];
 
-        public Block<T> this[long index]
+        public Block<TTxAction> this[long index]
         {
             get
             {
@@ -120,7 +123,7 @@ namespace Libplanet.Blockchain
         }
 
         public void Validate(
-            IReadOnlyList<Block<T>> blocks,
+            IReadOnlyList<Block<TTxAction>> blocks,
             DateTimeOffset currentTime
         )
         {
@@ -133,7 +136,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        public IEnumerator<Block<T>> GetEnumerator()
+        public IEnumerator<Block<TTxAction>> GetEnumerator()
         {
             try
             {
@@ -160,14 +163,14 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Gets the state of the given <paramref name="addresses"/> in the
-        /// <see cref="BlockChain{T}"/> from <paramref name="offset"/>.
+        /// <see cref="BlockChain{TTxaction, TBlockAction}"/> from <paramref name="offset"/>.
         /// </summary>
         /// <param name="addresses">The list of <see cref="Address"/>es to get
         /// their states.</param>
-        /// <param name="offset">The <see cref="HashDigest{T}"/> of the block to
+        /// <param name="offset">The <see cref="HashDigest{TTxaction}"/> of the block to
         /// start finding the state. It will be The tip of the
-        /// <see cref="BlockChain{T}"/> if it is <c>null</c>.</param>
-        /// <param name="completeStates">When the <see cref="BlockChain{T}"/>
+        /// <see cref="BlockChain{TTxaction, TBlockAction}"/> if it is <c>null</c>.</param>
+        /// <param name="completeStates">When the <see cref="BlockChain{TTxaction, TBlockAction}"/>
         /// instance does not contain states dirty of the block which lastly
         /// updated states of a requested address, this option makes
         /// the incomplete states calculated and filled on the fly.
@@ -179,7 +182,7 @@ namespace Libplanet.Blockchain
         /// <returns>The <see cref="AddressStateMap"/> of given
         /// <paramref name="addresses"/>.</returns>
         /// <exception cref="IncompleteBlockStatesException">Thrown when
-        /// the <see cref="BlockChain{T}"/> instance does not contain
+        /// the <see cref="BlockChain{TTxaction, TBlockAction}"/> instance does not contain
         /// states dirty of the block which lastly updated states of a requested
         /// address, because actions in the block have never been executed.
         /// If <paramref name="completeStates"/> option is turned on
@@ -212,7 +215,7 @@ namespace Libplanet.Blockchain
                 return states;
             }
 
-            Block<T> block = Blocks[offset.Value];
+            Block<TTxAction> block = Blocks[offset.Value];
 
             ImmutableHashSet<Address> requestedAddresses =
                 addresses.ToImmutableHashSet();
@@ -241,14 +244,14 @@ namespace Libplanet.Blockchain
                     {
                         // Calculates and fills the incomplete states
                         // on the fly.
-                        foreach (Block<T> b in this)
+                        foreach (Block<TTxAction> b in this)
                         {
                             if (!(Store.GetBlockStates(b.Hash) is null))
                             {
                                 continue;
                             }
 
-                            ActionEvaluation<T>[] evaluations =
+                            ActionEvaluation<TTxAction>[] evaluations =
                                 b.Evaluate(
                                     DateTimeOffset.UtcNow,
                                     a => GetStates(
@@ -290,16 +293,16 @@ namespace Libplanet.Blockchain
         /// the <paramref name="block"/> is confirmed (and thus all states
         /// reflect changes in the <paramref name="block"/>).</para>
         /// </summary>
-        /// <param name="block">A next <see cref="Block{T}"/>, which is mined,
+        /// <param name="block">A next <see cref="Block{TTxaction}"/>, which is mined,
         /// to add.</param>
         /// <exception cref="InvalidBlockException">Thrown when the given
         /// <paramref name="block"/> is invalid, in itself or according to
         /// the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
-        /// <see cref="Transaction{T}.Nonce"/> is different from
+        /// <see cref="Transaction{TTxaction}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{T}.Signer"/>.</exception>
-        public void Append(Block<T> block) =>
+        /// <see cref="Transaction{TTxaction}.Signer"/>.</exception>
+        public void Append(Block<TTxAction> block) =>
             Append(block, DateTimeOffset.UtcNow);
 
         /// <summary>
@@ -310,33 +313,33 @@ namespace Libplanet.Blockchain
         /// the <paramref name="block"/> is confirmed (and thus all states
         /// reflect changes in the <paramref name="block"/>).</para>
         /// </summary>
-        /// <param name="block">A next <see cref="Block{T}"/>, which is mined,
+        /// <param name="block">A next <see cref="Block{TTxaction}"/>, which is mined,
         /// to add.</param>
         /// <param name="currentTime">The current time.</param>
         /// <exception cref="InvalidBlockException">Thrown when the given
         /// <paramref name="block"/> is invalid, in itself or according to
         /// the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
-        /// <see cref="Transaction{T}.Nonce"/> is different from
+        /// <see cref="Transaction{TTxaction}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{T}.Signer"/>.</exception>
-        public void Append(Block<T> block, DateTimeOffset currentTime) =>
+        /// <see cref="Transaction{TTxaction}.Signer"/>.</exception>
+        public void Append(Block<TTxAction> block, DateTimeOffset currentTime) =>
             Append(block, currentTime, render: true);
 
         /// <summary>
         /// Adds <paramref name="transactions"/> to the pending list so that
-        /// a next <see cref="Block{T}"/> to be mined contains these
+        /// a next <see cref="Block{TTxaction}"/> to be mined contains these
         /// <paramref name="transactions"/>.
         /// </summary>
-        /// <param name="transactions"> <see cref="Transaction{T}"/>s to add to the pending list.
-        /// Keys are <see cref="Transactions"/>s and values are whether to broadcast.</param>
-        public void StageTransactions(IDictionary<Transaction<T>, bool> transactions)
+        /// <param name="transactions"> <see cref="Transaction{TTxaction}"/>s to add to the pending
+        /// list. Keys are <see cref="Transactions"/>s and values are whether to broadcast.</param>
+        public void StageTransactions(IDictionary<Transaction<TTxAction>, bool> transactions)
         {
             _rwlock.EnterWriteLock();
 
             try
             {
-                foreach (KeyValuePair<Transaction<T>, bool> kv in transactions)
+                foreach (KeyValuePair<Transaction<TTxAction>, bool> kv in transactions)
                 {
                     var tx = kv.Key;
                     Transactions[tx.Id] = tx;
@@ -354,10 +357,10 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// Removes <paramref name="transactions"/> from the pending list.
         /// </summary>
-        /// <param name="transactions"><see cref="Transaction{T}"/>s
+        /// <param name="transactions"><see cref="Transaction{TTxaction}"/>s
         /// to remove from the pending list.</param>
         /// <seealso cref="StageTransactions"/>
-        public void UnstageTransactions(ISet<Transaction<T>> transactions)
+        public void UnstageTransactions(ISet<Transaction<TTxAction>> transactions)
         {
             _rwlock.EnterWriteLock();
 
@@ -373,22 +376,22 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Gets next <see cref="Transaction{T}.Nonce"/> of the address.
+        /// Gets next <see cref="Transaction{TTxaction}.Nonce"/> of the address.
         /// </summary>
         /// <param name="address">The <see cref="Address"/> from which to obtain the
-        /// <see cref="Transaction{T}.Nonce"/> value.</param>
-        /// <returns>The next <see cref="Transaction{T}.Nonce"/> value of the
+        /// <see cref="Transaction{TTxaction}.Nonce"/> value.</param>
+        /// <returns>The next <see cref="Transaction{TTxaction}.Nonce"/> value of the
         /// <paramref name="address"/>.</returns>
         public long GetNextTxNonce(Address address)
         {
             long nonce = Store.GetTxNonce(Id.ToString(), address);
 
-            IEnumerable<Transaction<T>> stagedTxs = Store
+            IEnumerable<Transaction<TTxAction>> stagedTxs = Store
                 .IterateStagedTransactionIds()
-                .Select(Store.GetTransaction<T>)
+                .Select(Store.GetTransaction<TTxAction>)
                 .Where(tx => tx.Signer.Equals(address));
 
-            foreach (Transaction<T> tx in stagedTxs)
+            foreach (Transaction<TTxAction> tx in stagedTxs)
             {
                 if (nonce <= tx.Nonce)
                 {
@@ -399,7 +402,7 @@ namespace Libplanet.Blockchain
             return nonce;
         }
 
-        public Block<T> MineBlock(
+        public Block<TTxAction> MineBlock(
             Address miner,
             DateTimeOffset currentTime
         )
@@ -411,11 +414,11 @@ namespace Libplanet.Blockchain
                 @namespace,
                 index - 1
             );
-            IEnumerable<Transaction<T>> transactions = Store
+            IEnumerable<Transaction<TTxAction>> transactions = Store
                 .IterateStagedTransactionIds()
-                .Select(Store.GetTransaction<T>);
+                .Select(Store.GetTransaction<TTxAction>);
 
-            Block<T> block = Block<T>.Mine(
+            Block<TTxAction> block = Block<TTxAction>.Mine(
                 index: index,
                 difficulty: difficulty,
                 miner: miner,
@@ -428,11 +431,11 @@ namespace Libplanet.Blockchain
             return block;
         }
 
-        public Block<T> MineBlock(Address miner) =>
+        public Block<TTxAction> MineBlock(Address miner) =>
             MineBlock(miner, DateTimeOffset.UtcNow);
 
         /// <summary>
-        /// Creates a new <see cref="Transaction{T}"/> and stage the transaction.
+        /// Creates a new <see cref="Transaction{TTxaction}"/> and stage the transaction.
         /// </summary>
         /// <param name="privateKey">A <see cref="PrivateKey"/> of the account who creates and
         /// signs a new transaction.</param>
@@ -440,15 +443,15 @@ namespace Libplanet.Blockchain
         /// </param>
         /// <param name="updatedAddresses"><see cref="Address"/>es whose states affected by
         /// <paramref name="actions"/>.</param>
-        /// <param name="timestamp">The time this <see cref="Transaction{T}"/> is created and
-        /// signed.</param>
+        /// <param name="timestamp">The time this <see cref="Transaction{TTxaction}"/> is created
+        /// and signed.</param>
         /// <param name="broadcast">Whether to broadcast created transaction.</param>
-        /// <returns>A created new <see cref="Transaction{T}"/> signed by the given
+        /// <returns>A created new <see cref="Transaction{TTxaction}"/> signed by the given
         /// <paramref name="privateKey"/>.</returns>
-        /// <seealso cref="Transaction{T}.Create" />
-        public Transaction<T> MakeTransaction(
+        /// <seealso cref="Transaction{TTxaction}.Create" />
+        public Transaction<TTxAction> MakeTransaction(
             PrivateKey privateKey,
-            IEnumerable<T> actions,
+            IEnumerable<TTxAction> actions,
             IImmutableSet<Address> updatedAddresses = null,
             DateTimeOffset? timestamp = null,
             bool broadcast = true)
@@ -456,13 +459,14 @@ namespace Libplanet.Blockchain
             timestamp = timestamp ?? DateTimeOffset.UtcNow;
             lock (_txLock)
             {
-                Transaction<T> tx = Transaction<T>.Create(
+                Transaction<TTxAction> tx = Transaction<TTxAction>.Create(
                     GetNextTxNonce(privateKey.PublicKey.ToAddress()),
                     privateKey,
                     actions,
                     updatedAddresses,
                     timestamp);
-                StageTransactions(new Dictionary<Transaction<T>, bool> { { tx, broadcast } });
+                StageTransactions(
+                    new Dictionary<Transaction<TTxAction>, bool> { { tx, broadcast } });
 
                 return tx;
             }
@@ -487,13 +491,13 @@ namespace Libplanet.Blockchain
         }
 
         internal void Append(
-            Block<T> block,
+            Block<TTxAction> block,
             DateTimeOffset currentTime,
             bool render
         )
         {
             _rwlock.EnterUpgradeableReadLock();
-            ActionEvaluation<T>[] evaluations;
+            ActionEvaluation<TTxAction>[] evaluations;
             try
             {
                 InvalidBlockException e =
@@ -549,10 +553,10 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal void ValidateNonce(Block<T> block)
+        internal void ValidateNonce(Block<TTxAction> block)
         {
             var nonces = new Dictionary<Address, long>();
-            foreach (Transaction<T> tx in block.Transactions)
+            foreach (Transaction<TTxAction> tx in block.Transactions)
             {
                 Address signer = tx.Signer;
                 if (!nonces.TryGetValue(signer, out long nonce))
@@ -665,16 +669,16 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal BlockChain<T> Fork(HashDigest<SHA256> point)
+        internal BlockChain<TTxAction, TBlockAction> Fork(HashDigest<SHA256> point)
         {
             return Fork(point, DateTimeOffset.UtcNow);
         }
 
-        internal BlockChain<T> Fork(
+        internal BlockChain<TTxAction, TBlockAction> Fork(
             HashDigest<SHA256> point,
             DateTimeOffset currentTime)
         {
-            var forked = new BlockChain<T>(Policy, Store, Guid.NewGuid());
+            var forked = new BlockChain<TTxAction, TBlockAction>(Policy, Store, Guid.NewGuid());
             string id = Id.ToString();
             string forkedId = forked.Id.ToString();
             try
@@ -689,13 +693,13 @@ namespace Libplanet.Blockchain
                     }
                 }
 
-                Block<T> pointBlock = Blocks[point];
+                Block<TTxAction> pointBlock = Blocks[point];
 
                 var addressesToStrip = new HashSet<Address>();
                 var signersToStrip = new Dictionary<Address, int>();
 
                 for (
-                    Block<T> block = Tip;
+                    Block<TTxAction> block = Tip;
                     block.PreviousHash is HashDigest<SHA256> hash
                     && !block.Hash.Equals(point);
                     block = Blocks[hash])
@@ -773,7 +777,7 @@ namespace Libplanet.Blockchain
                 while (current is HashDigest<SHA256> hash)
                 {
                     hashes.Add(hash);
-                    Block<T> currentBlock = Blocks[hash];
+                    Block<TTxAction> currentBlock = Blocks[hash];
 
                     if (currentBlock.Index == 0)
                     {
@@ -800,14 +804,14 @@ namespace Libplanet.Blockchain
         // FIXME it's very dangerous because replacing Id means
         // ALL blocks (referenced by MineBlock(), etc.) will be changed.
         // we need to add a synchronization mechanism to handle this correctly.
-        internal void Swap(BlockChain<T> other)
+        internal void Swap(BlockChain<TTxAction, TBlockAction> other)
         {
             // Finds the branch point.
-            Block<T> topmostCommon = null;
+            Block<TTxAction> topmostCommon = null;
             long shorterHeight =
                 Math.Min(this.LongCount(), other.LongCount()) - 1;
             for (
-                Block<T> t = this[shorterHeight], o = other[shorterHeight];
+                Block<TTxAction> t = this[shorterHeight], o = other[shorterHeight];
                 t.PreviousHash is HashDigest<SHA256> tp &&
                     o.PreviousHash is HashDigest<SHA256> op;
                 t = Blocks[tp], o = other.Blocks[op]
@@ -822,7 +826,7 @@ namespace Libplanet.Blockchain
 
             // Unrender stale actions.
             for (
-                Block<T> b = Tip;
+                Block<TTxAction> b = Tip;
                 !(b is null) && b.Index > (topmostCommon?.Index ?? -1) &&
                     b.PreviousHash is HashDigest<SHA256> ph;
                 b = Blocks[ph]
@@ -846,8 +850,8 @@ namespace Libplanet.Blockchain
 
                 Store.DeleteNamespace(Id.ToString());
                 Id = other.Id;
-                Blocks = new BlockSet<T>(Store);
-                Transactions = new TransactionSet<T>(Store);
+                Blocks = new BlockSet<TTxAction>(Store);
+                Transactions = new TransactionSet<TTxAction>(Store);
             }
             finally
             {
@@ -855,11 +859,11 @@ namespace Libplanet.Blockchain
             }
 
             // Render actions that had been behind.
-            IEnumerable<Block<T>> blocksToRender =
-                topmostCommon is Block<T> branchPoint
+            IEnumerable<Block<TTxAction>> blocksToRender =
+                topmostCommon is Block<TTxAction> branchPoint
                     ? this.SkipWhile(b => b.Index <= branchPoint.Index)
                     : this;
-            foreach (Block<T> b in blocksToRender)
+            foreach (Block<TTxAction> b in blocksToRender)
             {
                 var actions = b.EvaluateActionsPerTx(a =>
                     GetStates(new[] { a }, b.PreviousHash).GetValueOrDefault(a)
@@ -889,8 +893,8 @@ namespace Libplanet.Blockchain
         }
 
         private void SetStates(
-            Block<T> block,
-            IReadOnlyList<ActionEvaluation<T>> actionEvaluations,
+            Block<TTxAction> block,
+            IReadOnlyList<ActionEvaluation<TTxAction>> actionEvaluations,
             bool buildIndices
         )
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -951,7 +951,7 @@ namespace Libplanet.Blockchain
 
             var actions = new List<TBlockAction>();
 
-            if (!Equals(Policy.BlockAction, default(TBlockAction)))
+            if (!Equals(Policy.BlockAction, null))
             {
                 actions.Add(Policy.BlockAction);
             }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -163,14 +163,14 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Gets the state of the given <paramref name="addresses"/> in the
-        /// <see cref="BlockChain{TTxaction, TBlockAction}"/> from <paramref name="offset"/>.
+        /// <see cref="BlockChain{TTxAction, TBlockAction}"/> from <paramref name="offset"/>.
         /// </summary>
         /// <param name="addresses">The list of <see cref="Address"/>es to get
         /// their states.</param>
-        /// <param name="offset">The <see cref="HashDigest{TTxaction}"/> of the block to
+        /// <param name="offset">The <see cref="HashDigest{TTxAction}"/> of the block to
         /// start finding the state. It will be The tip of the
-        /// <see cref="BlockChain{TTxaction, TBlockAction}"/> if it is <c>null</c>.</param>
-        /// <param name="completeStates">When the <see cref="BlockChain{TTxaction, TBlockAction}"/>
+        /// <see cref="BlockChain{TTxAction, TBlockAction}"/> if it is <c>null</c>.</param>
+        /// <param name="completeStates">When the <see cref="BlockChain{TTxAction, TBlockAction}"/>
         /// instance does not contain states dirty of the block which lastly
         /// updated states of a requested address, this option makes
         /// the incomplete states calculated and filled on the fly.
@@ -182,7 +182,7 @@ namespace Libplanet.Blockchain
         /// <returns>The <see cref="AddressStateMap"/> of given
         /// <paramref name="addresses"/>.</returns>
         /// <exception cref="IncompleteBlockStatesException">Thrown when
-        /// the <see cref="BlockChain{TTxaction, TBlockAction}"/> instance does not contain
+        /// the <see cref="BlockChain{TTxAction, TBlockAction}"/> instance does not contain
         /// states dirty of the block which lastly updated states of a requested
         /// address, because actions in the block have never been executed.
         /// If <paramref name="completeStates"/> option is turned on
@@ -303,15 +303,15 @@ namespace Libplanet.Blockchain
         /// the <paramref name="block"/> is confirmed (and thus all states
         /// reflect changes in the <paramref name="block"/>).</para>
         /// </summary>
-        /// <param name="block">A next <see cref="Block{TTxaction}"/>, which is mined,
+        /// <param name="block">A next <see cref="Block{TTxAction}"/>, which is mined,
         /// to add.</param>
         /// <exception cref="InvalidBlockException">Thrown when the given
         /// <paramref name="block"/> is invalid, in itself or according to
         /// the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
-        /// <see cref="Transaction{TTxaction}.Nonce"/> is different from
+        /// <see cref="Transaction{TTxAction}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{TTxaction}.Signer"/>.</exception>
+        /// <see cref="Transaction{TTxAction}.Signer"/>.</exception>
         public void Append(Block<TTxAction> block) =>
             Append(block, DateTimeOffset.UtcNow);
 
@@ -323,25 +323,25 @@ namespace Libplanet.Blockchain
         /// the <paramref name="block"/> is confirmed (and thus all states
         /// reflect changes in the <paramref name="block"/>).</para>
         /// </summary>
-        /// <param name="block">A next <see cref="Block{TTxaction}"/>, which is mined,
+        /// <param name="block">A next <see cref="Block{TTxAction}"/>, which is mined,
         /// to add.</param>
         /// <param name="currentTime">The current time.</param>
         /// <exception cref="InvalidBlockException">Thrown when the given
         /// <paramref name="block"/> is invalid, in itself or according to
         /// the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
-        /// <see cref="Transaction{TTxaction}.Nonce"/> is different from
+        /// <see cref="Transaction{TTxAction}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{TTxaction}.Signer"/>.</exception>
+        /// <see cref="Transaction{TTxAction}.Signer"/>.</exception>
         public void Append(Block<TTxAction> block, DateTimeOffset currentTime) =>
             Append(block, currentTime, render: true);
 
         /// <summary>
         /// Adds <paramref name="transactions"/> to the pending list so that
-        /// a next <see cref="Block{TTxaction}"/> to be mined contains these
+        /// a next <see cref="Block{TTxAction}"/> to be mined contains these
         /// <paramref name="transactions"/>.
         /// </summary>
-        /// <param name="transactions"> <see cref="Transaction{TTxaction}"/>s to add to the pending
+        /// <param name="transactions"> <see cref="Transaction{TTxAction}"/>s to add to the pending
         /// list. Keys are <see cref="Transactions"/>s and values are whether to broadcast.</param>
         public void StageTransactions(IDictionary<Transaction<TTxAction>, bool> transactions)
         {
@@ -367,7 +367,7 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// Removes <paramref name="transactions"/> from the pending list.
         /// </summary>
-        /// <param name="transactions"><see cref="Transaction{TTxaction}"/>s
+        /// <param name="transactions"><see cref="Transaction{TTxAction}"/>s
         /// to remove from the pending list.</param>
         /// <seealso cref="StageTransactions"/>
         public void UnstageTransactions(ISet<Transaction<TTxAction>> transactions)
@@ -386,11 +386,11 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Gets next <see cref="Transaction{TTxaction}.Nonce"/> of the address.
+        /// Gets next <see cref="Transaction{TTxAction}.Nonce"/> of the address.
         /// </summary>
         /// <param name="address">The <see cref="Address"/> from which to obtain the
-        /// <see cref="Transaction{TTxaction}.Nonce"/> value.</param>
-        /// <returns>The next <see cref="Transaction{TTxaction}.Nonce"/> value of the
+        /// <see cref="Transaction{TTxAction}.Nonce"/> value.</param>
+        /// <returns>The next <see cref="Transaction{TTxAction}.Nonce"/> value of the
         /// <paramref name="address"/>.</returns>
         public long GetNextTxNonce(Address address)
         {
@@ -445,7 +445,7 @@ namespace Libplanet.Blockchain
             MineBlock(miner, DateTimeOffset.UtcNow);
 
         /// <summary>
-        /// Creates a new <see cref="Transaction{TTxaction}"/> and stage the transaction.
+        /// Creates a new <see cref="Transaction{TTxAction}"/> and stage the transaction.
         /// </summary>
         /// <param name="privateKey">A <see cref="PrivateKey"/> of the account who creates and
         /// signs a new transaction.</param>
@@ -453,12 +453,12 @@ namespace Libplanet.Blockchain
         /// </param>
         /// <param name="updatedAddresses"><see cref="Address"/>es whose states affected by
         /// <paramref name="actions"/>.</param>
-        /// <param name="timestamp">The time this <see cref="Transaction{TTxaction}"/> is created
+        /// <param name="timestamp">The time this <see cref="Transaction{TTxAction}"/> is created
         /// and signed.</param>
         /// <param name="broadcast">Whether to broadcast created transaction.</param>
-        /// <returns>A created new <see cref="Transaction{TTxaction}"/> signed by the given
+        /// <returns>A created new <see cref="Transaction{TTxAction}"/> signed by the given
         /// <paramref name="privateKey"/>.</returns>
-        /// <seealso cref="Transaction{TTxaction}.Create" />
+        /// <seealso cref="Transaction{TTxAction}.Create" />
         public Transaction<TTxAction> MakeTransaction(
             PrivateKey privateKey,
             IEnumerable<TTxAction> actions,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -949,6 +949,13 @@ namespace Libplanet.Blockchain
                 lastStates = lastStates.SetState(miner, minerState);
             }
 
+            var actions = new List<TBlockAction>();
+
+            if (!Equals(Policy.BlockAction, default(TBlockAction)))
+            {
+                actions.Add(Policy.BlockAction);
+            }
+
             return ActionEvaluation<TBlockAction>.EvaluateActionsGradually(
                 block.Hash,
                 block.Index,
@@ -956,7 +963,7 @@ namespace Libplanet.Blockchain
                 miner,
                 miner,
                 Array.Empty<byte>(),
-                Policy.BlockActions.ToImmutableList());
+                actions.ToImmutableList());
         }
 
         private

--- a/Libplanet/Blockchain/IncompleteBlockStatesException.cs
+++ b/Libplanet/Blockchain/IncompleteBlockStatesException.cs
@@ -5,7 +5,7 @@ using Libplanet.Blocks;
 namespace Libplanet.Blockchain
 {
     /// <summary>
-    /// The exception that is thrown when a <see cref="BlockChain{T}"/> have
+    /// The exception that is thrown when a <see cref="BlockChain{TTxAction, TBlockAction}"/> have
     /// not calculated the complete states for all blocks, but an operation
     /// that needs some lacked states is requested.
     /// </summary>
@@ -32,7 +32,7 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// The <see cref="Block{T}.Hash"/> of <see cref="Block{T}"/> that
-        /// a <see cref="BlockChain{T}"/> lacks the states.
+        /// a <see cref="BlockChain{TTxAction, TBlockAction}"/> lacks the states.
         /// </summary>
         public HashDigest<SHA256> BlockHash { get; }
     }

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -3,19 +3,25 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
 {
     /// <summary>
-    /// A default implementation of <see cref="IBlockPolicy{T}"/> interface.
+    /// A default implementation of <see cref="IBlockPolicy{TTxAction, TBlockAction}"/> interface.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
-    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
-    public class BlockPolicy<T> : IBlockPolicy<T>
-        where T : IAction, new()
+    /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
+    /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type parameter.
+    /// </typeparam>
+    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
+    /// It should match to <see cref="Block{T}"/>'s type parameter.
+    /// </typeparam>
+    public class BlockPolicy<TTxAction, TBlockAction> : IBlockPolicy<TTxAction, TBlockAction>
+        where TTxAction : IAction, new()
+        where TBlockAction : IAction, new()
     {
         /// <summary>
-        /// Creates a <see cref="BlockPolicy{T}"/> with configuring
+        /// Creates a <see cref="BlockPolicy{TTxAction, TBlockAction}"/> with configuring
         /// <see cref="BlockInterval"/> in milliseconds,
         /// <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
@@ -40,7 +46,7 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <summary>
-        /// Creates a <see cref="BlockPolicy{T}"/> with configuring
+        /// Creates a <see cref="BlockPolicy{TxAction, TBlockActionT}"/> with configuring
         /// <see cref="BlockInterval"/>, <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
@@ -86,10 +92,10 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <summary>
-        /// An appropriate interval between consecutive <see cref="Block{T}"/>s.
+        /// An appropriate interval between consecutive <see cref="Block{TTxAction}"/>s.
         /// It is usually from 20 to 30 seconds.
         /// <para>If a previous interval took longer than this
-        /// <see cref="GetNextBlockDifficulty(IReadOnlyList{Block{T}})"/> method
+        /// <see cref="GetNextBlockDifficulty(IReadOnlyList{Block{TTxAction}})"/> method
         /// raises the <see cref="Block{T}.Difficulty"/>.  If it took shorter
         /// than this <see cref="Block{T}.Difficulty"/> is dropped.</para>
         /// </summary>
@@ -101,13 +107,13 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         public InvalidBlockException ValidateNextBlock(
-            IReadOnlyList<Block<T>> blocks,
-            Block<T> nextBlock)
+            IReadOnlyList<Block<TTxAction>> blocks,
+            Block<TTxAction> nextBlock)
         {
             int index = blocks.Count;
             long difficulty = GetNextBlockDifficulty(blocks);
 
-            Block<T> lastBlock = index >= 1 ? blocks[index - 1] : null;
+            Block<TTxAction> lastBlock = index >= 1 ? blocks[index - 1] : null;
             HashDigest<SHA256>? prevHash = lastBlock?.Hash;
             DateTimeOffset? prevTimestamp = lastBlock?.Timestamp;
 
@@ -154,7 +160,7 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc />
-        public long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks)
+        public long GetNextBlockDifficulty(IReadOnlyList<Block<TTxAction>> blocks)
         {
             int index = blocks.Count;
 

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -27,7 +27,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
-        /// <param name="blockActions">A list of <see cref="IAction"/>s for a miner.</param>
+        /// <param name="blockAction">A <see cref="IAction"/>s to execute when appending a block.
+        /// </param>
         /// <param name="blockIntervalMilliseconds">Configures
         /// <see cref="BlockInterval"/> in milliseconds.
         /// 5000 milliseconds by default.
@@ -37,12 +38,12 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         public BlockPolicy(
-            IEnumerable<TBlockAction> blockActions = null,
+            TBlockAction blockAction = default(TBlockAction),
             int blockIntervalMilliseconds = 5000,
             long minimumDifficulty = 1024,
             int difficultyBoundDivisor = 128)
             : this(
-                blockActions,
+                blockAction,
                 TimeSpan.FromMilliseconds(blockIntervalMilliseconds),
                 minimumDifficulty,
                 difficultyBoundDivisor)
@@ -54,7 +55,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="BlockInterval"/>, <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
-        /// <param name="blockActions">A list of <see cref="IAction"/>s for a miner.</param>
+        /// <param name="blockAction">A <see cref="IAction"/>s to execute when appending a block.
+        /// </param>
         /// <param name="blockInterval">Configures <see cref="BlockInterval"/>.
         /// </param>
         /// <param name="minimumDifficulty">Configures
@@ -62,7 +64,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>.</param>
         public BlockPolicy(
-            IEnumerable<TBlockAction> blockActions,
+            TBlockAction blockAction,
             TimeSpan blockInterval,
             long minimumDifficulty,
             int difficultyBoundDivisor)
@@ -92,9 +94,7 @@ namespace Libplanet.Blockchain.Policies
                     message);
             }
 
-            BlockActions = blockActions is null
-                ? new List<TBlockAction>()
-                : blockActions.ToList();
+            BlockAction = blockAction;
             BlockInterval = blockInterval;
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
@@ -111,7 +111,7 @@ namespace Libplanet.Blockchain.Policies
         public TimeSpan BlockInterval { get; }
 
         /// <inheritdoc/>
-        public IList<TBlockAction> BlockActions { get; }
+        public TBlockAction BlockAction { get; }
 
         private long MinimumDifficulty { get; }
 

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         public BlockPolicy(
-            TBlockAction blockAction = default(TBlockAction),
+            TBlockAction blockAction,
             int blockIntervalMilliseconds = 5000,
             long minimumDifficulty = 1024,
             int difficultyBoundDivisor = 128)

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -14,9 +14,8 @@ namespace Libplanet.Blockchain.Policies
     /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
     /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type parameter.
     /// </typeparam>
-    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
-    /// It should match to <see cref="Block{T}"/>'s type parameter.
-    /// </typeparam>
+    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type for
+    /// <see cref="IBlockPolicy{TTxAction,TBlockAction}.BlockAction"/>.</typeparam>
     public class BlockPolicy<TTxAction, TBlockAction> : IBlockPolicy<TTxAction, TBlockAction>
         where TTxAction : IAction, new()
         where TBlockAction : IAction, new()

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -26,6 +27,7 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
+        /// <param name="blockActions">A list of <see cref="IAction"/>s for a miner.</param>
         /// <param name="blockIntervalMilliseconds">Configures
         /// <see cref="BlockInterval"/> in milliseconds.
         /// 5000 milliseconds by default.
@@ -35,10 +37,12 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         public BlockPolicy(
+            IEnumerable<TBlockAction> blockActions = null,
             int blockIntervalMilliseconds = 5000,
             long minimumDifficulty = 1024,
             int difficultyBoundDivisor = 128)
             : this(
+                blockActions,
                 TimeSpan.FromMilliseconds(blockIntervalMilliseconds),
                 minimumDifficulty,
                 difficultyBoundDivisor)
@@ -50,6 +54,7 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="BlockInterval"/>, <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
+        /// <param name="blockActions">A list of <see cref="IAction"/>s for a miner.</param>
         /// <param name="blockInterval">Configures <see cref="BlockInterval"/>.
         /// </param>
         /// <param name="minimumDifficulty">Configures
@@ -57,6 +62,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>.</param>
         public BlockPolicy(
+            IEnumerable<TBlockAction> blockActions,
             TimeSpan blockInterval,
             long minimumDifficulty,
             int difficultyBoundDivisor)
@@ -86,6 +92,9 @@ namespace Libplanet.Blockchain.Policies
                     message);
             }
 
+            BlockActions = blockActions is null
+                ? new List<TBlockAction>()
+                : blockActions.ToList();
             BlockInterval = blockInterval;
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
@@ -100,6 +109,9 @@ namespace Libplanet.Blockchain.Policies
         /// than this <see cref="Block{T}.Difficulty"/> is dropped.</para>
         /// </summary>
         public TimeSpan BlockInterval { get; }
+
+        /// <inheritdoc/>
+        public IList<TBlockAction> BlockActions { get; }
 
         private long MinimumDifficulty { get; }
 

--- a/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
@@ -2,14 +2,15 @@ using System;
 using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
 {
     /// <summary>
     /// This extension class enables some convenient methods (sugar for
-    /// the most part) to deal with <see cref="IBlockPolicy{T}"/>.
+    /// the most part) to deal with <see cref="IBlockPolicy{TTxAction, TBlockAction}"/>.
     /// </summary>
-    /// <seealso cref="IBlockPolicy{T}"/>
+    /// <seealso cref="IBlockPolicy{TTxAction, TBlockAction}"/>
     public static class BlockPolicyExtension
     {
         /// <summary>
@@ -18,7 +19,7 @@ namespace Libplanet.Blockchain.Policies
         /// <para>Note that it returns <c>null</c> when blocks are
         /// <em>valid</em>.</para>
         /// </summary>
-        /// <param name="policy"><see cref="IBlockPolicy{T}"/> to used for
+        /// <param name="policy"><see cref="IBlockPolicy{TTxAction, TBlockAction}"/> to used for
         /// validation <paramref name="blocks"/>.</param>
         /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
         /// validate.</param>
@@ -28,18 +29,23 @@ namespace Libplanet.Blockchain.Policies
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
-        /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
-        /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
-        /// <seealso cref="IBlockPolicy{T}"/>
-        /// <seealso cref="IBlockPolicy{T}.ValidateNextBlock"/>
-        public static InvalidBlockException ValidateBlocks<T>(
-            this IBlockPolicy<T> policy,
-            IReadOnlyList<Block<T>> blocks,
+        /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
+        /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type
+        /// parameter.</typeparam>
+        /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
+        /// It should match to <see cref="Block{T}"/>'s type parameter.
+        /// </typeparam>
+        /// <seealso cref="IBlockPolicy{TTxAction, TBlockAction}"/>
+        /// <seealso cref="IBlockPolicy{TTxAction, TBlockAction}.ValidateNextBlock"/>
+        public static InvalidBlockException ValidateBlocks<TTxAction, TBlockAction>(
+            this IBlockPolicy<TTxAction, TBlockAction> policy,
+            IReadOnlyList<Block<TTxAction>> blocks,
             DateTimeOffset currentTime)
-            where T : IAction, new()
+            where TTxAction : IAction, new()
+            where TBlockAction : IAction, new()
         {
-            var tempBlocks = new List<Block<T>>();
-            foreach (Block<T> block in blocks)
+            var tempBlocks = new List<Block<TTxAction>>();
+            foreach (Block<TTxAction> block in blocks)
             {
                 InvalidBlockException exception =
                     policy.ValidateNextBlock(tempBlocks, block);

--- a/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicyExtension.cs
@@ -32,9 +32,8 @@ namespace Libplanet.Blockchain.Policies
         /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
         /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type
         /// parameter.</typeparam>
-        /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
-        /// It should match to <see cref="Block{T}"/>'s type parameter.
-        /// </typeparam>
+        /// <typeparam name="TBlockAction">An <see cref="IAction"/> type for
+        /// <see cref="IBlockPolicy{TTxAction,TBlockAction}.BlockAction"/>.</typeparam>
         /// <seealso cref="IBlockPolicy{TTxAction, TBlockAction}"/>
         /// <seealso cref="IBlockPolicy{TTxAction, TBlockAction}.ValidateNextBlock"/>
         public static InvalidBlockException ValidateBlocks<TTxAction, TBlockAction>(

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -13,18 +13,16 @@ namespace Libplanet.Blockchain.Policies
     /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
     /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type parameter.
     /// </typeparam>
-    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
-    /// It should match to <see cref="Block{T}"/>'s type parameter.
-    /// </typeparam>
+    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type for
+    /// <see cref="IBlockPolicy{TTxAction,TBlockAction}.BlockAction"/>.</typeparam>
     /// <seealso cref="BlockPolicyExtension"/>
     public interface IBlockPolicy<TTxAction, out TBlockAction>
         where TTxAction : IAction, new()
         where TBlockAction : IAction, new()
     {
         /// <summary>
-        /// Gets a block action to execute when appending a block.
+        /// A block action to execute and be rendered for every block.
         /// </summary>
-        /// <returns>A list of <see cref="IAction"/>s for a miner.</returns>
         TBlockAction BlockAction { get; }
 
         /// <summary>

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -22,6 +22,12 @@ namespace Libplanet.Blockchain.Policies
         where TBlockAction : IAction, new()
     {
         /// <summary>
+        /// Gets a list of block actions to execute when appending a block.
+        /// </summary>
+        /// <returns>A list of <see cref="IAction"/>s for a miner.</returns>
+        IList<TBlockAction> BlockActions { get; }
+
+        /// <summary>
         /// Checks if <paramref name="nextBlock"/> is invalid, and if that
         /// returns the reason.
         /// <para>Note that it returns <c>null</c> when

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -17,15 +17,15 @@ namespace Libplanet.Blockchain.Policies
     /// It should match to <see cref="Block{T}"/>'s type parameter.
     /// </typeparam>
     /// <seealso cref="BlockPolicyExtension"/>
-    public interface IBlockPolicy<TTxAction, TBlockAction>
+    public interface IBlockPolicy<TTxAction, out TBlockAction>
         where TTxAction : IAction, new()
         where TBlockAction : IAction, new()
     {
         /// <summary>
-        /// Gets a list of block actions to execute when appending a block.
+        /// Gets a block action to execute when appending a block.
         /// </summary>
         /// <returns>A list of <see cref="IAction"/>s for a miner.</returns>
-        IList<TBlockAction> BlockActions { get; }
+        TBlockAction BlockAction { get; }
 
         /// <summary>
         /// Checks if <paramref name="nextBlock"/> is invalid, and if that

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
 {
@@ -9,11 +10,16 @@ namespace Libplanet.Blockchain.Policies
     /// valid, and to suggest how difficult a <see cref="Block{T}.Nonce"/>
     /// for a <see cref="Block{T}"/> to be mined.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
-    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    /// <typeparam name="TTxAction">An <see cref="IAction"/> type used for
+    /// <see cref="Transaction{T}"/>.  It should match to <see cref="Block{T}"/>'s type parameter.
+    /// </typeparam>
+    /// <typeparam name="TBlockAction">An <see cref="IAction"/> type used when mining.
+    /// It should match to <see cref="Block{T}"/>'s type parameter.
+    /// </typeparam>
     /// <seealso cref="BlockPolicyExtension"/>
-    public interface IBlockPolicy<T>
-        where T : IAction, new()
+    public interface IBlockPolicy<TTxAction, TBlockAction>
+        where TTxAction : IAction, new()
+        where TBlockAction : IAction, new()
     {
         /// <summary>
         /// Checks if <paramref name="nextBlock"/> is invalid, and if that
@@ -28,10 +34,10 @@ namespace Libplanet.Blockchain.Policies
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
-        /// <seealso cref="BlockPolicyExtension.ValidateBlocks{T}"/>
+        /// <seealso cref="BlockPolicyExtension.ValidateBlocks{TTxAction, TBlockAction}"/>
         InvalidBlockException ValidateNextBlock(
-            IReadOnlyList<Block<T>> blocks,
-            Block<T> nextBlock);
+            IReadOnlyList<Block<TTxAction>> blocks,
+            Block<TTxAction> nextBlock);
 
         /// <summary>
         /// Determines a right <see cref="Block{T}.Difficulty"/>
@@ -42,6 +48,6 @@ namespace Libplanet.Blockchain.Policies
         /// followed by a new <see cref="Block{T}"/> to be mined.</param>
         /// <returns>A right <see cref="Block{T}.Difficulty"/>
         /// for a new <see cref="Block{T}"/> to be mined.</returns>
-        long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks);
+        long GetNextBlockDifficulty(IReadOnlyList<Block<TTxAction>> blocks);
     }
 }

--- a/Libplanet/Net/DifferentAppProtocolVersionException.cs
+++ b/Libplanet/Net/DifferentAppProtocolVersionException.cs
@@ -4,7 +4,7 @@ namespace Libplanet.Net
 {
     /// <summary>
     /// The exception that is thrown when the version of the
-    /// <see cref="Peer" /> that <see cref="Swarm{T}" /> is trying to connect
+    /// <see cref="Peer" /> that <see cref="Swarm{TTxAction, TBlockAction}" /> is trying to connect
     /// to is different.
     /// </summary>
     [Serializable]
@@ -15,10 +15,10 @@ namespace Libplanet.Net
         /// <see cref="DifferentAppProtocolVersionException"/> class.
         /// </summary>
         /// <param name="expectedVersion">The protocol version of the current
-        /// <see cref="Swarm{T}"/>.</param>
+        /// <see cref="Swarm{TTxAction, TBlockAction}"/>.</param>
         /// <param name="actualVersion">The protocol version of the
-        /// <see cref="Peer"/> that <see cref="Swarm{T}" /> is trying to connect
-        /// to.</param>
+        /// <see cref="Peer"/> that <see cref="Swarm{TTxAction, TBlockAction}" /> is trying to
+        /// connect to.</param>
         /// <param name="message">Specifies an <see cref="Exception.Message"/>.
         /// </param>
         public DifferentAppProtocolVersionException(
@@ -33,13 +33,13 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// The protocol version of the current <see cref="Swarm{T}"/>.
+        /// The protocol version of the current <see cref="Swarm{TTxAction, TBlockAction}"/>.
         /// </summary>
         public int ExpectedVersion { get; }
 
         /// <summary>
         /// The protocol version of the <see cref="Peer"/> that the
-        /// <see cref="Swarm{T}" /> is trying to connect to.
+        /// <see cref="Swarm{TTxAction, TBlockAction}" /> is trying to connect to.
         /// </summary>
         public int ActualVersion { get; }
     }

--- a/Libplanet/Net/DifferentProtocolVersionEventArgs.cs
+++ b/Libplanet/Net/DifferentProtocolVersionEventArgs.cs
@@ -2,18 +2,18 @@ namespace Libplanet.Net
 {
     /// <summary>
     /// The event data that provides a value when
-    /// <see cref="Swarm{T}.DifferentVersionPeerEncountered" /> is occured.
+    /// <see cref="Swarm{TTxAction, TBlockAction}.DifferentVersionPeerEncountered" /> is occured.
     /// </summary>
     public class DifferentProtocolVersionEventArgs
     {
         /// <summary>
-        /// The protocol version of the current <see cref="Swarm{T}"/>.
+        /// The protocol version of the current <see cref="Swarm{TTxAction, TBlockAction}"/>.
         /// </summary>
         public int ExpectedVersion { get; set; }
 
         /// <summary>
         /// The protocol version of the <see cref="Peer"/> that the
-        /// <see cref="Swarm{T}" /> is trying to connect to.
+        /// <see cref="Swarm{TTxAction, TBlockAction}" /> is trying to connect to.
         /// </summary>
         public int ActualVersion { get; set; }
     }

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Net
     /// <summary>
     /// A representation of peer node.
     /// </summary>
-    /// <seealso cref="Swarm{T}"/>
+    /// <seealso cref="Swarm{TTxAction, TBlockAction}"/>
     [Serializable]
     [Equals]
     public class Peer : ISerializable
@@ -92,7 +92,7 @@ namespace Libplanet.Net
         /// <summary>
         /// The corresponding application protocol version of this peer.
         /// </summary>
-        /// <seealso cref="Swarm{T}.DifferentVersionPeerEncountered"/>
+        /// <seealso cref="Swarm{TTxAction, TBlockAction}.DifferentVersionPeerEncountered"/>
         [IgnoreDuringEquals]
         [Pure]
         public int? AppProtocolVersion { get; }

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -156,7 +156,8 @@ namespace Libplanet.Store
         /// <paramref name="block"/>.</typeparam>
         /// <remarks>State reference must be stored in the same order as the blocks. For now,
         /// it is assumed that this is only called by
-        /// <see cref="BlockChain{T}.Append(Block{T}, DateTimeOffset, bool)"/> method.</remarks>
+        /// <see cref="BlockChain{TTxAction, TBlockAction}.Append(
+        /// Block{TTxAction}, DateTimeOffset, bool)"/> method.</remarks>
         /// <seealso cref="IterateStateReferences(string, Address)"/>
         void StoreStateReference<T>(
             string @namespace,

--- a/Libplanet/Tx/InvalidTxNonceException.cs
+++ b/Libplanet/Tx/InvalidTxNonceException.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Tx
 {
     /// <summary>
     /// The exception that is thrown when the <see cref="Transaction{T}.Nonce"/>
-    /// is different from <see cref="BlockChain{T}.GetNextTxNonce"/> result of
+    /// is different from <see cref="BlockChain{TTxAction, TBlockAction}.GetNextTxNonce"/> result of
     /// the <see cref="Transaction{T}.Signer"/>.
     /// </summary>
     [Serializable]
@@ -19,7 +19,8 @@ namespace Libplanet.Tx
         /// <param name="txid">The invalid <see cref="Transaction{T}"/>'s
         /// <see cref="Transaction{T}.Id"/>.  It is automatically included to
         /// the <see cref="Exception.Message"/> string.</param>
-        /// <param name="expectedNonce"><see cref="BlockChain{T}.GetNextTxNonce"/>
+        /// <param name="expectedNonce">
+        /// <see cref="BlockChain{TTxAction, TBlockAction}.GetNextTxNonce"/>
         /// result of the <see cref="Transaction{T}.Signer"/>.</param>
         /// <param name="improperNonce">The actual
         /// <see cref="Transaction{T}.Nonce"/>.</param>
@@ -44,7 +45,7 @@ namespace Libplanet.Tx
         }
 
         /// <summary>
-        /// <see cref="BlockChain{T}.GetNextTxNonce"/> result of the
+        /// <see cref="BlockChain{TTxAction, TBlockAction}.GetNextTxNonce"/> result of the
         /// <see cref="Transaction{T}.Signer"/>.
         /// </summary>
         public long ExpectedNonce { get; }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -521,69 +521,15 @@ namespace Libplanet.Tx
             bool rehearsal = false
         )
         {
-            ActionContext CreateActionContext(
-                IAccountStateDelta prevStates,
-                int randomSeed
-            ) =>
-                new ActionContext(
-                    signer: Signer,
-                    miner: minerAddress,
-                    blockIndex: blockIndex,
-                    previousStates: prevStates,
-                    randomSeed: randomSeed,
-                    rehearsal: rehearsal
-                );
-
-            int seed =
-                BitConverter.ToInt32(blockHash.ToByteArray(), 0) ^
-                (Signature.Any() ? BitConverter.ToInt32(Signature, 0) : 0);
-            IAccountStateDelta states = previousStates;
-            foreach (T action in Actions)
-            {
-                ActionContext context =
-                    CreateActionContext(states, seed);
-                IAccountStateDelta nextStates;
-                try
-                {
-                    nextStates = action.Execute(context);
-                }
-                catch (Exception e)
-                {
-                    if (!rehearsal)
-                    {
-                        throw;
-                    }
-
-                    var msg =
-                        $"The action {action} threw an exception during its " +
-                        "rehearsal.  It is probably because the logic of the " +
-                        $"action {action} is not enough generic so that it " +
-                        "can cover every case including rehearsal mode.\n" +
-                        "The IActionContext.Rehearsal property also might be " +
-                        "useful to make the action can deal with the case of " +
-                        "rehearsal mode.\n" +
-                        "See also this exception's InnerException property.";
-                    throw new UnexpectedlyTerminatedTxRehearsalException(
-                        action, msg, e
-                    );
-                }
-
-                // As IActionContext.Random is stateful, we cannot reuse
-                // the context which is once consumed by Execute().
-                ActionContext equivalentContext =
-                    CreateActionContext(states, seed);
-
-                yield return new ActionEvaluation<T>(
-                    action,
-                    equivalentContext,
-                    nextStates
-                );
-                states = nextStates;
-                unchecked
-                {
-                    seed++;
-                }
-            }
+            return ActionEvaluation<T>.EvaluateActionsGradually(
+                blockHash,
+                blockIndex,
+                previousStates,
+                minerAddress,
+                Signer,
+                Signature,
+                Actions,
+                rehearsal);
         }
 
         /// <summary>

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Tx
     /// Each game usually defines its own concrete class which implements
     /// <see cref="IAction"/>, and uses it for this type parameter.
     /// This type parameter is aligned with <see cref="Blocks.Block{T}"/>'s
-    /// and <see cref="Blockchain.BlockChain{T}"/>'s type parameters.
+    /// and <see cref="Blockchain.BlockChain{TTxAction, TBlockAction}"/>'s type parameters.
     /// </typeparam>
     /// <seealso cref="IAction"/>
     /// <seealso cref="PolymorphicAction{T}"/>


### PR DESCRIPTION
This implements #319.

There are a lot of changes, so please refer to the following:
- The first commit simply changes generic types of classes.
- The second commit adds `BlockActions` property to `IBlockPolicy`.
- The third commit implements block action evaluation.
- Later commits are clean up tests and changelog.