### PR TITLE
Properly scope state/state refs to download/reuse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ To be released.
 
 ### Backward-incompatible interface changes
 
+ -  Added `IStore.GetBlockIndex()` method.  [[#385]]
  -  `StoreExtension.LookupStateReference<T>()` method became to return
     `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
     and `Block<T>.Index`.  [[#350]]
@@ -50,6 +51,7 @@ To be released.
 [#363]: https://github.com/planetarium/libplanet/pull/363
 [#365]: https://github.com/planetarium/libplanet/pull/365
 [#366]: https://github.com/planetarium/libplanet/pull/366
+[#385]: https://github.com/planetarium/libplanet/pull/385
 [#386]: https://github.com/planetarium/libplanet/pull/366
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,9 @@ To be released.
     a feasible user interface so that they can decide whom to trust
     for themselves.
     [[#272], [#343]]
- -  Added `StoreExtension.ListAllStateReferences(this IStore, string)` extension
-    method.  [[#363]]
+ -  Added `StoreExtension.ListAllStateReferences(this IStore, string,
+    HashDigest<SHA256>?, HashDigest<SHA256>?)` extension method.
+    [[#363], [#384], [#385]]
  -  `Address` class became to implement `IComparable<Address>` and
     `IComparable` interfaces.  [[#363]]
 
@@ -51,6 +52,7 @@ To be released.
 [#363]: https://github.com/planetarium/libplanet/pull/363
 [#365]: https://github.com/planetarium/libplanet/pull/365
 [#366]: https://github.com/planetarium/libplanet/pull/366
+[#384]: https://github.com/planetarium/libplanet/issues/384
 [#385]: https://github.com/planetarium/libplanet/pull/385
 [#386]: https://github.com/planetarium/libplanet/pull/366
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -116,9 +116,10 @@ namespace Libplanet.Tests.Store
             chain.Append(block5);
             chain.Append(block6);
 
-            IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> refs =
-                fx.Store.ListAllStateReferences(chain.Id.ToString());
+            string chainId = chain.Id.ToString();
+            IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> refs;
 
+            refs = fx.Store.ListAllStateReferences(chainId);
             Assert.Equal(
                 new HashSet<Address> { address1, address2, address3 },
                 refs.Keys.ToHashSet()
@@ -126,6 +127,16 @@ namespace Libplanet.Tests.Store
             Assert.Equal(new[] { block4.Hash, block5.Hash }, refs[address1]);
             Assert.Equal(new[] { block4.Hash }, refs[address2]);
             Assert.Equal(new[] { block5.Hash }, refs[address3]);
+
+            refs = fx.Store.ListAllStateReferences(chainId, onlyAfter: block5.Hash);
+            Assert.Equal(new HashSet<Address> { address1, address3 }, refs.Keys.ToHashSet());
+            Assert.Equal(new[] { block5.Hash }, refs[address1]);
+            Assert.Equal(new[] { block5.Hash }, refs[address3]);
+
+            refs = fx.Store.ListAllStateReferences(chainId, ignoreAfter: block4.Hash);
+            Assert.Equal(new HashSet<Address> { address1, address2, }, refs.Keys.ToHashSet());
+            Assert.Equal(new[] { block4.Hash }, refs[address1]);
+            Assert.Equal(new[] { block4.Hash }, refs[address2]);
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -108,6 +108,9 @@ namespace Libplanet.Tests.Store
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block1.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block3.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block1.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block2.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
             Assert.False(Fx.Store.DeleteBlock(Fx.Block1.Hash));
 
             Fx.Store.PutBlock(Fx.Block1);
@@ -123,6 +126,9 @@ namespace Libplanet.Tests.Store
                 Fx.Store.GetBlock<DumbAction>(Fx.Block1.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block3.Hash));
+            Assert.Equal(Fx.Block1.Index, Fx.Store.GetBlockIndex(Fx.Block1.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block2.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
 
             Fx.Store.PutBlock(Fx.Block2);
             Assert.Equal(2, Fx.Store.CountBlocks());
@@ -140,6 +146,9 @@ namespace Libplanet.Tests.Store
                 Fx.Block2,
                 Fx.Store.GetBlock<DumbAction>(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block3.Hash));
+            Assert.Equal(Fx.Block1.Index, Fx.Store.GetBlockIndex(Fx.Block1.Hash));
+            Assert.Equal(Fx.Block2.Index, Fx.Store.GetBlockIndex(Fx.Block2.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
 
             Assert.True(Fx.Store.DeleteBlock(Fx.Block1.Hash));
             Assert.Equal(1, Fx.Store.CountBlocks());
@@ -154,6 +163,9 @@ namespace Libplanet.Tests.Store
                 Fx.Block2,
                 Fx.Store.GetBlock<DumbAction>(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlock<DumbAction>(Fx.Block3.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block1.Hash));
+            Assert.Equal(Fx.Block2.Index, Fx.Store.GetBlockIndex(Fx.Block2.Hash));
+            Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -87,6 +87,12 @@ namespace Libplanet.Tests.Store
             return _store.GetBlock<T>(blockHash);
         }
 
+        public long? GetBlockIndex(HashDigest<SHA256> blockHash)
+        {
+            _logs.Add((nameof(GetBlockIndex), blockHash, null));
+            return _store.GetBlockIndex(blockHash);
+        }
+
         public AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
         {
             _logs.Add((nameof(GetBlockStates), blockHash, null));

--- a/Libplanet/Net/Messages/GetRecentStates.cs
+++ b/Libplanet/Net/Messages/GetRecentStates.cs
@@ -6,17 +6,25 @@ namespace Libplanet.Net.Messages
 {
     internal class GetRecentStates : Message
     {
-        public GetRecentStates(HashDigest<SHA256> blockHash)
+        public GetRecentStates(HashDigest<SHA256>? @base, HashDigest<SHA256> target)
         {
-            BlockHash = blockHash;
+            BaseBlockHash = @base;
+            TargetBlockHash = target;
         }
 
         public GetRecentStates(NetMQFrame[] frames)
-            : this(new HashDigest<SHA256>(frames[0].Buffer))
+            : this(
+                frames.Length > 1
+                    ? new HashDigest<SHA256>(frames[1].Buffer)
+                    : (HashDigest<SHA256>?)null,
+                new HashDigest<SHA256>(frames[0].Buffer)
+            )
         {
         }
 
-        public HashDigest<SHA256> BlockHash { get; }
+        public HashDigest<SHA256>? BaseBlockHash { get; }
+
+        public HashDigest<SHA256> TargetBlockHash { get; }
 
         protected override MessageType Type => MessageType.GetRecentStates;
 
@@ -24,7 +32,11 @@ namespace Libplanet.Net.Messages
         {
             get
             {
-                yield return new NetMQFrame(BlockHash.ToByteArray());
+                yield return new NetMQFrame(TargetBlockHash.ToByteArray());
+                if (BaseBlockHash is HashDigest<SHA256> @base)
+                {
+                    yield return new NetMQFrame(@base.ToByteArray());
+                }
             }
         }
     }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
@@ -57,8 +58,40 @@ namespace Libplanet.Store
 
         public abstract IEnumerable<HashDigest<SHA256>> IterateBlockHashes();
 
-        public abstract Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
-            where T : IAction, new();
+        /// <inheritdoc/>
+        public Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
+            where T : IAction, new()
+        {
+            if (GetRawBlock(blockHash) is RawBlock rawBlock)
+            {
+                HashDigest<SHA256>? prevHash = rawBlock.PreviousHash is byte[] h
+                    ? new HashDigest<SHA256>(h)
+                    : (HashDigest<SHA256>?)null;
+                return new Block<T>(
+                    index: rawBlock.Index,
+                    difficulty: rawBlock.Difficulty,
+                    nonce: new Nonce(rawBlock.Nonce),
+                    miner: new Address(rawBlock.Miner),
+                    previousHash: prevHash,
+                    timestamp: DateTimeOffset.ParseExact(
+                        rawBlock.Timestamp,
+                        Block<T>.TimestampFormat,
+                        CultureInfo.InvariantCulture
+                    ).ToUniversalTime(),
+                    transactions: rawBlock.Transactions
+                        .Cast<byte[]>()
+                        .Select(bytes => GetTransaction<T>(new TxId(bytes)))
+                );
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public long? GetBlockIndex(HashDigest<SHA256> blockHash)
+        {
+            return GetRawBlock(blockHash)?.Index;
+        }
 
         /// <inheritdoc />
         public abstract void PutBlock<T>(Block<T> block)
@@ -120,5 +153,7 @@ namespace Libplanet.Store
 
         /// <inheritdoc/>
         public abstract void DeleteNamespace(string @namespace);
+
+        internal abstract RawBlock? GetRawBlock(HashDigest<SHA256> blockHash);
     }
 }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -103,12 +103,12 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public abstract void IncreaseTxNonce(string @namespace, Address signer, long delta = 1);
 
-        public long CountTransactions()
+        public virtual long CountTransactions()
         {
             return IterateTransactionIds().LongCount();
         }
 
-        public long CountBlocks()
+        public virtual long CountBlocks()
         {
             return IterateBlockHashes().LongCount();
         }

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -84,8 +84,29 @@ namespace Libplanet.Store
 
         IEnumerable<HashDigest<SHA256>> IterateBlockHashes();
 
+        /// <summary>
+        /// Gets the corresponding stored <see cref="Block{T}"/> to the given
+        /// <paramref name="blockHash"/>.
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to find.</param>
+        /// <returns>A found block, or <c>null</c> if no block having such
+        /// <paramref name="blockHash"/> is stored.</returns>
+        /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+        /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
         Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
             where T : IAction, new();
+
+        /// <summary>
+        /// Gets a stored block's <see cref="Block{T}.Index"/> by its <see cref="Block{T}.Hash"/>.
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to find.</param>
+        /// <remarks>
+        /// It provides only limited information, but can be called without any type parameter
+        /// unlike <see cref="GetBlock{T}(HashDigest{SHA256})"/>.
+        /// </remarks>
+        /// <returns>A found block's <see cref="Block{T}.Index"/>, or <c>null</c> if no block having
+        /// such <paramref name="blockHash"/> is stored.</returns>
+        long? GetBlockIndex(HashDigest<SHA256> blockHash);
 
         /// <summary>
         /// Puts the given <paramref name="block"/> in to the store.

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Store
     /// <see cref="IStore"/> implementation using <a href="https://www.litedb.org/">LiteDB</a>.
     /// </summary>
     /// <seealso cref="IStore"/>
-    public class LiteDBStore : IStore, IDisposable
+    public class LiteDBStore : BaseStore, IDisposable
     {
         private const string TxIdPrefix = "tx/";
 
@@ -77,7 +77,7 @@ namespace Libplanet.Store
             _db.GetCollection<StagedTxIdDoc>("staged_txids");
 
         /// <inheritdoc/>
-        public IEnumerable<string> ListNamespaces()
+        public override IEnumerable<string> ListNamespaces()
         {
             return _db.GetCollectionNames()
                 .Where(name => name.StartsWith(IndexColPrefix))
@@ -85,7 +85,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void DeleteNamespace(string @namespace)
+        public override void DeleteNamespace(string @namespace)
         {
             _db.DropCollection(IndexCollection(@namespace).Name);
             _db.DropCollection($"{NonceIdPrefix}{@namespace}");
@@ -97,13 +97,13 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public long CountIndex(string @namespace)
+        public override long CountIndex(string @namespace)
         {
             return IndexCollection(@namespace).Count();
         }
 
         /// <inheritdoc/>
-        public IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace)
+        public override IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace)
         {
             return IndexCollection(@namespace)
                 .FindAll()
@@ -111,7 +111,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public HashDigest<SHA256>? IndexBlockHash(string @namespace, long index)
+        public override HashDigest<SHA256>? IndexBlockHash(string @namespace, long index)
         {
             if (index < 0)
             {
@@ -127,14 +127,14 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public long AppendIndex(string @namespace, HashDigest<SHA256> hash)
+        public override long AppendIndex(string @namespace, HashDigest<SHA256> hash)
         {
             return IndexCollection(@namespace)
                        .Insert(new HashDoc { Hash = hash }) - 1;
         }
 
         /// <inheritdoc/>
-        public bool DeleteIndex(string @namespace, HashDigest<SHA256> hash)
+        public override bool DeleteIndex(string @namespace, HashDigest<SHA256> hash)
         {
             int deleted = IndexCollection(@namespace)
                 .Delete(i => i.Hash.Equals(hash));
@@ -142,7 +142,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IEnumerable<Address> ListAddresses(string @namespace)
+        public override IEnumerable<Address> ListAddresses(string @namespace)
         {
             var prefix = $"{StateRefIdPrefix}{@namespace}/";
             foreach (LiteFileInfo fileInfo in _db.FileStorage.Find(prefix))
@@ -175,7 +175,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void StageTransactionIds(IDictionary<TxId, bool> txids)
+        public override void StageTransactionIds(IDictionary<TxId, bool> txids)
         {
             StagedTxIds.InsertBulk(
                 txids.Select(kv => new StagedTxIdDoc
@@ -186,13 +186,13 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void UnstageTransactionIds(ISet<TxId> txids)
+        public override void UnstageTransactionIds(ISet<TxId> txids)
         {
             StagedTxIds.Delete(tx => txids.Contains(tx.TxId));
         }
 
         /// <inheritdoc/>
-        public IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)
+        public override IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)
         {
             IEnumerable<StagedTxIdDoc> docs = StagedTxIds.FindAll();
             if (toBroadcast)
@@ -204,7 +204,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IEnumerable<TxId> IterateTransactionIds()
+        public override IEnumerable<TxId> IterateTransactionIds()
         {
             return _db.FileStorage
                 .Find(TxIdPrefix)
@@ -212,8 +212,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public Transaction<T> GetTransaction<T>(TxId txid)
-            where T : IAction, new()
+        public override Transaction<T> GetTransaction<T>(TxId txid)
         {
             LiteFileInfo file = _db.FileStorage.FindById(TxFileId(txid));
             if (file is null)
@@ -230,20 +229,19 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void PutTransaction<T>(Transaction<T> tx)
-            where T : IAction, new()
+        public override void PutTransaction<T>(Transaction<T> tx)
         {
             UploadFile(TxFileId(tx.Id), tx.Id.ToHex(), tx.ToBencodex(true));
         }
 
         /// <inheritdoc/>
-        public bool DeleteTransaction(TxId txid)
+        public override bool DeleteTransaction(TxId txid)
         {
             return _db.FileStorage.Delete(TxFileId(txid));
         }
 
         /// <inheritdoc/>
-        public IEnumerable<HashDigest<SHA256>> IterateBlockHashes()
+        public override IEnumerable<HashDigest<SHA256>> IterateBlockHashes()
         {
             return _db.FileStorage
                 .Find("block/")
@@ -252,8 +250,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
-            where T : IAction, new()
+        public override Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
         {
             LiteFileInfo file =
                 _db.FileStorage.FindById(BlockFileId(blockHash));
@@ -295,8 +292,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void PutBlock<T>(Block<T> block)
-            where T : IAction, new()
+        public override void PutBlock<T>(Block<T> block)
         {
             foreach (Transaction<T> tx in block.Transactions)
             {
@@ -311,13 +307,13 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public bool DeleteBlock(HashDigest<SHA256> blockHash)
+        public override bool DeleteBlock(HashDigest<SHA256> blockHash)
         {
             return _db.FileStorage.Delete(BlockFileId(blockHash));
         }
 
         /// <inheritdoc/>
-        public AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
+        public override AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
         {
             LiteFileInfo file =
                 _db.FileStorage.FindById(BlockStateFileId(blockHash));
@@ -336,7 +332,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void SetBlockStates(
+        public override void SetBlockStates(
             HashDigest<SHA256> blockHash,
             AddressStateMap states)
         {
@@ -353,7 +349,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
+        public override IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,
             Address address)
         {
@@ -400,11 +396,10 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void StoreStateReference<T>(
+        public override void StoreStateReference<T>(
             string @namespace,
             IImmutableSet<Address> addresses,
             Block<T> block)
-            where T : IAction, new()
         {
             int hashSize = HashDigest<SHA256>.Size;
             byte[] hashBytes = block.Hash.ToByteArray();
@@ -440,12 +435,11 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void ForkStateReferences<T>(
+        public override void ForkStateReferences<T>(
             string srcNamespace,
             string destNamespace,
             Block<T> branchPoint,
             IImmutableSet<Address> addressesToStrip)
-            where T : IAction, new()
         {
             long branchPointIndex = branchPoint.Index;
             List<LiteFileInfo> files =
@@ -504,7 +498,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace)
+        public override IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace)
         {
             var collectionId = $"{NonceIdPrefix}{@namespace}";
             LiteCollection<BsonDocument> collection = _db.GetCollection<BsonDocument>(collectionId);
@@ -525,7 +519,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public long GetTxNonce(string @namespace, Address address)
+        public override long GetTxNonce(string @namespace, Address address)
         {
             var collectionId = $"{NonceIdPrefix}{@namespace}";
             LiteCollection<BsonDocument> collection = _db.GetCollection<BsonDocument>(collectionId);
@@ -535,7 +529,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public void IncreaseTxNonce(string @namespace, Address signer, long delta = 1)
+        public override void IncreaseTxNonce(string @namespace, Address signer, long delta = 1)
         {
             long nextNonce = GetTxNonce(@namespace, signer) + delta;
             var collectionId = $"{NonceIdPrefix}{@namespace}";
@@ -545,13 +539,13 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public long CountTransactions()
+        public override long CountTransactions()
         {
             return _db.FileStorage.Find(TxIdPrefix).Count();
         }
 
         /// <inheritdoc/>
-        public long CountBlocks()
+        public override long CountBlocks()
         {
             return _db.FileStorage.Find("block/").Count();
         }


### PR DESCRIPTION
There had been a corner case where a trusted peer sends inconsistent states and state refs, because the exact times to get both data from the store can subtly differ each other.  In order to avoid that specific case, I added filtering options named `onlyAfter`/`ignoreAfter` to `ListAllStateReferences()` method, and made `Swarm` to query state refs with a strict scope so that state refs to send are consistent with states to send.