### PR TITLE
Prune state after sync state from trusted peers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,9 +44,12 @@ To be released.
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
  -  Added `Block<T>.ToBlockDigest()` method.  [[#785]]
  -  Added `ByteArrayExtensions` class.  [[#803]]
+ -  Added `IStore.PruneBlockStates<T>(Guid, Block<T>)` method.  [[#790]]
 
 ### Behavioral changes
 
+ -  `Swarm<T>.PreloadAsync()` became to prune states until its parameter
+    `thickness` if any trusted peers were given.  [[#790]]
  -  `BlockChain.MineBlock()` method became to ignore transactions having
     lower nonce than the expected nonce in the chain.  [[#791]]
  -  `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()` became to download
@@ -73,6 +76,7 @@ To be released.
 [#785]: https://github.com/planetarium/libplanet/pull/785
 [#788]: https://github.com/planetarium/libplanet/pull/788
 [#789]: https://github.com/planetarium/libplanet/pull/789
+[#790]: https://github.com/planetarium/libplanet/pull/790
 [#791]: https://github.com/planetarium/libplanet/pull/791
 [#798]: https://github.com/planetarium/libplanet/pull/798
 [#802]: https://github.com/planetarium/libplanet/pull/802

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,8 +48,6 @@ To be released.
 
 ### Behavioral changes
 
- -  `Swarm<T>.PreloadAsync()` became to prune states until its parameter
-    `thickness` if any trusted peers were given.  [[#790]]
  -  `BlockChain.MineBlock()` method became to ignore transactions having
     lower nonce than the expected nonce in the chain.  [[#791]]
  -  `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()` became to download

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -587,6 +587,37 @@ namespace Libplanet.RocksDBStore
             _statesCache.AddOrUpdate(blockHash, states);
         }
 
+        /// <inheritdoc/>
+        public override void PruneBlockStates<T>(
+            Guid chainId,
+            Block<T> until)
+        {
+            string[] keys = ListStateKeys(chainId).ToArray();
+            long untilIndex = until.Index;
+            foreach (var key in keys)
+            {
+                Tuple<HashDigest<SHA256>, long>[] stateRefs =
+                    IterateStateReferences(chainId, key, untilIndex, null, null)
+                        .OrderByDescending(tuple => tuple.Item2)
+                        .ToArray();
+                var dict = new Dictionary<HashDigest<SHA256>, List<string>>();
+                foreach ((HashDigest<SHA256> blockHash, long index) in stateRefs.Skip(1))
+                {
+                    if (!dict.ContainsKey(blockHash))
+                    {
+                        dict.Add(blockHash, new List<string>());
+                    }
+
+                    dict[blockHash].Add(key);
+                }
+
+                foreach (var kv in dict)
+                {
+                    DeleteBlockStates(kv.Key, kv.Value);
+                }
+            }
+        }
+
         public override Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             Guid chainId,
             string key,
@@ -804,6 +835,38 @@ namespace Libplanet.RocksDBStore
             _stateDb?.Dispose();
             _blockDb?.Dispose();
             _stagedTxDb?.Dispose();
+        }
+
+        /// <summary>
+        /// Deletes the states with specified keys (i.e., <paramref name="stateKeys"/>)
+        /// updated by actions in the specified block (i.e., <paramref name="blockHash"/>).
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to delete states.
+        /// </param>
+        /// <param name="stateKeys">The state keys to delete which were updated by actions
+        /// in the specified block (i.e., <paramref name="blockHash"/>).
+        /// </param>
+        /// <seealso cref="GetBlockStates"/>
+        private void DeleteBlockStates(
+            HashDigest<SHA256> blockHash,
+            IEnumerable<string> stateKeys)
+        {
+            IImmutableDictionary<string, IValue> dict = GetBlockStates(blockHash);
+            if (dict is null)
+            {
+                return;
+            }
+
+            dict = dict.RemoveRange(stateKeys);
+            if (dict.Any())
+            {
+                SetBlockStates(blockHash, dict);
+            }
+            else
+            {
+                _stateDb.Remove(BlockStateKey(blockHash));
+                _statesCache.Remove(blockHash);
+            }
         }
 
         private IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2237,8 +2237,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarm2);
 
                 await swarm1.AddPeersAsync(new[] { swarm0.AsPeer }, null);
-                await swarm1.PreloadAsync(trustedStateValidators:
-                    new[] { swarm0.Address }.ToImmutableHashSet());
+                await swarm1.PreloadAsync(
+                    trustedStateValidators: new[] { swarm0.Address }.ToImmutableHashSet(),
+                    thickness: 20);
 
                 Assert.Equal(chain0.BlockHashes, chain1.BlockHashes);
 
@@ -2275,8 +2276,9 @@ namespace Libplanet.Tests.Net
                 }
 
                 await swarm2.AddPeersAsync(new[] { swarm1.AsPeer }, null);
-                await swarm2.PreloadAsync(trustedStateValidators:
-                    new[] { swarm1.Address }.ToImmutableHashSet());
+                await swarm2.PreloadAsync(
+                    trustedStateValidators: new[] { swarm1.Address }.ToImmutableHashSet(),
+                    thickness: 20);
 
                 Assert.Equal(chain1.BlockHashes, chain2.BlockHashes);
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2238,8 +2238,7 @@ namespace Libplanet.Tests.Net
 
                 await swarm1.AddPeersAsync(new[] { swarm0.AsPeer }, null);
                 await swarm1.PreloadAsync(
-                    trustedStateValidators: new[] { swarm0.Address }.ToImmutableHashSet(),
-                    thickness: 20);
+                    trustedStateValidators: new[] { swarm0.Address }.ToImmutableHashSet());
 
                 Assert.Equal(chain0.BlockHashes, chain1.BlockHashes);
 
@@ -2277,8 +2276,7 @@ namespace Libplanet.Tests.Net
 
                 await swarm2.AddPeersAsync(new[] { swarm1.AsPeer }, null);
                 await swarm2.PreloadAsync(
-                    trustedStateValidators: new[] { swarm1.Address }.ToImmutableHashSet(),
-                    thickness: 20);
+                    trustedStateValidators: new[] { swarm1.Address }.ToImmutableHashSet());
 
                 Assert.Equal(chain1.BlockHashes, chain2.BlockHashes);
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1086,10 +1086,10 @@ namespace Libplanet.Tests.Store
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task PruneBlockStates()
         {
-            using (DefaultStoreFixture fx = new DefaultStoreFixture(memory: true))
+            using (StoreFixture fx = FxConstructor())
             {
                 IStore store = fx.Store;
                 var blocks = new BlockChain<DumbAction>(

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1086,6 +1086,68 @@ namespace Libplanet.Tests.Store
             }
         }
 
+        [Fact]
+        public async Task PruneBlockStates()
+        {
+            using (DefaultStoreFixture fx = new DefaultStoreFixture(memory: true))
+            {
+                IStore store = fx.Store;
+                var blocks = new BlockChain<DumbAction>(
+                    new NullPolicy<DumbAction>(),
+                    store,
+                    Fx.GenesisBlock
+                );
+
+                var privKey = new PrivateKey();
+                Transaction<DumbAction> tx1 = Transaction<DumbAction>.Create(
+                    0,
+                    privKey,
+                    new[] { new DumbAction(fx.Address1, "item0") });
+                Transaction<DumbAction> tx2 = Transaction<DumbAction>.Create(
+                    1,
+                    privKey,
+                    new[] { new DumbAction(fx.Address1, "item1") });
+                Transaction<DumbAction> tx3 = Transaction<DumbAction>.Create(
+                    2,
+                    privKey,
+                    new[] { new DumbAction(fx.Address1, "item2") });
+                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx1));
+                var block1 = await blocks.MineBlock(fx.Address2);
+                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx2));
+                var block2 = await blocks.MineBlock(fx.Address2);
+                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx3));
+                var block3 = await blocks.MineBlock(fx.Address2);
+                Assert.Equal(
+                    (Text)"item0",
+                    blocks.GetState(fx.Address1, block1.Hash));
+                Assert.Equal(
+                    (Text)"item0,item1",
+                    blocks.GetState(fx.Address1, block2.Hash));
+                Assert.Equal(
+                    (Text)"item0,item1,item2",
+                    blocks.GetState(fx.Address1, block3.Hash));
+
+                store.PruneBlockStates(blocks.Id, block2);
+                Assert.Throws<IncompleteBlockStatesException>(
+                    () => blocks.GetState(fx.Address1, block1.Hash));
+                Assert.Equal(
+                    (Text)"item0,item1",
+                    blocks.GetState(fx.Address1, block2.Hash));
+                Assert.Equal(
+                    (Text)"item0,item1,item2",
+                    blocks.GetState(fx.Address1, block3.Hash));
+
+                store.PruneBlockStates(blocks.Id, block3);
+                Assert.Throws<IncompleteBlockStatesException>(
+                    () => blocks.GetState(fx.Address1, block1.Hash));
+                Assert.Throws<IncompleteBlockStatesException>(
+                    () => blocks.GetState(fx.Address1, block2.Hash));
+                Assert.Equal(
+                    (Text)"item0,item1,item2",
+                    blocks.GetState(fx.Address1, block3.Hash));
+            }
+        }
+
         private class AtomicityTestAction : IAction
         {
             public ImmutableArray<byte> ArbitraryBytes { get; set; }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -188,6 +188,24 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
+        public void DeleteBlockStates(
+            HashDigest<SHA256> blockHash,
+            IEnumerable<string> stateKeys
+        )
+        {
+            Log(nameof(DeleteBlockStates), blockHash, stateKeys);
+            _store.DeleteBlockStates(blockHash, stateKeys);
+        }
+
+        public void PruneBlockStates<T>(
+            Guid chainId,
+            Block<T> until)
+            where T : IAction, new()
+        {
+            Log(nameof(PruneBlockStates), chainId, until);
+            _store.PruneBlockStates(chainId, until);
+        }
+
         public Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             Guid chainId,
             string key,

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -188,15 +188,6 @@ namespace Libplanet.Tests.Store
             _store.SetBlockStates(blockHash, states);
         }
 
-        public void DeleteBlockStates(
-            HashDigest<SHA256> blockHash,
-            IEnumerable<string> stateKeys
-        )
-        {
-            Log(nameof(DeleteBlockStates), blockHash, stateKeys);
-            _store.DeleteBlockStates(blockHash, stateKeys);
-        }
-
         public void PruneBlockStates<T>(
             Guid chainId,
             Block<T> until)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -262,7 +262,7 @@ namespace Libplanet.Net
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
         /// these actions in the behind blocks use <see cref=
         /// "PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address},
-        /// EventHandler{PreloadBlockDownloadFailEventArgs}, long, CancellationToken)"
+        /// EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"
         /// /> method too.</remarks>
         public async Task StartAsync(
             TimeSpan dialTimeout,
@@ -392,7 +392,6 @@ namespace Libplanet.Net
         /// <param name="blockDownloadFailed">
         /// The <see cref="EventHandler" /> triggered when block downloading fails.
         /// </param>
-        /// <param name="thickness">A thickness to leave state history.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -414,7 +413,6 @@ namespace Libplanet.Net
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
             EventHandler<PreloadBlockDownloadFailEventArgs> blockDownloadFailed = null,
-            long thickness = 10,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
@@ -744,13 +742,6 @@ namespace Libplanet.Net
                         receivedStateHeight,
                         progress,
                         cancellationToken);
-                }
-
-                if (trustedStateValidators.Any() && height > thickness)
-                {
-                    _store.PruneBlockStates(
-                        workspace.Id,
-                        workspace[height - thickness]);
                 }
 
                 complete = true;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -262,7 +262,7 @@ namespace Libplanet.Net
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
         /// these actions in the behind blocks use <see cref=
         /// "PreloadAsync(TimeSpan?, IProgress{PreloadState}, IImmutableSet{Address},
-        /// EventHandler{PreloadBlockDownloadFailEventArgs}, CancellationToken)"
+        /// EventHandler{PreloadBlockDownloadFailEventArgs}, long, CancellationToken)"
         /// /> method too.</remarks>
         public async Task StartAsync(
             TimeSpan dialTimeout,
@@ -392,6 +392,7 @@ namespace Libplanet.Net
         /// <param name="blockDownloadFailed">
         /// The <see cref="EventHandler" /> triggered when block downloading fails.
         /// </param>
+        /// <param name="thickness">A thickness to leave state history.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -413,6 +414,7 @@ namespace Libplanet.Net
             IProgress<PreloadState> progress = null,
             IImmutableSet<Address> trustedStateValidators = null,
             EventHandler<PreloadBlockDownloadFailEventArgs> blockDownloadFailed = null,
+            long thickness = 10,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
@@ -742,6 +744,13 @@ namespace Libplanet.Net
                         receivedStateHeight,
                         progress,
                         cancellationToken);
+                }
+
+                if (trustedStateValidators.Any() && height > thickness)
+                {
+                    _store.PruneBlockStates(
+                        workspace.Id,
+                        workspace[height - thickness]);
                 }
 
                 complete = true;

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -131,6 +131,18 @@ namespace Libplanet.Store
         );
 
         /// <inheritdoc />
+        public abstract void DeleteBlockStates(
+            HashDigest<SHA256> blockHash,
+            IEnumerable<string> stateKeys
+        );
+
+        /// <inheritdoc />
+        public abstract void PruneBlockStates<T>(
+            Guid chainId,
+            Block<T> until)
+            where T : IAction, new();
+
+        /// <inheritdoc />
         public abstract Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
             Guid chainId,
             string key,

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -131,12 +131,6 @@ namespace Libplanet.Store
         );
 
         /// <inheritdoc />
-        public abstract void DeleteBlockStates(
-            HashDigest<SHA256> blockHash,
-            IEnumerable<string> stateKeys
-        );
-
-        /// <inheritdoc />
         public abstract void PruneBlockStates<T>(
             Guid chainId,
             Block<T> until)

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -124,6 +124,7 @@ namespace Libplanet.Store
             HashDigest<SHA256> blockHash
         );
 
+        /// <inheritdoc />
         public abstract void SetBlockStates(
             HashDigest<SHA256> blockHash,
             IImmutableDictionary<string, IValue> states

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -631,10 +631,10 @@ namespace Libplanet.Store
             long untilIndex = until.Index;
             foreach (var key in keys)
             {
-                Tuple<HashDigest<SHA256>, long>[] stateRefs =
+                IEnumerable<Tuple<HashDigest<SHA256>, long>> stateRefs =
                     IterateStateReferences(chainId, key, untilIndex, null, null)
-                        .OrderByDescending(tuple => tuple.Item2)
-                        .ToArray();
+                        .OrderByDescending(tuple => tuple.Item2);
+
                 var dict = new Dictionary<HashDigest<SHA256>, List<string>>();
                 foreach ((HashDigest<SHA256> blockHash, long index) in stateRefs.Skip(1))
                 {

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -242,21 +242,6 @@ namespace Libplanet.Store
         );
 
         /// <summary>
-        /// Deletes the states with specified keys (i.e., <paramref name="stateKeys"/>)
-        /// updated by actions in the specified block (i.e., <paramref name="blockHash"/>).
-        /// </summary>
-        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to delete states.
-        /// </param>
-        /// <param name="stateKeys">The state keys to delete which were updated by actions
-        /// in the specified block (i.e., <paramref name="blockHash"/>).
-        /// </param>
-        /// <seealso cref="GetBlockStates"/>
-        void DeleteBlockStates(
-            HashDigest<SHA256> blockHash,
-            IEnumerable<string> stateKeys
-        );
-
-        /// <summary>
         /// Prunes states in blockchain <paramref name="chainId"/> with until specified block
         /// <paramref name="until"/>.
         /// </summary>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -242,6 +242,34 @@ namespace Libplanet.Store
         );
 
         /// <summary>
+        /// Deletes the states with specified keys (i.e., <paramref name="stateKeys"/>)
+        /// updated by actions in the specified block (i.e., <paramref name="blockHash"/>).
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to delete states.
+        /// </param>
+        /// <param name="stateKeys">The state keys to delete which were updated by actions
+        /// in the specified block (i.e., <paramref name="blockHash"/>).
+        /// </param>
+        /// <seealso cref="GetBlockStates"/>
+        void DeleteBlockStates(
+            HashDigest<SHA256> blockHash,
+            IEnumerable<string> stateKeys
+        );
+
+        /// <summary>
+        /// Prunes states in blockchain <paramref name="chainId"/> with until specified block
+        /// <paramref name="until"/>.
+        /// </summary>
+        /// <param name="chainId">The chain ID to prune block states.</param>
+        /// <param name="until">The upper bound block to prune states.</param>
+        /// <typeparam name="T">An <see cref="IAction"/> class used with
+        /// <paramref name="until"/>.</typeparam>
+        void PruneBlockStates<T>(
+            Guid chainId,
+            Block<T> until)
+            where T : IAction, new();
+
+        /// <summary>
         /// Looks up a state reference, which is a block's <see cref="Block{T}.Hash"/> that contains
         /// an action mutating the <paramref name="key"/>'s tate.
         /// </summary>


### PR DESCRIPTION
Since trusted peers became not to transfer *recent* states, receiver with trusted validators prunes states after preloading finished.