### PR TITLE
Introduce Swarm<T>.Peers property to public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,7 +62,9 @@ To be released.
  -  Added `StateDownloadState` class which reports state preloading iteration
     progress.  [[#703]]
  -  Added `PeerDiscoveryException` class which inherits `SwarmException`
-    class. [[#604], [#726]]
+    class.  [[#604], [#726]]
+ -  Added `Swarm<T>.Peers` property which returns an enumerable of peers in
+    `Swarm<T>`'s routing table.  [[#739]]
 
 ### Behavioral changes
 
@@ -136,6 +138,7 @@ To be released.
 [#728]: https://github.com/planetarium/libplanet/pull/728
 [#734]: https://github.com/planetarium/libplanet/pull/734
 [#736]: https://github.com/planetarium/libplanet/pull/736
+[#739]: https://github.com/planetarium/libplanet/pull/739
 
 
 Version 0.7.0

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -262,6 +262,8 @@ namespace Libplanet.Net
             }
         }
 
+        public IEnumerable<BoundPeer> Peers => Protocol.Peers;
+
         internal AsyncAutoResetEvent TxReceived { get; }
 
         internal AsyncAutoResetEvent BlockReceived { get; }
@@ -270,8 +272,6 @@ namespace Libplanet.Net
         internal AsyncAutoResetEvent BlockAppended { get; }
 
         internal TimeSpan BlockHashRecvTimeout { get; set; } = TimeSpan.FromSeconds(30);
-
-        internal IEnumerable<BoundPeer> Peers => Protocol.Peers;
 
         internal IProtocol Protocol { get; private set; }
 


### PR DESCRIPTION
User of libplanet may want to get information of peers in its routing table.