### PR TITLE
Fix FindBranchPoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,13 @@ To be released.
     which consists of incomplete states (i.e., precalculated states downloaded
     from trusted peers), encounters a new branch so that reorg is made.
     [[#454], [#466]]
+ -  Fixed a bug that unnecessarily received all blocks in multiple miner
+    situations.  [[#457], [#468]]
 
 [#454]: https://github.com/planetarium/libplanet/issues/454
+[#457]: https://github.com/planetarium/libplanet/issues/457
 [#466]: https://github.com/planetarium/libplanet/pull/466
+[#468]: https://github.com/planetarium/libplanet/pull/468
 
 
 Version 0.5.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -493,6 +493,22 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void FindNextHashesAfterFork()
+        {
+            _blockChain.MineBlock(_fx.Address1);
+            _blockChain.MineBlock(_fx.Address1);
+            _blockChain.MineBlock(_fx.Address1);
+
+            BlockChain<DumbAction> forked = _blockChain.Fork(_blockChain[0].Hash);
+            forked.MineBlock(_fx.Address1);
+
+            BlockLocator locator = _blockChain.GetBlockLocator();
+            IEnumerable<HashDigest<SHA256>> hashes = forked.FindNextHashes(locator);
+
+            Assert.Equal(new[] { forked[0].Hash, forked[1].Hash }, hashes);
+        }
+
+        [Fact]
         public void Fork()
         {
             var block1 = _blockChain.MineBlock(_fx.Address1);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -738,7 +738,9 @@ namespace Libplanet.Blockchain
 
                 foreach (HashDigest<SHA256> hash in locator)
                 {
-                    if (Blocks.ContainsKey(hash))
+                    if (Blocks.ContainsKey(hash)
+                        && Blocks[hash] is Block<T> block
+                        && hash.Equals(Store.IndexBlockHash(Id.ToString(), block.Index)))
                     {
                         return hash;
                     }


### PR DESCRIPTION
This fixes an issue where `FindBranchPoint()` returns a branch point if it exists in the `BlockSet` even if the block does not exist in the chain.