### PR TITLE
Remove forked chain when AppendBlocksAsync fail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,7 +122,7 @@ To be released.
     equivalent results between actions of different transactions in
     a `Block<T>`.  [[#519]]
  -  Fixed a bug where a forked chain would not be deleted when an exception
-    occurred during fetching block from other peers.  [[#527], [#535]]
+    occurred during fetching block from other peers.  [[#527], [#537], [#540]]
 
 [#244]: https://github.com/planetarium/libplanet/issues/244
 [#353]: https://github.com/planetarium/libplanet/pull/353
@@ -151,7 +151,8 @@ To be released.
 [#522]: https://github.com/planetarium/libplanet/pull/522
 [#526]: https://github.com/planetarium/libplanet/pull/526
 [#527]: https://github.com/planetarium/libplanet/issues/527
-[#535]: https://github.com/planetarium/libplanet/issues/535
+[#537]: https://github.com/planetarium/libplanet/issues/537
+[#540]: https://github.com/planetarium/libplanet/issues/540
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 [RFC 4122]: https://tools.ietf.org/html/rfc4122

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,8 +151,8 @@ To be released.
 [#522]: https://github.com/planetarium/libplanet/pull/522
 [#526]: https://github.com/planetarium/libplanet/pull/526
 [#527]: https://github.com/planetarium/libplanet/issues/527
-[#537]: https://github.com/planetarium/libplanet/issues/537
-[#540]: https://github.com/planetarium/libplanet/issues/540
+[#537]: https://github.com/planetarium/libplanet/pull/537
+[#540]: https://github.com/planetarium/libplanet/pull/540
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 [RFC 4122]: https://tools.ietf.org/html/rfc4122

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1628,7 +1628,7 @@ namespace Libplanet.Net
                 finally
                 {
                     Guid? canonicalChainId = _blockChain.Store.GetCanonicalChainId();
-                    if (previousBlocks != null && canonicalChainId != previousBlocks.Id)
+                    if (canonicalChainId != previousBlocks?.Id)
                     {
                         _blockChain.Store.DeleteChainId(previousBlocks.Id);
                     }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1597,29 +1597,41 @@ namespace Libplanet.Net
 
             if (tip is null || latest.Index > tip.Index)
             {
-                _logger.Debug("Trying to fill up previous blocks...");
-                BlockChain<T> previousBlocks = await SyncPreviousBlocksAsync(
-                    _blockChain,
-                    peer,
-                    oldest.PreviousHash,
-                    null,
-                    blocks.Count,
-                    evaluateActions: true,
-                    cancellationToken: cancellationToken
-                );
-                _logger.Debug("Filled up. trying to concatenation...");
-
-                foreach (Block<T> block in blocks)
+                BlockChain<T> previousBlocks = null;
+                try
                 {
-                    previousBlocks.Append(block);
+                    _logger.Debug("Trying to fill up previous blocks...");
+                    previousBlocks = await SyncPreviousBlocksAsync(
+                        _blockChain,
+                        peer,
+                        oldest.PreviousHash,
+                        null,
+                        blocks.Count,
+                        evaluateActions: true,
+                        cancellationToken: cancellationToken
+                    );
+                    _logger.Debug("Filled up. trying to concatenation...");
+
+                    foreach (Block<T> block in blocks)
+                    {
+                        previousBlocks.Append(block);
+                    }
+
+                    _logger.Debug("Sync is done.");
+                    if (!previousBlocks.Id.Equals(_blockChain.Id))
+                    {
+                        _logger.Debug("trying to swapping chain...");
+                        _blockChain.Swap(previousBlocks, render: true);
+                        _logger.Debug("Swapping complete");
+                    }
                 }
-
-                _logger.Debug("Sync is done.");
-                if (!previousBlocks.Id.Equals(_blockChain.Id))
+                finally
                 {
-                    _logger.Debug("trying to swapping chain...");
-                    _blockChain.Swap(previousBlocks, render: true);
-                    _logger.Debug("Swapping complete");
+                    Guid? canonicalChainId = _blockChain.Store.GetCanonicalChainId();
+                    if (previousBlocks != null && canonicalChainId != previousBlocks.Id)
+                    {
+                        _blockChain.Store.DeleteChainId(previousBlocks.Id);
+                    }
                 }
 
                 var blockHashes =


### PR DESCRIPTION
This removes forked chain when `FillBlocksAsync` fail.

