### PR TITLE
Report total block download status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ To be released.
  -  `LiteDBStore()` constructor became to have a new option named `flush` and turned on by default.
     [[#387], [LiteDB #1268]]
  -  `BaseIndex.ContainsKey()` method became `abstract`.  [[#390]]
+ -  `BlockDownloadState.TotalBlockCount` and `BlockDownloadState.ReceivedBlockCount`
+    became to long type.  [[#396], [#399]]
 
 ### Added interfaces
 
@@ -48,6 +50,8 @@ To be released.
     own retrieve implementations.  [[#390]]
  -  The way `LiteDBStore` stores state references became efficient,
     but the file-level backward compatibility was also broken.  [[#395], [#398]]
+ -  `PreloadAsync` became to report total block download status instead of
+    chunked download status.  [[#396], [#399]]
 
 ### Bug fixes
 
@@ -71,7 +75,9 @@ To be released.
 [#389]: https://github.com/planetarium/libplanet/pull/389
 [#390]: https://github.com/planetarium/libplanet/pull/390
 [#395]: https://github.com/planetarium/libplanet/issues/395
+[#396]: https://github.com/planetarium/libplanet/issues/396
 [#398]: https://github.com/planetarium/libplanet/pull/398
+[#399]: https://github.com/planetarium/libplanet/pull/399
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ To be released.
     [[#387], [LiteDB #1268]]
  -  `BaseIndex.ContainsKey()` method became `abstract`.  [[#390]]
  -  `BlockDownloadState.TotalBlockCount` and `BlockDownloadState.ReceivedBlockCount`
-    became to long type.  [[#396], [#399]]
+    became to `Int64` type.  [[#396], [#399]]
 
 ### Added interfaces
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -440,11 +440,12 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     stop: block2.Hash));
+
+            _blockChain.FindNextHashesChunkSize = 2;
             Assert.Equal(
                 new[] { block0.Hash, block1.Hash },
                 _blockChain.FindNextHashes(
-                    new BlockLocator(new[] { block0.Hash }),
-                    count: 2));
+                    new BlockLocator(new[] { block0.Hash })));
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1022,6 +1022,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarm);
                 await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
+                minerChain.FindNextHashesChunkSize = 2;
                 await receiverSwarm.PreloadAsync(progress);
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -128,6 +128,8 @@ namespace Libplanet.Blockchain
 
         internal IStore Store { get; }
 
+        internal int FindNextHashesChunkSize { get; set; } = 500;
+
         /// <inheritdoc/>
         public Block<T> this[int index] => this[(long)index];
 
@@ -726,9 +728,9 @@ namespace Libplanet.Blockchain
 
         internal IEnumerable<HashDigest<SHA256>> FindNextHashes(
             BlockLocator locator,
-            HashDigest<SHA256>? stop = null,
-            int count = 500)
+            HashDigest<SHA256>? stop = null)
         {
+            int count = FindNextHashesChunkSize;
             try
             {
                 _rwlock.EnterReadLock();

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -128,6 +128,7 @@ namespace Libplanet.Blockchain
 
         internal IStore Store { get; }
 
+        // It's virtually a constant in production, but used for unit tests.
         internal int FindNextHashesChunkSize { get; set; } = 500;
 
         /// <inheritdoc/>

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -11,12 +11,12 @@ namespace Libplanet.Net
         /// <summary>
         /// Total number of blocks to receive in the current batch.
         /// </summary>
-        public int TotalBlockCount { get; internal set; }
+        public long TotalBlockCount { get; internal set; }
 
         /// <summary>
         /// The number of currently received blocks.
         /// </summary>
-        public int ReceivedBlockCount { get; internal set; }
+        public long ReceivedBlockCount { get; internal set; }
 
         /// <summary>
         /// The hash digest of the block just received.


### PR DESCRIPTION
This makes `PreloadAsync` report total block download status instead of chunked download status.

Resolves #396.