### PR TITLE
Tune Swarm<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,7 +120,7 @@ To be released.
  -  Fixed a bug where the states became empty between the tip of the peer to
     receive the states and the tip of the downloaded block.  [[#736]]
  -  Fixed a bug where `Swarm<T>.StartAsync()` had thrown
-    `NullReferenceException` when without using NAT and `host` parameter.
+    `NullReferenceException` when `host` parameter is present on the outside of NAT.
     [[#744]]
  -  Fixed a bug where `Swarm<T>` had failed to request a TURN relay when it has
     an IPv6 address.  [[#744]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,8 @@ To be released.
     in the same chain, since these virtually never become valid.  [[#721], [#728]]
  -  `Swarm<T>` became not to fill blocks if received block hashes are
     continuous.  [[#732]]
+ -  `Swarm<T>` became to can process more requests at once by creating TURN
+    relaying proxy concurrently.  [[#744]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,8 @@ To be released.
  -  Fixed a bug where `Swarm<T>.StartAsync()` had thrown
     `NullReferenceException` when without using NAT and `host` parameter.
     [[#744]]
+ -  Fixed a bug where `Swarm<T>` had failed to request a TURN relay when it has
+    an IPv6 address.  [[#744]]
 
 [#570]: https://github.com/planetarium/libplanet/issues/570
 [#580]: https://github.com/planetarium/libplanet/pull/580

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,9 @@ To be released.
     [[#734]]
  -  Fixed a bug where the states became empty between the tip of the peer to
     receive the states and the tip of the downloaded block.  [[#736]]
+ -  Fixed a bug where `Swarm<T>.StartAsync()` had thrown
+    `NullReferenceException` when without using NAT and `host` parameter.
+    [[#744]]
 
 [#570]: https://github.com/planetarium/libplanet/issues/570
 [#580]: https://github.com/planetarium/libplanet/pull/580
@@ -152,6 +155,7 @@ To be released.
 [#734]: https://github.com/planetarium/libplanet/pull/734
 [#736]: https://github.com/planetarium/libplanet/pull/736
 [#739]: https://github.com/planetarium/libplanet/pull/739
+[#744]: https://github.com/planetarium/libplanet/pull/744
 
 
 Version 0.7.0

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -3,7 +3,6 @@ using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -449,6 +448,9 @@ namespace Libplanet.Net
                 );
                 EndPoint = new DnsEndPoint(turnEp.Address.ToString(), turnEp.Port);
 
+                // FIXME should be parameterized
+                tasks.Add(BindingProxies(_cancellationToken));
+                tasks.Add(BindingProxies(_cancellationToken));
                 tasks.Add(BindingProxies(_cancellationToken));
                 tasks.Add(RefreshAllocate(_cancellationToken));
                 tasks.Add(RefreshPermissions(_cancellationToken));
@@ -1190,7 +1192,6 @@ namespace Libplanet.Net
                     {
                         using (var proxy = new NetworkStreamProxy(stream))
                         {
-                            Debug.Assert(_listenPort != null, nameof(_listenPort) + " != null");
                             await proxy.StartAsync(IPAddress.Loopback, _listenPort.Value);
                         }
                     }).ContinueWith(_ => stream.Dispose());

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2489,7 +2489,11 @@ namespace Libplanet.Net
                     ep = await _turnClient.GetMappedAddressAsync();
                 }
 
-                await _turnClient.CreatePermissionAsync(ep);
+                // FIXME Can we really ignore IPv6 case?
+                if (ip.AddressFamily.Equals(AddressFamily.InterNetwork))
+                {
+                    await _turnClient.CreatePermissionAsync(ep);
+                }
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -191,11 +191,19 @@ namespace Libplanet.Net
                             runtime.Run(workerTasks);
                         }
                     }
-                    catch (NetMQException)
+                    catch (NetMQException e)
                     {
+                        _logger.Error(
+                            e,
+                            $"NetMQException occurred in {nameof(_runtimeProcessor)}."
+                        );
                     }
-                    catch (ObjectDisposedException)
+                    catch (ObjectDisposedException e)
                     {
+                        _logger.Error(
+                            e,
+                            $"ObjectDisposedException occurred in {nameof(_runtimeProcessor)}."
+                        );
                     }
                 },
                 CancellationToken.None,


### PR DESCRIPTION
This PR addresses some issues as below

- Fixed a bug where `Swarm<T>.StartAsync()` had thrown `NullReferenceException` when without using NAT and `host` parameter.
- To stabilize request processing, `Swarm<T>._runtimeProcessor` became a long-running task. (it's a dedicated thread.)
- `Swarm<T>` became spawn more `BindingProxies()` to handle TURN request concurrently.
  - We should parameterize its count in the future.