### PR TITLE
Remove Trace.Fail in Swarm.ProcessMessageAsync

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,8 @@ To be released.
     nonce when transactions with an old nonce were staged.  [[#637]]
  -  Fixed a bug that `BlockChain<T>` had reset when `Swarm<T>.PreloadAsync()`
     fails.  [[#644]]
+ -  Fixed bug that whole processes could halt when received an invalid
+    type of message.  [[#628], [#641]]
 
 [#209]: https://github.com/planetarium/libplanet/issues/209
 [#405]: https://github.com/planetarium/libplanet/issues/405
@@ -146,7 +148,9 @@ To be released.
 [#614]: https://github.com/planetarium/libplanet/pull/614
 [#622]: https://github.com/planetarium/libplanet/pull/622
 [#627]: https://github.com/planetarium/libplanet/pull/627
+[#628]: https://github.com/planetarium/libplanet/issues/628
 [#637]: https://github.com/planetarium/libplanet/pull/637
+[#641]: https://github.com/planetarium/libplanet/pull/641
 [#644]: https://github.com/planetarium/libplanet/pull/644
 
 

--- a/Libplanet/Net/InvalidMessageException.cs
+++ b/Libplanet/Net/InvalidMessageException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using Libplanet.Net.Messages;
 
 namespace Libplanet.Net
 {
@@ -20,6 +21,12 @@ namespace Libplanet.Net
         {
         }
 
+        internal InvalidMessageException(string message, Message receivedMessage)
+            : base(message)
+        {
+            ReceivedMessage = receivedMessage;
+        }
+
         protected InvalidMessageException(
             SerializationInfo info,
             StreamingContext context
@@ -27,5 +34,7 @@ namespace Libplanet.Net
             : base(info, context)
         {
         }
+
+        internal Message ReceivedMessage { get; }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1421,8 +1421,7 @@ namespace Libplanet.Net
                     }
 
                 default:
-                    Trace.Fail($"Can't handle message. [{message}]");
-                    break;
+                    throw new InvalidMessageException($"Can't handle message: {message}");
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1421,7 +1421,7 @@ namespace Libplanet.Net
                     }
 
                 default:
-                    throw new InvalidMessageException($"Can't handle message: {message}");
+                    throw new InvalidMessageException($"Can't handle message: {message}", message);
             }
         }
 


### PR DESCRIPTION
I believe this patch resolves #628.