### PR TITLE
Change total block count when received count is bigger

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1014,6 +1014,11 @@ namespace Libplanet.Tests.Net
                 lock (actualStates)
                 {
                     actualStates.Add(state);
+
+                    if (actualStates.Count == 8)
+                    {
+                        minerChain.MineBlock(_fx1.Address1);
+                    }
                 }
             });
 
@@ -1027,15 +1032,16 @@ namespace Libplanet.Tests.Net
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
 
-                IEnumerable<BlockDownloadState> expectedStates = minerChain.Select((b, i) =>
+                BlockDownloadState[] expectedStates = minerChain.Select((b, i) =>
                 {
-                    return new BlockDownloadState()
+                    return new BlockDownloadState
                     {
                         ReceivedBlockHash = b.Hash,
                         TotalBlockCount = 10,
                         ReceivedBlockCount = i + 1,
                     };
-                });
+                }).ToArray();
+                expectedStates[10].TotalBlockCount = 11;
 
                 Assert.Equal(expectedStates, actualStates);
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1364,6 +1364,8 @@ namespace Libplanet.Net
                     $"(tip: {blockChain.Tip?.Hash})"
                 );
 
+                totalBlockCount = Math.Max(totalBlockCount, receivedBlockCount + hashCount);
+
                 await GetBlocksAsync(peer, hashesAsArray)
                     .ForEachAsync(
                     block =>


### PR DESCRIPTION
Currently, received count is displayed bigger than total block count if seed node mine another block while IBD. This patch changes the total block count when that situation happens.