### PR TITLE
Check Preload completeness

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -593,6 +593,8 @@ namespace Libplanet.Net
                 ? _blockChain.Fork(tip.Hash)
                 : new BlockChain<T>(_blockChain.Policy, _blockChain.Store, Guid.NewGuid());
 
+            var complete = false;
+
             try
             {
                 await SyncBehindsBlocksFromPeersAsync(
@@ -668,6 +670,8 @@ namespace Libplanet.Net
 
                     _logger.Debug("Finished to execute actions.");
                 }
+
+                complete = true;
             }
             finally
             {
@@ -676,7 +680,9 @@ namespace Libplanet.Net
                     _logger.Information($"{nameof(PreloadAsync)}() is canceled.");
                 }
 
-                if (workspace.Tip == _blockChain.Tip || cancellationToken.IsCancellationRequested)
+                if (!complete
+                    || workspace.Tip == _blockChain.Tip
+                    || cancellationToken.IsCancellationRequested)
                 {
                     _logger.Debug(
                         "Preloading is aborted; delete the temporary working chain ({0}: {1}), " +


### PR DESCRIPTION
Currently, `_blockChain.Swap` is performed when an exception occurred while preloading. We need to check the completeness of preloading before swapping.