### PR TITLE
Fix 604

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,8 @@ To be released.
  -  Added `InvalidGenesisBlockException` class.  [[#688]]
  -  Added `StateDownloadState` class which reports state preloading iteration
     progress.  [[#703]]
+ -  Added `PeerDiscoveryException` class which inherits `SwarmException`
+    class. [[#604], [#726]]
 
 ### Behavioral changes
 
@@ -76,6 +78,8 @@ To be released.
     [[#706]]
  -  Increased `Swarm<T>`'s network timeout value, in order to be stable
     a high latency internet connection.  [[#709]]
+ -  `Swarm<T>.BootstrapAsync()` became to report `PeerDiscoveryException`
+    instead of `SwarmException` directly. [[#604], [#726]]
 
 ### Bug fixes
 
@@ -92,6 +96,7 @@ To be released.
     nonce.  [[#718]]
  -  Fixed a bug where mined transactions were staged again.  [[#719]]
 
+[#604]: https://github.com/planetarium/libplanet/issues/604
 [#613]: https://github.com/planetarium/libplanet/issues/613
 [#662]: https://github.com/planetarium/libplanet/pull/662
 [#665]: https://github.com/planetarium/libplanet/pull/665
@@ -112,6 +117,7 @@ To be released.
 [#718]: https://github.com/planetarium/libplanet/pull/718
 [#719]: https://github.com/planetarium/libplanet/pull/719
 [#725]: https://github.com/planetarium/libplanet/pull/725
+[#726]: https://github.com/planetarium/libplanet/pull/726
 [#727]: https://github.com/planetarium/libplanet/pull/727
 
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -15,6 +15,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
 using Libplanet.Store;
 using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
@@ -334,7 +335,7 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await Assert.ThrowsAsync<SwarmException>(
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
                     () => swarmB.BootstrapAsync(new[] { swarmA.AsPeer }, 3000, 3000));
 
                 await StartAsync(swarmA);
@@ -530,7 +531,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(b);
 
-                await Assert.ThrowsAsync<SwarmException>(() => BootstrapAsync(a, b.AsPeer));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(() => BootstrapAsync(a, b.AsPeer));
 
                 Assert.True(isCalled);
             }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -103,13 +103,12 @@ namespace Libplanet.Net.Protocols
 
             if (!_routing.Peers.Any())
             {
-                // FIXME: Need more precise exception
-                throw new SwarmException("No seed available.");
+                throw new PeerDiscoveryException("All seeds are unreachable.");
             }
 
             if (findPeerTasks.Count == 0)
             {
-                throw new SwarmException("Bootstrap failed.");
+                throw new PeerDiscoveryException("Bootstrap failed.");
             }
 
             try

--- a/Libplanet/Net/Protocols/PeerDiscoveryException.cs
+++ b/Libplanet/Net/Protocols/PeerDiscoveryException.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Net.Protocols
+{
+    public class PeerDiscoveryException : SwarmException
+    {
+        public PeerDiscoveryException()
+        {
+        }
+
+        public PeerDiscoveryException(string message)
+            : base(message)
+        {
+        }
+
+        public PeerDiscoveryException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected PeerDiscoveryException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Changed `KademliaProtocol.BootstrapAsync` exception type from `SwarmException` to `PeerDiscoveryException`.

This pr fixes #604 