### PR TITLE
Fixed a bug that some actions were not rendered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,8 +49,6 @@ To be released.
  -  Added .NET Core 2.2 as a targeted framework.  [[#209], [#561]]
  -  `TurnClient.AcceptRelayedStreamAsync()` became to ignore disconnected
     connections.  [[#469]]
- -  `Swarm<T>.AppendBlocksAsync()` became to render blocks after all blocks
-    are appended.  [[#579]]
 
 ### Bug fixes
 
@@ -64,10 +62,10 @@ To be released.
     occurred.  [[#575]]
  -  Fixed a bug that `Swarm<T>` had thrown `InvalidBlockIndexException` during
     synchronizing with other reorganized peer.  [[#528], [#576]]
- -  Fixed a bug where `Swarm<T>.AppendBlocksAsync()` does not render blocks
-    that are filled from other peers.  [[#579]]
- -  Fixed a bug where `Swarm<T>.AppendBlocksAsync()` renders actions multiple
-    times when reorg happens.  [[#579]]
+ -  Fixed a bug where `Swarm<T>` does not render actions in blocks which are
+    filled from other peers.  [[#579]]
+ -  Fixed a bug where `Swarm<T>` renders actions in same block multiple times
+    when reorg happens.  [[#579]]
  -  `LiteDBStore` became to guarantee atomicity of storing blocks. [[#584]]
 
 [#209]: https://github.com/planetarium/libplanet/issues/209

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@ To be released.
  -  Added .NET Core 2.2 as a targeted framework.  [[#209], [#561]]
  -  `TurnClient.AcceptRelayedStreamAsync()` became to ignore disconnected
     connections.  [[#469]]
+ -  `Swarm<T>.AppendBlocksAsync()` became to render blocks after all blocks
+    are appended.  [[#579]]
 
 ### Bug fixes
 
@@ -62,6 +64,10 @@ To be released.
     occurred.  [[#575]]
  -  Fixed a bug that `Swarm<T>` had thrown `InvalidBlockIndexException` during
     synchronizing with other reorganized peer.  [[#528], [#576]]
+ -  Fixed a bug where `Swarm<T>.AppendBlocksAsync()` does not render blocks
+    that are filled from other peers.  [[#579]]
+ -  Fixed a bug where `Swarm<T>.AppendBlocksAsync()` renders actions multiple
+    times when reorg happens.  [[#579]]
  -  `LiteDBStore` became to guarantee atomicity of storing blocks. [[#584]]
 
 [#209]: https://github.com/planetarium/libplanet/issues/209
@@ -86,6 +92,7 @@ To be released.
 [#566]: https://github.com/planetarium/libplanet/pull/566
 [#575]: https://github.com/planetarium/libplanet/pull/575
 [#576]: https://github.com/planetarium/libplanet/pull/576
+[#579]: https://github.com/planetarium/libplanet/pull/579
 [#581]: https://github.com/planetarium/libplanet/pull/581
 [#583]: https://github.com/planetarium/libplanet/pull/583
 [#584]: https://github.com/planetarium/libplanet/pull/584

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -33,6 +33,8 @@ namespace Libplanet.Tests.Common.Action
             RecordRandom = recordRandom;
         }
 
+        public static EventHandler<IAction> RenderEventHandler { get; set; }
+
         public static AsyncLocal<ImmutableList<RenderRecord>>
             RenderRecords { get; } =
                 new AsyncLocal<ImmutableList<RenderRecord>>();
@@ -144,6 +146,8 @@ namespace Libplanet.Tests.Common.Action
                 Context = context,
                 NextStates = nextStates,
             });
+
+            RenderEventHandler?.Invoke(this, this);
         }
 
         public void Unrender(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -750,6 +750,19 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
+        /// Render actions from block index of <paramref name="offset"/> + 1.
+        /// </summary>
+        /// <param name="offset">Index of latest block which was rendered.</param>
+        internal void Render(long offset)
+        {
+            foreach (var block in IterateBlocks((int)offset + 1))
+            {
+                // FIXME: Execution duplicated?
+                ExecuteActions(block, true);
+            }
+        }
+
+        /// <summary>
         /// Evaluates actions in the given <paramref name="block"/> and fills states with the
         /// results, and renders them if <paramref name="render"/> is turned on.
         /// </summary>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1554,10 +1554,19 @@ namespace Libplanet.Net
             }
             finally
             {
-                if (synced is BlockChain<T> syncedNotNull &&
-                    !syncedNotNull.Id.Equals(blockChain?.Id))
+                if (synced is BlockChain<T> syncedNotNull)
                 {
-                    blockChain.Swap(synced, evaluateActions);
+                    if (syncedNotNull.Id.Equals(blockChain?.Id))
+                    {
+                        if (evaluateActions)
+                        {
+                            blockChain.Render(previousTipIndex);
+                        }
+                    }
+                    else
+                    {
+                        blockChain.Swap(synced, evaluateActions);
+                    }
                 }
 
                 IStore store = BlockChain.Store;

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2250</MaxFileLines>
+  <MaxFileLines>2500</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
This PR fixes a bug that some actions were not rendered which are included in blocks that were received by `SyncPreviousBlocksAsync()` method by adding `BlockChain<T>.Render()` method.

This also fixes a bug that some actions were rendered multiple times when sync happened.