### PR TITLE
Improve LookupStateReference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,10 +14,15 @@ To be released.
     [[#462], [#560]]
  -  `Swarm<T>` class became to implement `IDisposable` again and should be
     disposed to clean up its internal resources. [[#485]]
+ -  `IStore.IterateStateReferences()` method became to receive
+    `highestIndex`, `lowestIndex`, and `limit` parameters.  [[#447], [#545]]
 
 ### Added interfaces
 
 ### Behavioral changes
+
+ -  Improved performance of `StoreExtension.LookupStateReference<T>()` method.
+    [[#447], [#545]]
 
 ### Bug fixes
 
@@ -27,8 +32,10 @@ To be released.
     `Operation on non-blocking socket would block`.  [[#405], [#485]]
 
 [#405]: https://github.com/planetarium/libplanet/issues/405
+[#447]: https://github.com/planetarium/libplanet/issues/447
 [#462]: https://github.com/planetarium/libplanet/issues/462
 [#485]: https://github.com/planetarium/libplanet/pull/485
+[#545]: https://github.com/planetarium/libplanet/pull/545
 [#550]: https://github.com/planetarium/libplanet/issues/550
 [#555]: https://github.com/planetarium/libplanet/issues/555
 [#558]: https://github.com/planetarium/libplanet/pull/558

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -167,10 +167,15 @@ namespace Libplanet.Tests.Store
 
         public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             Guid chainId,
-            Address address)
+            Address address,
+            long? highestIndex,
+            long? lowestIndex,
+            int? limit)
         {
+            // FIXME: Log arguments properly
             _logs.Add((nameof(IterateStateReferences), chainId, address));
-            return _store.IterateStateReferences(chainId, address);
+            return _store.IterateStateReferences(
+                chainId, address, highestIndex, lowestIndex, limit);
         }
 
         public void StoreStateReference(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -119,7 +119,10 @@ namespace Libplanet.Store
         /// <inheritdoc />
         public abstract IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             Guid chainId,
-            Address address);
+            Address address,
+            long? highestIndex,
+            long? lowestIndex,
+            int? limit);
 
         public abstract void StoreStateReference(
             Guid chainId,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -198,14 +198,25 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="chainId">The chain ID.</param>
         /// <param name="address">The <see cref="Address"/> to get state references.</param>
+        /// <param name="highestIndex">The highest index of state references to get. If it is
+        /// <c>null</c>, it will be the highest index possible.</param>
+        /// <param name="lowestIndex">The lowest index of state references to get.  If it is
+        /// <c>null</c>, it will be the lowest index possible.</param>
+        /// <param name="limit">The maximum number of state references to get.  If it is
+        /// <c>null</c>, it does not limit the number of state references.</param>
         /// <returns><em>Ordered</em> pairs of a state reference and a corresponding
         /// <see cref="Block{T}.Index"/>.  The highest index (i.e., the closest to the tip) goes
         /// first and the lowest index (i.e., the closest to the genesis) goes last.</returns>
+        /// <exception cref="ArgumentException">Thrown when the given
+        /// <paramref name="highestIndex"/> is less than <paramref name="lowestIndex"/>.</exception>
         /// <seealso
         /// cref="StoreStateReference(Guid , IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
         IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             Guid chainId,
-            Address address);
+            Address address,
+            long? highestIndex = null,
+            long? lowestIndex = null,
+            int? limit = null);
 
         /// <summary>
         /// Stores a state reference, which is a <see cref="Block{T}.Hash"/>
@@ -220,7 +231,7 @@ namespace Libplanet.Store
         /// <param name="blockIndex">The <see cref="Block{T}.Index"/> which has the state
         /// of the <see cref="Address"/>. This must refer to the same block
         /// that <paramref name="blockHash"/> refers to.</param>
-        /// <seealso cref="IterateStateReferences(Guid, Address)"/>
+        /// <seealso cref="IterateStateReferences(Guid, Address, long?, long?, int?)"/>
         void StoreStateReference(
             Guid chainId,
             IImmutableSet<Address> addresses,
@@ -243,7 +254,7 @@ namespace Libplanet.Store
         /// <paramref name="branchPoint"/>.</typeparam>
         /// <exception cref="ChainIdNotFoundException">Thrown when the given
         /// <paramref name="sourceChainId"/> does not exist.</exception>
-        /// <seealso cref="IterateStateReferences(Guid, Address)"/>
+        /// <seealso cref="IterateStateReferences(Guid, Address, long?, long?, int?)"/>
         /// <seealso
         /// cref="StoreStateReference(Guid, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
         void ForkStateReferences<T>(

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -433,13 +433,12 @@ namespace Libplanet.Store
             string addressString = address.ToHex().ToLower();
             IEnumerable<StateRefDoc> stateRefs = coll.Find(
                 Query.And(
-                    Query.EQ("AddressString", addressString),
-                    Query.All("BlockIndex", Query.Descending)
+                    Query.All("BlockIndex", Query.Descending),
+                    Query.EQ("AddressString", addressString)
                 )
             );
             return stateRefs
-                .Select(doc => new Tuple<HashDigest<SHA256>, long>(doc.BlockHash, doc.BlockIndex))
-                .OrderByDescending(pair => pair.Item2);
+                .Select(doc => new Tuple<HashDigest<SHA256>, long>(doc.BlockHash, doc.BlockIndex));
         }
 
         /// <inheritdoc/>
@@ -484,6 +483,9 @@ namespace Libplanet.Store
                     "The source chain to be forked does not exist."
                 );
             }
+
+            dstColl.EnsureIndex("AddressString");
+            dstColl.EnsureIndex("BlockIndex");
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Store
         /// <typeparam name="T">An <see cref="IAction"/> class used with
         /// <paramref name="lookupUntil"/>.</typeparam>
         /// <seealso cref="IStore.StoreStateReference(Guid, IImmutableSet{Address}, HashDigest{SHA256}, long)"/>
-        /// <seealso cref="IStore.IterateStateReferences(Guid, Address)"/>
+        /// <seealso cref="IStore.IterateStateReferences(Guid, Address, long?, long?, int?)"/>
         #pragma warning restore MEN002
         public static Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             this IStore store,
@@ -40,17 +40,8 @@ namespace Libplanet.Store
                 throw new ArgumentNullException(nameof(lookupUntil));
             }
 
-            IEnumerable<Tuple<HashDigest<SHA256>, long>> stateRefs =
-                store.IterateStateReferences(chainId, address);
-            foreach (Tuple<HashDigest<SHA256>, long> pair in stateRefs)
-            {
-                if (pair.Item2 <= lookupUntil.Index)
-                {
-                    return Tuple.Create(pair.Item1, pair.Item2);
-                }
-            }
-
-            return null;
+            return store.IterateStateReferences(chainId, address, lookupUntil.Index, limit: 1)
+                    .FirstOrDefault();
         }
 
         /// <summary>


### PR DESCRIPTION
To mitigate #447, this improves `IStore.LookupStateReference()` method by limiting the number of results.