### PR TITLE
LiteDBStore.IterateStagedTransactionIds() should returns unique txids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,10 +36,14 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where the `LiteDBStore.IterateStagedTransactionIds()` returns
+    duplicated transaction ids.  [[#366]]
+
 
 [#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350
 [#365]: https://github.com/planetarium/libplanet/pull/365
+[#366]: https://github.com/planetarium/libplanet/pull/366
 
 
 Version 0.4.1

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -413,6 +413,29 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
+        public void StoreStageOnce()
+        {
+            Fx.Store.PutTransaction(Fx.Transaction1);
+            Fx.Store.PutTransaction(Fx.Transaction2);
+
+            var txIds = new HashSet<TxId>()
+            {
+                Fx.Transaction1.Id,
+                Fx.Transaction2.Id,
+            };
+
+            Dictionary<TxId, bool> toStage = txIds.ToDictionary(txId => txId, _ => true);
+
+            Fx.Store.StageTransactionIds(toStage);
+            Fx.Store.StageTransactionIds(
+                new Dictionary<TxId, bool> { { Fx.Transaction1.Id, true } });
+
+            Assert.Equal(
+                new[] { Fx.Transaction1.Id, Fx.Transaction2.Id }.OrderBy(txId => txId.ToHex()),
+                Fx.Store.IterateStagedTransactionIds(false).OrderBy(txId => txId.ToHex()));
+        }
+
+        [Fact]
         public void IterateStagedTransactionIdsToBroadcast()
         {
             var toStage = new Dictionary<TxId, bool>

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -194,12 +194,13 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)
         {
+            IEnumerable<StagedTxIdDoc> docs = StagedTxIds.FindAll();
             if (toBroadcast)
             {
-                return StagedTxIds.FindAll().Where(t => t.Broadcast).Select(t => t.TxId);
+                docs = docs.Where(d => d.Broadcast);
             }
 
-            return StagedTxIds.FindAll().Select(t => t.TxId);
+            return docs.Select(d => d.TxId).Distinct();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR fixes a bug that `LiteDBStore.IterateStagedTransactionIds()` returns duplicated transaction ids.