### PR TITLE
Refactor `Swarm<T>` constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
  -  Removed `BlockChain<T>.Transactions`.  [[#409], [#583]]
  -  Removed the `linger` parameter from the `Swarm<T>` constructor and added
     `waitFor` to `Swarm<T>.StopAsync()`.  [[#581]]
+ -  Removed the `dialTimeout` parameter from the `Swarm<T>` constructor and
+    added it to `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()`.  [[#581]]
 
 ### Added interfaces
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ To be released.
      -  Added `BencodexExtension` static class.
  -  Removed `BlockChain<T>.Blocks`.  [[#409], [#583]]
  -  Removed `BlockChain<T>.Transactions`.  [[#409], [#583]]
+ -  Removed the `linger` parameter from the `Swarm<T>` constructor and added
+    `waitFor` to `Swarm<T>.StopAsync()`.  [[#581]]
 
 ### Added interfaces
 
@@ -80,6 +82,7 @@ To be released.
 [#566]: https://github.com/planetarium/libplanet/pull/566
 [#575]: https://github.com/planetarium/libplanet/pull/575
 [#576]: https://github.com/planetarium/libplanet/pull/576
+[#581]: https://github.com/planetarium/libplanet/pull/581
 [#583]: https://github.com/planetarium/libplanet/pull/583
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,10 +26,11 @@ To be released.
      -  Added `BencodexExtension` static class.
  -  Removed `BlockChain<T>.Blocks`.  [[#409], [#583]]
  -  Removed `BlockChain<T>.Transactions`.  [[#409], [#583]]
- -  Removed the `linger` parameter from the `Swarm<T>` constructor and added
-    `waitFor` to `Swarm<T>.StopAsync()`.  [[#581]]
- -  Removed the `dialTimeout` parameter from the `Swarm<T>` constructor and
-    added it to `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()`.  [[#581]]
+ -  Removed the `linger` parameter from the `Swarm<T>()` constructor, and added
+    the `waitFor` parameter to `Swarm<T>.StopAsync()` method instead.  [[#581]]
+ -  Removed the `dialTimeout` parameter from the `Swarm<T>`() constructor, and
+    added it to `Swarm<T>.PreloadAsync()` & `Swarm<T>.StartAsync()` methods.
+    [[#581]]
 
 ### Added interfaces
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -425,7 +425,6 @@ namespace Libplanet.Tests.Net
                 blockchain,
                 new PrivateKey(),
                 appProtocolVersion: 1,
-                dialTimeout: TimeSpan.FromMilliseconds(15000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());
@@ -472,7 +471,6 @@ namespace Libplanet.Tests.Net
                 blockchain,
                 new PrivateKey(),
                 appProtocolVersion: 1,
-                dialTimeout: TimeSpan.FromMilliseconds(15000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());
@@ -525,7 +523,6 @@ namespace Libplanet.Tests.Net
                 blockchain,
                 new PrivateKey(),
                 appProtocolVersion: 1,
-                dialTimeout: TimeSpan.FromMilliseconds(15000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());
@@ -1599,7 +1596,7 @@ namespace Libplanet.Tests.Net
                 await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
 
                 minerSwarm.FindNextHashesChunkSize = 2;
-                await receiverSwarm.PreloadAsync(progress);
+                await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15), progress);
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
 
@@ -1686,7 +1683,7 @@ namespace Libplanet.Tests.Net
                 await nominerSwarm1.AddPeersAsync(new[] { nominerSwarm0.AsPeer }, null);
                 await nominerSwarm1.PreloadAsync();
                 await receiverSwarm.AddPeersAsync(new[] { nominerSwarm1.AsPeer }, null);
-                await receiverSwarm.PreloadAsync(progress);
+                await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15), progress);
 
                 Assert.Equal(minerChain.AsEnumerable(), receiverChain.AsEnumerable());
 
@@ -2178,7 +2175,7 @@ namespace Libplanet.Tests.Net
         )
             where T : IAction, new()
         {
-            Task task = swarm.StartAsync(200, cancellationToken);
+            Task task = swarm.StartAsync(200, 200, cancellationToken);
             await swarm.WaitForRunningAsync();
             return task;
         }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -426,7 +426,6 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 appProtocolVersion: 1,
                 dialTimeout: TimeSpan.FromMilliseconds(15000),
-                linger: TimeSpan.FromMilliseconds(1000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());
@@ -474,7 +473,6 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 appProtocolVersion: 1,
                 dialTimeout: TimeSpan.FromMilliseconds(15000),
-                linger: TimeSpan.FromMilliseconds(1000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());
@@ -528,7 +526,6 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 appProtocolVersion: 1,
                 dialTimeout: TimeSpan.FromMilliseconds(15000),
-                linger: TimeSpan.FromMilliseconds(1000),
                 tableSize: 1,
                 bucketSize: 1,
                 host: IPAddress.Loopback.ToString());

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -54,7 +54,6 @@ namespace Libplanet.Net
         private readonly AsyncLock _blockSyncMutex;
         private readonly string _host;
         private readonly IList<IceServer> _iceServers;
-        private readonly TimeSpan _linger;
 
         private readonly ILogger _logger;
 
@@ -88,7 +87,6 @@ namespace Libplanet.Net
             PrivateKey privateKey,
             int appProtocolVersion,
             int millisecondsDialTimeout = 15000,
-            int millisecondsLinger = 1000,
             string host = null,
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
@@ -100,7 +98,6 @@ namespace Libplanet.Net
                   privateKey,
                   appProtocolVersion,
                   TimeSpan.FromMilliseconds(millisecondsDialTimeout),
-                  TimeSpan.FromMilliseconds(millisecondsLinger),
                   null,
                   null,
                   host,
@@ -116,7 +113,6 @@ namespace Libplanet.Net
             PrivateKey privateKey,
             int appProtocolVersion,
             TimeSpan dialTimeout,
-            TimeSpan linger,
             string host = null,
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
@@ -128,7 +124,6 @@ namespace Libplanet.Net
                 privateKey,
                 appProtocolVersion,
                 dialTimeout,
-                linger,
                 null,
                 null,
                 host,
@@ -144,7 +139,6 @@ namespace Libplanet.Net
             PrivateKey privateKey,
             int appProtocolVersion,
             TimeSpan dialTimeout,
-            TimeSpan linger,
             int? tableSize,
             int? bucketSize,
             string host = null,
@@ -175,7 +169,6 @@ namespace Libplanet.Net
             _host = host;
             _listenPort = listenPort;
             _appProtocolVersion = appProtocolVersion;
-            _linger = linger;
 
             if (_host != null && _listenPort is int listenPortAsInt)
             {
@@ -321,7 +314,16 @@ namespace Libplanet.Net
         }
 
         public async Task StopAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken)
+        )
+        {
+            await StopAsync(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        public async Task StopAsync(
+            TimeSpan waitFor,
+            CancellationToken cancellationToken = default(CancellationToken)
+        )
         {
             _workerCancellationTokenSource?.Cancel();
             _logger.Debug("Stopping...");
@@ -329,7 +331,7 @@ namespace Libplanet.Net
             {
                 if (Running)
                 {
-                    await Task.Delay(_linger, cancellationToken);
+                    await Task.Delay(waitFor, cancellationToken);
 
                     _broadcastQueue.ReceiveReady -= DoBroadcast;
                     _replyQueue.ReceiveReady -= DoReply;
@@ -2051,7 +2053,6 @@ namespace Libplanet.Net
 
                 using (var dealer = new DealerSocket(ToNetMQAddress(req.Peer)))
                 {
-                    dealer.Options.Linger = _linger;
                     _logger.Debug(
                         "Trying to send {@Message} to {PeerAddress}...",
                         req.Message,


### PR DESCRIPTION
This PR refactor `Swarm<T>`'s constructor as below

- The `linger` parameter is replaced with `waitFor` in `Swarm<T>.StopAsync()`.
- The `dialTimeout` parameter is moved to `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()`.

And, it also makes some changes as below

- Removed `Swarm<T>._blockChain` using the auto-implemented property.
- Removed `Swarm<T>._protocol` using the auto-implemented property.