### PR TITLE
Fix NullReferenceException in AppendBlocksAsync

### DIFF
--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -77,5 +77,11 @@ namespace Libplanet.Net
             info.AddValue("app_protocol_version", AppProtocolVersion);
             info.AddValue("public_ip_address", PublicIPAddress?.ToString());
         }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{nameof(Peer)} {{ {nameof(Address)} = {Address} }}";
+        }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1628,7 +1628,7 @@ namespace Libplanet.Net
                 finally
                 {
                     Guid? canonicalChainId = _blockChain.Store.GetCanonicalChainId();
-                    if (canonicalChainId != previousBlocks?.Id)
+                    if (!(previousBlocks is null) && canonicalChainId != previousBlocks.Id)
                     {
                         _blockChain.Store.DeleteChainId(previousBlocks.Id);
                     }


### PR DESCRIPTION
This fixes `NullReferenceException` in `AppendBlocksAsync()` and adds `ToString()` to `Peer`.
I skipped the changelog because `Peer` is changed at 0.6.0.