### PR TITLE
Re-stage transactions when receiving already unstaged

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,12 +30,15 @@ To be released.
     `IAction`s in the preloaded behind blocks.  [[#272], [#343]]
  -  `Swarm<T>` became to have two more message types: `GetRecentStates` (`0x0b`)
     and `RecentStates` (`0x0c`).  [[#272], [#343]]
+ -  `Swarm<T>` became to stage transanctions again when receiving already
+    unstaged.  [[#362]]
 
 ### Bug fixes
 
 
 [#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350
+[#362]: https://github.com/planetarium/libplanet/pull/362
 
 
 Version 0.4.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,9 @@ To be released.
     `IAction`s in the preloaded behind blocks.  [[#272], [#343]]
  -  `Swarm<T>` became to have two more message types: `GetRecentStates` (`0x0b`)
     and `RecentStates` (`0x0c`).  [[#272], [#343]]
- -  `Swarm<T>` became to stage transanctions again when receiving already
-    unstaged.  [[#362]]
+ -  `Swarm<T>` became to stage transactions again even if a transaction was
+    already received and unstaged due to some error (e.g., invalid tx nonce).
+    [[#362]]
 
 ### Bug fixes
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -731,6 +731,51 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
+        public async Task RestageWhenTxIdReceived()
+        {
+            Swarm<DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction> swarmB = _swarms[1];
+
+            BlockChain<DumbAction> chainA = _blockchains[0];
+            BlockChain<DumbAction> chainB = _blockchains[1];
+
+            Transaction<DumbAction>[] txs = new[]
+            {
+                Transaction<DumbAction>.Create(
+                    0,
+                    new PrivateKey(),
+                    new DumbAction[] { }),
+                Transaction<DumbAction>.Create(
+                    0,
+                    new PrivateKey(),
+                    new DumbAction[] { }),
+            };
+
+            chainA.StageTransactions(txs.ToDictionary(tx => tx, _ => true));
+
+            // chainB also knows `txs[1]`, but it didn't stage.
+            chainB.Transactions[txs[1].Id] = txs[1];
+
+            try
+            {
+                await StartAsync(swarmA);
+                await StartAsync(swarmB);
+
+                // Broadcast tx swarmA to swarmB
+                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer });
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                Assert.Contains(txs[0].Id, chainB.GetStagedTransactionIds(true));
+                Assert.Contains(txs[1].Id, chainB.GetStagedTransactionIds(true));
+            }
+            finally
+            {
+                await Task.WhenAll(
+                    swarmA.StopAsync(),
+                    swarmB.StopAsync());
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
         public async Task CanBroadcastBlock()
         {
             Swarm<DumbAction> swarmA = _swarms[0];


### PR DESCRIPTION
This PR makes `Swarm<T>` to re-stage transactions when receiving already unstaged.