### PR TITLE
Stage transactions not included in swapped chain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -188,6 +188,8 @@ To be released.
     [[#759]]
  -  Fixed a bug where `BlockChain<T>` had rendered and evaluated actions in
     the genesis block during forking.  [[#763]]
+ -  Fixed a bug where transactions which were not propagated sufficiently,
+    could not be included in a block when reorg happened.  [[#775]]
 
 [#368]: https://github.com/planetarium/libplanet/issues/368
 [#570]: https://github.com/planetarium/libplanet/issues/570
@@ -241,6 +243,7 @@ To be released.
 [#767]: https://github.com/planetarium/libplanet/pull/767
 [#772]: https://github.com/planetarium/libplanet/pull/772
 [#774]: https://github.com/planetarium/libplanet/pull/774
+[#775]: https://github.com/planetarium/libplanet/pull/775
 
 
 Version 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -188,8 +188,10 @@ To be released.
     [[#759]]
  -  Fixed a bug where `BlockChain<T>` had rendered and evaluated actions in
     the genesis block during forking.  [[#763]]
- -  Fixed a bug where transactions which were not propagated sufficiently,
-    could not be included in a block when reorg happened.  [[#775]]
+ -  Fixed a `Swam<T>`'s bug that some `Transaction<T>`s had become excluded from
+    mining `Block<T>`s after reorg from α to β where a `Transaction<T>` was once
+    included by a `Block<T>` (α) and not included by an other `Block<T>` (β) for
+    the same `Index` due to the latency gap between nodes.  [[#775]]
 
 [#368]: https://github.com/planetarium/libplanet/issues/368
 [#570]: https://github.com/planetarium/libplanet/issues/570

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2271,7 +2271,7 @@ namespace Libplanet.Tests.Net
             BlockChain<DumbAction> minerChain = _blockchains[0];
             BlockChain<DumbAction> receiverChain = _blockchains[1];
 
-            Guid receiverChainId = _blockchains[1].Id;
+            Guid receiverChainId = receiverChain.Id;
 
             (Address address, IEnumerable<Block<DumbAction>> blocks) =
                 await MakeFixtureBlocksForPreloadAsyncCancellationTest();
@@ -2434,6 +2434,72 @@ namespace Libplanet.Tests.Net
                 miner1.Dispose();
                 miner2.Dispose();
                 receiver.Dispose();
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async void RestageTransactionsAfterReorg()
+        {
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            var minerA = CreateSwarm(TestUtils.MakeBlockChain(policy, new DefaultStore(null)));
+            var minerB = CreateSwarm(TestUtils.MakeBlockChain(policy, new DefaultStore(null)));
+
+            var privateKeyA = new PrivateKey();
+            var privateKeyB = new PrivateKey();
+
+            try
+            {
+                await StartAsync(minerA);
+                await StartAsync(minerB);
+
+                const string dumbItem = "item0.0";
+                var txA = minerA.BlockChain.MakeTransaction(
+                    privateKeyA,
+                    new[] { new DumbAction(_fx1.Address1, dumbItem), });
+                var txB = minerB.BlockChain.MakeTransaction(
+                    privateKeyB,
+                    new[] { new DumbAction(_fx1.Address2, dumbItem), });
+
+                // Make minerB's chain longer than minerA's chain.
+                var blockA = await minerA.BlockChain.MineBlock(minerA.Address);
+                var blockB = await minerB.BlockChain.MineBlock(minerB.Address);
+                var blockC = await minerB.BlockChain.MineBlock(minerB.Address);
+
+                // Check each states.
+                await BootstrapAsync(minerA, minerB.AsPeer);
+
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address1));
+                Assert.Equal((Text)dumbItem, minerB.BlockChain.GetState(_fx1.Address2));
+
+                // Occur reorg.
+                minerB.BroadcastBlock(blockC);
+                minerA.BlockAppended.Wait();
+
+                // Check sync.
+                Assert.Equal(minerA.BlockChain.Tip, minerB.BlockChain.Tip);
+                Assert.Equal(3, minerA.BlockChain.Count);
+                Assert.Null(minerA.BlockChain.GetState(_fx1.Address1));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address2));
+
+                // Expect stage txs in unrendered blocks.
+                Assert.Contains(txA.Id, minerA.BlockChain.GetStagedTransactionIds());
+
+                await minerA.BlockChain.MineBlock(minerA.Address);
+                minerA.BroadcastBlock(minerA.BlockChain.Tip);
+                minerB.BlockAppended.Wait();
+
+                // Check sync.
+                Assert.Equal(minerA.BlockChain.Tip, minerB.BlockChain.Tip);
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address1));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address2));
+            }
+            finally
+            {
+                await StopAsync(minerA);
+                await StopAsync(minerB);
+
+                minerA.Dispose();
+                minerB.Dispose();
             }
         }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1171,8 +1171,8 @@ namespace Libplanet.Blockchain
             if (other?.Tip is null)
             {
                 throw new ArgumentException(
-                        $"The chain to be swapped is invalid. Id: {other?.Id}, Tip: {other?.Tip}",
-                        nameof(other));
+                    $"The chain to be swapped is invalid. Id: {other?.Id}, Tip: {other?.Tip}",
+                    nameof(other));
             }
 
             _logger.Debug(
@@ -1180,20 +1180,15 @@ namespace Libplanet.Blockchain
 
             // Finds the branch point.
             Block<T> topmostCommon = null;
-            if (render && !(Tip is null))
+            if (!(Tip is null))
             {
                 long shorterHeight =
                     Math.Min(Count, other.Count) - 1;
-                for (
-                    Block<T> t = this[shorterHeight], o = other[shorterHeight];
-                    t.PreviousHash is HashDigest<SHA256> tp &&
-                        o.PreviousHash is HashDigest<SHA256> op;
-                    t = this[tp], o = other[op]
-                )
+                for (long index = shorterHeight; index >= 0; --index)
                 {
-                    if (t.Equals(o))
+                    if (this[index].Equals(other[index]))
                     {
-                        topmostCommon = t;
+                        topmostCommon = this[index];
                         break;
                     }
                 }
@@ -1210,7 +1205,7 @@ namespace Libplanet.Blockchain
                 for (
                     Block<T> b = Tip;
                     !(b is null) && b.Index > (topmostCommon?.Index ?? -1) &&
-                        b.PreviousHash is HashDigest<SHA256> ph;
+                    b.PreviousHash is HashDigest<SHA256> ph;
                     b = this[ph]
                 )
                 {
@@ -1229,6 +1224,19 @@ namespace Libplanet.Blockchain
 
                 _logger.Debug($"Unrender for {nameof(Swap)}() is completed.");
             }
+
+            IEnumerable<TxId> GetTxIdsWithRange(BlockChain<T> chain, Block<T> start, Block<T> end)
+                => Enumerable
+                    .Range((int)start.Index + 1, (int)(end.Index - start.Index))
+                    .SelectMany(x => chain[x].Transactions.Select(tx => tx.Id));
+
+            // It assumes reorg is small size. If it was big, this may be heavy task.
+            var unstagedTxIds =
+                GetTxIdsWithRange(this, topmostCommon, Tip).ToImmutableHashSet();
+            var stageTxIds =
+                GetTxIdsWithRange(other, topmostCommon, other.Tip).ToImmutableHashSet();
+            var restageTxIds = unstagedTxIds.Except(stageTxIds);
+            Store.StageTransactionIds(restageTxIds);
 
             try
             {

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2850</MaxFileLines>
+  <MaxFileLines>2900</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
It fixes a bug where transactions included in unrendered blocks, could not be included in a block when reorg happened. It's based on network problem which they were not propagated sufficiently, so IMO it will be better to see this PR while looking message propagation after #767 PR was merged.