### PR TITLE
Add Address(ImmutableArray<byte>) constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ To be released.
     which is underspecified, likely introduce
     indeterminism][floating-point determinism].  [[#410], [#419]]
  -  Added `IActionContext.NewGuId()` method.  [[#371], [#439]]
+ -  `Address(byte[])` became to throw `ArgumentNullException`
+    instead of `NullReferenceException`.  [[#443]]
 
 ### Added interfaces
 
@@ -53,6 +55,7 @@ To be released.
  -  Added `PreloadState`, `ActionExecutionState`, `StateReferenceDownloadState`,
     and `BlockStateDownloadState` classes to cover all phases in the entire
     preloading process.  [[#397], [#400]]
+ -  Added `Address(ImmutableArray<byte>)` constructor.  [[#442], [#443]]
 
 ### Behavioral changes
 
@@ -149,6 +152,8 @@ To be released.
 [#434]: https://github.com/planetarium/libplanet/pull/434
 [#438]: https://github.com/planetarium/libplanet/pull/438
 [#439]: https://github.com/planetarium/libplanet/pull/439
+[#442]: https://github.com/planetarium/libplanet/issues/442
+[#443]: https://github.com/planetarium/libplanet/pull/443
 [LiteDB #1268]: https://github.com/mbdavid/LiteDB/issues/1268
 [floating-point determinism]: https://wp.me/p1fTCO-kT
 

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -12,8 +13,24 @@ namespace Libplanet.Tests
         [Fact]
         public void ConstructorDoesNotTakeNullValue()
         {
-            Assert.Throws<NullReferenceException>(
+            Assert.Throws<ArgumentNullException>(
                 () => new Address((byte[])null)
+            );
+        }
+
+        [Fact]
+        public void ConstructWithImmutableArray()
+        {
+            byte[] addr = new byte[20]
+            {
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab,
+                0xcd, 0xef, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef, 0xab,
+                0xcd, 0xef,
+            };
+
+            Assert.Equal(
+                new Address("0123456789ABcdefABcdEfABcdEFabcDEFabCDEF"),
+                new Address(addr.ToImmutableArray())
             );
         }
 

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Runtime.Serialization;
 using System.Text;
 using Libplanet.Crypto;
@@ -51,13 +49,35 @@ namespace Libplanet
         private ImmutableArray<byte> _byteArray;
 
         /// <summary>
+        /// Creates an <see cref="Address"/> instance from the given immutable <see
+        /// cref="byte"/> array (i.e., <paramref name="address"/>).
+        /// </summary>
+        /// <param name="address">An immutable array of 20 <see cref="byte"/>s which
+        /// represents an <see cref="Address"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when the given <paramref
+        /// name="address"/> array did not lengthen 20 bytes.</exception>
+        /// <remarks>A valid <see cref="byte"/> array which represents an
+        /// <see cref="Address"/> can be gotten using <see cref="ToByteArray()"
+        /// /> method.</remarks>
+        /// <seealso cref="ByteArray"/>
+        public Address(ImmutableArray<byte> address)
+        {
+            if (address.Length != Size)
+            {
+                throw new ArgumentException("address must be 20 bytes", nameof(address));
+            }
+
+            _byteArray = address;
+        }
+
+        /// <summary>
         /// Creates an <see cref="Address"/> instance from the given <see
         /// cref="byte"/> array (i.e., <paramref name="address"/>).
         /// </summary>
         /// <param name="address">An array of 20 <see cref="byte"/>s which
         /// represents an <see cref="Address"/>.  This must not be <c>null</c>.
         /// </param>
-        /// <exception cref="NullReferenceException">Thrown when <c>null</c> was
+        /// <exception cref="ArgumentNullException">Thrown when <c>null</c> was
         /// passed to <paramref name="address"/>.</exception>
         /// <exception cref="ArgumentException">Thrown when the given <paramref
         /// name="address"/> array did not lengthen 20 bytes.</exception>
@@ -66,18 +86,8 @@ namespace Libplanet
         /// /> method.</remarks>
         /// <seealso cref="ToByteArray()"/>
         public Address(byte[] address)
+            : this(address?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(address)))
         {
-            if (address == null)
-            {
-                throw new NullReferenceException("address must not be null");
-            }
-
-            if (address.Length != Size)
-            {
-                throw new ArgumentException("address must be 20 bytes");
-            }
-
-            _byteArray = address.ToImmutableArray();
         }
 
         public Address(


### PR DESCRIPTION
- Resolve #442 
- `Address(byte[])` became to throw `ArgumentNullException`
    instead of `NullReferenceException`.