### PR TITLE
Restrict actions and states types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,14 @@ To be released.
     disposed to clean up its internal resources. [[#485]]
  -  `IStore.IterateStateReferences()` method became to receive
     `highestIndex`, `lowestIndex`, and `limit` parameters.  [[#447], [#545]]
- -  Reworked `BlockChain<T>.GetStates()` into `GetState()` which takes only one `Address` instead of `IEnumerable<Address>`.  [[#510], [#563]]
+ -  Reworked `BlockChain<T>.GetStates()` into `GetState()` which takes only
+    one `Address` instead of `IEnumerable<Address>`.  [[#510], [#563]]
+ -  Types of `IAction.PlainValue` and states became restricted to
+    `Bencodex.Types.IValue`.  [[#541], [#552]]
+     -  `IAction.LoadPlainValue(IImmutableDictionary<string, object>)` method
+        became replaced by `LoadPlainValue(IValue)`.
+     -  `AccountStateGetter` became to return `IValue`, not `object`.
+     -  Added `BencodexExtension` static class.
 
 ### Added interfaces
 
@@ -48,8 +55,10 @@ To be released.
 [#485]: https://github.com/planetarium/libplanet/pull/485
 [#510]: https://github.com/planetarium/libplanet/issues/510
 [#528]: https://github.com/planetarium/libplanet/issues/528
+[#541]: https://github.com/planetarium/libplanet/issues/541
 [#545]: https://github.com/planetarium/libplanet/pull/545
 [#550]: https://github.com/planetarium/libplanet/issues/550
+[#552]: https://github.com/planetarium/libplanet/pull/552
 [#555]: https://github.com/planetarium/libplanet/issues/555
 [#558]: https://github.com/planetarium/libplanet/pull/558
 [#560]: https://github.com/planetarium/libplanet/pull/560

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Xunit;
@@ -9,7 +10,7 @@ namespace Libplanet.Tests.Action
     public class AccountStateDeltaImplTest
     {
         private readonly Address[] _addr;
-        private readonly IImmutableDictionary<Address, object> _states;
+        private readonly IImmutableDictionary<Address, IValue> _states;
 
         public AccountStateDeltaImplTest()
         {
@@ -22,10 +23,10 @@ namespace Libplanet.Tests.Action
                 Addr(),
             };
 
-            _states = new Dictionary<Address, object>()
+            _states = new Dictionary<Address, IValue>
             {
-                [_addr[0]] = "a",
-                [_addr[1]] = "b",
+                [_addr[0]] = (Text)"a",
+                [_addr[1]] = (Text)"b",
             }.ToImmutableDictionary();
         }
 
@@ -34,8 +35,8 @@ namespace Libplanet.Tests.Action
         {
             IAccountStateDelta delta = new AccountStateDeltaImpl(GetState);
             Assert.Empty(delta.UpdatedAddresses);
-            Assert.Equal("a", delta.GetState(_addr[0]));
-            Assert.Equal("b", delta.GetState(_addr[1]));
+            Assert.Equal("a", (Text)delta.GetState(_addr[0]));
+            Assert.Equal("b", (Text)delta.GetState(_addr[1]));
             Assert.Null(delta.GetState(_addr[2]));
         }
 
@@ -43,11 +44,11 @@ namespace Libplanet.Tests.Action
         public void GetSetState()
         {
             IAccountStateDelta init = new AccountStateDeltaImpl(GetState);
-            IAccountStateDelta a = init.SetState(_addr[0], "A");
-            Assert.Equal("A", a.GetState(_addr[0]));
-            Assert.Equal("a", init.GetState(_addr[0]));
-            Assert.Equal("b", a.GetState(_addr[1]));
-            Assert.Equal("b", init.GetState(_addr[1]));
+            IAccountStateDelta a = init.SetState(_addr[0], (Text)"A");
+            Assert.Equal("A", (Text)a.GetState(_addr[0]));
+            Assert.Equal("a", (Text)init.GetState(_addr[0]));
+            Assert.Equal("b", (Text)a.GetState(_addr[1]));
+            Assert.Equal("b", (Text)init.GetState(_addr[1]));
             Assert.Null(a.GetState(_addr[2]));
             Assert.Null(init.GetState(_addr[2]));
             Assert.Equal(
@@ -56,12 +57,12 @@ namespace Libplanet.Tests.Action
             );
             Assert.Empty(init.UpdatedAddresses);
 
-            IAccountStateDelta b = a.SetState(_addr[0], "z");
-            Assert.Equal("z", b.GetState(_addr[0]));
-            Assert.Equal("A", a.GetState(_addr[0]));
-            Assert.Equal("a", init.GetState(_addr[0]));
-            Assert.Equal("b", b.GetState(_addr[1]));
-            Assert.Equal("b", a.GetState(_addr[1]));
+            IAccountStateDelta b = a.SetState(_addr[0], (Text)"z");
+            Assert.Equal("z", (Text)b.GetState(_addr[0]));
+            Assert.Equal("A", (Text)a.GetState(_addr[0]));
+            Assert.Equal("a", (Text)init.GetState(_addr[0]));
+            Assert.Equal("b", (Text)b.GetState(_addr[1]));
+            Assert.Equal("b", (Text)a.GetState(_addr[1]));
             Assert.Null(b.GetState(_addr[2]));
             Assert.Null(a.GetState(_addr[2]));
             Assert.Equal(
@@ -70,13 +71,13 @@ namespace Libplanet.Tests.Action
             );
             Assert.Empty(init.UpdatedAddresses);
 
-            IAccountStateDelta c = b.SetState(_addr[0], "a");
-            Assert.Equal("a", c.GetState(_addr[0]));
-            Assert.Equal("z", b.GetState(_addr[0]));
+            IAccountStateDelta c = b.SetState(_addr[0], (Text)"a");
+            Assert.Equal("a", (Text)c.GetState(_addr[0]));
+            Assert.Equal("z", (Text)b.GetState(_addr[0]));
             Assert.Empty(init.UpdatedAddresses);
         }
 
-        private object GetState(Address address)
+        private IValue GetState(Address address)
         {
             try
             {

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 using Xunit;
 
@@ -104,12 +105,12 @@ namespace Libplanet.Tests.Action
             public IImmutableSet<Address> UpdatedAddresses =>
                 ImmutableHashSet<Address>.Empty;
 
-            public object GetState(Address address)
+            public IValue GetState(Address address)
             {
                 return null;
             }
 
-            public IAccountStateDelta SetState(Address address, object state)
+            public IAccountStateDelta SetState(Address address, IValue state)
             {
                 return this;
             }

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -1,3 +1,4 @@
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
@@ -22,7 +23,7 @@ namespace Libplanet.Tests.Action
                     false
                 ),
                 new AccountStateDeltaImpl(
-                    a => a.Equals(address) ? "item" : null
+                    a => a.Equals(address) ? (Text)"item" : null
                 )
             );
             var action = (DumbAction)evaluation.Action;
@@ -36,7 +37,7 @@ namespace Libplanet.Tests.Action
                 evaluation.InputContext.PreviousStates.GetState(address)
             );
             Assert.Equal(
-                "item",
+                (Text)"item",
                 evaluation.OutputStates.GetState(address)
             );
         }

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
-using Libplanet.Tx;
 using Xunit;
 
 namespace Libplanet.Tests.Action
@@ -23,19 +22,16 @@ namespace Libplanet.Tests.Action
                 }
             );
             Assert.Equal(
-                new Dictionary<string, object>
+                new Dictionary(new Dictionary<IKey, IValue>
                 {
-                    { "type_id", "attack" },
+                    [(Text)"type_id"] = (Text)"attack",
+                    [(Text)"values"] = new Dictionary(new Dictionary<IKey, IValue>
                     {
-                        "values",
-                        new Dictionary<string, object>
-                        {
-                            { "weapon", "frying pan" },
-                            { "target", "mosquito" },
-                            { "target_address", addr.ToByteArray() },
-                        }.ToImmutableDictionary()
-                    },
-                }.ToImmutableDictionary(),
+                        [(Text)"weapon"] = (Text)"frying pan",
+                        [(Text)"target"] = (Text)"mosquito",
+                        [(Text)"target_address"] = new Binary(addr.ToByteArray()),
+                    }),
+                }),
                 pa.PlainValue
             );
         }
@@ -48,19 +44,16 @@ namespace Libplanet.Tests.Action
             var pa = new PolymorphicAction<BaseAction>();
 #pragma warning restore 612
             pa.LoadPlainValue(
-                new Dictionary<string, object>
+                new Dictionary(new Dictionary<IKey, IValue>
                 {
-                    { "type_id", "attack" },
+                    [(Text)"type_id"] = (Text)"attack",
+                    [(Text)"values"] = new Dictionary(new Dictionary<IKey, IValue>
                     {
-                        "values",
-                        new Dictionary<string, object>
-                        {
-                            { "weapon", "frying pan" },
-                            { "target", "mosquito" },
-                            { "target_address", addr.ToByteArray() },
-                        }.ToImmutableDictionary()
-                    },
-                }.ToImmutableDictionary()
+                        [(Text)"weapon"] = (Text)"frying pan",
+                        [(Text)"target"] = (Text)"mosquito",
+                        [(Text)"target_address"] = new Binary(addr.ToByteArray()),
+                    }),
+                })
             );
 
             Assert.IsType<Attack>(pa.InnerAction);
@@ -100,12 +93,17 @@ namespace Libplanet.Tests.Action
             {
             }
 
-            public IImmutableDictionary<string, object> PlainValue =>
-                new Dictionary<string, object>().ToImmutableDictionary();
+            public IValue PlainValue =>
+                default(Dictionary);
 
             public void LoadPlainValue(
-                IImmutableDictionary<string, object> plainValue)
+                Dictionary plainValue)
             {
+            }
+
+            public void LoadPlainValue(IValue plainValue)
+            {
+                LoadPlainValue((Dictionary)plainValue);
             }
 
             public IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 
 namespace Libplanet.Tests.Common.Action
@@ -7,13 +8,13 @@ namespace Libplanet.Tests.Common.Action
     [ActionType("attack")]
     public class Attack : BaseAction
     {
-        public override IImmutableDictionary<string, object> PlainValue =>
-            new Dictionary<string, object>()
+        public override IValue PlainValue =>
+            new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
-                { "weapon", Weapon },
-                { "target", Target },
-                { "target_address", TargetAddress.ToByteArray() },
-            }.ToImmutableDictionary();
+                [(Text)"weapon"] = (Text)Weapon,
+                [(Text)"target"] = (Text)Target,
+                [(Text)"target_address"] = new Binary(TargetAddress.ToByteArray()),
+            });
 
         public string Weapon { get; set; }
 
@@ -22,11 +23,16 @@ namespace Libplanet.Tests.Common.Action
         public Address TargetAddress { get; set; }
 
         public override void LoadPlainValue(
-            IImmutableDictionary<string, object> plainValue)
+            IValue plainValue)
         {
-            Weapon = (string)plainValue["weapon"];
-            Target = (string)plainValue["target"];
-            TargetAddress = new Address((byte[])plainValue["target_address"]);
+            LoadPlainValue((Bencodex.Types.Dictionary)plainValue);
+        }
+
+        public void LoadPlainValue(Bencodex.Types.Dictionary plainValue)
+        {
+            Weapon = (Text)plainValue[(Text)"weapon"];
+            Target = (Text)plainValue[(Text)"target"];
+            TargetAddress = new Address(((Binary)plainValue[(Text)"target_address"]).Value);
         }
 
         public override IAccountStateDelta Execute(IActionContext context)
@@ -38,7 +44,7 @@ namespace Libplanet.Tests.Common.Action
             object value = previousStates.GetState(TargetAddress);
             if (!ReferenceEquals(value, null))
             {
-                var previousResult = (BattleResult)value;
+                var previousResult = BattleResult.FromBencodex((Bencodex.Types.Dictionary)value);
                 usedWeapons = previousResult.UsedWeapons;
                 targets = previousResult.Targets;
             }
@@ -47,7 +53,7 @@ namespace Libplanet.Tests.Common.Action
             targets = targets.Add(Target);
             var result = new BattleResult(usedWeapons, targets);
 
-            return previousStates.SetState(TargetAddress, result);
+            return previousStates.SetState(TargetAddress, result.ToBencodex());
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/BaseAction.cs
+++ b/Libplanet.Tests/Common/Action/BaseAction.cs
@@ -1,11 +1,12 @@
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 
 namespace Libplanet.Tests.Common.Action
 {
     public abstract class BaseAction : IAction
     {
-        public abstract IImmutableDictionary<string, object> PlainValue { get; }
+        public abstract IValue PlainValue { get; }
 
         public abstract IAccountStateDelta Execute(IActionContext context);
 
@@ -21,6 +22,6 @@ namespace Libplanet.Tests.Common.Action
         {
         }
 
-        public abstract void LoadPlainValue(IImmutableDictionary<string, object> plainValue);
+        public abstract void LoadPlainValue(IValue plainValue);
     }
 }

--- a/Libplanet.Tests/Common/Action/BattleResult.cs
+++ b/Libplanet.Tests/Common/Action/BattleResult.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.Serialization;
+using Bencodex.Types;
 using Libplanet.Serialization;
 
 namespace Libplanet.Tests.Common.Action
@@ -33,6 +35,21 @@ namespace Libplanet.Tests.Common.Action
         public IImmutableSet<string> UsedWeapons { get; }
 
         public IImmutableSet<string> Targets { get; }
+
+        public static BattleResult FromBencodex(Bencodex.Types.Dictionary dictionary)
+        {
+            return new BattleResult(
+                dictionary.GetValue<List>("used_weapons").Select(x => x.ToString()),
+                dictionary.GetValue<List>("targets").Select(x => x.ToString()));
+        }
+
+        public Bencodex.Types.Dictionary ToBencodex() =>
+            new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
+            {
+                [(Text)"used_weapons"] = new List(
+                    UsedWeapons.Select(x => (IValue)((Text)x))),
+                [(Text)"targets"] = new List(Targets.Select(x => (IValue)((Text)x))),
+            });
 
         public override bool Equals(object other)
         {

--- a/Libplanet.Tests/Common/Action/Sleep.cs
+++ b/Libplanet.Tests/Common/Action/Sleep.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Numerics;
+using Bencodex.Types;
 using Libplanet.Action;
 
 namespace Libplanet.Tests.Common.Action
@@ -11,11 +12,11 @@ namespace Libplanet.Tests.Common.Action
     {
         public int ZoneId { get; set; }
 
-        public override IImmutableDictionary<string, object> PlainValue =>
-            new Dictionary<string, object>()
+        public override IValue PlainValue =>
+            new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
-                { "zone_id", ZoneId },
-            }.ToImmutableDictionary();
+                { (Text)"zone_id", (Integer)ZoneId },
+            });
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
@@ -23,14 +24,15 @@ namespace Libplanet.Tests.Common.Action
             return context.PreviousStates;
         }
 
-        public override void LoadPlainValue(
-            IImmutableDictionary<string, object> plainValue)
+        public override void LoadPlainValue(IValue plainValue)
         {
-            object serialized = plainValue["zone_id"];
+            LoadPlainValue((Dictionary)plainValue);
+        }
 
-            // FIXME: The reason why the type of the serialized value is not
-            // consistent should be analyzed.
-            ZoneId = serialized is BigInteger v ? (int)v : (int)serialized;
+        public void LoadPlainValue(
+            Dictionary plainValue)
+        {
+            ZoneId = (int)plainValue.GetValue<Integer>("zone_id").Value;
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/ThrowException.cs
+++ b/Libplanet.Tests/Common/Action/ThrowException.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
+using Boolean = Bencodex.Types.Boolean;
 
 namespace Libplanet.Tests.Common.Action
 {
@@ -15,15 +17,20 @@ namespace Libplanet.Tests.Common.Action
 
         public bool ThrowOnExecution { get; set; } = false;
 
-        public IImmutableDictionary<string, object> PlainValue =>
-            new Dictionary<string, object>()
+        public IValue PlainValue =>
+            new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
-                { "throw", ThrowOnRehearsal },
-            }.ToImmutableDictionary();
+                [(Text)"throw"] = new Bencodex.Types.Boolean(ThrowOnRehearsal),
+            });
 
-        public void LoadPlainValue(IImmutableDictionary<string, object> plainValue)
+        public void LoadPlainValue(IValue plainValue)
         {
-            ThrowOnRehearsal = (bool)plainValue["throw"];
+            LoadPlainValue((Dictionary)plainValue);
+        }
+
+        public void LoadPlainValue(Dictionary plainValue)
+        {
+            ThrowOnRehearsal = plainValue.GetValue<Boolean>("throw").Value;
         }
 
         public IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -1401,7 +1402,7 @@ namespace Libplanet.Tests.Net
                 await receiverSwarm.PreloadAsync(true);
                 var states = receiverChain.GetState(address);
 
-                Assert.Equal("foo,bar,baz", states[address]);
+                Assert.Equal("foo,bar,baz", (Text)states[address]);
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
             }
             finally
@@ -1680,7 +1681,7 @@ namespace Libplanet.Tests.Net
                     {
                         var deepStates = TryToGetDeepStates();
                         Assert.Single(deepStates);
-                        Assert.Equal($"Item0.{i},Item1.{i}", deepStates[target]);
+                        Assert.Equal($"Item0.{i},Item1.{i}", (Text)deepStates[target]);
                     }
 
                     i++;
@@ -1695,7 +1696,7 @@ namespace Libplanet.Tests.Net
                             completeStates: false
                         );
                         Assert.Single(states);
-                        Assert.Equal("Genesis", states[genesisTarget]);
+                        Assert.Equal("Genesis", (Text)states[genesisTarget]);
                     }
                 }
 
@@ -1707,7 +1708,7 @@ namespace Libplanet.Tests.Net
                     Assert.Single(minerState);
                     Assert.Equal(
                         (genesisWithAction ? 1 : 0) + repeat * fixturePairs.Length,
-                        minerState[minerSwarm.Address]
+                        (Integer)minerState[minerSwarm.Address]
                     );
                 }
             }
@@ -1846,7 +1847,7 @@ namespace Libplanet.Tests.Net
                             string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item{i}.{j}"))
                         )
                     ),
-                    receiverChain.GetState(address)[address]
+                    receiverChain.GetState(address)[address].ToString()
                 );
             }
         }
@@ -2045,8 +2046,7 @@ namespace Libplanet.Tests.Net
 
         private class Sleep : IAction
         {
-            public IImmutableDictionary<string, object> PlainValue =>
-                ImmutableDictionary<string, object>.Empty;
+            public IValue PlainValue => default(Null);
 
             public IAccountStateDelta Execute(IActionContext context)
             {
@@ -2054,7 +2054,7 @@ namespace Libplanet.Tests.Net
                 return context.PreviousStates;
             }
 
-            public void LoadPlainValue(IImmutableDictionary<string, object> plainValue)
+            public void LoadPlainValue(IValue plainValue)
             {
             }
 

--- a/Libplanet.sln.DotSettings
+++ b/Libplanet.sln.DotSettings
@@ -5,6 +5,7 @@
   xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
   xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=Bencodex/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=Bitcoin/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=Ethereum/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=Kademlia/@EntryIndexedValue">True</s:Boolean>

--- a/Libplanet/Action/AccountStateGetter.cs
+++ b/Libplanet/Action/AccountStateGetter.cs
@@ -1,3 +1,5 @@
+using Bencodex.Types;
+
 namespace Libplanet.Action
 {
     /// <summary>
@@ -12,5 +14,5 @@ namespace Libplanet.Action
     /// its state.</param>
     /// <returns>The account state if exists.  Otherwise <c>null</c>.
     /// </returns>
-    public delegate object AccountStateGetter(Address address);
+    public delegate IValue AccountStateGetter(Address address);
 }

--- a/Libplanet/Action/AddressStateMap.cs
+++ b/Libplanet/Action/AddressStateMap.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.Serialization;
+using Bencodex.Types;
 
 namespace Libplanet.Action
 {
@@ -16,15 +17,15 @@ namespace Libplanet.Action
     /// </summary>
     [Serializable]
     public class AddressStateMap
-        : IImmutableDictionary<Address, object>, ISerializable
+        : IImmutableDictionary<Address, IValue>, ISerializable
     {
-        private IImmutableDictionary<Address, object> _impl;
+        private IImmutableDictionary<Address, IValue> _impl;
 
         /// <summary>
         /// Creates an empty map.
         /// </summary>
         public AddressStateMap()
-            : this(new Dictionary<Address, object>().ToImmutableDictionary())
+            : this(new Dictionary<Address, IValue>().ToImmutableDictionary())
         {
         }
 
@@ -34,7 +35,7 @@ namespace Libplanet.Action
         /// </summary>
         /// <param name="dictionary">A dictionary of items to
         /// fill the new map with.</param>
-        public AddressStateMap(IImmutableDictionary<Address, object> dictionary)
+        public AddressStateMap(IImmutableDictionary<Address, IValue> dictionary)
         {
             _impl = dictionary;
         }
@@ -44,11 +45,11 @@ namespace Libplanet.Action
             StreamingContext context
         )
         {
-            var dict = new Dictionary<Address, object>();
+            var dict = new Dictionary<Address, IValue>();
 
             foreach (SerializationEntry entry in info)
             {
-                dict[new Address(entry.Name)] = entry.Value;
+                dict[new Address(entry.Name)] = (IValue)entry.Value;
             }
 
             _impl = dict.ToImmutableDictionary();
@@ -58,39 +59,39 @@ namespace Libplanet.Action
         public IEnumerable<Address> Keys => _impl.Keys;
 
         /// <inheritdoc />
-        public IEnumerable<object> Values => _impl.Values;
+        public IEnumerable<IValue> Values => _impl.Values;
 
         /// <inheritdoc />
         public int Count => _impl.Count;
 
         /// <inheritdoc />
-        public object this[Address key] => _impl[key];
+        public IValue this[Address key] => _impl[key];
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> Add(
+        public IImmutableDictionary<Address, IValue> Add(
             Address key,
-            object value
+            IValue value
         )
         {
             return new AddressStateMap(_impl.Add(key, value));
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> AddRange(
-            IEnumerable<KeyValuePair<Address, object>> pairs
+        public IImmutableDictionary<Address, IValue> AddRange(
+            IEnumerable<KeyValuePair<Address, IValue>> pairs
         )
         {
             return new AddressStateMap(_impl.AddRange(pairs));
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> Clear()
+        public IImmutableDictionary<Address, IValue> Clear()
         {
             return new AddressStateMap(_impl.Clear());
         }
 
         /// <inheritdoc />
-        public bool Contains(KeyValuePair<Address, object> pair)
+        public bool Contains(KeyValuePair<Address, IValue> pair)
         {
             return _impl.Contains(pair);
         }
@@ -102,19 +103,19 @@ namespace Libplanet.Action
         }
 
         /// <inheritdoc />
-        public IEnumerator<KeyValuePair<Address, object>> GetEnumerator()
+        public IEnumerator<KeyValuePair<Address, IValue>> GetEnumerator()
         {
             return _impl.GetEnumerator();
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> Remove(Address key)
+        public IImmutableDictionary<Address, IValue> Remove(Address key)
         {
             return new AddressStateMap(_impl.Remove(key));
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> RemoveRange(
+        public IImmutableDictionary<Address, IValue> RemoveRange(
             IEnumerable<Address> keys
         )
         {
@@ -122,17 +123,17 @@ namespace Libplanet.Action
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> SetItem(
+        public IImmutableDictionary<Address, IValue> SetItem(
             Address key,
-            object value
+            IValue value
         )
         {
             return new AddressStateMap(_impl.SetItem(key, value));
         }
 
         /// <inheritdoc />
-        public IImmutableDictionary<Address, object> SetItems(
-            IEnumerable<KeyValuePair<Address, object>> items
+        public IImmutableDictionary<Address, IValue> SetItems(
+            IEnumerable<KeyValuePair<Address, IValue>> items
         )
         {
             return new AddressStateMap(_impl.SetItems(items));
@@ -145,7 +146,7 @@ namespace Libplanet.Action
         }
 
         /// <inheritdoc />
-        public bool TryGetValue(Address key, out object value)
+        public bool TryGetValue(Address key, out IValue value)
         {
             return _impl.TryGetValue(key, out value);
         }

--- a/Libplanet/Action/IAccountStateDelta.cs
+++ b/Libplanet/Action/IAccountStateDelta.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using Bencodex.Types;
 
 namespace Libplanet.Action
 {
@@ -29,7 +30,7 @@ namespace Libplanet.Action
     /// </list>
     /// </summary>
     /// <remarks>
-    /// This interface is immutable.  <see cref="SetState(Address, object)"/>
+    /// This interface is immutable.  <see cref="SetState(Address, IValue)"/>
     /// method does not manipulate the instance, but returns a new
     /// <see cref="IAccountStateDelta"/> instance with updated states.
     /// </remarks>
@@ -51,7 +52,7 @@ namespace Libplanet.Action
         /// If it has never been set to any state it returns <c>null</c>
         /// instead.</returns>
         [Pure]
-        object GetState(Address address);
+        IValue GetState(Address address);
 
         /// <summary>
         /// Gets a new instance that the account state of the given
@@ -70,7 +71,7 @@ namespace Libplanet.Action
         /// with updated states instead.
         /// </remarks>
         [Pure]
-        IAccountStateDelta SetState(Address address, object state);
+        IAccountStateDelta SetState(Address address, IValue state);
     }
 
     internal static class AccountStateDeltaExtensions
@@ -82,12 +83,12 @@ namespace Libplanet.Action
         // the IAccountStateDelta interface exposes, it is quite inefficient
         // when an implementing class maintains their own dirty dictionary.
         // (See also AccountStateDeltaImpl.UpdatedStates field.)
-        public static IImmutableDictionary<Address, object> GetUpdatedStates(
+        public static IImmutableDictionary<Address, IValue> GetUpdatedStates(
             this IAccountStateDelta delta
         )
         {
             return delta.UpdatedAddresses.Select(address =>
-                new KeyValuePair<Address, object>(
+                new KeyValuePair<Address, IValue>(
                     address,
                     delta.GetState(address)
                 )

--- a/Libplanet/BencodexExtension.cs
+++ b/Libplanet/BencodexExtension.cs
@@ -1,0 +1,13 @@
+using Bencodex.Types;
+
+namespace Libplanet
+{
+    public static class BencodexExtension
+    {
+        public static T GetValue<T>(this Dictionary dictionary, string name)
+            where T : IValue
+        {
+            return (T)dictionary[(Text)name];
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -1073,9 +1074,9 @@ namespace Libplanet.Blockchain
                     ImmutableHashSet<Address>.Empty,
                     (a, b) => a.Union(b)
                 );
-            ImmutableDictionary<Address, object> totalDelta =
+            ImmutableDictionary<Address, IValue> totalDelta =
                 updatedAddresses.Select(
-                    a => new KeyValuePair<Address, object>(
+                    a => new KeyValuePair<Address, IValue>(
                         a,
                         lastStates?.GetState(a)
                     )

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Net.Messages;
 using Serilog;
+using Random = System.Random;
 
 namespace Libplanet.Net.Protocols
 {
@@ -26,7 +27,7 @@ namespace Libplanet.Net.Protocols
         private readonly Swarm<T> _swarm;
         private readonly Address _address;
         private readonly int _appProtocolVersion;
-        private readonly System.Random _random;
+        private readonly Random _random;
         private readonly RoutingTable _routing;
 
         private readonly ILogger _logger;
@@ -42,7 +43,7 @@ namespace Libplanet.Net.Protocols
             _logger = logger;
 
             _address = address;
-            _random = new System.Random();
+            _random = new Random();
             _routing = new RoutingTable(
                 _address, TableSize, BucketSize, _random);
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -12,6 +12,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncIO;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -1817,7 +1818,7 @@ namespace Libplanet.Net
             HashDigest<SHA256>? @base = _blockChain.FindBranchPoint(baseLocator);
             HashDigest<SHA256> target = getRecentStates.TargetBlockHash;
             IImmutableDictionary<HashDigest<SHA256>,
-                IImmutableDictionary<Address, object>
+                IImmutableDictionary<Address, IValue>
             > blockStates = null;
             IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
                 stateRefs = null;
@@ -1846,7 +1847,7 @@ namespace Libplanet.Net
                         .Select(bh =>
                             new KeyValuePair<
                                 HashDigest<SHA256>,
-                                IImmutableDictionary<Address, object>
+                                IImmutableDictionary<Address, IValue>
                             >(bh, store.GetBlockStates(bh))
                         )
                         .ToImmutableDictionary();

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
@@ -669,12 +670,7 @@ namespace Libplanet.Tx
                     a.ByteArray).ToImmutableArray(),
                 publicKey: PublicKey.Format(false).ToImmutableArray(),
                 timestamp: Timestamp.ToString(TimestampFormat),
-                actions: Actions.Select(a =>
-                    a.PlainValue.ToImmutableDictionary(
-                        kv => kv.Key,
-                        kv => kv.Value
-                    )
-                )
+                actions: Actions.Select(a => a.PlainValue)
             );
 
             if (includeSign)
@@ -685,10 +681,10 @@ namespace Libplanet.Tx
             return rawTx;
         }
 
-        private static T ToAction(IImmutableDictionary<string, object> arg)
+        private static T ToAction(IValue value)
         {
             var action = new T();
-            action.LoadPlainValue(arg.ToImmutableDictionary());
+            action.LoadPlainValue(value);
             return action;
         }
 


### PR DESCRIPTION
This pr is related with #541.

- Restrict types of `IAction.PlainValue` to `Bencodex.Types.IValue`.