### PR TITLE
Add PreloadBlockDownloadFailed event handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ To be released.
      -  `IStore.SetBlockStates()` method became to take
         `IImmutableDictionary<Address, IValue>` instead of `AddressStateMap`.
  -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
-    to receive `preloadBlockDownloadFailed` event handler as a parameter.
+    to take `preloadBlockDownloadFailed` event handler as an argument.
     [[#693]]
 
 ### Backward-incompatible network protocol changes
@@ -49,9 +49,9 @@ To be released.
  -  `Swarm<T>` became to send 100 blocks (instead of 500 blocks) for each
     reply during IDL, in order to stabilize connection in high latency
     environments.  [[#679]]
- -  When the block downloading fails in `Swarm<T>.PreloadAsync()` method,
+ -  When `Swarm<T>.PreloadAsync()` method fails to download blocks,
     `Swarm<T>` became to call `preloadBlockDownloadFailed` event handler
-    received as a parameter. If the event handler doesn't exist, `Swarm<T>`
+    taken as an argument.  If the event handler is not present, `Swarm<T>`
     throws `SwarmException`.  [[#693]]
 
 ### Bug fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@ To be released.
         `IImmutableDictionary<Address, IValue>` instead of `AddressStateMap`.
  -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
     to take `preloadBlockDownloadFailed` event handler as an argument.
-    [[#693]]
+    [[#694]]
 
 ### Backward-incompatible network protocol changes
 
@@ -52,7 +52,7 @@ To be released.
  -  When `Swarm<T>.PreloadAsync()` method fails to download blocks,
     `Swarm<T>` became to call `preloadBlockDownloadFailed` event handler
     taken as an argument.  If the event handler is not present, `Swarm<T>`
-    throws `SwarmException`.  [[#693]]
+    throws `SwarmException`.  [[#694]]
 
 ### Bug fixes
 
@@ -69,7 +69,7 @@ To be released.
 [#680]: https://github.com/planetarium/libplanet/pull/680
 [#685]: https://github.com/planetarium/libplanet/pull/685
 [#692]: https://github.com/planetarium/libplanet/pull/692
-[#693]: https://github.com/planetarium/libplanet/pull/693
+[#694]: https://github.com/planetarium/libplanet/pull/694
 
 
 Version 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ To be released.
         `IImmutableDictionary<Address, IValue>` (was `AddressStateMap`).
      -  `IStore.SetBlockStates()` method became to take
         `IImmutableDictionary<Address, IValue>` instead of `AddressStateMap`.
+ -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
+    to receive `preloadBlockDownloadFailed` event handler as a parameter.
+    [[#693]]
 
 ### Backward-incompatible network protocol changes
 
@@ -46,6 +49,10 @@ To be released.
  -  `Swarm<T>` became to send 100 blocks (instead of 500 blocks) for each
     reply during IDL, in order to stabilize connection in high latency
     environments.  [[#679]]
+ -  When the block downloading fails in `Swarm<T>.PreloadAsync()` method,
+    `Swarm<T>` became to call `preloadBlockDownloadFailed` event handler
+    received as a parameter. If the event handler doesn't exist, `Swarm<T>`
+    throws `SwarmException`.  [[#693]]
 
 ### Bug fixes
 
@@ -62,6 +69,7 @@ To be released.
 [#680]: https://github.com/planetarium/libplanet/pull/680
 [#685]: https://github.com/planetarium/libplanet/pull/685
 [#692]: https://github.com/planetarium/libplanet/pull/692
+[#693]: https://github.com/planetarium/libplanet/pull/693
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1667,7 +1667,7 @@ namespace Libplanet.Tests.Net
 
                 t = receiverSwarm.PreloadAsync(
                     TimeSpan.FromSeconds(15),
-                    preloadBlockDownloadFailed: Handler);
+                    blockDownloadFailed: Handler);
                 await receiverSwarm.PreloadStarted.WaitAsync();
                 await StopAsync(minerSwarm);
                 await t;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1629,6 +1629,56 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [Fact]
+        public async Task PreloadFailed()
+        {
+            Swarm<DumbAction> minerSwarm = _swarms[0];
+            Swarm<DumbAction> receiverSwarm = _swarms[1];
+
+            foreach (var unused in Enumerable.Range(0, 10))
+            {
+                await minerSwarm.BlockChain.MineBlock(_fx1.Address1);
+            }
+
+            receiverSwarm.BlockHashRecvTimeout = TimeSpan.FromMilliseconds(10);
+
+            var isCalled = false;
+            void Handler(object sender, PreloadBlockDownloadFailEventArgs e)
+            {
+                if (e.InnerExceptions.All(ex => ex is TimeoutException))
+                {
+                    isCalled = true;
+                }
+            }
+
+            try
+            {
+                // SwarmException should be thrown if event handler doesn't exist.
+                await StartAsync(minerSwarm);
+
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                var t = receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15));
+                await receiverSwarm.PreloadStarted.WaitAsync();
+                await StopAsync(minerSwarm);
+                await Assert.ThrowsAsync<AggregateException>(async () => await t);
+
+                // Event handler should be called if it exists.
+                await StartAsync(minerSwarm);
+
+                t = receiverSwarm.PreloadAsync(
+                    TimeSpan.FromSeconds(15),
+                    preloadBlockDownloadFailed: Handler);
+                await receiverSwarm.PreloadStarted.WaitAsync();
+                await StopAsync(minerSwarm);
+                await t;
+                Assert.True(isCalled);
+            }
+            finally
+            {
+                await StopAsync(minerSwarm);
+            }
+        }
+
         [Fact(Timeout = Timeout)]
         public async Task PreloadFromNominer()
         {
@@ -2324,7 +2374,7 @@ namespace Libplanet.Tests.Net
         )
             where T : IAction, new()
         {
-            Task task = swarm.StartAsync(200, 200, cancellationToken);
+            Task task = swarm.StartAsync(200, 200, null, cancellationToken);
             await swarm.WaitForRunningAsync();
             return task;
         }

--- a/Libplanet/Net/PreloadBlockDownloadFailEventArgs.cs
+++ b/Libplanet/Net/PreloadBlockDownloadFailEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// The event data that provides value to the event handler which is triggered when the block
+    /// downloading fails during preloading.
+    /// </summary>
+    public class PreloadBlockDownloadFailEventArgs
+    {
+        /// <summary>
+        /// The exceptions thrown while the block downloading in preloading.
+        /// </summary>
+        public IReadOnlyList<Exception> InnerExceptions { get; set; }
+    }
+}

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -342,7 +342,6 @@ namespace Libplanet.Net
             );
         }
 
-#pragma warning disable MEN002 // Line is too long
         /// <summary>
         /// Starts to periodically synchronize the <see cref="BlockChain"/>.
         /// </summary>
@@ -373,7 +372,6 @@ namespace Libplanet.Net
         /// "PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address},
         /// EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"
         /// /> method too.</remarks>
-#pragma warning restore MEN002 // Line is too long
         public async Task StartAsync(
             TimeSpan dialTimeout,
             TimeSpan broadcastTxInterval,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -613,7 +613,7 @@ namespace Libplanet.Net
         /// intended to be exposed to end users through a feasible user
         /// interface so that they can decide whom to trust for themselves.
         /// </param>
-        /// <param name="preloadBlockDownloadFailed">
+        /// <param name="blockDownloadFailed">
         /// The <see cref="EventHandler" /> triggered when block downloading fails.
         /// </param>
         /// <param name="cancellationToken">
@@ -630,13 +630,13 @@ namespace Libplanet.Net
         /// <see cref="StartAsync(TimeSpan, TimeSpan, EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"/>
         /// method instead.</remarks>
         /// <exception cref="AggregateException">Thrown when the given the block downloading is
-        /// failed and if <paramref name="preloadBlockDownloadFailed "/> is <c>null</c>.</exception>
+        /// failed and if <paramref name="blockDownloadFailed "/> is <c>null</c>.</exception>
 #pragma warning restore MEN002 // Line is too long
         public Task PreloadAsync(
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
-            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
+            EventHandler<PreloadBlockDownloadFailEventArgs> blockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
@@ -645,7 +645,7 @@ namespace Libplanet.Net
                 dialTimeout: dialTimeout,
                 progress: progress,
                 trustedStateValidators: trustedStateValidators,
-                preloadBlockDownloadFailed: preloadBlockDownloadFailed,
+                blockDownloadFailed: blockDownloadFailed,
                 cancellationToken: cancellationToken
             );
         }
@@ -656,7 +656,7 @@ namespace Libplanet.Net
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
-            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
+            EventHandler<PreloadBlockDownloadFailEventArgs> blockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
@@ -733,7 +733,7 @@ namespace Libplanet.Net
 
                 if (!blockDownloadComplete)
                 {
-                    if (preloadBlockDownloadFailed is null)
+                    if (blockDownloadFailed is null)
                     {
                         throw new AggregateException(
                             "Failed to download blocks from peers.",
@@ -741,7 +741,7 @@ namespace Libplanet.Net
                     }
                     else
                     {
-                        preloadBlockDownloadFailed.Invoke(
+                        blockDownloadFailed.Invoke(
                             this,
                             new PreloadBlockDownloadFailEventArgs { InnerExceptions = exceptions });
                     }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -112,8 +112,7 @@ namespace Libplanet.Net
             int? listenPort = null,
             DateTimeOffset? createdAt = null,
             IEnumerable<IceServer> iceServers = null,
-            EventHandler<DifferentProtocolVersionEventArgs>
-                differentVersionPeerEncountered = null)
+            EventHandler<DifferentProtocolVersionEventArgs> differentVersionPeerEncountered = null)
         {
             Running = false;
 
@@ -201,7 +200,7 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// The <see cref="EventHandler" /> called when the different version of
+        /// The <see cref="EventHandler" /> triggered when the different version of
         /// <see cref="Peer" /> is discovered.
         /// </summary>
         public event EventHandler<DifferentProtocolVersionEventArgs>
@@ -268,6 +267,8 @@ namespace Libplanet.Net
 
         internal int FindNextHashesChunkSize { get; set; } = 100;
 
+        internal AsyncAutoResetEvent PreloadStarted { get; } = new AsyncAutoResetEvent();
+
         internal AsyncAutoResetEvent FillBlocksAsyncStarted { get; } = new AsyncAutoResetEvent();
 
         internal AsyncAutoResetEvent FillBlocksAsyncFailed { get; } = new AsyncAutoResetEvent();
@@ -330,11 +331,13 @@ namespace Libplanet.Net
         public async Task StartAsync(
             int millisecondsDialTimeout = 15000,
             int millisecondsBroadcastTxInterval = 5000,
+            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             await StartAsync(
                 TimeSpan.FromMilliseconds(millisecondsDialTimeout),
                 TimeSpan.FromMilliseconds(millisecondsBroadcastTxInterval),
+                preloadBlockDownloadFailed: preloadBlockDownloadFailed,
                 cancellationToken
             );
         }
@@ -347,6 +350,12 @@ namespace Libplanet.Net
         /// A timeout value for dialing.
         /// </param>
         /// <param name="broadcastTxInterval">The time period of exchange of staged transactions.
+        /// </param>
+        /// <param name="preloadBlockDownloadFailed">
+        /// The <see cref="EventHandler" /> triggered when
+        /// <see cref="PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address},
+        /// EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)" />
+        /// fails to download blocks.
         /// </param>
         /// /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
@@ -361,12 +370,14 @@ namespace Libplanet.Net
         /// so that there are a lot of calls to <see cref="IAction.Render"/> method in a short
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
         /// these actions in the behind blocks use <see cref=
-        /// "PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address}, CancellationToken)"
+        /// "PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address},
+        /// EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"
         /// /> method too.</remarks>
 #pragma warning restore MEN002 // Line is too long
         public async Task StartAsync(
             TimeSpan dialTimeout,
             TimeSpan broadcastTxInterval,
+            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (Running)
@@ -585,6 +596,7 @@ namespace Libplanet.Net
             _replyQueue.Enqueue(message);
         }
 
+#pragma warning disable MEN002 // Line is too long
         /// <summary>
         /// Preemptively downloads blocks from registered <see cref="Peer"/>s.
         /// </summary>
@@ -603,6 +615,9 @@ namespace Libplanet.Net
         /// intended to be exposed to end users through a feasible user
         /// interface so that they can decide whom to trust for themselves.
         /// </param>
+        /// <param name="preloadBlockDownloadFailed">
+        /// The <see cref="EventHandler" /> triggered when block downloading fails.
+        /// </param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -613,12 +628,17 @@ namespace Libplanet.Net
         /// </returns>
         /// <remarks>This does not render downloaded <see cref="IAction"/>s, but fills states only.
         /// If you want to render all <see cref="IAction"/>s from the genesis block to the recent
-        /// blocks use <see cref="StartAsync(TimeSpan, TimeSpan, CancellationToken)"/> method
-        /// instead.</remarks>
+        /// blocks use
+        /// <see cref="StartAsync(TimeSpan, TimeSpan, EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"/>
+        /// method instead.</remarks>
+        /// <exception cref="AggregateException">Thrown when the given the block downloading is
+        /// failed and if <paramref name="preloadBlockDownloadFailed "/> is <c>null</c>.</exception>
+#pragma warning restore MEN002 // Line is too long
         public Task PreloadAsync(
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
+            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
@@ -627,6 +647,7 @@ namespace Libplanet.Net
                 dialTimeout: dialTimeout,
                 progress: progress,
                 trustedStateValidators: trustedStateValidators,
+                preloadBlockDownloadFailed: preloadBlockDownloadFailed,
                 cancellationToken: cancellationToken
             );
         }
@@ -637,35 +658,29 @@ namespace Libplanet.Net
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
+            EventHandler<PreloadBlockDownloadFailEventArgs> preloadBlockDownloadFailed = null,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
-            if (trustedStateValidators is null)
-            {
-                trustedStateValidators = ImmutableHashSet<Address>.Empty;
-            }
+            trustedStateValidators = trustedStateValidators ?? ImmutableHashSet<Address>.Empty;
 
             Block<T> initialTip = BlockChain.Tip;
             BlockLocator initialLocator = BlockChain.GetBlockLocator();
             _logger.Debug($"initialTip? : {BlockChain.Tip}");
 
             IList<(BoundPeer, long?)> peersWithHeight =
-                await DialToExistingPeers(
-                    dialTimeout,
-                    cancellationToken
-                )
-                .Where(
-                    pp => pp.Item2.TipIndex > (initialTip?.Index ?? -1)
-                )
-                .Select(pp =>
-                    (pp.Item1, pp.Item2.TipIndex)
-                ).ToListAsync(cancellationToken);
+                await DialToExistingPeers(dialTimeout, cancellationToken)
+                .Where(pp => pp.Item2.TipIndex > (initialTip?.Index ?? -1))
+                .Select(pp => (pp.Item1, pp.Item2.TipIndex))
+                .ToListAsync(cancellationToken);
 
             if (!peersWithHeight.Any())
             {
                 _logger.Information("There is no appropriate peer for preloading.");
                 return;
             }
+
+            PreloadStarted.Set();
 
             // As preloading takes long, the blockchain data can corrupt if a program suddenly
             // terminates during preloading is going on.  In order to make preloading done
@@ -680,6 +695,7 @@ namespace Libplanet.Net
 
             try
             {
+                var exceptions = new List<Exception>();
                 var blockDownloadComplete = false;
                 foreach ((BoundPeer Peer, long? Height) peerWithHeight in peersWithHeight)
                 {
@@ -705,6 +721,7 @@ namespace Libplanet.Net
                             peerWithHeight.Peer.EndPoint,
                             peerWithHeight.Peer.Address.ToHex(),
                             e);
+                        exceptions.Add(e);
                         continue;
                     }
 
@@ -718,8 +735,18 @@ namespace Libplanet.Net
 
                 if (!blockDownloadComplete)
                 {
-                    _logger.Information("Failed to download blocks from peers.");
-                    return;
+                    if (preloadBlockDownloadFailed is null)
+                    {
+                        throw new AggregateException(
+                            "Failed to download blocks from peers.",
+                            exceptions);
+                    }
+                    else
+                    {
+                        preloadBlockDownloadFailed.Invoke(
+                            this,
+                            new PreloadBlockDownloadFailEventArgs { InnerExceptions = exceptions });
+                    }
                 }
 
                 if (workspace.Tip is null)
@@ -743,12 +770,9 @@ namespace Libplanet.Net
                     peersWithHeight.Where(pair =>
                         trustedStateValidators.Contains(pair.Item1.Address) &&
                         !(pair.Item2 is null) &&
-                        pair.Item2 <= height
-                    ).OrderByDescending(pair =>
-                        pair.Item2
-                    ).Select(pair =>
-                        (pair.Item1, workspace[pair.Item2.Value].Hash)
-                    );
+                        pair.Item2 <= height)
+                        .OrderByDescending(pair => pair.Item2)
+                        .Select(pair => (pair.Item1, workspace[pair.Item2.Value].Hash));
 
                 bool received = await SyncRecentStatesFromTrustedPeersAsync(
                     workspace,


### PR DESCRIPTION
When the block downloading fails in `Swarm<T>.PreloadAsync`, `Swarm<T>` became to call `Swarm<T>.PreloadBlockDownloadFailed` event handler. If the event handler doesn't exist, `Swarm<T>` throws `SwarmException`.