### PR TITLE
Avoid infinite loop when a peer is evicted from routing table and add cached peer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  Changed to send `Pong` before updating the message sender to the routing
+    table when `Ping` is received.  [[#566]]
  -  Improved performance of `StoreExtension.LookupStateReference<T>()` method.
     [[#447], [#545]]
  -  Added .NET Core 2.2 as a targeted framework.  [[#209], [#561]]
@@ -39,6 +41,8 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `KademliaProtocol<T>.UpdateAsync()` runs infinitely when
+    a peer is evicted from `Bucket` and replacement cache is used.  [[#566]]
  -  Fixed a bug where `Swarm<T>.AppendBlocksAsync()` re-requests blocks that
     already received when blockchain is empty.  [[#550], [#562]]
  -  Fixed a bug that `Swarm<T>` had thrown `SocketException` with a message
@@ -48,6 +52,7 @@ To be released.
  -  Fixed a bug that `Swarm<T>` had thrown `InvalidBlockIndexException` during
     synchronizing with other reorganized peer.  [[#528], [#576]]
 
+[#209]: https://github.com/planetarium/libplanet/issues/209
 [#405]: https://github.com/planetarium/libplanet/issues/405
 [#447]: https://github.com/planetarium/libplanet/issues/447
 [#462]: https://github.com/planetarium/libplanet/issues/462
@@ -62,10 +67,10 @@ To be released.
 [#555]: https://github.com/planetarium/libplanet/issues/555
 [#558]: https://github.com/planetarium/libplanet/pull/558
 [#560]: https://github.com/planetarium/libplanet/pull/560
+[#561]: https://github.com/planetarium/libplanet/pull/561
 [#562]: https://github.com/planetarium/libplanet/pull/562
 [#563]: https://github.com/planetarium/libplanet/pull/563
-[#209]: https://github.com/planetarium/libplanet/issues/209
-[#561]: https://github.com/planetarium/libplanet/pull/561
+[#566]: https://github.com/planetarium/libplanet/pull/566
 [#575]: https://github.com/planetarium/libplanet/pull/575
 [#576]: https://github.com/planetarium/libplanet/pull/576
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -498,7 +498,7 @@ namespace Libplanet.Tests.Net
 
                 await swarmA.StopAsync();
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
-                await Task.Delay(Kademlia.IdleRequestTimeout + TimeSpan.FromSeconds(1));
+                await Task.Delay(Kademlia.IdleRequestTimeout + 1000);
 
                 Assert.Equal(1, swarm.Peers.Count);
                 Assert.DoesNotContain(swarmA.AsPeer, swarm.Peers);
@@ -554,7 +554,7 @@ namespace Libplanet.Tests.Net
                 await swarmB.StopAsync();
 
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
-                await Task.Delay(Kademlia.IdleRequestTimeout * 2 + TimeSpan.FromSeconds(1));
+                await Task.Delay(Kademlia.IdleRequestTimeout * 2 + 1000);
 
                 Assert.Equal(1, swarmA.Peers.Count);
                 Assert.DoesNotContain(swarmA.AsPeer, swarm.Peers);

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -21,9 +21,9 @@ namespace Libplanet.Net.Protocols
             TimeSpan? findPeerTimeout,
             CancellationToken cancellationToken);
 
-        Task RefreshTableAsync(TimeSpan? period, CancellationToken cancellationToken);
+        Task RefreshTableAsync(TimeSpan period, CancellationToken cancellationToken);
 
-        Task RebuildConnectionAsync(TimeSpan? period, CancellationToken cancellationToken);
+        Task RebuildConnectionAsync(TimeSpan period, CancellationToken cancellationToken);
 
         void ReceiveMessage(object sender, Message message);
 

--- a/Libplanet/Net/Protocols/Kademlia.cs
+++ b/Libplanet/Net/Protocols/Kademlia.cs
@@ -10,8 +10,7 @@ namespace Libplanet.Net.Protocols
         public const int TableSize = Address.Size * sizeof(byte) * 8;
         public const int FindConcurrency = 3;
         public const int MaxDepth = 3;
-
-        public static TimeSpan IdleRequestTimeout { get; } = TimeSpan.FromSeconds(5);
+        public const int IdleRequestTimeout = 5000;
 
         public static Address CalculateDistance(Address a, Address b)
         {

--- a/Libplanet/Net/Protocols/Kademlia.cs
+++ b/Libplanet/Net/Protocols/Kademlia.cs
@@ -6,6 +6,13 @@ namespace Libplanet.Net.Protocols
 {
     internal static class Kademlia
     {
+        public const int BucketSize = 16;
+        public const int TableSize = Address.Size * sizeof(byte) * 8;
+        public const int FindConcurrency = 3;
+        public const int MaxDepth = 3;
+
+        public static TimeSpan IdleRequestTimeout { get; } = TimeSpan.FromSeconds(5);
+
         public static Address CalculateDistance(Address a, Address b)
         {
             var dba = new byte[Address.Size];

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -268,7 +268,7 @@ namespace Libplanet.Net.Protocols
                 trace = trace.TrimEnd(' ', ',');
             }
 
-            return "Total peer count : " + count + "\n" + trace.Trim('\n');
+            return $"Total peer count: {count}\n{trace.Trim('\n')}";
         }
 
         internal async Task PingAsync(

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -14,21 +14,14 @@ namespace Libplanet.Net.Protocols
     internal class KademliaProtocol<T> : IProtocol
         where T : IAction, new()
     {
-        private const int BucketSize = 16;
-        private const int TableSize = Address.Size * sizeof(byte) * 8;
-        private const int FindConcurrency = 3;
-        private const int MaxDepth = 3;
-
-        // FIXME: This should be configurable?
-        private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
-        private static readonly TimeSpan IdleRefreshInterval = TimeSpan.FromSeconds(5);
-        private static readonly TimeSpan IdleRebuildInterval = TimeSpan.FromMinutes(30);
-
+        private readonly TimeSpan _requestTimeout;
         private readonly Swarm<T> _swarm;
         private readonly Address _address;
         private readonly int _appProtocolVersion;
         private readonly Random _random;
         private readonly RoutingTable _routing;
+        private readonly int _tableSize;
+        private readonly int _bucketSize;
 
         private readonly ILogger _logger;
 
@@ -36,16 +29,21 @@ namespace Libplanet.Net.Protocols
             Swarm<T> swarm,
             Address address,
             int appProtocolVersion,
-            ILogger logger)
+            ILogger logger,
+            int? tableSize,
+            int? bucketSize,
+            TimeSpan? requestTimeout = null)
         {
             _swarm = swarm;
             _appProtocolVersion = appProtocolVersion;
             _logger = logger;
 
             _address = address;
-            _random = new Random();
-            _routing = new RoutingTable(
-                _address, TableSize, BucketSize, _random);
+            _random = new System.Random();
+            _tableSize = tableSize ?? Kademlia.TableSize;
+            _bucketSize = bucketSize ?? Kademlia.BucketSize;
+            _routing = new RoutingTable(_address, _tableSize, _bucketSize, _random);
+            _requestTimeout = requestTimeout ?? Kademlia.IdleRequestTimeout;
         }
 
         public int Count => _routing.Count;
@@ -156,24 +154,23 @@ namespace Libplanet.Net.Protocols
         /// Periodically checks whether <see cref="Peer"/>s in <see cref="RoutingTable"/> is
         /// online by sending <see cref="Ping"/>.
         /// </summary>
-        /// <param name="period">The cycle in which the operation is executed. If null,
-        /// <see cref="IdleRefreshInterval"/> will be used.</param>
+        /// <param name="period">The cycle in which the operation is executed.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
         public async Task RefreshTableAsync(
-            TimeSpan? period,
+            TimeSpan period,
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await Task.Delay(period ?? IdleRefreshInterval, cancellationToken);
+                    await Task.Delay(period, cancellationToken);
 
                     _logger.Debug("Refreshing table...");
                     List<Task> tasks = PeersToBroadcast.Select(
-                        peer => PingAsync(peer, RequestTimeout, cancellationToken)).ToList();
+                        peer => PingAsync(peer, _requestTimeout, cancellationToken)).ToList();
 
                     await Task.WhenAll(tasks);
                     cancellationToken.ThrowIfCancellationRequested();
@@ -193,13 +190,12 @@ namespace Libplanet.Net.Protocols
         /// Reconstructs network connection between peers on network. It runs operation once
         /// right after called, repeated every <see cref="TimeSpan"/> of <paramref name="period"/>.
         /// </summary>
-        /// <param name="period">The cycle in which the operation is executed. If null,
-        /// <see cref="IdleRebuildInterval"/> will be used.</param>
+        /// <param name="period">The cycle in which the operation is executed.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>>An awaitable task without value.</returns>
         public async Task RebuildConnectionAsync(
-            TimeSpan? period,
+            TimeSpan period,
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
@@ -207,18 +203,18 @@ namespace Libplanet.Net.Protocols
                 _logger.Debug("Rebuilding connection...");
                 var buffer = new byte[20];
                 var tasks = new List<Task>();
-                for (int i = 0; i < FindConcurrency; i++)
+                for (int i = 0; i < Kademlia.FindConcurrency; i++)
                 {
                     _random.NextBytes(buffer);
                     tasks.Add(FindPeerAsync(
                         new Address(buffer),
                         null,
                         -1,
-                        RequestTimeout,
+                        _requestTimeout,
                         cancellationToken));
                 }
 
-                tasks.Add(FindPeerAsync(_address, null, -1, RequestTimeout, cancellationToken));
+                tasks.Add(FindPeerAsync(_address, null, -1, _requestTimeout, cancellationToken));
                 try
                 {
                     await Task.WhenAll(tasks);
@@ -227,7 +223,7 @@ namespace Libplanet.Net.Protocols
                 {
                 }
 
-                await Task.Delay(period ?? IdleRebuildInterval, cancellationToken);
+                await Task.Delay(period, cancellationToken);
             }
         }
 
@@ -255,7 +251,7 @@ namespace Libplanet.Net.Protocols
         {
             var trace = $"Routing table of [{_address.ToHex()}]\n";
             var count = 0;
-            for (var i = 0; i < TableSize; i++)
+            for (var i = 0; i < _tableSize; i++)
             {
                 if (_routing.BucketOf(i).IsEmpty())
                 {
@@ -371,7 +367,7 @@ namespace Libplanet.Net.Protocols
                     _routing.BucketOf(peer).ReplacementCache.Add(peer);
                     await PingAsync(
                         evictionCandidate,
-                        RequestTimeout,
+                        _requestTimeout,
                         cancellationToken);
                 }
                 catch (TimeoutException)
@@ -394,7 +390,7 @@ namespace Libplanet.Net.Protocols
                 foreach (BoundPeer replacement in bucket.ReplacementCache)
                 {
                     // FIXME: appropriate cancellation token required.
-                    await PingAsync(replacement, RequestTimeout, CancellationToken.None);
+                    await PingAsync(replacement, _requestTimeout, CancellationToken.None);
                 }
             }
         }
@@ -420,7 +416,7 @@ namespace Libplanet.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
-            if (depth >= MaxDepth)
+            if (depth >= Kademlia.MaxDepth)
             {
                 return;
             }
@@ -443,9 +439,11 @@ namespace Libplanet.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
-            List<BoundPeer> neighbors = _routing.Neighbors(target, BucketSize).ToList();
+            List<BoundPeer> neighbors = _routing.Neighbors(target, _bucketSize).ToList();
             var found = new List<BoundPeer>();
-            int count = neighbors.Count < FindConcurrency ? neighbors.Count : FindConcurrency;
+            int count = (neighbors.Count < Kademlia.FindConcurrency)
+                ? neighbors.Count
+                : Kademlia.FindConcurrency;
             bool timeoutOccurred = true;
             for (int i = 0; i < count; i++)
             {
@@ -550,10 +548,10 @@ namespace Libplanet.Net.Protocols
 
             peers = Kademlia.SortByDistance(peers, target);
 
-            List<BoundPeer> closestCandidate = _routing.Neighbors(target, BucketSize).ToList();
+            List<BoundPeer> closestCandidate = _routing.Neighbors(target, _bucketSize).ToList();
 
             Task[] awaitables = peers.Select(peer =>
-                PingAsync(peer, RequestTimeout, cancellationToken)
+                PingAsync(peer, _requestTimeout, cancellationToken)
             ).ToArray();
             try
             {
@@ -565,7 +563,7 @@ namespace Libplanet.Net.Protocols
                     e.InnerExceptions.Count == awaitables.Length)
                 {
                     throw new TimeoutException(
-                        $"All neighbors found do not respond in {RequestTimeout}."
+                        $"All neighbors found do not respond in {_requestTimeout}."
                     );
                 }
 
@@ -578,7 +576,7 @@ namespace Libplanet.Net.Protocols
 
             var findNeighboursTasks = new List<Task>();
             Peer closestKnown = closestCandidate.Count == 0 ? null : closestCandidate[0];
-            for (int i = 0; i < FindConcurrency && i < peers.Count; i++)
+            for (int i = 0; i < Kademlia.FindConcurrency && i < peers.Count; i++)
             {
                 if (closestKnown is null ||
                     string.CompareOrdinal(
@@ -618,7 +616,7 @@ namespace Libplanet.Net.Protocols
                 await UpdateAsync(findNeighbors.Remote);
             }
 
-            List<BoundPeer> found = _routing.Neighbors(findNeighbors.Target, BucketSize).ToList();
+            List<BoundPeer> found = _routing.Neighbors(findNeighbors.Target, _bucketSize).ToList();
 
             Neighbors neighbors = new Neighbors(found)
             {

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -43,7 +43,9 @@ namespace Libplanet.Net.Protocols
             _tableSize = tableSize ?? Kademlia.TableSize;
             _bucketSize = bucketSize ?? Kademlia.BucketSize;
             _routing = new RoutingTable(_address, _tableSize, _bucketSize, _random);
-            _requestTimeout = requestTimeout ?? Kademlia.IdleRequestTimeout;
+            _requestTimeout =
+                requestTimeout ??
+                TimeSpan.FromMilliseconds(Kademlia.IdleRequestTimeout);
         }
 
         public int Count => _routing.Count;

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -254,7 +254,7 @@ namespace Libplanet.Net.Protocols
         public string Trace()
         {
             var trace = $"Routing table of [{_address.ToHex()}]\n";
-            var count = 1;
+            var count = 0;
             for (var i = 0; i < TableSize; i++)
             {
                 if (_routing.BucketOf(i).IsEmpty())
@@ -264,12 +264,12 @@ namespace Libplanet.Net.Protocols
 
                 trace += $"**Bucket {i}**\n";
                 trace = _routing.BucketOf(i).Peers.Aggregate(trace, (current, peer) =>
-                    current + $"{count++} : [{peer.Address.ToHex()}]\n");
+                    current + $"{++count} : [{peer.Address.ToHex()}]\n");
 
                 trace = trace.TrimEnd(' ', ',');
             }
 
-            return trace.Trim('\n');
+            return "Total peer count : " + count + "\n" + trace.Trim('\n');
         }
 
         internal async Task PingAsync(

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -104,6 +104,7 @@ namespace Libplanet.Net.Protocols
                 catch (TimeoutException)
                 {
                     _logger.Error("A timeout exception occurred connecting to seed peer.");
+                    await RemovePeerAsync(peer);
                     continue;
                 }
                 catch (Exception)
@@ -302,19 +303,18 @@ namespace Libplanet.Net.Protocols
                 }
 
                 _logger.Verbose(
-                    $"Trying to {nameof(UpdateAsync)}() with pong: {{Message}}",
+                    $"Trying to {nameof(UpdateAsync)}() with pong: {{@Pong}}",
                     pong);
 
                 // update process required
                 await UpdateAsync(pong.Remote, cancellationToken);
                 _logger.Verbose(
-                    $"{nameof(UpdateAsync)}() finished with pong: {{Pong}}",
+                    $"{nameof(UpdateAsync)}() finished with pong: {{@Pong}}",
                     pong);
             }
             catch (TimeoutException)
             {
-                await RemovePeerAsync(target);
-                throw;
+                throw new TimeoutException($"Timeout occurred during {nameof(PingAsync)}().");
             }
             catch (DifferentAppProtocolVersionException)
             {

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -505,14 +505,14 @@ namespace Libplanet.Net.Protocols
                     "Cannot receive ping from self");
             }
 
-            await UpdateAsync(ping.Remote);
-
             Pong pong = new Pong((long?)null)
             {
                 Identity = ping.Identity,
             };
 
             _swarm.ReplyMessage(pong);
+
+            await UpdateAsync(ping.Remote);
         }
 
         /// <summary>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -101,6 +101,8 @@ namespace Libplanet.Net
                   appProtocolVersion,
                   TimeSpan.FromMilliseconds(millisecondsDialTimeout),
                   TimeSpan.FromMilliseconds(millisecondsLinger),
+                  null,
+                  null,
                   host,
                   listenPort,
                   createdAt,
@@ -115,6 +117,36 @@ namespace Libplanet.Net
             int appProtocolVersion,
             TimeSpan dialTimeout,
             TimeSpan linger,
+            string host = null,
+            int? listenPort = null,
+            DateTimeOffset? createdAt = null,
+            IEnumerable<IceServer> iceServers = null,
+            EventHandler<DifferentProtocolVersionEventArgs>
+                differentVersionPeerEncountered = null)
+            : this(
+                blockChain,
+                privateKey,
+                appProtocolVersion,
+                dialTimeout,
+                linger,
+                null,
+                null,
+                host,
+                listenPort,
+                createdAt,
+                iceServers,
+                differentVersionPeerEncountered)
+        {
+        }
+
+        internal Swarm(
+            BlockChain<T> blockChain,
+            PrivateKey privateKey,
+            int appProtocolVersion,
+            TimeSpan dialTimeout,
+            TimeSpan linger,
+            int? tableSize,
+            int? bucketSize,
             string host = null,
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
@@ -167,7 +199,9 @@ namespace Libplanet.Net
                 this,
                 _privateKey.PublicKey.ToAddress(),
                 _appProtocolVersion,
-                _logger);
+                _logger,
+                tableSize,
+                bucketSize);
 
             _requests = new AsyncCollection<MessageRequest>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
If a bucket is full, later peers who requested connection were cached into `Bucket.ReplacementCache`. If a peer is removed from a bucket then cached peer will be added automatically after liveness checking.

Previously, live check had a bug so check procedure repeats infinitely. This patch fixes such bug and added two test cases for the case and fixed one test case.