### PR TITLE
Fix a bug in DefaultStore.ContainsBlock and ContainsTransaction

### DIFF
--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Store
                 );
             }
 
-            Store = new DefaultStore(Path);
+            Store = new DefaultStore(Path, blockCacheSize: 2, txCacheSize: 2);
         }
 
         public string Path { get; }

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -91,6 +91,7 @@ namespace Libplanet.Tests.Store
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
             Transaction2 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
+            Transaction3 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
         }
 
         public Guid StoreChainId { get; }
@@ -126,6 +127,8 @@ namespace Libplanet.Tests.Store
         public Transaction<DumbAction> Transaction1 { get; }
 
         public Transaction<DumbAction> Transaction2 { get; }
+
+        public Transaction<DumbAction> Transaction3 { get; }
 
         public IStore Store { get; set; }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -719,6 +719,30 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
+        public void ContainsBlockWithoutCache()
+        {
+            Fx.Store.PutBlock(Fx.Block1);
+            Fx.Store.PutBlock(Fx.Block2);
+            Fx.Store.PutBlock(Fx.Block3);
+
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block1.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block2.Hash));
+            Assert.True(Fx.Store.ContainsBlock(Fx.Block3.Hash));
+        }
+
+        [Fact]
+        public void ContainsTransactionWithoutCache()
+        {
+            Fx.Store.PutTransaction(Fx.Transaction1);
+            Fx.Store.PutTransaction(Fx.Transaction2);
+            Fx.Store.PutTransaction(Fx.Transaction3);
+
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction1.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction2.Id));
+            Assert.True(Fx.Store.ContainsTransaction(Fx.Transaction3.Id));
+        }
+
+        [Fact]
         public void TxAtomicity()
         {
             Transaction<AtomicityTestAction> MakeTx(


### PR DESCRIPTION
This PR fixes a bug that `DefaultStore.ContainsBlock()` and `.ContainsTransaction()` hadn't worked properly if the block or transaction hadn't existed in the cache.

I omit the changelog because `DefaultStore` was introduced in 0.8.0 isn't released.