### PR TITLE
Make the order of Block<T>.Transactions aware of their nonce

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,7 +96,11 @@ To be released.
  -  The order of `Block<T>.Transactions` became to be determined by
     both a `Block<T>.Hash` and a `Transaction<T>.Id`, so that signers cannot
     predict the order of transactions in a block before it's mined.
-    [[#244], [#355], [#511]]
+    If there are multiple transactions signed by the same signer in a block
+    these transactions become grouped together and the order is determined by
+    a `Block<T>.Hash` and a fingerprint derived from all these transactions,
+    and transactions in each group (per signer) are ordered by
+    `Transaction<T>.Nonce`.  [[#244], [#355], [#511], [#520]]
 
 ### Bug fixes
 
@@ -120,6 +124,7 @@ To be released.
 [#508]: https://github.com/planetarium/libplanet/pull/508
 [#511]: https://github.com/planetarium/libplanet/pull/511
 [#512]: https://github.com/planetarium/libplanet/pull/512
+[#520]: https://github.com/planetarium/libplanet/pull/520
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -21,6 +21,44 @@ namespace Libplanet.Tests.Blocks
         public BlockTest(BlockFixture fixture) => _fx = fixture;
 
         [Fact]
+        public void Transactions()
+        {
+            // Creates fixtures.
+            PrivateKey[] privKeys =
+                Enumerable.Repeat((object)null, 5).Select(_ => new PrivateKey()).ToArray();
+            var random = new System.Random();
+            Transaction<DumbAction>[] txs = Enumerable.Range(0, 50)
+                .Select(i => (privKeys[i % privKeys.Length], i / privKeys.Length))
+                .Select(pair =>
+                    Transaction<DumbAction>.Create(
+                        nonce: pair.Item2,
+                        privateKey: pair.Item1,
+                        actions: new DumbAction[0]
+                    )
+                )
+                .OrderBy(_ => random.Next())
+                .ToArray();
+            var block = new Block<DumbAction>(
+                index: 0,
+                difficulty: 0,
+                nonce: new Nonce(new byte[0]),
+                miner: null,
+                previousHash: null,
+                timestamp: DateTimeOffset.UtcNow,
+                transactions: txs
+            );
+
+            // For transactions signed by the same signer, these should be ordered by its tx nonce.
+            Address[] signers = privKeys.Select(pk => pk.PublicKey.ToAddress()).ToArray();
+            foreach (Address signer in signers)
+            {
+                IEnumerable<Transaction<DumbAction>> signersTxs =
+                    block.Transactions.Where(tx => tx.Signer == signer);
+                Assert.Equal(signersTxs.OrderBy(tx => tx.Nonce).ToArray(), signersTxs.ToArray());
+            }
+        }
+
+        [Fact]
         public void CanMine()
         {
             Assert.Equal(0, _fx.Genesis.Index);


### PR DESCRIPTION
See also the changelog and comments in the `Block<T>()` constructor.