### PR TITLE
Fix a bug to have invalid state references cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,6 +141,8 @@ To be released.
     [[#744]]
  -  Fixed a bug where `Swarm<T>` had failed to request a TURN relay when it has
     an IPv6 address.  [[#744]]
+ -  Fixed a bug where `DefaultStore` had invalid state references cache after fork.
+    [[#759]]
 
 [#570]: https://github.com/planetarium/libplanet/issues/570
 [#580]: https://github.com/planetarium/libplanet/pull/580
@@ -181,6 +183,7 @@ To be released.
 [#751]: https://github.com/planetarium/libplanet/pull/751
 [#753]: https://github.com/planetarium/libplanet/pull/753
 [#758]: https://github.com/planetarium/libplanet/pull/758
+[#759]: https://github.com/planetarium/libplanet/pull/759
 
 
 Version 0.7.0

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -729,6 +729,8 @@ namespace Libplanet.Store
 
             dstColl.EnsureIndex("AddressString");
             dstColl.EnsureIndex("BlockIndex");
+
+            _lastStateRefCaches.Remove(destinationChainId);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Originally, when the chain has forked, it was able to execute the genesis block multiple times and it caused invalid states cache because states cache works on only `SetBlockStates()`, `GetBlockStates()`.  So `ForkStateReferences()` became to clear state references cache after the end of the task.