### PR TITLE
Implement protocol test and boost bootstrapping by using cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  `Swarm<T>` became to compare only peer's addresses instead of public keys
+    to determine if a peer is in routing table or not.  [[#665]]
  -  `Swarm<T>` became to send 100 blocks (instead of 500 blocks) for each
     reply during IDL, in order to stabilize connection in high latency
     environments.  [[#679]]
@@ -45,6 +47,7 @@ To be released.
  -  Fixed bug that re-download block from scratch in preloading.  [[#685]]
 
 [#662]: https://github.com/planetarium/libplanet/pull/662
+[#665]: https://github.com/planetarium/libplanet/pull/665
 [#675]: https://github.com/planetarium/libplanet/pull/675
 [#676]: https://github.com/planetarium/libplanet/pull/676
 [#678]: https://github.com/planetarium/libplanet/pull/678

--- a/Libplanet.Benchmarks/Protocol.cs
+++ b/Libplanet.Benchmarks/Protocol.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Libplanet.Crypto;
+using Libplanet.Tests.Net.Protocols;
+
+namespace Libplanet.Benchmarks
+{
+    public class Protocol
+    {
+        private readonly Dictionary<Address, TestSwarm> _swarms;
+
+        public Protocol()
+        {
+            _swarms = new Dictionary<Address, TestSwarm>();
+        }
+
+        [Benchmark]
+        public async Task BootstrapManyTestSwarms()
+        {
+            const int count = 100;
+            var seed = CreateTestSwarm();
+            seed.Start();
+            var swarms = new TestSwarm[count];
+            for (var i = 0; i < count; i++)
+            {
+                swarms[i] = CreateTestSwarm();
+                swarms[i].Start();
+            }
+
+            foreach (var swarm in swarms)
+            {
+                await swarm.BootstrapAsync(new[] { seed.AsPeer });
+            }
+        }
+
+        private TestSwarm CreateTestSwarm(
+            PrivateKey privateKey = null,
+            int? tableSize = null,
+            int? bucketSize = null,
+            TimeSpan? networkDelay = null)
+        {
+            return new TestSwarm(
+                _swarms,
+                privateKey ?? new PrivateKey(),
+                tableSize,
+                bucketSize,
+                networkDelay);
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Net.Protocols;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,6 +29,27 @@ namespace Libplanet.Tests.Net.Protocols
                 .ForContext<ProtocolTest>();
 
             _swarms = new Dictionary<Address, TestSwarm>();
+        }
+
+        [Fact]
+        public void KademliaTest()
+        {
+            var addr1 = new Address("0000000000000000000000000000000000000000");
+            var addr2 = new Address("0000000000000000000000000000000000000001");
+            var addr3 = new Address("000000000000000000000000000000000000000c");
+            var addr4 = new Address("0000000001000001111110001000011001000001");
+
+            Assert.Equal(
+                new Address("000000000100000111111000100001100100000d"),
+                Kademlia.CalculateDistance(addr3, addr4));
+
+            Assert.Equal(159, Kademlia.CommonPrefixLength(addr1, addr2));
+            Assert.Equal(156, Kademlia.CommonPrefixLength(addr1, addr3));
+            Assert.Equal(39, Kademlia.CommonPrefixLength(addr1, addr4));
+
+            Assert.True(string.CompareOrdinal(addr1.ToHex(), addr2.ToHex()) < 1);
+            Assert.True(string.CompareOrdinal(addr2.ToHex(), addr3.ToHex()) < 1);
+            Assert.True(string.CompareOrdinal(addr3.ToHex(), addr4.ToHex()) < 1);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -119,11 +119,11 @@ namespace Libplanet.Tests.Net.Protocols
             }
         }
 
-        // TODO: scale up to 200 by boosting bootstrapping
         [Theory(Timeout = Timeout)]
         [InlineData(1)]
         [InlineData(5)]
         [InlineData(20)]
+        [InlineData(50)]
         public async Task BroadcastMessage(int count)
         {
             var seed = CreateTestSwarm();
@@ -147,9 +147,10 @@ namespace Libplanet.Tests.Net.Protocols
                     await swarm.Protocol.RebuildConnectionAsync(default(CancellationToken));
                 }
 
-                Log.Debug("Start broadcasting.");
+                Log.Debug("Bootstrap completed.");
+
                 seed.BroadcastTestMessage("foo");
-                Log.Debug("End broadcasting.");
+                Log.Debug("Broadcast completed.");
 
                 var tasks = swarms.Select(swarm => swarm.WaitForTestMessageWithData("foo"));
 

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Net.Protocols
+{
+    public class ProtocolTest
+    {
+        private const int Timeout = 60 * 1000;
+        private readonly Dictionary<Address, TestSwarm> _swarms;
+
+        public ProtocolTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss}[@{Address}][{ThreadId}] - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ProtocolTest>();
+
+            _swarms = new Dictionary<Address, TestSwarm>();
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task Start()
+        {
+            var swarmA = CreateTestSwarm();
+            var swarmB = CreateTestSwarm();
+
+            Assert.Throws<SwarmException>(() => swarmA.SendPing(swarmB.AsPeer));
+            swarmA.Start();
+            swarmA.SendPing(swarmB.AsPeer);
+            await swarmB.MessageReceived.WaitAsync();
+            Assert.Empty(swarmA.ReceivedMessages);
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task Ping()
+        {
+            var swarmA = CreateTestSwarm();
+            var swarmB = CreateTestSwarm();
+
+            try
+            {
+                swarmA.Start();
+                swarmB.Start();
+                swarmA.SendPing(swarmB.AsPeer);
+                await swarmA.MessageReceived.WaitAsync();
+
+                Assert.Single(swarmA.ReceivedMessages);
+                Assert.Single(swarmB.ReceivedMessages);
+                Assert.Contains(swarmA.AsPeer, swarmB.Protocol.Peers);
+            }
+            finally
+            {
+                swarmA.Stop();
+                swarmB.Stop();
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task PingTwice()
+        {
+            var swarmA = CreateTestSwarm();
+            var swarmB = CreateTestSwarm();
+
+            try
+            {
+                swarmA.Start();
+                swarmB.Start();
+
+                swarmA.SendPing(swarmB.AsPeer);
+                await swarmA.MessageReceived.WaitAsync();
+                await swarmB.MessageReceived.WaitAsync();
+                swarmB.SendPing(swarmA.AsPeer);
+                await swarmA.MessageReceived.WaitAsync();
+                await swarmB.MessageReceived.WaitAsync();
+
+                Assert.Equal(2, swarmA.ReceivedMessages.Count);
+                Assert.Equal(2, swarmB.ReceivedMessages.Count);
+                Assert.Contains(swarmA.AsPeer, swarmB.Protocol.Peers);
+                Assert.Contains(swarmB.AsPeer, swarmA.Protocol.Peers);
+            }
+            finally
+            {
+                swarmA.Stop();
+                swarmB.Stop();
+            }
+        }
+
+        // TODO: scale up to 200 by boosting bootstrapping
+        [Theory(Timeout = Timeout)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(20)]
+        public async Task BroadcastMessage(int count)
+        {
+            var seed = CreateTestSwarm();
+            seed.Start();
+            var swarms = new TestSwarm[count];
+            for (var i = 0; i < count; i++)
+            {
+                swarms[i] = CreateTestSwarm();
+                swarms[i].Start();
+            }
+
+            try
+            {
+                foreach (var swarm in swarms)
+                {
+                    await swarm.BootstrapAsync(new[] { seed.AsPeer });
+                }
+
+                foreach (var swarm in swarms)
+                {
+                    await swarm.Protocol.RebuildConnectionAsync(default(CancellationToken));
+                }
+
+                Log.Debug("Start broadcasting.");
+                seed.BroadcastTestMessage("foo");
+                Log.Debug("End broadcasting.");
+
+                var tasks = swarms.Select(swarm => swarm.WaitForTestMessageWithData("foo"));
+
+                await Task.WhenAll(tasks);
+            }
+            finally
+            {
+                foreach (var swarm in swarms)
+                {
+                    Assert.True(swarm.ReceivedTestMessageOfData("foo"));
+                    swarm.Stop();
+                }
+            }
+        }
+
+        private TestSwarm CreateTestSwarm(
+            PrivateKey privateKey = null,
+            int? tableSize = null,
+            int? bucketSize = null,
+            TimeSpan? networkDelay = null)
+        {
+            return new TestSwarm(
+                _swarms,
+                privateKey ?? new PrivateKey(),
+                tableSize,
+                bucketSize,
+                networkDelay);
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -140,11 +139,6 @@ namespace Libplanet.Tests.Net.Protocols
                 foreach (var swarm in swarms)
                 {
                     await swarm.BootstrapAsync(new[] { seed.AsPeer });
-                }
-
-                foreach (var swarm in swarms)
-                {
-                    await swarm.Protocol.RebuildConnectionAsync(default(CancellationToken));
                 }
 
                 Log.Debug("Bootstrap completed.");

--- a/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
@@ -7,9 +7,9 @@ using Libplanet.Net.Protocols;
 using Serilog.Core;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Tests.Net.Protocols
 {
-    public class ProtocolTest
+    public class RoutingTableTest
     {
         private const int BucketSize = 16;
         private const int TableSize = Address.Size * sizeof(byte) * 8;

--- a/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
@@ -131,19 +131,6 @@ namespace Libplanet.Tests.Net.Protocols
             Assert.True(ret);
         }
 
-        [Fact]
-        public void PrefixLength()
-        {
-            var addr1 = new Address("0000000000000000000000000000000000000000");
-            var addr2 = new Address("0000000000000000000000000000000000000001");
-            var addr3 = new Address("000000000000000000000000000000000000000c");
-            var addr4 = new Address("0000000001000001111110001000011001000001");
-
-            Assert.Equal(159, Kademlia.CommonPrefixLength(addr1, addr2));
-            Assert.Equal(156, Kademlia.CommonPrefixLength(addr1, addr3));
-            Assert.Equal(39, Kademlia.CommonPrefixLength(addr1, addr4));
-        }
-
         private RoutingTable CreateTable(Address addr)
         {
             return new RoutingTable(addr, TableSize, BucketSize, new System.Random(), Logger.None);

--- a/Libplanet.Tests/Net/Protocols/TestMessage.cs
+++ b/Libplanet.Tests/Net/Protocols/TestMessage.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Libplanet.Net.Messages;
+using NetMQ;
+
+namespace Libplanet.Tests.Net.Protocols
+{
+    internal class TestMessage : Message
+    {
+        public TestMessage(string data)
+        {
+            Data = data;
+        }
+
+        public TestMessage(NetMQFrame[] body)
+        {
+        }
+
+        public string Data { get; }
+
+        protected override MessageType Type => MessageType.Ping;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Protocols/TestSwarm.cs
+++ b/Libplanet.Tests/Net/Protocols/TestSwarm.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
+using Nito.AsyncEx;
+using Serilog;
+
+namespace Libplanet.Tests.Net.Protocols
+{
+    public class TestSwarm : ISwarm
+    {
+        private readonly Dictionary<Address, TestSwarm> _swarms;
+        private readonly ILogger _logger;
+        private readonly ConcurrentDictionary<byte[], Address> _peersToReply;
+        private readonly ConcurrentDictionary<byte[], Message> _replyToReceive;
+        private readonly List<Request> _requests;
+        private readonly List<string> _ignoreTestMessageWithData;
+        private readonly PrivateKey _privateKey;
+        private readonly Random _random;
+
+        private CancellationTokenSource swarmCancellationTokenSource;
+        private TimeSpan _networkDelay;
+
+        public TestSwarm(
+            Dictionary<Address, TestSwarm> swarms,
+            PrivateKey privateKey,
+            int? tableSize,
+            int? bucketSize,
+            TimeSpan? networkDelay)
+        {
+            _privateKey = privateKey;
+            var loggerId = _privateKey.PublicKey.ToAddress().ToHex();
+            _logger = Log.ForContext<TestSwarm>()
+                .ForContext("Address", loggerId);
+            Protocol = new KademliaProtocol(this, Address, 0, _logger, tableSize, bucketSize);
+            _peersToReply = new ConcurrentDictionary<byte[], Address>();
+            _replyToReceive = new ConcurrentDictionary<byte[], Message>();
+            ReceivedMessages = new ConcurrentBag<Message>();
+            MessageReceived = new AsyncAutoResetEvent();
+            _swarms = swarms;
+            _swarms[privateKey.PublicKey.ToAddress()] = this;
+            _networkDelay = networkDelay ?? TimeSpan.Zero;
+            _requests = new List<Request>();
+            _ignoreTestMessageWithData = new List<string>();
+            _random = new Random();
+        }
+
+        public AsyncAutoResetEvent MessageReceived { get; }
+
+        public Address Address => _privateKey.PublicKey.ToAddress();
+
+        public BoundPeer AsPeer => new BoundPeer(
+            _privateKey.PublicKey,
+            new DnsEndPoint("localhost", 1234),
+            0);
+
+        internal ConcurrentBag<Message> ReceivedMessages { get; }
+
+        internal IProtocol Protocol { get; }
+
+        public void Dispose()
+        {
+        }
+
+        public async void Start()
+        {
+            swarmCancellationTokenSource = new CancellationTokenSource();
+            await DoSendMessage(swarmCancellationTokenSource.Token);
+        }
+
+        public Task BootstrapAsync(
+            IEnumerable<BoundPeer> peers,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            if (peers is null)
+            {
+                throw new ArgumentNullException(nameof(peers));
+            }
+
+            async Task DoBootstrapAsync()
+            {
+                await Protocol.BootstrapAsync(
+                    peers.ToImmutableList(),
+                    null,
+                    null,
+                    cancellationToken);
+            }
+
+            return DoBootstrapAsync();
+        }
+
+        public void Stop()
+        {
+            swarmCancellationTokenSource.Cancel();
+        }
+
+        public void SendPing(Peer target, TimeSpan? timeSpan = null)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            if (!(target is BoundPeer boundPeer))
+            {
+                throw new ArgumentException("Target peer does not have endpoint.", nameof(target));
+            }
+
+            Task.Run(() =>
+            {
+                (Protocol as KademliaProtocol).PingAsync(
+                    boundPeer,
+                    timeSpan,
+                    default(CancellationToken));
+            });
+        }
+
+        public void BroadcastTestMessage(string data)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            var message = new TestMessage(data) { Remote = AsPeer };
+            var peers = Protocol.PeersToBroadcast;
+            _ignoreTestMessageWithData.Add(data);
+            _logger.Debug(
+                "Broadcasting test message {Data} to {Count} peers.",
+                data,
+                peers.Count);
+            foreach (var peer in peers)
+            {
+                _requests.Add(new Request()
+                {
+                    RequestTime = DateTimeOffset.UtcNow,
+                    Message = message,
+                    Target = peer,
+                });
+            }
+        }
+
+#pragma warning disable 4014, S4457
+        async Task<Message> ISwarm.SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            CancellationToken cancellationToken)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            if (!(peer is BoundPeer boundPeer))
+            {
+                throw new ArgumentException("Target peer is not a BoundPeer.");
+            }
+
+            message.Remote = AsPeer;
+            var bytes = new byte[10];
+            _random.NextBytes(bytes);
+            message.Identity = _privateKey.PublicKey.ToAddress().ByteArray.Concat(bytes).ToArray();
+            var sendTime = DateTimeOffset.UtcNow;
+            _requests.Add(new Request()
+            {
+                RequestTime = sendTime,
+                Message = message,
+                Target = peer,
+            });
+
+            while (!cancellationToken.IsCancellationRequested &&
+                   !_replyToReceive.ContainsKey(message.Identity))
+            {
+                if (DateTimeOffset.UtcNow - sendTime > (timeout ?? TimeSpan.MaxValue))
+                {
+                    _logger.Error(
+                        "Reply of {Message} did not received in expected timespan {TimeSpan}.",
+                        message,
+                        timeout ?? TimeSpan.MaxValue);
+                    throw new TimeoutException(
+                        $"Timeout occurred during {nameof(ISwarm.SendMessageWithReplyAsync)}().");
+                }
+
+                await Task.Delay(10, cancellationToken);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(
+                    $"Operation is canceled during {nameof(ISwarm.SendMessageWithReplyAsync)}().");
+            }
+
+            if (_replyToReceive.TryRemove(message.Identity, out Message reply))
+            {
+                _logger.Debug(
+                    "Received reply {Reply} of message with identity {identity}.",
+                    reply,
+                    message.Identity);
+                ReceivedMessages.Add(reply);
+                MessageReceived.Set();
+                return reply;
+            }
+            else
+            {
+                _logger.Error(
+                    "Unexpected error occurred during " +
+                    $"{nameof(ISwarm.SendMessageWithReplyAsync)}()");
+                throw new SwarmException();
+            }
+        }
+#pragma warning restore 4014, S4457
+
+        void ISwarm.ReplyMessage(Message message)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            _logger.Debug("Replying {Message}...", message);
+            message.Remote = AsPeer;
+            Task.Run(async () =>
+            {
+                await Task.Delay(_networkDelay);
+                _swarms[_peersToReply[message.Identity]].ReceiveReply(message);
+                _peersToReply.TryRemove(message.Identity, out Address addr);
+            });
+        }
+
+        public async Task WaitForTestMessageWithData(string data)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            while (!ReceivedTestMessageOfData(data))
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        public bool ReceivedTestMessageOfData(string data)
+        {
+            if (swarmCancellationTokenSource is null)
+            {
+                throw new SwarmException("Start swarm before use.");
+            }
+
+            return ReceivedMessages.OfType<TestMessage>().Select(msg => msg.Data == data).Any();
+        }
+
+        private void ReceiveMessage(Message message)
+        {
+            if (!(message.Remote is BoundPeer boundPeer))
+            {
+                throw new ArgumentException("Sender of message is not a BoundPeer.");
+            }
+
+            if (message is TestMessage testMessage)
+            {
+                if (_ignoreTestMessageWithData.Contains(testMessage.Data))
+                {
+                    _logger.Debug("Ignore received test message {Data}.", testMessage.Data);
+                    return;
+                }
+                else
+                {
+                    _logger.Debug("Received test message with {Data}.", testMessage.Data);
+                    _ignoreTestMessageWithData.Add(testMessage.Data);
+                    BroadcastTestMessage(testMessage.Data);
+                }
+            }
+            else
+            {
+                _peersToReply[message.Identity] = boundPeer.Address;
+            }
+
+            ReceivedMessages.Add(message);
+            MessageReceived.Set();
+
+            Protocol.ReceiveMessage(message);
+        }
+
+        private void ReceiveReply(Message message)
+        {
+            _replyToReceive[message.Identity] = message;
+        }
+
+        private async Task DoSendMessage(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var copy = new Request[_requests.Count];
+                _requests.CopyTo(copy);
+                foreach (var request in copy)
+                {
+                    if (request.RequestTime <= DateTimeOffset.UtcNow + _networkDelay)
+                    {
+                        _logger.Debug(
+                            "Send {Message} with {Identity} to {Peer}.",
+                            request.Message,
+                            request.Message.Identity,
+                            request.Target);
+                        _swarms[request.Target.Address].ReceiveMessage(request.Message);
+                        _requests.Remove(request);
+                    }
+                }
+
+                await Task.Delay(10, cancellationToken);
+            }
+        }
+
+        private struct Request
+        {
+            public DateTimeOffset RequestTime;
+
+            public BoundPeer Target;
+
+            public Message Message;
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Protocols/TestSwarm.cs
+++ b/Libplanet.Tests/Net/Protocols/TestSwarm.cs
@@ -96,6 +96,7 @@ namespace Libplanet.Tests.Net.Protocols
                     peers.ToImmutableList(),
                     null,
                     null,
+                    Kademlia.MaxDepth,
                     cancellationToken);
             }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2352,7 +2352,7 @@ namespace Libplanet.Tests.Net
                 new[] { seed },
                 null,
                 TimeSpan.FromSeconds(3),
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
 
         private class Sleep : IAction

--- a/Libplanet/Net/ISwarm.cs
+++ b/Libplanet/Net/ISwarm.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net
+{
+    internal interface ISwarm
+    {
+        Task<Message> SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            CancellationToken cancellationToken);
+
+        void ReplyMessage(Message message);
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -81,7 +81,7 @@ namespace Libplanet.Net.Messages
 
         public byte[] Identity { get; set; }
 
-        public Peer Remote { get; private set; }
+        public Peer Remote { get; set; }
 
         protected abstract MessageType Type { get; }
 

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -16,6 +16,7 @@ namespace Libplanet.Net.Protocols
             ImmutableList<BoundPeer> bootstrapPeers,
             TimeSpan? pingSeedTimeout,
             TimeSpan? findPeerTimeout,
+            int depth,
             CancellationToken cancellationToken);
 
         Task RefreshTableAsync(TimeSpan maxAge, CancellationToken cancellationToken);

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Net.Protocols
         {
             _lastUpdated = DateTimeOffset.UtcNow;
             int exists =
-                _peers.FindIndex(p => p.Item2.PublicKey.Equals(peer.PublicKey));
+                _peers.FindIndex(p => p.Item2.Address.Equals(peer.Address));
 
             if (exists != -1)
             {
@@ -102,7 +102,7 @@ namespace Libplanet.Net.Protocols
 
         public bool RemovePeer(BoundPeer peer)
         {
-            int index = _peers.FindIndex(item => item.Item2.PublicKey.Equals(peer.PublicKey));
+            int index = _peers.FindIndex(item => item.Item2.Address.Equals(peer.Address));
             if (index == -1)
             {
                 return false;

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -75,7 +75,7 @@ namespace Libplanet.Net.Protocols
             }
             else
             {
-                _logger.Verbose("Bucket does not contains [{peer}]", peer);
+                _logger.Verbose("Add [{peer}] to bucket.", peer);
                 if (ReplacementCache.Remove(peer))
                 {
                     _logger.Verbose(

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -54,19 +54,19 @@ namespace Libplanet.Net.Protocols
 
             if (exists != -1)
             {
-                _logger.Verbose("Bucket already contains [{peer}]", peer);
+                _logger.Verbose("Bucket already contains peer {Peer}", peer);
                 _peers.RemoveAt(exists);
                 _peers.Add((DateTimeOffset.UtcNow, peer));
                 return null;
             }
             else if (IsFull())
             {
-                _logger.Verbose("Bucket is full to add [{peer}]", peer);
+                _logger.Verbose("Bucket is full to add peer {Peer}", peer);
                 if (!ReplacementCache.Contains(peer))
                 {
                     ReplacementCache.Add(peer);
                     _logger.Verbose(
-                        "Added [{peer}] to replacement cache. (total: {count})",
+                        "Added peer {Peer} to replacement cache. (total: {Count})",
                         peer,
                         ReplacementCache.Count);
                 }
@@ -75,11 +75,11 @@ namespace Libplanet.Net.Protocols
             }
             else
             {
-                _logger.Verbose("Add [{peer}] to bucket.", peer);
+                _logger.Verbose("Adding peer {Peer} to bucket.", peer);
                 if (ReplacementCache.Remove(peer))
                 {
                     _logger.Verbose(
-                        "Removed [{peer}] from replacement cache. (total: {count})",
+                        "Removed peer {Peer} from replacement cache. (total: {Count})",
                         peer,
                         ReplacementCache.Count);
                 }

--- a/Libplanet/Net/Protocols/Kademlia.cs
+++ b/Libplanet/Net/Protocols/Kademlia.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -324,15 +324,8 @@ namespace Libplanet.Net.Protocols
                         "Cannot receive pong from self");
                 }
 
-                _logger.Verbose(
-                    $"Trying to {nameof(UpdateAsync)}() with pong: {{Pong}}",
-                    pong);
-
                 // update process required
                 await UpdateAsync(pong.Remote, cancellationToken);
-                _logger.Verbose(
-                    $"{nameof(UpdateAsync)}() finished with pong: {{Pong}}",
-                    pong);
             }
             catch (TimeoutException)
             {

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Net.Protocols
                 {
                     _logger.Error(
                         e,
-                        "An unexpected exception occurred connecting to seed peer. {e}",
+                        "An unexpected exception occurred connecting to seed peer. {Exception}",
                         e);
                 }
             }
@@ -141,12 +141,14 @@ namespace Libplanet.Net.Protocols
                 if (findPeerTasks.All(findPeerTask => findPeerTask.IsFaulted))
                 {
                     throw new TimeoutException(
-                        "Timeout exception occurred during BootstrapAsync().");
+                        $"Timeout exception occurred during {nameof(BootstrapAsync)}().");
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                _logger.Error("An unexpected exception occurred during BootstrapAsync().");
+                var msg = $"An unexpected exception occurred during {nameof(BootstrapAsync)}()." +
+                          " {Exception}";
+                _logger.Error(e, msg, e);
                 throw;
             }
         }
@@ -163,7 +165,7 @@ namespace Libplanet.Net.Protocols
         {
             try
             {
-                _logger.Debug("Refreshing table... total peers: {count}", Peers.Count);
+                _logger.Debug("Refreshing table... total peers: {Count}", Peers.Count);
                 List<Task> tasks = _routing.NonEmptyBuckets
                     .Where(bucket => bucket.Tail.Item1 + maxAge < DateTimeOffset.UtcNow)
                     .Select(bucket =>
@@ -173,7 +175,7 @@ namespace Libplanet.Net.Protocols
                             cancellationToken)
                 ).ToList();
 
-                _logger.Debug("Refresh candidates: {count}", tasks.Count);
+                _logger.Debug("Refresh candidates: {Count}", tasks.Count);
 
                 await Task.WhenAll(tasks);
                 cancellationToken.ThrowIfCancellationRequested();
@@ -242,7 +244,7 @@ namespace Libplanet.Net.Protocols
                 {
                     try
                     {
-                        _logger.Debug("Check {peer}.", replacement);
+                        _logger.Debug("Check peer {Peer}.", replacement);
                         if (bucket.IsFull())
                         {
                             break;
@@ -253,7 +255,7 @@ namespace Libplanet.Net.Protocols
                     catch (TimeoutException)
                     {
                         _logger.Debug(
-                            "Remove stale peer [{peer}] from replacement cache.",
+                            "Remove stale peer {Peer} from replacement cache.",
                             replacement);
                         bucket.ReplacementCache.Remove(replacement);
                     }
@@ -365,12 +367,12 @@ namespace Libplanet.Net.Protocols
         {
             try
             {
-                _logger.Debug("Validating {Peer}", peer);
+                _logger.Debug("Validating peer {Peer}", peer);
                 await PingAsync(peer, timeout, cancellationToken);
             }
             catch (TimeoutException)
             {
-                _logger.Debug("{Peer} is invalid, removing...", peer);
+                _logger.Debug("Peer {Peer} is invalid, removing...", peer);
                 await RemovePeerAsync(peer, cancellationToken);
                 throw;
             }
@@ -406,7 +408,7 @@ namespace Libplanet.Net.Protocols
 
         private async Task RemovePeerAsync(BoundPeer peer, CancellationToken cancellationToken)
         {
-            _logger.Debug("Removing peer [{peer}] from table.", peer);
+            _logger.Debug("Removing peer {Peer} from table.", peer);
             await _routing.RemovePeerAsync(peer, cancellationToken);
         }
 
@@ -434,8 +436,8 @@ namespace Libplanet.Net.Protocols
             CancellationToken cancellationToken)
         {
             _logger.Debug(
-                $"{nameof(FindPeerAsync)}() with {{target}} to {{viaPeer}}. " +
-                "(depth: {depth})",
+                $"{nameof(FindPeerAsync)}() with {{Target}} to {{Peer}}. " +
+                "(depth: {Depth})",
                 target,
                 viaPeer,
                 depth);
@@ -644,7 +646,7 @@ namespace Libplanet.Net.Protocols
                 if (findNeighboursTasks.All(findPeerTask => findPeerTask.IsFaulted))
                 {
                     throw new TimeoutException(
-                        "Timeout exception occurred during ProcessFoundAsync().");
+                        $"Timeout exception occurred during {nameof(ProcessFoundAsync)}().");
                 }
             }
         }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -437,7 +437,7 @@ namespace Libplanet.Net.Protocols
                 return;
             }
 
-            ImmutableList<BoundPeer> found;
+            IEnumerable<BoundPeer> found;
             if (viaPeer is null)
             {
                 found = await QueryNeighborsAsync(target, timeout, cancellationToken);
@@ -450,7 +450,7 @@ namespace Libplanet.Net.Protocols
             await ProcessFoundAsync(found, target, depth, timeout, cancellationToken);
         }
 
-        private async Task<ImmutableList<BoundPeer>> QueryNeighborsAsync(
+        private async Task<IEnumerable<BoundPeer>> QueryNeighborsAsync(
             Address target,
             TimeSpan? timeout,
             CancellationToken cancellationToken)
@@ -481,10 +481,10 @@ namespace Libplanet.Net.Protocols
                     $"Timeout occurred during {nameof(QueryNeighborsAsync)}.");
             }
 
-            return found.ToImmutableList();
+            return found;
         }
 
-        private async Task<ImmutableList<BoundPeer>> GetNeighbors(
+        private async Task<IEnumerable<BoundPeer>> GetNeighbors(
             BoundPeer addressee,
             Address target,
             TimeSpan? timeout,
@@ -502,7 +502,7 @@ namespace Libplanet.Net.Protocols
                     throw new InvalidMessageException("Reply of FindNeighbors is invalid.");
                 }
 
-                return neighbors.Found.ToImmutableList();
+                return neighbors.Found;
             }
             catch (TimeoutException)
             {
@@ -544,7 +544,7 @@ namespace Libplanet.Net.Protocols
         /// <exception cref="TimeoutException">Thrown when all peers that found are
         /// not online.</exception>
         private async Task ProcessFoundAsync(
-            ImmutableList<BoundPeer> found,
+            IEnumerable<BoundPeer> found,
             Address target,
             int depth,
             TimeSpan? timeout,
@@ -601,7 +601,6 @@ namespace Libplanet.Net.Protocols
                     break;
                 }
 
-
                 findNeighboursTasks.Add(FindPeerAsync(
                     target,
                     peer,
@@ -632,7 +631,7 @@ namespace Libplanet.Net.Protocols
         // maybe ping/pong/ping/pong is required
         private void ReceiveFindPeer(FindNeighbors findNeighbors)
         {
-            List<BoundPeer> found = _routing.Neighbors(findNeighbors.Target, _bucketSize).ToList();
+            IEnumerable<BoundPeer> found = _routing.Neighbors(findNeighbors.Target, _bucketSize);
 
             Neighbors neighbors = new Neighbors(found)
             {

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -103,9 +103,12 @@ namespace Libplanet.Net.Protocols
                     _logger.Error("A timeout exception occurred connecting to seed peer.");
                     await RemovePeerAsync(peer, cancellationToken);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    _logger.Error("An unexpected exception occurred connecting to seed peer.");
+                    _logger.Error(
+                        e,
+                        "An unexpected exception occurred connecting to seed peer. {e}",
+                        e);
                 }
             }
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -390,13 +390,13 @@ namespace Libplanet.Net.Protocols
                 throw new TaskCanceledException();
             }
 
-            await _routing.AddPeerAsync(peer);
+            await _routing.AddPeerAsync(peer, cancellationToken);
         }
 
         private async Task RemovePeerAsync(BoundPeer peer, CancellationToken cancellationToken)
         {
             _logger.Debug("Removing peer [{peer}] from table.", peer);
-            await _routing.RemovePeerAsync(peer);
+            await _routing.RemovePeerAsync(peer, cancellationToken);
         }
 
         /// <summary>

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -4,18 +4,16 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Libplanet.Action;
 using Libplanet.Net.Messages;
 using Serilog;
 using Random = System.Random;
 
 namespace Libplanet.Net.Protocols
 {
-    internal class KademliaProtocol<T> : IProtocol
-        where T : IAction, new()
+    internal class KademliaProtocol : IProtocol
     {
         private readonly TimeSpan _requestTimeout;
-        private readonly Swarm<T> _swarm;
+        private readonly ISwarm _swarm;
         private readonly Address _address;
         private readonly int _appProtocolVersion;
         private readonly Random _random;
@@ -26,7 +24,7 @@ namespace Libplanet.Net.Protocols
         private readonly ILogger _logger;
 
         public KademliaProtocol(
-            Swarm<T> swarm,
+            ISwarm swarm,
             Address address,
             int appProtocolVersion,
             ILogger logger,

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -87,10 +87,6 @@ namespace Libplanet.Net.Protocols
             using (await _bucketMutex.LockAsync())
             {
                 evicted = _buckets[index].AddPeer(peer);
-                _logger.Debug(
-                    "Adding [{peer}] to routing table. (evicted : {evicted})",
-                    peer,
-                    evicted);
             }
 
             return evicted;

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -146,14 +146,14 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        public ICollection<BoundPeer> Neighbors(Peer target, int k)
+        public IEnumerable<BoundPeer> Neighbors(Peer target, int k)
         {
             return Neighbors(target.Address, k);
         }
 
         // returns k nearest peers to given parameter peer from routing table.
         // return value is already sorted with respect to target.
-        public ICollection<BoundPeer> Neighbors(Address target, int k)
+        public IEnumerable<BoundPeer> Neighbors(Address target, int k)
         {
             var sorted = _buckets
                 .Where(b => !b.IsEmpty())

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Nito.AsyncEx;
 using Serilog;
@@ -68,7 +69,9 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        public async Task<BoundPeer> AddPeerAsync(BoundPeer peer)
+        public async Task<BoundPeer> AddPeerAsync(
+            BoundPeer peer,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (peer is null)
             {
@@ -84,7 +87,7 @@ namespace Libplanet.Net.Protocols
             BoundPeer evicted;
 
             // lock required
-            using (await _bucketMutex.LockAsync())
+            using (await _bucketMutex.LockAsync(cancellationToken))
             {
                 evicted = _buckets[index].AddPeer(peer);
             }
@@ -92,7 +95,9 @@ namespace Libplanet.Net.Protocols
             return evicted;
         }
 
-        public async Task<bool> RemovePeerAsync(BoundPeer peer)
+        public async Task<bool> RemovePeerAsync(
+            BoundPeer peer,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (peer is null)
             {
@@ -108,7 +113,7 @@ namespace Libplanet.Net.Protocols
             bool ret;
 
             // lock required
-            using (await _bucketMutex.LockAsync())
+            using (await _bucketMutex.LockAsync(cancellationToken))
             {
                 ret = _buckets[index].RemovePeer(peer);
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -497,12 +497,14 @@ namespace Libplanet.Net
            IEnumerable<Peer> seedPeers,
            double pingSeedTimeout,
            double findPeerTimeout,
+           int depth = Kademlia.MaxDepth,
            CancellationToken cancellationToken = default(CancellationToken))
         {
             await BootstrapAsync(
                 seedPeers,
                 TimeSpan.FromMilliseconds(pingSeedTimeout),
                 TimeSpan.FromMilliseconds(findPeerTimeout),
+                depth,
                 cancellationToken);
         }
 
@@ -512,6 +514,8 @@ namespace Libplanet.Net
         /// <param name="seedPeers">List of seed peers.</param>
         /// <param name="pingSeedTimeout">Timeout for connecting to seed peers.</param>
         /// <param name="findNeighborsTimeout">Timeout for requesting neighbors.</param>
+        /// <param name="depth">Depth to find neighbors of current <see cref="Peer"/>
+        /// from seed peers.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
@@ -521,6 +525,7 @@ namespace Libplanet.Net
             IEnumerable<Peer> seedPeers,
             TimeSpan? pingSeedTimeout,
             TimeSpan? findNeighborsTimeout,
+            int depth = Kademlia.MaxDepth,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (seedPeers is null)
@@ -534,6 +539,7 @@ namespace Libplanet.Net
                 peers.ToImmutableList(),
                 pingSeedTimeout,
                 findNeighborsTimeout,
+                depth,
                 cancellationToken);
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -437,6 +437,7 @@ namespace Libplanet.Net
             _broadcastQueue.ReceiveReady += DoBroadcast;
 
             _logger.Debug("Starting swarm...");
+            _logger.Debug("Peer information : {Peer}", AsPeer);
 
             using (await _runningMutex.LockAsync())
             {
@@ -2177,9 +2178,9 @@ namespace Libplanet.Net
             {
                 dealer.Options.Linger = Timeout.InfiniteTimeSpan;
                 _logger.Debug(
-                    "Trying to send {Message} to {PeerAddress}...",
+                    "Trying to send {Message} to {Peer}...",
                     req.Message,
-                    req.Peer.Address
+                    req.Peer
                 );
                 var message = req.Message.ToNetMQMessage(_privateKey, AsPeer);
                 var result = new List<Message>();


### PR DESCRIPTION
Previously protocol is tested with swarm, thus it is unsure whether the error is caused by network or protocol. Added `ISwarm` interface and `TestSwarm` which act like network, so cause of error is more clear.

Additionally, bootstrap procedure became faster by preventing peer to re-send `FindNeighbors` request to same peer.