### PR TITLE
PutBlock method checks whether a block exists. [skip changelog]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@ To be released.
     not related with [Kademlia protocol][Kademlia].  [[#594], [#627]]
  -  `Swarm<T>` became not to check least recently used peer every time when
     new peer is fetched.  [[#627]]
+ -  `IStore.PutBlock<T>()` became to do nothing when it takes
+    the `Block<T>` more than once.  [[#647]]
 
 ### Bug fixes
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -154,6 +154,7 @@ namespace Libplanet.Store
 
         /// <summary>
         /// Puts the given <paramref name="block"/> in to the store.
+        /// If the same block already exists in the store it does nothing.
         /// </summary>
         /// <param name="block">A <see cref="Block{T}"/> to put into the store.
         /// </param>

--- a/Libplanet/Store/LiteDBStore.cs
+++ b/Libplanet/Store/LiteDBStore.cs
@@ -376,6 +376,12 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public override void PutBlock<T>(Block<T> block)
         {
+            // checks whether a block already exists or not.
+            if (!(_db.FileStorage.FindById(BlockFileId(block.Hash)) is null))
+            {
+                return;
+            }
+
             _blockLock.EnterWriteLock();
             try
             {


### PR DESCRIPTION
Resolving https://github.com/planetarium/libplanet/issues/616 ,
PutBlock method in LiteDBStore.cs checks whether a block exists and if the answer is yes it returns from the method without writing the block (performance upgrades).