### PR TITLE
Calculate state if received state height is shorter than Tip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,8 @@ To be released.
     some `CultureInfo.CurrentCulture` (e.g., `ar_SA`, `fr_FR`, `th_TH`)
     so that it had caused network protocol incompatibilities.
     [[#734]]
+ -  Fixed a bug where the states became empty between the tip of the peer to
+    receive the states and the tip of the downloaded block.  [[#736]]
 
 [#604]: https://github.com/planetarium/libplanet/issues/604
 [#613]: https://github.com/planetarium/libplanet/issues/613
@@ -133,6 +135,7 @@ To be released.
 [#727]: https://github.com/planetarium/libplanet/pull/727
 [#728]: https://github.com/planetarium/libplanet/pull/728
 [#734]: https://github.com/planetarium/libplanet/pull/734
+[#736]: https://github.com/planetarium/libplanet/pull/736
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1856,6 +1856,72 @@ namespace Libplanet.Tests.Net
             */
         }
 
+        [Fact]
+        public async Task PreloadWhilePeerTipIsChanging()
+        {
+            var key = new PrivateKey();
+            var address = key.PublicKey.ToAddress();
+
+            var policy = new NullPolicy<DumbAction>();
+
+            var fxMiner = new DefaultStoreFixture(memory: true);
+            var minerChain = new BlockChain<DumbAction>(
+                policy, fxMiner.Store, fxMiner.GenesisBlock);
+            var minerAddress = fxMiner.Address1;
+
+            async Task MineBlocks()
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var actions = new[] { new DumbAction(address, $"{i}") };
+                    minerChain.MakeTransaction(key, actions);
+
+                    await minerChain.MineBlock(minerAddress);
+                }
+            }
+
+            await MineBlocks();
+
+            var fxReceiver = new DefaultStoreFixture(memory: true);
+            var receiverChain = new BlockChain<DumbAction>(
+                policy, fxReceiver.Store, fxReceiver.GenesisBlock);
+
+            var minerSwarm = CreateSwarm(minerChain);
+            var receiverSwarm = CreateSwarm(receiverChain);
+
+            try
+            {
+                await StartAsync(minerSwarm);
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                var trustedStateValidators = new[] { minerSwarm.Address }.ToImmutableHashSet();
+
+                var t = MineBlocks();
+                await receiverSwarm.PreloadAsync(trustedStateValidators: trustedStateValidators);
+
+                await t;
+
+                var minerStateRefs = minerChain.Store
+                    .ListAllStateReferences(minerChain.Id, 0, receiverChain.Count)
+                    .FirstOrDefault().Value;
+
+                var receiverStateRefs = receiverChain.Store
+                    .ListAllStateReferences(receiverChain.Id, 0, receiverChain.Count)
+                    .FirstOrDefault().Value;
+
+                Assert.Equal(receiverChain.Count, receiverStateRefs.Count + 1);
+                Assert.Equal(minerStateRefs, receiverStateRefs);
+            }
+            finally
+            {
+                await StopAsync(minerSwarm);
+                await StopAsync(receiverSwarm);
+                minerSwarm.Dispose();
+                receiverSwarm.Dispose();
+                fxMiner.Dispose();
+                fxReceiver.Dispose();
+            }
+        }
+
         [Fact(Timeout = Timeout)]
         public async Task PreloadSparseStateWithTrustedPeers()
         {


### PR DESCRIPTION
This fixes a bug where the states were empty between the tip of the peer to receive the states and the tip of the downloaded block.