### PR TITLE
Second approach to LiteDB's data corruption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
  -  `StoreExtension.LookupStateReference<T>()` method became to return
     `Tuple<HashDigest<SHA256>, long>` which is a nullable tuple of `Block<T>.Hash`
     and `Block<T>.Index`.  [[#350]]
+ -  `LiteDBStore()` constructor became to have a new option named `flush` and turned on by default.
+    [[#387], [LiteDB #1268]]
 
 ### Added interfaces
 
@@ -45,7 +47,7 @@ To be released.
  -  Fixed a bug where the `LiteDBStore.IterateStagedTransactionIds()` returns
     duplicated transaction ids.  [[#366]]
  -  Fixed a `LiteDBStore` bug that blocks or transactions had got corrupted
-    sometimes.  [[#386], [LiteDB #1268]]
+    sometimes.  [[#386], [#387], [LiteDB #1268]]
 
 [#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350
@@ -54,7 +56,8 @@ To be released.
 [#366]: https://github.com/planetarium/libplanet/pull/366
 [#384]: https://github.com/planetarium/libplanet/issues/384
 [#385]: https://github.com/planetarium/libplanet/pull/385
-[#386]: https://github.com/planetarium/libplanet/pull/366
+[#386]: https://github.com/planetarium/libplanet/pull/386
+[#387]: https://github.com/planetarium/libplanet/pull/387
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,8 @@ To be released.
     duplicated transaction ids.  [[#366]]
  -  Fixed a `LiteDBStore` bug that blocks or transactions had got corrupted
     sometimes.  Instead, `LiteDBStore.GetTransaction()` became possible to
-    return `null` even for already stored transactions.
+    return `null` even for already stored transactions, and for that case,
+    a warning will be logged through Serilog.
     [[#386], [#387], [LiteDB #1268]]
 
 [#343]: https://github.com/planetarium/libplanet/pull/343

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,9 @@ To be released.
  -  Fixed a bug where the `LiteDBStore.IterateStagedTransactionIds()` returns
     duplicated transaction ids.  [[#366]]
  -  Fixed a `LiteDBStore` bug that blocks or transactions had got corrupted
-    sometimes.  [[#386], [#387], [LiteDB #1268]]
+    sometimes.  Instead, `LiteDBStore.GetTransaction()` became possible to
+    return `null` even for already stored transactions.
+    [[#386], [#387], [LiteDB #1268]]
 
 [#343]: https://github.com/planetarium/libplanet/pull/343
 [#350]: https://github.com/planetarium/libplanet/pull/350

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -232,7 +232,14 @@ namespace Libplanet.Store
             {
                 file.CopyTo(stream);
                 stream.Seek(0, SeekOrigin.Begin);
-                return Transaction<T>.FromBencodex(stream.ToArray());
+                byte[] bytes = stream.ToArray();
+                if (bytes.Length < 1)
+                {
+                    DeleteTransaction(txid);
+                    return null;
+                }
+
+                return Transaction<T>.FromBencodex(bytes);
             }
         }
 


### PR DESCRIPTION
It turns out that LiteDB's data corruption (mbdavid/LiteDB#1268) seems to happen due to sudden termination of program.  So the workaround made in the previous workaround (#386) was reverted for the most part, and a new option named `flush` was added to `LiteDBStore()` constructor, so that every write is immediately flushed to disk.  As a bonus, I made `LiteDBStore.GetTransaction()` method to treat corrupted transactions nonexistent, though I am not sure how would it be going and if work well together with other parts of Libplanet (I guess there could be some assumptions that once stored transactions must be existent in a store).