### PR TITLE
Fix slow block appending

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1596,7 +1596,7 @@ namespace Libplanet.Net
                 );
                 _logger.Debug("Filled up; trying to concatenation...");
 
-                foreach (Block<T> block in blocks.SkipWhile(b => BlockChain.Contains(b)))
+                foreach (Block<T> block in blocks.SkipWhile(b => BlockChain.Contains(b.Hash)))
                 {
                     BlockChain.Append(block);
                 }


### PR DESCRIPTION
This PR fixes `Swarm<T>.AppendBlocksAsync()` by using `BlockChain<T>.Contains(HashDigest<SHA256>)`.