### PR TITLE
Restore IceServerTest on Windows

### DIFF
--- a/Libplanet.Tests/Net/IceServerTest.cs
+++ b/Libplanet.Tests/Net/IceServerTest.cs
@@ -10,7 +10,6 @@ namespace Libplanet.Tests.Net
     {
         private const int Timeout = 60 * 1000;
 
-        [Trait("RequireTurnServer", "true")]
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task CreateTurnClient()
         {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1154,7 +1154,6 @@ namespace Libplanet.Tests.Net
             await swarm.StopAsync();
         }
 
-        [Trait("RequireTurnServer", "true")]
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task ExchangeWithIceServer()
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,6 @@ jobs:
       testArguments: >-
         --logger trx
         --collect "Code coverage"
-        --filter "RequireTurnServer!=true"
-      # FIXME: For unknown reason, on Windows tests depending on TURN_SERVER_URL
-      #        seems to never end or to take too long time.  We should diagnose
-      #        this and make Windows builds to run these tests too.
   - task: Bash@3
     displayName: codecov
     inputs:
@@ -158,10 +154,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: '--filter "RequireTurnServer!=true"'
-      # FIXME: For unknown reason, on Windows tests depending on TURN_SERVER_URL
-      #        seems to never end or to take too long time.  We should diagnose
-      #        this and make Windows builds to run these tests too.
+      testArguments: '-v n'
   timeoutInMinutes: 30
 
 - job: Windows_NETFramework
@@ -171,6 +164,7 @@ jobs:
   - template: .azure-pipelines/windows-net461.yml
     parameters:
       configuration: $(configuration)
+      turnServerUrl: $(turnServerUrl)
 
 - job: Windows_NETCore_Benchmark
   pool:


### PR DESCRIPTION
It seems to be able to run IceServerTests on Windows again.
Resolves #221 
Resolves #249 
Resolves #478.