### PR TITLE
Fix a bug when serializing default address

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ To be released.
 
  -  Fixed a bug where the `LiteDBStore.IterateStagedTransactionIds()` returns
     duplicated transaction ids.  [[#366]]
+ -  Fixed a bug that `NullReferenceException` occurred when serializing default
+    `Address`.  [[#369]]
 
 
 [#319]: https://github.com/planetarium/libplanet/issues/319
@@ -56,6 +58,7 @@ To be released.
 [#365]: https://github.com/planetarium/libplanet/pull/365
 [#366]: https://github.com/planetarium/libplanet/pull/366
 [#367]: https://github.com/planetarium/libplanet/pull/367
+[#369]: https://github.com/planetarium/libplanet/pull/369
 
 
 Version 0.4.1

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -201,7 +201,7 @@ namespace Libplanet.Tests
         }
 
         [Fact]
-        public void CanSerializeAndDeserialize()
+        public void SerializeAndDeserialize()
         {
             // Serialize and deserialize to and from memory
             var expectedAddress = new Address(
@@ -221,6 +221,21 @@ namespace Libplanet.Tests
             }
 
             Assert.Equal(deserializedAddress, expectedAddress);
+        }
+
+        [Fact]
+        public void SerializeAndDeserializeWithDefault()
+        {
+            var defaultAddress = default(Address);
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            using (var memoryStream = new MemoryStream())
+            {
+                formatter.Serialize(memoryStream, defaultAddress);
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                var deserializedAddress = (Address)formatter.Deserialize(memoryStream);
+                Assert.Equal(default, deserializedAddress);
+            }
         }
 
         [Fact]

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -208,7 +208,7 @@ namespace Libplanet
             SerializationInfo info,
             StreamingContext context)
         {
-            info.AddValue("address", _byteArray.ToArray());
+            info.AddValue("address", ToByteArray());
         }
 
         int IComparable<Address>.CompareTo(Address other)


### PR DESCRIPTION
This PR fixes a bug that `NullReferenceException` occurred when serializing default `Address`.