### PR TITLE
Separate cache checking with removing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,8 +54,10 @@ To be released.
  -  `Swarm<T>.PreloadAsync()` became to ignore peers with lower tip.  [[#592]]
  -  `KademliaProtocol<T>.RefreshTableAsync()` became to validate only stale
     peers.  [[#568], [#593]]
- -  `KademliaProtocol<T>.RemovePeerAsync()` became not to check cached peers
-    immediately.  [[#608]]
+ -  `KademliaProtocol<T>` became not to check cached peers immediately after
+    removing peers from table. Instead, added
+    `IProtocol.CheckReplacementCacheAsync()` to check cached peers
+    periodically.  [[#608]]
  -  Marked `Address` and `HashDigest` as readonly.  [[#610]]
 
 ### Bug fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@ To be released.
  -  `Swarm<T>.PreloadAsync()` became to ignore peers with lower tip.  [[#592]]
  -  `KademliaProtocol<T>.RefreshTableAsync()` became to validate only stale
     peers.  [[#568], [#593]]
+ -  `KademliaProtocol<T>.RemovePeerAsync()` became not to check cached peers
+    immediately.  [[#608]]
  -  Marked `Address` and `HashDigest` as readonly.  [[#610]]
 
 ### Bug fixes
@@ -113,6 +115,7 @@ To be released.
 [#593]: https://github.com/planetarium/libplanet/pull/593
 [#599]: https://github.com/planetarium/libplanet/pull/599
 [#602]: https://github.com/planetarium/libplanet/pull/602
+[#608]: https://github.com/planetarium/libplanet/pull/608
 [#609]: https://github.com/planetarium/libplanet/pull/609
 [#610]: https://github.com/planetarium/libplanet/pull/610
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -514,15 +514,16 @@ namespace Libplanet.Tests.Net
                 await swarmA.AddPeersAsync(new[] { swarm.AsPeer }, null);
                 await swarmB.AddPeersAsync(new[] { swarm.AsPeer }, null);
 
-                Assert.Equal(1, swarmA.Peers.Count);
+                Assert.Single(swarmA.Peers);
                 Assert.Contains(swarmA.AsPeer, swarm.Peers);
                 Assert.DoesNotContain(swarmB.AsPeer, swarm.Peers);
 
                 await swarmA.StopAsync();
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
                 await Task.Delay(Kademlia.IdleRequestTimeout + 1000);
+                await swarm.Protocol.CheckReplacementCacheAsync(default(CancellationToken));
 
-                Assert.Equal(1, swarm.Peers.Count);
+                Assert.Single(swarm.Peers);
                 Assert.DoesNotContain(swarmA.AsPeer, swarm.Peers);
                 Assert.Contains(swarmB.AsPeer, swarm.Peers);
                 Assert.DoesNotContain(swarmC.AsPeer, swarm.Peers);
@@ -566,7 +567,7 @@ namespace Libplanet.Tests.Net
                 await swarmA.AddPeersAsync(new[] { swarm.AsPeer }, null);
                 await swarmB.AddPeersAsync(new[] { swarm.AsPeer }, null);
 
-                Assert.Equal(1, swarmA.Peers.Count);
+                Assert.Single(swarm.Peers);
                 Assert.Contains(swarmA.AsPeer, swarm.Peers);
                 Assert.DoesNotContain(swarmB.AsPeer, swarm.Peers);
 
@@ -575,8 +576,9 @@ namespace Libplanet.Tests.Net
 
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
                 await Task.Delay(Kademlia.IdleRequestTimeout * 2 + 1000);
+                await swarm.Protocol.CheckReplacementCacheAsync(default(CancellationToken));
 
-                Assert.Equal(1, swarmA.Peers.Count);
+                Assert.Single(swarm.Peers);
                 Assert.DoesNotContain(swarmA.AsPeer, swarm.Peers);
                 Assert.DoesNotContain(swarmB.AsPeer, swarm.Peers);
                 Assert.Contains(swarmC.AsPeer, swarm.Peers);

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -23,6 +23,8 @@ namespace Libplanet.Net.Protocols
 
         Task RebuildConnectionAsync(CancellationToken cancellationToken);
 
+        Task CheckReplacementCacheAsync(CancellationToken cancellationToken);
+
         void ReceiveMessage(object sender, Message message);
 
         string Trace();

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -216,8 +216,9 @@ namespace Libplanet.Net.Protocols
         }
 
         /// <summary>
-        /// Checks peers in ReplacementCache in each <see cref="KBucket"/> of
-        /// <see cref="RoutingTable"/>.
+        /// Checks the <see cref="KBucket"/> in the <see cref="RoutingTable"/> and if
+        /// there is an empty <see cref="KBucket"/>, fill it with <see cref="Peer"/>s
+        /// in the <see cref="KBucket.ReplacementCache"/>.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -215,6 +215,42 @@ namespace Libplanet.Net.Protocols
             }
         }
 
+        /// <summary>
+        /// Checks peers in ReplacementCache in each <see cref="KBucket"/> of
+        /// <see cref="RoutingTable"/>.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token used to propagate notification
+        /// that this operation should be canceled.</param>
+        /// <returns>>An awaitable task without value.</returns>
+        public async Task CheckReplacementCacheAsync(CancellationToken cancellationToken)
+        {
+            _logger.Debug("Checking replacement cache.");
+            foreach (var bucket in _routing.NonFullBuckets)
+            {
+                var cachePeers = new BoundPeer[bucket.ReplacementCache.Count];
+                bucket.ReplacementCache.CopyTo(cachePeers);
+                foreach (BoundPeer replacement in cachePeers)
+                {
+                    try
+                    {
+                        _logger.Debug("Send ping to {peer}.", replacement);
+                        await PingAsync(replacement, _requestTimeout, cancellationToken);
+
+                        if (bucket.IsFull())
+                        {
+                            break;
+                        }
+                    }
+                    catch (TimeoutException)
+                    {
+                        bucket.ReplacementCache.Remove(replacement);
+                    }
+                }
+            }
+
+            _logger.Debug("Replacement cache checked.");
+        }
+
 #pragma warning disable CS4014
         public void ReceiveMessage(object sender, Message message)
         {
@@ -311,7 +347,8 @@ namespace Libplanet.Net.Protocols
         }
 
         /// <summary>
-        /// Validate peer by send <see cref="Ping"/> to <paramref name="peer"/>.
+        /// Validate peer by send <see cref="Ping"/> to <paramref name="peer"/>. If target peer
+        /// does not responds, remove it from the table.
         /// </summary>
         /// <param name="peer">A <see cref="BoundPeer"/> to validate.</param>
         /// <param name="timeout">Timeout for waiting reply of <see cref="Ping"/>.</param>
@@ -368,7 +405,7 @@ namespace Libplanet.Net.Protocols
                 if (!contains)
                 {
                     _routing.BucketOf(peer).ReplacementCache.Remove(peer);
-                    _logger.Debug($"Added [{peer.Address.ToHex()}] to table");
+                    _logger.Debug("Added [{peer}] to table", peer);
                 }
             }
             else
@@ -376,6 +413,7 @@ namespace Libplanet.Net.Protocols
                 if (!_routing.BucketOf(peer).ReplacementCache.Contains(peer))
                 {
                     _routing.BucketOf(peer).ReplacementCache.Add(peer);
+                    _logger.Debug("Added [{peer}] to replacement cache.", peer);
                 }
 
                 _logger.Verbose(
@@ -397,26 +435,10 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        // FIXME: If this method is called almost same time, problem occurs.
         private async Task RemovePeerAsync(BoundPeer peer, CancellationToken cancellationToken)
         {
             _logger.Debug($"Removing peer [{peer.Address.ToHex()}] from table.");
             await _routing.RemovePeerAsync(peer);
-            var bucket = _routing.BucketOf(peer);
-            var cachePeers = new BoundPeer[bucket.ReplacementCache.Count];
-            bucket.ReplacementCache.CopyTo(cachePeers);
-            foreach (BoundPeer replacement in cachePeers)
-            {
-                try
-                {
-                    await PingAsync(replacement, _requestTimeout, cancellationToken);
-                    break;
-                }
-                catch (TimeoutException)
-                {
-                    bucket.ReplacementCache.Remove(replacement);
-                }
-            }
         }
 
         /// <summary>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -449,7 +449,6 @@ namespace Libplanet.Net
                         TimeSpan.FromSeconds(10),
                         _cancellationToken));
                 tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
-                tasks.Add(CheckReplacementCacheAsync(TimeSpan.FromSeconds(5), _cancellationToken));
                 tasks.Add(
                     Task.Run(() =>
                     {
@@ -2190,6 +2189,7 @@ namespace Libplanet.Net
                 {
                     await Task.Delay(period, cancellationToken);
                     await Protocol.RefreshTableAsync(maxAge, cancellationToken);
+                    await Protocol.CheckReplacementCacheAsync(cancellationToken);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -2213,25 +2213,6 @@ namespace Libplanet.Net
                 catch (OperationCanceledException e)
                 {
                     _logger.Warning(e, $"{nameof(RebuildConnectionAsync)}() is cancelled.");
-                    throw;
-                }
-            }
-        }
-
-        private async Task CheckReplacementCacheAsync(
-            TimeSpan period,
-            CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(period, cancellationToken);
-                    await Protocol.CheckReplacementCacheAsync(cancellationToken);
-                }
-                catch (OperationCanceledException e)
-                {
-                    _logger.Warning(e, $"{nameof(CheckReplacementCacheAsync)}() is cancelled.");
                     throw;
                 }
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -449,6 +449,7 @@ namespace Libplanet.Net
                         TimeSpan.FromSeconds(10),
                         _cancellationToken));
                 tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
+                tasks.Add(CheckReplacementCacheAsync(TimeSpan.FromSeconds(5), _cancellationToken));
                 tasks.Add(
                     Task.Run(() =>
                     {
@@ -2212,6 +2213,25 @@ namespace Libplanet.Net
                 catch (OperationCanceledException e)
                 {
                     _logger.Warning(e, $"{nameof(RebuildConnectionAsync)}() is cancelled.");
+                    throw;
+                }
+            }
+        }
+
+        private async Task CheckReplacementCacheAsync(
+            TimeSpan period,
+            CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(period, cancellationToken);
+                    await Protocol.CheckReplacementCacheAsync(cancellationToken);
+                }
+                catch (OperationCanceledException e)
+                {
+                    _logger.Warning(e, $"{nameof(CheckReplacementCacheAsync)}() is cancelled.");
                     throw;
                 }
             }


### PR DESCRIPTION
This patch separates `KademliaProtocol<T>.CheckReplacementCacheAsync()` from `KademliaProtocol<T>.RemovePeerAsync()`.