### PR TITLE
Restore Libplanet.RocksDBStore.Tests

### DIFF
--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -30,9 +30,13 @@ steps:
   displayName: ${{ parameters.testDisplayName }}
   inputs:
     script: |
-      ${{ parameters.testCommand }} \
-        "$(pwd)"/*.Tests/bin/${{ parameters.configuration }}/net*/*.Tests.dll \
-        ${{ parameters.testArguments }}
+      # Because Libplanet.RocksDBStore.Tests has Libplanet.Tests as a dependency,
+      # Libplanet.Tests is executed twice without this.
+      for f in *.Tests; do
+        ${{ parameters.testCommand }} \
+          $(pwd)/"$f"/bin/${{ parameters.configuration }}/net*/"$f".dll \
+          ${{ parameters.testArguments }}
+      done
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,16 +71,16 @@ Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/s
 We write as complete tests as possible to the corresponding implementation code.
 Going near to the [code coverage][3] 100% is one of our goals.
 
-The *Libplanet* solution consists of several projects.  *Libplanet* and
-*Libplanet.Stun* are actual implementations.  These are built to *Libplanet.dll*
-and *Libplanet.Stun.dll* assemblies and packed into one NuGet package.
+The *Libplanet* solution consists of several projects.
+Every project without *.Tests* suffix is an actual implementation.
+These are built to *Libplanet\*.dll* assemblies and packed into one NuGet
+package.
 
-*Libplanet.Tests* is a test suite for the *Libplanet.dll* assembly, and
-*Libplanet.Stun.Tests* is a test suite for the *Libplanet.Stun.dll* assembly.
-Both depend on [Xunit], and every namespace and class in these corresponds to
-one in *Libplanet* or *Libplanet.Stun* projects.
+*Libplanet\*.Tests* is a test suite for the *Libplanet\*.dll* assembly.
+All of them depend on [Xunit], and every namespace and class in these
+corresponds to one in *Libplanet&ast;* projects.
 If there's *Libplanet.Foo.Bar* class there also should be
-*Libplanet.Tests.Foo.BarTest* to test it.
+*Libplanet.Foo.Bar.Tests* to test it.
 
 To build and run unit tests at a time execute the below command:
 
@@ -141,7 +141,7 @@ To sum up, the instruction is like below (the example is assuming Linux):
 
     msbuild -r
     xunit-unity-runner/StandaloneLinux64 \
-      "`pwd`"/*.Tests/bin/Debug/net461/*.Tests.dll
+      "`pwd`"/*.Tests/bin/Debug/net47/*.Tests.dll
 
 [xunit-unity-runner]: https://github.com/planetarium/xunit-unity-runner
 [4]: https://github.com/planetarium/xunit-unity-runner/releases/latest

--- a/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
                              '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-  Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+    Sdk="Microsoft.NET.Sdk">
+<PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -33,7 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -54,7 +53,6 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
@@ -62,18 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
-    <ProjectReference Include="..\Libplanet.Stun\Libplanet.Stun.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
-    <!--
-    As Mono has no proper AppDomain, we prevent it on Mono.
-    This works around Xunit's fatal error on Mono.
-    -->
-    <Content Include="xunit.runner.mono.json">
-      <Link>xunit.runner.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using Libplanet.Tests.Store;
+
+namespace Libplanet.RocksDBStore.Tests
+{
+    public class RocksDBStoreFixture : StoreFixture
+    {
+        public RocksDBStoreFixture()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"rocksdb_test_{Guid.NewGuid()}"
+            );
+
+            Store = new RocksDBStore(Path, blockCacheSize: 2, txCacheSize: 2);
+        }
+
+        public string Path { get; }
+
+        public override void Dispose()
+        {
+            (Store as RocksDBStore)?.Dispose();
+
+            if (!(Path is null))
+            {
+                Directory.Delete(Path, true);
+            }
+        }
+    }
+}

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -1,0 +1,28 @@
+using System;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.RocksDBStore.Tests
+{
+    public class RocksDBStoreTest : StoreTest, IDisposable
+    {
+        private readonly RocksDBStoreFixture _fx;
+
+        public RocksDBStoreTest()
+        {
+            try
+            {
+                Fx = _fx = new RocksDBStoreFixture();
+            }
+            catch (TypeInitializationException)
+            {
+                throw new SkipException("RocksDB is not available.");
+            }
+        }
+
+        public void Dispose()
+        {
+            _fx?.Dispose();
+        }
+    }
+}

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -1,6 +1,4 @@
-<Project
-xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-Sdk="Microsoft.NET.Sdk">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
   <TargetFramework>netstandard2.0</TargetFramework>
   <RootNamespace>Libplanet.RocksDBStore</RootNamespace>
@@ -22,14 +20,13 @@ Sdk="Microsoft.NET.Sdk">
   <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
     <PrivateAssets>all</PrivateAssets>
   </PackageReference>
-  <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
+  <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>
       runtime; build; native; contentfiles; analyzers; buildtransitive
     </IncludeAssets>
   </PackageReference>
+  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.1-planetarium" />
   <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
     <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     <PrivateAssets>all</PrivateAssets>
@@ -41,7 +38,6 @@ Sdk="Microsoft.NET.Sdk">
     </IncludeAssets>
   </PackageReference>
   <PackageReference Include="Serilog" Version="2.8.0" />
-  <PackageReference Include="RocksDbSharp" Version="6.2.2" />
 </ItemGroup>
 
 <ItemGroup>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
                              '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Benchmarks", "Lib
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore", "Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj", "{A5DE942D-912D-4012-8493-1E958E5445F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore.Tests", "Libplanet.RocksDBStore.Tests\Libplanet.RocksDBStore.Tests.csproj", "{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{A5DE942D-912D-4012-8493-1E958E5445F4}.Release|x64.Build.0 = Release|Any CPU
 		{A5DE942D-912D-4012-8493-1E958E5445F4}.Release|x86.ActiveCfg = Release|Any CPU
 		{A5DE942D-912D-4012-8493-1E958E5445F4}.Release|x86.Build.0 = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x64.Build.0 = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This restores `Libplanet.RocksDBStore.Tests` removed in 63b1c457b44bf26c5fd54c2acaf43a0f56bbd8ff.

Currently, the tests only run on .NET Core.