### PR TITLE
Fix a bug that LiteDBStore.ForkStateReferences<T>() throws ChainIdNotFoundException even if sourceChinId exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,8 +40,8 @@ To be released.
     HashDigest<SHA256>, long)` method so that it takes hash and index of
     a block instead of an entire block.  [[#420]]
  -  Added `IStore.ForkBlockIndexes()` method.  [[#420]]
- -  Removed `addressesToStrip` parameter from `IStore.ForkStateReferences()`
-    method.  [[#454], [#467]]
+ -  Removed `addressesToStrip` parameter from `IStore.ForkStateReferences<T>()`
+    method.  [[#454], [#467], [#509], [#522]]
  -  Removed the concept of "staged transactions that should not be broadcasted,"
     because its primary usage had been to make a transaction of a reward action
     for a candidate for block miner, and the case became achieved through
@@ -118,6 +118,7 @@ To be released.
 [#450]: https://github.com/planetarium/libplanet/pull/450
 [#461]: https://github.com/planetarium/libplanet/issues/461
 [#463]: https://github.com/planetarium/libplanet/issues/463
+[#467]: https://github.com/planetarium/libplanet/pull/467
 [#470]: https://github.com/planetarium/libplanet/pull/470
 [#481]: https://github.com/planetarium/libplanet/pull/481
 [#483]: https://github.com/planetarium/libplanet/issues/483
@@ -126,10 +127,12 @@ To be released.
 [#498]: https://github.com/planetarium/libplanet/pull/498
 [#496]: https://github.com/planetarium/libplanet/pull/496
 [#508]: https://github.com/planetarium/libplanet/pull/508
+[#509]: https://github.com/planetarium/libplanet/issues/509
 [#511]: https://github.com/planetarium/libplanet/pull/511
 [#512]: https://github.com/planetarium/libplanet/pull/512
 [#519]: https://github.com/planetarium/libplanet/pull/519
 [#520]: https://github.com/planetarium/libplanet/pull/520
+[#522]: https://github.com/planetarium/libplanet/pull/522
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 [RFC 4122]: https://tools.ietf.org/html/rfc4122

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -84,6 +84,7 @@ namespace Libplanet.Tests.Store
                 0x9c, 0xee,
             });
 
+            // FIXME: Following names are misleading, because we index the genesis block 0, not 1.
             Block1 = TestUtils.MineGenesis<DumbAction>();
             Block2 = TestUtils.MineNext(Block1);
             Block3 = TestUtils.MineNext(Block2);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet.Action;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Store;
+using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -462,8 +464,6 @@ namespace Libplanet.Tests.Store
             );
 
             var branchPoint = blocks[branchPointIndex];
-            var addressesToStrip = new[] { address1, address2 }.ToImmutableHashSet();
-
             Fx.Store.ForkStateReferences(
                 Fx.StoreChainId,
                 targetChainId,
@@ -496,6 +496,13 @@ namespace Libplanet.Tests.Store
             Assert.Throws<ChainIdNotFoundException>(() =>
                 Fx.Store.ForkStateReferences(Fx.StoreChainId, targetChainId, Fx.Block1)
             );
+
+            var chain = new BlockChain<DumbAction>(new NullPolicy<DumbAction>(), Fx.Store);
+            chain.Append(Fx.Block1);
+
+            // Even if state references in a chain are empty it should not throw
+            // ChainIdNotFoundException unless the chain in itself does not exist.
+            Fx.Store.ForkStateReferences(chain.Id, targetChainId, Fx.Block1);
         }
 
         [Fact]

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -471,7 +471,7 @@ namespace Libplanet.Store
 
             dstColl.InsertBulk(srcColl.Find(Query.LTE("BlockIndex", branchPoint.Index)));
 
-            if (dstColl.Count() < 1)
+            if (!dstColl.Exists(_ => true) && CountIndex(sourceChainId) < 1)
             {
                 throw new ChainIdNotFoundException(
                     sourceChainId,


### PR DESCRIPTION
Fixed a bug that `LiteDBStore.ForkStateReferences<T>()` had thrown `ChainIdNotFoundException` where a `sourceChainId` exists but it has no state references (#509).