### PR TITLE
Use in-memory LiteDBStore in tests

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -43,7 +43,7 @@ steps:
       ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
-  timeoutInMinutes: 11
+  timeoutInMinutes: 10
 
 - task: PublishTestResults@2
   inputs:

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -36,4 +36,4 @@ steps:
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive
-  timeoutInMinutes: 11
+  timeoutInMinutes: 10

--- a/.azure-pipelines/windows-net461.yml
+++ b/.azure-pipelines/windows-net461.yml
@@ -44,4 +44,4 @@ steps:
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive
-  timeoutInMinutes: 11
+  timeoutInMinutes: 10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,8 @@ To be released.
     a `Block<T>.Hash` and a fingerprint derived from all these transactions,
     and transactions in each group (per signer) are ordered by
     `Transaction<T>.Nonce`.  [[#244], [#355], [#511], [#520]]
+ -  `LiteDBStore()` became to create the database in memory if the `path`
+    parameter is `null`.  [[#521]]
 
 ### Bug fixes
 
@@ -132,6 +134,7 @@ To be released.
 [#512]: https://github.com/planetarium/libplanet/pull/512
 [#519]: https://github.com/planetarium/libplanet/pull/519
 [#520]: https://github.com/planetarium/libplanet/pull/520
+[#521]: https://github.com/planetarium/libplanet/pull/521
 [#522]: https://github.com/planetarium/libplanet/pull/522
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Blockchain
 
         public BlockChainTest()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new LiteDBStoreFixture(memory: true);
             _blockChain = new BlockChain<DumbAction>(
                 new BlockPolicy<DumbAction>(new MinerReward(1)),
                 _fx.Store
@@ -1116,8 +1116,8 @@ namespace Libplanet.Tests.Blockchain
             var emptyLocator = new BlockLocator(new HashDigest<SHA256>[0]);
             var locator = new BlockLocator(new[] { b4.Hash, b3.Hash, b1.Hash });
 
-            using (var emptyFx = new LiteDBStoreFixture())
-            using (var forkFx = new LiteDBStoreFixture())
+            using (var emptyFx = new LiteDBStoreFixture(memory: true))
+            using (var forkFx = new LiteDBStoreFixture(memory: true))
             {
                 var emptyChain = new BlockChain<DumbAction>(_blockChain.Policy, emptyFx.Store);
                 var fork = new BlockChain<DumbAction>(_blockChain.Policy, forkFx.Store);

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -5,14 +5,13 @@ using System.Security.Cryptography;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
-using Libplanet.Tests.Store;
 using Libplanet.Tx;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Blockchain.Policies
 {
-    public class BlockPolicyTest : IClassFixture<LiteDBStoreFixture>
+    public class BlockPolicyTest
     {
         private static readonly DateTimeOffset FixtureEpoch =
             new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -56,9 +56,9 @@ namespace Libplanet.Tests.Net
             _output = output;
 
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            _fx1 = new LiteDBStoreFixture();
-            _fx2 = new LiteDBStoreFixture();
-            _fx3 = new LiteDBStoreFixture();
+            _fx1 = new LiteDBStoreFixture(memory: true);
+            _fx2 = new LiteDBStoreFixture(memory: true);
+            _fx3 = new LiteDBStoreFixture(memory: true);
 
             _blockchains = new List<BlockChain<DumbAction>>
             {
@@ -484,7 +484,7 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < size; i++)
             {
-                fxs[i] = new LiteDBStoreFixture();
+                fxs[i] = new LiteDBStoreFixture(memory: true);
                 blockchains[i] = new BlockChain<DumbAction>(policy, fxs[i].Store);
                 swarms[i] = new Swarm<DumbAction>(
                     blockchains[i],
@@ -607,7 +607,8 @@ namespace Libplanet.Tests.Net
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 2);
             var d = new Swarm<DumbAction>(
-                new BlockChain<DumbAction>(_blockchains[0].Policy, new LiteDBStoreFixture().Store),
+                new BlockChain<DumbAction>(
+                    _blockchains[0].Policy, new LiteDBStoreFixture(memory: true).Store),
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
@@ -957,7 +958,7 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < size; i++)
             {
-                fxs[i] = new LiteDBStoreFixture();
+                fxs[i] = new LiteDBStoreFixture(memory: true);
                 blockchains[i] = new BlockChain<DumbAction>(policy, fxs[i].Store);
                 swarms[i] = new Swarm<DumbAction>(
                     blockchains[i],
@@ -1413,8 +1414,8 @@ namespace Libplanet.Tests.Net
             Swarm<DumbAction> minerSwarm = _swarms[0];
             Swarm<DumbAction> receiverSwarm = _swarms[1];
             var fxForNominers = new StoreFixture[2];
-            fxForNominers[0] = new LiteDBStoreFixture();
-            fxForNominers[1] = new LiteDBStoreFixture();
+            fxForNominers[0] = new LiteDBStoreFixture(memory: true);
+            fxForNominers[1] = new LiteDBStoreFixture(memory: true);
             var policy = new BlockPolicy<DumbAction>();
             var blockChainsForNominers = new BlockChain<DumbAction>[2];
             blockChainsForNominers[0] = new BlockChain<DumbAction>(policy, fxForNominers[0].Store);
@@ -1786,7 +1787,7 @@ namespace Libplanet.Tests.Net
             if (blocks is null)
             {
                 var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-                using (var storeFx = new LiteDBStoreFixture())
+                using (var storeFx = new LiteDBStoreFixture(memory: true))
                 {
                     var chain = new BlockChain<DumbAction>(policy, storeFx.Store);
                     Address miner = new PrivateKey().PublicKey.ToAddress();

--- a/Libplanet.Tests/Store/LiteDBStoreFixture.cs
+++ b/Libplanet.Tests/Store/LiteDBStoreFixture.cs
@@ -6,11 +6,12 @@ namespace Libplanet.Tests.Store
 {
     public class LiteDBStoreFixture : StoreFixture, IDisposable
     {
-        public LiteDBStoreFixture()
+        public LiteDBStoreFixture(bool memory = false)
         {
             string postfix = Guid.NewGuid().ToString();
-            Path = System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(), $"litedb_{postfix}.db");
+            Path = memory
+                ? null
+                : System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"litedb_{postfix}.db");
             Store = new LiteDBStore(Path);
         }
 
@@ -19,7 +20,11 @@ namespace Libplanet.Tests.Store
         public override void Dispose()
         {
             (Store as LiteDBStore)?.Dispose();
-            File.Delete(Path);
+
+            if (!(Path is null))
+            {
+                File.Delete(Path);
+            }
         }
     }
 }

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -34,6 +34,8 @@ namespace Libplanet.Store
 
         private readonly ILogger _logger;
 
+        private readonly MemoryStream _memoryStream;
+
         private readonly LiteDatabase _db;
 
         private readonly ReaderWriterLockSlim _txLock;
@@ -41,15 +43,15 @@ namespace Libplanet.Store
         /// <summary>
         /// Creates a new <seealso cref="LiteDBStore"/>.
         /// </summary>
-        /// <param name="path">The path where the storage file will be saved.</param>
+        /// <param name="path">The path where the storage file will be saved.  If the path is
+        /// <c>null</c>, The database is created in memory with <see cref="MemoryStream"/>.</param>
         /// <param name="journal">
         /// Enables or disables double write check to ensure durability.
         /// </param>
         /// <param name="cacheSize">Max number of pages in the cache.</param>
         /// <param name="flush">Writes data direct to disk avoiding OS cache.  Turned on by default.
         /// </param>
-        /// <param name="readOnly">Opens database readonly mode. Turned off by default.
-        /// </param>
+        /// <param name="readOnly">Opens database readonly mode. Turned off by default.</param>
         public LiteDBStore(
             string path,
             bool journal = true,
@@ -58,11 +60,6 @@ namespace Libplanet.Store
             bool readOnly = false
         )
         {
-            if (path is null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
             _logger = Log.ForContext<LiteDBStore>();
 
             var connectionString = new ConnectionString
@@ -84,7 +81,16 @@ namespace Libplanet.Store
                 connectionString.Mode = LiteDB.FileMode.Exclusive;
             }
 
-            _db = new LiteDatabase(connectionString);
+            if (path is null)
+            {
+                _memoryStream = new MemoryStream();
+                _db = new LiteDatabase(_memoryStream);
+            }
+            else
+            {
+                _db = new LiteDatabase(connectionString);
+            }
+
             lock (_db.Mapper)
             {
                 _db.Mapper.RegisterType(
@@ -536,6 +542,7 @@ namespace Libplanet.Store
         public void Dispose()
         {
             _db?.Dispose();
+            _memoryStream?.Dispose();
         }
 
         internal static Guid ParseChainId(string chainIdString) =>


### PR DESCRIPTION
This improves the test speed by using in-memory LiteDBStore in tests and restores test timeout to 10 minutes.