### PR TITLE
Broadcast single block header instead of block hashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,11 +40,14 @@ To be released.
     [[#613], [#727]]
  -  `Block<T>` class became not to implement `ISerializable`.  [[#751]]
  -  `Transaction<T>` class became not to implement `ISerializable`.  [[#751]]
- -  `Block<T>.ToBencodex()` became to return `Bencodex.Types.Dictionary`.  [[#751]]
- -  `Transaction<T>.ToBencodex()` became to return `Bencodex.Types.Dictionary`.  [[#751]]
+ -  `Block<T>.ToBencodex()` became to return `Bencodex.Types.Dictionary`.
+    [[#751]]
+ -  `Transaction<T>.ToBencodex()` became to return `Bencodex.Types.Dictionary`.
+    [[#751]]
  -  Removed `Block<T>.FromBencodex(byte[])` method.  [[#751]]
  -  Removed `Transaction<T>.FromBencodex(byte[])` method.  [[#751]]
  -  `Block<T>.ToBencodex()` became to take no arguments.  [[#749], [#757]]
+ -  Removed `Swarm<T>.BroadcastBlocks(IEnumerable<Block<T>>)` method.  [[#764]]
 
 ### Backward-incompatible network protocol changes
 
@@ -52,6 +55,7 @@ To be released.
     `GetRecentStates` messages.  [[#703]]
  -  Added `int`-typed `iteration` parameter to `RecentStates` message.
     [[#703]]
+ -  Added `BlockHeaderMessage` message.  [[#764]]
 
 ### Backward-incompatible storage format changes
 
@@ -86,6 +90,7 @@ To be released.
  -  Added `CryptoConfig` class.  [[#758]]
  -  Added `ICryptoBackend` class.  [[#758]]
  -  Added `DefaultCryptoBackend` class.  [[#758]]
+ -  Added `Swarm<T>.BroadcastBlock(Block<T>)` method.  [[#764]]
 
 ### Behavioral changes
 
@@ -116,6 +121,8 @@ To be released.
     `Swarm<T>.StartAsync()` became not to call `Swarm<T>.PreloadAsync()`.  [[#735], [#760]]
  -  The hash of `Block<T>` has changed due to the change in the method of
     serialization.  [[#762]]
+ -  `Swarm<T>` became to ignore broadcasted block that has lower index than
+    the current tip.  [[#764]]
 
 ### Bug fixes
 
@@ -199,6 +206,7 @@ To be released.
 [#760]: https://github.com/planetarium/libplanet/pull/760
 [#762]: https://github.com/planetarium/libplanet/pull/762
 [#763]: https://github.com/planetarium/libplanet/pull/763
+[#764]: https://github.com/planetarium/libplanet/pull/764
 
 
 Version 0.7.0

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -176,7 +176,7 @@ namespace Libplanet.Benchmarks
         public async Task BroadcastBlock()
         {
             Task t = _swarms[SwarmNumber - 1].BlockAppended.WaitAsync();
-            _swarms[0].BroadcastBlocks(new [] { _blockChains[0][-1] });
+            _swarms[0].BroadcastBlock(_blockChains[0][-1]);
             await t;
         }
 
@@ -184,7 +184,7 @@ namespace Libplanet.Benchmarks
         public async Task BroadcastBlockWithoutFill()
         {
             Task t = _swarms[SwarmNumber - 1].BlockAppended.WaitAsync();
-            _swarms[0].BroadcastBlocks(new [] { _blockChains[0][1] });
+            _swarms[0].BroadcastBlock(_blockChains[0][1]);
             await t;
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -220,7 +220,7 @@ namespace Libplanet.Tests.Net
                 Assert.Contains(swarmB.AsPeer, seed.Peers);
                 Assert.Contains(seed.AsPeer, swarmB.Peers);
 
-                seed.BroadcastBlocks(new[] { chainWithBlocks.Tip });
+                seed.BroadcastBlock(chainWithBlocks.Tip);
 
                 await swarmB.BlockAppended.WaitAsync();
 
@@ -432,7 +432,7 @@ namespace Libplanet.Tests.Net
                                 "Block mined. [Node: {0}, Block: {1}]",
                                 swarm.Address,
                                 block.Hash);
-                            swarm.BroadcastBlocks(new[] { block });
+                            swarm.BroadcastBlock(block);
                         }
                         catch (OperationCanceledException)
                         {
@@ -444,7 +444,7 @@ namespace Libplanet.Tests.Net
                         }
                     }
 
-                    swarm.BroadcastBlocks(new[] { chain[-1] });
+                    swarm.BroadcastBlock(chain[-1]);
                     Log.Debug("Mining complete.");
                 });
             }
@@ -979,16 +979,15 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
                 await BootstrapAsync(swarmC, swarmA.AsPeer);
 
-                swarmB.BroadcastBlocks(new[] { chainB[-1] });
+                swarmB.BroadcastBlock(chainB[-1]);
 
-                await swarmA.BlockReceived.WaitAsync();
                 await swarmC.BlockAppended.WaitAsync();
 
                 // chainB doesn't applied to chainA since chainB is shorter
                 // than chainA
                 Assert.NotEqual(chainB, chainA);
 
-                swarmA.BroadcastBlocks(new[] { chainA[-1] });
+                swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
                 await swarmC.BlockAppended.WaitAsync();
@@ -1031,14 +1030,14 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(swarmA, swarmB.AsPeer);
 
                 Task t = swarmB.BlockAppended.WaitAsync();
-                swarmA.BroadcastBlocks(new[] { block1 });
+                swarmA.BroadcastBlock(block1);
                 await t;
                 // Make sure that FillBlocksAsync did not run.
                 Assert.False(swarmB.FillBlocksAsyncStarted.IsSet);
                 Assert.Equal(chainB.BlockHashes, new[] { chainA[0].Hash, chainA[1].Hash });
 
                 t = swarmB.BlockAppended.WaitAsync();
-                swarmA.BroadcastBlocks(new[] { block2 });
+                swarmA.BroadcastBlock(block2);
                 await t;
                 // Make sure that FillBlocksAsync is ran.
                 Assert.True(swarmB.FillBlocksAsyncStarted.IsSet);
@@ -1118,7 +1117,7 @@ namespace Libplanet.Tests.Net
                     policy.GetNextBlockDifficulty(blockChain));
                 blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, false);
                 Log.Debug("Ready to broadcast blocks.");
-                minerSwarm.BroadcastBlocks(new[] { block2 });
+                minerSwarm.BroadcastBlock(block2);
                 await receiverSwarm.BlockAppended.WaitAsync();
 
                 Assert.Equal(3, _blockchains[0].Count);
@@ -1150,14 +1149,14 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
 
                 await chainA.MineBlock(_fx1.Address1);
-                swarmA.BroadcastBlocks(new[] { chainA[-1] });
+                swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
 
                 Assert.Equal(chainB.BlockHashes, chainA.BlockHashes);
 
                 await chainA.MineBlock(_fx1.Address1);
-                swarmA.BroadcastBlocks(new[] { chainA[-1] });
+                swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
 
@@ -1193,13 +1192,13 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
 
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
-                swarmA.BroadcastBlocks(new[] { chainA[-1] });
+                swarmA.BroadcastBlock(chainA[-1]);
                 await swarmB.BlockAppended.WaitAsync();
 
                 Assert.Equal(chainA.BlockHashes, chainB.BlockHashes);
 
                 CancellationTokenSource cts = new CancellationTokenSource();
-                swarmA.BroadcastBlocks(new[] { chainA[-1] });
+                swarmA.BroadcastBlock(chainA[-1]);
                 Task t = swarmB.BlockAppended.WaitAsync(cts.Token);
 
                 // Actually, previous code may pass this test if message is
@@ -2362,7 +2361,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarm2);
                 await swarm1.AddPeersAsync(new[] { swarm2.AsPeer }, null);
 
-                swarm2.BroadcastBlocks(new[] { block3 });
+                swarm2.BroadcastBlock(block3);
                 await swarm1.FillBlocksAsyncFailed.WaitAsync();
 
                 List<Guid> chainIds = fx1.Store.ListChainIds().ToList();
@@ -2417,7 +2416,7 @@ namespace Libplanet.Tests.Net
                 await miner1.BlockChain.MineBlock(miner1.Address);
                 await miner2.BlockChain.MineBlock(miner2.Address);
                 Block<Sleep> latest = await miner2.BlockChain.MineBlock(miner2.Address);
-                miner2.BroadcastBlocks(new[] { latest });
+                miner2.BroadcastBlock(latest);
                 await t;
 
                 Assert.Equal(miner1.BlockChain.Tip, miner2.BlockChain.Tip);
@@ -2467,21 +2466,21 @@ namespace Libplanet.Tests.Net
                 // Broadcast SwarmA's first block.
                 var b1 = await minerChainA.MineBlock(_fx1.Address1);
                 await minerChainB.MineBlock(_fx1.Address1);
-                minerSwarmA.BroadcastBlocks(new[] { b1 });
+                minerSwarmA.BroadcastBlock(b1);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainA.Tip);
 
                 // Broadcast SwarmB's second block.
                 await minerChainA.MineBlock(_fx1.Address1);
                 var b2 = await minerChainB.MineBlock(_fx1.Address1);
-                minerSwarmB.BroadcastBlocks(new[] { b2 });
+                minerSwarmB.BroadcastBlock(b2);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainB.Tip);
 
                 // Broadcast SwarmA's third block.
                 var b3 = await minerChainA.MineBlock(_fx1.Address1);
                 await minerChainB.MineBlock(_fx1.Address1);
-                minerSwarmA.BroadcastBlocks(new[] { b3 });
+                minerSwarmA.BroadcastBlock(b3);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainA.Tip);
             }
@@ -2518,7 +2517,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await BootstrapAsync(swarmA, swarmB.AsPeer);
 
-                swarmA.BroadcastBlocks(new[] { block });
+                swarmA.BroadcastBlock(block);
                 await swarmB.FillBlocksAsyncStarted.WaitAsync();
                 await StopAsync(swarmA);
                 await swarmB.FillBlocksAsyncFailed.WaitAsync();
@@ -2577,7 +2576,7 @@ namespace Libplanet.Tests.Net
                 Task.WaitAll(new[]
                 {
                     Task.Run(() => swarmC.BlockAppended.Wait()),
-                    Task.Run(() => swarmA.BroadcastBlocks(new[] { block })),
+                    Task.Run(() => swarmA.BroadcastBlock(block)),
                 });
 
                 Assert.NotEqual(genesisChainA.Genesis, genesisChainB.Genesis);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -981,7 +981,10 @@ namespace Libplanet.Tests.Net
 
                 swarmB.BroadcastBlock(chainB[-1]);
 
+                // chainA ignores block header received because its index is shorter.
+                await swarmA.BlockHeaderReceived.WaitAsync();
                 await swarmC.BlockAppended.WaitAsync();
+                Assert.False(swarmA.BlockAppended.IsSet);
 
                 // chainB doesn't applied to chainA since chainB is shorter
                 // than chainA

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using Bencodex;
 using Bencodex.Types;
 
 namespace Libplanet.Blocks
@@ -81,6 +82,24 @@ namespace Libplanet.Blocks
         public ImmutableArray<byte> TxHash { get; }
 
         public ImmutableArray<byte> Hash { get; }
+
+        public static BlockHeader Deserialize(byte[] bytes)
+        {
+            IValue value = new Codec().Decode(bytes);
+            if (!(value is Bencodex.Types.Dictionary dict))
+            {
+                throw new DecodingException(
+                    $"Expected {typeof(Bencodex.Types.Dictionary)} but " +
+                    $"{value.GetType()}");
+            }
+
+            return new BlockHeader(dict);
+        }
+
+        public byte[] Serialize()
+        {
+            return new Codec().Encode(ToBencodex());
+        }
 
         public Bencodex.Types.Dictionary ToBencodex()
         {

--- a/Libplanet/Net/Messages/BlockHashes.cs
+++ b/Libplanet/Net/Messages/BlockHashes.cs
@@ -7,8 +7,7 @@ namespace Libplanet.Net.Messages
 {
     internal class BlockHashes : Message
     {
-        public BlockHashes(
-            Address sender, IEnumerable<HashDigest<SHA256>> hashes)
+        public BlockHashes(IEnumerable<HashDigest<SHA256>> hashes)
         {
             Hashes = hashes.ToList();
         }

--- a/Libplanet/Net/Messages/BlockHeaderMessage.cs
+++ b/Libplanet/Net/Messages/BlockHeaderMessage.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Libplanet.Blocks;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class BlockHeaderMessage : Message
+    {
+        public BlockHeaderMessage(
+            Address sender, BlockHeader header)
+        {
+            Header = header;
+        }
+
+        public BlockHeaderMessage(NetMQFrame[] frames)
+        {
+            Header = BlockHeader.Deserialize(frames[0].Buffer);
+        }
+
+        public BlockHeader Header { get; }
+
+        protected override MessageType Type => MessageType.BlockHeaderMessage;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(Header.Serialize());
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/BlockHeaderMessage.cs
+++ b/Libplanet/Net/Messages/BlockHeaderMessage.cs
@@ -6,8 +6,7 @@ namespace Libplanet.Net.Messages
 {
     internal class BlockHeaderMessage : Message
     {
-        public BlockHeaderMessage(
-            Address sender, BlockHeader header)
+        public BlockHeaderMessage(BlockHeader header)
         {
             Header = header;
         }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Blocks;
 using Libplanet.Crypto;
 using NetMQ;
 
@@ -77,6 +78,11 @@ namespace Libplanet.Net.Messages
             /// Contains the calculated recent states and state references.
             /// </summary>
             RecentStates = 0x0c,
+
+            /// <summary>
+            /// Message containing a single <see cref="BlockHeader"/>.
+            /// </summary>
+            BlockHeaderMessage = 0x0d,
         }
 
         public byte[] Identity { get; set; }
@@ -118,6 +124,7 @@ namespace Libplanet.Net.Messages
                 { MessageType.Neighbors, typeof(Neighbors) },
                 { MessageType.GetRecentStates, typeof(GetRecentStates) },
                 { MessageType.RecentStates, typeof(RecentStates) },
+                { MessageType.BlockHeaderMessage, typeof(BlockHeaderMessage) },
             };
 
             if (!types.TryGetValue(rawType, out Type type))

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -103,6 +103,7 @@ namespace Libplanet.Net
                 DateTimeOffset.UtcNow);
             LastReceived = now;
             TxReceived = new AsyncAutoResetEvent();
+            BlockHeaderReceived = new AsyncAutoResetEvent();
             BlockAppended = new AsyncAutoResetEvent();
             BlockReceived = new AsyncAutoResetEvent();
 
@@ -167,6 +168,8 @@ namespace Libplanet.Net
         internal IProtocol Protocol => (_transport as NetMQTransport)?.Protocol;
 
         internal AsyncAutoResetEvent TxReceived { get; }
+
+        internal AsyncAutoResetEvent BlockHeaderReceived { get; }
 
         internal AsyncAutoResetEvent BlockReceived { get; }
 
@@ -1177,7 +1180,10 @@ namespace Libplanet.Net
                 return;
             }
 
+            BlockHeaderReceived.Set();
             BlockHeader header = message.Header;
+
+            // FIXME: this should be changed into total difficulty.
             if (header.Index > BlockChain.Tip.Index)
             {
                 await FetchBlocks(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -738,7 +738,7 @@ namespace Libplanet.Net
         private void BroadcastBlock(Address? except, Block<T> block)
         {
             _logger.Debug("Trying to broadcast blocks...");
-            var message = new BlockHeaderMessage(Address, block.GetBlockHeader());
+            var message = new BlockHeaderMessage(block.GetBlockHeader());
             BroadcastMessage(except, message);
             _logger.Debug("Block broadcasting complete.");
         }
@@ -1087,7 +1087,7 @@ namespace Libplanet.Net
                                 getBlockHashes.Locator,
                                 getBlockHashes.Stop,
                                 FindNextHashesChunkSize);
-                        var reply = new BlockHashes(Address, hashes)
+                        var reply = new BlockHashes(hashes)
                         {
                             Identity = getBlockHashes.Identity,
                         };
@@ -1193,7 +1193,7 @@ namespace Libplanet.Net
             }
             else
             {
-                _logger.Debug($"No blocks to require. Ignore {nameof(BlockHeader)}.");
+                _logger.Debug($"No blocks to require. Ignore {nameof(BlockHeaderMessage)}.");
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1164,7 +1164,7 @@ namespace Libplanet.Net
             }
             else
             {
-                _logger.Debug($"No blocks to require. Ignore {nameof(BlockHashes)}.");
+               _logger.Debug($"No blocks are required; {nameof(BlockHashes)} is ignored.");
             }
         }
 
@@ -1193,7 +1193,7 @@ namespace Libplanet.Net
             }
             else
             {
-                _logger.Debug($"No blocks to require. Ignore {nameof(BlockHeaderMessage)}.");
+                _logger.Debug($"No blocks are required; {nameof(BlockHeaderMessage)} is ignored.");
             }
         }
 


### PR DESCRIPTION
We can ignore a block in different branch with lower index by this patch. See #757.