### PR TITLE
Ffwd already had blocks without fetch during preloading phase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ To be released.
     [[#363], [#384], [#385]]
  -  `Address` class became to implement `IComparable<Address>` and
     `IComparable` interfaces.  [[#363]]
+ -  Added `BlockChain<T>.BlockHashes` property.  [[#389]]
 
 ### Behavioral changes
 
@@ -61,6 +62,7 @@ To be released.
 [#385]: https://github.com/planetarium/libplanet/pull/385
 [#386]: https://github.com/planetarium/libplanet/pull/386
 [#387]: https://github.com/planetarium/libplanet/pull/387
+[#389]: https://github.com/planetarium/libplanet/pull/389
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -115,12 +115,28 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanIterate()
+        public void Enumerate()
         {
             Assert.Empty(_blockChain);
-            _blockChain.MineBlock(_fx.Address1);
+            Assert.Empty(_blockChain.BlockHashes);
 
-            Assert.NotEmpty(_blockChain);
+            Block<DumbAction> genesis = _blockChain.MineBlock(_fx.Address1);
+            Assert.Equal(new Block<DumbAction>[] { genesis }, _blockChain);
+            Assert.Equal(new HashDigest<SHA256>[] { genesis.Hash }, _blockChain.BlockHashes);
+
+            Block<DumbAction> b1 = _blockChain.MineBlock(_fx.Address1);
+            Assert.Equal(new Block<DumbAction>[] { genesis, b1 }, _blockChain);
+            Assert.Equal(
+                new HashDigest<SHA256>[] { genesis.Hash, b1.Hash },
+                _blockChain.BlockHashes
+            );
+
+            Block<DumbAction> b2 = _blockChain.MineBlock(_fx.Address1);
+            Assert.Equal(new Block<DumbAction>[] { genesis, b1, b2 }, _blockChain);
+            Assert.Equal(
+                new HashDigest<SHA256>[] { genesis.Hash, b1.Hash, b2.Hash },
+                _blockChain.BlockHashes
+            );
         }
 
         [Fact]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -91,6 +91,37 @@ namespace Libplanet.Blockchain
             get; private set;
         }
 
+        /// <summary>
+        /// All <see cref="Block{T}.Hash"/>es in the current index.  The genesis block's hash goes
+        /// first, and the tip goes last.
+        /// </summary>
+        public IEnumerable<HashDigest<SHA256>> BlockHashes
+        {
+            get
+            {
+                try
+                {
+                    _rwlock.EnterUpgradeableReadLock();
+
+                    IEnumerable<HashDigest<SHA256>> indices = Store.IterateIndex(
+                        Id.ToString()
+                    );
+
+                    // NOTE: The reason why this does not simply return indices, but iterates over
+                    // indices and yields hashes step by step instead, is that we need to ensure
+                    // the read lock held until the whole iteration completes.
+                    foreach (HashDigest<SHA256> hash in indices)
+                    {
+                        yield return hash;
+                    }
+                }
+                finally
+                {
+                    _rwlock.ExitUpgradeableReadLock();
+                }
+            }
+        }
+
         /// <inheritdoc/>
         int IReadOnlyCollection<Block<T>>.Count =>
             checked((int)Store.CountIndex(Id.ToString()));
@@ -141,22 +172,7 @@ namespace Libplanet.Blockchain
 
         public IEnumerator<Block<T>> GetEnumerator()
         {
-            try
-            {
-                _rwlock.EnterUpgradeableReadLock();
-
-                IEnumerable<HashDigest<SHA256>> indexes = Store.IterateIndex(
-                    Id.ToString()
-                );
-                foreach (HashDigest<SHA256> hash in indexes)
-                {
-                    yield return Blocks[hash];
-                }
-            }
-            finally
-            {
-                _rwlock.ExitUpgradeableReadLock();
-            }
+            return BlockHashes.Select(hash => Blocks[hash]).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -613,8 +613,9 @@ namespace Libplanet.Net
                     initialTip is null || !_blockChain[initialTip.Index].Equals(initialTip)
                     ? 0
                     : initialTip.Index;
-                foreach (Block<T> block in _blockChain.Skip((int)initHeight))
+                foreach (HashDigest<SHA256> hash in _blockChain.BlockHashes.Skip((int)initHeight))
                 {
+                    Block<T> block = _blockChain.Blocks[hash];
                     if (block.Index < initHeight)
                     {
                         continue;


### PR DESCRIPTION
As `BlockChain<T>.GetEnumerator()` always fetches block data and instantiates actual `Block<T>` objects, skipping on that still had a lot of redundant operations.  This patch fixes that inefficiency.