### PR TITLE
Access blocks and transactions of the chain with lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,10 +24,13 @@ To be released.
         became replaced by `LoadPlainValue(IValue)`.
      -  `AccountStateGetter` became to return `IValue`, not `object`.
      -  Added `BencodexExtension` static class.
+ -  Removed `BlockChain<T>.Blocks`.  [[#409], [#583]]
 
 ### Added interfaces
 
  -  Added `BlockChain<T>.LongCount()` method.  [[#575]]
+ -  Added `BlockChain<T>[HashDigest<T>]` indexer.  [[#409], [#583]]
+ -  Added `BlockChain<T>.Contains(HashDigest<T>)` method.  [[#409], [#583]]
 
 ### Behavioral changes
 
@@ -54,6 +57,7 @@ To be released.
 
 [#209]: https://github.com/planetarium/libplanet/issues/209
 [#405]: https://github.com/planetarium/libplanet/issues/405
+[#409]: https://github.com/planetarium/libplanet/issues/409
 [#447]: https://github.com/planetarium/libplanet/issues/447
 [#462]: https://github.com/planetarium/libplanet/issues/462
 [#469]: https://github.com/planetarium/libplanet/pull/469
@@ -73,6 +77,7 @@ To be released.
 [#566]: https://github.com/planetarium/libplanet/pull/566
 [#575]: https://github.com/planetarium/libplanet/pull/575
 [#576]: https://github.com/planetarium/libplanet/pull/576
+[#583]: https://github.com/planetarium/libplanet/pull/583
 
 
 Version 0.6.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,12 +25,15 @@ To be released.
      -  `AccountStateGetter` became to return `IValue`, not `object`.
      -  Added `BencodexExtension` static class.
  -  Removed `BlockChain<T>.Blocks`.  [[#409], [#583]]
+ -  Removed `BlockChain<T>.Transactions`.  [[#409], [#583]]
 
 ### Added interfaces
 
  -  Added `BlockChain<T>.LongCount()` method.  [[#575]]
  -  Added `BlockChain<T>[HashDigest<T>]` indexer.  [[#409], [#583]]
  -  Added `BlockChain<T>.Contains(HashDigest<T>)` method.  [[#409], [#583]]
+ -  Added `BlockChain<T>.GetTransaction(TxId)` method.  [[#409], [#583]]
+ -  Added `BlockChain<T>.Contains(TxId)` method.  [[#409], [#583]]
 
 ### Behavioral changes
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -164,23 +164,23 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void StageTransactions()
         {
-            Assert.Empty(_blockChain.Transactions);
             var txs = new HashSet<Transaction<DumbAction>>()
             {
                 _fx.Transaction1,
                 _fx.Transaction2,
             };
+            Assert.Empty(txs.Where(tx => _blockChain.Contains(tx.Id)));
+
             _blockChain.StageTransactions(txs.ToImmutableHashSet());
             Assert.Equal(
                 txs,
-                _blockChain.Transactions.Values.ToHashSet()
-            );
+                txs.Where(tx => _blockChain.Contains(tx.Id)).ToHashSet());
         }
 
         [Fact]
         public void UnstageTransactions()
         {
-            Assert.Empty(_blockChain.Transactions);
+            Assert.Empty(_blockChain.GetStagedTransactionIds());
             var txs = new HashSet<Transaction<DumbAction>>()
             {
                 _fx.Transaction1,
@@ -188,11 +188,10 @@ namespace Libplanet.Tests.Blockchain
             };
             _blockChain.StageTransactions(txs.ToImmutableHashSet());
             HashSet<TxId> txIds = txs.Select(tx => tx.Id).ToHashSet();
-            HashSet<TxId> stagedTxIds = _blockChain.Store
-                .IterateStagedTransactionIds().ToHashSet();
+            HashSet<TxId> stagedTxIds = _blockChain.GetStagedTransactionIds().ToHashSet();
             Assert.Equal(txIds, stagedTxIds);
             _blockChain.UnstageTransactions(txs);
-            Assert.Empty(_blockChain.Store.IterateStagedTransactionIds());
+            Assert.Empty(_blockChain.GetStagedTransactionIds());
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -297,7 +297,7 @@ namespace Libplanet.Tests.Blockchain
 
             (Address[] addresses, Block<DumbAction>[] blocks) = MakeFixturesForAppendTests();
 
-            Assert.Empty(_blockChain.Blocks);
+            Assert.Empty(_blockChain);
             Assert.Empty(MinerReward.RenderRecords.Value);
             try
             {
@@ -1034,10 +1034,10 @@ namespace Libplanet.Tests.Blockchain
                     if (sr?.Item1 is HashDigest<SHA256> reference)
                     {
                         refs.Add(reference);
-                        block = chain.Blocks[reference];
+                        block = chain[reference];
                         if (block.PreviousHash is HashDigest<SHA256> prev)
                         {
-                            block = chain.Blocks[prev];
+                            block = chain[prev];
                             continue;
                         }
                     }
@@ -1481,7 +1481,7 @@ namespace Libplanet.Tests.Blockchain
 
             // Build the store has incomplete states
             Block<DumbAction> b = TestUtils.MineGenesis<DumbAction>();
-            chain.Blocks[b.Hash] = b;
+            store.PutBlock(b);
             BuildIndex(chainId, b);
             IImmutableDictionary<Address, IValue> dirty =
                 GetDirty(b.Evaluate(DateTimeOffset.UtcNow, _ => null));
@@ -1507,7 +1507,7 @@ namespace Libplanet.Tests.Blockchain
                         )
                     );
                     Assert.NotEmpty(dirty);
-                    chain.Blocks[b.Hash] = b;
+                    store.PutBlock(b);
                     store.StoreStateReference(
                         chainId,
                         dirty.Keys.ToImmutableHashSet(),

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1079,8 +1079,8 @@ namespace Libplanet.Tests.Net
                 await swarmC.TxReceived.WaitAsync();
                 await swarmB.TxReceived.WaitAsync();
 
-                Assert.Equal(tx, chainB.Transactions[tx.Id]);
-                Assert.Equal(tx, chainC.Transactions[tx.Id]);
+                Assert.Equal(tx, chainB.GetTransaction(tx.Id));
+                Assert.Equal(tx, chainC.GetTransaction(tx.Id));
             }
             finally
             {
@@ -1119,7 +1119,7 @@ namespace Libplanet.Tests.Net
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
 
                 await swarmB.TxReceived.WaitAsync();
-                Assert.Equal(tx, chainB.Transactions[tx.Id]);
+                Assert.Equal(tx, chainB.GetTransaction(tx.Id));
 
                 await swarmA.StopAsync();
 
@@ -1127,7 +1127,7 @@ namespace Libplanet.Tests.Net
                 await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
 
                 await swarmC.TxReceived.WaitAsync();
-                Assert.Equal(tx, chainC.Transactions[tx.Id]);
+                Assert.Equal(tx, chainC.GetTransaction(tx.Id));
             }
             finally
             {
@@ -1189,7 +1189,7 @@ namespace Libplanet.Tests.Net
 
                 for (int i = 0; i < size; i++)
                 {
-                    Assert.Equal(tx, blockchains[i].Transactions[tx.Id]);
+                    Assert.Equal(tx, blockchains[i].GetTransaction(tx.Id));
                 }
             }
             finally

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -172,7 +172,7 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// Gets the block corresponding to the <paramref name="hash"/>.
         /// </summary>
-        /// <param name="hash">A <see cref="HashDigest{T}"/> of the <see cref="Block{T}"/> to get.
+        /// <param name="hash">A <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/> to get.
         /// </param>
         /// <exception cref="KeyNotFoundException">Thrown when there is no <see cref="Block{T}"/>
         /// with a given <paramref name="hash"/>.</exception>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -19,6 +19,15 @@ using Libplanet.Tx;
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
 namespace Libplanet.Blockchain
 {
+    /// <summary>
+    /// A class have <see cref="Block{T}"/>s, <see cref="Transaction{T}"/>s, and the chain
+    /// information.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    /// <seealso cref="IAction"/>
+    /// <seealso cref="Block{T}"/>
+    /// <seealso cref="Transaction{T}"/>
     public class BlockChain<T> : IReadOnlyList<Block<T>>
         where T : IAction, new()
     {
@@ -46,6 +55,13 @@ namespace Libplanet.Blockchain
         /// </summary>
         private IDictionary<TxId, Transaction<T>> _transactions;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockChain{T}"/> class.
+        /// </summary>
+        /// <param name="policy"><see cref="IBlockPolicy{T}"/> to use in the
+        /// <see cref="BlockChain{T}"/>.</param>
+        /// <param name="store"><see cref="IStore"/> to store <see cref="Block{T}"/>s,
+        /// <see cref="Transaction{T}"/>s, and <see cref="BlockChain{T}"/> information.</param>
         public BlockChain(IBlockPolicy<T> policy, IStore store)
             : this(
                 policy,
@@ -117,9 +133,20 @@ namespace Libplanet.Blockchain
 
         internal IStore Store { get; }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Gets the block corresponding to the <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">A number of index of <see cref="Block{T}"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the given index of
+        /// <see cref="Block{T}"/> does not exist.</exception>
         public Block<T> this[int index] => this[(long)index];
 
+        /// <summary>
+        /// Gets the block corresponding to the <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">A number of index of <see cref="Block{T}"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the given index of
+        /// <see cref="Block{T}"/> does not exist.</exception>
         public Block<T> this[long index]
         {
             get

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -703,7 +703,7 @@ namespace Libplanet.Net
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        Block<T> block = workspace.Blocks[hash];
+                        Block<T> block = workspace[hash];
                         if (block.Index < initHeight)
                         {
                             continue;
@@ -1442,7 +1442,7 @@ namespace Libplanet.Net
             }
 
             ImmutableList<HashDigest<SHA256>> newHashes = message.Hashes
-                .Where(hash => !_blockChain.Blocks.ContainsKey(hash))
+                .Where(hash => !_blockChain.Contains(hash))
                 .ToImmutableList();
 
             if (!newHashes.Any())
@@ -1673,11 +1673,11 @@ namespace Libplanet.Net
                     _logger.Debug("It doesn't need to fork.");
                 }
 
-                // FIXME BlockChain.Blocks.ContainsKey() can be very
+                // FIXME BlockChain<T>.Contains() can be very
                 // expensive.
                 // we can omit this clause if assume every chain shares
                 // same genesis block...
-                else if (!workspace.Blocks.ContainsKey(branchPoint))
+                else if (!workspace.Contains(branchPoint))
                 {
                     // Create a whole new chain because the branch point doesn't exist on
                     // the current chain.
@@ -1817,8 +1817,9 @@ namespace Libplanet.Net
 
             foreach (HashDigest<SHA256> hash in getData.BlockHashes)
             {
-                if (_blockChain.Blocks.TryGetValue(hash, out Block<T> block))
+                if (_blockChain.Contains(hash))
                 {
+                    Block<T> block = _blockChain[hash];
                     byte[] payload = block.ToBencodex(true, true);
                     blocks.Add(payload);
                 }
@@ -1857,7 +1858,7 @@ namespace Libplanet.Net
             IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
                 stateRefs = null;
 
-            if (_blockChain.Blocks.ContainsKey(target))
+            if (_blockChain.Contains(target))
             {
                 ReaderWriterLockSlim rwlock = _blockChain._rwlock;
                 rwlock.EnterReadLock();
@@ -1894,12 +1895,12 @@ namespace Libplanet.Net
 
             if (_logger.IsEnabled(LogEventLevel.Debug))
             {
-                if (BlockChain.Blocks.ContainsKey(target))
+                if (BlockChain.Contains(target))
                 {
                     var baseString = @base is HashDigest<SHA256> h
-                        ? $"{BlockChain.Blocks[h].Index}:{h}"
+                        ? $"{BlockChain[h].Index}:{h}"
                         : null;
-                    var targetString = $"{BlockChain.Blocks[target].Index}:{target}";
+                    var targetString = $"{BlockChain[target].Index}:{target}";
                     _logger.Debug(
                         "State references to send (preload): {@StateReferences} ({Base}-{Target})",
                         stateRefs.Select(kv =>


### PR DESCRIPTION
#409 occurs when a task tries to read a block or transaction from `BlockChain<T>.Blocks` or `BlockChain<T>.Transactions` while another task is writing it. This fixes #409 by changing blocks and transactions in the `BlockChain<T>` so that it cannot be accessed without the lock from the outside of the chain.