### PR TITLE
Make all staged transactions broadcasted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,7 @@ To be released.
 
 ### Bug fixes
 
- -  Fixed a bug that `Swarm<T>` hadn't released its TURN releated resources on
+ -  Fixed a bug that `Swarm<T>` hadn't released its TURN related resources on
     `Swarm<T>.StopAsync()`.  [[#450]]
  -  Fixed a bug that `ArgumentNullException` had been thrown when a blockchain,
     which consists of incomplete states (i.e., precalculated states downloaded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@ To be released.
  -  Added `IStore.ForkBlockIndexes()` method.  [[#420]]
  -  Removed `addressesToStrip` parameter from `IStore.ForkStateReferences()`
     method.  [[#454], [#467]]
+ -  Removed the concept of "staged transactions that should not be broadcasted,"
+    because its primary usage had been to make a transaction of a reward action
+    for a candidate for block miner, and the case became achieved through
+    `IBlockPolicy<T>.BlockAction` property which was introduced at 0.5.0.
+    All staged transactions became broadcasted.  [[#319], [#470]]
+     -  `BlockChain<T>.StageTransactions(IDictionary<Transaction<T>, bool>)`
+        method became replaced by
+        `StageTransactions(IImmutableSet<Transaction<T>>)`.
+     -  Removed `toBroadcast` parameter from
+        `IStore.IterateStagedTransactionIds(bool)` method.
+     -  `IStore.StageTransactionIds(IDictionary<TxId, bool>)` method became
+        replaced by `StageTransactionIds(IImmutableSet<TxId>()`.
 
 ### Added interfaces
 
@@ -34,6 +46,7 @@ To be released.
 [#450]: https://github.com/planetarium/libplanet/pull/450
 [#454]: https://github.com/planetarium/libplanet/issues/454
 [#467]: https://github.com/planetarium/libplanet/pull/467
+[#470]: https://github.com/planetarium/libplanet/pull/470
 
 
 Version 0.5.0

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -574,8 +574,7 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 new DumbAction[0]
             );
-            chainB.StageTransactions(
-                new Dictionary<Transaction<DumbAction>, bool> { { tx, true } });
+            chainB.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
             chainB.MineBlock(_fx1.Address1);
 
             try
@@ -621,8 +620,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[] { }
             );
 
-            chainA.StageTransactions(
-                new Dictionary<Transaction<DumbAction>, bool> { { tx, true } });
+            chainA.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
             chainA.MineBlock(_fx1.Address1);
 
             try
@@ -656,42 +654,6 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task TxStagedNotToBroadcast()
-        {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-
-            Transaction<DumbAction> txA = chainA.MakeTransaction(
-                new PrivateKey(),
-                new DumbAction[] { },
-                broadcast: true);
-            Transaction<DumbAction> txB = chainA.MakeTransaction(
-                new PrivateKey(),
-                new DumbAction[] { },
-                broadcast: false);
-
-            try
-            {
-                await StartAsync(swarmA);
-                await StartAsync(swarmB);
-
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer });
-                await swarmB.TxReceived.WaitAsync();
-                Assert.Equal(txA, chainB.Transactions[txA.Id]);
-                Assert.False(chainB.Transactions.ContainsKey(txB.Id));
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    swarmA.StopAsync(),
-                    swarmB.StopAsync());
-            }
-        }
-
-        [Fact(Timeout = Timeout)]
         public async Task BroadcastTxAsync()
         {
             Swarm<DumbAction> swarmA = _swarms[0];
@@ -708,8 +670,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[] { }
             );
 
-            chainA.StageTransactions(
-                new Dictionary<Transaction<DumbAction>, bool> { { tx, true } });
+            chainA.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
 
             try
             {

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -470,15 +470,13 @@ namespace Libplanet.Tests.Store
             Fx.Store.PutTransaction(Fx.Transaction2);
             Assert.Empty(Fx.Store.IterateStagedTransactionIds());
 
-            var txIds = new HashSet<TxId>()
+            var txIds = new HashSet<TxId>
             {
                 Fx.Transaction1.Id,
                 Fx.Transaction2.Id,
-            };
+            }.ToImmutableHashSet();
 
-            Dictionary<TxId, bool> toStage = txIds.ToDictionary(txId => txId, _ => true);
-
-            Fx.Store.StageTransactionIds(toStage);
+            Fx.Store.StageTransactionIds(txIds);
             Assert.Equal(
                 new HashSet<TxId>()
                 {
@@ -506,42 +504,18 @@ namespace Libplanet.Tests.Store
             Fx.Store.PutTransaction(Fx.Transaction1);
             Fx.Store.PutTransaction(Fx.Transaction2);
 
-            var txIds = new HashSet<TxId>()
+            var txIds = new HashSet<TxId>
             {
                 Fx.Transaction1.Id,
                 Fx.Transaction2.Id,
-            };
+            }.ToImmutableHashSet();
 
-            Dictionary<TxId, bool> toStage = txIds.ToDictionary(txId => txId, _ => true);
-
-            Fx.Store.StageTransactionIds(toStage);
-            Fx.Store.StageTransactionIds(
-                new Dictionary<TxId, bool> { { Fx.Transaction1.Id, true } });
+            Fx.Store.StageTransactionIds(txIds);
+            Fx.Store.StageTransactionIds(ImmutableHashSet<TxId>.Empty.Add(Fx.Transaction1.Id));
 
             Assert.Equal(
                 new[] { Fx.Transaction1.Id, Fx.Transaction2.Id }.OrderBy(txId => txId.ToHex()),
-                Fx.Store.IterateStagedTransactionIds(false).OrderBy(txId => txId.ToHex()));
-        }
-
-        [Fact]
-        public void IterateStagedTransactionIdsToBroadcast()
-        {
-            var toStage = new Dictionary<TxId, bool>
-            {
-                { Fx.Transaction1.Id, false },
-                { Fx.Transaction2.Id, true },
-            };
-            Fx.Store.StageTransactionIds(toStage);
-
-            Assert.Equal(
-                new HashSet<TxId> { Fx.Transaction2.Id, },
-                Fx.Store.IterateStagedTransactionIds(true).ToHashSet());
-
-            Fx.Store.UnstageTransactionIds(new HashSet<TxId> { Fx.Transaction2.Id });
-
-            Assert.Equal(
-                new HashSet<TxId>(),
-                Fx.Store.IterateStagedTransactionIds(true).ToHashSet());
+                Fx.Store.IterateStagedTransactionIds().OrderBy(txId => txId.ToHex()));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -127,9 +127,9 @@ namespace Libplanet.Tests.Store
              return _store.IterateIndex(@namespace, offset, limit);
         }
 
-        public IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)
+        public IEnumerable<TxId> IterateStagedTransactionIds()
         {
-            _logs.Add((nameof(IterateStagedTransactionIds), toBroadcast, null));
+            _logs.Add((nameof(IterateStagedTransactionIds), null, null));
             return _store.IterateStagedTransactionIds();
         }
 
@@ -226,7 +226,7 @@ namespace Libplanet.Tests.Store
             _store.IncreaseTxNonce(@namespace, address, delta);
         }
 
-        public void StageTransactionIds(IDictionary<TxId, bool> txids)
+        public void StageTransactionIds(IImmutableSet<TxId> txids)
         {
             _logs.Add((nameof(StageTransactionIds), txids, null));
             _store.StageTransactionIds(txids);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1186,7 +1186,7 @@ namespace Libplanet.Net
                         () =>
                         {
                             List<TxId> txIds = _blockChain
-                                .GetStagedTransactionIds(true)
+                                .GetStagedTransactionIds()
                                 .ToList();
 
                             if (txIds.Any())
@@ -1618,9 +1618,8 @@ namespace Libplanet.Net
             IAsyncEnumerable<Transaction<T>> fetched = GetTxsAsync(
                 peer, newTxIds, cancellationToken);
             List<Transaction<T>> txs = await fetched.ToListAsync(cancellationToken);
-            var toStage = txs.ToDictionary(tx => tx, _ => true);
 
-            _blockChain.StageTransactions(toStage);
+            _blockChain.StageTransactions(txs.ToImmutableHashSet());
             TxReceived.Set();
             _logger.Debug("Txs staged successfully.");
         }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -48,16 +48,14 @@ namespace Libplanet.Store
         public abstract IEnumerable<Address> ListAddresses(string @namespace);
 
         /// <inheritdoc />
-        public abstract void StageTransactionIds(
-            IDictionary<TxId, bool> txids
-        );
+        public abstract void StageTransactionIds(IImmutableSet<TxId> txids);
 
         public abstract void UnstageTransactionIds(
             ISet<TxId> txids
         );
 
         /// <inheritdoc />
-        public abstract IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast);
+        public abstract IEnumerable<TxId> IterateStagedTransactionIds();
 
         public abstract IEnumerable<TxId> IterateTransactionIds();
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -98,19 +98,16 @@ namespace Libplanet.Store
         /// a next <see cref="Block{T}"/> to be mined contains the corresponding
         /// <see cref="Transaction{T}"/>s.
         /// </summary>
-        /// <param name="txids"><see cref="TxId"/>s to add to pending list. Keys are
-        /// <see cref="TxId"/>s and values are whether to broadcast.</param>
-        void StageTransactionIds(IDictionary<TxId, bool> txids);
+        /// <param name="txids"><see cref="TxId"/>s to add to pending list.</param>
+        void StageTransactionIds(IImmutableSet<TxId> txids);
 
         void UnstageTransactionIds(ISet<TxId> txids);
 
         /// <summary>
         /// Iterates staged <see cref="TxId"/>s.
         /// </summary>
-        /// <param name="toBroadcast">Whether to iterate only the <see cref="TxId "/>s set to
-        /// broadcast.</param>
         /// <returns>Staged <see cref="TxId"/>s.</returns>
-        IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast = false);
+        IEnumerable<TxId> IterateStagedTransactionIds();
 
         IEnumerable<TxId> IterateTransactionIds();
 

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -215,14 +215,11 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override void StageTransactionIds(IDictionary<TxId, bool> txids)
+        public override void StageTransactionIds(IImmutableSet<TxId> txids)
         {
             StagedTxIds.InsertBulk(
-                txids.Select(kv => new StagedTxIdDoc
-                {
-                    TxId = kv.Key,
-                    Broadcast = kv.Value,
-                }));
+                txids.Select(txid => new StagedTxIdDoc { TxId = txid, })
+            );
         }
 
         /// <inheritdoc/>
@@ -232,14 +229,9 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<TxId> IterateStagedTransactionIds(bool toBroadcast)
+        public override IEnumerable<TxId> IterateStagedTransactionIds()
         {
             IEnumerable<StagedTxIdDoc> docs = StagedTxIds.FindAll();
-            if (toBroadcast)
-            {
-                docs = docs.Where(d => d.Broadcast);
-            }
-
             return docs.Select(d => d.TxId).Distinct();
         }
 
@@ -673,8 +665,6 @@ namespace Libplanet.Store
             public long Id { get; set; }
 
             public TxId TxId { get; set; }
-
-            public bool Broadcast { get; set; }
         }
     }
 }


### PR DESCRIPTION
Removed the concept of “staged transactions that should not be broadcasted,” because its primary usage had been to make a transaction of a reward action for a candidate for block miner, and the case became achieved through `IBlockPolicy<T>.BlockAction` property which was made by the patch #367.

So all staged transactions became broadcasted.