### PR TITLE
Store blocks and transactions as bare files instead of embeded files in LiteDB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,10 +14,10 @@ To be released.
 
 ### Backward-incompatible storage format changes
 
- -  The introduced `DefaultStore` is incompatible with the existed `LiteDBStore`
-    at file-level.  `DefaultStore` became to take a directory instead of
-    a single file, and it consists of multiple subdirectories and
-    a LiteDB file for indices.  [[#662]]
+ -  The introduced `DefaultStore` is incompatible at the file-level with
+    the `LiteDBStore` which had existed.  `DefaultStore` became to take
+    a directory instead of a single file, and it consists of multiple
+    subdirectories and a LiteDB file for indices.  [[#662]]
 
 ### Added APIs
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,15 +8,26 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `LiteDBStore` class.  Use `DefaultStore` instead.  [[#662]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
+ -  The introduced `DefaultStore` is incompatible with the existed `LiteDBStore`
+    at file-level.  `DefaultStore` became to take a directory instead of
+    a single file, and it consists of multiple subdirectories and
+    a LiteDB file for indices.  [[#662]]
+
 ### Added APIs
+
+ -  Added `DefaultStore` class to replace `LiteDBStore`.  [[#662]]
 
 ### Behavioral changes
 
 ### Bug fixes
+
+[#662]: https://github.com/planetarium/libplanet/pull/662
 
 
 Version 0.7.0

--- a/Libplanet.Benchmarks/MineBlock.cs
+++ b/Libplanet.Benchmarks/MineBlock.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Benchmarks
 
         public MineBlock()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _blockChain = new BlockChain<DumbAction>(
                 new NullPolicy<DumbAction>(),
                 _fx.Store

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using BenchmarkDotNet.Attributes;

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -49,7 +49,7 @@ namespace Libplanet.Benchmarks
         [IterationSetup]
         public void InitializeFixture()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _store = _fx.Store;
         }
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Blockchain
 
         public BlockChainTest()
         {
-            _fx = new LiteDBStoreFixture(memory: true);
+            _fx = new DefaultStoreFixture(memory: true);
             _blockChain = new BlockChain<DumbAction>(
                 new BlockPolicy<DumbAction>(new MinerReward(1)),
                 _fx.Store
@@ -1210,8 +1210,8 @@ namespace Libplanet.Tests.Blockchain
             var emptyLocator = new BlockLocator(new HashDigest<SHA256>[0]);
             var locator = new BlockLocator(new[] { b4.Hash, b3.Hash, b1.Hash });
 
-            using (var emptyFx = new LiteDBStoreFixture(memory: true))
-            using (var forkFx = new LiteDBStoreFixture(memory: true))
+            using (var emptyFx = new DefaultStoreFixture(memory: true))
+            using (var forkFx = new DefaultStoreFixture(memory: true))
             {
                 var emptyChain = new BlockChain<DumbAction>(_blockChain.Policy, emptyFx.Store);
                 var fork = new BlockChain<DumbAction>(_blockChain.Policy, forkFx.Store);
@@ -1755,8 +1755,8 @@ namespace Libplanet.Tests.Blockchain
             // because to make a mining task run forever just for testing.
             var policy1 = new NullPolicy<DumbAction>(difficulty: 1);
             var policy2 = new NullPolicy<DumbAction>(difficulty: -1);
-            StoreFixture fx1 = new LiteDBStoreFixture();
-            StoreFixture fx2 = new LiteDBStoreFixture();
+            StoreFixture fx1 = new DefaultStoreFixture();
+            StoreFixture fx2 = new DefaultStoreFixture();
             var chain1 = new BlockChain<DumbAction>(policy1, fx1.Store);
             var chain2 = new BlockChain<DumbAction>(policy2, fx2.Store);
 

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Blockchain.Policies
 
         private readonly ITestOutputHelper _output;
 
-        private LiteDBStoreFixture _fx;
+        private StoreFixture _fx;
         private BlockChain<DumbAction> _chain;
         private IBlockPolicy<DumbAction> _policy;
         private List<Transaction<DumbAction>> _emptyTransaction;
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blockchain.Policies
 
         public BlockPolicyTest(ITestOutputHelper output)
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _output = output;
             _policy = new BlockPolicy<DumbAction>(
                 null,

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -58,9 +58,9 @@ namespace Libplanet.Tests.Net
             _output = output;
 
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            _fx1 = new LiteDBStoreFixture(memory: true);
-            _fx2 = new LiteDBStoreFixture(memory: true);
-            _fx3 = new LiteDBStoreFixture(memory: true);
+            _fx1 = new DefaultStoreFixture(memory: true);
+            _fx2 = new DefaultStoreFixture(memory: true);
+            _fx3 = new DefaultStoreFixture(memory: true);
 
             _blockchains = new List<BlockChain<DumbAction>>
             {
@@ -439,7 +439,7 @@ namespace Libplanet.Tests.Net
         public async Task RoutingTableFull()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var fx = new LiteDBStoreFixture(memory: true);
+            var fx = new DefaultStoreFixture(memory: true);
 
             var blockchain = new BlockChain<DumbAction>(policy, fx.Store);
 
@@ -485,7 +485,7 @@ namespace Libplanet.Tests.Net
         public async Task ReplacementCache()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var fx = new LiteDBStoreFixture(memory: true);
+            var fx = new DefaultStoreFixture(memory: true);
 
             var blockchain = new BlockChain<DumbAction>(policy, fx.Store);
 
@@ -538,7 +538,7 @@ namespace Libplanet.Tests.Net
         public async Task RemoveDeadReplacementCache()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var fx = new LiteDBStoreFixture(memory: true);
+            var fx = new DefaultStoreFixture(memory: true);
 
             var blockchain = new BlockChain<DumbAction>(policy, fx.Store);
 
@@ -671,7 +671,7 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < size; i++)
             {
-                fxs[i] = new LiteDBStoreFixture(memory: true);
+                fxs[i] = new DefaultStoreFixture(memory: true);
                 blockchains[i] = new BlockChain<DumbAction>(policy, fxs[i].Store);
                 swarms[i] = new Swarm<DumbAction>(
                     blockchains[i],
@@ -804,7 +804,7 @@ namespace Libplanet.Tests.Net
                 appProtocolVersion: 2);
             var d = new Swarm<DumbAction>(
                 new BlockChain<DumbAction>(
-                    _blockchains[0].Policy, new LiteDBStoreFixture(memory: true).Store),
+                    _blockchains[0].Policy, new DefaultStoreFixture(memory: true).Store),
                 new PrivateKey(),
                 host: IPAddress.Loopback.ToString(),
                 appProtocolVersion: 3);
@@ -1165,7 +1165,7 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < size; i++)
             {
-                fxs[i] = new LiteDBStoreFixture(memory: true);
+                fxs[i] = new DefaultStoreFixture(memory: true);
                 blockchains[i] = new BlockChain<DumbAction>(policy, fxs[i].Store);
                 swarms[i] = new Swarm<DumbAction>(
                     blockchains[i],
@@ -1283,7 +1283,7 @@ namespace Libplanet.Tests.Net
         public async Task BroadcastBlockWithSkip()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var fx = new LiteDBStoreFixture(memory: true);
+            var fx = new DefaultStoreFixture(memory: true);
             var blockChain = new BlockChain<DumbAction>(policy, fx.Store);
             var privateKey = new PrivateKey();
             var minerSwarm = new Swarm<DumbAction>(
@@ -1753,8 +1753,8 @@ namespace Libplanet.Tests.Net
             Swarm<DumbAction> minerSwarm = _swarms[0];
             Swarm<DumbAction> receiverSwarm = _swarms[1];
             var fxForNominers = new StoreFixture[2];
-            fxForNominers[0] = new LiteDBStoreFixture(memory: true);
-            fxForNominers[1] = new LiteDBStoreFixture(memory: true);
+            fxForNominers[0] = new DefaultStoreFixture(memory: true);
+            fxForNominers[1] = new DefaultStoreFixture(memory: true);
             var policy = new BlockPolicy<DumbAction>();
             var blockChainsForNominers = new BlockChain<DumbAction>[2];
             blockChainsForNominers[0] = new BlockChain<DumbAction>(policy, fxForNominers[0].Store);
@@ -2192,8 +2192,8 @@ namespace Libplanet.Tests.Net
             // while FillBlocksAsync.
             var policy1 = new BlockPolicy<DumbAction>();
             var policy2 = new NullPolicy<DumbAction>();
-            var fx1 = new LiteDBStoreFixture();
-            var fx2 = new LiteDBStoreFixture();
+            var fx1 = new DefaultStoreFixture();
+            var fx2 = new DefaultStoreFixture();
 
             var chain1 = new BlockChain<DumbAction>(policy1, fx1.Store);
             var chain2 = new BlockChain<DumbAction>(policy2, fx2.Store);
@@ -2396,7 +2396,7 @@ namespace Libplanet.Tests.Net
             if (blocks is null)
             {
                 var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-                using (var storeFx = new LiteDBStoreFixture(memory: true))
+                using (var storeFx = new DefaultStoreFixture(memory: true))
                 {
                     var chain = new BlockChain<DumbAction>(policy, storeFx.Store);
                     Address miner = new PrivateKey().PublicKey.ToAddress();

--- a/Libplanet.Tests/Store/BlockSetTest.cs
+++ b/Libplanet.Tests/Store/BlockSetTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Store
 
         public BlockSetTest()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _set = new BlockSet<DumbAction>(_fx.Store);
         }
 

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -4,22 +4,22 @@ using Libplanet.Store;
 
 namespace Libplanet.Tests.Store
 {
-    public class LiteDBStoreFixture : StoreFixture, IDisposable
+    public class DefaultStoreFixture : StoreFixture, IDisposable
     {
-        public LiteDBStoreFixture(bool memory = false)
+        public DefaultStoreFixture(bool memory = false)
         {
             string postfix = Guid.NewGuid().ToString();
             Path = memory
                 ? null
                 : System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"litedb_{postfix}.db");
-            Store = new LiteDBStore(Path);
+            Store = new DefaultStore(Path);
         }
 
         public string Path { get; }
 
         public override void Dispose()
         {
-            (Store as LiteDBStore)?.Dispose();
+            (Store as DefaultStore)?.Dispose();
 
             if (!(Path is null))
             {

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Tests.Store
             string postfix = Guid.NewGuid().ToString();
             Path = memory
                 ? null
-                : System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"litedb_{postfix}.db");
+                : System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"litedb_{postfix}");
             Store = new DefaultStore(Path);
         }
 
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Store
 
             if (!(Path is null))
             {
-                File.Delete(Path);
+                Directory.Delete(Path, true);
             }
         }
     }

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using Libplanet.Crypto;
 using Libplanet.Store;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Store
 {
@@ -10,8 +11,9 @@ namespace Libplanet.Tests.Store
     {
         private readonly DefaultStoreFixture _fx;
 
-        public DefaultStoreTest()
+        public DefaultStoreTest(ITestOutputHelper testOutputHelper)
         {
+            TestOutputHelper = testOutputHelper;
             Fx = _fx = new DefaultStoreFixture();
         }
 

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -6,13 +6,13 @@ using Xunit;
 
 namespace Libplanet.Tests.Store
 {
-    public class LiteDBStoreTest : StoreTest, IDisposable
+    public class DefaultStoreTest : StoreTest, IDisposable
     {
-        private readonly LiteDBStoreFixture _fx;
+        private readonly DefaultStoreFixture _fx;
 
-        public LiteDBStoreTest()
+        public DefaultStoreTest()
         {
-            Fx = _fx = new LiteDBStoreFixture();
+            Fx = _fx = new DefaultStoreFixture();
         }
 
         public void Dispose()
@@ -28,13 +28,13 @@ namespace Libplanet.Tests.Store
             var bytes = new byte[32];
             random.NextBytes(bytes);
             var hashDigest = new HashDigest<SHA256>(bytes);
-            var stateRef = new LiteDBStore.StateRefDoc
+            var stateRef = new DefaultStore.StateRefDoc
             {
                 Address = address,
                 BlockIndex = 123,
                 BlockHash = hashDigest,
             };
-            var stateRef2 = new LiteDBStore.StateRefDoc
+            var stateRef2 = new DefaultStore.StateRefDoc
             {
                 AddressString = stateRef.AddressString,
                 BlockIndex = 123,

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Store
         {
             get
             {
-                yield return new object[] { new LiteDBStoreFixture() };
+                yield return new object[] { new DefaultStoreFixture() };
             }
         }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -14,11 +14,14 @@ using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Store
 {
     public abstract class StoreTest
     {
+        protected ITestOutputHelper TestOutputHelper { get; set; }
+
         protected StoreFixture Fx { get; set; }
 
         [Fact]
@@ -755,7 +758,19 @@ namespace Libplanet.Tests.Store
                 tasks[i] = task;
             }
 
-            Task.WaitAll(tasks);
+            try
+            {
+                Task.WaitAll(tasks);
+            }
+            catch (AggregateException e)
+            {
+                foreach (Exception innerException in e.InnerExceptions)
+                {
+                    TestOutputHelper.WriteLine(innerException.ToString());
+                }
+
+                throw;
+            }
 
             Assert.Equal(1 + (taskCount * txCount), Fx.Store.CountTransactions());
             foreach (TxId txid in Fx.Store.IterateTransactionIds())

--- a/Libplanet.Tests/Store/StoreTrackerTest.cs
+++ b/Libplanet.Tests/Store/StoreTrackerTest.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Tests.Store
 
         public StoreTrackerTest()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _tracker = new StoreTracker(_fx.Store);
         }
 

--- a/Libplanet.Tests/Store/TransactionSetTest.cs
+++ b/Libplanet.Tests/Store/TransactionSetTest.cs
@@ -14,7 +14,7 @@ namespace Libplanet.Tests.Store
 
         public TransactionSetTest()
         {
-            _fx = new LiteDBStoreFixture();
+            _fx = new DefaultStoreFixture();
             _set = new TransactionSet<DumbAction>(_fx.Store);
         }
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -72,6 +72,7 @@ https://docs.libplanet.io/</Description>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -99,6 +99,7 @@ https://docs.libplanet.io/</Description>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="Zio" Version="0.7.4" />
   </ItemGroup>
 
   <!-- The above hacky trick is borrowed from the following Stack Overflow

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -18,10 +18,11 @@ using FileMode = LiteDB.FileMode;
 namespace Libplanet.Store
 {
     /// <summary>
-    /// <see cref="IStore"/> implementation using <a href="https://www.litedb.org/">LiteDB</a>.
+    /// The default built-in <see cref="IStore"/> implementation.  This stores data in files
+    /// using <a href="https://www.litedb.org/">LiteDB</a>.
     /// </summary>
     /// <seealso cref="IStore"/>
-    public class LiteDBStore : BaseStore, IDisposable
+    public class DefaultStore : BaseStore, IDisposable
     {
         private const string TxIdPrefix = "tx/";
 
@@ -42,7 +43,7 @@ namespace Libplanet.Store
         private readonly ReaderWriterLockSlim _blockLock;
 
         /// <summary>
-        /// Creates a new <seealso cref="LiteDBStore"/>.
+        /// Creates a new <seealso cref="DefaultStore"/>.
         /// </summary>
         /// <param name="path">The path where the storage file will be saved.  If the path is
         /// <c>null</c>, The database is created in memory with <see cref="MemoryStream"/>.</param>
@@ -53,7 +54,7 @@ namespace Libplanet.Store
         /// <param name="flush">Writes data direct to disk avoiding OS cache.  Turned on by default.
         /// </param>
         /// <param name="readOnly">Opens database readonly mode. Turned off by default.</param>
-        public LiteDBStore(
+        public DefaultStore(
             string path,
             bool journal = true,
             int cacheSize = 50000,
@@ -61,7 +62,7 @@ namespace Libplanet.Store
             bool readOnly = false
         )
         {
-            _logger = Log.ForContext<LiteDBStore>();
+            _logger = Log.ForContext<DefaultStore>();
 
             var connectionString = new ConnectionString
             {

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -406,16 +406,18 @@ namespace Libplanet.Store
                 return;
             }
 
+            UPath path = BlockPath(block.Hash);
+            if (_blocks.FileExists(path))
+            {
+                return;
+            }
+
             foreach (Transaction<T> tx in block.Transactions)
             {
                 PutTransaction(tx);
             }
 
-            WriteContentAddressableFile(
-                _blocks,
-                BlockPath(block.Hash),
-                block.ToBencodex(true, false)
-            );
+            WriteContentAddressableFile(_blocks, path, block.ToBencodex(true, false));
             _blockCache.AddOrUpdate(block.Hash, block.ToRawBlock(false, false));
         }
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -295,6 +295,7 @@ namespace Libplanet.Store
                     }
                     catch (Exception)
                     {
+                        // Skip if a filename does not match to the format.
                         continue;
                     }
 
@@ -425,6 +426,7 @@ namespace Libplanet.Store
                     }
                     catch (Exception)
                     {
+                        // Skip if a filename does not match to the format.
                         continue;
                     }
 


### PR DESCRIPTION
This makes blocks and transactions stored as bare files, instead of LiteDB's `FileStorage`.  Therefore, now it cannot be called just `LiteDBStore` anymore, so I renamed it to `DefaultStore`.  As more than a single file are made, it became to take a directory instead of a single file.

Note that this still has only a single LiteDB file yet.  I'm going to make another patch to make each chain ID has its own LiteDB file.

Here are small and not-that-accurate benchmarks:

### [`LiteDBStore` (Linux)](https://github.com/planetarium/libplanet/runs/296967231)

```
BenchmarkDotNet=v0.11.5, OS=ubuntu 18.04
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |        Mean |        Error |       StdDev |
|------------------------------ |------------:|-------------:|-------------:|
|            PutFirstEmptyBlock |  4,947.0 us |  14,308.1 us |    784.27 us |
|          PutFirstBlockWithTxs | 26,977.8 us |  64,829.5 us |  3,553.52 us |
|          PutBlockOnManyBlocks | 31,588.7 us | 206,062.2 us | 11,294.96 us |
|    GetOldBlockOutOfManyBlocks |  1,494.3 us |   9,766.6 us |    535.34 us |
| GetRecentBlockOutOfManyBlocks |  2,370.9 us |  11,128.9 us |    610.01 us |
|    TryGetNonExistentBlockHash |    210.2 us |     573.5 us |     31.44 us |
|                    PutFirstTx |  5,980.1 us |  10,278.1 us |    563.38 us |
|                PutTxOnManyTxs |  4,331.6 us |   5,927.9 us |    324.93 us |
|          GetOldTxOutOfManyTxs |  1,727.5 us |   7,369.2 us |    403.93 us |
|       GetRecentTxOutOfManyTxs |  1,564.4 us |  19,936.8 us |  1,092.81 us |
|         TryGetNonExistentTxId |    140.8 us |     761.7 us |     41.75 us |

### [`DefaultStore` (Linux)](https://github.com/dahlia/libplanet/runs/297031589)

```
BenchmarkDotNet=v0.11.5, OS=ubuntu 18.04
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |        Mean |       Error |      StdDev |
|------------------------------ |------------:|------------:|------------:|
|            PutFirstEmptyBlock |   567.80 us | 1,090.80 us |  59.7906 us |
|          PutFirstBlockWithTxs | 2,271.70 us | 1,489.49 us |  81.6442 us |
|          PutBlockOnManyBlocks | 1,732.67 us | 3,479.72 us | 190.7354 us |
|    GetOldBlockOutOfManyBlocks |   283.53 us |   621.83 us |  34.0847 us |
| GetRecentBlockOutOfManyBlocks |   481.47 us | 1,962.74 us | 107.5845 us |
|    TryGetNonExistentBlockHash |   114.87 us |   695.88 us |  38.1435 us |
|                    PutFirstTx |   701.24 us | 2,942.95 us | 161.3127 us |
|                PutTxOnManyTxs |   443.07 us |   476.14 us |  26.0988 us |
|          GetOldTxOutOfManyTxs |    25.40 us |    44.39 us |   2.4334 us |
|       GetRecentTxOutOfManyTxs |    22.10 us |    15.59 us |   0.8544 us |
|         TryGetNonExistentTxId |   133.80 us |   317.46 us |  17.4009 us |

### [`LiteDBStore` (macOS)](https://github.com/planetarium/libplanet/runs/296967216)

```
BenchmarkDotNet=v0.11.5, OS=macOS 10.15.1 (19B88) [Darwin 19.0.0]
Intel Xeon CPU E5-1650 v2 3.50GHz (Max: 3.34GHz), 2 CPU, 4 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |        Mean |        Error |       StdDev |      Median |
|------------------------------ |------------:|-------------:|-------------:|------------:|
|            PutFirstEmptyBlock | 11,993.2 us | 110,056.5 us | 6,032.569 us |  8,631.9 us |
|          PutFirstBlockWithTxs | 30,739.1 us |  38,474.8 us | 2,108.935 us | 30,326.4 us |
|          PutBlockOnManyBlocks | 38,760.6 us |  63,501.6 us | 3,480.738 us | 39,643.5 us |
|    GetOldBlockOutOfManyBlocks |    877.0 us |   2,232.9 us |   122.395 us |    940.9 us |
| GetRecentBlockOutOfManyBlocks |  1,669.2 us |     657.7 us |    36.049 us |  1,680.9 us |
|    TryGetNonExistentBlockHash |    363.3 us |     160.5 us |     8.799 us |    359.7 us |
|                    PutFirstTx |  7,117.5 us |   7,046.4 us |   386.236 us |  7,323.9 us |
|                PutTxOnManyTxs |  6,499.8 us |   9,103.8 us |   499.009 us |  6,363.6 us |
|          GetOldTxOutOfManyTxs |    821.9 us |     709.1 us |    38.867 us |    802.1 us |
|       GetRecentTxOutOfManyTxs |    753.3 us |   1,345.1 us |    73.727 us |    795.3 us |
|         TryGetNonExistentTxId |    363.6 us |     126.5 us |     6.937 us |    366.6 us |

### [`DefaultStore` (macOS)](https://github.com/dahlia/libplanet/runs/297031583)

```
BenchmarkDotNet=v0.11.5, OS=macOS 10.15.1 (19B88) [Darwin 19.0.0]
Intel Xeon CPU E5-1650 v2 3.50GHz (Max: 3.34GHz), 2 CPU, 4 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |        Mean |      Error |     StdDev |      Median |
|------------------------------ |------------:|-----------:|-----------:|------------:|
|            PutFirstEmptyBlock | 1,591.24 us | 1,870.6 us | 102.536 us | 1,639.54 us |
|          PutFirstBlockWithTxs | 6,441.34 us | 5,953.7 us | 326.340 us | 6,299.32 us |
|          PutBlockOnManyBlocks | 5,282.62 us | 3,904.4 us | 214.012 us | 5,325.88 us |
|    GetOldBlockOutOfManyBlocks |   319.00 us |   501.2 us |  27.474 us |   313.77 us |
| GetRecentBlockOutOfManyBlocks |   502.60 us |   525.3 us |  28.794 us |   511.39 us |
|    TryGetNonExistentBlockHash |   143.26 us |   179.5 us |   9.837 us |   141.98 us |
|                    PutFirstTx | 1,552.22 us | 1,734.7 us |  95.084 us | 1,526.22 us |
|                PutTxOnManyTxs | 1,438.01 us | 6,382.3 us | 349.835 us | 1,249.71 us |
|          GetOldTxOutOfManyTxs |    64.68 us |   627.6 us |  34.403 us |    74.21 us |
|       GetRecentTxOutOfManyTxs |    43.98 us |   576.6 us |  31.607 us |    31.30 us |
|         TryGetNonExistentTxId |   206.18 us |   863.2 us |  47.315 us |   180.80 us |

### [`LiteDBStore` (Windows)](https://github.com/planetarium/libplanet/runs/296967238)

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.805 (1809/October2018Update/Redstone5)
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |         Mean |        Error |       StdDev |
|------------------------------ |-------------:|-------------:|-------------:|
|            PutFirstEmptyBlock |  34,039.0 us |  84,240.2 us |  4,617.49 us |
|          PutFirstBlockWithTxs | 164,840.5 us |  65,459.9 us |  3,588.08 us |
|          PutBlockOnManyBlocks | 269,539.2 us | 284,784.2 us | 15,609.98 us |
|    GetOldBlockOutOfManyBlocks |   1,366.2 us |   1,809.5 us |     99.18 us |
| GetRecentBlockOutOfManyBlocks |   2,054.2 us |   4,737.0 us |    259.65 us |
|    TryGetNonExistentBlockHash |     677.3 us |     945.5 us |     51.82 us |
|                    PutFirstTx |  42,991.1 us |  92,887.2 us |  5,091.46 us |
|                PutTxOnManyTxs |  55,486.5 us | 175,563.6 us |  9,623.24 us |
|          GetOldTxOutOfManyTxs |   1,047.1 us |   3,824.1 us |    209.61 us |
|       GetRecentTxOutOfManyTxs |   1,248.3 us |   6,392.9 us |    350.41 us |
|         TryGetNonExistentTxId |     756.4 us |     815.5 us |     44.70 us |

### [`DefaultStore` (Windows)](https://github.com/dahlia/libplanet/runs/297031593)

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.805 (1809/October2018Update/Redstone5)
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.0.100
  [Host]   : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  ShortRun : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT

Job=ShortRun  InvocationCount=1  IterationCount=3  
LaunchCount=1  UnrollFactor=1  WarmupCount=3  
```

|                        Method |        Mean |       Error |     StdDev |      Median |
|------------------------------ |------------:|------------:|-----------:|------------:|
|            PutFirstEmptyBlock | 1,597.33 us | 2,410.59 us | 132.133 us | 1,577.40 us |
|          PutFirstBlockWithTxs | 7,476.67 us | 4,706.88 us | 258.000 us | 7,538.40 us |
|          PutBlockOnManyBlocks | 6,305.90 us | 4,596.80 us | 251.966 us | 6,309.20 us |
|    GetOldBlockOutOfManyBlocks |   303.90 us | 1,436.33 us |  78.730 us |   299.80 us |
| GetRecentBlockOutOfManyBlocks |   459.07 us |   982.25 us |  53.841 us |   487.00 us |
|    TryGetNonExistentBlockHash |    90.17 us |   274.90 us |  15.068 us |    94.90 us |
|                    PutFirstTx | 1,660.03 us |   895.54 us |  49.088 us | 1,643.30 us |
|                PutTxOnManyTxs | 1,353.43 us | 1,591.14 us |  87.216 us | 1,320.10 us |
|          GetOldTxOutOfManyTxs |    34.80 us |   313.26 us |  17.171 us |    25.80 us |
|       GetRecentTxOutOfManyTxs |    24.73 us |    78.73 us |   4.315 us |    22.60 us |
|         TryGetNonExistentTxId |   101.03 us |   110.35 us |   6.048 us |   103.20 us |

![「힘의 차이」가 느껴지십니까?](https://user-images.githubusercontent.com/12431/68564563-55d64c80-0494-11ea-9182-66fbc23cc3ca.png)