### PR TITLE
Mine block without txs having lower nonce

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,18 +23,25 @@ To be released.
 
 ### Behavioral changes
 
+ -  `BlockChain.MineBlock()` method became to ignore transactions having
+    lower nonce than expected nonce in the chain.  [[#791]]
+
 ### Bug fixes
 
  -  `Swarm<T>` became not to sync the same `Block<T>`s or `Transaction<T>`s
     multiple times.  [[#784]]
  -  Fixed a `Swarm<T>`'s bug that had broadcasted a message to its source peer when
     the number of peers is not enough (less than the minimum number).  [[#788]]
+ -  Fixed a bug where `BlockChain.MineBlock()` couldn't mine valid block
+    if there was staged transaction which, has lower nonce than expected nonce,
+    in other word, has same nonce with transactions which signed by
+    same signer and already included.  [[#791]]
 
 [#784]: https://github.com/planetarium/libplanet/pull/784
 [#785]: https://github.com/planetarium/libplanet/pull/785
 [#788]: https://github.com/planetarium/libplanet/pull/788
 [#789]: https://github.com/planetarium/libplanet/pull/789
-
+[#791]: https://github.com/planetarium/libplanet/pull/791
 
 Version 0.8.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ To be released.
 ### Behavioral changes
 
  -  `BlockChain.MineBlock()` method became to ignore transactions having
-    lower nonce than expected nonce in the chain.  [[#791]]
+    lower nonce than the expected nonce in the chain.  [[#791]]
 
 ### Bug fixes
 
@@ -32,10 +32,9 @@ To be released.
     multiple times.  [[#784]]
  -  Fixed a `Swarm<T>`'s bug that had broadcasted a message to its source peer when
     the number of peers is not enough (less than the minimum number).  [[#788]]
- -  Fixed a bug where `BlockChain.MineBlock()` couldn't mine valid block
-    if there was staged transaction which, has lower nonce than expected nonce,
-    in other word, has same nonce with transactions which signed by
-    same signer and already included.  [[#791]]
+ -  Fixed a bug where `BlockChain.MineBlock()` had produced an invalid block
+    when there is any staged transaction which has lower nonce than the expected nonce,
+    that means, shares an already taken nonce by the same signer.  [[#791]]
 
 [#784]: https://github.com/planetarium/libplanet/pull/784
 [#785]: https://github.com/planetarium/libplanet/pull/785

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -625,7 +625,8 @@ namespace Libplanet.Blockchain
             IEnumerable<Transaction<T>> transactions = Store
                 .IterateStagedTransactionIds()
                 .Select(Store.GetTransaction<T>)
-                .Where(tx => tx.Nonce < GetNextTxNonce(tx.Signer));
+                .Where(tx => Store.GetTxNonce(Id, tx.Signer) <= tx.Nonce
+                             && tx.Nonce < GetNextTxNonce(tx.Signer));
 
             CancellationTokenSource cts = new CancellationTokenSource();
             CancellationTokenSource cancellationTokenSource =


### PR DESCRIPTION
There was a problem that `BlockChain.MineBlock()` method couldn't mine valid block when there was transactions having lower nonce than expected nonce. So, in this PR, `BlockChain.MineBlock()` method became to ignore the transactions and to mine.