### PR TITLE
Fix #465

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug that `Swarm<T>.PreloadAsync()` method had thrown `LiteException`
+    (or other exception depending on `IStore`), which indicates a state
+    reference is duplicate, where `trustedStateValidators` is present and
+    a miner tries to download precalculated states from a trusted peer.
+    [[#465], [#474]]
+
+[#465]: https://github.com/planetarium/libplanet/issues/465
+[#474]: https://github.com/planetarium/libplanet/pull/474
+
 
 Version 0.5.1
 -------------

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -360,6 +360,38 @@ namespace Libplanet.Tests.Store
             );
         }
 
+        [Fact]
+        public void StoreStateReferenceAllowsDuplication()
+        {
+            Address address3 = new PrivateKey().PublicKey.ToAddress();
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                new[] { Fx.Address1, Fx.Address2 }.ToImmutableHashSet(),
+                Fx.Block1
+            );
+            Fx.Store.StoreStateReference(
+                Fx.StoreNamespace,
+                new[] { Fx.Address2, address3 }.ToImmutableHashSet(),
+                Fx.Block1
+            );
+            var expectedStateRefs = new[]
+            {
+                new Tuple<HashDigest<SHA256>, long>(Fx.Block1.Hash, Fx.Block1.Index),
+            };
+            Assert.Equal(
+                expectedStateRefs,
+                Fx.Store.IterateStateReferences(Fx.StoreNamespace, Fx.Address1)
+            );
+            Assert.Equal(
+                expectedStateRefs,
+                Fx.Store.IterateStateReferences(Fx.StoreNamespace, Fx.Address2)
+            );
+            Assert.Equal(
+                expectedStateRefs,
+                Fx.Store.IterateStateReferences(Fx.StoreNamespace, address3)
+            );
+        }
+
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -439,14 +439,15 @@ namespace Libplanet.Store
         {
             string collId = StateRefId(@namespace);
             LiteCollection<StateRefDoc> coll = _db.GetCollection<StateRefDoc>(collId);
-            coll.InsertBulk(
-                addresses.Select(addr => new StateRefDoc
+            IEnumerable<StateRefDoc> stateRefDocs = addresses
+                .Select(addr => new StateRefDoc
                 {
                     Address = addr,
                     BlockIndex = block.Index,
                     BlockHash = block.Hash,
                 })
-            );
+                .Where(doc => !coll.Exists(d => d.Id == doc.Id));
+            coll.InsertBulk(stateRefDocs);
             coll.EnsureIndex("AddressString");
             coll.EnsureIndex("BlockIndex");
         }


### PR DESCRIPTION
See also <https://github.com/planetarium/libplanet/issues/465#issuecomment-525682219> and the changelog.

I'm going to fix `Swarm<T>.SyncRecentStatesFromTrustedPeersAsync()` method to find the proper branchpoint before sending `GetRecentStates` message in the master branch.