### PR TITLE
Update routing table when non-protocol-messages received

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,10 +72,10 @@ To be released.
  -  Marked `Address` and `HashDigest` as readonly.  [[#610]]
  -  `IceServer.CreateTurnClient()` became to throw `ArgumentException` when
     received invalid url.  [[#622]]
- -  `KademliaProtocol<T>` became to update peer table when receiving messages
-    that are not related with protocol.  [[#594], [#627]]
- -  `KademliaProtocol<T>` became not to check least recently used peer when
-    new peer is updated.  [[#627]]
+ -  `Swarm<T>` became to update peer table when receiving messages that are
+    not related with [Kademlia protocol][Kademlia].  [[#594], [#627]]
+ -  `Swarm<T>` became not to check least recently used peer every time when
+    new peer is fetched.  [[#627]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,10 @@ To be released.
  -  Marked `Address` and `HashDigest` as readonly.  [[#610]]
  -  `IceServer.CreateTurnClient()` became to throw `ArgumentException` when
     received invalid url.  [[#622]]
+ -  `KademliaProtocol<T>` became to update peer table when receiving messages
+    that are not related with protocol.  [[#594], [#627]]
+ -  `KademliaProtocol<T>` became not to check least recently used peer when
+    new peer is updated.  [[#627]]
 
 ### Bug fixes
 
@@ -131,6 +135,7 @@ To be released.
 [#591]: https://github.com/planetarium/libplanet/pull/591
 [#592]: https://github.com/planetarium/libplanet/pull/592
 [#593]: https://github.com/planetarium/libplanet/pull/593
+[#594]: https://github.com/planetarium/libplanet/issues/594
 [#599]: https://github.com/planetarium/libplanet/pull/599
 [#602]: https://github.com/planetarium/libplanet/pull/602
 [#608]: https://github.com/planetarium/libplanet/pull/608
@@ -138,6 +143,7 @@ To be released.
 [#610]: https://github.com/planetarium/libplanet/pull/610
 [#614]: https://github.com/planetarium/libplanet/pull/614
 [#622]: https://github.com/planetarium/libplanet/pull/622
+[#627]: https://github.com/planetarium/libplanet/pull/627
 
 
 Version 0.6.0

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -427,10 +427,7 @@ namespace Libplanet.Tests.Net
                 Assert.Single(swarmA.Peers);
 
                 await swarmB.StopAsync();
-                await Task.Delay(100);
-                await swarmA.Protocol.RefreshTableAsync(
-                    TimeSpan.Zero,
-                    default(CancellationToken));
+                await swarmA.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
                 Assert.Empty(swarmA.Peers);
             }
             finally
@@ -520,7 +517,7 @@ namespace Libplanet.Tests.Net
 
                 await swarmA.StopAsync();
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
-                await Task.Delay(Kademlia.IdleRequestTimeout + 1000);
+                await swarm.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
                 await swarm.Protocol.CheckReplacementCacheAsync(default(CancellationToken));
 
                 Assert.Single(swarm.Peers);
@@ -575,7 +572,7 @@ namespace Libplanet.Tests.Net
                 await swarmB.StopAsync();
 
                 await swarmC.AddPeersAsync(new[] { swarm.AsPeer }, null);
-                await Task.Delay(Kademlia.IdleRequestTimeout * 2 + 1000);
+                await swarm.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
                 await swarm.Protocol.CheckReplacementCacheAsync(default(CancellationToken));
 
                 Assert.Single(swarm.Peers);

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Protocols
 
         Task CheckReplacementCacheAsync(CancellationToken cancellationToken);
 
-        void ReceiveMessage(object sender, Message message);
+        void ReceiveMessage(Message message);
 
         string Trace();
     }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -401,26 +401,7 @@ namespace Libplanet.Net.Protocols
                 throw new TaskCanceledException();
             }
 
-            BoundPeer evictionCandidate = await _routing.AddPeerAsync(peer);
-            if (!(evictionCandidate is null))
-            {
-                _logger.Verbose(
-                    "Need to evict {Candidate}; trying...",
-                    evictionCandidate);
-                try
-                {
-                    await ValidateAsync(
-                        evictionCandidate,
-                        _requestTimeout,
-                        cancellationToken);
-                }
-                catch (TimeoutException)
-                {
-                    _logger.Verbose(
-                        "Peer ({Candidate}) has been evicted.",
-                        evictionCandidate);
-                }
-            }
+            await _routing.AddPeerAsync(peer);
         }
 
         private async Task RemovePeerAsync(BoundPeer peer, CancellationToken cancellationToken)

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -256,7 +256,7 @@ namespace Libplanet.Net.Protocols
         }
 
 #pragma warning disable CS4014
-        public void ReceiveMessage(object sender, Message message)
+        public void ReceiveMessage(Message message)
         {
             switch (message)
             {

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -88,7 +88,7 @@ namespace Libplanet.Net.Protocols
             {
                 evicted = _buckets[index].AddPeer(peer);
                 _logger.Debug(
-                    "Adding [{peer}] to routing table. (eviced : {evicted})",
+                    "Adding [{peer}] to routing table. (evicted : {evicted})",
                     peer,
                     evicted);
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -917,6 +917,7 @@ namespace Libplanet.Net
                 cancellationToken: token
             );
 
+            Protocol.ReceiveMessage(parsedMessage);
             ValidateSender(parsedMessage.Remote);
 
             if (parsedMessage is BlockHashes blockHashes)
@@ -957,6 +958,7 @@ namespace Libplanet.Net
 
                 foreach (Message message in replies)
                 {
+                    Protocol.ReceiveMessage(message);
                     ValidateSender(message.Remote);
                     if (message is Messages.Blocks blockMessage)
                     {
@@ -1004,6 +1006,7 @@ namespace Libplanet.Net
 
                 foreach (Message message in replies)
                 {
+                    Protocol.ReceiveMessage(message);
                     ValidateSender(message.Remote);
                     if (message is Messages.Tx parsed)
                     {
@@ -1078,6 +1081,7 @@ namespace Libplanet.Net
                         );
                         if (reply is Pong pong)
                         {
+                            Protocol.ReceiveMessage(reply);
                             await yield.ReturnAsync((peer, pong));
                         }
                     }
@@ -1157,6 +1161,9 @@ namespace Libplanet.Net
                         timeout: TimeSpan.FromSeconds(30),
                         cancellationToken: cancellationToken
                     );
+
+                    // Do not call Protocol.ReceiveMessage since swarm is not started
+                    // when synchronizing previous states.
                     _logger.Debug("Received recent states from a peer ({Peer}).", peer);
                 }
                 catch (TimeoutException e)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1353,19 +1353,18 @@ namespace Libplanet.Net
             Message message,
             CancellationToken cancellationToken)
         {
+            Protocol.ReceiveMessage(this, message);
             switch (message)
             {
                 case Ping ping:
                     {
                         _logger.Debug($"Ping received.");
-                        Protocol.ReceiveMessage(this, ping);
                         break;
                     }
 
                 case FindNeighbors findPeer:
                     {
                         _logger.Debug($"FindNeighbors received.");
-                        Protocol.ReceiveMessage(this, findPeer);
                         break;
                     }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1353,7 +1353,7 @@ namespace Libplanet.Net
             Message message,
             CancellationToken cancellationToken)
         {
-            Protocol.ReceiveMessage(this, message);
+            Protocol.ReceiveMessage(message);
             switch (message)
             {
                 case Ping ping:


### PR DESCRIPTION
This PR contains followings:
- Update routing table when any messages are received. (Excluding replies)
- Do not live check least recently used peer when a peer is updated.

For these changes, some tests were modified.