### PR TITLE
Remove `IActionContext.NewGuid()` & Add `RandomExtension.GenerateRandomGuid()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,8 @@ To be released.
     `Swarm<T>.BootstrapAsync()` method instead.  [[#353]]
  -  `Peer` with endpoints should be typed as `BoundPeer` which is inherited from
     `Peer`.  [[#353]]
+ -  Removed `IActionContext.NewGuid()` method. To get a randomly generated [Guid][Guid],
+    use `RandomExtension.GenerateRandomGuid()` instead. [[#508]]
 
 ### Added interfaces
 
@@ -71,6 +73,8 @@ To be released.
     both a `Block<T>.Hash` and a `Transaction<T>.Id`, so that signers cannot
     predict the order of transactions in a block before it's mined.
     [[#244], [#355]]
+ -  Added `RandomExtension.GenerateRandomGuid()` method that generates a random
+    [Guid][Guid]. [[#508]]
 
 ### Behavioral changes
 
@@ -111,7 +115,9 @@ To be released.
 [#486]: https://github.com/planetarium/libplanet/pull/486
 [#498]: https://github.com/planetarium/libplanet/pull/498
 [#496]: https://github.com/planetarium/libplanet/pull/496
+[#508]: https://github.com/planetarium/libplanet/pull/508
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
+[Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 
 
 Version 0.5.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,8 +73,7 @@ To be released.
     both a `Block<T>.Hash` and a `Transaction<T>.Id`, so that signers cannot
     predict the order of transactions in a block before it's mined.
     [[#244], [#355]]
- -  Added `RandomExtension.GenerateRandomGuid()` method that generates a random
-    [Guid][Guid]. [[#508]]
+ -  Added `RandomExtension` static class. [[#508]]
 
 ### Behavioral changes
 

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -72,9 +72,9 @@ namespace Libplanet.Tests.Action
 
             foreach (var (expected, diff) in testCases)
             {
-                Assert.Equal(expected, context1.NewGuid());
-                Assert.Equal(expected, context2.NewGuid());
-                Assert.Equal(diff, context3.NewGuid());
+                Assert.Equal(expected, context1.Random.GenerateRandomGuid());
+                Assert.Equal(expected, context2.Random.GenerateRandomGuid());
+                Assert.Equal(diff, context3.Random.GenerateRandomGuid());
             }
         }
 

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -32,13 +32,5 @@ namespace Libplanet.Action
         public IAccountStateDelta PreviousStates { get; }
 
         public IRandom Random { get; }
-
-        public Guid NewGuid()
-        {
-            // FIXME implement rfc4122 https://www.ietf.org/rfc/rfc4122.txt
-            var b = new byte[16];
-            Random.NextBytes(b);
-            return new Guid(b);
-        }
     }
 }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -55,12 +55,5 @@ namespace Libplanet.Action
         /// <returns>A random object that shares interface mostly equivalent
         /// to <see cref="System.Random"/>.</returns>
         IRandom Random { get; }
-
-        /// <summary>
-        /// Creates new <see cref="Guid"/>.  Its seed (state) is determined by a block and
-        /// a transaction, which is deterministic as like <see cref="Random"/>.
-        /// </summary>
-        /// <returns>A deterministic guid.</returns>
-        Guid NewGuid();
     }
 }

--- a/Libplanet/Action/RandomExtension.cs
+++ b/Libplanet/Action/RandomExtension.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// This extension class provides some convenient methods
+    /// to deal with <see cref="IRandom"/>.
+    /// </summary>
+    public static class RandomExtension
+    {
+        /// <summary>
+        /// Generates a random <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="random"> <see cref="IRandom"/> to generate
+        /// a random <see cref="Guid"/>.</param>
+        /// <returns> Generated random <see cref="Guid"/>.
+        /// </returns>
+        /// <seealso cref="IRandom"/>
+        public static Guid GenerateRandomGuid(this IRandom random)
+        {
+            var bytes = new byte[16];
+            random.NextBytes(bytes);
+            return new Guid(bytes);
+        }
+    }
+}

--- a/Libplanet/Action/RandomExtension.cs
+++ b/Libplanet/Action/RandomExtension.cs
@@ -18,6 +18,7 @@ namespace Libplanet.Action
         /// <seealso cref="IRandom"/>
         public static Guid GenerateRandomGuid(this IRandom random)
         {
+            // FIXME implement rfc4122 https://www.ietf.org/rfc/rfc4122.txt
             var bytes = new byte[16];
             random.NextBytes(bytes);
             return new Guid(bytes);


### PR DESCRIPTION
I think getting a random `Guid` in `IActionContext` is a bad usage because dummy objects (for testing, debugging or etc ...) using random `Guid` in games don't need `IActionContext`. `IRandom`s are enough to acquire the same thing.

So I removed `IActionContext.NewGuid()`.
Instead I added an extension class, `RandomExtension` that includes a extension method, `GenerateRandomGuid()`.
Since `RandomExtension` is an extension class, I implemented generating a random `Guid`.