### PR TITLE
Hash signature before feeding as seed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,9 @@ To be released.
 
  -  Fixed a bug that `Swarm<T>` hadn't released its TURN related resources on
     `Swarm<T>.StopAsync()`.  [[#450]]
+ -  Fixed a bug that `IActionContext.Random` had been possible to generated
+    equivalent results between actions of different transactions in
+    a `Block<T>`.  [[#519]]
 
 [#244]: https://github.com/planetarium/libplanet/issues/244
 [#353]: https://github.com/planetarium/libplanet/pull/353
@@ -125,6 +128,7 @@ To be released.
 [#508]: https://github.com/planetarium/libplanet/pull/508
 [#511]: https://github.com/planetarium/libplanet/pull/511
 [#512]: https://github.com/planetarium/libplanet/pull/512
+[#519]: https://github.com/planetarium/libplanet/pull/519
 [#520]: https://github.com/planetarium/libplanet/pull/520
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -109,9 +109,16 @@ namespace Libplanet.Action
                     rehearsal: rehearsal
                 );
 
+            byte[] hashedSignature;
+            using (var hasher = SHA1.Create())
+            {
+                hashedSignature = hasher.ComputeHash(signature);
+            }
+
             int seed =
                 BitConverter.ToInt32(blockHash.ToByteArray(), 0) ^
-                (signature.Any() ? BitConverter.ToInt32(signature, 0) : 0);
+                (signature.Any() ? BitConverter.ToInt32(hashedSignature, 0) : 0);
+
             IAccountStateDelta states = previousStates;
             foreach (IAction action in actions)
             {


### PR DESCRIPTION
This PR fixes a bug that `IActionContext.Random` had generated the same result in different `IAction.Execute()` against the same `Block<T>`.