### PR TITLE
Add a 'static' keyword to the class declaration.

### DIFF
--- a/Libplanet.Stun/Stun/Crc32.cs
+++ b/Libplanet.Stun/Stun/Crc32.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Libplanet.Stun
 {
-    public class Crc32
+    public static class Crc32
     {
         private const uint _generator = 0xEDB88320;
         private static readonly uint[] _checksumTable;

--- a/Libplanet.ruleset
+++ b/Libplanet.ruleset
@@ -48,9 +48,6 @@
     <Rule Id="S112" Action="None" />
     <!-- Add the default parameter value defined in the overridden method. -->
     <Rule Id="S1006" Action="None" />
-    <!-- Add a 'protected' constructor or the 'static' keyword to the class
-    declaration. -->
-    <Rule Id="S1118" Action="None" />
     <!-- Add an explanation -->
     <Rule Id="S1123" Action="None" />
     <!-- Take the required action to fix the issue indicated by this


### PR DESCRIPTION
Add a 'static' keyword to `Crc32` class

fix #664