### PR TITLE
Unsure to merge: Compress blocks and txs as well

### DIFF
--- a/Libplanet.Tests/Store/CompressedDefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/CompressedDefaultStoreTest.cs
@@ -1,0 +1,12 @@
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Store
+{
+    public class CompressedDefaultStoreTest : DefaultStoreTest
+    {
+        public CompressedDefaultStoreTest(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper, compress: true)
+        {
+        }
+    }
+}

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Tests.Store
 {
     public class DefaultStoreFixture : StoreFixture, IDisposable
     {
-        public DefaultStoreFixture(bool memory = false)
+        public DefaultStoreFixture(bool memory = false, bool compress = false)
         {
             if (memory)
             {
@@ -20,7 +20,12 @@ namespace Libplanet.Tests.Store
                 );
             }
 
-            Store = new DefaultStore(Path, blockCacheSize: 2, txCacheSize: 2);
+            Store = new DefaultStore(
+                Path,
+                compress: compress,
+                blockCacheSize: 2,
+                txCacheSize: 2
+            );
         }
 
         public string Path { get; }

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -13,10 +13,10 @@ namespace Libplanet.Tests.Store
     {
         private readonly DefaultStoreFixture _fx;
 
-        public DefaultStoreTest(ITestOutputHelper testOutputHelper)
+        public DefaultStoreTest(ITestOutputHelper testOutputHelper, bool compress = false)
         {
             TestOutputHelper = testOutputHelper;
-            Fx = _fx = new DefaultStoreFixture();
+            Fx = _fx = new DefaultStoreFixture(compress: compress);
         }
 
         public void Dispose()


### PR DESCRIPTION
This patch is continued from #753.  Besides block states, this compresses blocks and txs as well.  Unfortunately, the compression rate is almost the same to #753 (5.1G → 1.6G).