### PR TITLE
BlockChain<T>.Fork() should skip eval and render the genesis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -148,6 +148,8 @@ To be released.
     an IPv6 address.  [[#744]]
  -  Fixed a bug where `DefaultStore` had invalid state references cache after fork.
     [[#759]]
+ -  Fixed a bug where `BlockChain<T>` had rendered and evaluated actions in
+    the genesis block during forking.  [[#763]]
 
 [#570]: https://github.com/planetarium/libplanet/issues/570
 [#580]: https://github.com/planetarium/libplanet/pull/580
@@ -193,6 +195,7 @@ To be released.
 [#758]: https://github.com/planetarium/libplanet/pull/758
 [#759]: https://github.com/planetarium/libplanet/pull/759
 [#760]: https://github.com/planetarium/libplanet/pull/760
+[#763]: https://github.com/planetarium/libplanet/pull/763
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Common/Action/ExecuteRecord.cs
+++ b/Libplanet.Tests/Common/Action/ExecuteRecord.cs
@@ -1,0 +1,13 @@
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public struct ExecuteRecord
+    {
+        public IAction Action { get; set; }
+
+        public IAccountStateDelta NextState { get; set; }
+
+        public bool Rehearsal { get; set; }
+    }
+}

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -92,10 +92,18 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return bytes;
         }
 
-        public static Block<T> MineGenesis<T>(Address? miner = null)
+        public static Block<T> MineGenesis<T>(
+            Address? miner = null,
+            IEnumerable<Transaction<T>> transactions = null
+        )
             where T : IAction, new()
         {
             var timestamp = new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero);
+            if (transactions is null)
+            {
+                transactions = new List<Transaction<T>>();
+            }
+
             return new Block<T>(
                 index: 0,
                 difficulty: 0,
@@ -103,7 +111,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 miner: miner ?? GenesisMinerAddress,
                 previousHash: null,
                 timestamp: timestamp,
-                transactions: new List<Transaction<T>>()
+                transactions: transactions
             );
         }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -88,7 +88,25 @@ namespace Libplanet.Blockchain
             IBlockPolicy<T> policy,
             IStore store,
             Guid id,
-            Block<T> genesisBlock)
+            Block<T> genesisBlock
+        )
+            : this(
+                policy,
+                store,
+                id,
+                genesisBlock,
+                false
+            )
+        {
+        }
+
+        private BlockChain(
+            IBlockPolicy<T> policy,
+            IStore store,
+            Guid id,
+            Block<T> genesisBlock,
+            bool inFork
+        )
         {
             Id = id;
             Policy = policy;
@@ -109,7 +127,12 @@ namespace Libplanet.Blockchain
 
             if (Count == 0)
             {
-                Append(genesisBlock);
+                Append(
+                    genesisBlock,
+                    currentTime: genesisBlock.Timestamp,
+                    renderActions: !inFork,
+                    evaluateActions: !inFork
+                );
             }
             else if (!Genesis.Equals(genesisBlock))
             {
@@ -1032,7 +1055,7 @@ namespace Libplanet.Blockchain
                     nameof(point));
             }
 
-            var forked = new BlockChain<T>(Policy, Store, Guid.NewGuid(), Genesis);
+            var forked = new BlockChain<T>(Policy, Store, Guid.NewGuid(), Genesis, true);
             Guid forkedId = forked.Id;
             _logger.Debug(
                 "Trying to fork chain at {branchPoint}" +


### PR DESCRIPTION
This PR fixes a bug where `BlockChain<T>` had evaluated and render actions in the genesis block during forking.