### PR TITLE
Upgrade C# to 8.0 with maintaining .NET Standard 2.0

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -15,7 +15,7 @@ steps:
   displayName: Install .NET Core SDK
   inputs:
     packageType: sdk
-    version: 2.2.203
+    version: 3.1.101
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: CmdLine@2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,4 +20,7 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.100
     - run: 'dotnet run -p Libplanet.Benchmarks -c Release -- -j short -f "*"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.100
     - run: .github/bin/dist-version.ps1
       shell: pwsh
     - run: .github/bin/dist-release-note.sh CHANGES.md obj/release_note.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,20 +29,14 @@ for purposes in the *Libplanet* category:
 Prerequisites
 -------------
 
-You need [.NET Core] SDK 2.2+ which provides the latest C# compiler and .NET VM.
+You need [.NET Core] SDK 3.1+ which provides the latest C# compiler and .NET VM.
 Read and follow the instruction to install .NET Core SDK on
 the [.NET Core downloads page][1].
 FYI if you use macOS and [Homebrew] you can install it by
 `brew cask install dotnet-sdk` command.
 
-Make sure that your .NET Core SDK is 2.2 or higher.  You could show
+Make sure that your .NET Core SDK is 3.1 or higher.  You could show
 the version you are using by `dotnet --info` command.
-
-If it's Windows please check if the environment variable named
-`MSBuildSDKsPath` refers to the proper version of .NET Core SDK.
-If you use Visual Studio 2017 (not 2019) you can only use .NET Core 2.2.105
-at the highest.  .NET Core SDK higher than the version 2.2.105 is not
-recognized by Visual Studio 2017.
 
 Although it is not necessary, you should install a proper IDE for .NET
 (or an [OmniSharp] extension for your favorite editor — except it takes
@@ -203,24 +197,3 @@ As our benchmarks are based on [BenchmarkDotNet], please read their official
 docs for details.
 
 [BenchmarkDotNet]: https://benchmarkdotnet.org/
-
-
-Troubleshooting
---------------
-
-### I got the error like `Fody is only supported on MSBuild 16 and above. Current version: 15.`
-
-Your .NET Core SDK version probably is outdated.  Our recommended version is: *2.2.300*.
-
-1. Download the lastest (as of June 2019) .NET Core SDK binary from the official website:
-
-   <https://dotnet.microsoft.com/download/dotnet-core/2.2#sdk-2.2.300>
-
-2. Extract *.tar.gz* in proper directory.
-
-3. You could permanently add the following commands into your shell profile.
-
-    ~~~~
-    export DOTNET_ROOT="$YOUR_DOTNET_INSTALLATION_PATH/dotnet"
-    export PATH="$PATH:$DOTNET_ROOT"
-    ~~~~

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -2,7 +2,8 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
   Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Stun</RootNamespace>
     <AssemblyName>Libplanet.Stun</AssemblyName>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -23,7 +23,7 @@ https://docs.libplanet.io/</Description>
     <!-- FIXME: The above summary/description should be rewritten. -->
     <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <PackageDocumentationFile>README.md</PackageDocumentationFile>
     <Authors>Hong Minhee; Swen Mun</Authors>
     <Company>Planetarium</Company>
@@ -38,18 +38,13 @@ https://docs.libplanet.io/</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;NU5104;MEN001</NoWarn>
     <!-- FIXME: CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
-                             '$(MSBuildVersion)'&gt;='16.3.0'">
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -64,6 +59,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TODO: We should replace AsyncEnumerator with C# 8.0's async streams -->
     <PackageReference Include="AsyncEnumerator" Version="2.2.2" />
     <PackageReference Include="Bencodex" Version="0.3.0-dev.1b62adcbf3bf91d1a96787f4447dc6cc518d9734" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It has competitive advantages over other solutions for decentralized gaming:
  -  *Token-independent*: Unlike almost every blockchain system, it does not
     force users to create and deal with yet-another-cryptocurrency. Your
     game can be free to play, and enjoyed by regular gamers.
-    
+
 To learn more about why Planetarium is creating technology for fully
 decentralized games, please refer to our [blog post].
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,12 @@ jobs:
 
 - job: Windows_NETCore_coverage
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: windows-2019
   steps:
   - task: CmdLine@2
     displayName: dotnet tool install Codecov.Tool
     inputs:
-      script: dotnet tool install --global Codecov.Tool --version 1.5.0
+      script: dotnet tool install --global Codecov.Tool --version 1.10.0
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: Debug
@@ -36,10 +36,11 @@ jobs:
           echo "codecovToken variable is not configured." > /dev/stderr
           exit 0
         fi
+        mcc_ver=16.5.0
         curl \
-          -o microsoft.codecoverage.16.1.0.nupkg -L \
-          https://www.nuget.org/api/v2/package/Microsoft.CodeCoverage/16.1.0
-        unzip microsoft.codecoverage.16.1.0.nupkg
+          -o microsoft.codecoverage.$mcc_ver.nupkg -L \
+          https://www.nuget.org/api/v2/package/Microsoft.CodeCoverage/$mcc_ver
+        unzip microsoft.codecoverage.$mcc_ver.nupkg
         i=0
         for cov in **/*.coverage; do
           echo build/netstandard1.0/CodeCoverage/CodeCoverage.exe analyze \
@@ -69,7 +70,7 @@ jobs:
     displayName: Stick with .NET Core SDK version compatible to Mono toolchain
     inputs:
       packageType: sdk
-      version: 2.2.301  # See also: https://github.com/mono/mono/issues/13537
+      version: 3.1.101
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - template: .azure-pipelines/mono.yml
     parameters:
@@ -79,7 +80,7 @@ jobs:
 
 - job: macOS_Mono
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   steps:
   - template: .azure-pipelines/mono.yml
     parameters:
@@ -87,7 +88,6 @@ jobs:
       turnServerUrl: $(turnServerUrl)
   timeoutInMinutes: 30
 
-# FIXME: Currently mono version fixed to 6.0.0.334 for testing, it needs to be reverted.
 - job: Windows_Mono
   pool:
     vmImage: windows-2019
@@ -95,7 +95,7 @@ jobs:
   - task: CmdLine@2
     displayName: choco install mono
     inputs:
-      script: choco install mono --version 6.0.0.334 --yes
+      script: choco install mono --yes
   - template: .azure-pipelines/windows-net471.yml
     parameters:
       configuration: $(configuration)
@@ -106,7 +106,7 @@ jobs:
 
 - job: macOS_Unity
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   steps:
   - task: CmdLine@2
     displayName: Download xunit-unity-runner
@@ -140,7 +140,7 @@ jobs:
 
 - job: macOS_NETCore
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: macOS-10.15
   steps:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
@@ -151,7 +151,7 @@ jobs:
 
 - job: Windows_NETCore
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: windows-2019
   steps:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:


### PR DESCRIPTION
Introduce C# 8.0 so that we use native async streams and null reference checks (#468).  However, in this patch we just upgrade only *Libplanet* and *Libplanet.Stun* projects to use C# 8.0, without such new features.  `<Nullable>enable</Nullable>` is not turned on yet, and *AsyncEnumerator* package is still there (see also the `TODO` comment in the *Libplanet.csproj*).  *Libplanet.Tests* and *Libplanet.Stun.Tests* projects are still stuck with C# 7.1 as Unity is still so too.  This patch is a smallest change to keep the build barely unbroken.

So this also require @planetarium/libplanet you folks to upgrade .NET Core SDK to 3.1+ and Mono (MDK) to 6.4+.