### PR TITLE
Preload blocks from multiple peers at a time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,14 @@ To be released.
 
 ### Added APIs
 
+ -  Added `BlockHashDownloadState` class, a subclass of `PreloadState`.
+    [[#707]]
+
 ### Behavioral changes
+
+ -  `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()` became to download
+    only a list of block hashes first and then download blocks from
+    simultaneously multiple peers.  [[#707]]
 
 ### Bug fixes
 
@@ -117,8 +124,8 @@ Released on February 4, 2020.
  -  Added `BlockChain<T>.Genesis` property.  [[#688]]
  -  Added `BlockChain<T>.MakeGenesisBlock()` static method.  [[#688]]
  -  Added `InvalidGenesisBlockException` class.  [[#688]]
- -  Added `StateDownloadState` class which reports state preloading iteration
-    progress.  [[#703]]
+ -  Added `StateDownloadState` class, a subclass of `PreloadState`,
+    which reports state preloading iteration progress.  [[#703]]
  -  Added `PeerDiscoveryException` class which inherits `SwarmException`
     class.  [[#604], [#726]]
  -  Added `Swarm<T>.Peers` property which returns an enumerable of peers in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ To be released.
 
  -  The existing `BlockHashes` message type (with the type number `0x05`) was
     replaced by a new `BlockHashes` message type (with type number `0x0e`)
-    so that include block indices as well as block hashes.  [[#707]]
+    in order to include an offset block index besides block hashes
+    so that a receiver is able to determine their block indices too.  [[#707]]
 
 ### Backward-incompatible storage format changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
+ -  The existing `BlockHashes` message type (with the type number `0x05`) was
+    replaced by a new `BlockHashes` message type (with type number `0x0e`)
+    so that include block indices as well as block hashes.  [[#707]]
+
 ### Backward-incompatible storage format changes
 
 ### Added APIs
@@ -17,6 +21,8 @@ To be released.
 ### Behavioral changes
 
 ### Bug fixes
+
+[#707]: https://github.com/planetarium/libplanet/pull/707
 
 
 Version 0.8.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -598,43 +598,36 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public async void FindNextHashes()
         {
-            (long? OffsetIndex, IReadOnlyList<HashDigest<SHA256>> Hashes) hashes;
+            long? offsetIndex;
+            IReadOnlyList<HashDigest<SHA256>> hashes;
 
-            hashes = _blockChain.FindNextHashes(new BlockLocator(new HashDigest<SHA256>[] { }));
-            Assert.Single(hashes.Hashes);
+            _blockChain.FindNextHashes(new BlockLocator(new HashDigest<SHA256>[] { }))
+                .Deconstruct(out offsetIndex, out hashes);
+            Assert.Single(hashes);
             var block0 = _blockChain.Genesis;
             var block1 = await _blockChain.MineBlock(_fx.Address1);
             var block2 = await _blockChain.MineBlock(_fx.Address1);
             var block3 = await _blockChain.MineBlock(_fx.Address1);
 
-            hashes = _blockChain.FindNextHashes(new BlockLocator(new[] { block0.Hash }));
-            Assert.Equal(0, hashes.OffsetIndex);
-            Assert.Equal(
-                new[] { block0.Hash, block1.Hash, block2.Hash, block3.Hash },
-                hashes.Hashes);
+            _blockChain.FindNextHashes(new BlockLocator(new[] { block0.Hash }))
+                .Deconstruct(out offsetIndex, out hashes);
+            Assert.Equal(0, offsetIndex);
+            Assert.Equal(new[] { block0.Hash, block1.Hash, block2.Hash, block3.Hash }, hashes);
 
-            hashes = _blockChain.FindNextHashes(
-                new BlockLocator(new[] { block1.Hash, block0.Hash }));
-            Assert.Equal(1, hashes.OffsetIndex);
-            Assert.Equal(
-                new[] { block1.Hash, block2.Hash, block3.Hash },
-                hashes.Hashes);
+            _blockChain.FindNextHashes(new BlockLocator(new[] { block1.Hash, block0.Hash }))
+                .Deconstruct(out offsetIndex, out hashes);
+            Assert.Equal(1, offsetIndex);
+            Assert.Equal(new[] { block1.Hash, block2.Hash, block3.Hash }, hashes);
 
-            hashes = _blockChain.FindNextHashes(
-                new BlockLocator(new[] { block0.Hash }),
-                stop: block2.Hash);
-            Assert.Equal(0, hashes.OffsetIndex);
-            Assert.Equal(
-                new[] { block0.Hash, block1.Hash, block2.Hash },
-                hashes.Hashes);
+            _blockChain.FindNextHashes(new BlockLocator(new[] { block0.Hash }), stop: block2.Hash)
+                .Deconstruct(out offsetIndex, out hashes);
+            Assert.Equal(0, offsetIndex);
+            Assert.Equal(new[] { block0.Hash, block1.Hash, block2.Hash }, hashes);
 
-            hashes = _blockChain.FindNextHashes(
-                new BlockLocator(new[] { block0.Hash }),
-                count: 2);
-            Assert.Equal(0, hashes.OffsetIndex);
-            Assert.Equal(
-                new[] { block0.Hash, block1.Hash },
-                hashes.Hashes);
+            _blockChain.FindNextHashes(new BlockLocator(new[] { block0.Hash }), count: 2)
+                .Deconstruct(out offsetIndex, out hashes);
+            Assert.Equal(0, offsetIndex);
+            Assert.Equal(new[] { block0.Hash, block1.Hash }, hashes);
         }
 
         [Fact]
@@ -648,7 +641,8 @@ namespace Libplanet.Tests.Blockchain
             await forked.MineBlock(_fx.Address1);
 
             BlockLocator locator = _blockChain.GetBlockLocator();
-            (long? offset, IEnumerable<HashDigest<SHA256>> hashes) = forked.FindNextHashes(locator);
+            forked.FindNextHashes(locator)
+                .Deconstruct(out long? offset, out IReadOnlyList<HashDigest<SHA256>> hashes);
 
             Assert.Equal(forked[0].Index, offset);
             Assert.Equal(new[] { forked[0].Hash, forked[1].Hash }, hashes);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -959,7 +959,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void CanGetBlockLocator()
+        public async void GetBlockLocator()
         {
             List<Block<DumbAction>> blocks = new List<Block<DumbAction>>();
             foreach (var i in Enumerable.Range(0, 10))
@@ -968,7 +968,7 @@ namespace Libplanet.Tests.Blockchain
                 blocks.Add(block);
             }
 
-            BlockLocator actual = _blockChain.GetBlockLocator(threshold: 2);
+            BlockLocator actual = _blockChain.GetBlockLocator(threshold: 3);
             BlockLocator expected = new BlockLocator(new[]
             {
                 blocks[9].Hash,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -607,21 +607,21 @@ namespace Libplanet.Tests.Blockchain
             var block3 = await _blockChain.MineBlock(_fx.Address1);
 
             Assert.Equal(
-                new[] { block0.Hash, block1.Hash, block2.Hash, block3.Hash, },
+                new[] { (0L, block0.Hash), (1, block1.Hash), (2, block2.Hash), (3, block3.Hash), },
                 _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash })));
             Assert.Equal(
-                new[] { block1.Hash, block2.Hash, block3.Hash },
+                new[] { (1L, block1.Hash), (2L, block2.Hash), (3L, block3.Hash) },
                 _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block1.Hash, block0.Hash })));
             Assert.Equal(
-                new[] { block0.Hash, block1.Hash, block2.Hash },
+                new[] { (0L, block0.Hash), (1L, block1.Hash), (2L, block2.Hash) },
                 _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     stop: block2.Hash));
 
             Assert.Equal(
-                new[] { block0.Hash, block1.Hash },
+                new[] { (0L, block0.Hash), (1L, block1.Hash) },
                 _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     count: 2));
@@ -638,9 +638,12 @@ namespace Libplanet.Tests.Blockchain
             await forked.MineBlock(_fx.Address1);
 
             BlockLocator locator = _blockChain.GetBlockLocator();
-            IEnumerable<HashDigest<SHA256>> hashes = forked.FindNextHashes(locator);
+            IEnumerable<(long, HashDigest<SHA256>)> hashes = forked.FindNextHashes(locator);
 
-            Assert.Equal(new[] { forked[0].Hash, forked[1].Hash }, hashes);
+            Assert.Equal(
+                new[] { (forked[0].Index, forked[0].Hash), (forked[1].Index, forked[1].Hash) },
+                hashes
+            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Blockchain;
+using NetMQ;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public class BlockLocatorTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public BlockLocatorTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            // Generate fixture block hashes looks like 0x000...1, 0x000...2, 0x000...3, and so on,
+            // for the sake of easier debugging.
+            ImmutableArray<HashDigest<SHA256>> blocks = Enumerable.Range(0, 0x10).Select(i =>
+            {
+                byte[] bytes = NetworkOrderBitsConverter.GetBytes(i);
+                var buffer = new byte[HashDigest<SHA256>.Size];
+                bytes.CopyTo(buffer, buffer.Length - bytes.Length);
+                return new HashDigest<SHA256>(buffer);
+            }).ToImmutableArray();
+
+            var locator = new BlockLocator(
+                indexBlockHash: idx => blocks[(int)(idx < 0 ? blocks.Length + idx : idx)],
+                blockHashByIndex: hash => blocks.IndexOf(hash),
+                sampleAfter: 5
+            );
+
+            foreach (HashDigest<SHA256> hash in locator)
+            {
+                _output.WriteLine(hash.ToString());
+            }
+
+            Assert.Equal(
+                new[]
+                {
+                    blocks[0xf],
+                    blocks[0xe],
+                    blocks[0xd],
+                    blocks[0xc],
+                    blocks[0xb],
+                    blocks[0xa],
+                    blocks[0x8],
+                    blocks[0x4],
+                    blocks[0x0],
+                },
+                locator
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
@@ -33,7 +33,7 @@ namespace Libplanet.Tests.Blockchain
 
             var locator = new BlockLocator(
                 indexBlockHash: idx => blocks[(int)(idx < 0 ? blocks.Length + idx : idx)],
-                blockHashByIndex: hash => blocks.IndexOf(hash),
+                indexByBlockHash: hash => blocks.IndexOf(hash),
                 sampleAfter: 5
             );
 

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -11,6 +11,7 @@ using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Net;
 using Libplanet.Tests.Common.Action;
+using Nito.AsyncEx;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -117,7 +118,7 @@ namespace Libplanet.Tests.Net
                 window
             );
             var logs = new ConcurrentBag<(int, ImmutableArray<HashDigest<SHA256>>)>();
-            var ev = new AutoResetEvent(false);
+            var ev = new AsyncAutoResetEvent(false);
             var bg = Task.Run(async () =>
             {
                 int i = 0;
@@ -151,7 +152,7 @@ namespace Libplanet.Tests.Net
 
             // Chunk: 2, 3, 4, 5, 6
             _logger.Verbose("Waiting demand #2-6...");
-            ev.WaitOne();
+            await ev.WaitAsync();
             _logger.Verbose("Demand #2-6 processed.");
             Assert.Single(logs);
             Assert.True(logs.TryTake(out var log));
@@ -169,7 +170,7 @@ namespace Libplanet.Tests.Net
 
             // Chunk: 7, 8, 9, 10, 11
             _logger.Verbose("Waiting demand #7-11...");
-            ev.WaitOne();
+            await ev.WaitAsync();
             _logger.Verbose("Demand #7-11 processed.");
             Assert.Single(logs);
             Assert.True(logs.TryTake(out log));
@@ -187,7 +188,7 @@ namespace Libplanet.Tests.Net
 
             // Chunk: 12, 13, 14
             _logger.Verbose("Waiting demand #12-14...");
-            ev.WaitOne();
+            await ev.WaitAsync();
             _logger.Verbose("Demand #12-14 processed.");
             Assert.Single(logs);
             Assert.True(logs.TryTake(out log));

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -143,15 +143,8 @@ namespace Libplanet.Tests.Net
             // Demand: 2, 3, 4, 5
             for (int i = initialHeight; i < initialHeight + window - 1; ++i)
             {
-                var message = "There should be no logs recorded, but:\n" + string.Join(
-                    "\n",
-                    logs.Select(t => $"- {t.Item1}, {t.Item2}")
-                );
-                Assert.True(logs.IsEmpty, message);
                 bc.Demand(fixture[i].Hash);
             }
-
-            Assert.True(logs.IsEmpty);
 
             // Demand: 6
             bc.Demand(fixture[initialHeight + window - 1].Hash);

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -83,7 +83,7 @@ namespace Libplanet.Tests.Net
                     finally
                     {
                         Interlocked.Increment(ref done);
-                        _output.WriteLine(i.ToString());
+                        _output.WriteLine($"Task {i} finished.");
                     }
                 });
             }).ToArray();

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -145,7 +145,7 @@ namespace Libplanet.Tests.Net
             {
                 var message = "There should be no logs recorded, but:\n" + string.Join(
                     "\n",
-                    logs.Select(t => $"- {t.Item1:02d}, {t.Item2}")
+                    logs.Select(t => $"- {t.Item1}, {t.Item2}")
                 );
                 Assert.True(logs.IsEmpty, message);
                 bc.Demand(fixture[i].Hash);

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Async;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Net;
+using Libplanet.Tests.Common.Action;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Net
+{
+    public class BlockCompletionTest
+    {
+        private const int Timeout = 20000;
+        private readonly ITestOutputHelper _output;
+        private readonly ILogger _logger;
+
+        public BlockCompletionTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} [thread/{ThreadId}] {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<BlockCompletionTest>();
+            _logger = Log.ForContext<BlockCompletionTest>();
+            _output = output;
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task PeerPool()
+        {
+            const int tasks = 50;
+            ConcurrentDictionary<int, int> peers = new ConcurrentDictionary<int, int>(
+                Enumerable.Range(0, 3).Select(peerId => new KeyValuePair<int, int>(peerId, 0))
+            );
+            var concurrentWorkersLogs = new ConcurrentBag<int>();
+            long done = 0;
+            var pool = new BlockCompletion<int, DumbAction>.PeerPool(peers.Keys);
+            var random = new System.Random();
+            Task[] spawns = Enumerable.Range(0, tasks).Select(i =>
+            {
+                int sleep = random.Next(50, 500);
+                return pool.SpawnAsync(async peerId =>
+                {
+                    try
+                    {
+                        int counter;
+                        do
+                        {
+                            counter = peers[peerId];
+                        }
+                        while (!peers.TryUpdate(peerId, counter + 1, counter));
+
+                        concurrentWorkersLogs.Add(
+                            peers.Where(kv => kv.Key != peerId).Sum(kv => kv.Value) +
+                            counter + 1
+                        );
+
+                        await Task.Delay(sleep);
+
+                        do
+                        {
+                            counter = peers[peerId];
+                        }
+                        while (!peers.TryUpdate(peerId, counter - 1, counter));
+                    }
+                    catch (Exception e)
+                    {
+                        _output.WriteLine(e.ToString());
+                    }
+                    finally
+                    {
+                        Interlocked.Increment(ref done);
+                        _output.WriteLine(i.ToString());
+                    }
+                });
+            }).ToArray();
+
+            _output.WriteLine("Wait spawned tasks to be finished...");
+            await Task.WhenAll(spawns);
+            _output.WriteLine("All spawned tasks finished; wait PeerPool to be finished...");
+            await pool.WaitAll();
+            _output.WriteLine("PeerPool finished.");
+
+            Assert.Equal(tasks, Interlocked.Read(ref done));
+            Assert.Equal(tasks, concurrentWorkersLogs.Count);
+            foreach (int log in concurrentWorkersLogs)
+            {
+                Assert.InRange(log, 0, 3);
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async void EnumerateChunks()
+        {
+            // 0, 1: Already existed blocks
+            // 2, 3, 4,  5,  6: first chunk
+            // 7, 8, 9, 10, 11: second chunk
+            //   12,    13, 14: last chunk
+            ImmutableArray<Block<DumbAction>> fixture =
+                GenerateBlocks<DumbAction>(15).ToImmutableArray();
+            const int initialHeight = 2;
+            const int window = 5;
+            var bc = new BlockCompletion<int, DumbAction>(
+                fixture.Take(initialHeight).Select(b => b.Hash).ToImmutableHashSet().Contains,
+                window
+            );
+            var logs = new ConcurrentBag<(int, ImmutableArray<HashDigest<SHA256>>)>();
+            var ev = new AutoResetEvent(false);
+            var bg = Task.Run(async () =>
+            {
+                int i = 0;
+                await bc.EnumerateChunks().ForEachAsync(hashes =>
+                {
+                    ImmutableArray<HashDigest<SHA256>> hashesArray = hashes.ToImmutableArray();
+                    logs.Add((i, hashesArray));
+                    i++;
+
+                    // To test dynamic demands
+                    if (hashesArray.Contains(fixture[7].Hash))
+                    {
+                        bc.Demand(fixture[14].Hash);
+                        bc.Demand(fixture[0].Hash);  // This should be ignored as it's existed.
+                        bc.Demand(fixture[3].Hash);  // This should be ignored as it's satisfied.
+                    }
+
+                    ev.Set();
+                    _logger.Verbose("Got a chunk of hashes: {0}", string.Join(", ", hashesArray));
+                });
+            });
+
+            // Demand: 2, 3, 4, 5
+            for (int i = initialHeight; i < initialHeight + window - 1; ++i)
+            {
+                var message = "There should be no logs recorded, but:\n" + string.Join(
+                    "\n",
+                    logs.Select(t => $"- {t.Item1:02d}, {t.Item2}")
+                );
+                Assert.True(logs.IsEmpty, message);
+                bc.Demand(fixture[i].Hash);
+            }
+
+            Assert.True(logs.IsEmpty);
+
+            // Demand: 6
+            bc.Demand(fixture[initialHeight + window - 1].Hash);
+
+            // Chunk: 2, 3, 4, 5, 6
+            _logger.Verbose("Waiting demand #2-6...");
+            ev.WaitOne();
+            _logger.Verbose("Demand #2-6 processed.");
+            Assert.Single(logs);
+            Assert.True(logs.TryTake(out var log));
+            Assert.Equal(0, log.Item1);
+            Assert.Equal(fixture.Skip(initialHeight).Take(window).Select(b => b.Hash), log.Item2);
+
+            // Complete: 2, 3, 4, 5 (and no 6)
+            for (int i = initialHeight; i < initialHeight + window - 1; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            // Demand: 7, 8, 9, 10, 11, 12, 13 (and 14 <- 7 will be added soon)
+            bc.Demand(fixture.Skip(initialHeight + window).Select(b => b.Hash));
+
+            // Chunk: 7, 8, 9, 10, 11
+            _logger.Verbose("Waiting demand #7-11...");
+            ev.WaitOne();
+            _logger.Verbose("Demand #7-11 processed.");
+            Assert.Single(logs);
+            Assert.True(logs.TryTake(out log));
+            Assert.Equal(1, log.Item1);
+            Assert.Equal(
+                fixture.Skip(initialHeight + window).Take(window).Select(b => b.Hash),
+                log.Item2
+            );
+
+            // Complete: 6, 7, 8, 9, 10, 11
+            for (int i = initialHeight + window - 1; i < initialHeight + window * 2; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            // Chunk: 12, 13, 14
+            _logger.Verbose("Waiting demand #12-14...");
+            ev.WaitOne();
+            _logger.Verbose("Demand #12-14 processed.");
+            Assert.Single(logs);
+            Assert.True(logs.TryTake(out log));
+            Assert.Equal(2, log.Item1);
+            Assert.Equal(
+                fixture.Skip(initialHeight + window * 2).Select(b => b.Hash).ToImmutableHashSet(),
+                log.Item2.ToImmutableHashSet()
+            );
+
+            // Complete: 12, 13, 14
+            for (int i = initialHeight + window * 2; i < fixture.Length; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            await bg;
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task Complete()
+        {
+            // 0, 1: Already existed blocks
+            // 2, 3, 4,  5,  6: first chunk
+            // 7, 8, 9, 10, 11: second chunk
+            //   12,    13, 14: last chunk
+            ImmutableArray<Block<DumbAction>> fixture =
+                GenerateBlocks<DumbAction>(15).ToImmutableArray();
+
+            // Blocks each block has:
+            //   A: 0, 4, 8,  12
+            //   B: 1, 5, 9,  13
+            //   C: 2, 6, 10, 14
+            //   D: 3, 7, 11
+            char[] peers = { 'A', 'B', 'C', 'D' };
+            ImmutableDictionary<char, ImmutableDictionary<HashDigest<SHA256>, Block<DumbAction>>>
+                peerBlocks = peers.ToImmutableDictionary(
+                    p => p,
+                    p => fixture.Skip(p - 'A').Where((_, i) => i % 4 < 1).ToImmutableDictionary(
+                        b => b.Hash,
+                        b => b
+                    )
+                );
+
+            const int initialHeight = 2;
+            const int window = 5;
+            var bc = new BlockCompletion<char, DumbAction>(
+                fixture.Take(initialHeight).Select(b => b.Hash).ToImmutableHashSet().Contains,
+                window
+            );
+            ImmutableArray<HashDigest<SHA256>> initialDemands = fixture
+                .Skip(initialHeight + 10)
+                .Select(b => b.Hash)
+                .ToImmutableArray();
+            bc.Demand(initialDemands);
+            _logger.Verbose("Initial demands: {0}", initialDemands);
+            System.Collections.Async.IAsyncEnumerable<Block<DumbAction>> result = bc.Complete(
+                new[] { 'A', 'B', 'C', 'D' },
+                (peer, hashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                {
+                    var blocksPeerHas = peerBlocks[peer];
+                    var sent = new HashSet<HashDigest<SHA256>>();
+                    foreach (HashDigest<SHA256> hash in hashes)
+                    {
+                        if (blocksPeerHas.ContainsKey(hash))
+                        {
+                            Block<DumbAction> block = blocksPeerHas[hash];
+                            await yield.ReturnAsync(block);
+                            sent.Add(block.Hash);
+                        }
+                    }
+
+                    _logger.Verbose("Peer {Peer} sent blocks: {SentBlockHashes}.", peer, sent);
+                })
+            );
+
+            var downloadedBlocks = new HashSet<Block<DumbAction>>();
+            await result.ForEachAsync(block =>
+            {
+                downloadedBlocks.Add(block);
+            });
+
+            Assert.Equal(fixture.Skip(2).ToHashSet(), downloadedBlocks);
+        }
+
+        private IEnumerable<Block<T>> GenerateBlocks<T>(int count)
+            where T : IAction, new()
+        {
+            if (count >= 1)
+            {
+                Block<T> block = TestUtils.MineGenesis<T>();
+                yield return block;
+
+                for (int i = 1; i < count; i++)
+                {
+                    block = TestUtils.MineNext(block);
+                    yield return block;
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -14,16 +14,28 @@ namespace Libplanet.Tests.Net.Messages
     public class BlockHashesTest
     {
         [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new BlockHashes(null, new[] { default(HashDigest<SHA256>) })
+            );
+            Assert.Throws<ArgumentException>(() =>
+                new BlockHashes(123, new HashDigest<SHA256>[0])
+            );
+        }
+
+        [Fact]
         public void DataFrames()
         {
-            (long, HashDigest<SHA256> hash)[] blockHashes =
-                GenerateRandomBlockHashes(100L).Select((hash, i) => ((long)i, hash)).ToArray();
-            var msg = new BlockHashes(blockHashes);
+            HashDigest<SHA256>[] blockHashes = GenerateRandomBlockHashes(100L).ToArray();
+            var msg = new BlockHashes(123, blockHashes);
+            Assert.Equal(123, msg.StartIndex);
             Assert.Equal(blockHashes, msg.Hashes);
             var privKey = new PrivateKey();
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234), 0);
             NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
             var restored = new BlockHashes(frames);
+            Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);
         }
 

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using NetMQ;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Messages
+{
+    public class BlockHashesTest
+    {
+        [Fact]
+        public void DataFrames()
+        {
+            (long, HashDigest<SHA256> hash)[] blockHashes =
+                GenerateRandomBlockHashes(100L).Select((hash, i) => ((long)i, hash)).ToArray();
+            var msg = new BlockHashes(blockHashes);
+            Assert.Equal(blockHashes, msg.Hashes);
+            var privKey = new PrivateKey();
+            Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234), 0);
+            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
+            var restored = new BlockHashes(frames);
+            Assert.Equal(msg.Hashes, restored.Hashes);
+        }
+
+        private static IEnumerable<HashDigest<SHA256>> GenerateRandomBlockHashes(long count)
+        {
+            var random = new Random();
+            var buffer = new byte[HashDigest<SHA256>.Size];
+            for (long i = 0; i < count; i++)
+            {
+                random.NextBytes(buffer);
+                yield return new HashDigest<SHA256>(buffer);
+            }
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -982,7 +982,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal IEnumerable<HashDigest<SHA256>> FindNextHashes(
+        internal IEnumerable<(long i, HashDigest<SHA256> hash)> FindNextHashes(
             BlockLocator locator,
             HashDigest<SHA256>? stop = null,
             int count = 500)
@@ -1015,6 +1015,7 @@ namespace Libplanet.Blockchain
                 IEnumerable<HashDigest<SHA256>> hashes = Store
                     .IterateIndexes(Id, branchPointIndex, count);
 
+                long i = branchPointIndex;
                 foreach (HashDigest<SHA256> hash in hashes)
                 {
                     if (count == 0)
@@ -1022,13 +1023,14 @@ namespace Libplanet.Blockchain
                         yield break;
                     }
 
-                    yield return hash;
+                    yield return (i, hash);
 
                     if (hash.Equals(stop))
                     {
                         yield break;
                     }
 
+                    i++;
                     count--;
                 }
             }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1134,30 +1134,11 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
-                HashDigest<SHA256>? current = Store.IndexBlockHash(Id, -1);
-                long step = 1;
-                var hashes = new List<HashDigest<SHA256>>();
-
-                while (current is HashDigest<SHA256> hash)
-                {
-                    hashes.Add(hash);
-                    Block<T> currentBlock = _blocks[hash];
-
-                    if (currentBlock.Index == 0)
-                    {
-                        break;
-                    }
-
-                    long nextIndex = Math.Max(currentBlock.Index - step, 0);
-                    current = Store.IndexBlockHash(Id, nextIndex);
-
-                    if (hashes.Count > threshold)
-                    {
-                        step *= 2;
-                    }
-                }
-
-                return new BlockLocator(hashes);
+                return new BlockLocator(
+                    indexBlockHash: idx => Store.IndexBlockHash(Id, idx),
+                    blockHashByIndex: hash => _blocks[hash].Index,
+                    sampleAfter: threshold
+                );
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -982,7 +982,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal IEnumerable<(long i, HashDigest<SHA256> hash)> FindNextHashes(
+        internal (long? OffsetIndex, IReadOnlyList<HashDigest<SHA256>> Hashes) FindNextHashes(
             BlockLocator locator,
             HashDigest<SHA256>? stop = null,
             int count = 500)
@@ -994,7 +994,7 @@ namespace Libplanet.Blockchain
                 HashDigest<SHA256>? tip = Store.IndexBlockHash(Id, -1);
                 if (tip is null)
                 {
-                    yield break;
+                    return (null, new HashDigest<SHA256>[0]);
                 }
 
                 HashDigest<SHA256>? branchPoint = FindBranchPoint(locator);
@@ -1015,24 +1015,25 @@ namespace Libplanet.Blockchain
                 IEnumerable<HashDigest<SHA256>> hashes = Store
                     .IterateIndexes(Id, branchPointIndex, count);
 
-                long i = branchPointIndex;
+                var result = new List<HashDigest<SHA256>>();
                 foreach (HashDigest<SHA256> hash in hashes)
                 {
                     if (count == 0)
                     {
-                        yield break;
+                        break;
                     }
 
-                    yield return (i, hash);
+                    result.Add(hash);
 
                     if (hash.Equals(stop))
                     {
-                        yield break;
+                        break;
                     }
 
-                    i++;
                     count--;
                 }
+
+                return (branchPointIndex, result);
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -982,7 +982,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal (long? OffsetIndex, IReadOnlyList<HashDigest<SHA256>> Hashes) FindNextHashes(
+        internal Tuple<long?, IReadOnlyList<HashDigest<SHA256>>> FindNextHashes(
             BlockLocator locator,
             HashDigest<SHA256>? stop = null,
             int count = 500)
@@ -994,7 +994,10 @@ namespace Libplanet.Blockchain
                 HashDigest<SHA256>? tip = Store.IndexBlockHash(Id, -1);
                 if (tip is null)
                 {
-                    return (null, new HashDigest<SHA256>[0]);
+                    return new Tuple<long?, IReadOnlyList<HashDigest<SHA256>>>(
+                        null,
+                        new HashDigest<SHA256>[0]
+                    );
                 }
 
                 HashDigest<SHA256>? branchPoint = FindBranchPoint(locator);
@@ -1033,7 +1036,10 @@ namespace Libplanet.Blockchain
                     count--;
                 }
 
-                return (branchPointIndex, result);
+                return new Tuple<long?, IReadOnlyList<HashDigest<SHA256>>>(
+                    branchPointIndex,
+                    result
+                );
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1143,7 +1143,7 @@ namespace Libplanet.Blockchain
 
                 return new BlockLocator(
                     indexBlockHash: idx => Store.IndexBlockHash(Id, idx),
-                    blockHashByIndex: hash => _blocks[hash].Index,
+                    indexByBlockHash: hash => _blocks[hash].Index,
                     sampleAfter: threshold
                 );
             }

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
@@ -7,6 +8,37 @@ namespace Libplanet.Blockchain
     internal class BlockLocator : IEnumerable<HashDigest<SHA256>>
     {
         private readonly IEnumerable<HashDigest<SHA256>> _impl;
+
+        public BlockLocator(
+            Func<long, HashDigest<SHA256>?> indexBlockHash,
+            Func<HashDigest<SHA256>, long> blockHashByIndex,
+            int sampleAfter = 10
+        )
+        {
+            HashDigest<SHA256>? current = indexBlockHash(-1);
+            long step = 1;
+            var hashes = new List<HashDigest<SHA256>>();
+            while (current is HashDigest<SHA256> hash)
+            {
+                hashes.Add(hash);
+                long currentBlockIndex = blockHashByIndex(hash);
+
+                if (currentBlockIndex == 0)
+                {
+                    break;
+                }
+
+                long nextIndex = Math.Max(currentBlockIndex - step, 0);
+                current = indexBlockHash(nextIndex);
+
+                if (hashes.Count >= sampleAfter)
+                {
+                    step *= 2;
+                }
+            }
+
+            _impl = hashes;
+        }
 
         public BlockLocator(IEnumerable<HashDigest<SHA256>> hashes)
         {

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Blockchain
 
         public BlockLocator(
             Func<long, HashDigest<SHA256>?> indexBlockHash,
-            Func<HashDigest<SHA256>, long> blockHashByIndex,
+            Func<HashDigest<SHA256>, long> indexByBlockHash,
             int sampleAfter = 10
         )
         {
@@ -21,7 +21,7 @@ namespace Libplanet.Blockchain
             while (current is HashDigest<SHA256> hash)
             {
                 hashes.Add(hash);
-                long currentBlockIndex = blockHashByIndex(hash);
+                long currentBlockIndex = indexByBlockHash(hash);
 
                 if (currentBlockIndex == 0)
                 {

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Async;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Serilog;
+
+namespace Libplanet.Net
+{
+    internal class BlockCompletion<TPeer, TAction>
+        where TAction : IAction, new()
+    {
+        private readonly ILogger _logger;
+        private readonly Func<HashDigest<SHA256>, bool> _completionPredicate;
+        private readonly int _window;
+        private readonly ConcurrentDictionary<HashDigest<SHA256>, bool> _satisfiedBlocks;
+        private readonly ConcurrentQueue<HashDigest<SHA256>> _demands;
+        private readonly SemaphoreSlim _demandEnqueued;
+        private bool _started;
+
+        public BlockCompletion(
+            Func<HashDigest<SHA256>, bool> completionPredicate = null,
+            int window = 100
+        )
+        {
+            _logger = Log.ForContext<BlockCompletion<TPeer, TAction>>();
+            _completionPredicate = completionPredicate;
+            _window = window;
+            _satisfiedBlocks = new ConcurrentDictionary<HashDigest<SHA256>, bool>();
+            _started = false;
+            _demands = new ConcurrentQueue<HashDigest<SHA256>>();
+            _demandEnqueued = new SemaphoreSlim(0);
+        }
+
+        public delegate System.Collections.Async.IAsyncEnumerable<Block<TAction>> BlockFetcher(
+            TPeer peer,
+            IEnumerable<HashDigest<SHA256>> blockHashes
+        );
+
+        public void Demand(HashDigest<SHA256> blockHash) =>
+            Demand(blockHash, retry: false);
+
+        public void Demand(IEnumerable<HashDigest<SHA256>> blockHashes) =>
+            Demand(blockHashes, retry: false);
+
+        public System.Collections.Async.IAsyncEnumerable<IEnumerable<HashDigest<SHA256>>>
+        EnumerateChunks() =>
+            new AsyncEnumerable<IEnumerable<HashDigest<SHA256>>>(async yield =>
+            {
+                var chunk = new List<HashDigest<SHA256>>(capacity: _window);
+                bool QueuedDemandCompleted() =>
+                    _started && _demands.IsEmpty && _satisfiedBlocks.All(kv => kv.Value);
+                while (!(yield.CancellationToken.IsCancellationRequested ||
+                         QueuedDemandCompleted()))
+                {
+                    yield.CancellationToken.ThrowIfCancellationRequested();
+                    _logger.Verbose(
+                        "Waiting a demand enqueued...\n" +
+                        "Demands in the buffer: {DemandCount}.\n" +
+                        "Incomplete downloads: {IncompleteDownloads}.",
+                        chunk.Count,
+                        _satisfiedBlocks.Count(kv => !kv.Value && !chunk.Contains(kv.Key))
+                    );
+
+                    await _demandEnqueued.WaitAsync(100, yield.CancellationToken);
+                    if (_demands.TryDequeue(out HashDigest<SHA256> demand))
+                    {
+                        chunk.Add(demand);
+                    }
+
+                    if (chunk.Count >= _window || (
+                            _started && _demands.IsEmpty && _satisfiedBlocks.All(kv =>
+                                kv.Value || chunk.Contains(kv.Key))))
+                    {
+                        await yield.ReturnAsync(chunk.ToImmutableArray());
+                        _logger.Verbose("A chunk of {Window} demands made.", _window);
+                        chunk.Clear();
+                    }
+                    else
+                    {
+                        _logger.Verbose(
+                            "The number of buffered demands: {DemandCount}.\n" +
+                            "The number of demands in the backlog: {BacklogCount}.\n" +
+                            "The number of incomplete downloads: {IncompleteDownloads}.",
+                            chunk.Count,
+                            _demands.Count,
+                            _satisfiedBlocks.Count(kv => !kv.Value && !chunk.Contains(kv.Key))
+                        );
+                    }
+                }
+
+                if (!yield.CancellationToken.IsCancellationRequested && chunk.Count > 0)
+                {
+                    _logger.Verbose("A chunk of {Window} demands made.", chunk.Count);
+                    await yield.ReturnAsync(chunk);
+                }
+
+                _logger.Verbose("The stream of demand chunks finished.");
+
+                yield.CancellationToken.ThrowIfCancellationRequested();
+            });
+
+        [Pure]
+        public bool Satisfies(HashDigest<SHA256> blockHash, bool ignoreTransientCompletions = false)
+        {
+            return (!ignoreTransientCompletions && _satisfiedBlocks.ContainsKey(blockHash)) ||
+                   (!(_completionPredicate is null) && _completionPredicate(blockHash));
+        }
+
+        public bool Satisfy(Block<TAction> block)
+        {
+            if (block is null)
+            {
+                throw new ArgumentNullException(nameof(block));
+            }
+
+            if (block.PreviousHash is HashDigest<SHA256> prevHash)
+            {
+                _logger.Verbose(
+                    "The block #{BlockIndex} {BlockHash}'s previous block #{PreviousIndex} " +
+                    "{PreviousHash} is needed; add it to the queue...",
+                    block.Index,
+                    block.Hash,
+                    block.Index - 1,
+                    prevHash
+                );
+                Demand(prevHash);
+            }
+
+            if (_satisfiedBlocks.TryUpdate(block.Hash, true, false))
+            {
+                _logger.Verbose(
+                    "Completed the block #{BlockIndex} {BlockHash}. " +
+                    "(Remained incomplete demands: {IncompleteDemands})",
+                    block.Index,
+                    block.Hash,
+                    _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
+                );
+                return true;
+            }
+
+            _logger.Verbose(
+                "The block #{BlockIndex} {BlockHash} is already complete. " +
+                "(Remained incomplete demands: {IncompleteDemands})",
+                block.Index,
+                block.Hash,
+                _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
+            );
+            return false;
+        }
+
+        public System.Collections.Async.IAsyncEnumerable<Block<TAction>> Complete(
+            IReadOnlyList<TPeer> peers,
+            BlockFetcher blockFetcher
+        )
+        {
+            if (!peers.Any())
+            {
+                throw new ArgumentException("The list of peers must not be empty.", nameof(peers));
+            }
+
+            PeerPool pool = new PeerPool(peers);
+            return new AsyncEnumerable<Block<TAction>>(async yield =>
+            {
+                await EnumerateChunks().ForEachAsync(
+                    async hashes =>
+                    {
+                        yield.CancellationToken.ThrowIfCancellationRequested();
+                        IList<HashDigest<SHA256>> hashDigests =
+                            hashes is IList<HashDigest<SHA256>> l ? l : hashes.ToList();
+                        await pool.SpawnAsync(
+                            async (peer) =>
+                            {
+                                yield.CancellationToken.ThrowIfCancellationRequested();
+                                var demands = new HashSet<HashDigest<SHA256>>(hashDigests);
+                                try
+                                {
+                                    _logger.Debug(
+                                        "Request blocks {BlockHashes} to {Peer}...",
+                                        hashDigests,
+                                        peer
+                                    );
+                                    await blockFetcher(peer, hashDigests).ForEachAsync(
+                                        async block =>
+                                        {
+                                            yield.CancellationToken.ThrowIfCancellationRequested();
+                                            _logger.Debug(
+                                                "Downloaded a block #{BlockIndex} {BlockHash} " +
+                                                "from {Peer}.",
+                                                block.Index,
+                                                block.Hash,
+                                                peer
+                                            );
+                                            await yield.ReturnAsync(block);
+                                            Satisfy(block);
+                                            demands.Remove(block.Hash);
+                                        },
+                                        yield.CancellationToken
+                                    );
+                                }
+                                finally
+                                {
+                                    _logger.Verbose(
+                                        "Enqueue unsatisfied demands again: {UnsatisfiedDemands}.",
+                                        demands
+                                    );
+                                    Demand(demands, retry: true);
+                                }
+                            },
+                            cancellationToken: yield.CancellationToken
+                        );
+                    },
+                    yield.CancellationToken
+                );
+            });
+        }
+
+        private void Demand(HashDigest<SHA256> blockHash, bool retry)
+        {
+            if (Satisfies(blockHash, ignoreTransientCompletions: retry))
+            {
+                return;
+            }
+
+            if (_satisfiedBlocks.TryAdd(blockHash, false) || retry)
+            {
+                _demands.Enqueue(blockHash);
+                _started = true;
+                _demandEnqueued.Release();
+                _logger.Verbose("A demand was enqueued: {BlockHash}", blockHash);
+            }
+        }
+
+        private void Demand(IEnumerable<HashDigest<SHA256>> blockHashes, bool retry)
+        {
+            foreach (HashDigest<SHA256> hash in blockHashes)
+            {
+                Demand(hash, retry);
+            }
+        }
+
+        internal class PeerPool
+        {
+            private readonly ConcurrentQueue<TPeer> _completions;
+            private readonly ConcurrentDictionary<TPeer, Task> _tasks;
+            private long _taken;
+            private long _finished;
+
+            public PeerPool(IEnumerable<TPeer> peers)
+            {
+                _completions = new ConcurrentQueue<TPeer>(peers);
+                _tasks = new ConcurrentDictionary<TPeer, Task>();
+                _taken = 0;
+                _finished = 0;
+            }
+
+            public async Task SpawnAsync(
+                Func<TPeer, Task> action,
+                CancellationToken cancellationToken = default
+            )
+            {
+                Interlocked.Increment(ref _taken);
+                TPeer peer;
+                while (!_completions.TryDequeue(out peer))
+                {
+                    Task[] tasks = _tasks.Values
+                        .Concat(new[] { Task.Delay(500, cancellationToken) })
+                        .ToArray();
+                    await Task.WhenAny(tasks);
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (_tasks.TryRemove(peer, out Task completeTask))
+                {
+                    await completeTask;
+                }
+
+                _tasks[peer] = Task.Run(
+                    async () =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        try
+                        {
+                            await action(peer);
+                        }
+                        finally
+                        {
+                            _completions.Enqueue(peer);
+                            Interlocked.Increment(ref _finished);
+                        }
+                    },
+                    cancellationToken: cancellationToken
+                );
+            }
+
+            public async Task WaitAll(CancellationToken cancellationToken = default)
+            {
+                while (Interlocked.Read(ref _taken) > Interlocked.Read(ref _finished))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Task[] tasks = _tasks.Values.ToArray();
+                    if (tasks.Any())
+                    {
+                        var tcs = new TaskCompletionSource<object>();
+                        cancellationToken.Register(
+                            () => tcs.TrySetCanceled(),
+                            useSynchronizationContext: false
+                        );
+                        await Task.WhenAny(Task.WhenAll(tasks), tcs.Task);
+                    }
+                    else
+                    {
+                        await Task.Delay(100, cancellationToken);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -156,7 +156,7 @@ namespace Libplanet.Net
             return false;
         }
 
-        public System.Collections.Async.IAsyncEnumerable<Block<TAction>> Complete(
+        public System.Collections.Async.IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
             IReadOnlyList<TPeer> peers,
             BlockFetcher blockFetcher
         )
@@ -167,7 +167,7 @@ namespace Libplanet.Net
             }
 
             PeerPool pool = new PeerPool(peers);
-            return new AsyncEnumerable<Block<TAction>>(async yield =>
+            return new AsyncEnumerable<Tuple<Block<TAction>, TPeer>>(async yield =>
             {
                 await EnumerateChunks().ForEachAsync(
                     async hashes =>
@@ -198,7 +198,9 @@ namespace Libplanet.Net
                                                 block.Hash,
                                                 peer
                                             );
-                                            await yield.ReturnAsync(block);
+                                            await yield.ReturnAsync(
+                                                new Tuple<Block<TAction>, TPeer>(block, peer)
+                                            );
                                             Satisfy(block);
                                             demands.Remove(block.Hash);
                                         },

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -79,8 +79,15 @@ namespace Libplanet.Net
                             _started && _demands.IsEmpty && _satisfiedBlocks.All(kv =>
                                 kv.Value || chunk.Contains(kv.Key))))
                     {
+                        _logger.Verbose("_satisfiedBlocks.Keys @{keys}", _satisfiedBlocks.Keys);
+                        _logger.Verbose(
+                            "_satisfiedBlocks.Values @{values}",
+                            _satisfiedBlocks.Values
+                        );
+                        _logger.Verbose("chunks: @{chunk}", chunk);
                         await yield.ReturnAsync(chunk.ToImmutableArray());
                         _logger.Verbose("A chunk of {Window} demands made.", _window);
+
                         chunk.Clear();
                     }
                     else

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 1;
+        public override int CurrentPhase => 2;
 
         /// <summary>
         /// The peer which sent the block.

--- a/Libplanet/Net/BlockHashDownloadState.cs
+++ b/Libplanet/Net/BlockHashDownloadState.cs
@@ -1,0 +1,27 @@
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// Indicates a progress of downloading block hashes.
+    /// </summary>
+    [Equals]
+    public class BlockHashDownloadState : PreloadState
+    {
+        /// <summary>
+        /// The estimated number of block hashes to receive in the current batch.
+        /// </summary>
+        public long EstimatedTotalBlockHashCount { get; internal set; }
+
+        /// <summary>
+        /// The number of currently received block hashes.
+        /// </summary>
+        public long ReceivedBlockHashCount { get; internal set; }
+
+        /// <summary>
+        /// The peer which sent the block hashes.
+        /// </summary>
+        public BoundPeer SourcePeer { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 1;
+    }
+}

--- a/Libplanet/Net/Messages/BlockHashes.cs
+++ b/Libplanet/Net/Messages/BlockHashes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -7,26 +8,53 @@ namespace Libplanet.Net.Messages
 {
     internal class BlockHashes : Message
     {
-        public BlockHashes(IEnumerable<(long, HashDigest<SHA256>)> hashes)
+        public BlockHashes(long? startIndex, IEnumerable<HashDigest<SHA256>> hashes)
         {
+            StartIndex = startIndex;
             Hashes = hashes.ToList();
+
+            if (StartIndex is null && Hashes.Any())
+            {
+                throw new ArgumentNullException(
+                    nameof(startIndex),
+                    "The startIndex can be null iff hashes are empty."
+                );
+            }
+            else if (!Hashes.Any() && !(StartIndex is null))
+            {
+                throw new ArgumentException(
+                    "The startIndex has to be null if hashes are empty.",
+                    nameof(startIndex)
+                );
+            }
         }
 
         public BlockHashes(NetMQFrame[] frames)
         {
             int hashCount = frames[0].ConvertToInt32();
-            var hashes = new List<(long, HashDigest<SHA256>)>(hashCount);
-            for (int i = 1, end = i + hashCount * 2; i < end; i += 2)
+            var hashes = new List<HashDigest<SHA256>>(hashCount);
+            if (hashCount > 0)
             {
-                long index = frames[i].ConvertToInt64();
-                HashDigest<SHA256> hash = frames[i + 1].ConvertToHashDigest<SHA256>();
-                hashes.Add((index, hash));
+                StartIndex = frames[1].ConvertToInt64();
+                for (int i = 2, end = hashCount + 2; i < end; i++)
+                {
+                    hashes.Add(frames[i].ConvertToHashDigest<SHA256>());
+                }
             }
 
             Hashes = hashes;
         }
 
-        public IEnumerable<(long, HashDigest<SHA256>)> Hashes { get; }
+        /// <summary>
+        /// The block index of the first hash in <see cref="Hashes"/>.
+        /// It is <c>null</c> iff <see cref="Hashes"/> are empty.
+        /// </summary>
+        public long? StartIndex { get; }
+
+        /// <summary>
+        /// The continuous block hashes, from the lowest index to the highest index.
+        /// </summary>
+        public IEnumerable<HashDigest<SHA256>> Hashes { get; }
 
         protected override MessageType Type => MessageType.BlockHashes;
 
@@ -36,11 +64,15 @@ namespace Libplanet.Net.Messages
             {
                 yield return new NetMQFrame(
                     NetworkOrderBitsConverter.GetBytes(Hashes.Count()));
-
-                foreach ((long index, HashDigest<SHA256> hash) in Hashes)
+                if (StartIndex is long offset)
                 {
-                    yield return new NetMQFrame(NetworkOrderBitsConverter.GetBytes(index));
-                    yield return new NetMQFrame(hash.ToByteArray());
+                    yield return new NetMQFrame(
+                        NetworkOrderBitsConverter.GetBytes(offset));
+
+                    foreach (HashDigest<SHA256> hash in Hashes)
+                    {
+                        yield return new NetMQFrame(hash.ToByteArray());
+                    }
                 }
             }
         }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -29,11 +29,6 @@ namespace Libplanet.Net.Messages
             GetBlockHashes = 0x04,
 
             /// <summary>
-            /// Inventory to transfer blocks.
-            /// </summary>
-            BlockHashes = 0x05,
-
-            /// <summary>
             /// Inventory to transfer transactions.
             /// </summary>
             TxIds = 0x06,
@@ -83,6 +78,11 @@ namespace Libplanet.Net.Messages
             /// Message containing a single <see cref="BlockHeader"/>.
             /// </summary>
             BlockHeaderMessage = 0x0d,
+
+            /// <summary>
+            /// Message containing demand block hashes with their index numbers.
+            /// </summary>
+            BlockHashes = 0x0e,
         }
 
         public byte[] Identity { get; set; }

--- a/Libplanet/Net/StateDownloadState.cs
+++ b/Libplanet/Net/StateDownloadState.cs
@@ -16,6 +16,6 @@ namespace Libplanet.Net
         public int ReceivedIterationCount { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 2;
+        public override int CurrentPhase => 3;
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -646,7 +646,7 @@ namespace Libplanet.Net
 
             if (parsedMessage is BlockHashes blockHashes)
             {
-                return blockHashes.Hashes;
+                return blockHashes.Hashes.Select(b => b.Item2);
             }
 
             throw new InvalidMessageException(
@@ -1108,7 +1108,7 @@ namespace Libplanet.Net
 
                 case GetBlockHashes getBlockHashes:
                     {
-                        IEnumerable<HashDigest<SHA256>> hashes =
+                        IEnumerable<(long i, HashDigest<SHA256> hash)> hashes =
                             BlockChain.FindNextHashes(
                                 getBlockHashes.Locator,
                                 getBlockHashes.Stop,
@@ -1181,6 +1181,7 @@ namespace Libplanet.Net
             }
 
             ImmutableList<HashDigest<SHA256>> newHashes = message.Hashes
+                .Select(b => b.Item2)
                 .Where(hash => !_store.ContainsBlock(hash))
                 .ToImmutableList();
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -694,6 +694,7 @@ namespace Libplanet.Net
                         }
 
                         workspace.Swap(fork, render: false);
+                        wId = fork.Id;
                     }
                     else
                     {

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2900</MaxFileLines>
+  <MaxFileLines>3000</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
This patch makes IDL parallel by requesting chunks of blocks to multiple peers.  As complexity of IDL logic grows up, I added a separated class named `BlockCompletion<T>` which has only a pure logic of dealing with block demands and completion without actual I/Os, and made `Swarm<T>.PreloadAsync()` method to use it.