### PR TITLE
Read–write lock on TransactionSet

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -595,6 +595,14 @@ namespace Libplanet.Blockchain
                 _indexLock.EnterWriteLock();
                 try
                 {
+                    // This could seem redundant, because the below Blocks[block.Hash] = block
+                    // would do the same thing under the hood, but this purposes to ensure
+                    // each transaction in the block is atomically stored.
+                    foreach (Transaction<T> tx in block.Transactions)
+                    {
+                        Transactions[tx.Id] = tx;
+                    }
+
                     Blocks[block.Hash] = block;
                     foreach (KeyValuePair<Address, long> pair in nonceDeltas)
                     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -943,7 +943,7 @@ namespace Libplanet.Net
                     Message parsedMessage = Message.Parse(reply, reply: true);
                     if (parsedMessage is RecentStates recentStates && !recentStates.Missing)
                     {
-                        ReaderWriterLockSlim rwlock = BlockChain._rwlock;
+                        ReaderWriterLockSlim rwlock = BlockChain._indexLock;
                         rwlock.EnterWriteLock();
                         try
                         {
@@ -1500,7 +1500,7 @@ namespace Libplanet.Net
 
             if (_blockChain.Blocks.ContainsKey(target))
             {
-                ReaderWriterLockSlim rwlock = _blockChain._rwlock;
+                ReaderWriterLockSlim rwlock = _blockChain._indexLock;
                 rwlock.EnterReadLock();
                 try
                 {


### PR DESCRIPTION
Since `IStore` implementations could have some problems with concurrent `PutTransaction<T>()` calls, I believe it's way safer to have read–write lock on `TransactionSet` interface.