### PR TITLE
Ensure mutex for TurnClient.EnsureConnection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@ To be released.
     `Address`.  [[#369]]
  -  Removed unnecessary mutex in `Swarm<T>` to avoid continuous delays in peer
     registration in some situations.  [[#375]]
+ -  Fixed a bug that `TurnClient` had thrown `SocketException` saying
+    `A connect request was made on an already connected socket`.  [[#376]]
  -  Fixed a bug that `TurnClient` had thrown `KeyNotFoundException` and
     `IOException` on startup.  [[#377], [#378]]
 
@@ -65,6 +67,7 @@ To be released.
 [#375]: https://github.com/planetarium/libplanet/pull/375
 [#377]: https://github.com/planetarium/libplanet/issues/377
 [#378]: https://github.com/planetarium/libplanet/pull/378
+[#376]: https://github.com/planetarium/libplanet/pull/376
 
 
 Version 0.4.1

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -26,6 +26,7 @@ namespace Libplanet.Stun
 
         private readonly AsyncProducerConsumerQueue<ConnectionAttempt> _connectionAttempts;
         private readonly TcpClient _control;
+        private readonly AsyncLock _connMutex;
 
         private Task _messageProcessor;
 
@@ -47,6 +48,7 @@ namespace Libplanet.Stun
             _responses =
                 new Dictionary<byte[], TaskCompletionSource<StunMessage>>(
                     new ByteArrayComparer());
+            _connMutex = new AsyncLock();
         }
 
         public string Username { get; }
@@ -263,10 +265,13 @@ namespace Libplanet.Stun
 
         private async Task EnsureConnection()
         {
-            if (!_control.Connected)
+            using (await _connMutex.LockAsync())
             {
-                await _control.ConnectAsync(_host, _port);
-                _messageProcessor = ProcessMessage();
+                if (!_control.Connected)
+                {
+                    await _control.ConnectAsync(_host, _port);
+                    _messageProcessor = ProcessMessage();
+                }
             }
         }
 


### PR DESCRIPTION
This PR aids `SocketException` during `TurnClient.EnsureConnection` by introducing aa mutex (`TurnClient._connMutex`) and awaiting it.