### PR TITLE
Fix slow FindNextHashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ To be released.
  -  `BaseIndex.ContainsKey()` method became `abstract`.  [[#390]]
  -  `BlockDownloadState.TotalBlockCount` and `BlockDownloadState.ReceivedBlockCount`
     became to `Int64` type.  [[#396], [#399]]
+ -  `IStore.IterateIndex()` method became to receive `offset` and `limit`
+    parameters.  [[#425]]
  -  Added `IStore.GetCanonicalNamespace()` method.  [[#426]]
  -  Added `IStore.SetCanonicalNamespace()` method.  [[#426]]
  -  Removed `IRandom.NextDouble()` method, because [floating-point arithmetics,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -283,6 +283,50 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
+        public void IterateIndex()
+        {
+            var ns = Fx.StoreNamespace;
+            var store = Fx.Store;
+
+            store.AppendIndex(ns, Fx.Hash1);
+            store.AppendIndex(ns, Fx.Hash2);
+            store.AppendIndex(ns, Fx.Hash3);
+
+            var indexes = store.IterateIndex(ns).ToArray();
+            Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
+
+            indexes = store.IterateIndex(ns, 1).ToArray();
+            Assert.Equal(new[] { Fx.Hash2, Fx.Hash3 }, indexes);
+
+            indexes = store.IterateIndex(ns, 2).ToArray();
+            Assert.Equal(new[] { Fx.Hash3 }, indexes);
+
+            indexes = store.IterateIndex(ns, 3).ToArray();
+            Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
+
+            indexes = store.IterateIndex(ns, 4).ToArray();
+            Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
+
+            indexes = store.IterateIndex(ns, limit: 0).ToArray();
+            Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
+
+            indexes = store.IterateIndex(ns, limit: 1).ToArray();
+            Assert.Equal(new[] { Fx.Hash1 }, indexes);
+
+            indexes = store.IterateIndex(ns, limit: 2).ToArray();
+            Assert.Equal(new[] { Fx.Hash1, Fx.Hash2 }, indexes);
+
+            indexes = store.IterateIndex(ns, limit: 3).ToArray();
+            Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
+
+            indexes = store.IterateIndex(ns, limit: 4).ToArray();
+            Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
+
+            indexes = store.IterateIndex(ns, 1, 1).ToArray();
+            Assert.Equal(new[] { Fx.Hash2 }, indexes);
+        }
+
+        [Fact]
         public void IterateStateReferences()
         {
             Address address = this.Fx.Address1;

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -118,10 +118,13 @@ namespace Libplanet.Tests.Store
             return _store.IterateBlockHashes();
         }
 
-        public IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace)
+        public IEnumerable<HashDigest<SHA256>> IterateIndex(
+            string @namespace,
+            int offset,
+            int? limit)
         {
             _logs.Add((nameof(IterateIndex), @namespace, null));
-            return _store.IterateIndex(@namespace);
+            return _store.IterateIndex(@namespace, offset, limit);
         }
 
         public IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -123,8 +123,8 @@ namespace Libplanet.Tests.Store
             int offset,
             int? limit)
         {
-            _logs.Add((nameof(IterateIndex), @namespace, null));
-            return _store.IterateIndex(@namespace, offset, limit);
+             _logs.Add((nameof(IterateIndex), @namespace, (offset, limit)));
+             return _store.IterateIndex(@namespace, offset, limit);
         }
 
         public IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -736,39 +736,15 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
-                IEnumerable<HashDigest<SHA256>> indexes = Store.IterateIndex(
-                    Id.ToString()
-                );
-
-                ImmutableArray<HashDigest<SHA256>> hashes = locator.ToImmutableArray();
-                var hashesIndex = hashes.Length - 1;
-
-                // Supposes the indexes are sorted in the order of the chain.
-                foreach (HashDigest<SHA256> index in indexes)
+                foreach (var hash in locator)
                 {
-                    for (int i = hashesIndex; i >= 0; --i)
+                    if (Blocks.ContainsKey(hash))
                     {
-                        if (index.Equals(hashes[i]))
-                        {
-                            hashesIndex = i;
-                            break;
-                        }
-                    }
-
-                    if (hashesIndex == 0)
-                    {
-                        break;
+                        return hash;
                     }
                 }
 
-                if (hashesIndex + 1 == hashes.Length)
-                {
-                    return this[0].Hash;
-                }
-                else
-                {
-                    return hashes[hashesIndex];
-                }
+                return this[0].Hash;
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -736,7 +736,7 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
-                foreach (var hash in locator)
+                foreach (HashDigest<SHA256> hash in locator)
                 {
                     if (Blocks.ContainsKey(hash))
                     {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -771,8 +771,7 @@ namespace Libplanet.Blockchain
                 HashDigest<SHA256> branchPoint = FindBranchPoint(locator);
                 var branchPointIndex = (int)Blocks[branchPoint].Index;
                 IEnumerable<HashDigest<SHA256>> hashes = Store
-                    .IterateIndex(Id.ToString())
-                    .Skip(branchPointIndex);
+                    .IterateIndex(Id.ToString(), branchPointIndex);
 
                 foreach (HashDigest<SHA256> hash in hashes)
                 {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -24,8 +24,9 @@ namespace Libplanet.Store
         public abstract long CountIndex(string @namespace);
 
         public abstract IEnumerable<HashDigest<SHA256>> IterateIndex(
-            string @namespace
-        );
+            string @namespace,
+            int offset,
+            int? limit);
 
         public abstract HashDigest<SHA256>? IndexBlockHash(
             string @namespace,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -38,9 +38,14 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="namespace">The namespace of the index that contains block hashes to
         /// iterate.</param>
+        /// <param name="offset">The starting point to return block hashes.</param>
+        /// <param name="limit">The maximum number of block hashes to get.</param>
         /// <returns>Block hashes in the index of the <paramref name="namespace"/>, in ascending
         /// order; the genesis block goes first, and the tip block goes last.</returns>
-        IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace);
+        IEnumerable<HashDigest<SHA256>> IterateIndex(
+            string @namespace,
+            int offset = 0,
+            int? limit = null);
 
         HashDigest<SHA256>? IndexBlockHash(string @namespace, long index);
 

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -143,10 +143,13 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<HashDigest<SHA256>> IterateIndex(string @namespace)
+        public override IEnumerable<HashDigest<SHA256>> IterateIndex(
+            string @namespace,
+            int offset,
+            int? limit)
         {
             return IndexCollection(@namespace)
-                .FindAll()
+                .Find(Query.All(), offset, limit ?? int.MaxValue)
                 .Select(i => i.Hash);
         }
 


### PR DESCRIPTION
This fixes a problem where `BlockChain.FinxNextHashes()` method is slow when there are many blocks.