### PR TITLE
Remove unnecessary addressesToStrip parameter from IStore.ForkStateReferences()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ To be released.
     method so that it takes hash and index of a block instead of an entire
     block.  [[#420]]
  -  Added `IStore.ForkBlockIndexes()` method.  [[#420]]
+ -  Removed `addressesToStrip` parameter from `IStore.ForkStateReferences()`
+    method.  [[#454], [#467]]
 
 ### Added interfaces
 
@@ -23,9 +25,15 @@ To be released.
 
  -  Fixed a bug that `Swarm<T>` hadn't released its TURN releated resources on
     `Swarm<T>.StopAsync()`.  [[#450]]
+ -  Fixed a bug that `ArgumentNullException` had been thrown when a blockchain,
+    which consists of incomplete states (i.e., precalculated states downloaded
+    from trusted peers), encounters a new branch so that reorg is made.
+    [[#454], [#467]]
 
 [#420]: https://github.com/planetarium/libplanet/pull/420
 [#450]: https://github.com/planetarium/libplanet/pull/450
+[#454]: https://github.com/planetarium/libplanet/issues/454
+[#467]: https://github.com/planetarium/libplanet/pull/467
 
 
 Version 0.5.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -493,7 +493,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void CanFork()
+        public void Fork()
         {
             var block1 = _blockChain.MineBlock(_fx.Address1);
             var block2 = _blockChain.MineBlock(_fx.Address1);
@@ -503,6 +503,14 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(new[] { block1, block2, block3 }, _blockChain);
             Assert.Equal(new[] { block1, block2 }, forked);
+        }
+
+        [Fact]
+        public void ForkChainWithIncompleteBlockStates()
+        {
+            (_, _, BlockChain<DumbAction> chain) = MakeIncompleteBlockStates();
+            BlockChain<DumbAction> forked = chain.Fork(chain[5].Hash);
+            Assert.Equal(chain.Take(6), forked);
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -430,8 +430,7 @@ namespace Libplanet.Tests.Store
             Fx.Store.ForkStateReferences(
                 Fx.StoreNamespace,
                 targetNamespace,
-                branchPoint,
-                addressesToStrip);
+                branchPoint);
 
             var actual = Fx.Store.LookupStateReference(
                 Fx.StoreNamespace,
@@ -461,8 +460,7 @@ namespace Libplanet.Tests.Store
                 Fx.Store.ForkStateReferences(
                     Fx.StoreNamespace,
                     targetNamespace,
-                    Fx.Block1,
-                    new HashSet<Address> { address }.ToImmutableHashSet()));
+                    Fx.Block1));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -190,14 +190,12 @@ namespace Libplanet.Tests.Store
         public void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
+            Block<T> branchPoint)
             where T : IAction, new()
         {
             // FIXME: Log arguments properly.
             _logs.Add((nameof(ForkStateReferences), null, null));
-            _store.ForkStateReferences(
-                sourceNamespace, destinationNamespace, branchPoint, addressesToStrip);
+            _store.ForkStateReferences(sourceNamespace, destinationNamespace, branchPoint);
         }
 
         public void ForkBlockIndexes(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -816,7 +816,6 @@ namespace Libplanet.Blockchain
                 Store.ForkBlockIndexes(id, forkedId, point);
                 Block<T> pointBlock = Blocks[point];
 
-                var addressesToStrip = new HashSet<Address>();
                 var signersToStrip = new Dictionary<Address, int>();
 
                 for (
@@ -825,13 +824,6 @@ namespace Libplanet.Blockchain
                     && !block.Hash.Equals(point);
                     block = Blocks[hash])
                 {
-                    ImmutableHashSet<Address> addresses =
-                        Store.GetBlockStates(block.Hash)
-                        .Select(kv => kv.Key)
-                        .ToImmutableHashSet();
-
-                    addressesToStrip.UnionWith(addresses);
-
                     IEnumerable<(Address, int)> signers = block
                         .Transactions
                         .GroupBy(tx => tx.Signer)
@@ -845,11 +837,7 @@ namespace Libplanet.Blockchain
                     }
                 }
 
-                Store.ForkStateReferences(
-                    id,
-                    forked.Id.ToString(),
-                    pointBlock,
-                    addressesToStrip.ToImmutableHashSet());
+                Store.ForkStateReferences(id, forked.Id.ToString(), pointBlock);
 
                 foreach (KeyValuePair<Address, long> pair in Store.ListTxNonces(id))
                 {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -135,8 +135,7 @@ namespace Libplanet.Store
         public abstract void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
+            Block<T> branchPoint)
             where T : IAction, new();
 
         /// <inheritdoc/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -241,8 +241,7 @@ namespace Libplanet.Store
         /// <para>This method copies state references from
         /// <paramref name="sourceNamespace"/> to
         /// <paramref name="destinationNamespace"/> and strips
-        /// <paramref name="addressesToStrip"/> of state references after
-        /// <paramref name="branchPoint"/>.</para>
+        /// state references after <paramref name="branchPoint"/>.</para>
         /// </summary>
         /// <param name="sourceNamespace">The namespace of state references to
         /// fork.</param>
@@ -250,20 +249,17 @@ namespace Libplanet.Store
         /// state references.</param>
         /// <param name="branchPoint">The branch point <see cref="Block{T}"/>
         /// to fork.</param>
-        /// <param name="addressesToStrip">The set of <see cref="Address"/>es
-        /// to strip <see cref="Block{T}.Hash"/> after forking.</param>
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="branchPoint"/>.</typeparam>
         /// <exception cref="NamespaceNotFoundException">Thrown when the given
         /// <paramref name="sourceNamespace"/> does not exist.</exception>
         /// <seealso cref="IterateStateReferences(string, Address)"/>
         /// <seealso cref="StoreStateReference(string, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
-        #pragma warning restore MEN002
+#pragma warning restore MEN002
         void ForkStateReferences<T>(
             string sourceNamespace,
             string destinationNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
+            Block<T> branchPoint)
             where T : IAction, new();
 
         /// <summary>

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -469,8 +469,7 @@ namespace Libplanet.Store
         public override void ForkStateReferences<T>(
             string srcNamespace,
             string destNamespace,
-            Block<T> branchPoint,
-            IImmutableSet<Address> addressesToStrip)
+            Block<T> branchPoint)
         {
             string srcCollId = StateRefId(srcNamespace);
             string dstCollId = StateRefId(destNamespace);
@@ -479,7 +478,7 @@ namespace Libplanet.Store
 
             dstColl.InsertBulk(srcColl.Find(Query.LTE("BlockIndex", branchPoint.Index)));
 
-            if (dstColl.Count() < 1 && addressesToStrip.Any())
+            if (dstColl.Count() < 1)
             {
                 throw new NamespaceNotFoundException(
                     srcNamespace,


### PR DESCRIPTION
It's a port of the patch #466, and removes unnecessary `addressesToStrip` parameter from `IStore.ForkStateReferences()` method.