### PR TITLE
Make preload continue with peers when block download failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ To be released.
  -  Added `BlockChain<T>.GetTransaction(TxId)` method.  [[#409], [#583]]
  -  Added `BlockChain<T>.Contains(TxId)` method.  [[#409], [#583]]
  -  Added `ByteUtil.Hex(ImmutableArray<byte>)` overloaded method.  [[#614]]
+ -  Added `BlockDownloadState.SourcePeer` property.  [[#636]]
 
 ### Behavioral changes
 
@@ -80,6 +81,8 @@ To be released.
     incomplete states from the beginning if necessary.  [[#645]]
  -  `IStore.PutBlock<T>()` became to do nothing when it takes
     the `Block<T>` more than once.  [[#647]]
+ -  `PreloadAsync()` became to retry block-download process with another peers
+    when the process failed.  [[#636]]
 
 ### Bug fixes
 
@@ -155,6 +158,7 @@ To be released.
 [#622]: https://github.com/planetarium/libplanet/pull/622
 [#627]: https://github.com/planetarium/libplanet/pull/627
 [#628]: https://github.com/planetarium/libplanet/issues/628
+[#636]: https://github.com/planetarium/libplanet/pull/636
 [#637]: https://github.com/planetarium/libplanet/pull/637
 [#641]: https://github.com/planetarium/libplanet/pull/641
 [#644]: https://github.com/planetarium/libplanet/pull/644

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,8 +81,8 @@ To be released.
     incomplete states from the beginning if necessary.  [[#645]]
  -  `IStore.PutBlock<T>()` became to do nothing when it takes
     the `Block<T>` more than once.  [[#647]]
- -  `PreloadAsync()` became to retry block-download process with another peers
-    when the process failed.  [[#636]]
+ -  `Swarm<T>.PreloadAsync()` became to try downloading blocks from all neighbor peers,
+    even if any peer among them is unavailable to send blocks.  [[#636]]
 
 ### Bug fixes
 

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -26,5 +26,10 @@ namespace Libplanet.Net
 
         /// <inheritdoc />
         public override int CurrentPhase => 1;
+
+        /// <summary>
+        /// The peer which sent the block.
+        /// </summary>
+        public BoundPeer SourcePeer { get; internal set; }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -647,7 +647,7 @@ namespace Libplanet.Net
                     try
                     {
                         _logger.Information(
-                            "Try to download blocks from {EndPoint}@{Address}",
+                            "Try to download blocks from {EndPoint}@{Address}.",
                             peerWithHeight.Peer.EndPoint,
                             peerWithHeight.Peer.Address.ToHex());
                         await SyncBehindsBlocksFromPeerAsync(
@@ -661,8 +661,8 @@ namespace Libplanet.Net
                     catch (Exception e)
                     {
                         _logger.Error(
-                            "Exception was thrown during block download with {EndPoint}@{Address}\n"
-                            + "{Exception}",
+                            "Exception was thrown during downloading blocks from "
+                            + "{EndPoint}@{Address}.\n{Exception}",
                             peerWithHeight.Peer.EndPoint,
                             peerWithHeight.Peer.Address.ToHex(),
                             e);
@@ -670,7 +670,7 @@ namespace Libplanet.Net
                     }
 
                     _logger.Information(
-                        "Finished to download blocks from {EndPoint}@{Address}",
+                        "Finished to download blocks from {EndPoint}@{Address}.",
                         peerWithHeight.Peer.EndPoint,
                         peerWithHeight.Peer.Address.ToHex());
                     blockDownloadComplete = true;


### PR DESCRIPTION
It was aborted if block-download peer became unavailable though it can download blocks from another peers. so it became to continue block-download with another peers if changed.

This pr might be related with #634. 