### PR TITLE
Prevent unintended delays in `Swarm<T>.ProcessDeltaAsync()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,8 @@ To be released.
     duplicated transaction ids.  [[#366]]
  -  Fixed a bug that `NullReferenceException` occurred when serializing default
     `Address`.  [[#369]]
-
+ -  Removed unnecessary mutex in `Swarm<T>` to avoid continuous delays in peer
+    registration in some situations.  [[#375]]
 
 [#319]: https://github.com/planetarium/libplanet/issues/319
 [#343]: https://github.com/planetarium/libplanet/pull/343
@@ -59,6 +60,7 @@ To be released.
 [#366]: https://github.com/planetarium/libplanet/pull/366
 [#367]: https://github.com/planetarium/libplanet/pull/367
 [#369]: https://github.com/planetarium/libplanet/pull/369
+[#375]: https://github.com/planetarium/libplanet/pull/375
 
 
 Version 0.4.1

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -50,7 +50,6 @@ namespace Libplanet.Net
 
         private readonly TimeSpan _dialTimeout;
         private readonly AsyncLock _runningMutex;
-        private readonly AsyncLock _receiveMutex;
         private readonly AsyncLock _blockSyncMutex;
         private readonly string _host;
         private readonly IList<IceServer> _iceServers;
@@ -143,7 +142,6 @@ namespace Libplanet.Net
             _broadcastQueue = new NetMQQueue<Message>();
             _poller = new NetMQPoller { _router, _replyQueue, _broadcastQueue };
 
-            _receiveMutex = new AsyncLock();
             _blockSyncMutex = new AsyncLock();
             _runningMutex = new AsyncLock();
 
@@ -1581,25 +1579,21 @@ namespace Libplanet.Net
 
             _logger.Debug($"Received the delta[{delta}].");
 
-            using (await _receiveMutex.LockAsync(cancellationToken))
+            await ApplyDelta(delta, cancellationToken);
+
+            bool alreadyReceived =
+                LastSeenTimestamps.TryGetValue(
+                    delta.Sender,
+                    out DateTimeOffset existingTimestamp) &&
+                existingTimestamp > delta.Timestamp;
+
+            if (!alreadyReceived)
             {
-                _logger.Debug($"Trying to apply the delta[{delta}]...");
-                await ApplyDelta(delta, cancellationToken);
-
-                bool alreadyReceived =
-                    LastSeenTimestamps.TryGetValue(
-                        delta.Sender,
-                        out DateTimeOffset existingTimestamp) &&
-                    existingTimestamp > delta.Timestamp;
-
-                if (!alreadyReceived)
-                {
-                    LastReceived = delta.Timestamp;
-                    LastSeenTimestamps[delta.Sender] = delta.Timestamp;
-                }
-
-                DeltaReceived.Set();
+                LastReceived = delta.Timestamp;
+                LastSeenTimestamps[delta.Sender] = delta.Timestamp;
             }
+
+            DeltaReceived.Set();
 
             _logger.Debug($"The delta[{delta}] has been applied.");
         }


### PR DESCRIPTION
This PR removes `Swarm<T>._receiveMutex` to avoid continuous delays about peer registration (using `.ApplyDelta`).