### PR TITLE
Refactor block related features in BlockChain<T> and IStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@ To be released.
  -  Removed `LiteDBStore` class.  Use `DefaultStore` instead.  [[#662]]
  -  Removed `BlockChain<T>.Contains(TxId)` method.
     Use `IStore.ContainsTransaction(TxId)` instead.  [[#676]]
+ -  Renamed `BlockChain<T>.Contains(HashDigest<SHA256>)` method to
+    `BlockChain<T>.ContainsBlock(HashDigest<SHA256>)`.  [[#678]]
+ -  Removed `BlockChain<T>.Contains(Block<T>)` method.  [[#678]]
+ -  Changed semantics of `BlockChain<T>.ContainsBlock(HashDigest<SHA256>)`
+    method and `BlockChain<T>[HashDigest<SHA256>]` indexer as lookups only
+    the current chain, not entire storage.  [[#678]]
+ -  Added `IStore.ContainsBlock(HashDigest<SHA256>)` method.  [[#678]]
 
 ### Backward-incompatible network protocol changes
 
@@ -34,6 +41,7 @@ To be released.
 [#662]: https://github.com/planetarium/libplanet/pull/662
 [#675]: https://github.com/planetarium/libplanet/pull/675
 [#676]: https://github.com/planetarium/libplanet/pull/676
+[#678]: https://github.com/planetarium/libplanet/pull/678
 
 
 Version 0.7.0

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -11,7 +11,6 @@ namespace Libplanet.Benchmarks
 {
     public class BlockChain
     {
-        
         private StoreFixture _fx;
         private BlockChain<DumbAction> _blockChain;
 

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Libplanet.Blockchain;
+using Libplanet.Tests.Blockchain;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+
+namespace Libplanet.Benchmarks
+{
+    public class BlockChain
+    {
+        
+        private StoreFixture _fx;
+        private BlockChain<DumbAction> _blockChain;
+
+        public BlockChain()
+        {
+        }
+
+        [IterationCleanup]
+        public void FinalizeFixture()
+        {
+            _fx.Dispose();
+        }
+
+        [IterationSetup(Target = nameof(ContainsBlock))]
+        public void SetupChain()
+        {
+            _fx = new DefaultStoreFixture();
+            _blockChain = new BlockChain<DumbAction>(new NullPolicy<DumbAction>(), _fx.Store);
+            for (var i = 0; i < 500; i++)
+            {
+                _blockChain.MineBlock(_fx.Address1).Wait();
+            }
+        }
+
+        [Benchmark]
+        public void ContainsBlock()
+        {
+            _blockChain.ContainsBlock(_blockChain.Tip.Hash);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -42,11 +42,13 @@ namespace Libplanet.Tests.Blockchain
         {
             Block<DumbAction> block = await _blockChain.MineBlock(_fx.Address1);
             block.Validate(DateTimeOffset.UtcNow);
-            Assert.True(_blockChain.Contains(block));
+
+            Assert.True(_blockChain.ContainsBlock(block.Hash));
 
             Block<DumbAction> anotherBlock = await _blockChain.MineBlock(_fx.Address2);
             anotherBlock.Validate(DateTimeOffset.UtcNow);
-            Assert.True(_blockChain.Contains(anotherBlock));
+
+            Assert.True(_blockChain.ContainsBlock(anotherBlock.Hash));
         }
 
         [Fact]
@@ -93,7 +95,8 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.StageTransactions(txs.ToImmutableHashSet());
             Block<DumbAction> block = await _blockChain.MineBlock(_fx.Address1);
-            Assert.True(_blockChain.Contains(block));
+
+            Assert.True(_blockChain.ContainsBlock(block.Hash));
             Assert.Contains(txs[0], block.Transactions);
             Assert.Contains(txs[1], block.Transactions);
             Assert.DoesNotContain(txs[2], block.Transactions);
@@ -299,7 +302,8 @@ namespace Libplanet.Tests.Blockchain
             try
             {
                 _blockChain.Append(genesis);
-                Assert.True(_blockChain.Contains(genesis));
+
+                Assert.True(_blockChain.ContainsBlock(genesis.Hash));
                 Assert.NotNull(_blockChain.Store.GetBlockStates(genesis.Hash));
                 Assert.Empty(DumbAction.RenderRecords.Value);
 
@@ -310,7 +314,7 @@ namespace Libplanet.Tests.Blockchain
                 );
 
                 _blockChain.Append(block1);
-                Assert.True(_blockChain.Contains(block1));
+                Assert.True(_blockChain.ContainsBlock(block1.Hash));
                 Assert.NotNull(_blockChain.Store.GetBlockStates(block1.Hash));
                 var renders = DumbAction.RenderRecords.Value;
                 var actions = renders.Select(r => (DumbAction)r.Action).ToArray();
@@ -403,7 +407,7 @@ namespace Libplanet.Tests.Blockchain
                         renderActions: true
                     )
                 );
-                Assert.False(_blockChain.Contains(genesis));
+                Assert.False(_blockChain.ContainsBlock(genesis.Hash));
                 Assert.Empty(DumbAction.RenderRecords.Value);
 
                 _blockChain.Append(

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -137,6 +137,9 @@ namespace Libplanet.Tests.Store
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
             Assert.False(Fx.Store.DeleteBlock(Fx.Block1.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block1.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block2.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block3.Hash));
 
             Fx.Store.PutBlock(Fx.Block1);
             Assert.Equal(1, Fx.Store.CountBlocks());
@@ -154,6 +157,9 @@ namespace Libplanet.Tests.Store
             Assert.Equal(Fx.Block1.Index, Fx.Store.GetBlockIndex(Fx.Block1.Hash));
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block1.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block2.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block3.Hash));
 
             Fx.Store.PutBlock(Fx.Block2);
             Assert.Equal(2, Fx.Store.CountBlocks());
@@ -174,6 +180,9 @@ namespace Libplanet.Tests.Store
             Assert.Equal(Fx.Block1.Index, Fx.Store.GetBlockIndex(Fx.Block1.Hash));
             Assert.Equal(Fx.Block2.Index, Fx.Store.GetBlockIndex(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block1.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block2.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block3.Hash));
 
             Assert.True(Fx.Store.DeleteBlock(Fx.Block1.Hash));
             Assert.Equal(1, Fx.Store.CountBlocks());
@@ -191,6 +200,9 @@ namespace Libplanet.Tests.Store
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block1.Hash));
             Assert.Equal(Fx.Block2.Index, Fx.Store.GetBlockIndex(Fx.Block2.Hash));
             Assert.Null(Fx.Store.GetBlockIndex(Fx.Block3.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block1.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block2.Hash));
+            Assert.False(Fx.Store.ContainsBlock(Fx.Block3.Hash));
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -56,6 +56,12 @@ namespace Libplanet.Tests.Store
             return _store.DeleteBlock(blockHash);
         }
 
+        public bool ContainsBlock(HashDigest<SHA256> blockHash)
+        {
+            _logs.Add((nameof(ContainsBlock), blockHash, null));
+            return _store.ContainsBlock(blockHash);
+        }
+
         public bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash)
         {
             _logs.Add((nameof(DeleteIndex), chainId, hash));

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -107,6 +107,9 @@ namespace Libplanet.Store
 
         public abstract bool DeleteBlock(HashDigest<SHA256> blockHash);
 
+        /// <inheritdoc />
+        public abstract bool ContainsBlock(HashDigest<SHA256> blockHash);
+
         public abstract AddressStateMap GetBlockStates(
             HashDigest<SHA256> blockHash
         );

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -60,12 +60,12 @@ namespace Libplanet.Store
         public override bool Contains(
             KeyValuePair<HashDigest<SHA256>, Block<T>> item)
         {
-            return Store.IterateBlockHashes().Contains(item.Key);
+            return Store.ContainsBlock(item.Key);
         }
 
         public override bool ContainsKey(HashDigest<SHA256> key)
         {
-            return Store.GetBlock<T>(key) is Block<T>;
+            return Store.ContainsBlock(key);
         }
 
         public override bool Remove(HashDigest<SHA256> key)

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -444,6 +444,18 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public override bool ContainsBlock(HashDigest<SHA256> blockHash)
+        {
+            if (_blockCache.ContainsKey(blockHash))
+            {
+                return true;
+            }
+
+            UPath blockPath = BlockPath(blockHash);
+            return _root.FileExists(blockPath);
+        }
+
+        /// <inheritdoc/>
         public override AddressStateMap GetBlockStates(HashDigest<SHA256> blockHash)
         {
             LiteFileInfo file =

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -165,6 +165,18 @@ namespace Libplanet.Store
         bool DeleteBlock(HashDigest<SHA256> blockHash);
 
         /// <summary>
+        /// Determines whether the <see cref="IStore"/> contains <see cref="Block{T}"/>
+        /// the specified <paramref name="blockHash"/>.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="HashDigest{T}"/> of the <see cref="Block{T}"/> to
+        /// check if it is in the <see cref="IStore"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the <see cref="IStore"/> contains <see cref="Block{T}"/> with
+        /// the specified <paramref name="blockHash"/>; otherwise, <c>false</c>.
+        /// </returns>
+        bool ContainsBlock(HashDigest<SHA256> blockHash);
+
+        /// <summary>
         /// Gets the states updated by actions in the inquired block.
         /// </summary>
         /// <param name="blockHash"><see cref="Block{T}.Hash"/> to query.


### PR DESCRIPTION
This PR makes some changes in block related features in `BlockChain<T>` and `IStore` to distinguish `BlockChain<T>.ContainsBlock` and `IStore.ContainsBlock()`.