### PR TITLE
Make IStore to represent state keys as string (was Address)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,21 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  The internal representation for state keys became `string` (was `Address`).
+    [[#368], [#774]]
+     -  The return type of `IStore.GetBlockStates()` method became
+        `IImmutableDictionary<string, IValue>` (was `AddressStateMap`,
+        which was removed too).  [[#368], [#774]]
+     -  The type of the second parameter of `IStore.SetBlockStates()` method
+        became `IImmutableDictionary<string, IValue>` (was `AddressStateMap`,
+        which was removed too).  [[#368], [#774]]
+     -  The second parameter of `IStore.IterateStateReferences()` method became
+        `string key` (was `Address address`).  [[#368], [#774]]
+     -  The second parameter of `IStore.StoreStateReference()` method became
+        `IImmutableSet<string> keys` (was `IImmutableSet<Address> addresses`).
+        [[#368], [#774]]
+     -  `IStore.ListAddresses()` method was replaced by `IStore.ListStateKeys()`
+        method. [[#368], [#774]]
  -  Added `Swarm<T>.FindSpecificPeer()` method to find a specific peer given
     the address.  [[#570], [#580]]
  -  Removed `LiteDBStore` class.  Use `DefaultStore` instead.  [[#662]]
@@ -20,13 +35,13 @@ To be released.
     method and `BlockChain<T>[HashDigest<SHA256>]` indexer as lookups only
     the current chain, not entire storage.  [[#678]]
  -  Added `IStore.ContainsBlock(HashDigest<SHA256>)` method.  [[#678]]
- -  Removed `AddressStateMap` class.  [[#98], [#692]]
+ -  Removed `AddressStateMap` class.  [[#98], [#368], [#692], [#774]]
      -  The return type of `BlockChain<T>.GetState()` method became `IValue`
         (was `AddressStateMap`).
      -  The return type of `IStore.GetBlockStates()` method became
-        `IImmutableDictionary<Address, IValue>` (was `AddressStateMap`).
+        `IImmutableDictionary<string, IValue>` (was `AddressStateMap`).
      -  `IStore.SetBlockStates()` method became to take
-        `IImmutableDictionary<Address, IValue>` instead of `AddressStateMap`.
+        `IImmutableDictionary<string, IValue>` instead of `AddressStateMap`.
  -  `Swarm<T>.PreloadAsync()` method and `Swarm<T>.StartAsync()` method became
     to take `preloadBlockDownloadFailed` event handler as an argument.
     [[#694]]
@@ -48,6 +63,8 @@ To be released.
  -  Removed `Transaction<T>.FromBencodex(byte[])` method.  [[#751]]
  -  `Block<T>.ToBencodex()` became to take no arguments.  [[#749], [#757]]
  -  Removed `Swarm<T>.BroadcastBlocks(IEnumerable<Block<T>>)` method.  [[#764]]
+ -  `StoreExtension.LookupStateReference<T>()` method was replaced by
+    `IStore.LookupStateReference<T>()` method.  [[#722], [#774]]
 
 ### Backward-incompatible network protocol changes
 
@@ -68,6 +85,10 @@ To be released.
 
  -  Added `DefaultStore` class to replace `LiteDBStore`.  [[#662]]
  -  Added `IStore.ListAllStateReferences<T>()` method.  [[#701], [#703]]
+ -  Added `IStore.ListStateKeys()` method to replace `IStore.ListAddresses()`
+    method.  [[#368], [#774]]
+ -  Added `IStore.LookupStateReference<T>()` method to replace
+    `StoreExtension.LookupStateReference<T>()` method.  [[#368], [#722], [#774]]
  -  Added `BlockChain<T>.Genesis` property.  [[#688]]
  -  Added `BlockChain<T>.MakeGenesisBlock()` static method.  [[#688]]
  -  Added `InvalidGenesisBlockException` class.  [[#688]]
@@ -77,7 +98,6 @@ To be released.
     class.  [[#604], [#726]]
  -  Added `Swarm<T>.Peers` property which returns an enumerable of peers in
     `Swarm<T>`'s routing table.  [[#739]]
- -  Added `IStore.LookupStateReference<T>()` method.  [[#722]]
  -  Added `Block<T>.Serialize()` method which returns `byte[]`.  [[#751]]
  -  Added `Transaction<T>.Serialize()` method which returns `byte[]`.  [[#751]]
  -  Added `Block<T>(Bencodex.Types.Dictionary)` constructor.  [[#751]]
@@ -165,6 +185,7 @@ To be released.
  -  Fixed a bug where `BlockChain<T>` had rendered and evaluated actions in
     the genesis block during forking.  [[#763]]
 
+[#368]: https://github.com/planetarium/libplanet/issues/368
 [#570]: https://github.com/planetarium/libplanet/issues/570
 [#580]: https://github.com/planetarium/libplanet/pull/580
 [#604]: https://github.com/planetarium/libplanet/issues/604
@@ -214,6 +235,7 @@ To be released.
 [#764]: https://github.com/planetarium/libplanet/pull/764
 [#765]: https://github.com/planetarium/libplanet/issues/765
 [#767]: https://github.com/planetarium/libplanet/pull/767
+[#774]: https://github.com/planetarium/libplanet/pull/774
 
 
 Version 0.7.0
@@ -255,9 +277,9 @@ Released on November 8, 2019.
      -  Removed `BlockChain<T>.GetEnumerate()` method.  [[#630]]
      -  Removed `BlockPolicyExtension.ValidateBlocks()` method.  [[#630]]
      -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
-        `BlockChain<T>` instead of `IReadOnlyList<Block<<T>>`.  [[#630]]
+        `BlockChain<T>` instead of `IReadOnlyList<Block<T>>`.  [[#630]]
      -  `IBlockPolicy<T>.ValidateNextBlock()` method became to receive
-        `BlockChain<T>` instead of `IReadOnlyList<Block<<T>>`.  [[#630]]
+        `BlockChain<T>` instead of `IReadOnlyList<Block<T>>`.  [[#630]]
 
 ### Added interfaces
 
@@ -945,9 +967,9 @@ Released on May 31, 2019.
  -  Added `IAction.Unrender(IActionContext, IAccountStateDelta)` method.
     [[#31], [#212]]
  -  `BlockChain<T>.Validate()` method became to receive
-    `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
+    `IReadOnlyList<Block<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
  -  `IBlockPolicy<T>.GetNextBlockDifficulty()` method became to receive
-    `IReadOnlyList<Block<<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
+    `IReadOnlyList<Block<T>>` instead of `IEnumerable<Block<T>>`.  [[#205]]
  -  Added
     `IBlockPolicy<T>.ValidateNextBlock(IReadOnlyList<Block<T>>, Block<T>)`
     method.  [[#210]]

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -69,17 +69,16 @@ namespace Libplanet.Tests.Store
             var hashDigest = new HashDigest<SHA256>(bytes);
             var stateRef = new DefaultStore.StateRefDoc
             {
-                Address = address,
+                StateKey = address.ToHex().ToLowerInvariant(),
                 BlockIndex = 123,
                 BlockHash = hashDigest,
             };
             var stateRef2 = new DefaultStore.StateRefDoc
             {
-                AddressString = stateRef.AddressString,
+                StateKey = stateRef.StateKey,
                 BlockIndex = 123,
                 BlockHashString = stateRef.BlockHashString,
             };
-            Assert.Equal(stateRef.Address, stateRef2.Address);
             Assert.Equal(stateRef.BlockHash, stateRef2.BlockHash);
         }
     }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -69,13 +69,13 @@ namespace Libplanet.Tests.Store
             return _store.DeleteIndex(chainId, hash);
         }
 
-        public IEnumerable<Address> ListAddresses(Guid chainId)
+        public IEnumerable<string> ListStateKeys(Guid chainId)
         {
-            Log(nameof(ListAddresses), chainId);
-            return _store.ListAddresses(chainId);
+            Log(nameof(ListStateKeys), chainId);
+            return _store.ListStateKeys(chainId);
         }
 
-        public IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+        public IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>
             ListAllStateReferences(
                 Guid chainId,
                 long lowestIndex,
@@ -110,7 +110,7 @@ namespace Libplanet.Tests.Store
             return _store.GetBlockIndex(blockHash);
         }
 
-        public IImmutableDictionary<Address, IValue> GetBlockStates(HashDigest<SHA256> blockHash)
+        public IImmutableDictionary<string, IValue> GetBlockStates(HashDigest<SHA256> blockHash)
         {
             Log(nameof(GetBlockStates), blockHash);
             return _store.GetBlockStates(blockHash);
@@ -181,7 +181,7 @@ namespace Libplanet.Tests.Store
 
         public void SetBlockStates(
             HashDigest<SHA256> blockHash,
-            IImmutableDictionary<Address, IValue> states
+            IImmutableDictionary<string, IValue> states
         )
         {
             Log(nameof(SetBlockStates), blockHash, states);
@@ -190,17 +190,17 @@ namespace Libplanet.Tests.Store
 
         public Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             Guid chainId,
-            Address address,
+            string key,
             Block<T> lookupUntil)
             where T : IAction, new()
         {
-            Log(nameof(LookupStateReference), chainId, address, lookupUntil);
-            return _store.LookupStateReference(chainId, address, lookupUntil);
+            Log(nameof(LookupStateReference), chainId, key, lookupUntil);
+            return _store.LookupStateReference(chainId, key, lookupUntil);
         }
 
         public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             Guid chainId,
-            Address address,
+            string key,
             long? highestIndex,
             long? lowestIndex,
             int? limit)
@@ -208,22 +208,22 @@ namespace Libplanet.Tests.Store
             Log(
                 nameof(IterateStateReferences),
                 chainId,
-                address,
+                key,
                 highestIndex,
                 lowestIndex,
                 limit);
             return _store.IterateStateReferences(
-                chainId, address, highestIndex, lowestIndex, limit);
+                chainId, key, highestIndex, lowestIndex, limit);
         }
 
         public void StoreStateReference(
             Guid chainId,
-            IImmutableSet<Address> addresses,
+            IImmutableSet<string> keys,
             HashDigest<SHA256> blockHash,
             long blockIndex)
         {
-            Log(nameof(StoreStateReference), chainId, addresses, blockHash, blockIndex);
-            _store.StoreStateReference(chainId, addresses, blockHash, blockIndex);
+            Log(nameof(StoreStateReference), chainId, keys, blockHash, blockIndex);
+            _store.StoreStateReference(chainId, keys, blockHash, blockIndex);
         }
 
         public void ForkStateReferences<T>(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -43,10 +43,10 @@ namespace Libplanet.Store
             HashDigest<SHA256> branchPoint);
 
         /// <inheritdoc />
-        public abstract IEnumerable<Address> ListAddresses(Guid chainId);
+        public abstract IEnumerable<string> ListStateKeys(Guid chainId);
 
         /// <inheritdoc/>
-        public abstract IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>
+        public abstract IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>
             ListAllStateReferences(
                 Guid chainId,
                 long lowestIndex = 0,
@@ -117,33 +117,33 @@ namespace Libplanet.Store
         /// <inheritdoc />
         public abstract bool ContainsBlock(HashDigest<SHA256> blockHash);
 
-        public abstract IImmutableDictionary<Address, IValue> GetBlockStates(
+        public abstract IImmutableDictionary<string, IValue> GetBlockStates(
             HashDigest<SHA256> blockHash
         );
 
         public abstract void SetBlockStates(
             HashDigest<SHA256> blockHash,
-            IImmutableDictionary<Address, IValue> states
+            IImmutableDictionary<string, IValue> states
         );
 
         /// <inheritdoc />
         public abstract Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             Guid chainId,
-            Address address,
+            string key,
             Block<T> lookupUntil)
             where T : IAction, new();
 
         /// <inheritdoc />
         public abstract IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
             Guid chainId,
-            Address address,
+            string key,
             long? highestIndex,
             long? lowestIndex,
             int? limit);
 
         public abstract void StoreStateReference(
             Guid chainId,
-            IImmutableSet<Address> addresses,
+            IImmutableSet<string> keys,
             HashDigest<SHA256> blockHash,
             long blockIndex);
 


### PR DESCRIPTION
It's the first step to refer to states by arbitrary `string` keys instead of `Address`es, as I suggested in the issue #368:

> Although it's further than the topic, I've recently started to believe keys of the global state map don't have to be (and shouldn't be) addresses, but arbitrary strings instead, which is more easier to understand to existing programmers who are familiar to Redis or memcached.

I am going to send more patches to make state keys arbitrary `string`s instead of `Address`es in the whole of Libplanet.