### PR TITLE
Document Libplanet.Stun partially

### DIFF
--- a/Libplanet.Stun/Stun/Attributes/Attribute.cs
+++ b/Libplanet.Stun/Stun/Attributes/Attribute.cs
@@ -5,131 +5,133 @@ namespace Libplanet.Stun.Attributes
     public abstract class Attribute
     {
         /// <summary>
-        /// A enum type of classes inherited <see cref="Attribute"/>.
+        /// Enum values that correspond to <see cref="Attribute"/> subclasses.
         /// </summary>
         /// <remarks>
-        /// https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml.
+        /// This document is from
+        /// <a href="https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml">
+        /// IANA STUN Attributes</a>.
         /// </remarks>
         public enum AttributeType : ushort
         {
             /// <summary>
-            /// <see cref="Attribute"/> used for message integrity. It identifies the username and
-            /// password combination.
+            /// An <see cref="Attribute"/> used for message integrity, identifies a combination
+            /// of username and password.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.3
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.3">RFC5389</a>
             /// </remarks>
             Username = 0x0006,
 
             /// <summary>
-            /// <see cref="Attribute"/> contains an HMAC-SHA1 of the STUN message.
+            /// An <see cref="Attribute"/> which contains an HMAC-SHA1 of the STUN message.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.4.
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.4">RFC5389</a>
             /// </remarks>
             MessageIntegrity = 0x0008,
 
             /// <summary>
-            /// <see cref="Attribute"/> contains a numeric error code value in range of 300 to 699
-            /// and a textual reason phrase encoded in UTF-8.
+            /// An <see cref="Attribute"/> which contains a numeric error code value in range of
+            /// 300 to 699 and a textual reason phrase encoded in UTF-8.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.6
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.6">RFC5389</a>
             /// </remarks>
             ErrorCode = 0x0009,
 
             /// <summary>
-            /// <see cref="Attribute"/> specifies the address and port of the peer as seen from the
-            /// TURN server, obfuscated through the XOR function.
+            /// An <see cref="Attribute"/> which specifies the address and port of the peer as seen
+            /// from the TURN server, obfuscated through the XOR function.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5766#section-14.3
+            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.3">RFC5766</a>
             /// </remarks>
             XorPeerAddress = 0x0012,
 
             /// <summary>
-            /// <see cref="Attribute"/> contains an unquoted realm-value, UTF-8 encoded sequence of
-            /// less than 128 characters. If this attribute presences in a request, there was used
-            /// long-term credentials for authentication. And it is to wish the clien to use
-            /// long-term credentials for authentication if there is this attribute
+            /// An <see cref="Attribute"/> which contains an unquoted realm-value, UTF-8 encoded
+            /// sequence of less than 128 characters. If this attribute presences in a request,
+            /// there was used long-term credentials for authentication. And it is to wish the
+            /// client to use long-term credentials for authentication if there is this attribute
             /// in certain error-response.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.7
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.7">RFC5389</a>
             /// </remarks>
             Realm = 0x0014,
 
             /// <summary>
-            /// <see cref="Attribute"/> contains a sequence of qdtext of quoted-pair and
+            /// An <see cref="Attribute"/> which contains a sequence of qdtext of quoted-pair and
             /// protects replay attacks.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.8
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.8">RFC5389</a>
             /// </remarks>
             Nonce = 0x0015,
 
             /// <summary>
-            /// <see cref="Attribute"/> in allocate-responses, specifies the address and port than
-            /// the server allocated to the client, obfuscated through the XOR function.
+            /// An <see cref="Attribute"/> in allocate-responses, which specifies the address and
+            /// port than the server allocated to the client, obfuscated through the XOR function.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5766#section-14.5
+            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.5">RFC5766</a>
             /// </remarks>
             XorRelayedAddress = 0x0016,
 
             /// <summary>
-            /// <see cref="Attribute"/> used by the client to request a specific transport protocol
-            /// for the allocated transport address.
+            /// An <see cref="Attribute"/> used by the client to request a specific transport
+            /// protocol for the allocated transport address.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5766#section-14.7
+            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.7">RFC5766</a>
             /// </remarks>
             RequestedTransport = 0x0019,
 
             /// <summary>
-            /// <see cref="Attribute"/> indicates a reflexive transport address obfuscated through
-            /// the XOR function.
+            /// An <see cref="Attribute"/> which indicates a reflexive transport address obfuscated
+            /// through the XOR function.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.2
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.2">RFC5389</a>
             /// </remarks>
             XorMappedAddress = 0x0020,
 
             /// <summary>
-            /// <see cref="Attribute"/> uniquely indentifies a peer data connection.
+            /// An <see cref="Attribute"/> which uniquely identifies a peer data connection.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc6062#section-6.2.1
+            /// <a href="https://tools.ietf.org/html/rfc6062#section-6.2.1">RFC6062</a>
             /// </remarks>
             ConnectionId = 0x002a,
 
             /// <summary>
-            /// <see cref="Attribute"/> represents the duration for which the server will maintain
-            /// an allocation in the absence of a refresh.
+            /// An <see cref="Attribute"/> which represents the duration for which the server will
+            /// maintain an allocation in the absence of a refresh.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5766#section-14.2
+            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.2">RFC5766</a>
             /// </remarks>
             Lifetime = 0x000d,
 
             /// <summary>
-            /// <see cref="Attribute"/> contains a textual description of the software being used by
-            /// the agent sending the message. It should include manufacturer and version number.
-            /// Also it has no impact on operation of the protocol, and serves only as a tool for
-            /// diagnostic and debugging purposes.
+            /// An <see cref="Attribute"/> which contains a textual description of the software
+            /// being used by the agent sending the message. It should include manufacturer and
+            /// version number. Also it has no impact on operation of the protocol, and serves only
+            /// as a tool for diagnostic and debugging purposes.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.10
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.10">RFC5389</a>
             /// </remarks>
             Software = 0x8022,
 
             /// <summary>
-            /// <see cref="Attribute"/> may be present in all STUN messages.
+            /// An <see cref="Attribute"/> may be present in all STUN messages.
             /// It has the value computed as the CRC-32 of the STUN message.
             /// Also it aids in distinguishing STUN packets from packets of other protocols.
             /// </summary>
             /// <remarks>
-            /// https://tools.ietf.org/html/rfc5389#section-15.5
+            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.5">RFC5389</a>
             /// </remarks>
             Fingerprint = 0x8028,
         }

--- a/Libplanet.Stun/Stun/Attributes/Attribute.cs
+++ b/Libplanet.Stun/Stun/Attributes/Attribute.cs
@@ -4,25 +4,135 @@ namespace Libplanet.Stun.Attributes
 {
     public abstract class Attribute
     {
-        // TODO Should document following STUN / TURN RFC
-        #pragma warning disable SA1602
+        /// <summary>
+        /// A enum type of classes inherited <see cref="Attribute"/>.
+        /// </summary>
+        /// <remarks>
+        /// https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml.
+        /// </remarks>
         public enum AttributeType : ushort
         {
+            /// <summary>
+            /// <see cref="Attribute"/> used for message integrity. It identifies the username and
+            /// password combination.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.3
+            /// </remarks>
             Username = 0x0006,
+
+            /// <summary>
+            /// <see cref="Attribute"/> contains an HMAC-SHA1 of the STUN message.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.4.
+            /// </remarks>
             MessageIntegrity = 0x0008,
+
+            /// <summary>
+            /// <see cref="Attribute"/> contains a numeric error code value in range of 300 to 699
+            /// and a textual reason phrase encoded in UTF-8.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.6
+            /// </remarks>
             ErrorCode = 0x0009,
+
+            /// <summary>
+            /// <see cref="Attribute"/> specifies the address and port of the peer as seen from the
+            /// TURN server, obfuscated through the XOR function.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5766#section-14.3
+            /// </remarks>
             XorPeerAddress = 0x0012,
+
+            /// <summary>
+            /// <see cref="Attribute"/> contains an unquoted realm-value, UTF-8 encoded sequence of
+            /// less than 128 characters. If this attribute presences in a request, there was used
+            /// long-term credentials for authentication. And it is to wish the clien to use
+            /// long-term credentials for authentication if there is this attribute
+            /// in certain error-response.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.7
+            /// </remarks>
             Realm = 0x0014,
+
+            /// <summary>
+            /// <see cref="Attribute"/> contains a sequence of qdtext of quoted-pair and
+            /// protects replay attacks.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.8
+            /// </remarks>
             Nonce = 0x0015,
+
+            /// <summary>
+            /// <see cref="Attribute"/> in allocate-responses, specifies the address and port than
+            /// the server allocated to the client, obfuscated through the XOR function.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5766#section-14.5
+            /// </remarks>
             XorRelayedAddress = 0x0016,
+
+            /// <summary>
+            /// <see cref="Attribute"/> used by the client to request a specific transport protocol
+            /// for the allocated transport address.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5766#section-14.7
+            /// </remarks>
             RequestedTransport = 0x0019,
+
+            /// <summary>
+            /// <see cref="Attribute"/> indicates a reflexive transport address obfuscated through
+            /// the XOR function.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.2
+            /// </remarks>
             XorMappedAddress = 0x0020,
+
+            /// <summary>
+            /// <see cref="Attribute"/> uniquely indentifies a peer data connection.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc6062#section-6.2.1
+            /// </remarks>
             ConnectionId = 0x002a,
+
+            /// <summary>
+            /// <see cref="Attribute"/> represents the duration for which the server will maintain
+            /// an allocation in the absence of a refresh.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5766#section-14.2
+            /// </remarks>
             Lifetime = 0x000d,
+
+            /// <summary>
+            /// <see cref="Attribute"/> contains a textual description of the software being used by
+            /// the agent sending the message. It should include manufacturer and version number.
+            /// Also it has no impact on operation of the protocol, and serves only as a tool for
+            /// diagnostic and debugging purposes.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.10
+            /// </remarks>
             Software = 0x8022,
+
+            /// <summary>
+            /// <see cref="Attribute"/> may be present in all STUN messages.
+            /// It has the value computed as the CRC-32 of the STUN message.
+            /// Also it aids in distinguishing STUN packets from packets of other protocols.
+            /// </summary>
+            /// <remarks>
+            /// https://tools.ietf.org/html/rfc5389#section-15.5
+            /// </remarks>
             Fingerprint = 0x8028,
         }
-        #pragma warning restore SA1602
 
         public abstract AttributeType Type { get; }
 

--- a/Libplanet.Stun/Stun/Attributes/Attribute.cs
+++ b/Libplanet.Stun/Stun/Attributes/Attribute.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Stun.Attributes
         /// Enum values that correspond to <see cref="Attribute"/> subclasses.
         /// </summary>
         /// <remarks>
-        /// This document is from
+        /// See also
         /// <a href="https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml">
         /// IANA STUN Attributes</a>.
         /// </remarks>
@@ -19,7 +19,7 @@ namespace Libplanet.Stun.Attributes
             /// of username and password.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.3">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.3">RFC 5389</a>.
             /// </remarks>
             Username = 0x0006,
 
@@ -27,7 +27,7 @@ namespace Libplanet.Stun.Attributes
             /// An <see cref="Attribute"/> which contains an HMAC-SHA1 of the STUN message.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.4">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.4">RFC 5389</a>.
             /// </remarks>
             MessageIntegrity = 0x0008,
 
@@ -36,7 +36,7 @@ namespace Libplanet.Stun.Attributes
             /// 300 to 699 and a textual reason phrase encoded in UTF-8.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.6">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.6">RFC 5389</a>.
             /// </remarks>
             ErrorCode = 0x0009,
 
@@ -45,7 +45,7 @@ namespace Libplanet.Stun.Attributes
             /// from the TURN server, obfuscated through the XOR function.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.3">RFC5766</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5766#section-14.3">RFC 5766</a>.
             /// </remarks>
             XorPeerAddress = 0x0012,
 
@@ -57,7 +57,7 @@ namespace Libplanet.Stun.Attributes
             /// in certain error-response.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.7">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.7">RFC 5389</a>.
             /// </remarks>
             Realm = 0x0014,
 
@@ -66,7 +66,7 @@ namespace Libplanet.Stun.Attributes
             /// protects replay attacks.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.8">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.8">RFC 5389</a>.
             /// </remarks>
             Nonce = 0x0015,
 
@@ -75,7 +75,7 @@ namespace Libplanet.Stun.Attributes
             /// port than the server allocated to the client, obfuscated through the XOR function.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.5">RFC5766</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5766#section-14.5">RFC 5766</a>.
             /// </remarks>
             XorRelayedAddress = 0x0016,
 
@@ -84,7 +84,7 @@ namespace Libplanet.Stun.Attributes
             /// protocol for the allocated transport address.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.7">RFC5766</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5766#section-14.7">RFC 5766</a>.
             /// </remarks>
             RequestedTransport = 0x0019,
 
@@ -93,7 +93,7 @@ namespace Libplanet.Stun.Attributes
             /// through the XOR function.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.2">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.2">RFC 5389</a>.
             /// </remarks>
             XorMappedAddress = 0x0020,
 
@@ -101,7 +101,7 @@ namespace Libplanet.Stun.Attributes
             /// An <see cref="Attribute"/> which uniquely identifies a peer data connection.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc6062#section-6.2.1">RFC6062</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc6062#section-6.2.1">RFC 6062</a>.
             /// </remarks>
             ConnectionId = 0x002a,
 
@@ -110,7 +110,7 @@ namespace Libplanet.Stun.Attributes
             /// maintain an allocation in the absence of a refresh.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5766#section-14.2">RFC5766</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5766#section-14.2">RFC 5766</a>.
             /// </remarks>
             Lifetime = 0x000d,
 
@@ -121,7 +121,7 @@ namespace Libplanet.Stun.Attributes
             /// as a tool for diagnostic and debugging purposes.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.10">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.10">RFC 5389</a>.
             /// </remarks>
             Software = 0x8022,
 
@@ -131,7 +131,7 @@ namespace Libplanet.Stun.Attributes
             /// Also it aids in distinguishing STUN packets from packets of other protocols.
             /// </summary>
             /// <remarks>
-            /// <a href="https://tools.ietf.org/html/rfc5389#section-15.5">RFC5389</a>
+            /// See also <a href="https://tools.ietf.org/html/rfc5389#section-15.5">RFC 5389</a>.
             /// </remarks>
             Fingerprint = 0x8028,
         }

--- a/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -25,6 +25,7 @@ namespace Libplanet.Stun.Messages
         }
 
         // TODO Should document following STUN / TURN RFC
+        // https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml
         #pragma warning disable SA1602
         public enum MessageClass : byte
         {
@@ -49,19 +50,42 @@ namespace Libplanet.Stun.Messages
         }
         #pragma warning restore SA1602
 
+        /// <summary>
+        /// A <see cref="MessageClass"/> of STUN packet.
+        /// </summary>
         public abstract MessageClass Class { get; }
 
+        /// <summary>
+        /// A <see cref="MessageMethod"/> of STUN packet.
+        /// </summary>
         public abstract MessageMethod Method { get; }
 
+        /// <summary>
+        /// A 96-bit length identifier, used to uniquely identify STUN transactions.
+        /// </summary>
         public byte[] TransactionId { get; internal set; }
 
+        /// <summary>
+        /// A fixed value to distinguish STUN packets from packets of another protocol.
+        /// </summary>
+        /// <remarks>It should be always 0x2112A442 in network byte order.</remarks>
         internal static byte[] MagicCookie => new byte[]
         {
             0x21, 0x12, 0xa4, 0x42,
         };
 
+        /// <summary>
+        /// A list of <see cref="Attribute"/> of STUN packet.
+        /// </summary>
         protected IEnumerable<Attribute> Attributes { get; set; }
 
+        /// <summary>
+        /// Parse <see cref="StunMessage"/> from <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="stream">A view of a sequence of STUN packet's bytes.</param>
+        /// <returns>A <see cref="StunMessage"/> derived on
+        /// bytes read from <paramref name="stream"/>.
+        /// </returns>
         public static async Task<StunMessage> Parse(Stream stream)
         {
             var header = new byte[20];

--- a/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Stun.Messages
         protected IEnumerable<Attribute> Attributes { get; set; }
 
         /// <summary>
-        /// Parse <see cref="StunMessage"/> from <paramref name="stream"/>.
+        /// Parses <see cref="StunMessage"/> from <paramref name="stream"/>.
         /// </summary>
         /// <param name="stream">A view of a sequence of STUN packet's bytes.</param>
         /// <returns>A <see cref="StunMessage"/> derived on


### PR DESCRIPTION
It documented `enum Libplanet.Stun.Attributes.Attribute.AttributeType` and some part in `class Libplanet.Stun.Messages.StunMessage`. 📖 

It's based on documents below. 
- https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml
- https://tools.ietf.org/html/rfc5389
- https://tools.ietf.org/html/rfc5766, etc..

If there is some mistake or unnaturalness, please leave your comment or suggestion. 💪 