### PR TITLE
Guarantee at least 10 peers to broadcast

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,11 @@ To be released.
     serialization.  [[#762]]
  -  `Swarm<T>` became to ignore broadcasted block that has lower index than
     the current tip.  [[#764]]
+ -  The way `Swarm<T>` chose peers to spread messages has changed.  [[#765], [#767]]
+     -  If there are less than 10 peers in the routing table, select all peers.
+     -  If there are more than 10 peers in the routing table,
+        choose one from each bucket, and if the number is less than 10,
+        then select an additional peers so that the total is 10.
 
 ### Bug fixes
 
@@ -207,6 +212,8 @@ To be released.
 [#762]: https://github.com/planetarium/libplanet/pull/762
 [#763]: https://github.com/planetarium/libplanet/pull/763
 [#764]: https://github.com/planetarium/libplanet/pull/764
+[#765]: https://github.com/planetarium/libplanet/issues/765
+[#767]: https://github.com/planetarium/libplanet/pull/767
 
 
 Version 0.7.0

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
@@ -251,10 +252,14 @@ namespace Libplanet.Tests.Net.Protocols
         public void BroadcastMessage(Address? except, Message message)
         {
             var peers = Protocol.PeersToBroadcast(except).ToList();
+            var peersString = peers.Aggregate(
+                new StringBuilder(),
+                (builder, peer) => builder.Append($"{peer.Address.ToHex()}, ")).ToString();
             _logger.Debug(
-                "Broadcasting test message {Data} to {Count} peers.",
+                "Broadcasting test message {Data} to {Count} peers which are: {Peers}.",
                 ((TestMessage)message).Data,
-                peers.Count);
+                peers.Count,
+                peersString);
             foreach (var peer in peers)
             {
                 _requests.Add(new Request()
@@ -394,7 +399,7 @@ namespace Libplanet.Tests.Net.Protocols
                 throw new SwarmException("Start swarm before use.");
             }
 
-            return ReceivedMessages.OfType<TestMessage>().Select(msg => msg.Data == data).Any();
+            return ReceivedMessages.OfType<TestMessage>().Any(msg => msg.Data == data);
         }
 
         private void ReceiveMessage(Message message)

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -83,7 +83,7 @@ namespace Libplanet.Net.Protocols
 
         public IEnumerable<BoundPeer> PeersToBroadcast(Address? except)
         {
-            var peers = NonEmptyBuckets
+            List<BoundPeer> peers = NonEmptyBuckets
                 .Select(bucket => bucket.GetRandomPeer(except))
                 .Where(peer => !(peer is null)).ToList();
             var count = peers.Count;


### PR DESCRIPTION
If the number of total peers in routing table is less then 10, broadcast messages to all peers.
If not, pick one from each bucket, and pick additional peers which were not selected in first step until total peers count reach 10.

Closes #765.