### PR TITLE
Renamed InterateIndex to IterateIndexes (resolves issue #462)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ To be released.
 ### Backward-incompatible interface changes
 
  -  Renamed `minValue`/`maxValue` parameters to `lowerBound`/`upperBound` of `IRandom.Next()` methods.   [[#555], [#558]]
+ -  Renamed `IterateIndex()` method to `IterateIndexes` on `IStore` interface and usages. [[#462]]
 
 ### Added interfaces
 
@@ -145,6 +146,7 @@ Released on October 1, 2019.
 [#450]: https://github.com/planetarium/libplanet/pull/450
 [#460]: https://github.com/planetarium/libplanet/issues/460
 [#461]: https://github.com/planetarium/libplanet/issues/461
+[#462]: https://github.com/planetarium/libplanet/issues/462
 [#463]: https://github.com/planetarium/libplanet/issues/463
 [#467]: https://github.com/planetarium/libplanet/pull/467
 [#470]: https://github.com/planetarium/libplanet/pull/470

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ To be released.
 ### Backward-incompatible interface changes
 
  -  Renamed `minValue`/`maxValue` parameters to `lowerBound`/`upperBound` of `IRandom.Next()` methods.   [[#555], [#558]]
- -  Renamed `IterateIndex()` method to `IterateIndexes` on `IStore` interface and usages. [[#462]]
+ -  Renamed `IStore.IterateIndex()` method to `IterateIndexes()`.  [[#462], [#560]]
 
 ### Added interfaces
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ To be released.
 
 ### Bug fixes
 
+[#462]: https://github.com/planetarium/libplanet/issues/462
+[#560]: https://github.com/planetarium/libplanet/pull/560
 
 
 Version 0.6.0
@@ -146,7 +148,6 @@ Released on October 1, 2019.
 [#450]: https://github.com/planetarium/libplanet/pull/450
 [#460]: https://github.com/planetarium/libplanet/issues/460
 [#461]: https://github.com/planetarium/libplanet/issues/461
-[#462]: https://github.com/planetarium/libplanet/issues/462
 [#463]: https://github.com/planetarium/libplanet/issues/463
 [#467]: https://github.com/planetarium/libplanet/pull/467
 [#470]: https://github.com/planetarium/libplanet/pull/470

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ To be released.
 ### Bug fixes
 
 [#462]: https://github.com/planetarium/libplanet/issues/462
+[#555]: https://github.com/planetarium/libplanet/issues/555
+[#558]: https://github.com/planetarium/libplanet/pull/558
 [#560]: https://github.com/planetarium/libplanet/pull/560
 
 
@@ -170,8 +172,6 @@ Released on October 1, 2019.
 [#527]: https://github.com/planetarium/libplanet/issues/527
 [#537]: https://github.com/planetarium/libplanet/pull/537
 [#540]: https://github.com/planetarium/libplanet/pull/540
-[#555]: https://github.com/planetarium/libplanet/issues/555
-[#558]: https://github.com/planetarium/libplanet/pull/558
 [Kademlia]: https://en.wikipedia.org/wiki/Kademlia
 [Guid]: https://docs.microsoft.com/ko-kr/dotnet/api/system.guid?view=netframework-4.8
 [RFC 4122]: https://tools.ietf.org/html/rfc4122

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -850,7 +850,7 @@ namespace Libplanet.Tests.Blockchain
                 Guid previousChainId = _blockChain.Id;
                 _blockChain.Swap(fork, render);
 
-                Assert.Empty(_blockChain.Store.IterateIndex(previousChainId));
+                Assert.Empty(_blockChain.Store.IterateIndexes(previousChainId));
                 Assert.Empty(_blockChain.Store.ListAddresses(previousChainId));
                 Assert.Empty(_blockChain.Store.ListTxNonces(previousChainId));
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -251,7 +251,7 @@ namespace Libplanet.Tests.Store
         public void StoreIndex()
         {
             Assert.Equal(0, Fx.Store.CountIndex(Fx.StoreChainId));
-            Assert.Empty(Fx.Store.IterateIndex(Fx.StoreChainId));
+            Assert.Empty(Fx.Store.IterateIndexes(Fx.StoreChainId));
             Assert.Null(Fx.Store.IndexBlockHash(Fx.StoreChainId, 0));
             Assert.Null(Fx.Store.IndexBlockHash(Fx.StoreChainId, -1));
 
@@ -262,7 +262,7 @@ namespace Libplanet.Tests.Store
                 {
                     Fx.Hash1,
                 },
-                Fx.Store.IterateIndex(Fx.StoreChainId));
+                Fx.Store.IterateIndexes(Fx.StoreChainId));
             Assert.Equal(Fx.Hash1, Fx.Store.IndexBlockHash(Fx.StoreChainId, 0));
             Assert.Equal(Fx.Hash1, Fx.Store.IndexBlockHash(Fx.StoreChainId, -1));
 
@@ -274,7 +274,7 @@ namespace Libplanet.Tests.Store
                     Fx.Hash1,
                     Fx.Hash2,
                 },
-                Fx.Store.IterateIndex(Fx.StoreChainId));
+                Fx.Store.IterateIndexes(Fx.StoreChainId));
             Assert.Equal(Fx.Hash1, Fx.Store.IndexBlockHash(Fx.StoreChainId, 0));
             Assert.Equal(Fx.Hash2, Fx.Store.IndexBlockHash(Fx.StoreChainId, 1));
             Assert.Equal(Fx.Hash2, Fx.Store.IndexBlockHash(Fx.StoreChainId, -1));
@@ -286,13 +286,13 @@ namespace Libplanet.Tests.Store
         {
             Assert.False(Fx.Store.DeleteIndex(Fx.StoreChainId, Fx.Hash1));
             Fx.Store.AppendIndex(Fx.StoreChainId, Fx.Hash1);
-            Assert.NotEmpty(Fx.Store.IterateIndex(Fx.StoreChainId));
+            Assert.NotEmpty(Fx.Store.IterateIndexes(Fx.StoreChainId));
             Assert.True(Fx.Store.DeleteIndex(Fx.StoreChainId, Fx.Hash1));
-            Assert.Empty(Fx.Store.IterateIndex(Fx.StoreChainId));
+            Assert.Empty(Fx.Store.IterateIndexes(Fx.StoreChainId));
         }
 
         [Fact]
-        public void IterateIndex()
+        public void IterateIndexes()
         {
             var ns = Fx.StoreChainId;
             var store = Fx.Store;
@@ -301,37 +301,37 @@ namespace Libplanet.Tests.Store
             store.AppendIndex(ns, Fx.Hash2);
             store.AppendIndex(ns, Fx.Hash3);
 
-            var indexes = store.IterateIndex(ns).ToArray();
+            var indexes = store.IterateIndexes(ns).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndex(ns, 1).ToArray();
+            indexes = store.IterateIndexes(ns, 1).ToArray();
             Assert.Equal(new[] { Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndex(ns, 2).ToArray();
+            indexes = store.IterateIndexes(ns, 2).ToArray();
             Assert.Equal(new[] { Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndex(ns, 3).ToArray();
+            indexes = store.IterateIndexes(ns, 3).ToArray();
             Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
 
-            indexes = store.IterateIndex(ns, 4).ToArray();
+            indexes = store.IterateIndexes(ns, 4).ToArray();
             Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
 
-            indexes = store.IterateIndex(ns, limit: 0).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 0).ToArray();
             Assert.Equal(new HashDigest<SHA256>[] { }, indexes);
 
-            indexes = store.IterateIndex(ns, limit: 1).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 1).ToArray();
             Assert.Equal(new[] { Fx.Hash1 }, indexes);
 
-            indexes = store.IterateIndex(ns, limit: 2).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 2).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2 }, indexes);
 
-            indexes = store.IterateIndex(ns, limit: 3).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 3).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndex(ns, limit: 4).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 4).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndex(ns, 1, 1).ToArray();
+            indexes = store.IterateIndexes(ns, 1, 1).ToArray();
             Assert.Equal(new[] { Fx.Hash2 }, indexes);
         }
 

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -118,10 +118,10 @@ namespace Libplanet.Tests.Store
             return _store.IterateBlockHashes();
         }
 
-        public IEnumerable<HashDigest<SHA256>> IterateIndex(Guid chainId, int offset, int? limit)
+        public IEnumerable<HashDigest<SHA256>> IterateIndexes(Guid chainId, int offset, int? limit)
         {
-             _logs.Add((nameof(IterateIndex), chainId, (offset, limit)));
-             return _store.IterateIndex(chainId, offset, limit);
+             _logs.Add((nameof(IterateIndexes), chainId, (offset, limit)));
+             return _store.IterateIndexes(chainId, offset, limit);
         }
 
         public IEnumerable<TxId> IterateStagedTransactionIds()

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -122,7 +122,7 @@ namespace Libplanet.Blockchain
                 {
                     _rwlock.EnterUpgradeableReadLock();
 
-                    IEnumerable<HashDigest<SHA256>> indices = Store.IterateIndex(Id);
+                    IEnumerable<HashDigest<SHA256>> indices = Store.IterateIndexes(Id);
 
                     // NOTE: The reason why this does not simply return indices, but iterates over
                     // indices and yields hashes step by step instead, is that we need to ensure
@@ -832,7 +832,7 @@ namespace Libplanet.Blockchain
                 }
 
                 IEnumerable<HashDigest<SHA256>> hashes = Store
-                    .IterateIndex(Id, branchPointIndex, count);
+                    .IterateIndexes(Id, branchPointIndex, count);
 
                 foreach (HashDigest<SHA256> hash in hashes)
                 {

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Store
 
         public abstract long CountIndex(Guid chainId);
 
-        public abstract IEnumerable<HashDigest<SHA256>> IterateIndex(
+        public abstract IEnumerable<HashDigest<SHA256>> IterateIndexes(
             Guid chainId,
             int offset,
             int? limit);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Store
         /// <param name="limit">The maximum number of block hashes to get.</param>
         /// <returns>Block hashes in the index of the <paramref name="chainId"/>, in ascending
         /// order; the genesis block goes first, and the tip block goes last.</returns>
-        IEnumerable<HashDigest<SHA256>> IterateIndex(
+        IEnumerable<HashDigest<SHA256>> IterateIndexes(
             Guid chainId,
             int offset = 0,
             int? limit = null);
@@ -78,7 +78,7 @@ namespace Libplanet.Store
         /// to fork.</param>
         /// <exception cref="ChainIdNotFoundException">Thrown when the given
         /// <paramref name="sourceChainId"/> does not exist.</exception>
-        /// <seealso cref="IterateIndex(Guid, int, int?)"/>
+        /// <seealso cref="IterateIndexes(Guid, int, int?)"/>
         /// <seealso cref="AppendIndex(Guid, HashDigest{SHA256})"/>
         void ForkBlockIndexes(
             Guid sourceChainId,

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -158,7 +158,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<HashDigest<SHA256>> IterateIndex(
+        public override IEnumerable<HashDigest<SHA256>> IterateIndexes(
             Guid chainId,
             int offset,
             int? limit)


### PR DESCRIPTION
Also renamed the corresponding StoreTest and StoreTracker-Methods to comply with the new name.

This change resolves issue [462](https://github.com/planetarium/libplanet/issues/462)