### PR TITLE
Evaluate Block Action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ To be released.
  -  `StoreExtension.LookupStateReference<T>()` method became to return
     `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
     and `Block<T>.Index`.  [[#350]]
+ -  Added `IBlockPolicy<T>.BlockAction` property.  [[#319], [#367]]
+ -  Removed the type parameter of `ActionEvaluation`.  [[#319], [#367]]
+ -  `ActionEvaluation.Action` became to `IAction` type.  [[#319], [#367]]
 
 ### Added interfaces
 
@@ -37,6 +40,8 @@ To be released.
  -  `BlockChain<T>.MineBlock()` and `BlockChain<T>.GetNextTxNonce()` methods
     became to ignore transactions that didn't follow `Transaction<T>.Nonce`
     sequentially and treat them as pendings.  [[#365]]
+ - `BlockChain<T>` became to evaluate `IBlockPolicy<T>.BlockAction` and set the
+   state when a block is appended to the chain.  [[#319], [#367]]
 
 ### Bug fixes
 
@@ -44,11 +49,13 @@ To be released.
     duplicated transaction ids.  [[#366]]
 
 
+[#319]: https://github.com/planetarium/libplanet/issues/319
 [#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350
 [#363]: https://github.com/planetarium/libplanet/pull/363
 [#365]: https://github.com/planetarium/libplanet/pull/365
 [#366]: https://github.com/planetarium/libplanet/pull/366
+[#367]: https://github.com/planetarium/libplanet/pull/367
 
 
 Version 0.4.1

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Tests.Action
         public void Constructor()
         {
             Address address = new PrivateKey().PublicKey.ToAddress();
-            var evaluation = new ActionEvaluation<DumbAction>(
+            var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(
                     address,
@@ -25,9 +25,10 @@ namespace Libplanet.Tests.Action
                     a => a.Equals(address) ? "item" : null
                 )
             );
+            var action = (DumbAction)evaluation.Action;
 
-            Assert.Equal(address, evaluation.Action.TargetAddress);
-            Assert.Equal("item", evaluation.Action.Item);
+            Assert.Equal(address, action.TargetAddress);
+            Assert.Equal("item", action.Item);
             Assert.Equal(address, evaluation.InputContext.Signer);
             Assert.Equal(address, evaluation.InputContext.Miner);
             Assert.Equal(1, evaluation.InputContext.BlockIndex);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1231,7 +1231,7 @@ namespace Libplanet.Tests.Blockchain
             Address signer = privateKey.PublicKey.ToAddress();
 
             IImmutableDictionary<Address, object> GetDirty(
-                IEnumerable<ActionEvaluation<DumbAction>> evaluations) =>
+                IEnumerable<ActionEvaluation> evaluations) =>
                 evaluations.Select(
                     a => a.OutputStates
                 ).Aggregate(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -260,8 +260,7 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void Append()
         {
-            DumbAction.RenderRecords.Value =
-                ImmutableList<DumbAction.RenderRecord>.Empty;
+            DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
             (
                 IImmutableDictionary<Address, object> expectedStates,
@@ -283,9 +282,10 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Equal(blocks, _blockChain.ToArray());
                 Assert.NotNull(_blockChain.Store.GetBlockStates(blocks[1].Hash));
                 var renders = DumbAction.RenderRecords.Value;
+                var actions = renders.Select(r => (DumbAction)r.Action).ToArray();
                 Assert.Equal(4, renders.Count);
                 Assert.True(renders.All(r => r.Render));
-                Assert.Equal("foo", renders[0].Action.Item);
+                Assert.Equal("foo", actions[0].Item);
                 Assert.Equal(1, renders[0].Context.BlockIndex);
                 Assert.Equal(
                     new string[] { null, null, null, null },
@@ -295,7 +295,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", null, null, null },
                     addresses.Select(renders[0].NextStates.GetState)
                 );
-                Assert.Equal("bar", renders[1].Action.Item);
+                Assert.Equal("bar", actions[1].Item);
                 Assert.Equal(1, renders[1].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[0].NextStates.GetState),
@@ -305,7 +305,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", "bar", null, null },
                     addresses.Select(renders[1].NextStates.GetState)
                 );
-                Assert.Equal("baz", renders[2].Action.Item);
+                Assert.Equal("baz", actions[2].Item);
                 Assert.Equal(1, renders[2].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[1].NextStates.GetState),
@@ -315,7 +315,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { "foo", "bar", "baz", null },
                     addresses.Select(renders[2].NextStates.GetState)
                 );
-                Assert.Equal("qux", renders[3].Action.Item);
+                Assert.Equal("qux", actions[3].Item);
                 Assert.Equal(1, renders[3].Context.BlockIndex);
                 Assert.Equal(
                     addresses.Select(renders[2].NextStates.GetState),
@@ -328,15 +328,14 @@ namespace Libplanet.Tests.Blockchain
             }
             finally
             {
-                DumbAction.RenderRecords.Value =
-                    ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 
         [Fact]
         public void AppendWithoutEvaluateActions()
         {
-            DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
+            DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
             (_, Block<DumbAction>[] blocks) = MakeFixturesForAppendTests();
 
@@ -365,7 +364,7 @@ namespace Libplanet.Tests.Blockchain
             }
             finally
             {
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 
@@ -714,8 +713,7 @@ namespace Libplanet.Tests.Blockchain
 
             try
             {
-                DumbAction.RenderRecords.Value =
-                    ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
                 Block<DumbAction> forkTip = TestUtils.MineNext(
                     fork.Tip,
@@ -738,6 +736,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Empty(_blockChain.Store.ListTxNonces(previousNamespace));
 
                 var renders = DumbAction.RenderRecords.Value;
+                var actions = renders.Select(r => (DumbAction)r.Action).ToArray();
 
                 int actionsCountA = txsA.Sum(
                     a => a.Sum(tx => tx.Actions.Count)
@@ -750,13 +749,13 @@ namespace Libplanet.Tests.Blockchain
                     Assert.True(renders.Take(actionsCountA).All(r => r.Unrender));
                     Assert.True(renders.Skip(actionsCountA).All(r => r.Render));
 
-                    Assert.Equal("qux", renders[0].Action.Item);
-                    Assert.Equal("baz", renders[1].Action.Item);
-                    Assert.Equal("bar", renders[2].Action.Item);
-                    Assert.Equal("foo", renders[3].Action.Item);
-                    Assert.Equal("fork-foo", renders[4].Action.Item);
-                    Assert.Equal("fork-bar", renders[5].Action.Item);
-                    Assert.Equal("fork-baz", renders[6].Action.Item);
+                    Assert.Equal("qux", actions[0].Item);
+                    Assert.Equal("baz", actions[1].Item);
+                    Assert.Equal("bar", actions[2].Item);
+                    Assert.Equal("foo", actions[3].Item);
+                    Assert.Equal("fork-foo", actions[4].Item);
+                    Assert.Equal("fork-bar", actions[5].Item);
+                    Assert.Equal("fork-baz", actions[6].Item);
                 }
                 else
                 {
@@ -765,8 +764,7 @@ namespace Libplanet.Tests.Blockchain
             }
             finally
             {
-                DumbAction.RenderRecords.Value =
-                    ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Tests.Blockchain
             _exceptionToThrow = exceptionToThrow;
         }
 
-        public IAction BlockAction { get; }
+        public IAction BlockAction => null;
 
         public long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
             blocks.Any() ? 1 : 0;

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -16,6 +16,8 @@ namespace Libplanet.Tests.Blockchain
             _exceptionToThrow = exceptionToThrow;
         }
 
+        public IAction BlockAction { get; }
+
         public long GetNextBlockDifficulty(IReadOnlyList<Block<T>> blocks) =>
             blocks.Any() ? 1 : 0;
 

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -31,6 +31,7 @@ namespace Libplanet.Tests.Blockchain.Policies
             _output = output;
             _blocks = new List<Block<DumbAction>>();
             _policy = new BlockPolicy<DumbAction>(
+                null,
                 TimeSpan.FromMilliseconds(5000),
                 1024,
                 128);
@@ -49,10 +50,10 @@ namespace Libplanet.Tests.Blockchain.Policies
         public void Constructors()
         {
             var tenSec = new TimeSpan(0, 0, 10);
-            var a = new BlockPolicy<DumbAction>(tenSec, 1024, 128);
+            var a = new BlockPolicy<DumbAction>(null, tenSec, 1024, 128);
             Assert.Equal(tenSec, a.BlockInterval);
 
-            var b = new BlockPolicy<DumbAction>(65000);
+            var b = new BlockPolicy<DumbAction>(null, 65000);
             Assert.Equal(
                 new TimeSpan(0, 1, 5),
                 b.BlockInterval);
@@ -63,20 +64,20 @@ namespace Libplanet.Tests.Blockchain.Policies
                 c.BlockInterval);
 
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction>(tenSec.Negate(), 1024, 128));
+                () => new BlockPolicy<DumbAction>(null, tenSec.Negate(), 1024, 128));
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction>(-5));
+                () => new BlockPolicy<DumbAction>(null, -5));
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(tenSec, 0, 128));
+                new BlockPolicy<DumbAction>(null, tenSec, 0, 128));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(tenSec, 1024, 1024));
+                new BlockPolicy<DumbAction>(null, tenSec, 1024, 1024));
         }
 
         [Fact]
         public void GetNextBlockDifficulty()
         {
-            var policy = new BlockPolicy<DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction>(null, new TimeSpan(3, 0, 0), 1024, 128);
             Block<DumbAction>[] blocks = MineBlocks(
                 new[] { (0, 0), (1, 1024), (3, 1032), (7, 1040), (9, 1040), (13, 1048) }
             ).ToArray();
@@ -229,7 +230,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         [Fact]
         public void ValidateBlocks()
         {
-            var policy = new BlockPolicy<DumbAction>(new TimeSpan(3, 0, 0), 1024, 128);
+            var policy = new BlockPolicy<DumbAction>(null, new TimeSpan(3, 0, 0), 1024, 128);
 
             // The genesis block must has the index #0.
             Assert.IsType<InvalidBlockIndexException>(

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -216,7 +216,7 @@ namespace Libplanet.Tests.Blocks
                 var (expect, pair) in expectations.Zip(pairs, ValueTuple.Create)
             )
             {
-                ActionEvaluation<DumbAction> eval = pair.Item2;
+                ActionEvaluation eval = pair.Item2;
                 Assert.Equal(blockIdx1Txs[expect.Item1], pair.Item1);
                 Assert.Equal(blockIdx1Txs[expect.Item1].Actions[expect.Item2], eval.Action);
                 Assert.Equal(expect.Item4, eval.InputContext.Signer);
@@ -295,7 +295,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(expectations.Length, pairs.Length);
             foreach (var (expect, pair) in expectations.Zip(pairs, ValueTuple.Create))
             {
-                ActionEvaluation<DumbAction> eval = pair.Item2;
+                ActionEvaluation eval = pair.Item2;
                 Assert.Equal(blockIdx2Txs[expect.Item1], pair.Item1);
                 Assert.Equal(
                     blockIdx2Txs[expect.Item1].Actions[expect.Item2],

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using Libplanet.Action;
 
@@ -177,23 +176,6 @@ namespace Libplanet.Tests.Common.Action
                 hashCode = (hashCode * 397) ^ RecordRehearsal.GetHashCode();
                 return hashCode;
             }
-        }
-
-        public struct RenderRecord
-        {
-            public bool Render { get; set; }
-
-            public bool Unrender
-            {
-                get => !Render;
-                set => Render = !value;
-            }
-
-            public DumbAction Action { get; set; }
-
-            public IActionContext Context { get; set; }
-
-            public IAccountStateDelta NextStates { get; set; }
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/MinerReward.cs
+++ b/Libplanet.Tests/Common/Action/MinerReward.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public sealed class MinerReward : IAction
+    {
+        public MinerReward()
+        {
+        }
+
+        public MinerReward(int reward)
+        {
+            Reward = reward;
+        }
+
+        public static AsyncLocal<ImmutableList<RenderRecord>>
+            RenderRecords { get; } = new AsyncLocal<ImmutableList<RenderRecord>>();
+
+        public int Reward { get; private set; }
+
+        public IImmutableDictionary<string, object> PlainValue =>
+            new Dictionary<string, object>
+            {
+                ["reward"] = Reward,
+            }.ToImmutableDictionary();
+
+        public void LoadPlainValue(IImmutableDictionary<string, object> plainValue)
+        {
+            Reward = (int)plainValue["reward"];
+        }
+
+        public IAccountStateDelta Execute(IActionContext ctx)
+        {
+            IAccountStateDelta states = ctx.PreviousStates;
+
+            int previousReward = (int?)states?.GetState(ctx.Miner) ?? 0;
+            int reward = previousReward + Reward;
+
+            return states.SetState(ctx.Miner, reward);
+        }
+
+        public void Render(IActionContext context, IAccountStateDelta nextStates)
+        {
+            if (RenderRecords.Value is null)
+            {
+                RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+            }
+
+            RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
+            {
+                Render = true,
+                Action = this,
+                Context = context,
+                NextStates = nextStates,
+            });
+        }
+
+        public void Unrender(IActionContext context, IAccountStateDelta nextStates)
+        {
+            if (RenderRecords.Value is null)
+            {
+                RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
+            }
+
+            RenderRecords.Value = RenderRecords.Value.Add(new RenderRecord()
+            {
+                Unrender = true,
+                Action = this,
+                Context = context,
+                NextStates = nextStates,
+            });
+        }
+    }
+}

--- a/Libplanet.Tests/Common/Action/RenderRecord.cs
+++ b/Libplanet.Tests/Common/Action/RenderRecord.cs
@@ -1,0 +1,21 @@
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public struct RenderRecord
+    {
+        public bool Render { get; set; }
+
+        public bool Unrender
+        {
+            get => !Render;
+            set => Render = !value;
+        }
+
+        public IAction Action { get; set; }
+
+        public IActionContext Context { get; set; }
+
+        public IAccountStateDelta NextStates { get; set; }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1055,7 +1055,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarm);
                 await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
 
                 IImmutableSet<Address> trustedPeers = trust
                     ? new[] { minerSwarm.Address }.ToImmutableHashSet()
@@ -1106,7 +1106,7 @@ namespace Libplanet.Tests.Net
             finally
             {
                 await minerSwarm.StopAsync();
-                DumbAction.RenderRecords.Value = ImmutableList<DumbAction.RenderRecord>.Empty;
+                DumbAction.RenderRecords.Value = ImmutableList<RenderRecord>.Empty;
             }
         }
 

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -79,7 +79,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return bytes;
         }
 
-        internal static Block<T> MineGenesis<T>()
+        internal static Block<T> MineGenesis<T>(Address? miner = null)
             where T : IAction, new()
         {
             var timestamp = new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero);
@@ -87,7 +87,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 index: 0,
                 difficulty: 0,
                 nonce: new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }),
-                miner: GenesisMinerAddress,
+                miner: miner ?? GenesisMinerAddress,
                 previousHash: null,
                 timestamp: timestamp,
                 transactions: new List<Transaction<T>>()

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -643,7 +643,7 @@ namespace Libplanet.Tests.Tx
 
                 for (int i = 0; i < evaluations.Length; i++)
                 {
-                    ActionEvaluation<DumbAction> eval = evaluations[i];
+                    ActionEvaluation eval = evaluations[i];
                     Assert.Equal(actions[i], eval.Action);
                     Assert.Equal(_fx.Address1, eval.InputContext.Signer);
                     Assert.Equal(addresses[0], eval.InputContext.Miner);

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -51,6 +51,40 @@ namespace Libplanet.Action
         /// </summary>
         public IAccountStateDelta OutputStates { get; }
 
+        /// <summary>
+        /// Executes the <paramref name="actions"/> step by step, and emits
+        /// <see cref="ActionEvaluation"/> for each step.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Libplanet.Blocks.Block{T}.Hash"/> of
+        /// <see cref="Libplanet.Blocks.Block{T}"/> that this <see cref="Transaction{T}"/> will
+        /// belong to.</param>
+        /// <param name="blockIndex">The <see cref="Libplanet.Blocks.Block{T}.Index"/> of
+        /// <see cref="Libplanet.Blocks.Block{T}"/> that this <see cref="Transaction{T}"/> will
+        /// belong to.</param>
+        /// <param name="previousStates">The states immediately before <paramref name="actions"/>
+        /// being executed.  Note that its <see cref="IAccountStateDelta.UpdatedAddresses"/> are
+        /// remained to the returned next states.</param>
+        /// <param name="minerAddress">An address of block miner.</param>
+        /// <param name="signer">Signer of the <paramref name="actions"/>.</param>
+        /// <param name="signature"><see cref="Transaction{T}"/> signature used to generate random
+        /// seeds.</param>
+        /// <param name="actions">Actions to evaluate.</param>
+        /// <param name="rehearsal">Pass <c>true</c> if it is intended
+        /// to be dry-run (i.e., the returned result will be never used).
+        /// The default value is <c>false</c>.</param>
+        /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
+        /// <paramref name="actions"/>.  The order is the same to the <paramref name="actions"/>.
+        /// Note that each <see cref="IActionContext.Random"/> object
+        /// has a unconsumed state.
+        /// </returns>
+        /// <exception cref="UnexpectedlyTerminatedTxRehearsalException">
+        /// Thrown when one of <paramref name="actions"/> throws some
+        /// exception during <paramref name="rehearsal"/> mode.
+        /// The actual exception that an <see cref="IAction"/> threw
+        /// is stored in its <see cref="Exception.InnerException"/> property.
+        /// It is never thrown if the <paramref name="rehearsal"/> option is
+        /// <c>false</c>.
+        /// </exception>
         internal static IEnumerable<ActionEvaluation> EvaluateActionsGradually(
             HashDigest<SHA256> blockHash,
             long blockIndex,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -2,15 +2,12 @@ namespace Libplanet.Action
 {
     /// <summary>
     /// A record type to represent an evaluation plan and result of
-    /// a single action (<typeparamref name="T"/>).
+    /// a single action.
     /// </summary>
-    /// <typeparam name="T">A concrete type that implements
-    /// <see cref="IAction"/>.</typeparam>
-    public class ActionEvaluation<T>
-        where T : IAction, new()
+    public class ActionEvaluation
     {
         /// <summary>
-        /// Creates an <see cref="ActionEvaluation{T}"/> instance
+        /// Creates an <see cref="ActionEvaluation"/> instance
         /// with filling properties.
         /// </summary>
         /// <param name="action">An action to evaluate.</param>
@@ -19,7 +16,7 @@ namespace Libplanet.Action
         /// <param name="outputStates">The result states that
         /// <paramref name="action"/> makes.</param>
         public ActionEvaluation(
-            T action,
+            IAction action,
             IActionContext inputContext,
             IAccountStateDelta outputStates
         )
@@ -32,7 +29,7 @@ namespace Libplanet.Action
         /// <summary>
         /// An action to evaluate.
         /// </summary>
-        public T Action { get; }
+        public IAction Action { get; }
 
         /// <summary>
         /// An input <see cref="IActionContext"/> to evaluate

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -1,3 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Tx;
+
 namespace Libplanet.Action
 {
     /// <summary>
@@ -43,5 +50,80 @@ namespace Libplanet.Action
         /// The result states that <see cref="Action"/> makes.
         /// </summary>
         public IAccountStateDelta OutputStates { get; }
+
+        internal static IEnumerable<ActionEvaluation> EvaluateActionsGradually(
+            HashDigest<SHA256> blockHash,
+            long blockIndex,
+            IAccountStateDelta previousStates,
+            Address minerAddress,
+            Address signer,
+            byte[] signature,
+            IImmutableList<IAction> actions,
+            bool rehearsal = false)
+        {
+            ActionContext CreateActionContext(
+                IAccountStateDelta prevStates,
+                int randomSeed
+            ) =>
+                new ActionContext(
+                    signer: signer,
+                    miner: minerAddress,
+                    blockIndex: blockIndex,
+                    previousStates: prevStates,
+                    randomSeed: randomSeed,
+                    rehearsal: rehearsal
+                );
+
+            int seed =
+                BitConverter.ToInt32(blockHash.ToByteArray(), 0) ^
+                (signature.Any() ? BitConverter.ToInt32(signature, 0) : 0);
+            IAccountStateDelta states = previousStates;
+            foreach (IAction action in actions)
+            {
+                ActionContext context =
+                    CreateActionContext(states, seed);
+                IAccountStateDelta nextStates;
+                try
+                {
+                    nextStates = action.Execute(context);
+                }
+                catch (Exception e)
+                {
+                    if (!rehearsal)
+                    {
+                        throw;
+                    }
+
+                    var msg =
+                        $"The action {action} threw an exception during its " +
+                        "rehearsal.  It is probably because the logic of the " +
+                        $"action {action} is not enough generic so that it " +
+                        "can cover every case including rehearsal mode.\n" +
+                        "The IActionContext.Rehearsal property also might be " +
+                        "useful to make the action can deal with the case of " +
+                        "rehearsal mode.\n" +
+                        "See also this exception's InnerException property.";
+                    throw new UnexpectedlyTerminatedTxRehearsalException(
+                        action, msg, e
+                    );
+                }
+
+                // As IActionContext.Random is stateful, we cannot reuse
+                // the context which is once consumed by Execute().
+                ActionContext equivalentContext =
+                    CreateActionContext(states, seed);
+
+                yield return new ActionEvaluation(
+                    action,
+                    equivalentContext,
+                    nextStates
+                );
+                states = nextStates;
+                unchecked
+                {
+                    seed++;
+                }
+            }
+        }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -263,7 +263,7 @@ namespace Libplanet.Blockchain
                                 continue;
                             }
 
-                            ActionEvaluation<T>[] evaluations =
+                            ActionEvaluation[] evaluations =
                                 b.Evaluate(
                                     DateTimeOffset.UtcNow,
                                     a => GetStates(
@@ -612,7 +612,7 @@ namespace Libplanet.Blockchain
         /// </remarks>
         internal void ExecuteActions(Block<T> block, bool render)
         {
-            IReadOnlyList<ActionEvaluation<T>> EvaluateActions()
+            IReadOnlyList<ActionEvaluation> EvaluateActions()
             {
                 AccountStateGetter stateGetter;
                 if (block.PreviousHash is null)
@@ -630,7 +630,7 @@ namespace Libplanet.Blockchain
                     .ToImmutableList();
             }
 
-            IReadOnlyList<ActionEvaluation<T>> evaluations = null;
+            IReadOnlyList<ActionEvaluation> evaluations = null;
             if (Store.GetBlockStates(block.Hash) is null)
             {
                 evaluations = EvaluateActions();
@@ -984,7 +984,7 @@ namespace Libplanet.Blockchain
 
         internal void SetStates(
             Block<T> block,
-            IReadOnlyList<ActionEvaluation<T>> actionEvaluations,
+            IReadOnlyList<ActionEvaluation> actionEvaluations,
             bool buildStateReferences
         )
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -272,7 +272,7 @@ namespace Libplanet.Blockchain
                                     ).GetValueOrDefault(a)
                                 ).ToList();
 
-                            if (!(Policy.BlockAction is null))
+                            if (Policy.BlockAction is IAction)
                             {
                                 evaluations.Add(EvaluateBlockAction(b, evaluations));
                             }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -682,7 +682,7 @@ namespace Libplanet.Blockchain
 
             IAccountStateDelta lastStates = null;
 
-            if (txActionEvaluations.Count > 0)
+            if (!(txActionEvaluations is null) && txActionEvaluations.Count > 0)
             {
                 lastStates = txActionEvaluations[txActionEvaluations.Count - 1].OutputStates;
             }

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -20,6 +20,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
+        /// <param name="blockAction">A block action to execute and be rendered for every block.
+        /// </param>
         /// <param name="blockIntervalMilliseconds">Configures
         /// <see cref="BlockInterval"/> in milliseconds.
         /// 5000 milliseconds by default.
@@ -29,10 +31,12 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         public BlockPolicy(
+            IAction blockAction = null,
             int blockIntervalMilliseconds = 5000,
             long minimumDifficulty = 1024,
             int difficultyBoundDivisor = 128)
             : this(
+                blockAction,
                 TimeSpan.FromMilliseconds(blockIntervalMilliseconds),
                 minimumDifficulty,
                 difficultyBoundDivisor)
@@ -44,6 +48,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="BlockInterval"/>, <see cref="MinimumDifficulty"/> and
         /// <see cref="DifficultyBoundDivisor"/>.
         /// </summary>
+        /// <param name="blockAction">A block action to execute and be rendered for every block.
+        /// </param>
         /// <param name="blockInterval">Configures <see cref="BlockInterval"/>.
         /// </param>
         /// <param name="minimumDifficulty">Configures
@@ -51,6 +57,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="difficultyBoundDivisor">Configures
         /// <see cref="DifficultyBoundDivisor"/>.</param>
         public BlockPolicy(
+            IAction blockAction,
             TimeSpan blockInterval,
             long minimumDifficulty,
             int difficultyBoundDivisor)
@@ -80,10 +87,14 @@ namespace Libplanet.Blockchain.Policies
                     message);
             }
 
+            BlockAction = blockAction;
             BlockInterval = blockInterval;
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
         }
+
+        /// <inheritdoc/>
+        public IAction BlockAction { get; }
 
         /// <summary>
         /// An appropriate interval between consecutive <see cref="Block{T}"/>s.

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -16,6 +16,11 @@ namespace Libplanet.Blockchain.Policies
         where T : IAction, new()
     {
         /// <summary>
+        /// A block action to execute and be rendered for every block.
+        /// </summary>
+        IAction BlockAction { get; }
+
+        /// <summary>
         /// Checks if <paramref name="nextBlock"/> is invalid, and if that
         /// returns the reason.
         /// <para>Note that it returns <c>null</c> when

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -146,7 +146,7 @@ namespace Libplanet.Blocks
         /// <summary>
         /// Executes every <see cref="IAction"/> in the
         /// <see cref="Transactions"/> step by step, and emits a pair of
-        /// a transaction, and an <see cref="ActionEvaluation{T}"/>
+        /// a transaction, and an <see cref="ActionEvaluation"/>
         /// for each step.
         /// </summary>
         /// <param name="accountStateGetter">An <see cref="AccountStateGetter"/>
@@ -154,7 +154,7 @@ namespace Libplanet.Blocks
         /// A <c>null</c> value, which is default, means a constant function
         /// that returns <c>null</c>.</param>
         /// <returns>Enumerates pair of a transaction, and
-        /// <see cref="ActionEvaluation{T}"/> for each action.
+        /// <see cref="ActionEvaluation"/> for each action.
         /// The order of pairs are the same to
         /// the <see cref="Transactions"/> and their
         /// <see cref="Transaction{T}.Actions"/> (e.g., tx&#xb9;-act&#xb9;,
@@ -165,7 +165,7 @@ namespace Libplanet.Blocks
         /// </returns>
         [Pure]
         public
-        IEnumerable<(Transaction<T>, ActionEvaluation<T>)>
+        IEnumerable<(Transaction<T>, ActionEvaluation)>
         EvaluateActionsPerTx(AccountStateGetter accountStateGetter = null)
         {
             IAccountStateDelta delta =
@@ -174,7 +174,7 @@ namespace Libplanet.Blocks
                 );
             foreach (Transaction<T> tx in Transactions)
             {
-                IEnumerable<ActionEvaluation<T>> evaluations =
+                IEnumerable<ActionEvaluation> evaluations =
                     tx.EvaluateActionsGradually(
                         Hash,
                         Index,
@@ -197,7 +197,7 @@ namespace Libplanet.Blocks
         /// <para>It throws an <see cref="InvalidBlockException"/> or
         /// an <see cref="InvalidTxException"/> if there is any
         /// integrity error.</para>
-        /// <para>Otherwise it enumerates an <see cref="ActionEvaluation{T}"/>
+        /// <para>Otherwise it enumerates an <see cref="ActionEvaluation"/>
         /// for each <see cref="IAction"/>.</para>
         /// </summary>
         /// <param name="currentTime">The current time to validate
@@ -205,7 +205,7 @@ namespace Libplanet.Blocks
         /// <param name="accountStateGetter">The getter of previous states.
         /// This affects the execution of <see cref="Transaction{T}.Actions"/>.
         /// </param>
-        /// <returns>An <see cref="ActionEvaluation{T}"/> for each
+        /// <returns>An <see cref="ActionEvaluation"/> for each
         /// <see cref="IAction"/>.</returns>
         /// <exception cref="InvalidBlockTimestampException">Thrown when
         /// the <see cref="Timestamp"/> is invalid, for example, it is the far
@@ -233,13 +233,13 @@ namespace Libplanet.Blocks
         /// any <see cref="IAction"/> of <see cref="Transactions"/> tries
         /// to update the states of <see cref="Address"/>es not included
         /// in <see cref="Transaction{T}.UpdatedAddresses"/>.</exception>
-        public IEnumerable<ActionEvaluation<T>> Evaluate(
+        public IEnumerable<ActionEvaluation> Evaluate(
             DateTimeOffset currentTime,
             AccountStateGetter accountStateGetter
         )
         {
             Validate(currentTime);
-            (Transaction<T>, ActionEvaluation<T>)[] txEvaluations =
+            (Transaction<T>, ActionEvaluation)[] txEvaluations =
                 EvaluateActionsPerTx(accountStateGetter).ToArray();
 
             var txUpdatedAddressesPairs = txEvaluations

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -165,7 +165,7 @@ namespace Libplanet.Blocks
         /// </returns>
         [Pure]
         public
-        IEnumerable<(Transaction<T>, ActionEvaluation)>
+        IEnumerable<Tuple<Transaction<T>, ActionEvaluation>>
         EvaluateActionsPerTx(AccountStateGetter accountStateGetter = null)
         {
             IAccountStateDelta delta =
@@ -182,7 +182,7 @@ namespace Libplanet.Blocks
                         Miner.Value);
                 foreach (var evaluation in evaluations)
                 {
-                    yield return (tx, evaluation);
+                    yield return Tuple.Create(tx, evaluation);
                     delta = evaluation.OutputStates;
                 }
 
@@ -239,7 +239,7 @@ namespace Libplanet.Blocks
         )
         {
             Validate(currentTime);
-            (Transaction<T>, ActionEvaluation)[] txEvaluations =
+            Tuple<Transaction<T>, ActionEvaluation>[] txEvaluations =
                 EvaluateActionsPerTx(accountStateGetter).ToArray();
 
             var txUpdatedAddressesPairs = txEvaluations

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -512,7 +512,7 @@ namespace Libplanet.Tx
         /// <c>false</c>.
         /// </exception>
         [Pure]
-        public IEnumerable<ActionEvaluation<T>>
+        public IEnumerable<ActionEvaluation>
         EvaluateActionsGradually(
             HashDigest<SHA256> blockHash,
             long blockIndex,
@@ -573,7 +573,7 @@ namespace Libplanet.Tx
                 ActionContext equivalentContext =
                     CreateActionContext(states, seed);
 
-                yield return new ActionEvaluation<T>(
+                yield return new ActionEvaluation(
                     action,
                     equivalentContext,
                     nextStates
@@ -634,7 +634,7 @@ namespace Libplanet.Tx
                 rehearsal: rehearsal
             );
 
-            ActionEvaluation<T> lastEvaluation;
+            ActionEvaluation lastEvaluation;
             try
             {
                 lastEvaluation = evaluations.Last();

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -477,7 +477,7 @@ namespace Libplanet.Tx
 
         /// <summary>
         /// Executes the <see cref="Actions"/> step by step, and emits
-        /// an action, input context, and output states for each step.
+        /// <see cref="ActionEvaluation"/> for each step.
         /// <para>If the needed value is only the final states,
         /// use <see cref="EvaluateActions"/> method instead.</para>
         /// </summary>
@@ -497,8 +497,8 @@ namespace Libplanet.Tx
         /// <param name="rehearsal">Pass <c>true</c> if it is intended
         /// to be dry-run (i.e., the returned result will be never used).
         /// The default value is <c>false</c>.</param>
-        /// <returns>Enumerates an action, input context, and
-        /// output states for each one in <see cref="Actions"/>.
+        /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
+        /// <see cref="Actions"/>.
         /// The order is the same to the <see cref="Actions"/>.
         /// Note that each <see cref="IActionContext.Random"/> object has
         /// a unconsumed state.

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -528,7 +528,7 @@ namespace Libplanet.Tx
                 minerAddress,
                 Signer,
                 Signature,
-                Actions.Select(a => (IAction)a).ToImmutableList(),
+                Actions.Cast<IAction>().ToImmutableList(),
                 rehearsal);
        }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,12 +120,7 @@ jobs:
       turnServerUrl: $(turnServerUrl)
       testDisplayName: StandaloneOSX *.Tests.dll
       testCommand: |-
-        /tmp/StandaloneOSX.app/Contents/MacOS/StandaloneOSX \
-          --exclude-method Libplanet.Tests.Blocks.BlockTest.EvaluateActionsPerTx
-      # FIXME: For unknown reason, on Unity methods returning ValueTuple<...>
-      #        cause MissingMethodException exception.  We should diagnose
-      #        this and make Unity builds to run these tests too.
-      #        See also: https://git.io/fjBDY
+        /tmp/StandaloneOSX.app/Contents/MacOS/StandaloneOSX
   timeoutInMinutes: 30
 
 - job: Linux_NETCore


### PR DESCRIPTION
This implements #319 and replaces #357.

- `IBlockPolicy<T>.BlockAction` is added.
- The type parameter of `ActionEvaluation` is removed.
- `IBlockPolicy<T>.BlockAction` evaluated after Tx evaluation.