### PR TITLE
Provide genesis block API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ To be released.
     to take `preloadBlockDownloadFailed` event handler as an argument.
     [[#694]]
  -  Removed `StoreExtension.ListAllStateReferences<T>()` method.  [[#701]]
+ -  Added the `genesisBlock` parameter to
+    `BlockChain<T>()` constructor.  [[#688]]
 
 ### Backward-incompatible network protocol changes
 
@@ -43,6 +45,9 @@ To be released.
 
  -  Added `DefaultStore` class to replace `LiteDBStore`.  [[#662]]
  -  Added `IStore.ListAllStateReferences<T>()` method.  [[#701]]
+ -  Added `BlockChain<T>.Genesis` property.  [[#688]]
+ -  Added `BlockChain<T>.MakeGenesisBlock()` static method.  [[#688]]
+ -  Added `InvalidGenesisBlockException` class.  [[#688]]
 
 ### Behavioral changes
 
@@ -70,6 +75,7 @@ To be released.
 [#679]: https://github.com/planetarium/libplanet/pull/679
 [#680]: https://github.com/planetarium/libplanet/pull/680
 [#685]: https://github.com/planetarium/libplanet/pull/685
+[#688]: https://github.com/planetarium/libplanet/pull/688
 [#692]: https://github.com/planetarium/libplanet/pull/692
 [#694]: https://github.com/planetarium/libplanet/pull/694
 [#701]: https://github.com/planetarium/libplanet/pull/701

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Blockchain;
+using Libplanet.Crypto;
 using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
@@ -28,7 +29,10 @@ namespace Libplanet.Benchmarks
         public void SetupChain()
         {
             _fx = new DefaultStoreFixture();
-            _blockChain = new BlockChain<DumbAction>(new NullPolicy<DumbAction>(), _fx.Store);
+            _blockChain = new BlockChain<DumbAction>(
+                new NullPolicy<DumbAction>(),
+                _fx.Store,
+                _fx.GenesisBlock);
             for (var i = 0; i < 500; i++)
             {
                 _blockChain.MineBlock(_fx.Address1).Wait();

--- a/Libplanet.Benchmarks/MineBlock.cs
+++ b/Libplanet.Benchmarks/MineBlock.cs
@@ -19,7 +19,8 @@ namespace Libplanet.Benchmarks
             _fx = new DefaultStoreFixture();
             _blockChain = new BlockChain<DumbAction>(
                 new NullPolicy<DumbAction>(),
-                _fx.Store
+                _fx.Store,
+                _fx.GenesisBlock
             );
         }
 

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -121,12 +121,13 @@ namespace Libplanet.Benchmarks
                 0x13, 0xf2,
             });
 
+            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
             var tasks = new List<Task>();
             for (int i = 0; i < SwarmNumber; i++)
             {
                 _keys[i] = _keys[i] ?? new PrivateKey();
                 _fxs[i] = new DefaultStoreFixture(memory: true);
-                _blockChains[i] = new BlockChain<DumbAction>(_policy, _fxs[i].Store);
+                _blockChains[i] = new BlockChain<DumbAction>(_policy, _fxs[i].Store, _blocks[0]);
                 _swarms[i] = new Swarm<DumbAction>(
                     _blockChains[i],
                     _keys[i],
@@ -143,7 +144,6 @@ namespace Libplanet.Benchmarks
                     .Wait(WaitTimeout);
             }
 
-            _blockChains[0].Append(_blocks[0]);
             _blockChains[0].Append(_blocks[1]);
             _blockChains[0].Append(_blocks[2]);
             _blockChains[0].Append(_blocks[3]);

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -84,8 +84,8 @@ namespace Libplanet.Tests.Store
                 0x9c, 0xee,
             });
 
-            // FIXME: Following names are misleading, because we index the genesis block 0, not 1.
-            Block1 = TestUtils.MineGenesis<DumbAction>();
+            GenesisBlock = TestUtils.MineGenesis<DumbAction>();
+            Block1 = TestUtils.MineNext(GenesisBlock);
             Block2 = TestUtils.MineNext(Block1);
             Block3 = TestUtils.MineNext(Block2);
 
@@ -117,6 +117,8 @@ namespace Libplanet.Tests.Store
         public HashDigest<SHA256> Hash2 { get; }
 
         public HashDigest<SHA256> Hash3 { get; }
+
+        public Block<DumbAction> GenesisBlock { get; }
 
         public Block<DumbAction> Block1 { get; }
 

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -6,7 +6,11 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Store;
 using Libplanet.Tx;
 using Xunit;
 
@@ -107,7 +111,9 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             Block<T> previousBlock,
             IEnumerable<Transaction<T>> txs = null,
             byte[] nonce = null,
-            long difficulty = 1
+            long difficulty = 1,
+            Address? miner = null,
+            TimeSpan? blockInterval = null
         )
             where T : IAction, new()
         {
@@ -118,15 +124,15 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
             long index = previousBlock.Index + 1;
             HashDigest<SHA256> previousHash = previousBlock.Hash;
-            DateTimeOffset timestamp = previousBlock.Timestamp.AddDays(1);
-            Address miner = previousBlock.Miner.Value;
+            DateTimeOffset timestamp =
+                previousBlock.Timestamp.Add(blockInterval ?? TimeSpan.FromDays(1));
 
             if (nonce == null)
             {
                 return Block<T>.Mine(
                     index: index,
                     difficulty: difficulty,
-                    miner: miner,
+                    miner: miner ?? previousBlock.Miner.Value,
                     previousHash: previousHash,
                     timestamp: timestamp,
                     transactions: txs
@@ -137,7 +143,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 index: index,
                 difficulty: difficulty,
                 nonce: new Nonce(nonce),
-                miner: miner,
+                miner: miner ?? previousBlock.Miner.Value,
                 previousHash: previousHash,
                 timestamp: timestamp,
                 transactions: txs
@@ -149,6 +155,41 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return new string(
                 bitArray.OfType<bool>().Select(b => b ? '1' : '0').ToArray()
             );
+        }
+
+        public static BlockChain<T> MakeBlockChain<T>(
+            IBlockPolicy<T> policy,
+            IStore store,
+            IEnumerable<T> actions = null,
+            PrivateKey privateKey = null,
+            DateTimeOffset? timestamp = null)
+            where T : IAction, new()
+        {
+            actions = actions ?? ImmutableArray<T>.Empty;
+            privateKey = privateKey ?? new PrivateKey(
+                new byte[]
+                {
+                    0xcf, 0x36, 0xec, 0xf9, 0xe4, 0x7c, 0x87, 0x9a, 0x0d, 0xbf,
+                    0x46, 0xb2, 0xec, 0xd8, 0x3f, 0xd2, 0x76, 0x18, 0x2a, 0xde,
+                    0x02, 0x65, 0x82, 0x5e, 0x3b, 0x8c, 0x6b, 0xa2, 0x14, 0x46,
+                    0x7b, 0x76,
+                }
+            );
+
+            var tx = Transaction<T>.Create(
+                0,
+                privateKey,
+                actions,
+                timestamp: timestamp ?? DateTimeOffset.MinValue);
+            var genesisBlock = new Block<T>(
+                0,
+                0,
+                new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }),
+                GenesisMinerAddress,
+                null,
+                timestamp ?? DateTimeOffset.MinValue,
+                new[] { tx, });
+            return new BlockChain<T>(policy, store, genesisBlock);
         }
     }
 }

--- a/Libplanet/Blocks/InvalidGenesisBlockException.cs
+++ b/Libplanet/Blocks/InvalidGenesisBlockException.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.Contracts;
+using System.Security.Cryptography;
+#pragma warning disable S1128 // Remove this unnecessary 'using'
+using Libplanet.Blockchain;
+using Libplanet.Store;
+#pragma warning restore S1128 // Remove this unnecessary 'using'
+
+namespace Libplanet.Blocks
+{
+    /// <summary>
+    /// The exception that is thrown when the genesis block the <see cref="IStore"/> contains
+    /// mismatches to the genesis block the <see cref="BlockChain{T}"/> constructor (i.e., network)
+    /// expects.
+    /// </summary>
+    public class InvalidGenesisBlockException : InvalidBlockException
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="InvalidGenesisBlockException"/> class.
+        /// </summary>
+        /// <param name="networkExpected">The genesis block that the network expects.</param>
+        /// <param name="stored">The genesis block that a local <see cref="IStore"/> contains.
+        /// </param>
+        /// <param name="message">The message that describes the error.</param>
+        public InvalidGenesisBlockException(
+            HashDigest<SHA256> networkExpected,
+            HashDigest<SHA256> stored,
+            string message)
+            : base(message)
+        {
+            NetworkExpected = networkExpected;
+            Stored = stored;
+        }
+
+        /// <summary>
+        /// The genesis block that the network expects.
+        /// </summary>
+        [Pure]
+        public HashDigest<SHA256> NetworkExpected { get; }
+
+        /// <summary>
+        /// The genesis block that a local <see cref="IStore"/> contains.
+        /// </summary>
+        [Pure]
+        public HashDigest<SHA256> Stored { get; }
+    }
+}

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -251,8 +251,13 @@ namespace Libplanet.Store
             LiteCollection<HashDoc> srcColl = IndexCollection(sourceChainId);
             LiteCollection<HashDoc> destColl = IndexCollection(destinationChainId);
 
-            destColl.InsertBulk(srcColl.FindAll().TakeWhile(i => !i.Hash.Equals(branchPoint)));
-            AppendIndex(destinationChainId, branchPoint);
+            var genesisHash = IterateIndexes(sourceChainId, 0, 1).First();
+            destColl.InsertBulk(srcColl.FindAll()
+                .TakeWhile(i => !i.Hash.Equals(branchPoint)).Skip(1));
+            if (!branchPoint.Equals(genesisHash))
+            {
+                AppendIndex(destinationChainId, branchPoint);
+            }
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -122,32 +122,7 @@ namespace Libplanet.Tx
         {
         }
 
-        // ReSharper disable once UnusedMember.Local
-        private Transaction(SerializationInfo info, StreamingContext context)
-            : this(new RawTransaction(info, context))
-        {
-        }
-
-        private Transaction(
-            long nonce,
-            Address signer,
-            PublicKey publicKey,
-            IImmutableSet<Address> updatedAddresses,
-            DateTimeOffset timestamp,
-            IEnumerable<T> actions)
-            : this(
-                nonce,
-                signer,
-                publicKey,
-                updatedAddresses,
-                timestamp,
-                actions.ToImmutableList(),
-                new byte[0],
-                false)
-        {
-        }
-
-        private Transaction(
+        internal Transaction(
             long nonce,
             Address signer,
             PublicKey publicKey,
@@ -179,6 +154,30 @@ namespace Libplanet.Tx
             {
                 Validate();
             }
+        }
+
+        private Transaction(SerializationInfo info, StreamingContext context)
+            : this(new RawTransaction(info, context))
+        {
+        }
+
+        private Transaction(
+            long nonce,
+            Address signer,
+            PublicKey publicKey,
+            IImmutableSet<Address> updatedAddresses,
+            DateTimeOffset timestamp,
+            IEnumerable<T> actions)
+            : this(
+                nonce,
+                signer,
+                publicKey,
+                updatedAddresses,
+                timestamp,
+                actions.ToImmutableList(),
+                new byte[0],
+                false)
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
In this pull-request, `BlockChain` became to have *genesis-block*. Also it doesn't allow to create new chain for another chain, having other genesis-block, during fork, because we can't know before append.