### PR TITLE
Remove the assumption on BlockChain<T> has a block at least

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,10 @@ To be released.
 
 ### Backward-incompatible storage format changes
 
+ -  Added `BlockChain<T>(IBlockPolicy<T>, IStore, HashDigest<SHA256>)` constructor.
+    It became available to receive also `genesisHash` instead `genesisBlock`.
+    [[#750], [#769]]
+
 ### Added APIs
 
  -  Added `BlockHashDownloadState` class, a subclass of `PreloadState`.
@@ -76,6 +80,9 @@ To be released.
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
  -  Added `Block<T>.ToBlockDigest()` method.  [[#785]]
  -  Added `ByteArrayExtensions` class.  [[#803]]
+ -  Added `BlockChain<T>(IBlockPolicy<T>, IStore, HashDigest<SHA256>)` constructor.
+    It became available to receive also `genesisHash` instead `genesisBlock`.
+    [[#750], [#769]]
  -  Added `IStore.PruneBlockStates<T>(Guid, Block<T>)` method.  [[#790]]
  -  Added `DifferentAppProtocolVersionEncountered` delegate.  [[#266], [#815]]
  -  Added `Swarm<T>.TrustedAppProtocolVersionSigners` property.
@@ -109,6 +116,8 @@ To be released.
 
 [#266]: https://github.com/planetarium/libplanet/issues/266
 [#707]: https://github.com/planetarium/libplanet/pull/707
+[#750]: https://github.com/planetarium/libplanet/issues/750
+[#769]: https://github.com/planetarium/libplanet/pull/769
 [#784]: https://github.com/planetarium/libplanet/pull/784
 [#785]: https://github.com/planetarium/libplanet/pull/785
 [#788]: https://github.com/planetarium/libplanet/pull/788

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -841,7 +841,6 @@ namespace Libplanet.Tests.Blockchain
 
             using (var store = new DefaultStore(null))
             {
-                store.PutBlock(genesis);
                 var blockChain = new BlockChain<DumbAction>(
                     _blockChain.Policy,
                     store,

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -34,7 +34,9 @@ namespace Libplanet.Tests.Net.Messages
             var privKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234), ver);
-            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
+            const int headerSize = 4;  // type, peer, sig, genesisHash
+            NetMQFrame[] frames =
+                msg.ToNetMQMessage(privKey, peer, blockHashes[0]).Skip(headerSize).ToArray();
             var restored = new BlockHashes(frames);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -161,9 +161,11 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
         public static byte[] GetRandomBytes(int size)
         {
-            var random = new System.Random();
             var bytes = new byte[size];
-            random.NextBytes(bytes);
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(bytes);
+            }
 
             return bytes;
         }
@@ -232,6 +234,12 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 timestamp: timestamp,
                 transactions: txs
             );
+        }
+
+        public static HashDigest<T> MakeRandomHashDigest<T>()
+            where T : HashAlgorithm
+        {
+            return new HashDigest<T>(GetRandomBytes(HashDigest<T>.Size));
         }
 
         public static string ToString(BitArray bitArray)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -517,6 +517,8 @@ namespace Libplanet.Blockchain
         /// <see cref="Transaction{T}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
         /// <see cref="Transaction{T}.Signer"/>.</exception>
+        /// <exception cref="InvalidGenesisBlockException">Thrown when given block's
+        /// <see cref="Block{T}.Hash"/> doesn't match to <see cref="GenesisHash"/>.</exception>
         public void Append(Block<T> block, DateTimeOffset currentTime) =>
             Append(block, currentTime, evaluateActions: true, renderActions: true);
 

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -420,6 +420,28 @@ namespace Libplanet.Net
             }
         }
 
+        public void RemovePeer(BoundPeer boundPeer)
+        {
+            if (Protocol is null)
+            {
+                throw new ArgumentNullException(nameof(Protocol));
+            }
+
+            try
+            {
+                var kp = (KademliaProtocol)Protocol;
+                kp.RemovePeer(boundPeer);
+                _logger.Debug("Removed peer {Peer}.", boundPeer);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    e,
+                    $"Unexpected exception occurred during {nameof(AddPeersAsync)}().");
+                throw;
+            }
+        }
+
         public async Task<BoundPeer> FindSpecificPeerAsync(
             Address target,
             Address searchAddress,

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -277,6 +277,12 @@ namespace Libplanet.Net.Protocols
         }
 #pragma warning restore CS4014
 
+        public void RemovePeer(BoundPeer peer)
+        {
+            _logger.Debug("Removing peer {Peer} from table.", peer);
+            _routing.RemovePeer(peer);
+        }
+
         public string Trace()
         {
             var trace = $"Routing table of [{_address.ToHex()}]\n";
@@ -461,12 +467,6 @@ namespace Libplanet.Net.Protocols
             }
 
             _routing.AddPeer(peer);
-        }
-
-        private void RemovePeer(BoundPeer peer)
-        {
-            _logger.Debug("Removing peer {Peer} from table.", peer);
-            _routing.RemovePeer(peer);
         }
 
         /// <summary>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -132,6 +132,7 @@ namespace Libplanet.Net
                 workers,
                 host,
                 listenPort,
+                BlockChain.GenesisHash,
                 iceServers,
                 differentAppProtocolVersionEncountered,
                 ProcessMessageHandler,
@@ -1462,7 +1463,7 @@ namespace Libplanet.Net
             {
                 case Ping ping:
                     {
-                        _logger.Debug($"Ping received.");
+                        _logger.Debug("Ping received.");
 
                         Pong pong = new Pong(BlockChain.Tip?.Index)
                         {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2099,6 +2099,12 @@ namespace Libplanet.Net
                     _logger.Debug($"Timeout occurred during {nameof(ProcessFillblock)}");
                     await Task.Delay(100, cancellationToken);
                 }
+                catch (InvalidGenesisBlockException)
+                {
+                    _logger.Debug("Peer[{Peer}] has the genesis block of other network", peer);
+                    var netMQTransport = (NetMQTransport)Transport;
+                    netMQTransport.RemovePeer(peer);
+                }
                 catch (Exception e)
                 {
                     var msg =

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -460,7 +460,12 @@ namespace Libplanet.Net
             // blockchain with it.
             BlockChain<T> workspace = initialTip is Block<T> tip
                 ? BlockChain.Fork(tip.Hash)
-                : new BlockChain<T>(BlockChain.Policy, _store, Guid.NewGuid(), BlockChain.Genesis);
+                : new BlockChain<T>(
+                    BlockChain.Policy,
+                    _store,
+                    Guid.NewGuid(),
+                    BlockChain.Genesis.Hash);
+
             Guid wId = workspace.Id;
             IStore wStore = workspace.Store;
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -464,8 +464,7 @@ namespace Libplanet.Net
                     BlockChain.Policy,
                     _store,
                     Guid.NewGuid(),
-                    BlockChain.Genesis.Hash);
-
+                    BlockChain.GenesisHash);
             Guid wId = workspace.Id;
             IStore wStore = workspace.Store;
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -256,13 +256,8 @@ namespace Libplanet.Store
             LiteCollection<HashDoc> srcColl = IndexCollection(sourceChainId);
             LiteCollection<HashDoc> destColl = IndexCollection(destinationChainId);
 
-            var genesisHash = IterateIndexes(sourceChainId, 0, 1).First();
-            destColl.InsertBulk(srcColl.FindAll()
-                .TakeWhile(i => !i.Hash.Equals(branchPoint)).Skip(1));
-            if (!branchPoint.Equals(genesisHash))
-            {
-                AppendIndex(destinationChainId, branchPoint);
-            }
+            destColl.InsertBulk(srcColl.FindAll().TakeWhile(i => !i.Hash.Equals(branchPoint)));
+            AppendIndex(destinationChainId, branchPoint);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
It resolves #750.

In this PR, it became to allow a chain not having the genesis block, but having the hash of it.
Also I updated changelog, but I'm not sure about it. Please leave your opinions to be better, if you have. 