### PR TITLE
Move BlockChain<T>.FindNextHashesChunkSize to Swarm<T>.FindNextHashesChunkSize

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -485,11 +485,11 @@ namespace Libplanet.Tests.Blockchain
                     new BlockLocator(new[] { block0.Hash }),
                     stop: block2.Hash));
 
-            _blockChain.FindNextHashesChunkSize = 2;
             Assert.Equal(
                 new[] { block0.Hash, block1.Hash },
                 _blockChain.FindNextHashes(
-                    new BlockLocator(new[] { block0.Hash })));
+                    new BlockLocator(new[] { block0.Hash }),
+                    count: 2));
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1049,7 +1049,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarm);
                 await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 
-                minerChain.FindNextHashesChunkSize = 2;
+                minerSwarm.FindNextHashesChunkSize = 2;
                 await receiverSwarm.PreloadAsync(progress);
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
@@ -1235,7 +1235,7 @@ namespace Libplanet.Tests.Net
             }
 
             Assert.NotNull(minerChain.Tip);
-            minerChain.FindNextHashesChunkSize = 2;
+            minerSwarm.FindNextHashesChunkSize = 2;
             await StartAsync(minerSwarm);
             await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer });
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -146,9 +146,6 @@ namespace Libplanet.Blockchain
 
         internal IStore Store { get; }
 
-        // It's virtually a constant in production, but used for unit tests.
-        internal int FindNextHashesChunkSize { get; set; } = 500;
-
         /// <inheritdoc/>
         public Block<T> this[int index] => this[(long)index];
 
@@ -754,9 +751,9 @@ namespace Libplanet.Blockchain
 
         internal IEnumerable<HashDigest<SHA256>> FindNextHashes(
             BlockLocator locator,
-            HashDigest<SHA256>? stop = null)
+            HashDigest<SHA256>? stop = null,
+            int count = 500)
         {
-            int count = FindNextHashesChunkSize;
             try
             {
                 _rwlock.EnterReadLock();

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -254,6 +254,8 @@ namespace Libplanet.Net
 
         internal ICollection<Peer> Peers => _peers.Keys;
 
+        internal int FindNextHashesChunkSize { get; set; }
+
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.
         /// </summary>
@@ -1235,7 +1237,8 @@ namespace Libplanet.Net
                         IEnumerable<HashDigest<SHA256>> hashes =
                             _blockChain.FindNextHashes(
                                 getBlockHashes.Locator,
-                                getBlockHashes.Stop);
+                                getBlockHashes.Stop,
+                                FindNextHashesChunkSize);
                         var reply = new BlockHashes(Address, hashes)
                         {
                             Identity = getBlockHashes.Identity,


### PR DESCRIPTION
As mentioned in issue, `BlockChain<T>.FindNextHashesChunkSize`  is used only for tests. So It's unneceesary to configure `FindNextHashesChunkSize` in `Swarm<T>` constructor.

So @dahlia suggest to make an property on `Swarm<T>`, and I applied it. cc @earlbread 

Resolve #407  