### PR TITLE
Fix bug that NetworkStreamProxy.StartAsync() never stops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,8 @@ To be released.
     return `null` even for already stored transactions, and for that case,
     a warning will be logged through Serilog.
     [[#386], [#387], [LiteDB #1268]]
+ -  Fixed a bug that `NetworkStreamProxy.StartAsync()` hadn't stopped properly
+    when the connection had reset by a remote peer.  [[#414]]
 
 [#319]: https://github.com/planetarium/libplanet/issues/319
 [#343]: https://github.com/planetarium/libplanet/pull/343
@@ -104,6 +106,7 @@ To be released.
 [#398]: https://github.com/planetarium/libplanet/pull/398
 [#399]: https://github.com/planetarium/libplanet/pull/399
 [#400]: https://github.com/planetarium/libplanet/pull/400
+[#414]: https://github.com/planetarium/libplanet/pull/414
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 
 

--- a/Libplanet/Net/NetworkStreamProxy.cs
+++ b/Libplanet/Net/NetworkStreamProxy.cs
@@ -35,9 +35,7 @@ namespace Libplanet.Net
             _targetClient.Connect(endPoint);
 #pragma warning restore PC001
             NetworkStream target = _targetClient.GetStream();
-            await Task.WhenAll(
-                Proxy(_source, target),
-                Proxy(target, _source));
+            await await Task.WhenAny(Proxy(_source, target), Proxy(target, _source));
         }
 
         public void Dispose()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1938,7 +1938,10 @@ namespace Libplanet.Net
             {
                 NetMQMessage raw = e.Socket.ReceiveMultipartMessage();
 
-                _logger.Verbose($"The raw message[{raw}] has received.");
+                _logger.Verbose(
+                    "The raw message[frame count: {0}] has received.",
+                    raw.FrameCount
+                );
                 Message message = Message.Parse(raw, reply: false);
                 _logger.Debug($"The message[{message}] has parsed.");
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -350,6 +350,11 @@ namespace Libplanet.Net
                     _replyQueue.ReceiveReady -= DoReply;
                     _router.ReceiveReady -= ReceiveMessage;
 
+                    if (_poller.IsRunning)
+                    {
+                        _poller.Dispose();
+                    }
+
                     _broadcastQueue.Dispose();
                     _replyQueue.Dispose();
                     _router.Dispose();


### PR DESCRIPTION
This PR fixes a bug that `NetworkStreamProxy.StartAsync()` never stops even if the connection had disconnected by a remote peer.