### PR TITLE
Boost PreloadAsync()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ To be released.
     method became replaced by
     `StoreStateReference(string, IImmutableSet<Address>, HashDigest<SHA256>, long)`
     method so that it takes hash and index of a block instead of an entire
-    block.
+    block.  [[#420]]
+ -  Added `IStore.ForkBlockIndexes()` method.  [[#420]]
 
 ### Added interfaces
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ To be released.
 
 ### Backward-incompatible interface changes
 
+ -  `IStore.StoreStateReference<T>(string, IImmutableSet<Address>, Block<T>)`
+    method became replaced by
+    `StoreStateReference(string, IImmutableSet<Address>, HashDigest<SHA256>, long)`
+    method so that it takes hash and index of a block instead of an entire
+    block.
+
 ### Added interfaces
 
 ### Behavioral changes
@@ -17,6 +23,7 @@ To be released.
  -  Fixed a bug that `Swarm<T>` hadn't released its TURN releated resources on
     `Swarm<T>.StopAsync()`.  [[#450]]
 
+[#420]: https://github.com/planetarium/libplanet/pull/420
 [#450]: https://github.com/planetarium/libplanet/pull/450
 
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1392,7 +1392,8 @@ namespace Libplanet.Tests.Blockchain
                     store.StoreStateReference(
                         chainId.ToString(),
                         dirty.Keys.ToImmutableHashSet(),
-                        b
+                        b.Hash,
+                        b.Index
                     );
                     BuildIndex(chainId, b);
                 }

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -47,7 +47,12 @@ namespace Libplanet.Tests.Store
             Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, block5));
             Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, block6));
 
-            fx.Store.StoreStateReference(fx.StoreNamespace, tx4.UpdatedAddresses, block4);
+            fx.Store.StoreStateReference(
+                fx.StoreNamespace,
+                tx4.UpdatedAddresses,
+                block4.Hash,
+                block4.Index
+            );
             Assert.Null(fx.Store.LookupStateReference(fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(
                 Tuple.Create(block4.Hash, block4.Index),
@@ -62,7 +67,12 @@ namespace Libplanet.Tests.Store
                 fx.Store.LookupStateReference(fx.StoreNamespace, address, block6)
             );
 
-            fx.Store.StoreStateReference(fx.StoreNamespace, tx5.UpdatedAddresses, block5);
+            fx.Store.StoreStateReference(
+                fx.StoreNamespace,
+                tx5.UpdatedAddresses,
+                block5.Hash,
+                block5.Index
+            );
             Assert.Null(fx.Store.LookupStateReference(
                 fx.StoreNamespace, address, fx.Block3));
             Assert.Equal(

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -51,7 +51,8 @@ namespace Libplanet.Tests.Store
             Fx.Store.StoreStateReference(
                 Fx.StoreNamespace,
                 addresses.Take(3).ToImmutableHashSet(),
-                block1
+                block1.Hash,
+                block1.Index
             );
             Fx.Store.IncreaseTxNonce(Fx.StoreNamespace, Fx.Transaction1.Signer);
 
@@ -87,7 +88,8 @@ namespace Libplanet.Tests.Store
             Fx.Store.StoreStateReference(
                 Fx.StoreNamespace,
                 addresses.Take(3).ToImmutableHashSet(),
-                Fx.Block1
+                Fx.Block1.Hash,
+                Fx.Block1.Index
             );
             Assert.Equal(
                 addresses.Take(3).ToImmutableHashSet(),
@@ -96,7 +98,8 @@ namespace Libplanet.Tests.Store
             Fx.Store.StoreStateReference(
                 Fx.StoreNamespace,
                 addresses.Skip(2).Take(3).ToImmutableHashSet(),
-                Fx.Block2
+                Fx.Block2.Hash,
+                Fx.Block2.Index
             );
             Assert.Equal(
                 addresses.Take(5).ToImmutableHashSet(),
@@ -105,7 +108,8 @@ namespace Libplanet.Tests.Store
             Fx.Store.StoreStateReference(
                 Fx.StoreNamespace,
                 addresses.Skip(5).Take(3).ToImmutableHashSet(),
-                Fx.Block3
+                Fx.Block3.Hash,
+                Fx.Block3.Index
             );
             Assert.Equal(
                 addresses.ToImmutableHashSet(),
@@ -343,13 +347,23 @@ namespace Libplanet.Tests.Store
 
             Assert.Empty(this.Fx.Store.IterateStateReferences(this.Fx.StoreNamespace, address));
 
-            Fx.Store.StoreStateReference(Fx.StoreNamespace, tx4.UpdatedAddresses, block4);
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                tx4.UpdatedAddresses,
+                block4.Hash,
+                block4.Index
+            );
             Assert.Equal(
                 new[] { Tuple.Create(block4.Hash, block4.Index) },
                 this.Fx.Store.IterateStateReferences(this.Fx.StoreNamespace, address)
             );
 
-            Fx.Store.StoreStateReference(Fx.StoreNamespace, tx5.UpdatedAddresses, block5);
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                tx5.UpdatedAddresses,
+                block5.Hash,
+                block5.Index
+            );
             Assert.Equal(
                 new[]
                 {
@@ -392,7 +406,11 @@ namespace Libplanet.Tests.Store
             {
                 updatedAddresses = new HashSet<Address> { address1 };
                 Fx.Store.StoreStateReference(
-                    Fx.StoreNamespace, updatedAddresses.ToImmutableHashSet(), block);
+                    Fx.StoreNamespace,
+                    updatedAddresses.ToImmutableHashSet(),
+                    block.Hash,
+                    block.Index
+                );
             }
 
             var txs2 = new[] { tx2 };
@@ -400,7 +418,11 @@ namespace Libplanet.Tests.Store
 
             updatedAddresses = new HashSet<Address> { address2 };
             Fx.Store.StoreStateReference(
-                Fx.StoreNamespace, updatedAddresses.ToImmutableHashSet(), blocks[3]);
+                Fx.StoreNamespace,
+                updatedAddresses.ToImmutableHashSet(),
+                blocks[3].Hash,
+                blocks[3].Index
+            );
 
             var branchPoint = blocks[branchPointIndex];
             var addressesToStrip = new[] { address1, address2 }.ToImmutableHashSet();

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -176,15 +176,15 @@ namespace Libplanet.Tests.Store
             return _store.IterateStateReferences(@namespace, address);
         }
 
-        public void StoreStateReference<T>(
+        public void StoreStateReference(
             string @namespace,
             IImmutableSet<Address> addresses,
-            Block<T> block)
-            where T : IAction, new()
+            HashDigest<SHA256> blockHash,
+            long blockIndex)
         {
             // FIXME: Log arguments properly (including @namespace).
-            _logs.Add((nameof(StoreStateReference), block.Hash, null));
-            _store.StoreStateReference(@namespace, addresses, block);
+            _logs.Add((nameof(StoreStateReference), blockHash, null));
+            _store.StoreStateReference(@namespace, addresses, blockHash, blockIndex);
         }
 
         public void ForkStateReferences<T>(

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -200,6 +200,15 @@ namespace Libplanet.Tests.Store
                 sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
         }
 
+        public void ForkBlockIndexes(
+            string sourceNamespace,
+            string destinationNamespace,
+            HashDigest<SHA256> branchPoint)
+        {
+            _logs.Add((nameof(ForkBlockIndexes), null, null));
+            _store.ForkBlockIndexes(sourceNamespace, destinationNamespace, branchPoint);
+        }
+
         public IEnumerable<KeyValuePair<Address, long>> ListTxNonces(string @namespace)
         {
             _logs.Add((nameof(ListTxNonces), @namespace, null));

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1080,7 +1080,12 @@ namespace Libplanet.Blockchain
 
             if (buildStateReferences)
             {
-                Store.StoreStateReference(Id.ToString(), updatedAddresses, block);
+                Store.StoreStateReference(
+                    Id.ToString(),
+                    updatedAddresses,
+                    block.Hash,
+                    block.Index
+                );
             }
         }
     }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -815,15 +815,8 @@ namespace Libplanet.Blockchain
             try
             {
                 _rwlock.EnterReadLock();
-                foreach (var index in Store.IterateIndex(id))
-                {
-                    Store.AppendIndex(forkedId, index);
-                    if (index.Equals(point))
-                    {
-                        break;
-                    }
-                }
 
+                Store.ForkBlockIndexes(id, forkedId, point);
                 Block<T> pointBlock = Blocks[point];
 
                 var addressesToStrip = new HashSet<Address>();

--- a/Libplanet/Net/StateReferenceDownloadState.cs
+++ b/Libplanet/Net/StateReferenceDownloadState.cs
@@ -17,11 +17,6 @@ namespace Libplanet.Net
         /// </summary>
         public int ReceivedStateReferenceCount { get; internal set; }
 
-        /// <summary>
-        /// The address of the state references just received.
-        /// </summary>
-        public Address ReceivedAddress { get; internal set; }
-
         /// <inheritdoc />
         public override int CurrentPhase => 2;
     }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -39,6 +39,12 @@ namespace Libplanet.Store
         );
 
         /// <inheritdoc />
+        public abstract void ForkBlockIndexes(
+            string sourceNamespace,
+            string destinationNamespace,
+            HashDigest<SHA256> branchPoint);
+
+        /// <inheritdoc />
         public abstract IEnumerable<Address> ListAddresses(string @namespace);
 
         /// <inheritdoc />

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -119,12 +119,11 @@ namespace Libplanet.Store
         public abstract IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace, Address address);
 
-        /// <inheritdoc />
-        public abstract void StoreStateReference<T>(
+        public abstract void StoreStateReference(
             string @namespace,
             IImmutableSet<Address> addresses,
-            Block<T> block)
-            where T : IAction, new();
+            HashDigest<SHA256> hashDigest,
+            long index);
 
         /// <inheritdoc />
         public abstract void ForkStateReferences<T>(

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -54,6 +54,26 @@ namespace Libplanet.Store
         bool DeleteIndex(string @namespace, HashDigest<SHA256> hash);
 
         /// <summary>
+        /// Forks block indexes from
+        /// <paramref name="sourceNamespace"/> to
+        /// <paramref name="destinationNamespace"/>.
+        /// </summary>
+        /// <param name="sourceNamespace">The namespace of block indexes to
+        /// fork.</param>
+        /// <param name="destinationNamespace">The namespace of destination
+        /// block indexes.</param>
+        /// <param name="branchPoint">The branch point <see cref="Block{T}"/>
+        /// to fork.</param>
+        /// <exception cref="NamespaceNotFoundException">Thrown when the given
+        /// <paramref name="sourceNamespace"/> does not exist.</exception>
+        /// <seealso cref="IterateIndex(string, int, int?)"/>
+        /// <seealso cref="AppendIndex(string, HashDigest{SHA256})"/>
+        void ForkBlockIndexes(
+            string sourceNamespace,
+            string destinationNamespace,
+            HashDigest<SHA256> branchPoint);
+
+        /// <summary>
         /// Deletes an index, tx nonces, and state references in the given
         /// <paramref name="namespace"/>.
         /// It also deletes namespace itself.  If there is no such <paramref name="namespace"/> it

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -175,6 +175,7 @@ namespace Libplanet.Store
             AddressStateMap states
         );
 
+        #pragma warning disable MEN002
         /// <summary>
         /// Gets pairs of a state reference and a corresponding <see cref="Block{T}.Index"/> of
         /// the requested <paramref name="address"/> in the specified <paramref name="namespace"/>.
@@ -184,7 +185,8 @@ namespace Libplanet.Store
         /// <returns><em>Ordered</em> pairs of a state reference and a corresponding
         /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) goes
         /// first and the lowest index (i.e., the closest to the genesis) goes last.</returns>
-        /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
+        /// <seealso cref="StoreStateReference(string, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
+        #pragma warning restore MEN002 // Line is too long
         IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             string @namespace,
             Address address);
@@ -193,25 +195,24 @@ namespace Libplanet.Store
         /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>
         /// that has the state of the <see cref="Address"/> for each updated
         /// <see cref="Address"/>es by the <see cref="Transaction{T}"/>s in the
-        /// <paramref name="block"/>.</summary>
+        /// <see cref="Block{T}" />.</summary>
         /// <param name="namespace">The namespace to store a state reference.
         /// </param>
         /// <param name="addresses">The <see cref="Address"/>es to store state
         /// reference.</param>
-        /// <param name="block">The <see cref="Block{T}"/> which has the state
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> which has the state
         /// of the <see cref="Address"/>.</param>
-        /// <typeparam name="T">An <see cref="IAction"/> class used with
-        /// <paramref name="block"/>.</typeparam>
-        /// <remarks>State reference must be stored in the same order as the blocks. For now,
-        /// it is assumed that this is only called by
-        /// <see cref="BlockChain{T}.Append(Block{T})"/> method.</remarks>
+        /// <param name="blockIndex">The <see cref="Block{T}.Index"/> which has the state
+        /// of the <see cref="Address"/>. This must refer to the same block
+        /// that <paramref name="blockHash"/> refers to.</param>
         /// <seealso cref="IterateStateReferences(string, Address)"/>
-        void StoreStateReference<T>(
+        void StoreStateReference(
             string @namespace,
             IImmutableSet<Address> addresses,
-            Block<T> block)
-            where T : IAction, new();
+            HashDigest<SHA256> blockHash,
+            long blockIndex);
 
+        #pragma warning disable MEN002
         /// <summary>
         /// Forks state references, which are <see cref="Block{T}.Hash"/>es that
         /// have the state of the <see cref="Address"/>es, from
@@ -236,7 +237,8 @@ namespace Libplanet.Store
         /// <exception cref="NamespaceNotFoundException">Thrown when the given
         /// <paramref name="sourceNamespace"/> does not exist.</exception>
         /// <seealso cref="IterateStateReferences(string, Address)"/>
-        /// <seealso cref="StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
+        /// <seealso cref="StoreStateReference(string, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
+        #pragma warning restore MEN002
         void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -192,6 +192,19 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public override void ForkBlockIndexes(
+            string sourceNamespace,
+            string destinationNamespace,
+            HashDigest<SHA256> branchPoint)
+        {
+            LiteCollection<HashDoc> srcColl = IndexCollection(sourceNamespace);
+            LiteCollection<HashDoc> destColl = IndexCollection(destinationNamespace);
+
+            destColl.InsertBulk(srcColl.FindAll().TakeWhile(i => !i.Hash.Equals(branchPoint)));
+            AppendIndex(destinationNamespace, branchPoint);
+        }
+
+        /// <inheritdoc/>
         public override IEnumerable<Address> ListAddresses(string @namespace)
         {
             string collId = StateRefId(@namespace);

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -432,10 +432,11 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override void StoreStateReference<T>(
+        public override void StoreStateReference(
             string @namespace,
             IImmutableSet<Address> addresses,
-            Block<T> block)
+            HashDigest<SHA256> hash,
+            long index)
         {
             string collId = StateRefId(@namespace);
             LiteCollection<StateRefDoc> coll = _db.GetCollection<StateRefDoc>(collId);
@@ -443,8 +444,8 @@ namespace Libplanet.Store
                 addresses.Select(addr => new StateRefDoc
                 {
                     Address = addr,
-                    BlockIndex = block.Index,
-                    BlockHash = block.Hash,
+                    BlockIndex = index,
+                    BlockHash = hash,
                 })
             );
             coll.EnsureIndex("AddressString");

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -10,6 +10,7 @@ namespace Libplanet.Store
 {
     public static class StoreExtension
     {
+        #pragma warning disable MEN002
         /// <summary>
         /// Looks up a state reference, which is a block's <see cref="Block{T}.Hash"/> that contains
         /// an action mutating the <paramref name="address"/>' state.
@@ -24,9 +25,9 @@ namespace Libplanet.Store
         /// address.</returns>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="lookupUntil"/>.</typeparam>
-        /// <seealso
-        /// cref="IStore.StoreStateReference{T}(string, IImmutableSet{Address}, Block{T})"/>
+        /// <seealso cref="IStore.StoreStateReference(string, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
         /// <seealso cref="IStore.IterateStateReferences(string, Address)"/>
+        #pragma warning restore MEN002
         public static Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             this IStore store,
             string @namespace,


### PR DESCRIPTION
This patch enhances the performance of `Swarm.PreloadAsync()` using two tricks as below.

- Instead of using `RecentStates.StateReferences` directly, `PreloadAsync` became to translate this message as `Dictionary<HashDigest<SHA256>, ISet<Address>>` to reduce file I/O.
  - To accomplish this, `IStore.StoreStateReference` became to take `blockHash` and `blockIndex`, not whole `Block`.
- `PreloadAsync()` are currently fork its chain to prevent corruption by unexpected termination. this patch reduces its file I/O by `IStore.ForkIndexes()`