### PR TITLE
Better cancellation & atomicity for PreloadAsync()

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -493,8 +493,7 @@ namespace Libplanet.Net
             {
                 _logger.Error(
                     e,
-                    $"An unexpected exception occurred during {nameof(StartAsync)}(): {0}",
-                    e
+                    $"An unexpected exception occurred during {nameof(StartAsync)}(): {e}"
                 );
                 throw;
             }
@@ -1020,9 +1019,8 @@ namespace Libplanet.Net
                     catch (TimeoutException e)
                     {
                         _logger.Error(
-                            "Failed to receive recent states from a peer ({0}): {1}",
-                            peer,
-                            e
+                            "Failed to receive recent states from a peer ({0}): " + e,
+                            peer
                         );
                         continue;
                     }
@@ -1151,8 +1149,7 @@ namespace Libplanet.Net
                 {
                     _logger.Error(
                         e,
-                        $"An unexpected exception occured during {nameof(BroadcastTxAsync)}(): {0}",
-                        e
+                        $"An unexpected exception occured during {nameof(BroadcastTxAsync)}(): {e}"
                     );
                 }
             }
@@ -2054,8 +2051,7 @@ namespace Libplanet.Net
                         {
                             _logger.Error(
                                 exc,
-                                "Something went wrong during message parsing: {0}",
-                                exc
+                                $"Something went wrong during message parsing: {exc}"
                             );
                             throw;
                         }
@@ -2064,14 +2060,13 @@ namespace Libplanet.Net
             }
             catch (InvalidMessageException ex)
             {
-                _logger.Error(ex, "Could not parse NetMQMessage properly; ignore: {0}", ex);
+                _logger.Error(ex, $"Could not parse NetMQMessage properly; ignore: {ex}");
             }
             catch (Exception ex)
             {
                 _logger.Error(
                     ex,
-                    "An unexpected exception occured during ReceiveMessage(): {0}",
-                    ex
+                    $"An unexpected exception occured during ReceiveMessage(): {ex}"
                 );
             }
         }

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -51,7 +51,8 @@ namespace Libplanet.Store
         /// <summary>
         /// Deletes an index, tx nonces, and state references in the given
         /// <paramref name="namespace"/>.
-        /// It also deletes namespace itself.
+        /// It also deletes namespace itself.  If there is no such <paramref name="namespace"/> it
+        /// does nothing.
         /// </summary>
         /// <param name="namespace">The namespace to delete.</param>
         /// <remarks>This does not delete blocks or transactions that belong to

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2150</MaxFileLines>
+  <MaxFileLines>2200</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
`Swarm<T>.PreloadAsync()` became to cleanup its working chain (store namespace) whether it normally finishes or is cancelled.  Also `Swarm` now more properly addresses cancellation requests.