### PR TITLE
Stick with .NET Core SDK compatible with Mono + Linux on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,12 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
+  - task: UseDotNet@2
+    displayName: Stick with .NET Core SDK version compatible to Mono toolchain
+    inputs:
+      packageType: sdk
+      version: 2.2.301  # See also: https://github.com/mono/mono/issues/13537
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - template: .azure-pipelines/mono.yml
     parameters:
       configuration: $(configuration)


### PR DESCRIPTION
This fixes broken builds of other pull requests like #376 and #387.