### PR TITLE
Increase test timeout to 11min

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -43,7 +43,7 @@ steps:
       ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
-  timeoutInMinutes: 10
+  timeoutInMinutes: 11
 
 - task: PublishTestResults@2
   inputs:

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -36,4 +36,4 @@ steps:
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive
-  timeoutInMinutes: 10
+  timeoutInMinutes: 11

--- a/.azure-pipelines/windows-net461.yml
+++ b/.azure-pipelines/windows-net461.yml
@@ -44,4 +44,4 @@ steps:
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive
-  timeoutInMinutes: 10
+  timeoutInMinutes: 11


### PR DESCRIPTION
This increases test timeout to 11 min to avoid frequent test failures due to timeout.