### PR TITLE
Skip sync recent states If it has already been evaluated

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -957,6 +957,47 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
+        public async Task InitialBlockDownloadStates()
+        {
+            Swarm<DumbAction> minerSwarm = _swarms[0];
+            Swarm<DumbAction> receiverSwarm = _swarms[1];
+
+            BlockChain<DumbAction> minerChain = _blockchains[0];
+            BlockChain<DumbAction> receiverChain = _blockchains[1];
+
+            var key = new PrivateKey();
+            var address = key.PublicKey.ToAddress();
+
+            minerChain.MakeTransaction(key, new[] { new DumbAction(address, "foo") });
+            minerChain.MineBlock(_fx1.Address1);
+
+            minerChain.MakeTransaction(key, new[] { new DumbAction(address, "bar") });
+            minerChain.MineBlock(_fx1.Address1);
+
+            minerChain.MakeTransaction(key, new[] { new DumbAction(address, "baz") });
+            minerChain.MineBlock(_fx1.Address1);
+
+            try
+            {
+                await StartAsync(minerSwarm);
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
+
+                var trustedStateValidators = new[] { minerSwarm.Address }.ToImmutableHashSet();
+
+                await receiverSwarm.PreloadAsync(trustedStateValidators: trustedStateValidators);
+                await receiverSwarm.PreloadAsync(true);
+                var states = receiverChain.GetStates(new[] { address });
+
+                Assert.Equal("foo,bar,baz", states[address]);
+                Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
+            }
+            finally
+            {
+                await minerSwarm.StopAsync();
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
         public async Task Preload()
         {
             Swarm<DumbAction> minerSwarm = _swarms[0];

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -591,7 +591,7 @@ namespace Libplanet.Net
                 render
             );
 
-            if (_blockChain.Tip is null)
+            if (_blockChain.Tip is null || render)
             {
                 // If there is no blocks in the network (or no consensus at least)
                 // it doesn't need to receive states from other peers at all.
@@ -619,7 +619,8 @@ namespace Libplanet.Net
 
             if (!received)
             {
-                long initHeight = initialTip is null || _blockChain[initialTip.Index] != initialTip
+                long initHeight =
+                    initialTip is null || _blockChain[initialTip.Index].Equals(initialTip)
                     ? 0
                     : initialTip.Index;
                 foreach (Block<T> block in _blockChain.Skip((int)initHeight))


### PR DESCRIPTION
This makes `PreloadAsync()` skip state synchronization if the most recent state has already been evaluated.