### PR TITLE
Add compress option to DefaultStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,6 @@ To be released.
  -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
     to take `preloadBlockDownloadFailed` event handler as an argument.
     [[#694]]
- -  Removed `StoreExtension` class.  [[#701], [#722]]
  -  Added the `genesisBlock` parameter to
     `BlockChain<T>()` constructor.  [[#688]]
  -  Removed `StateReferenceDownloadState` class.  [[#703]]
@@ -68,6 +67,7 @@ To be released.
  -  Added `Swarm<T>.Peers` property which returns an enumerable of peers in
     `Swarm<T>`'s routing table.  [[#739]]
  -  Added `IStore.LookupStateReference<T>()` method.  [[#722]]
+ -  Added `StoreExtension.Copy(this IStore, IStore)` extension method.  [[#753]]
 
 ### Behavioral changes
 
@@ -163,6 +163,7 @@ To be released.
 [#739]: https://github.com/planetarium/libplanet/pull/739
 [#744]: https://github.com/planetarium/libplanet/pull/744
 [#746]: https://github.com/planetarium/libplanet/pull/746
+[#753]: https://github.com/planetarium/libplanet/pull/753
 
 
 Version 0.7.0

--- a/Libplanet/Store/StoreExtension.cs
+++ b/Libplanet/Store/StoreExtension.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Tx;
 
 namespace Libplanet.Store
 {
@@ -41,6 +44,104 @@ namespace Libplanet.Store
 
             return store.IterateStateReferences(chainId, address, lookupUntil.Index, limit: 1)
                     .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Makes a store, <paramref name="to"/>, logically (but not necessarily physically)
+        /// identical to another store, <paramref name="from"/>.  As this copies the contents
+        /// of the store, instead of its physicall data, this can be used for migrating
+        /// between two different types of <see cref="IStore"/> implementations.
+        /// </summary>
+        /// <param name="from">The store containing the source contents.</param>
+        /// <param name="to">The store to contain the copied contents. Expected to be empty.</param>
+        /// <exception cref="ArgumentException">Thrown when the store passed through
+        /// <paramref name="to"/> is not empty.</exception>
+        public static void Copy(this IStore from, IStore to)
+        {
+            // TODO: take a IProgress<> so that a caller can be aware the progress of cloning.
+            if (to.ListChainIds().Any())
+            {
+                throw new ArgumentException("The destination store has to be empty.", nameof(to));
+            }
+
+            foreach (Guid chainId in from.ListChainIds().ToArray())
+            {
+                foreach (HashDigest<SHA256> blockHash in from.IterateIndexes(chainId))
+                {
+                    Block<NullAction> block = from.GetBlock<NullAction>(blockHash);
+                    to.PutBlock(block);
+                    IImmutableDictionary<Address, IValue> states = from.GetBlockStates(blockHash);
+                    to.SetBlockStates(blockHash, states);
+                    to.AppendIndex(chainId, blockHash);
+                }
+
+                foreach (KeyValuePair<Address, long> kv in from.ListTxNonces(chainId))
+                {
+                    to.IncreaseTxNonce(chainId, kv.Key, kv.Value);
+                }
+
+                foreach (Address address in from.ListAddresses(chainId))
+                {
+                    foreach (var pair in from.IterateStateReferences(chainId, address).Reverse())
+                    {
+                        pair.Deconstruct(out HashDigest<SHA256> refHash, out long refIndex);
+                        to.StoreStateReference(
+                            chainId,
+                            ImmutableHashSet.Create(address),
+                            refHash,
+                            refIndex
+                        );
+                    }
+                }
+            }
+
+            ImmutableHashSet<TxId> stagedTxIds =
+                from.IterateStagedTransactionIds().ToImmutableHashSet();
+            foreach (TxId txid in stagedTxIds)
+            {
+                to.PutTransaction(from.GetTransaction<NullAction>(txid));
+            }
+
+            to.StageTransactionIds(stagedTxIds);
+
+            if (from.GetCanonicalChainId() is Guid canonId)
+            {
+                to.SetCanonicalChainId(canonId);
+            }
+        }
+
+        /// <summary>
+        /// An action implementation which does nothing for filling type parameter taking of
+        /// <see cref="IAction"/>.
+        /// </summary>
+        private class NullAction : IAction
+        {
+            private IValue _value;
+
+            /// <inheritdoc/>
+            public IValue PlainValue => _value;
+
+            /// <inheritdoc/>
+            public IAccountStateDelta Execute(IActionContext context) =>
+                context.PreviousStates;
+
+            /// <inheritdoc/>
+            public void LoadPlainValue(IValue plainValue)
+            {
+                _value = plainValue;
+            }
+
+            /// <inheritdoc/>
+            public void Render(IActionContext context, IAccountStateDelta nextStates)
+            {
+                // Does nothing.
+            }
+
+            /// <inheritdoc/>
+            public void Unrender(IActionContext context, IAccountStateDelta nextStates)
+            {
+                // Does nothing.
+            }
         }
     }
 }


### PR DESCRIPTION
This patch adds the `compress` option to `DefaultStore()` constructor, which is turned off by default, to reduce the size of stored data.  This option does not compress blocks or transactions, but only block states.  The effect is ~31%: 5.1 GB → 1.6 GB.