### PR TITLE
Make swarm report more progresses during preload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,8 @@ To be released.
  -  `Swarm<T>.PreloadAsync(IProgress<PreloadState>, IImmutableSet<Address>,
     CancellationToken)` became to report progress for all phases.  [[#397], [#400]]
  -  Added `PreloadState`, `ActionExecutionState`, `StateReferenceDownloadState`,
-    and `BlockStateDownloadState` to provide progress about more phases.  [[#397], [#400]]
+    and `BlockStateDownloadState` classes to cover all phases in the entire
+    preloading process.  [[#397], [#400]]
 
 ### Behavioral changes
 
@@ -61,8 +62,8 @@ To be released.
     but the file-level backward compatibility was also broken.  [[#395], [#398]]
  -  `PreloadAsync` became to report total block download status instead of
     chunked download status.  [[#396], [#399]]
- -  `PreloadAsync` became to get first parameter, `progress`
-    as `PreloadState` type.  [[#397], [#400]]
+ -  `Swarm<T>.PreloadAsync()` became to get the first parameter, `progress`,
+    which accepts `IProgress<PreloadState>`.  [[#397], [#400]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@ To be released.
  -  `Address` class became to implement `IComparable<Address>` and
     `IComparable` interfaces.  [[#363]]
  -  Added `BlockChain<T>.BlockHashes` property.  [[#389]]
+ -  `Swarm<T>.PreloadAsync(IProgress<PreloadState>, IImmutableSet<Address>,
+    CancellationToken)` became to report progress for all phases.  [[#397], [#400]]
+ -  Added `PreloadState`, `ActionExecutionState`, `StateReferenceDownloadState`,
+    and `BlockStateDownloadState` to provide progress about more phases.  [[#397], [#400]]
 
 ### Behavioral changes
 
@@ -57,6 +61,8 @@ To be released.
     but the file-level backward compatibility was also broken.  [[#395], [#398]]
  -  `PreloadAsync` became to report total block download status instead of
     chunked download status.  [[#396], [#399]]
+ -  `PreloadAsync` became to get first parameter, `progress`
+    as `PreloadState` type.  [[#397], [#400]]
 
 ### Bug fixes
 
@@ -93,8 +99,10 @@ To be released.
 [#390]: https://github.com/planetarium/libplanet/pull/390
 [#395]: https://github.com/planetarium/libplanet/issues/395
 [#396]: https://github.com/planetarium/libplanet/issues/396
+[#397]: https://github.com/planetarium/libplanet/issues/397
 [#398]: https://github.com/planetarium/libplanet/pull/398
 [#399]: https://github.com/planetarium/libplanet/pull/399
+[#400]: https://github.com/planetarium/libplanet/pull/400
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1008,8 +1008,8 @@ namespace Libplanet.Tests.Net
                 minerChain.MineBlock(_fx1.Address1);
             }
 
-            var actualStates = new List<BlockDownloadState>();
-            var progress = new Progress<BlockDownloadState>(state =>
+            var actualStates = new List<PreloadState>();
+            var progress = new Progress<PreloadState>(state =>
             {
                 lock (actualStates)
                 {
@@ -1032,7 +1032,7 @@ namespace Libplanet.Tests.Net
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
 
-                BlockDownloadState[] expectedStates = minerChain.Select((b, i) =>
+                PreloadState[] expectedStates = minerChain.Select((b, i) =>
                 {
                     return new BlockDownloadState
                     {
@@ -1041,7 +1041,15 @@ namespace Libplanet.Tests.Net
                         ReceivedBlockCount = i + 1,
                     };
                 }).ToArray();
-                expectedStates[10].TotalBlockCount = 11;
+                (expectedStates[10] as BlockDownloadState).TotalBlockCount = 11;
+
+                expectedStates = expectedStates.Concat(minerChain.Select(
+                    (b, i) => new ActionExecutionState()
+                    {
+                        ExecutedBlockHash = b.Hash,
+                        TotalBlockCount = 11,
+                        ExecutedBlockCount = i + 1,
+                    })).ToArray();
 
                 Assert.Equal(expectedStates, actualStates);
             }

--- a/Libplanet/Net/ActionExecutionState.cs
+++ b/Libplanet/Net/ActionExecutionState.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// A container that indicates the progress of a block execution.
+    /// </summary>
+    [Equals]
+    public class ActionExecutionState : PreloadState
+    {
+        public ActionExecutionState()
+            : base(PreloadPhase.BlockEvaluate, 4)
+        {
+        }
+
+        /// <summary>
+        /// Total number of blocks to execute in the current batch.
+        /// </summary>
+        public int TotalBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The number of currently executed blocks.
+        /// </summary>
+        public int ExecutedBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The hash digest of the block just executed.
+        /// </summary>
+        public HashDigest<SHA256> ExecutedBlockHash { get; internal set; }
+    }
+}

--- a/Libplanet/Net/ActionExecutionState.cs
+++ b/Libplanet/Net/ActionExecutionState.cs
@@ -4,7 +4,7 @@ using Libplanet.Blocks;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A container that indicates the progress of a block execution.
+    /// Indicates a progress of executing block actions.
     /// </summary>
     [Equals]
     public class ActionExecutionState : PreloadState

--- a/Libplanet/Net/ActionExecutionState.cs
+++ b/Libplanet/Net/ActionExecutionState.cs
@@ -9,11 +9,6 @@ namespace Libplanet.Net
     [Equals]
     public class ActionExecutionState : PreloadState
     {
-        public ActionExecutionState()
-            : base(PreloadPhase.BlockEvaluate, 4)
-        {
-        }
-
         /// <summary>
         /// Total number of blocks to execute in the current batch.
         /// </summary>
@@ -28,5 +23,8 @@ namespace Libplanet.Net
         /// The hash digest of the block just executed.
         /// </summary>
         public HashDigest<SHA256> ExecutedBlockHash { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 4;
     }
 }

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -9,11 +9,6 @@ namespace Libplanet.Net
     [Equals]
     public class BlockDownloadState : PreloadState
     {
-        public BlockDownloadState()
-            : base(PreloadPhase.BlockDownload, 3)
-        {
-        }
-
         /// <summary>
         /// Total number of blocks to receive in the current batch.
         /// </summary>
@@ -28,5 +23,8 @@ namespace Libplanet.Net
         /// The hash digest of the block just received.
         /// </summary>
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 1;
     }
 }

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -4,7 +4,7 @@ using Libplanet.Blocks;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A container that indicates the progress of a block download.
+    /// Indicates a progress of downloading blocks.
     /// </summary>
     [Equals]
     public class BlockDownloadState : PreloadState

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Libplanet.Blocks;
 
 namespace Libplanet.Net
 {
@@ -6,8 +7,13 @@ namespace Libplanet.Net
     /// A container that indicates the progress of a block download.
     /// </summary>
     [Equals]
-    public class BlockDownloadState
+    public class BlockDownloadState : PreloadState
     {
+        public BlockDownloadState()
+            : base(PreloadPhase.BlockDownload, 3)
+        {
+        }
+
         /// <summary>
         /// Total number of blocks to receive in the current batch.
         /// </summary>

--- a/Libplanet/Net/BlockStateDownloadState.cs
+++ b/Libplanet/Net/BlockStateDownloadState.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// A container that indicates the progress of a block-state download.
+    /// </summary>
+    [Equals]
+    public class BlockStateDownloadState : PreloadState
+    {
+        public BlockStateDownloadState()
+            : base(PreloadPhase.BlockStatesDownload, 3)
+        {
+        }
+
+        /// <summary>
+        /// Total number of block-states to receive in the current batch.
+        /// </summary>
+        public int TotalBlockStateCount { get; internal set; }
+
+        /// <summary>
+        /// The number of currently received block-states.
+        /// </summary>
+        public int ReceivedBlockStateCount { get; internal set; }
+
+        /// <summary>
+        /// The hash digest of the block of the block-states just received.
+        /// </summary>
+        public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
+    }
+}

--- a/Libplanet/Net/BlockStateDownloadState.cs
+++ b/Libplanet/Net/BlockStateDownloadState.cs
@@ -4,7 +4,7 @@ using Libplanet.Blocks;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A container that indicates the progress of a block-state download.
+    /// Indicates a progress of downloading block states.
     /// </summary>
     [Equals]
     public class BlockStateDownloadState : PreloadState
@@ -15,17 +15,17 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Total number of block-states to receive in the current batch.
+        /// Total number of block states to receive in the current batch.
         /// </summary>
         public int TotalBlockStateCount { get; internal set; }
 
         /// <summary>
-        /// The number of currently received block-states.
+        /// The number of received block states until now.
         /// </summary>
         public int ReceivedBlockStateCount { get; internal set; }
 
         /// <summary>
-        /// The hash digest of the block of the block-states just received.
+        /// The blcok hash of the states just received.
         /// </summary>
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
     }

--- a/Libplanet/Net/BlockStateDownloadState.cs
+++ b/Libplanet/Net/BlockStateDownloadState.cs
@@ -9,11 +9,6 @@ namespace Libplanet.Net
     [Equals]
     public class BlockStateDownloadState : PreloadState
     {
-        public BlockStateDownloadState()
-            : base(PreloadPhase.BlockStatesDownload, 3)
-        {
-        }
-
         /// <summary>
         /// Total number of block states to receive in the current batch.
         /// </summary>
@@ -28,5 +23,8 @@ namespace Libplanet.Net
         /// The blcok hash of the states just received.
         /// </summary>
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 3;
     }
 }

--- a/Libplanet/Net/PreloadState.cs
+++ b/Libplanet/Net/PreloadState.cs
@@ -1,0 +1,50 @@
+namespace Libplanet.Net
+{
+    [Equals]
+    public class PreloadState
+    {
+        protected PreloadState(PreloadPhase currentPhase, int totalPhase)
+        {
+            CurrentPhase = (int)currentPhase;
+            TotalPhase = totalPhase;
+        }
+
+        /// <summary>
+        /// Enum to describe phases of progress in preload.
+        /// </summary>
+        protected enum PreloadPhase
+        {
+            /// <summary>
+            /// The phase to download blocks.
+            /// </summary>
+            BlockDownload = 1,
+
+            /// <summary>
+            /// The phase to downloading state references.
+            /// </summary>
+            StateReferenceDownload = 2,
+
+            /// <summary>
+            /// The phase to download blocks.
+            /// </summary>
+            BlockStatesDownload = 3,
+
+            /// <summary>
+            /// The phase to execute actions.
+            /// This phase will be came when <see cref="Swarm{T}"/> failed to receive
+            /// state-references or block-states.
+            /// </summary>
+            BlockEvaluate = 4,
+        }
+
+        /// <summary>
+        /// The current phase.
+        /// </summary>
+        public int CurrentPhase { get; }
+
+        /// <summary>
+        /// The number of total phases.
+        /// </summary>
+        public int TotalPhase { get; }
+    }
+}

--- a/Libplanet/Net/PreloadState.cs
+++ b/Libplanet/Net/PreloadState.cs
@@ -1,5 +1,8 @@
 namespace Libplanet.Net
 {
+    // <summary>
+    // Indicates a progress of preloading things from the network.
+    // </summary>
     [Equals]
     public class PreloadState
     {
@@ -10,7 +13,7 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Enum to describe phases of progress in preload.
+        /// Each phase in the whole preloading process.
         /// </summary>
         protected enum PreloadPhase
         {
@@ -20,19 +23,19 @@ namespace Libplanet.Net
             BlockDownload = 1,
 
             /// <summary>
-            /// The phase to downloading state references.
+            /// The phase to download state references.
             /// </summary>
             StateReferenceDownload = 2,
 
             /// <summary>
-            /// The phase to download blocks.
+            /// The phase to download block states.
             /// </summary>
             BlockStatesDownload = 3,
 
             /// <summary>
-            /// The phase to execute actions.
-            /// This phase will be came when <see cref="Swarm{T}"/> failed to receive
-            /// state-references or block-states.
+            /// The phase to execute block actions.
+            /// This phase is entered only when <see cref="Swarm{T}"/> fails to receive
+            /// precalculated states from trusted peers or has no trusted peers at all.
             /// </summary>
             BlockEvaluate = 4,
         }

--- a/Libplanet/Net/PreloadState.cs
+++ b/Libplanet/Net/PreloadState.cs
@@ -4,50 +4,16 @@ namespace Libplanet.Net
     // Indicates a progress of preloading things from the network.
     // </summary>
     [Equals]
-    public class PreloadState
+    public abstract class PreloadState
     {
-        protected PreloadState(PreloadPhase currentPhase, int totalPhase)
-        {
-            CurrentPhase = (int)currentPhase;
-            TotalPhase = totalPhase;
-        }
-
         /// <summary>
-        /// Each phase in the whole preloading process.
+        /// The number of total phases.
         /// </summary>
-        protected enum PreloadPhase
-        {
-            /// <summary>
-            /// The phase to download blocks.
-            /// </summary>
-            BlockDownload = 1,
-
-            /// <summary>
-            /// The phase to download state references.
-            /// </summary>
-            StateReferenceDownload = 2,
-
-            /// <summary>
-            /// The phase to download block states.
-            /// </summary>
-            BlockStatesDownload = 3,
-
-            /// <summary>
-            /// The phase to execute block actions.
-            /// This phase is entered only when <see cref="Swarm{T}"/> fails to receive
-            /// precalculated states from trusted peers or has no trusted peers at all.
-            /// </summary>
-            BlockEvaluate = 4,
-        }
+        public const int TotalPhase = 4;
 
         /// <summary>
         /// The current phase.
         /// </summary>
-        public int CurrentPhase { get; }
-
-        /// <summary>
-        /// The number of total phases.
-        /// </summary>
-        public int TotalPhase { get; }
+        public abstract int CurrentPhase { get; }
     }
 }

--- a/Libplanet/Net/StateReferenceDownloadState.cs
+++ b/Libplanet/Net/StateReferenceDownloadState.cs
@@ -1,0 +1,30 @@
+using System.Numerics;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// A container that indicates the progress of downloading state references..
+    /// </summary>
+    public class StateReferenceDownloadState : PreloadState
+    {
+        public StateReferenceDownloadState()
+            : base(PreloadPhase.StateReferenceDownload, 3)
+        {
+        }
+
+        /// <summary>
+        /// Total number of state references to receive in the current batch.
+        /// </summary>
+        public int TotalStateReferenceCount { get; internal set; }
+
+        /// <summary>
+        /// The number of received state references until now.
+        /// </summary>
+        public int ReceivedStateReferenceCount { get; internal set; }
+
+        /// <summary>
+        /// The address of the state references just received.
+        /// </summary>
+        public Address ReceivedAddress { get; internal set; }
+    }
+}

--- a/Libplanet/Net/StateReferenceDownloadState.cs
+++ b/Libplanet/Net/StateReferenceDownloadState.cs
@@ -7,11 +7,6 @@ namespace Libplanet.Net
     /// </summary>
     public class StateReferenceDownloadState : PreloadState
     {
-        public StateReferenceDownloadState()
-            : base(PreloadPhase.StateReferenceDownload, 3)
-        {
-        }
-
         /// <summary>
         /// Total number of state references to receive in the current batch.
         /// </summary>
@@ -26,5 +21,8 @@ namespace Libplanet.Net
         /// The address of the state references just received.
         /// </summary>
         public Address ReceivedAddress { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 2;
     }
 }

--- a/Libplanet/Net/StateReferenceDownloadState.cs
+++ b/Libplanet/Net/StateReferenceDownloadState.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A container that indicates the progress of downloading state references..
+    /// Indicates a progress of downloading state references.
     /// </summary>
     public class StateReferenceDownloadState : PreloadState
     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -614,6 +614,7 @@ namespace Libplanet.Net
                     ? 0
                     : initialTip.Index + 1;
                 int count = 0, totalCount = _blockChain.BlockHashes.Count() - (int)initHeight;
+                _logger.Debug("Starts to execute actions of {0} blocks.", totalCount);
                 foreach (HashDigest<SHA256> hash in _blockChain.BlockHashes.Skip((int)initHeight))
                 {
                     Block<T> block = _blockChain.Blocks[hash];
@@ -623,6 +624,7 @@ namespace Libplanet.Net
                     }
 
                     _blockChain.ExecuteActions(block, render: false);
+                    _logger.Debug("Executed actions in the block {0}.", block.Hash);
                     progress?.Report(new ActionExecutionState()
                     {
                         TotalBlockCount = totalCount,
@@ -630,6 +632,8 @@ namespace Libplanet.Net
                         ExecutedBlockHash = block.Hash,
                     });
                 }
+
+                _logger.Debug("Finished to execute actions.");
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -613,7 +613,7 @@ namespace Libplanet.Net
                     initialTip is null || !_blockChain[initialTip.Index].Equals(initialTip)
                     ? 0
                     : initialTip.Index + 1;
-                int count = 0, totalCount = _blockChain.BlockHashes.Count() - (int)initHeight;
+                int count = 0, totalCount = _blockChain.Count() - (int)initHeight;
                 _logger.Debug("Starts to execute actions of {0} blocks.", totalCount);
                 foreach (HashDigest<SHA256> hash in _blockChain.BlockHashes.Skip((int)initHeight))
                 {


### PR DESCRIPTION
It resolves #397.

Before this, there was no way to know progress of download state-references or block-states.
So this make swarm report progress with `State` classes inherited `PreloadState` during preload. :cat2: 