### PR TITLE
Fixed a bug in BlockChain<T>.GetNextTxNonce

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,8 @@ To be released.
  -  Fixed a bug where `Swarm<T>` had infinitely repeated failed requests.
     [[#709]]
  -  Fixed a bug where `Swarm<T>` hadn't stopped properly.  [[#709]]
+ -  Fixed a bug where `BlockChain<T>.GetNextTxNonce()` had returned invalid tx
+    nonce.  [[#718]]
 
 [#662]: https://github.com/planetarium/libplanet/pull/662
 [#665]: https://github.com/planetarium/libplanet/pull/665
@@ -100,6 +102,7 @@ To be released.
 [#704]: https://github.com/planetarium/libplanet/pull/704
 [#706]: https://github.com/planetarium/libplanet/pull/706
 [#709]: https://github.com/planetarium/libplanet/pull/709
+[#718]: https://github.com/planetarium/libplanet/pull/718
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1422,8 +1422,12 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.StageTransactions(txs.ToImmutableHashSet());
             await _blockChain.MineBlock(address);
 
-            var staleTx = _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0);
-            _blockChain.StageTransactions(new[] { staleTx }.ToImmutableHashSet());
+            Transaction<DumbAction>[] staleTxs =
+            {
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
+                _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
+            };
+            _blockChain.StageTransactions(staleTxs.ToImmutableHashSet());
 
             Assert.Equal(2, _blockChain.GetNextTxNonce(address));
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -550,7 +550,7 @@ namespace Libplanet.Blockchain
                 var prevNonce = nonce - 1;
                 var stagedTxNonces = Store.IterateStagedTransactionIds()
                     .Select(Store.GetTransaction<T>)
-                    .Where(tx => tx.Signer.Equals(address) && tx.Nonce >= prevNonce)
+                    .Where(tx => tx.Signer.Equals(address) && tx.Nonce > prevNonce)
                     .Select(tx => tx.Nonce)
                     .OrderBy(n => n);
 


### PR DESCRIPTION
It had returned duplicated tx nonce when `prevNonce` is in staged transactions somehow.