### PR TITLE
Throw exception with network based on different genesis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,8 @@ To be released.
     continuous.  [[#732]]
  -  `Swarm<T>` became to can process more requests at once by creating TURN
     relaying proxy concurrently.  [[#744]]
+ -  `Swarm<T>` became to throw `InvalidGenesisBlockException` when receiving the
+    genesis block of other network chain.  [[#746]]
 
 ### Bug fixes
 
@@ -160,6 +162,7 @@ To be released.
 [#736]: https://github.com/planetarium/libplanet/pull/736
 [#739]: https://github.com/planetarium/libplanet/pull/739
 [#744]: https://github.com/planetarium/libplanet/pull/744
+[#746]: https://github.com/planetarium/libplanet/pull/746
 
 
 Version 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,8 +92,8 @@ To be released.
     continuous.  [[#732]]
  -  `Swarm<T>` became to can process more requests at once by creating TURN
     relaying proxy concurrently.  [[#744]]
- -  `Swarm<T>` became to throw `InvalidGenesisBlockException` when receiving the
-    genesis block of other network chain.  [[#746]]
+ -  `Swarm<T>` became to throw `InvalidGenesisBlockException` when receiving
+    block from the nodes that have a different genesis block.  [[#746]]
 
 ### Bug fixes
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2612,15 +2612,15 @@ namespace Libplanet.Tests.Net
 
             await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
             Assert.NotEqual(chainA.Genesis, chainB.Genesis);
-            try
-            {
-                await swarmA.PreloadAsync();
-            }
-            catch (AggregateException exception)
-            {
-                var exceptions = exception.InnerExceptions.OfType<InvalidGenesisBlockException>();
-                Assert.True(exceptions.Any());
-            }
+            Task t = swarmA.PreloadAsync();
+            await Assert.ThrowsAsync<AggregateException>(async () => await t);
+            var exception = t.Exception.InnerException?.InnerException;
+            Assert.IsType<InvalidGenesisBlockException>(exception);
+
+            await StopAsync(swarmA);
+            await StopAsync(swarmB);
+            swarmA.Dispose();
+            swarmB.Dispose();
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet/Blocks/InvalidGenesisBlockException.cs
+++ b/Libplanet/Blocks/InvalidGenesisBlockException.cs
@@ -8,7 +8,9 @@ namespace Libplanet.Blocks
     /// <summary>
     /// The exception that is thrown when the genesis block the <see cref="IStore"/> contains
     /// mismatches to the genesis block the <see cref="BlockChain{T}"/> constructor (i.e., network)
-    /// expects.
+    /// expects or the first block of <see cref="BlockLocator"/> which the <see cref="IStore"/>
+    /// doesn't contain, because the block which <see cref="IStore"/> doesn't means
+    /// the genesis block in other network.
     /// </summary>
     public class InvalidGenesisBlockException : InvalidBlockException
     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1910,11 +1910,15 @@ namespace Libplanet.Net
                     // same genesis block...
                     else if (!BlockChain.ContainsBlock(branchPoint))
                     {
-                        _logger.Debug(
+                        var msg =
                             $"Since the genesis block is fixed to {BlockChain.Genesis} " +
                             "protocol-wise, the blockchain which does not share " +
-                            "any mutual block is not acceptable.");
-                        break;
+                            "any mutual block is not acceptable.";
+                        _logger.Debug(msg);
+                        throw new InvalidGenesisBlockException(
+                            branchPoint,
+                            workspace.Genesis.Hash,
+                            msg);
                     }
                     else
                     {

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2800</MaxFileLines>
+  <MaxFileLines>2900</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
There was no action when `Swarm<T>` received blocks of other network (chain). It caused that the node entered to wrong network but it couldn't realize. So I made it to throw exception in the case. In addition, IMO it's better to remove the peer from the peers table but I'm not sure it's okay.
Please leave commnets if you have some opinions about that. 😁 