### PR TITLE
Fix ArgumentNullException thrown by BlockChain<T>.Fork() where it has incomplete states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,14 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug that `ArgumentNullException` had been thrown when a blockchain,
+    which consists of incomplete states (i.e., precalculated states downloaded
+    from trusted peers), encounters a new branch so that reorg is made.
+    [[#454], [#466]]
+
+[#454]: https://github.com/planetarium/libplanet/issues/454
+[#466]: https://github.com/planetarium/libplanet/pull/466
+
 
 Version 0.5.0
 -------------

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -493,7 +493,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanFork()
+        public void Fork()
         {
             var block1 = _blockChain.MineBlock(_fx.Address1);
             var block2 = _blockChain.MineBlock(_fx.Address1);
@@ -503,6 +503,14 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(new[] { block1, block2, block3 }, _blockChain);
             Assert.Equal(new[] { block1, block2 }, forked);
+        }
+
+        [Fact]
+        public void ForkChainWithIncompleteBlockStates()
+        {
+            (_, _, BlockChain<DumbAction> chain) = MakeIncompleteBlockStates();
+            BlockChain<DumbAction> forked = chain.Fork(chain[5].Hash);
+            Assert.Equal(chain.Take(6), forked);
         }
 
         [Fact]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -826,7 +826,6 @@ namespace Libplanet.Blockchain
 
                 Block<T> pointBlock = Blocks[point];
 
-                var addressesToStrip = new HashSet<Address>();
                 var signersToStrip = new Dictionary<Address, int>();
 
                 for (
@@ -835,13 +834,6 @@ namespace Libplanet.Blockchain
                     && !block.Hash.Equals(point);
                     block = Blocks[hash])
                 {
-                    ImmutableHashSet<Address> addresses =
-                        Store.GetBlockStates(block.Hash)
-                        .Select(kv => kv.Key)
-                        .ToImmutableHashSet();
-
-                    addressesToStrip.UnionWith(addresses);
-
                     IEnumerable<(Address, int)> signers = block
                         .Transactions
                         .GroupBy(tx => tx.Signer)
@@ -855,11 +847,14 @@ namespace Libplanet.Blockchain
                     }
                 }
 
+                // FIXME: ForkStateReferences<T>() method's addressesToStrip parameter is no more
+                // used, because it was made for FileStore which was gone since 0.5.0.
                 Store.ForkStateReferences(
                     id,
                     forked.Id.ToString(),
                     pointBlock,
-                    addressesToStrip.ToImmutableHashSet());
+                    addressesToStrip: null
+                );
 
                 foreach (KeyValuePair<Address, long> pair in Store.ListTxNonces(id))
                 {


### PR DESCRIPTION
This fixes <https://github.com/planetarium/libplanet/issues/454>.  I'm going to make another patch to remove the `addressesToStrip` parameter at all from `IStore.ForkStateReferences()` method (see also `FIXME` comment) to the master branch.