### PR TITLE
Fixed a bug peer getter in KBucket throws ArgumentOutOfRangeException

### DIFF
--- a/Libplanet.Tests/Net/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/ProtocolTest.cs
@@ -39,6 +39,7 @@ namespace Libplanet.Tests.Net
                 new DnsEndPoint("0.0.0.0", 1234),
                 0);
 
+            Assert.Empty(bucket.Peers);
             Assert.True(bucket.IsEmpty());
             Assert.Null(bucket.AddPeer(peer1));
             Assert.True(bucket.Contains(peer1));

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -37,7 +37,8 @@ namespace Libplanet.Net.Protocols
         public (DateTimeOffset, BoundPeer) Tail =>
             IsEmpty() ? (DateTimeOffset.MinValue, null) : _peers[0];
 
-        public ImmutableList<BoundPeer> Peers =>
+        public ImmutableList<BoundPeer> Peers => IsEmpty() ?
+            ImmutableList<BoundPeer>.Empty :
             _peers.Select(peerInfo => peerInfo.Item2).ToImmutableList();
 
         // replacement candidate stored in this cache when


### PR DESCRIPTION
Peer getter in `KBucket` was throwing `ArgumentOutOfRangeException` when list `_peers` is empty.