### PR TITLE
Omit state transfer log on debug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@ To be released.
     `Swarm<T>` became to call `preloadBlockDownloadFailed` event handler
     taken as an argument.  If the event handler is not present, `Swarm<T>`
     throws `SwarmException`.  [[#694]]
+ -  `Swarm<T>` became prints less logs during transfer its states on debug level.
+    [[#706]]
 
 ### Bug fixes
 
@@ -79,6 +81,7 @@ To be released.
 [#692]: https://github.com/planetarium/libplanet/pull/692
 [#694]: https://github.com/planetarium/libplanet/pull/694
 [#701]: https://github.com/planetarium/libplanet/pull/701
+[#706]: https://github.com/planetarium/libplanet/pull/706
 
 
 Version 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,7 +60,7 @@ To be released.
     `Swarm<T>` became to call `preloadBlockDownloadFailed` event handler
     taken as an argument.  If the event handler is not present, `Swarm<T>`
     throws `SwarmException`.  [[#694]]
- -  `Swarm<T>` became prints less logs during transfer its states on debug level.
+ -  `Swarm<T>` became to print less logs on debug level during sending states.
     [[#706]]
 
 ### Bug fixes

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2029,7 +2029,7 @@ namespace Libplanet.Net
                 }
             }
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogEventLevel.Verbose))
             {
                 if (_store.ContainsBlock(target))
                 {
@@ -2037,7 +2037,7 @@ namespace Libplanet.Net
                         ? $"{BlockChain[h].Index}:{h}"
                         : null;
                     var targetString = $"{BlockChain[target].Index}:{target}";
-                    _logger.Debug(
+                    _logger.Verbose(
                         "State references to send (preload): {StateReferences} ({Base}-{Target})",
                         stateRefs.Select(kv =>
                             (
@@ -2048,7 +2048,7 @@ namespace Libplanet.Net
                         baseString,
                         targetString
                     );
-                    _logger.Debug(
+                    _logger.Verbose(
                         "Block states to send (preload): {BlockStates} ({Base}-{Target})",
                         blockStates.Select(kv => (kv.Key.ToString(), kv.Value)).ToArray(),
                         baseString,
@@ -2057,7 +2057,7 @@ namespace Libplanet.Net
                 }
                 else
                 {
-                    _logger.Debug("Nothing to reply because {TargetHash} doesn't exist.", target);
+                    _logger.Verbose("Nothing to reply because {TargetHash} doesn't exist.", target);
                 }
             }
 


### PR DESCRIPTION
This PR adjusts the logging level(`Debug` → `Verbose`) of some log messages related to state transfer.