### PR TITLE
Restore Swarm._poller and tweak something else

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -311,12 +311,9 @@ namespace Libplanet.Net
                             $"DialPeerAsync({peer}) failed. ignored."
                         );
                     }
-                    catch (TimeoutException e)
+                    catch (TimeoutException)
                     {
-                        _logger.Error(
-                            e,
-                            $"DialPeerAsync({peer}) failed. ignored."
-                        );
+                        _logger.Warning($"DialPeerAsync({peer}) timeout. ignored.");
                     }
                     catch (DifferentAppProtocolVersionException e)
                     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1965,8 +1965,17 @@ namespace Libplanet.Net
             Message msg = e.Queue.Dequeue();
             _logger.Debug($"Reply {msg} to {ByteUtil.Hex(msg.Identity)}...");
             NetMQMessage netMQMessage = msg.ToNetMQMessage(_privateKey);
-            _router.SendMultipartMessage(netMQMessage);
-            _logger.Debug($"Replied.");
+
+            // FIXME The current timeout value(5sec) is arbitrary.
+            // We should make this configurable or fix it to an unneeded structure.
+            if (_router.TrySendMultipartMessage(TimeSpan.FromSeconds(5), netMQMessage))
+            {
+                _logger.Debug($"Message[{msg}] replied.");
+            }
+            else
+            {
+                _logger.Debug($"Message[{msg}] replying failed.");
+            }
         }
 
         private void CheckStarted()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1032,7 +1032,6 @@ namespace Libplanet.Net
                 catch (Exception e)
                 {
                     _logger.Error(e, "An unexpected exception occured during BroadcastTxAsync()");
-                    throw;
                 }
             }
         }
@@ -1920,7 +1919,6 @@ namespace Libplanet.Net
             catch (Exception ex)
             {
                 _logger.Error(ex, "An unexpected exception occured during ReceiveMessage().");
-                throw;
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1930,13 +1930,13 @@ namespace Libplanet.Net
             // FIXME Should replace with PUB/SUB model.
             try
             {
-                // FIXME The current timeout value(5sec) is arbitrary.
+                // FIXME The current timeout value(1 sec) is arbitrary.
                 // We should make this configurable or fix it to an unneeded structure.
                 _dealers.Values.ParallelForEachAsync(async s =>
                 {
                     await Task.Run(() =>
                     {
-                        s.TrySendMultipartMessage(TimeSpan.FromSeconds(5), netMQMessage);
+                        s.TrySendMultipartMessage(TimeSpan.FromSeconds(1), netMQMessage);
                     });
                 });
             }
@@ -1961,9 +1961,9 @@ namespace Libplanet.Net
             _logger.Debug($"Reply {msg} to {ByteUtil.Hex(msg.Identity)}...");
             NetMQMessage netMQMessage = msg.ToNetMQMessage(_privateKey);
 
-            // FIXME The current timeout value(5sec) is arbitrary.
+            // FIXME The current timeout value(1 sec) is arbitrary.
             // We should make this configurable or fix it to an unneeded structure.
-            if (_router.TrySendMultipartMessage(TimeSpan.FromSeconds(5), netMQMessage))
+            if (_router.TrySendMultipartMessage(TimeSpan.FromSeconds(1), netMQMessage))
             {
                 _logger.Debug($"Message[{msg}] replied.");
             }


### PR DESCRIPTION
This PR reverts #381 partially to allow two processes (receiving and replying) to poll `_router` at the same time. 

it also tweaks `Swarm<T>`'s behavior to increase stability.