### PR TITLE
Prevent redundant message broadcasting

### DIFF
--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -329,10 +329,10 @@ namespace Libplanet.Tests.Net.Protocols
 
                 Log.Debug("Bootstrap completed.");
 
-                seed.BroadcastTestMessage("foo");
-                Log.Debug("Broadcast completed.");
-
                 var tasks = swarms.Select(swarm => swarm.WaitForTestMessageWithData("foo"));
+
+                seed.BroadcastTestMessage(null, "foo");
+                Log.Debug("Broadcast completed.");
 
                 await Task.WhenAll(tasks);
             }

--- a/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
@@ -52,6 +52,14 @@ namespace Libplanet.Tests.Net.Protocols
             Thread.Sleep(100);
             bucket.AddPeer(peer2);
             Thread.Sleep(100);
+            Assert.Contains(
+                bucket.GetRandomPeer(null),
+                new[] { peer1, peer2 }
+            );
+            Assert.Contains(
+                bucket.GetRandomPeer(peer1.Address),
+                new[] { peer2 }
+            );
             bucket.AddPeer(peer3);
             Thread.Sleep(100);
             bucket.AddPeer(peer4);
@@ -61,7 +69,7 @@ namespace Libplanet.Tests.Net.Protocols
                 new HashSet<BoundPeer> { peer1, peer2, peer3, peer4 }
             );
             Assert.Contains(
-                bucket.GetRandomPeer(),
+                bucket.GetRandomPeer(null),
                 new[] { peer1, peer2, peer3, peer4 }
             );
             Thread.Sleep(100);

--- a/Libplanet.Tests/Net/Protocols/TestSwarm.cs
+++ b/Libplanet.Tests/Net/Protocols/TestSwarm.cs
@@ -197,7 +197,7 @@ namespace Libplanet.Tests.Net.Protocols
             });
         }
 
-        public void BroadcastTestMessage(string data)
+        public void BroadcastTestMessage(Address? except, string data)
         {
             if (!Running)
             {
@@ -205,7 +205,7 @@ namespace Libplanet.Tests.Net.Protocols
             }
 
             var message = new TestMessage(data) { Remote = AsPeer };
-            var peers = Protocol.PeersToBroadcast.ToList();
+            var peers = Protocol.PeersToBroadcast(except).ToList();
             _ignoreTestMessageWithData.Add(data);
             _logger.Debug(
                 "Broadcasting test message {Data} to {Count} peers.",
@@ -360,7 +360,7 @@ namespace Libplanet.Tests.Net.Protocols
                 {
                     _logger.Debug("Received test message with {Data}.", testMessage.Data);
                     _ignoreTestMessageWithData.Add(testMessage.Data);
-                    BroadcastTestMessage(testMessage.Data);
+                    BroadcastTestMessage(testMessage.Remote.Address, testMessage.Data);
                 }
             }
             else

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Net.Protocols
     {
         IEnumerable<BoundPeer> Peers { get; }
 
-        IEnumerable<BoundPeer> PeersToBroadcast { get; }
+        IEnumerable<BoundPeer> PeersToBroadcast(Address? except);
 
         Task BootstrapAsync(
             ImmutableList<BoundPeer> bootstrapPeers,

--- a/Libplanet/Net/Protocols/KBucket.cs
+++ b/Libplanet/Net/Protocols/KBucket.cs
@@ -173,9 +173,20 @@ namespace Libplanet.Net.Protocols
             return _peers.Count >= _size;
         }
 
-        public BoundPeer GetRandomPeer()
+        public BoundPeer GetRandomPeer(Address? except)
         {
-            var peers = _peers.Keys.ToArray();
+            BoundPeer[] peers;
+            if (except is null)
+            {
+                peers = _peers.Keys.ToArray();
+            }
+            else
+            {
+                peers = _peers.Keys
+                    .Where(peer => !peer.Address.Equals(except.Value))
+                    .ToArray();
+            }
+
             int size = peers.Length;
 
             return size == 0 ? null : peers[_random.Next(size)];

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -49,7 +49,8 @@ namespace Libplanet.Net.Protocols
 
         public IEnumerable<BoundPeer> Peers => _routing.Peers;
 
-        public IEnumerable<BoundPeer> PeersToBroadcast => _routing.PeersToBroadcast;
+        public IEnumerable<BoundPeer> PeersToBroadcast(Address? except) =>
+            _routing.PeersToBroadcast(except);
 
         // FIXME: Currently bootstrap is done until it finds closest peer, but it should halt
         // when found neighbor's count is reached 2*k.

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -50,15 +50,6 @@ namespace Libplanet.Net.Protocols
         public IEnumerable<BoundPeer> Peers => NonEmptyBuckets
             .SelectMany((bucket, _) => bucket.Peers).ToList();
 
-        public IEnumerable<BoundPeer> PeersToBroadcast
-        {
-            get
-            {
-                return NonEmptyBuckets
-                    .Select(bucket => bucket.GetRandomPeer());
-            }
-        }
-
         public IEnumerable<IEnumerable<BoundPeer>> CachesToCheck
         {
             get
@@ -85,6 +76,13 @@ namespace Libplanet.Net.Protocols
             {
                 return _buckets.Where(bucket => !bucket.IsEmpty());
             }
+        }
+
+        public IEnumerable<BoundPeer> PeersToBroadcast(Address? except)
+        {
+            return NonEmptyBuckets
+                .Select(bucket => bucket.GetRandomPeer(except))
+                .Where(peer => !(peer is null));
         }
 
         public IEnumerable<BoundPeer> PeersToRefresh(TimeSpan maxAge)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -574,9 +574,7 @@ namespace Libplanet.Net
 
         public void BroadcastTxs(IEnumerable<Transaction<T>> txs)
         {
-            _logger.Debug("Broadcast Txs.");
-            List<TxId> txIds = txs.Select(tx => tx.Id).ToList();
-            BroadcastTxIds(txIds);
+            BroadcastTxs(null, txs);
         }
 
         public string TraceTable()
@@ -1151,6 +1149,13 @@ namespace Libplanet.Net
             _logger.Debug("Block broadcasting complete.");
         }
 
+        private void BroadcastTxs(Address? excpet, IEnumerable<Transaction<T>> txs)
+        {
+            _logger.Debug("Broadcast Txs.");
+            List<TxId> txIds = txs.Select(tx => tx.Id).ToList();
+            BroadcastTxIds(excpet, txIds);
+        }
+
         private void BroadcastMessage(Address? except, Message message)
         {
             _broadcastQueue.Enqueue((except, message));
@@ -1520,7 +1525,7 @@ namespace Libplanet.Net
                                 _logger.Debug(
                                     "Broadcast Staged Transactions: [{txIds}]",
                                     string.Join(", ", txIds));
-                                BroadcastTxIds(txIds);
+                                BroadcastTxIds(null, txIds);
                             }
                         }, cancellationToken);
                 }
@@ -1539,10 +1544,10 @@ namespace Libplanet.Net
             }
         }
 
-        private void BroadcastTxIds(IEnumerable<TxId> txIds)
+        private void BroadcastTxIds(Address? except, IEnumerable<TxId> txIds)
         {
             var message = new TxIds(Address, txIds);
-            BroadcastMessage(null, message);
+            BroadcastMessage(except, message);
         }
 
         private async Task ProcessMessageAsync(
@@ -2021,7 +2026,7 @@ namespace Libplanet.Net
             TxReceived.Set();
             _logger.Debug("Txs staged successfully.");
 
-            BroadcastTxs(txs);
+            BroadcastTxs(message.Remote.Address, txs);
         }
 
         private void TransferBlocks(GetBlocks getData)


### PR DESCRIPTION
This patch modifies `KademliaProtocol.PeersToBroadcast` prevent message to be re-broadcast to  previous broadcaster peer.