### PR TITLE
Tune BaseIndex.ContainsKey()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ To be released.
     and `Block<T>.Index`.  [[#350]]
  -  `LiteDBStore()` constructor became to have a new option named `flush` and turned on by default.
     [[#387], [LiteDB #1268]]
+ -  `BaseIndex.ContainsKey()` method became `abstract`.  [[#390]]
 
 ### Added interfaces
 
@@ -42,6 +43,9 @@ To be released.
  -  `BlockChain<T>.MineBlock()` and `BlockChain<T>.GetNextTxNonce()` methods
     became to ignore transactions that didn't follow `Transaction<T>.Nonce`
     sequentially and treat them as pendings.  [[#365]]
+ -  `BlockSet<T>.ContainsKey()` and `TransactionSet<T>.ContainsKey()` methods
+    became O(1) time complexity through omitting iteration and relying
+    own retrieve implementations.  [[#390]]
 
 ### Bug fixes
 
@@ -63,6 +67,7 @@ To be released.
 [#386]: https://github.com/planetarium/libplanet/pull/386
 [#387]: https://github.com/planetarium/libplanet/pull/387
 [#389]: https://github.com/planetarium/libplanet/pull/389
+[#390]: https://github.com/planetarium/libplanet/pull/390
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/Libplanet/Store/BaseIndex.cs
+++ b/Libplanet/Store/BaseIndex.cs
@@ -46,10 +46,7 @@ namespace Libplanet.Store
 
         public abstract bool Contains(KeyValuePair<TKey, TVal> item);
 
-        public bool ContainsKey(TKey key)
-        {
-            return Keys.Contains(key);
-        }
+        public abstract bool ContainsKey(TKey key);
 
         public void CopyTo(KeyValuePair<TKey, TVal>[] array, int arrayIndex)
         {

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -61,6 +61,11 @@ namespace Libplanet.Store
             return Store.IterateBlockHashes().Contains(item.Key);
         }
 
+        public override bool ContainsKey(HashDigest<SHA256> key)
+        {
+            return Store.GetBlock<T>(key) is Block<T>;
+        }
+
         public override bool Remove(HashDigest<SHA256> key)
         {
             return Store.DeleteBlock(key);

--- a/Libplanet/Store/TransactionSet.cs
+++ b/Libplanet/Store/TransactionSet.cs
@@ -68,6 +68,11 @@ namespace Libplanet.Store
             return Store.IterateTransactionIds().Contains(item.Key);
         }
 
+        public override bool ContainsKey(TxId key)
+        {
+            return Store.GetTransaction<T>(key) is Transaction<T>;
+        }
+
         public override bool Remove(TxId key)
         {
             return Store.DeleteTransaction(key);


### PR DESCRIPTION
This PR tunes `BlockSet<T>.ContainsKey()` and `TransactionSet<T>.ContainsKey()` to accomplish lookup in O(1).