### PR TITLE
Move BlockChain<T>.Contains(TxId) to IStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Removed `LiteDBStore` class.  Use `DefaultStore` instead.  [[#662]]
+ -  Removed `BlockChain<T>.Contains(TxId)` method.
+    Use `IStore.ContainsTransaction(TxId)` instead.  [[#676]]
 
 ### Backward-incompatible network protocol changes
 
@@ -31,6 +33,7 @@ To be released.
 
 [#662]: https://github.com/planetarium/libplanet/pull/662
 [#675]: https://github.com/planetarium/libplanet/pull/675
+[#676]: https://github.com/planetarium/libplanet/pull/676
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -165,12 +165,13 @@ namespace Libplanet.Tests.Blockchain
                 _fx.Transaction1,
                 _fx.Transaction2,
             };
-            Assert.Empty(txs.Where(tx => _blockChain.Contains(tx.Id)));
+            Assert.Empty(txs.Where(tx => _fx.Store.ContainsTransaction(tx.Id)));
 
             _blockChain.StageTransactions(txs.ToImmutableHashSet());
             Assert.Equal(
                 txs,
-                txs.Where(tx => _blockChain.Contains(tx.Id)).ToHashSet());
+                txs.Where(tx => _fx.Store.ContainsTransaction(tx.Id)).ToHashSet()
+            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -201,6 +201,8 @@ namespace Libplanet.Tests.Store
             Assert.Null(Fx.Store.GetTransaction<DumbAction>(Fx.Transaction1.Id));
             Assert.Null(Fx.Store.GetTransaction<DumbAction>(Fx.Transaction2.Id));
             Assert.False(Fx.Store.DeleteTransaction(Fx.Transaction1.Id));
+            Assert.False(Fx.Store.ContainsTransaction(Fx.Transaction1.Id));
+            Assert.False(Fx.Store.ContainsTransaction(Fx.Transaction2.Id));
 
             Fx.Store.PutTransaction(Fx.Transaction1);
             Assert.Equal(1, Fx.Store.CountTransactions());
@@ -216,6 +218,8 @@ namespace Libplanet.Tests.Store
                 Fx.Store.GetTransaction<DumbAction>(Fx.Transaction1.Id)
             );
             Assert.Null(Fx.Store.GetTransaction<DumbAction>(Fx.Transaction2.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction1.Id));
+            Assert.False(Fx.Store.ContainsTransaction(Fx.Transaction2.Id));
 
             Fx.Store.PutTransaction(Fx.Transaction2);
             Assert.Equal(2, Fx.Store.CountTransactions());
@@ -234,6 +238,8 @@ namespace Libplanet.Tests.Store
             Assert.Equal(
                 Fx.Transaction2,
                 Fx.Store.GetTransaction<DumbAction>(Fx.Transaction2.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction1.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction2.Id));
 
             Assert.True(Fx.Store.DeleteTransaction(Fx.Transaction1.Id));
             Assert.Equal(1, Fx.Store.CountTransactions());
@@ -249,6 +255,8 @@ namespace Libplanet.Tests.Store
                 Fx.Transaction2,
                 Fx.Store.GetTransaction<DumbAction>(Fx.Transaction2.Id)
             );
+            Assert.False(Fx.Store.ContainsTransaction(Fx.Transaction1.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction2.Id));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -156,6 +156,12 @@ namespace Libplanet.Tests.Store
             _store.PutTransaction<T>(tx);
         }
 
+        public bool ContainsTransaction(TxId txId)
+        {
+            _logs.Add((nameof(ContainsTransaction), txId, null));
+            return _store.ContainsTransaction(txId);
+        }
+
         public void SetBlockStates(
             HashDigest<SHA256> blockHash,
             AddressStateMap states

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -240,29 +240,6 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Determines whether the <see cref="BlockChain{T}"/> contains <see cref="Transaction{T}"/>
-        /// the specified <paramref name="txId"/>.
-        /// </summary>
-        /// <param name="txId">The <see cref="HashDigest{T}"/> of the <see cref="Transaction{T}"/>
-        /// to check if it is in the <see cref="BlockChain{T}"/>.</param>
-        /// <returns>
-        /// <c>true</c> if the <see cref="BlockChain{T}"/> contains <see cref="Transaction{T}"/>
-        /// with the specified <paramref name="txId"/>; otherwise, <c>false</c>.
-        /// </returns>
-        public bool Contains(TxId txId)
-        {
-            _rwlock.EnterReadLock();
-            try
-            {
-                return _transactions.ContainsKey(txId);
-            }
-            finally
-            {
-                _rwlock.ExitReadLock();
-            }
-        }
-
-        /// <summary>
         /// Gets the transaction corresponding to the <paramref name="txId"/>.
         /// </summary>
         /// <param name="txId">A <see cref="TxId"/> of the <see cref="Transaction{T}"/> to get.

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -158,6 +158,9 @@ namespace Libplanet.Store
 
         public abstract bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash);
 
+        /// <inheritdoc />
+        public abstract bool ContainsTransaction(TxId txId);
+
         /// <inheritdoc/>
         public abstract void DeleteChainId(Guid chainId);
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -360,6 +360,17 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public override bool ContainsTransaction(TxId txId)
+        {
+            if (_txCache.ContainsKey(txId))
+            {
+                return true;
+            }
+
+            return _root.FileExists(TxPath(txId));
+        }
+
+        /// <inheritdoc/>
         public override IEnumerable<HashDigest<SHA256>> IterateBlockHashes()
         {
             foreach (UPath path in _blocks.EnumerateDirectories(UPath.Root))

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -301,6 +301,18 @@ namespace Libplanet.Store
         /// <seealso cref="GetTxNonce(Guid, Address)"/>
         void IncreaseTxNonce(Guid chainId, Address signer, long delta = 1);
 
+        /// <summary>
+        /// Determines whether the <see cref="IStore"/> contains <see cref="Transaction{T}"/>
+        /// the specified <paramref name="txId"/>.
+        /// </summary>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>
+        /// to check if it is in the <see cref="IStore"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the <see cref="IStore"/> contains <see cref="Transaction{T}"/>
+        /// with the specified <paramref name="txId"/>; otherwise, <c>false</c>.
+        /// </returns>
+        bool ContainsTransaction(TxId txId);
+
         long CountTransactions();
 
         long CountBlocks();

--- a/Libplanet/Store/TransactionSet.cs
+++ b/Libplanet/Store/TransactionSet.cs
@@ -65,12 +65,12 @@ namespace Libplanet.Store
 
         public override bool Contains(KeyValuePair<TxId, Transaction<T>> item)
         {
-            return Store.IterateTransactionIds().Contains(item.Key);
+            return Store.ContainsTransaction(item.Key);
         }
 
         public override bool ContainsKey(TxId key)
         {
-            return Store.GetTransaction<T>(key) is Transaction<T>;
+            return Store.ContainsTransaction(key);
         }
 
         public override bool Remove(TxId key)


### PR DESCRIPTION
This PR moves `BlockChain<T>.Contains(TxId)` to `IStore` to separate the global transaction view from `BlockChain<T>`.