### PR TITLE
Fix KeyNotFoundException on Swarm<T>.TransferRecentStates()

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1856,24 +1856,34 @@ namespace Libplanet.Net
 
             if (_logger.IsEnabled(LogEventLevel.Debug))
             {
-                var baseString = @base is HashDigest<SHA256> h
-                    ? $"{BlockChain.Blocks[h].Index}:{h}"
-                    : null;
-                var targetString = $"{BlockChain.Blocks[target].Index}:{target}";
-                _logger.Debug(
-                    "State references to send (preload): {@StateReferences} ({Base}-{Target})",
-                    stateRefs.Select(kv =>
-                        (kv.Key.ToString(), string.Join(", ", kv.Value.Select(v => v.ToString())))
-                    ).ToArray(),
-                    baseString,
-                    targetString
-                );
-                _logger.Debug(
-                    "Block states to send (preload): {@BlockStates} ({Base}-{Target})",
-                    blockStates.Select(kv => (kv.Key.ToString(), kv.Value)).ToArray(),
-                    baseString,
-                    targetString
-                );
+                if (BlockChain.Blocks.ContainsKey(target))
+                {
+                    var baseString = @base is HashDigest<SHA256> h
+                        ? $"{BlockChain.Blocks[h].Index}:{h}"
+                        : null;
+                    var targetString = $"{BlockChain.Blocks[target].Index}:{target}";
+                    _logger.Debug(
+                        "State references to send (preload): {@StateReferences} ({Base}-{Target})",
+                        stateRefs.Select(kv =>
+                            (
+                                kv.Key.ToString(),
+                                string.Join(", ", kv.Value.Select(v => v.ToString()))
+                            )
+                        ).ToArray(),
+                        baseString,
+                        targetString
+                    );
+                    _logger.Debug(
+                        "Block states to send (preload): {@BlockStates} ({Base}-{Target})",
+                        blockStates.Select(kv => (kv.Key.ToString(), kv.Value)).ToArray(),
+                        baseString,
+                        targetString
+                    );
+                }
+                else
+                {
+                    _logger.Debug("Nothing to reply because {TargetHash} doesn't exist.", target);
+                }
             }
 
             var reply = new RecentStates(target, blockStates, stateRefs)

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -33,9 +33,11 @@ namespace Libplanet.Store
             get
             {
                 Block<T> block = Store.GetBlock<T>(key);
-                if (block == null)
+                if (block is null)
                 {
-                    throw new KeyNotFoundException();
+                    throw new KeyNotFoundException(
+                        $"The given hash[{key}] was not found in this set."
+                    );
                 }
 
                 Trace.Assert(block.Hash.Equals(key));


### PR DESCRIPTION
This PR fixes #531 

The direct reason for #531 is `target` that doesn't exist on the sender was used for a log message. so I've added condition about this.

This bug was caused by #512 that was not filing, so I also omit the changelog.