### PR TITLE
Improve ListAllStateReferences performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ To be released.
  -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
     to take `preloadBlockDownloadFailed` event handler as an argument.
     [[#694]]
+ -  Removed `StoreExtension.ListAllStateReferences<T>()` method.  [[#701]]
 
 ### Backward-incompatible network protocol changes
 
@@ -41,6 +42,7 @@ To be released.
 ### Added APIs
 
  -  Added `DefaultStore` class to replace `LiteDBStore`.  [[#662]]
+ -  Added `IStore.ListAllStateReferences<T>()` method.  [[#701]]
 
 ### Behavioral changes
 
@@ -70,6 +72,7 @@ To be released.
 [#685]: https://github.com/planetarium/libplanet/pull/685
 [#692]: https://github.com/planetarium/libplanet/pull/692
 [#694]: https://github.com/planetarium/libplanet/pull/694
+[#701]: https://github.com/planetarium/libplanet/pull/701
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Store/StoreExtensionTest.cs
+++ b/Libplanet.Tests/Store/StoreExtensionTest.cs
@@ -1,11 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Security.Cryptography;
-using Libplanet.Blockchain;
 using Libplanet.Blocks;
-using Libplanet.Crypto;
-using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -87,65 +82,6 @@ namespace Libplanet.Tests.Store
                 Tuple.Create(block5.Hash, block5.Index),
                 fx.Store.LookupStateReference(fx.StoreChainId, address, block6)
             );
-        }
-
-        [Theory]
-        [MemberData(nameof(StoreFixtures))]
-        public void ListAllStateReferences(StoreFixture fx)
-        {
-            Address address1 = fx.Address1;
-            Address address2 = fx.Address2;
-            Address address3 = new PrivateKey().PublicKey.ToAddress();
-
-            Transaction<DumbAction> tx4 = fx.MakeTransaction(
-                new[]
-                {
-                    new DumbAction(address1, "foo1"),
-                    new DumbAction(address2, "foo2"),
-                }
-            );
-            Block<DumbAction> block4 = TestUtils.MineNext(fx.Block3, new[] { tx4 });
-
-            Transaction<DumbAction> tx5 = fx.MakeTransaction(
-                new[]
-                {
-                    new DumbAction(address1, "bar1"),
-                    new DumbAction(address3, "bar3"),
-                }
-            );
-            Block<DumbAction> block5 = TestUtils.MineNext(block4, new[] { tx5 });
-
-            Block<DumbAction> block6 = TestUtils.MineNext(block5, new Transaction<DumbAction>[0]);
-
-            var chain = new BlockChain<DumbAction>(new NullPolicy<DumbAction>(), fx.Store);
-            chain.Append(fx.Block1);
-            chain.Append(fx.Block2);
-            chain.Append(fx.Block3);
-            chain.Append(block4);
-            chain.Append(block5);
-            chain.Append(block6);
-
-            Guid chainId = chain.Id;
-            IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>> refs;
-
-            refs = fx.Store.ListAllStateReferences(chainId);
-            Assert.Equal(
-                new HashSet<Address> { address1, address2, address3 },
-                refs.Keys.ToHashSet()
-            );
-            Assert.Equal(new[] { block4.Hash, block5.Hash }, refs[address1]);
-            Assert.Equal(new[] { block4.Hash }, refs[address2]);
-            Assert.Equal(new[] { block5.Hash }, refs[address3]);
-
-            refs = fx.Store.ListAllStateReferences(chainId, onlyAfter: block4.Hash);
-            Assert.Equal(new HashSet<Address> { address1, address3 }, refs.Keys.ToHashSet());
-            Assert.Equal(new[] { block5.Hash }, refs[address1]);
-            Assert.Equal(new[] { block5.Hash }, refs[address3]);
-
-            refs = fx.Store.ListAllStateReferences(chainId, ignoreAfter: block4.Hash);
-            Assert.Equal(new HashSet<Address> { address1, address2, }, refs.Keys.ToHashSet());
-            Assert.Equal(new[] { block4.Hash }, refs[address1]);
-            Assert.Equal(new[] { block4.Hash }, refs[address2]);
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -75,6 +75,17 @@ namespace Libplanet.Tests.Store
             return _store.ListAddresses(chainId);
         }
 
+        public IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+            ListAllStateReferences(
+                Guid chainId,
+                HashDigest<SHA256>? onlyAfter = null,
+                HashDigest<SHA256>? ignoreAfter = null)
+        {
+            // FIXME: Log arguments properly
+            _logs.Add((nameof(ListAllStateReferences), chainId, onlyAfter));
+            return _store.ListAllStateReferences(chainId, onlyAfter, ignoreAfter);
+        }
+
         public void DeleteChainId(Guid chainId)
         {
             _logs.Add((nameof(DeleteChainId), chainId, null));

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -46,6 +46,13 @@ namespace Libplanet.Store
         public abstract IEnumerable<Address> ListAddresses(Guid chainId);
 
         /// <inheritdoc />
+        public abstract IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+            ListAllStateReferences(
+                Guid chainId,
+                HashDigest<SHA256>? onlyAfter = null,
+                HashDigest<SHA256>? ignoreAfter = null);
+
+        /// <inheritdoc />
         public abstract void StageTransactionIds(IImmutableSet<TxId> txids);
 
         public abstract void UnstageTransactionIds(

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -94,6 +94,25 @@ namespace Libplanet.Store
         IEnumerable<Address> ListAddresses(Guid chainId);
 
         /// <summary>
+        /// Lists all accounts, that have any states, in the given <paramref name="chainId"/> and
+        /// their state references.
+        /// </summary>
+        /// <param name="chainId">The chain ID to look up state references.</param>
+        /// <param name="onlyAfter">Includes state references only made after the block
+        /// this argument refers to, if present.</param>
+        /// <param name="ignoreAfter">Excludes state references made after the block
+        /// this argument refers to, if present.</param>
+        /// <returns>A dictionary of account addresses to lists of their corresponding state
+        /// references.  Each list of state references is in ascending order, i.e., the block
+        /// closest to the genesis goes first and the block closest to the tip goes last.</returns>
+        IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+            ListAllStateReferences(
+                Guid chainId,
+                HashDigest<SHA256>? onlyAfter = null,
+                HashDigest<SHA256>? ignoreAfter = null
+            );
+
+        /// <summary>
         /// Adds <see cref="TxId"/>s to the pending list so that
         /// a next <see cref="Block{T}"/> to be mined contains the corresponding
         /// <see cref="Transaction{T}"/>s.


### PR DESCRIPTION
This moves `StoreExtension.ListAllStateReferences` to `IStore.ListAllStateReferences` and improve the preformance of the method.