### PR TITLE
Continue RefreshAllocate and RefreshPermission even if exc occurred.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,8 @@ To be released.
     disconnected while receiving.  [[#416]]
  -  Fixed a bug that `Swarm<T>.PreloadAsync()` had been processed even if there
     is no appropriate peer. [[#418]]
+ -  Fixed a bug that TURN related tasks hadn't restart automatically when an
+    exception occurred.  [[#422]]
  -  Fixed a bug that TURN relay connection had disconnected when preloading
     took a long time.  [[#424]]
 
@@ -135,6 +137,7 @@ To be released.
 [#417]: https://github.com/planetarium/libplanet/pull/417
 [#418]: https://github.com/planetarium/libplanet/pull/418
 [#419]: https://github.com/planetarium/libplanet/pull/419
+[#422]: https://github.com/planetarium/libplanet/pull/422
 [#423]: https://github.com/planetarium/libplanet/pull/423
 [#424]: https://github.com/planetarium/libplanet/pull/424
 [#426]: https://github.com/planetarium/libplanet/pull/426

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,7 +102,7 @@ To be released.
     disconnected while receiving.  [[#416]]
  -  Fixed a bug that `Swarm<T>.PreloadAsync()` had been processed even if there
     is no appropriate peer. [[#418]]
- -  Fixed a bug that TURN related tasks hadn't restart automatically when an
+ -  Fixed a bug that TURN-related tasks hadn't restarted automatically when an
     exception occurred.  [[#422]]
  -  Fixed a bug that TURN relay connection had disconnected when preloading
     took a long time.  [[#424]]

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2200</MaxFileLines>
+  <MaxFileLines>2250</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
This PR fixes a bug that `Swarm<T>` hadn't retried TURN related methods automatically when an exception occurred.