### PR TITLE
Fixed behavior of KademliaProtocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,7 @@ To be released.
  -  Fixed a bug that `BlockChain<T>` had appended a block even if fails to
     evaluate.  [[#591]]
  -  Fixed a bug where `KademliaProtocol<T>.RefreshTableAsync()` hadn't remove
-    stale peers.  [[#568], [#593]]
+    stale peers.  [[#568], [#593], [#602]]
  -  Fixed a bug that `TurnClient` had thrown `IOException` when accepting
     connection through a TURN relay server. [[#453], [#599]]
 
@@ -109,6 +109,7 @@ To be released.
 [#592]: https://github.com/planetarium/libplanet/pull/592
 [#593]: https://github.com/planetarium/libplanet/pull/593
 [#599]: https://github.com/planetarium/libplanet/pull/599
+[#602]: https://github.com/planetarium/libplanet/pull/602
 
 
 Version 0.6.0

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -424,14 +424,14 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
 
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
-                Assert.Equal(1, swarmA.Peers.Count);
+                Assert.Single(swarmA.Peers);
 
                 await swarmB.StopAsync();
                 await Task.Delay(100);
                 await swarmA.Protocol.RefreshTableAsync(
                     TimeSpan.Zero,
                     default(CancellationToken));
-                Assert.Equal(0, swarmA.Peers.Count);
+                Assert.Empty(swarmA.Peers);
             }
             finally
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -414,6 +414,32 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
+        public async Task RemoveStalePeers()
+        {
+            var swarmA = _swarms[0];
+            var swarmB = _swarms[1];
+            try
+            {
+                await StartAsync(swarmA);
+                await StartAsync(swarmB);
+
+                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                Assert.Equal(1, swarmA.Peers.Count);
+
+                await swarmB.StopAsync();
+                await Task.Delay(100);
+                await swarmA.Protocol.RefreshTableAsync(
+                    TimeSpan.Zero,
+                    default(CancellationToken));
+                Assert.Equal(0, swarmA.Peers.Count);
+            }
+            finally
+            {
+                await swarmA.StopAsync();
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
         public async Task RoutingTableFull()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -21,7 +21,10 @@ namespace Libplanet.Net.Protocols
             TimeSpan? findPeerTimeout,
             CancellationToken cancellationToken);
 
-        Task RefreshTableAsync(TimeSpan period, CancellationToken cancellationToken);
+        Task RefreshTableAsync(
+            TimeSpan period,
+            TimeSpan grace,
+            CancellationToken cancellationToken);
 
         Task RebuildConnectionAsync(TimeSpan period, CancellationToken cancellationToken);
 

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Net.Protocols
             TimeSpan? findPeerTimeout,
             CancellationToken cancellationToken);
 
-        Task RefreshTableAsync(TimeSpan grace, CancellationToken cancellationToken);
+        Task RefreshTableAsync(TimeSpan maxAge, CancellationToken cancellationToken);
 
         Task RebuildConnectionAsync(CancellationToken cancellationToken);
 

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -9,8 +9,6 @@ namespace Libplanet.Net.Protocols
 {
     internal interface IProtocol
     {
-        int Count { get; }
-
         ImmutableList<BoundPeer> Peers { get; }
 
         ImmutableList<BoundPeer> PeersToBroadcast { get; }

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -21,12 +21,9 @@ namespace Libplanet.Net.Protocols
             TimeSpan? findPeerTimeout,
             CancellationToken cancellationToken);
 
-        Task RefreshTableAsync(
-            TimeSpan period,
-            TimeSpan grace,
-            CancellationToken cancellationToken);
+        Task RefreshTableAsync(TimeSpan grace, CancellationToken cancellationToken);
 
-        Task RebuildConnectionAsync(TimeSpan period, CancellationToken cancellationToken);
+        Task RebuildConnectionAsync(CancellationToken cancellationToken);
 
         void ReceiveMessage(object sender, Message message);
 

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Net.Protocols
 
         public bool Contains(BoundPeer peer)
         {
-            return _peers.FindIndex(item => item.Item2 == peer) != -1;
+            return _peers.FindIndex(item => item.Item2.Equals(peer)) != -1;
         }
 
         public void Clear()
@@ -79,7 +79,7 @@ namespace Libplanet.Net.Protocols
 
         public bool RemovePeer(BoundPeer peer)
         {
-            int index = _peers.FindIndex(item => item.Item2 == peer);
+            int index = _peers.FindIndex(item => item.Item2.Equals(peer));
             if (index == -1)
             {
                 return false;

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -158,11 +158,13 @@ namespace Libplanet.Net.Protocols
         /// online by sending <see cref="Ping"/>.
         /// </summary>
         /// <param name="period">The cycle in which the operation is executed.</param>
+        /// <param name="grace">Maximum age of peer to validate.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
         public async Task RefreshTableAsync(
             TimeSpan period,
+            TimeSpan grace,
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
@@ -173,7 +175,7 @@ namespace Libplanet.Net.Protocols
 
                     _logger.Debug("Refreshing table...");
                     List<Task> tasks = _routing.NonEmptyBuckets
-                        .Where(bucket => bucket.Tail.Item1 > DateTimeOffset.UtcNow + period)
+                        .Where(bucket => bucket.Tail.Item1 + grace < DateTimeOffset.UtcNow)
                         .Select(bucket =>
                             ValidateAsync(
                                 bucket.Tail.Item2,

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -48,8 +48,6 @@ namespace Libplanet.Net.Protocols
                 TimeSpan.FromMilliseconds(Kademlia.IdleRequestTimeout);
         }
 
-        public int Count => _routing.Count;
-
         public ImmutableList<BoundPeer> Peers
         {
             get

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -155,17 +155,17 @@ namespace Libplanet.Net.Protocols
         /// Checks whether <see cref="Peer"/>s in <see cref="RoutingTable"/> is online by
         /// sending <see cref="Ping"/>.
         /// </summary>
-        /// <param name="grace">Maximum age of peer to validate.</param>
+        /// <param name="maxAge">Maximum age of peer to validate.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
-        public async Task RefreshTableAsync(TimeSpan grace, CancellationToken cancellationToken)
+        public async Task RefreshTableAsync(TimeSpan maxAge, CancellationToken cancellationToken)
         {
             try
             {
                 _logger.Debug("Refreshing table...");
                 List<Task> tasks = _routing.NonEmptyBuckets
-                    .Where(bucket => bucket.Tail.Item1 + grace < DateTimeOffset.UtcNow)
+                    .Where(bucket => bucket.Tail.Item1 + maxAge < DateTimeOffset.UtcNow)
                     .Select(bucket =>
                         ValidateAsync(
                             bucket.Tail.Item2,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -444,7 +444,10 @@ namespace Libplanet.Net
             {
                 tasks.Add(BroadcastTxAsync(broadcastTxInterval, _cancellationToken));
                 tasks.Add(
-                    Protocol.RefreshTableAsync(TimeSpan.FromSeconds(10), _cancellationToken));
+                    Protocol.RefreshTableAsync(
+                        TimeSpan.FromSeconds(10),
+                        TimeSpan.FromSeconds(10),
+                        _cancellationToken));
                 tasks.Add(
                     Protocol.RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
                 tasks.Add(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2180,7 +2180,7 @@ namespace Libplanet.Net
 
         private async Task RefreshTableAsync(
             TimeSpan period,
-            TimeSpan grace,
+            TimeSpan maxAge,
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
@@ -2188,7 +2188,7 @@ namespace Libplanet.Net
                 try
                 {
                     await Task.Delay(period, cancellationToken);
-                    await Protocol.RefreshTableAsync(grace, cancellationToken);
+                    await Protocol.RefreshTableAsync(maxAge, cancellationToken);
                 }
                 catch (OperationCanceledException e)
                 {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -444,12 +444,11 @@ namespace Libplanet.Net
             {
                 tasks.Add(BroadcastTxAsync(broadcastTxInterval, _cancellationToken));
                 tasks.Add(
-                    Protocol.RefreshTableAsync(
+                    RefreshTableAsync(
                         TimeSpan.FromSeconds(10),
                         TimeSpan.FromSeconds(10),
                         _cancellationToken));
-                tasks.Add(
-                    Protocol.RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
+                tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
                 tasks.Add(
                     Task.Run(() =>
                     {
@@ -2176,6 +2175,45 @@ namespace Libplanet.Net
                     $"Peer protocol version is different.",
                     _appProtocolVersion,
                     peer.AppProtocolVersion);
+            }
+        }
+
+        private async Task RefreshTableAsync(
+            TimeSpan period,
+            TimeSpan grace,
+            CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(period, cancellationToken);
+                    await Protocol.RefreshTableAsync(grace, cancellationToken);
+                }
+                catch (OperationCanceledException e)
+                {
+                    _logger.Warning(e, $"{nameof(RefreshTableAsync)}() is cancelled.");
+                    throw;
+                }
+            }
+        }
+
+        private async Task RebuildConnectionAsync(
+            TimeSpan period,
+            CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Protocol.RebuildConnectionAsync(cancellationToken);
+                    await Task.Delay(period, cancellationToken);
+                }
+                catch (OperationCanceledException e)
+                {
+                    _logger.Warning(e, $"{nameof(RebuildConnectionAsync)}() is cancelled.");
+                    throw;
+                }
             }
         }
 


### PR DESCRIPTION
This PR consist of several changes.
- `KademliaProtocol<T>.RefreshTableAsync()` and `KademliaProtocol<T>.RebuildConnectionAsync()` now loops in `Swarm<T>` instead of protocol.
- Comparing peer is now done via `.Equals()` method instead of `==`.
- Added a test case for removing stale peer.