### PR TITLE
Introduce message history for testing

### DIFF
--- a/Libplanet/FixedSizedQueue.cs
+++ b/Libplanet/FixedSizedQueue.cs
@@ -1,0 +1,54 @@
+using System.Collections.Concurrent;
+
+namespace Libplanet
+{
+    /// <summary>
+    /// Equivalent to <see cref="ConcurrentQueue{T}"/>, except this does not accept more than
+    /// the specified maximum size.
+    /// </summary>
+    /// <typeparam name="T">Specifies the type of elements in the queue.</typeparam>
+    // This class referenced the implementation of the following.
+    // https://git.io/Jvs1f
+    internal class FixedSizedQueue<T> : ConcurrentQueue<T>
+    {
+        /// <summary>
+        /// Simple object for thread synchronization.
+        /// </summary>
+        private readonly object _syncObject = new object();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="FixedSizedQueue{T}"/>
+        /// with the specified <paramref name="size"/>.
+        /// </summary>
+        /// <param name="size">The maximum size of the <see cref="FixedSizedQueue{T}"/>.</param>
+        public FixedSizedQueue(int size)
+        {
+            Size = size;
+        }
+
+        /// <summary>
+        /// Gets the fixed size of the <see cref="FixedSizedQueue{T}"/>.
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// Adds an object at the end of the <see cref="FixedSizedQueue{T}"/>.
+        /// </summary>
+        /// <param name="obj">The object to add at the
+        /// end of the <see cref="FixedSizedQueue{T}"/>.</param>
+        public new void Enqueue(T obj)
+        {
+            // Add the object to the queue.
+            base.Enqueue(obj);
+
+            lock (_syncObject)
+            {
+                while (Count > Size)
+                {
+                    // Ensure we don't exceed the maximum size.
+                    TryDequeue(out T _);
+                }
+            }
+        }
+    }
+}

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -20,6 +20,8 @@ namespace Libplanet.Net
 {
     internal class NetMQTransport : ITransport
     {
+        private const int MessageHistoryCapacity = 30;
+
         private static readonly TimeSpan TurnAllocationLifetime =
             TimeSpan.FromSeconds(777);
 
@@ -134,6 +136,7 @@ namespace Libplanet.Net
                 TaskScheduler.Default
             );
 
+            MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
             Protocol = new KademliaProtocol(
                 this,
                 _privateKey.PublicKey.ToAddress(),
@@ -190,6 +193,8 @@ namespace Libplanet.Net
         }
 
         internal IProtocol Protocol { get; }
+
+        internal FixedSizedQueue<Message> MessageHistory { get; }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
@@ -478,6 +483,11 @@ namespace Libplanet.Net
                 );
 
                 var reply = (await tcs.Task).ToList();
+                foreach (var msg in reply)
+                {
+                    MessageHistory.Enqueue(msg);
+                }
+
                 const string logMsg =
                     "Received {ReplyMessageCount} reply messages to {RequestId} " +
                     "from {PeerAddress}: {ReplyMessages}.";
@@ -559,6 +569,7 @@ namespace Libplanet.Net
                 );
                 Message message = Message.Parse(raw, reply: false);
                 _logger.Debug("A message has parsed: {0}, from {1}", message, message.Remote);
+                MessageHistory.Enqueue(message);
                 if (!(message is Ping))
                 {
                     ValidateSender(message.Remote);


### PR DESCRIPTION
This patch introduces message history queue for `NetMQTransport`. Since all related changes are internal, skipped changelog.