### PR TITLE
Restore tx corruption check in LiteDBStore

### DIFF
--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -213,7 +213,7 @@ namespace Libplanet.Store
                 DownloadFile(file, stream);
 
                 var bytes = stream.ToArray();
-                if (bytes.Length != file.Length)
+                if (bytes.Length != file.Length || bytes.Length < 1)
                 {
                     _logger.Warning(
                         "The data file for the transaction {TxId} seems corrupted; " +


### PR DESCRIPTION
This PR restores corruption check condition about empty transaction data (implemented #387 ).