### PR TITLE
Fix Swarm<T>.PreloadAsync() missing genesis states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,10 +90,12 @@ To be released.
     instead of `HashDigest<SHA256>`.  [[#465], [#481]]
  -  NetMQ instances are now initialized at `Swarm<T>.StartAsync()` instead of
     `Swarm<T>()`.  [[#353]]
- -  Peers now connected via [Kademlia protocol][Kademlia]. Peers are now selectively
-    connected to each peer.  [[#353]]
- -  `TxId`s and `Block`s are now broadcasted to selected peers from routing table of
-    the host peer.  [[#353]]
+ -  Peers now connected via [Kademlia protocol][Kademlia].
+    Peers are now selectively connected to each peer.  [[#353]]
+ -  `TxId`s and `Block`s are now broadcasted to selected peers from routing
+    table of the host peer.  [[#353]]
+ -  `PolymorphicAction<T>.ToString()` method became to show the runtime type of
+    its `InnerAction` for the sake of easier debugging.  [[#512]]
 
 ### Bug fixes
 
@@ -115,6 +117,7 @@ To be released.
 [#498]: https://github.com/planetarium/libplanet/pull/498
 [#496]: https://github.com/planetarium/libplanet/pull/496
 [#508]: https://github.com/planetarium/libplanet/pull/508
+[#512]: https://github.com/planetarium/libplanet/pull/512
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1104,6 +1104,39 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void FindBranchPoint()
+        {
+            Block<DumbAction> b0 = _blockChain.MineBlock(_fx.Address1);
+            Block<DumbAction> b1 = _blockChain.MineBlock(_fx.Address1);
+            Block<DumbAction> b2 = _blockChain.MineBlock(_fx.Address1);
+            Block<DumbAction> b3 = _blockChain.MineBlock(_fx.Address1);
+            Block<DumbAction> b4 = _blockChain.MineBlock(_fx.Address1);
+
+            var emptyLocator = new BlockLocator(new HashDigest<SHA256>[0]);
+            var locator = new BlockLocator(new[] { b4.Hash, b3.Hash, b1.Hash });
+
+            using (var emptyFx = new LiteDBStoreFixture())
+            using (var forkFx = new LiteDBStoreFixture())
+            {
+                var emptyChain = new BlockChain<DumbAction>(_blockChain.Policy, emptyFx.Store);
+                var fork = new BlockChain<DumbAction>(_blockChain.Policy, forkFx.Store);
+                fork.Append(b0);
+                fork.Append(b1);
+                fork.Append(b2);
+                fork.MineBlock(_fx.Address1);
+
+                Assert.Null(emptyChain.FindBranchPoint(emptyLocator));
+                Assert.Null(emptyChain.FindBranchPoint(locator));
+
+                Assert.Null(_blockChain.FindBranchPoint(emptyLocator));
+                Assert.Equal(b4.Hash, _blockChain.FindBranchPoint(locator));
+
+                Assert.Null(fork.FindBranchPoint(emptyLocator));
+                Assert.Equal(b1.Hash, fork.FindBranchPoint(locator));
+            }
+        }
+
+        [Fact]
         public void EvaluateActions()
         {
             PrivateKey fromPrivateKey = new PrivateKey();

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -305,5 +305,9 @@ namespace Libplanet.Action
             IAccountStateDelta nextStates
         ) =>
             InnerAction.Unrender(context, nextStates);
+
+        /// <inheritdoc/>
+        public override string ToString() =>
+            $"{nameof(PolymorphicAction<T>)}<{InnerAction.GetType().FullName}>({InnerAction})";
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -702,7 +702,14 @@ namespace Libplanet.Blockchain
                 new[] { Policy.BlockAction }.ToImmutableList()).First();
         }
 
-        internal HashDigest<SHA256> FindBranchPoint(BlockLocator locator)
+        /// <summary>
+        /// Find an approximate to the topmost common ancestor between this
+        /// <see cref="BlockChain{T}"/> and a given <see cref="BlockLocator"/>.
+        /// </summary>
+        /// <param name="locator">A block locator that contains candidate common ancestors.</param>
+        /// <returns>An approximate to the topmost common ancestor.  If it failed to find anything
+        /// returns <c>null</c>.</returns>
+        internal HashDigest<SHA256>? FindBranchPoint(BlockLocator locator)
         {
             try
             {
@@ -718,7 +725,7 @@ namespace Libplanet.Blockchain
                     }
                 }
 
-                return this[0].Hash;
+                return null;
             }
             finally
             {
@@ -741,8 +748,10 @@ namespace Libplanet.Blockchain
                     yield break;
                 }
 
-                HashDigest<SHA256> branchPoint = FindBranchPoint(locator);
-                var branchPointIndex = (int)Blocks[branchPoint].Index;
+                HashDigest<SHA256>? branchPoint = FindBranchPoint(locator);
+                var branchPointIndex = branchPoint is HashDigest<SHA256> h
+                    ? (int)Blocks[h].Index
+                    : 0;
 
                 // FIXME: Currently, increasing count by one to satisfy
                 // the number defined by FindNextHashesChunkSize variable

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1806,7 +1806,7 @@ namespace Libplanet.Net
         private void TransferRecentStates(GetRecentStates getRecentStates)
         {
             BlockLocator baseLocator = getRecentStates.BaseLocator;
-            HashDigest<SHA256> @base = _blockChain.FindBranchPoint(baseLocator);
+            HashDigest<SHA256>? @base = _blockChain.FindBranchPoint(baseLocator);
             HashDigest<SHA256> target = getRecentStates.TargetBlockHash;
             IImmutableDictionary<HashDigest<SHA256>,
                 IImmutableDictionary<Address, object>
@@ -1847,6 +1847,28 @@ namespace Libplanet.Net
                 {
                     rwlock.ExitReadLock();
                 }
+            }
+
+            if (_logger.IsEnabled(LogEventLevel.Debug))
+            {
+                var baseString = @base is HashDigest<SHA256> h
+                    ? $"{BlockChain.Blocks[h].Index}:{h}"
+                    : null;
+                var targetString = $"{BlockChain.Blocks[target].Index}:{target}";
+                _logger.Debug(
+                    "State references to send (preload): {@StateReferences} ({Base}-{Target})",
+                    stateRefs.Select(kv =>
+                        (kv.Key.ToString(), string.Join(", ", kv.Value.Select(v => v.ToString())))
+                    ).ToArray(),
+                    baseString,
+                    targetString
+                );
+                _logger.Debug(
+                    "Block states to send (preload): {@BlockStates} ({Base}-{Target})",
+                    blockStates.Select(kv => (kv.Key.ToString(), kv.Value)).ToArray(),
+                    baseString,
+                    targetString
+                );
             }
 
             var reply = new RecentStates(target, blockStates, stateRefs)


### PR DESCRIPTION
This patch fixes a bug, made by 6e7249f8e0feee76292acfbd256a6645bf1c00f5, that `Swarm<T>.PreloadAsync()` silently misses the states resulted from actins in a genesis block (both tx actions and block actions) when it downloads states from trusted peers.

As the change made this bug hasn't been released yet, I skipped the changelog.