### PR TITLE
Fix a bug that VS2019 hadn't used .netcore 3.0 even if has MSBuild 16.3+

### DIFF
--- a/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -12,8 +12,7 @@
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Core' And
-                             '$(MSBuildVersion)' >='16.3.0'">
+  <PropertyGroup Condition="'$(MSBuildVersion)' >='16.3.0'">
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -11,8 +11,8 @@
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Core' And
-                             '$(MSBuildVersion)' >='16.3.0'">
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)'!='Mono' And
+                            '$(MSBuildVersion)'>='16.3.0'">
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -12,11 +12,6 @@
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Core' And
-                             '$(MSBuildVersion)' >='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -18,14 +18,14 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
+                             '$(MSBuildVersion)'>='16.3.0'">
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
                              '$(BuildingByReSharper)'!='true'">
     <TargetFramework>net471</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Core' And
-                             '$(MSBuildVersion)' >='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -47,9 +47,9 @@ https://docs.libplanet.io/</Description>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Core' And
-                             '$(MSBuildVersion)' >='16.3.0'">
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
+                             '$(MSBuildVersion)'>='16.3.0'">
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The title says it all