### PR TITLE
Restore BlockCompletion<T> (#707) and more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,14 +8,21 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `BaseStore` class became to implement `IDisposable`.  [[#789]]
+
 ### Backward-incompatible network protocol changes
 
- -  `BaseStore` class became to implement `IDisposable`.  [[#789]]
+ -  The existing `BlockHashes` message type (with the type number `0x05`) was
+    replaced by a new `BlockHashes` message type (with type number `0x0e`)
+    in order to include an offset block index besides block hashes
+    so that a receiver is able to determine their block indices too.  [[#707]]
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
 
+ -  Added `BlockHashDownloadState` class, a subclass of `PreloadState`.
+    [[#707]]
  -  Added `BlockDigest` struct.  [[#785]]
  -  Added `BlockHeader` struct.  [[#785]]
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
@@ -25,17 +32,23 @@ To be released.
 
  -  `BlockChain.MineBlock()` method became to ignore transactions having
     lower nonce than the expected nonce in the chain.  [[#791]]
+ -  `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()` became to download
+    only a list of block hashes first and then download blocks from
+    simultaneously multiple peers.  [[#707]]
 
 ### Bug fixes
 
  -  `Swarm<T>` became not to sync the same `Block<T>`s or `Transaction<T>`s
     multiple times.  [[#784]]
- -  Fixed a `Swarm<T>`'s bug that had broadcasted a message to its source peer when
-    the number of peers is not enough (less than the minimum number).  [[#788]]
+ -  Fixed a `Swarm<T>`'s bug that had broadcasted a message to its source peer
+    when the number of peers is not enough (less than the minimum number).
+    [[#788]]
  -  Fixed a bug where `BlockChain.MineBlock()` had produced an invalid block
-    when there is any staged transaction which has lower nonce than the expected nonce,
-    that means, shares an already taken nonce by the same signer.  [[#791]]
+    when there is any staged transaction which has lower nonce than the expected
+    nonce, that means, shares an already taken nonce by the same signer.
+    [[#791]]
 
+[#707]: https://github.com/planetarium/libplanet/pull/707
 [#784]: https://github.com/planetarium/libplanet/pull/784
 [#785]: https://github.com/planetarium/libplanet/pull/785
 [#788]: https://github.com/planetarium/libplanet/pull/788
@@ -133,8 +146,8 @@ Released on February 4, 2020.
  -  Added `BlockChain<T>.Genesis` property.  [[#688]]
  -  Added `BlockChain<T>.MakeGenesisBlock()` static method.  [[#688]]
  -  Added `InvalidGenesisBlockException` class.  [[#688]]
- -  Added `StateDownloadState` class which reports state preloading iteration
-    progress.  [[#703]]
+ -  Added `StateDownloadState` class, a subclass of `PreloadState`,
+    which reports state preloading iteration progress.  [[#703]]
  -  Added `PeerDiscoveryException` class which inherits `SwarmException`
     class.  [[#604], [#726]]
  -  Added `Swarm<T>.Peers` property which returns an enumerable of peers in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@ To be released.
     when there is any staged transaction which has lower nonce than the expected
     nonce, that means, shares an already taken nonce by the same signer.
     [[#791]]
+ -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that temporary chain IDs
+    in the store had been completely cleaned up in some corner cases
+    if `cancellationToken` was requested.  [[#798]]
 
 [#707]: https://github.com/planetarium/libplanet/pull/707
 [#784]: https://github.com/planetarium/libplanet/pull/784

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,14 +15,17 @@ To be released.
  -  The existing `BlockHashes` message type (with the type number `0x05`) was
     replaced by a new `BlockHashes` message type (with type number `0x0e`)
     in order to include an offset block index besides block hashes
-    so that a receiver is able to determine their block indices too.  [[#707]]
+    so that a receiver is able to determine their block indices too.
+    [[#707], [#798]]
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
 
  -  Added `BlockHashDownloadState` class, a subclass of `PreloadState`.
-    [[#707]]
+    [[#707], [#798]]
+ -  Added `BlockVerificationState` class, a subclass of `PreloadState`.
+    [[#798]]
  -  Added `BlockDigest` struct.  [[#785]]
  -  Added `BlockHeader` struct.  [[#785]]
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
@@ -34,7 +37,7 @@ To be released.
     lower nonce than the expected nonce in the chain.  [[#791]]
  -  `Swarm<T>.PreloadAsync()` and `Swarm<T>.StartAsync()` became to download
     only a list of block hashes first and then download blocks from
-    simultaneously multiple peers.  [[#707]]
+    simultaneously multiple peers.  [[#707], [#798]]
 
 ### Bug fixes
 
@@ -54,6 +57,8 @@ To be released.
 [#788]: https://github.com/planetarium/libplanet/pull/788
 [#789]: https://github.com/planetarium/libplanet/pull/789
 [#791]: https://github.com/planetarium/libplanet/pull/791
+[#798]: https://github.com/planetarium/libplanet/pull/798
+
 
 Version 0.8.0
 -------------

--- a/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Blockchain;
+using NetMQ;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public class BlockLocatorTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public BlockLocatorTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            // Generate fixture block hashes looks like 0x000...1, 0x000...2, 0x000...3, and so on,
+            // for the sake of easier debugging.
+            ImmutableArray<HashDigest<SHA256>> blocks = Enumerable.Range(0, 0x10).Select(i =>
+            {
+                byte[] bytes = NetworkOrderBitsConverter.GetBytes(i);
+                var buffer = new byte[HashDigest<SHA256>.Size];
+                bytes.CopyTo(buffer, buffer.Length - bytes.Length);
+                return new HashDigest<SHA256>(buffer);
+            }).ToImmutableArray();
+
+            var locator = new BlockLocator(
+                indexBlockHash: idx => blocks[(int)(idx < 0 ? blocks.Length + idx : idx)],
+                indexByBlockHash: hash => blocks.IndexOf(hash),
+                sampleAfter: 5
+            );
+
+            foreach (HashDigest<SHA256> hash in locator)
+            {
+                _output.WriteLine(hash.ToString());
+            }
+
+            Assert.Equal(
+                new[]
+                {
+                    blocks[0xf],
+                    blocks[0xe],
+                    blocks[0xd],
+                    blocks[0xc],
+                    blocks[0xb],
+                    blocks[0xa],
+                    blocks[0x8],
+                    blocks[0x4],
+                    blocks[0x0],
+                },
+                locator
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tests/LoggerExtensions.cs
+++ b/Libplanet.Tests/LoggerExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Serilog;
+using Serilog.Events;
+
+namespace Libplanet.Tests
+{
+    public static class LoggerExtensions
+    {
+        public static void CompareBothChains<T>(
+            this ILogger logger,
+            LogEventLevel logLevel,
+            string labelA,
+            BlockChain<T> chainA,
+            string labelB,
+            BlockChain<T> chainB
+        )
+            where T : IAction, new()
+        {
+            if (!logger.IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            void Print(string i, string x, string y)
+            {
+                char bar = x.Equals(y) ? '|' : ':';
+                logger.Write(logLevel, $"{bar} {i,3} {bar} {x,-64} {bar} {y,-64} {bar}");
+            }
+
+            long aTipIdx = chainA.Tip.Index;
+            long bTipIdx = chainB.Tip.Index;
+            Print("Idx", $"{labelA} (tip: {aTipIdx})", $"{labelB} (tip: {bTipIdx})");
+            long tipIdx = Math.Max(aTipIdx, bTipIdx);
+            long idx = 0;
+            while (idx <= tipIdx)
+            {
+                Print(
+                    $"#{idx}",
+                    aTipIdx >= idx ? chainA[idx].ToString() : string.Empty,
+                    bTipIdx >= idx ? chainB[idx].ToString() : string.Empty
+                );
+                idx++;
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/LoggerExtensions.cs
+++ b/Libplanet.Tests/LoggerExtensions.cs
@@ -18,6 +18,15 @@ namespace Libplanet.Tests
         )
             where T : IAction, new()
         {
+            if (chainA is null)
+            {
+                throw new ArgumentNullException(nameof(chainA));
+            }
+            else if (chainB is null)
+            {
+                throw new ArgumentNullException(nameof(chainB));
+            }
+
             if (!logger.IsEnabled(logLevel))
             {
                 return;

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Async;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Net;
+using Libplanet.Tests.Common.Action;
+using Nito.AsyncEx;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Net
+{
+    public class BlockCompletionTest
+    {
+        private const int Timeout = 20000;
+        private readonly ITestOutputHelper _output;
+        private readonly ILogger _logger;
+
+        public BlockCompletionTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} [thread/{ThreadId}] {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<BlockCompletionTest>();
+            _logger = Log.ForContext<BlockCompletionTest>();
+            _output = output;
+        }
+
+        [Fact(Timeout = Timeout * 3)]
+        public async Task PeerPool()
+        {
+            const int tasks = 50;
+            ConcurrentDictionary<int, int> peers = new ConcurrentDictionary<int, int>(
+                Enumerable.Range(0, 3).Select(peerId => new KeyValuePair<int, int>(peerId, 0))
+            );
+            var concurrentWorkersLogs = new ConcurrentBag<int>();
+            long done = 0;
+            var pool = new BlockCompletion<int, DumbAction>.PeerPool(peers.Keys);
+            var random = new System.Random();
+            Task[] spawns = Enumerable.Range(0, tasks).Select(i =>
+            {
+                int sleep = random.Next(5, 50);
+                return pool.SpawnAsync(async peerId =>
+                {
+                    try
+                    {
+                        int counter;
+                        do
+                        {
+                            counter = peers[peerId];
+                        }
+                        while (!peers.TryUpdate(peerId, counter + 1, counter));
+
+                        concurrentWorkersLogs.Add(
+                            peers.Where(kv => kv.Key != peerId).Sum(kv => kv.Value) +
+                            counter + 1
+                        );
+
+                        await Task.Delay(sleep);
+
+                        do
+                        {
+                            counter = peers[peerId];
+                        }
+                        while (!peers.TryUpdate(peerId, counter - 1, counter));
+                    }
+                    catch (Exception e)
+                    {
+                        _output.WriteLine(e.ToString());
+                    }
+                    finally
+                    {
+                        Interlocked.Increment(ref done);
+                        _output.WriteLine($"Task {i} finished.");
+                    }
+                });
+            }).ToArray();
+
+            _output.WriteLine("Wait spawned tasks to be finished...");
+            await Task.WhenAll(spawns);
+            _output.WriteLine("All spawned tasks finished; wait PeerPool to be finished...");
+            await pool.WaitAll();
+            _output.WriteLine("PeerPool finished.");
+
+            Assert.Equal(tasks, Interlocked.Read(ref done));
+            Assert.Equal(tasks, concurrentWorkersLogs.Count);
+            foreach (int log in concurrentWorkersLogs)
+            {
+                Assert.InRange(log, 0, 3);
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async void EnumerateChunks()
+        {
+            // 0, 1: Already existed blocks
+            // 2, 3, 4,  5,  6: first chunk
+            // 7, 8, 9, 10, 11: second chunk
+            //   12,    13, 14: last chunk
+            ImmutableArray<Block<DumbAction>> fixture =
+                GenerateBlocks<DumbAction>(15).ToImmutableArray();
+            const int initialHeight = 2;
+            const int window = 5;
+            var bc = new BlockCompletion<int, DumbAction>(
+                fixture.Take(initialHeight).Select(b => b.Hash).ToImmutableHashSet().Contains,
+                window
+            );
+            var logs = new ConcurrentBag<(int, ImmutableArray<HashDigest<SHA256>>)>();
+            var ev = new AsyncAutoResetEvent(false);
+            var bg = Task.Run(async () =>
+            {
+                await Task.Delay(100);
+                int i = 0;
+                await bc.EnumerateChunks().ForEachAsync(hashes =>
+                {
+                    ImmutableArray<HashDigest<SHA256>> hashesArray = hashes.ToImmutableArray();
+                    logs.Add((i, hashesArray));
+                    i++;
+
+                    // To test dynamic demands
+                    if (hashesArray.Contains(fixture[7].Hash))
+                    {
+                        bc.Demand(fixture[14].Hash);
+                        bc.Demand(fixture[0].Hash);  // This should be ignored as it's existed.
+                        bc.Demand(fixture[3].Hash);  // This should be ignored as it's satisfied.
+                    }
+
+                    ev.Set();
+                    _logger.Verbose("Got a chunk of hashes: {0}", string.Join(", ", hashesArray));
+                });
+            });
+
+            // Demand: 2, 3, 4, 5, 6
+            bc.Demand(fixture.Skip(initialHeight).Take(5).Select(b => b.Hash));
+
+            // Chunk: 2, 3, 4, 5, 6
+            _logger.Verbose("Waiting demand #2-6...");
+
+            // TODO change waiting condition
+            await Task.Delay(1000);
+            _logger.Verbose("Demand #2-6 processed.");
+            var actual = new List<HashDigest<SHA256>>();
+            while (logs.TryTake(out var log))
+            {
+                actual.AddRange(log.Item2);
+            }
+
+            Assert.Equal(fixture.Skip(initialHeight).Take(window).Select(b => b.Hash), actual);
+
+            // Complete: 2, 3, 4, 5 (and no 6)
+            for (int i = initialHeight; i < initialHeight + window - 1; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            // Demand: 7, 8, 9, 10, 11, 12, 13 (and 14 <- 7 will be added soon)
+            bc.Demand(fixture.Skip(initialHeight + window).Select(b => b.Hash));
+
+            // Chunk: 7, 8, 9, 10, 11
+            _logger.Verbose("Waiting demand #7-11...");
+            // TODO change waiting condition
+            await Task.Delay(1000);
+            _logger.Verbose("Demand #7-11 processed.");
+
+            actual = new List<HashDigest<SHA256>>();
+            while (logs.TryTake(out var log))
+            {
+                actual.AddRange(log.Item2);
+            }
+
+            Assert.Equal(
+                fixture.Skip(initialHeight + window).Take(window).Select(b => b.Hash),
+                actual
+            );
+
+            // Complete: 6, 7, 8, 9, 10, 11
+            for (int i = initialHeight + window - 1; i < initialHeight + window * 2; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            // Chunk: 12, 13, 14
+            _logger.Verbose("Waiting demand #12-14...");
+            // TODO change waiting condition
+            await Task.Delay(1000);
+            _logger.Verbose("Demand #12-14 processed.");
+            actual = new List<HashDigest<SHA256>>();
+            while (logs.TryTake(out var log))
+            {
+                actual.AddRange(log.Item2);
+            }
+
+            Assert.Equal(
+                fixture.Skip(initialHeight + window * 2).Select(b => b.Hash).ToImmutableHashSet(),
+                actual.ToImmutableHashSet()
+            );
+
+            // Complete: 12, 13, 14
+            for (int i = initialHeight + window * 2; i < fixture.Length; i++)
+            {
+                bc.Satisfy(fixture[i]);
+            }
+
+            await bg;
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task Complete()
+        {
+            // 0, 1: Already existed blocks
+            // 2, 3, 4,  5,  6: first chunk
+            // 7, 8, 9, 10, 11: second chunk
+            //   12,    13, 14: last chunk
+            ImmutableArray<Block<DumbAction>> fixture =
+                GenerateBlocks<DumbAction>(15).ToImmutableArray();
+
+            // Blocks each block has:
+            //   A: 0, 4, 8,  12
+            //   B: 1, 5, 9,  13
+            //   C: 2, 6, 10, 14
+            //   D: 3, 7, 11
+            char[] peers = { 'A', 'B', 'C', 'D' };
+            ImmutableDictionary<char, ImmutableDictionary<HashDigest<SHA256>, Block<DumbAction>>>
+                peerBlocks = peers.ToImmutableDictionary(
+                    p => p,
+                    p => fixture.Skip(p - 'A').Where((_, i) => i % 4 < 1).ToImmutableDictionary(
+                        b => b.Hash,
+                        b => b
+                    )
+                );
+
+            const int initialHeight = 2;
+            const int window = 5;
+            var bc = new BlockCompletion<char, DumbAction>(
+                fixture.Take(initialHeight).Select(b => b.Hash).ToImmutableHashSet().Contains,
+                window
+            );
+            ImmutableArray<HashDigest<SHA256>> initialDemands = fixture
+                .Skip(initialHeight + 10)
+                .Select(b => b.Hash)
+                .ToImmutableArray();
+            bc.Demand(initialDemands);
+            _logger.Verbose("Initial demands: {0}", initialDemands);
+            System.Collections.Async.IAsyncEnumerable<Tuple<Block<DumbAction>, char>> rv =
+                bc.Complete(
+                    new[] { 'A', 'B', 'C', 'D' },
+                    (peer, hashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                    {
+                        var blocksPeerHas = peerBlocks[peer];
+                        var sent = new HashSet<HashDigest<SHA256>>();
+                        foreach (HashDigest<SHA256> hash in hashes)
+                        {
+                            if (blocksPeerHas.ContainsKey(hash))
+                            {
+                                Block<DumbAction> block = blocksPeerHas[hash];
+                                await yield.ReturnAsync(block);
+                                sent.Add(block.Hash);
+                            }
+                        }
+
+                        _logger.Verbose("Peer {Peer} sent blocks: {SentBlockHashes}.", peer, sent);
+                    })
+                );
+
+            var downloadedBlocks = new HashSet<Block<DumbAction>>();
+            var sourcePeers = new HashSet<char>();
+            await rv.ForEachAsync(pair =>
+            {
+                downloadedBlocks.Add(pair.Item1);
+                sourcePeers.Add(pair.Item2);
+            });
+
+            Assert.Equal(fixture.Skip(2).ToHashSet(), downloadedBlocks);
+            Assert.Subset(peers.ToHashSet(), sourcePeers);
+        }
+
+        private IEnumerable<Block<T>> GenerateBlocks<T>(int count)
+            where T : IAction, new()
+        {
+            if (count >= 1)
+            {
+                Block<T> block = TestUtils.MineGenesis<T>();
+                yield return block;
+
+                for (int i = 1; i < count; i++)
+                {
+                    block = TestUtils.MineNext(block);
+                    yield return block;
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Net
             Task[] spawns = Enumerable.Range(0, tasks).Select(i =>
             {
                 int sleep = random.Next(5, 50);
-                return pool.SpawnAsync(async peerId =>
+                return pool.SpawnAsync(async (peerId, cancellationToken) =>
                 {
                     try
                     {

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -7,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Net;
@@ -253,7 +253,7 @@ namespace Libplanet.Tests.Net
                 .ToImmutableArray();
             bc.Demand(initialDemands);
             _logger.Verbose("Initial demands: {0}", initialDemands);
-            System.Collections.Async.IAsyncEnumerable<Tuple<Block<DumbAction>, char>> rv =
+            IAsyncEnumerable<Tuple<Block<DumbAction>, char>> rv =
                 bc.Complete(
                     new[] { 'A', 'B', 'C', 'D' },
                     (peer, hashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -255,7 +255,7 @@ namespace Libplanet.Tests.Net
             _logger.Verbose("Initial demands: {0}", initialDemands);
             IAsyncEnumerable<Tuple<Block<DumbAction>, char>> rv = bc.Complete(
                 new[] { 'A', 'B', 'C', 'D' },
-                (peer, hashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                (peer, hashes, token) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
                 {
                     var blocksPeerHas = peerBlocks[peer];
                     var sent = new HashSet<HashDigest<SHA256>>();
@@ -302,7 +302,7 @@ namespace Libplanet.Tests.Net
 
             long counter = 0;
             BlockCompletion<char, DumbAction>.BlockFetcher wrongBlockFetcher =
-                (peer, blockHashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                (peer, blockHashes, token) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
                 {
                     // Provides a wrong block (i.e., not corresponding to the demand) at first call,
                     // and then provide a proper block later calls.
@@ -324,7 +324,7 @@ namespace Libplanet.Tests.Net
             bc.Demand(fixture.Select(b => b.Hash));
 
             BlockCompletion<char, DumbAction>.BlockFetcher blockFetcher =
-                (peer, blockHashes) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                (peer, blockHashes, token) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
                 {
                     // Peer A does not respond and Peer B does respond.
                     if (peer == 'A')

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -15,6 +15,7 @@ using Nito.AsyncEx;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
+using AsyncEnumerable = System.Linq.AsyncEnumerable;
 
 namespace Libplanet.Tests.Net
 {
@@ -123,7 +124,7 @@ namespace Libplanet.Tests.Net
             {
                 await Task.Delay(100);
                 int i = 0;
-                await bc.EnumerateChunks().ForEachAsync(hashes =>
+                await AsyncEnumerable.ForEachAsync(bc.EnumerateChunks(), hashes =>
                 {
                     ImmutableArray<HashDigest<SHA256>> hashesArray = hashes.ToImmutableArray();
                     logs.Add((i, hashesArray));
@@ -275,7 +276,7 @@ namespace Libplanet.Tests.Net
 
             var downloadedBlocks = new HashSet<Block<DumbAction>>();
             var sourcePeers = new HashSet<char>();
-            await rv.ForEachAsync(pair =>
+            await AsyncEnumerable.ForEachAsync(rv, pair =>
             {
                 downloadedBlocks.Add(pair.Item1);
                 sourcePeers.Add(pair.Item2);
@@ -311,7 +312,7 @@ namespace Libplanet.Tests.Net
                 });
 
             Tuple<Block<DumbAction>, char>[] result =
-                await bc.Complete(new[] { 'A' }, wrongBlockFetcher).ToArrayAsync();
+                await AsyncEnumerable.ToArrayAsync(bc.Complete(new[] { 'A' }, wrongBlockFetcher));
             Assert.Equal(new[] { Tuple.Create(demand, 'A') }, result);
         }
 
@@ -345,7 +346,7 @@ namespace Libplanet.Tests.Net
                 });
 
             Tuple<Block<DumbAction>, char>[] result =
-                await bc.Complete(new[] { 'A', 'B' }, blockFetcher).ToArrayAsync();
+                await AsyncEnumerable.ToArrayAsync(bc.Complete(new[] { 'A', 'B' }, blockFetcher));
             Assert.Equal(
                 fixture.Select(b => Tuple.Create(b, 'B')).ToHashSet(),
                 result.ToHashSet()

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using NetMQ;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Messages
+{
+    public class BlockHashesTest
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new BlockHashes(null, new[] { default(HashDigest<SHA256>) })
+            );
+            Assert.Throws<ArgumentException>(() =>
+                new BlockHashes(123, new HashDigest<SHA256>[0])
+            );
+        }
+
+        [Fact]
+        public void DataFrames()
+        {
+            HashDigest<SHA256>[] blockHashes = GenerateRandomBlockHashes(100L).ToArray();
+            var msg = new BlockHashes(123, blockHashes);
+            Assert.Equal(123, msg.StartIndex);
+            Assert.Equal(blockHashes, msg.Hashes);
+            var privKey = new PrivateKey();
+            Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234), 0);
+            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
+            var restored = new BlockHashes(frames);
+            Assert.Equal(msg.StartIndex, restored.StartIndex);
+            Assert.Equal(msg.Hashes, restored.Hashes);
+        }
+
+        private static IEnumerable<HashDigest<SHA256>> GenerateRandomBlockHashes(long count)
+        {
+            var random = new Random();
+            var buffer = new byte[HashDigest<SHA256>.Size];
+            for (long i = 0; i < count; i++)
+            {
+                random.NextBytes(buffer);
+                yield return new HashDigest<SHA256>(buffer);
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -475,9 +475,7 @@ namespace Libplanet.Tests.Net
                 await StopAsync(b);
             }
 
-            Log.Debug($"chainA: {string.Join(",", chainA)}");
-            Log.Debug($"chainB: {string.Join(",", chainB)}");
-
+            _logger.CompareBothChains(LogEventLevel.Debug, "A", chainA, "B", chainB);
             Assert.Equal(chainA.BlockHashes, chainB.BlockHashes);
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Async;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -8,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
+using Dasync.Collections;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -38,6 +38,7 @@ namespace Libplanet.Tests.Net
         private static Block<DumbAction>[] _fixtureBlocksForPreloadAsyncCancellationTest;
 
         private readonly ITestOutputHelper _output;
+        private readonly ILogger _logger;
         private readonly StoreFixture _fx1;
         private readonly StoreFixture _fx2;
         private readonly StoreFixture _fx3;
@@ -59,6 +60,7 @@ namespace Libplanet.Tests.Net
 
             Log.Logger.Debug($"Started to initialize a {nameof(SwarmTest)} instance.");
 
+            _logger = Log.ForContext<SwarmTest>();
             _output = output;
 
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
@@ -577,7 +579,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task CanGetBlock()
+        public async Task GetBlocks()
         {
             Swarm<DumbAction> swarmA = _swarms[0];
             Swarm<DumbAction> swarmB = _swarms[1];
@@ -585,6 +587,8 @@ namespace Libplanet.Tests.Net
             BlockChain<DumbAction> chainA = _blockchains[0];
             BlockChain<DumbAction> chainB = _blockchains[1];
 
+            // FIXME: Rename the following variables or reuse the real genesis block which
+            // already exists in chainA.  These are misleading as genesis.Index is not 0 but 1.
             Block<DumbAction> genesis = await chainA.MineBlock(_fx1.Address1);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
             Block<DumbAction> block1 = await chainA.MineBlock(_fx1.Address1);
@@ -597,32 +601,39 @@ namespace Libplanet.Tests.Net
 
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
 
-                IEnumerable<HashDigest<SHA256>> inventories1 =
-                    await swarmB.GetBlockHashesAsync(
+                (long, HashDigest<SHA256>)[] inventories1 = (
+                    await swarmB.GetBlockHashes(
                         swarmA.AsPeer as BoundPeer,
                         new BlockLocator(new[] { genesis.Hash }),
-                        null);
+                        null
+                    ).ToArrayAsync()
+                ).Select(p => p.ToValueTuple()).ToArray();
                 Assert.Equal(
-                    new[] { genesis.Hash, block1.Hash, block2.Hash },
+                    new[]
+                    {
+                        (genesis.Index, genesis.Hash),
+                        (block1.Index, block1.Hash),
+                        (block2.Index, block2.Hash),
+                    },
                     inventories1);
 
-                IEnumerable<HashDigest<SHA256>> inventories2 =
-                    await swarmB.GetBlockHashesAsync(
+                (long, HashDigest<SHA256>)[] inventories2 = (
+                    await swarmB.GetBlockHashes(
                         swarmA.AsPeer as BoundPeer,
                         new BlockLocator(new[] { genesis.Hash }),
-                        block1.Hash);
+                        block1.Hash
+                    ).ToArrayAsync()
+                ).Select(p => p.ToValueTuple()).ToArray();
                 Assert.Equal(
-                    new[] { genesis.Hash, block1.Hash },
+                    new[] { (genesis.Index, genesis.Hash), (block1.Index, block1.Hash) },
                     inventories2);
 
-                List<Block<DumbAction>> receivedBlocks =
+                Block<DumbAction>[] receivedBlocks =
                     await swarmB.GetBlocksAsync(
-                        swarmA.AsPeer as BoundPeer, inventories1
-                    ).ToListAsync();
-
-                Assert.Equal(
-                    new[] { genesis, block1, block2 },
-                    receivedBlocks);
+                        swarmA.AsPeer as BoundPeer,
+                        inventories1.Select(pair => pair.Item2)
+                    ).ToArrayAsync();
+                Assert.Equal(new[] { genesis, block1, block2 }, receivedBlocks);
             }
             finally
             {
@@ -656,16 +667,16 @@ namespace Libplanet.Tests.Net
 
                 await swarmB.AddPeersAsync(new[] { peer }, null);
 
-                IEnumerable<HashDigest<SHA256>> hashes =
-                    await swarmB.GetBlockHashesAsync(
-                        peer,
-                        new BlockLocator(new[] { genesis.Hash }),
-                        null);
+                Tuple<long, HashDigest<SHA256>>[] hashes = await swarmB.GetBlockHashes(
+                    peer,
+                    new BlockLocator(new[] { genesis.Hash }),
+                    null
+                ).ToArrayAsync();
 
                 var netMQAddress = $"tcp://{peer.EndPoint.Host}:{peer.EndPoint.Port}";
                 using (var socket = new DealerSocket(netMQAddress))
                 {
-                    var request = new GetBlocks(hashes, 2);
+                    var request = new GetBlocks(hashes.Select(pair => pair.Item2), 2);
                     socket.SendMultipartMessage(
                         request.ToNetMQMessage(privateKey, swarmB.AsPeer)
                     );
@@ -1398,6 +1409,7 @@ namespace Libplanet.Tests.Net
             var actualStates = new List<PreloadState>();
             var progress = new Progress<PreloadState>(state =>
             {
+                _logger.Information("Received a progress event: {@State}", state);
                 lock (actualStates)
                 {
                     actualStates.Add(state);
@@ -1428,18 +1440,27 @@ namespace Libplanet.Tests.Net
                 for (var i = 1; i < minerChain.Count; i++)
                 {
                     var b = minerChain[i];
-                    var state = new BlockDownloadState
+                    var state = new BlockHashDownloadState
                     {
-                        ReceivedBlockHash = b.Hash,
-                        TotalBlockCount = 10,
-                        ReceivedBlockCount = i,
+                        EstimatedTotalBlockHashCount = 10,
+                        ReceivedBlockHashCount = 1,
                         SourcePeer = minerSwarm.AsPeer as BoundPeer,
                     };
                     expectedStates.Add(state);
                 }
 
-                ((BlockDownloadState)expectedStates[9]).TotalBlockCount = 11;
-                ((BlockDownloadState)expectedStates[10]).TotalBlockCount = 11;
+                for (var i = 1; i < minerChain.Count; i++)
+                {
+                    var b = minerChain[i];
+                    var state = new BlockDownloadState
+                    {
+                        ReceivedBlockHash = b.Hash,
+                        TotalBlockCount = i == 9 || i == 10 ? 11 : 10,
+                        ReceivedBlockCount = i,
+                        SourcePeer = minerSwarm.AsPeer as BoundPeer,
+                    };
+                    expectedStates.Add(state);
+                }
 
                 for (var i = 1; i < minerChain.Count; i++)
                 {
@@ -1453,18 +1474,14 @@ namespace Libplanet.Tests.Net
                     expectedStates.Add(state);
                 }
 
+                _logger.Debug("{@expectedStates}", expectedStates);
+                _logger.Debug("{@actualStates}", actualStates);
+
                 Assert.Equal(expectedStates.Count, actualStates.Count);
                 foreach (var states in expectedStates.Zip(actualStates, ValueTuple.Create))
                 {
                     Assert.Equal(states.Item1, states.Item2);
                 }
-
-                Log.Debug("{@expectedStates}", expectedStates);
-                Log.Debug("{@actualStates}", actualStates);
-
-                Assert.Equal(
-                    expectedStates.ToImmutableHashSet(),
-                    actualStates.ToImmutableHashSet());
             }
             finally
             {
@@ -1583,6 +1600,18 @@ namespace Libplanet.Tests.Net
                 for (var i = 1; i < minerChain.Count; i++)
                 {
                     var b = minerChain[i];
+                    var state = new BlockHashDownloadState
+                    {
+                        EstimatedTotalBlockHashCount = 10,
+                        ReceivedBlockHashCount = i,
+                        SourcePeer = nominerSwarm1.AsPeer as BoundPeer,
+                    };
+                    expectedStates.Add(state);
+                }
+
+                for (var i = 1; i < minerChain.Count; i++)
+                {
+                    var b = minerChain[i];
                     var state = new BlockDownloadState
                     {
                         ReceivedBlockHash = b.Hash,
@@ -1664,13 +1693,11 @@ namespace Libplanet.Tests.Net
             await receiverSwarm.PreloadAsync(
                 progress: new Progress<PreloadState>(async (state) =>
                 {
-                    if (startedStop)
+                    if (!startedStop && state is BlockDownloadState)
                     {
-                        return;
+                        startedStop = true;
+                        await shouldStopSwarm.StopAsync(TimeSpan.Zero);
                     }
-
-                    startedStop = true;
-                    await shouldStopSwarm.StopAsync(TimeSpan.Zero);
                 }));
 
             Assert.Equal(swarm1.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);
@@ -1840,8 +1867,30 @@ namespace Libplanet.Tests.Net
             senderChain.Append(b2send);
             senderChain.Append(b3);
 
+            _logger.Verbose("Sender chain:");
+            foreach (Block<DumbAction> block in senderChain.IterateBlocks())
+            {
+                _logger.Verbose(
+                    "#{BlockIndex} {BlockHash} (<- {PreviousHash})",
+                    block.Index,
+                    block.Hash,
+                    block.PreviousHash
+                );
+            }
+
             receiverChain.Append(bp);
             receiverChain.Append(b2recv);
+
+            _logger.Verbose("Receiver chain:");
+            foreach (Block<DumbAction> block in receiverChain.IterateBlocks())
+            {
+                _logger.Verbose(
+                    "#{BlockIndex} {BlockHash} (<- {PreviousHash})",
+                    block.Index,
+                    block.Hash,
+                    block.PreviousHash
+                );
+            }
 
             try
             {
@@ -2076,7 +2125,7 @@ namespace Libplanet.Tests.Net
                 i = 1;
                 foreach (StateDownloadState state in downloadStates)
                 {
-                    Assert.Equal(2, state.CurrentPhase);
+                    Assert.Equal(3, state.CurrentPhase);
                     Assert.Equal(totalCount, state.TotalIterationCount);
                     Assert.Equal(i++, state.ReceivedIterationCount);
                 }
@@ -2270,6 +2319,10 @@ namespace Libplanet.Tests.Net
             if (canceled)
             {
                 Assert.Equal(receiverChainId, receiverChain.Id);
+                Assert.Equal(
+                    (blockArray[0].Index, blockArray[0].Hash),
+                    (receiverChain.Tip.Index, receiverChain.Tip.Hash)
+                );
                 Assert.Equal(blockArray[0], receiverChain.Tip);
                 Assert.Equal(
                     (Text)string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item0.{j}")),

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
@@ -7,6 +8,37 @@ namespace Libplanet.Blockchain
     internal class BlockLocator : IEnumerable<HashDigest<SHA256>>
     {
         private readonly IEnumerable<HashDigest<SHA256>> _impl;
+
+        public BlockLocator(
+            Func<long, HashDigest<SHA256>?> indexBlockHash,
+            Func<HashDigest<SHA256>, long> indexByBlockHash,
+            int sampleAfter = 10
+        )
+        {
+            HashDigest<SHA256>? current = indexBlockHash(-1);
+            long step = 1;
+            var hashes = new List<HashDigest<SHA256>>();
+            while (current is HashDigest<SHA256> hash)
+            {
+                hashes.Add(hash);
+                long currentBlockIndex = indexByBlockHash(hash);
+
+                if (currentBlockIndex == 0)
+                {
+                    break;
+                }
+
+                long nextIndex = Math.Max(currentBlockIndex - step, 0);
+                current = indexBlockHash(nextIndex);
+
+                if (hashes.Count >= sampleAfter)
+                {
+                    step *= 2;
+                }
+            }
+
+            _impl = hashes;
+        }
 
         public BlockLocator(IEnumerable<HashDigest<SHA256>> hashes)
         {

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -60,7 +60,7 @@ https://docs.libplanet.io/</Description>
 
   <ItemGroup>
     <!-- TODO: We should replace AsyncEnumerator with C# 8.0's async streams -->
-    <PackageReference Include="AsyncEnumerator" Version="2.2.2" />
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Bencodex" Version="0.3.0-dev.1b62adcbf3bf91d1a96787f4447dc6cc518d9734" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
     <PackageReference Include="Equals.Fody" Version="1.9.6" />

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -59,8 +59,6 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TODO: We should replace AsyncEnumerator with C# 8.0's async streams -->
-    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Bencodex" Version="0.3.0-dev.1b62adcbf3bf91d1a96787f4447dc6cc518d9734" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
     <PackageReference Include="Equals.Fody" Version="1.9.6" />
@@ -95,6 +93,7 @@ https://docs.libplanet.io/</Description>
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.*" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="Zio" Version="0.7.4" />
   </ItemGroup>

--- a/Libplanet/Net/ActionExecutionState.cs
+++ b/Libplanet/Net/ActionExecutionState.cs
@@ -24,6 +24,6 @@ namespace Libplanet.Net
         public HashDigest<SHA256> ExecutedBlockHash { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 4;
+        public override int CurrentPhase => 5;
     }
 }

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Async;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Serilog;
+
+namespace Libplanet.Net
+{
+    internal class BlockCompletion<TPeer, TAction>
+        where TAction : IAction, new()
+    {
+        private readonly ILogger _logger;
+        private readonly Func<HashDigest<SHA256>, bool> _completionPredicate;
+        private readonly int _window;
+        private readonly ConcurrentDictionary<HashDigest<SHA256>, bool> _satisfiedBlocks;
+        private readonly ConcurrentQueue<HashDigest<SHA256>> _demands;
+        private readonly SemaphoreSlim _demandEnqueued;
+        private bool _started;
+
+        public BlockCompletion(
+            Func<HashDigest<SHA256>, bool> completionPredicate = null,
+            int window = 100
+        )
+        {
+            _logger = Log.ForContext<BlockCompletion<TPeer, TAction>>();
+            _completionPredicate = completionPredicate;
+            _window = window;
+            _satisfiedBlocks = new ConcurrentDictionary<HashDigest<SHA256>, bool>();
+            _started = false;
+            _demands = new ConcurrentQueue<HashDigest<SHA256>>();
+            _demandEnqueued = new SemaphoreSlim(0);
+        }
+
+        public delegate System.Collections.Async.IAsyncEnumerable<Block<TAction>> BlockFetcher(
+            TPeer peer,
+            IEnumerable<HashDigest<SHA256>> blockHashes
+        );
+
+        public void Demand(HashDigest<SHA256> blockHash) =>
+            Demand(blockHash, retry: false);
+
+        public void Demand(IEnumerable<HashDigest<SHA256>> blockHashes) =>
+            Demand(blockHashes, retry: false);
+
+        public System.Collections.Async.IAsyncEnumerable<IEnumerable<HashDigest<SHA256>>>
+        EnumerateChunks() =>
+            new AsyncEnumerable<IEnumerable<HashDigest<SHA256>>>(async yield =>
+            {
+                var chunk = new List<HashDigest<SHA256>>(capacity: _window);
+                bool QueuedDemandCompleted() =>
+                    _started && _demands.IsEmpty && _satisfiedBlocks.All(kv => kv.Value);
+                while (!(yield.CancellationToken.IsCancellationRequested ||
+                         QueuedDemandCompleted()))
+                {
+                    yield.CancellationToken.ThrowIfCancellationRequested();
+                    _logger.Verbose(
+                        "Waiting a demand enqueued...\n" +
+                        "Demands in the buffer: {DemandCount}.\n" +
+                        "Incomplete downloads: {IncompleteDownloads}.",
+                        chunk.Count,
+                        _satisfiedBlocks.Count(kv => !kv.Value && !chunk.Contains(kv.Key))
+                    );
+
+                    await _demandEnqueued.WaitAsync(100, yield.CancellationToken);
+                    if (_demands.TryDequeue(out HashDigest<SHA256> demand))
+                    {
+                        chunk.Add(demand);
+                    }
+
+                    if (chunk.Count >= _window || (
+                            _started && _demands.IsEmpty && _satisfiedBlocks.All(kv =>
+                                kv.Value || chunk.Contains(kv.Key))))
+                    {
+                        _logger.Verbose("_satisfiedBlocks.Keys @{keys}", _satisfiedBlocks.Keys);
+                        _logger.Verbose(
+                            "_satisfiedBlocks.Values @{values}",
+                            _satisfiedBlocks.Values
+                        );
+                        _logger.Verbose("chunks: @{chunk}", chunk);
+                        await yield.ReturnAsync(chunk.ToImmutableArray());
+                        _logger.Verbose("A chunk of {Window} demands made.", _window);
+
+                        chunk.Clear();
+                    }
+                    else
+                    {
+                        _logger.Verbose(
+                            "The number of buffered demands: {DemandCount}.\n" +
+                            "The number of demands in the backlog: {BacklogCount}.\n" +
+                            "The number of incomplete downloads: {IncompleteDownloads}.",
+                            chunk.Count,
+                            _demands.Count,
+                            _satisfiedBlocks.Count(kv => !kv.Value && !chunk.Contains(kv.Key))
+                        );
+                    }
+                }
+
+                if (!yield.CancellationToken.IsCancellationRequested && chunk.Count > 0)
+                {
+                    _logger.Verbose("A chunk of {Window} demands made.", chunk.Count);
+                    await yield.ReturnAsync(chunk);
+                }
+
+                _logger.Verbose("The stream of demand chunks finished.");
+
+                yield.CancellationToken.ThrowIfCancellationRequested();
+            });
+
+        [Pure]
+        public bool Satisfies(HashDigest<SHA256> blockHash, bool ignoreTransientCompletions = false)
+        {
+            return (!ignoreTransientCompletions && _satisfiedBlocks.ContainsKey(blockHash)) ||
+                   (!(_completionPredicate is null) && _completionPredicate(blockHash));
+        }
+
+        public bool Satisfy(Block<TAction> block)
+        {
+            if (block is null)
+            {
+                throw new ArgumentNullException(nameof(block));
+            }
+
+            if (block.PreviousHash is HashDigest<SHA256> prevHash)
+            {
+                _logger.Verbose(
+                    "The block #{BlockIndex} {BlockHash}'s previous block #{PreviousIndex} " +
+                    "{PreviousHash} is needed; add it to the queue...",
+                    block.Index,
+                    block.Hash,
+                    block.Index - 1,
+                    prevHash
+                );
+                Demand(prevHash);
+            }
+
+            if (_satisfiedBlocks.TryUpdate(block.Hash, true, false))
+            {
+                _logger.Verbose(
+                    "Completed the block #{BlockIndex} {BlockHash}. " +
+                    "(Remained incomplete demands: {IncompleteDemands})",
+                    block.Index,
+                    block.Hash,
+                    _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
+                );
+                return true;
+            }
+
+            _logger.Verbose(
+                "The block #{BlockIndex} {BlockHash} is already complete. " +
+                "(Remained incomplete demands: {IncompleteDemands})",
+                block.Index,
+                block.Hash,
+                _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
+            );
+            return false;
+        }
+
+        public System.Collections.Async.IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
+            IReadOnlyList<TPeer> peers,
+            BlockFetcher blockFetcher
+        )
+        {
+            if (!peers.Any())
+            {
+                throw new ArgumentException("The list of peers must not be empty.", nameof(peers));
+            }
+
+            PeerPool pool = new PeerPool(peers);
+            return new AsyncEnumerable<Tuple<Block<TAction>, TPeer>>(async yield =>
+            {
+                await EnumerateChunks().ForEachAsync(
+                    async hashes =>
+                    {
+                        yield.CancellationToken.ThrowIfCancellationRequested();
+                        IList<HashDigest<SHA256>> hashDigests =
+                            hashes is IList<HashDigest<SHA256>> l ? l : hashes.ToList();
+                        await pool.SpawnAsync(
+                            async (peer) =>
+                            {
+                                yield.CancellationToken.ThrowIfCancellationRequested();
+                                var demands = new HashSet<HashDigest<SHA256>>(hashDigests);
+                                try
+                                {
+                                    _logger.Debug(
+                                        "Request blocks {BlockHashes} to {Peer}...",
+                                        hashDigests,
+                                        peer
+                                    );
+                                    await blockFetcher(peer, hashDigests).ForEachAsync(
+                                        async block =>
+                                        {
+                                            yield.CancellationToken.ThrowIfCancellationRequested();
+                                            _logger.Debug(
+                                                "Downloaded a block #{BlockIndex} {BlockHash} " +
+                                                "from {Peer}.",
+                                                block.Index,
+                                                block.Hash,
+                                                peer
+                                            );
+                                            await yield.ReturnAsync(
+                                                new Tuple<Block<TAction>, TPeer>(block, peer)
+                                            );
+                                            Satisfy(block);
+                                            demands.Remove(block.Hash);
+                                        },
+                                        yield.CancellationToken
+                                    );
+                                }
+                                finally
+                                {
+                                    _logger.Verbose(
+                                        "Enqueue unsatisfied demands again: {UnsatisfiedDemands}.",
+                                        demands
+                                    );
+                                    Demand(demands, retry: true);
+                                }
+                            },
+                            cancellationToken: yield.CancellationToken
+                        );
+                    },
+                    yield.CancellationToken
+                );
+            });
+        }
+
+        private void Demand(HashDigest<SHA256> blockHash, bool retry)
+        {
+            if (Satisfies(blockHash, ignoreTransientCompletions: retry))
+            {
+                return;
+            }
+
+            if (_satisfiedBlocks.TryAdd(blockHash, false) || retry)
+            {
+                _demands.Enqueue(blockHash);
+                _started = true;
+                _demandEnqueued.Release();
+                _logger.Verbose("A demand was enqueued: {BlockHash}", blockHash);
+            }
+        }
+
+        private void Demand(IEnumerable<HashDigest<SHA256>> blockHashes, bool retry)
+        {
+            foreach (HashDigest<SHA256> hash in blockHashes)
+            {
+                Demand(hash, retry);
+            }
+        }
+
+        internal class PeerPool
+        {
+            private readonly ConcurrentQueue<TPeer> _completions;
+            private readonly ConcurrentDictionary<TPeer, Task> _tasks;
+            private long _taken;
+            private long _finished;
+
+            public PeerPool(IEnumerable<TPeer> peers)
+            {
+                _completions = new ConcurrentQueue<TPeer>(peers);
+                _tasks = new ConcurrentDictionary<TPeer, Task>();
+                _taken = 0;
+                _finished = 0;
+            }
+
+            public async Task SpawnAsync(
+                Func<TPeer, Task> action,
+                CancellationToken cancellationToken = default
+            )
+            {
+                Interlocked.Increment(ref _taken);
+                TPeer peer;
+                while (!_completions.TryDequeue(out peer))
+                {
+                    Task[] tasks = _tasks.Values
+                        .Concat(new[] { Task.Delay(500, cancellationToken) })
+                        .ToArray();
+                    await Task.WhenAny(tasks);
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (_tasks.TryRemove(peer, out Task completeTask))
+                {
+                    await completeTask;
+                }
+
+                _tasks[peer] = Task.Run(
+                    async () =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        try
+                        {
+                            await action(peer);
+                        }
+                        finally
+                        {
+                            _completions.Enqueue(peer);
+                            Interlocked.Increment(ref _finished);
+                        }
+                    },
+                    cancellationToken: cancellationToken
+                );
+            }
+
+            public async Task WaitAll(CancellationToken cancellationToken = default)
+            {
+                while (Interlocked.Read(ref _taken) > Interlocked.Read(ref _finished))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Task[] tasks = _tasks.Values.ToArray();
+                    if (tasks.Any())
+                    {
+                        var tcs = new TaskCompletionSource<object>();
+                        cancellationToken.Register(
+                            () => tcs.TrySetCanceled(),
+                            useSynchronizationContext: false
+                        );
+                        await Task.WhenAny(Task.WhenAll(tasks), tcs.Task);
+                    }
+                    else
+                    {
+                        await Task.Delay(100, cancellationToken);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -8,6 +7,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Serilog;
@@ -39,7 +39,7 @@ namespace Libplanet.Net
             _demandEnqueued = new SemaphoreSlim(0);
         }
 
-        public delegate System.Collections.Async.IAsyncEnumerable<Block<TAction>> BlockFetcher(
+        public delegate IAsyncEnumerable<Block<TAction>> BlockFetcher(
             TPeer peer,
             IEnumerable<HashDigest<SHA256>> blockHashes
         );
@@ -50,8 +50,7 @@ namespace Libplanet.Net
         public void Demand(IEnumerable<HashDigest<SHA256>> blockHashes) =>
             Demand(blockHashes, retry: false);
 
-        public System.Collections.Async.IAsyncEnumerable<IEnumerable<HashDigest<SHA256>>>
-        EnumerateChunks() =>
+        public IAsyncEnumerable<IEnumerable<HashDigest<SHA256>>> EnumerateChunks() =>
             new AsyncEnumerable<IEnumerable<HashDigest<SHA256>>>(async yield =>
             {
                 var chunk = new List<HashDigest<SHA256>>(capacity: _window);
@@ -172,7 +171,7 @@ namespace Libplanet.Net
         /// download corresponding blocks.</param>
         /// <returns>An async enumerable that yields pairs of a fetched block and its source
         /// peer.  It terminates when all demands are satisfied.</returns>
-        public System.Collections.Async.IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
+        public IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
             IReadOnlyList<TPeer> peers,
             BlockFetcher blockFetcher
         )

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -338,17 +338,21 @@ namespace Libplanet.Net
         /// each single call of <paramref name="blockFetcher"/>.  If a call is timed out unsatisfied
         /// demands are automatically retried to fetch from other peers.  10 seconds by default.
         /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting
+        /// for the task to complete.</param>
         /// <returns>An async enumerable that yields pairs of a fetched block and its source
         /// peer.  It terminates when all demands are satisfied.</returns>
         public IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
             IReadOnlyList<TPeer> peers,
             BlockFetcher blockFetcher,
-            int millisecondsSingleSessionTimeout = 10000
+            int millisecondsSingleSessionTimeout = 10000,
+            CancellationToken cancellationToken = default
         ) =>
             Complete(
                 peers,
                 blockFetcher,
-                TimeSpan.FromMilliseconds(millisecondsSingleSessionTimeout)
+                TimeSpan.FromMilliseconds(millisecondsSingleSessionTimeout),
+                cancellationToken
             );
 
         private void Demand(HashDigest<SHA256> blockHash, bool retry)

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -163,6 +163,15 @@ namespace Libplanet.Net
             return false;
         }
 
+        /// <summary>
+        /// Downloads blocks from <paramref name="peers"/> in parallel,
+        /// using the given <paramref name="blockFetcher"/> function.
+        /// </summary>
+        /// <param name="peers">A list of peers to download blocks.</param>
+        /// <param name="blockFetcher">A function to take demands and a peer, and then
+        /// download corresponding blocks.</param>
+        /// <returns>An async enumerable that yields pairs of a fetched block and its source
+        /// peer.  It terminates when all demands are satisfied.</returns>
         public System.Collections.Async.IAsyncEnumerable<Tuple<Block<TAction>, TPeer>> Complete(
             IReadOnlyList<TPeer> peers,
             BlockFetcher blockFetcher
@@ -205,10 +214,13 @@ namespace Libplanet.Net
                                                 block.Hash,
                                                 peer
                                             );
-                                            await yield.ReturnAsync(
-                                                new Tuple<Block<TAction>, TPeer>(block, peer)
-                                            );
-                                            Satisfy(block);
+                                            if (Satisfy(block))
+                                            {
+                                                await yield.ReturnAsync(
+                                                    new Tuple<Block<TAction>, TPeer>(block, peer)
+                                                );
+                                            }
+
                                             demands.Remove(block.Hash);
                                         },
                                         yield.CancellationToken

--- a/Libplanet/Net/BlockDownloadState.cs
+++ b/Libplanet/Net/BlockDownloadState.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net
         public HashDigest<SHA256> ReceivedBlockHash { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 1;
+        public override int CurrentPhase => 2;
 
         /// <summary>
         /// The peer which sent the block.

--- a/Libplanet/Net/BlockHashDownloadState.cs
+++ b/Libplanet/Net/BlockHashDownloadState.cs
@@ -1,0 +1,27 @@
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// Indicates a progress of downloading block hashes.
+    /// </summary>
+    [Equals]
+    public class BlockHashDownloadState : PreloadState
+    {
+        /// <summary>
+        /// The estimated number of block hashes to receive in the current batch.
+        /// </summary>
+        public long EstimatedTotalBlockHashCount { get; internal set; }
+
+        /// <summary>
+        /// The number of currently received block hashes.
+        /// </summary>
+        public long ReceivedBlockHashCount { get; internal set; }
+
+        /// <summary>
+        /// The peer which sent the block hashes.
+        /// </summary>
+        public BoundPeer SourcePeer { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 1;
+    }
+}

--- a/Libplanet/Net/BlockVerificationState.cs
+++ b/Libplanet/Net/BlockVerificationState.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// Indicates a progress of verifying blocks.
+    /// </summary>
+    [Equals]
+    public class BlockVerificationState : PreloadState
+    {
+        /// <summary>
+        /// Total number of blocks to verify in the current batch.
+        /// </summary>
+        public long TotalBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The number of blocks that completed verification.
+        /// </summary>
+        public long VerifiedBlockCount { get; internal set; }
+
+        /// <summary>
+        /// The hash digest of the block just verified.
+        /// </summary>
+        public HashDigest<SHA256> VerifiedBlockHash { get; internal set; }
+
+        /// <inheritdoc />
+        public override int CurrentPhase => 3;
+    }
+}

--- a/Libplanet/Net/Messages/BlockHashes.cs
+++ b/Libplanet/Net/Messages/BlockHashes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -7,19 +8,52 @@ namespace Libplanet.Net.Messages
 {
     internal class BlockHashes : Message
     {
-        public BlockHashes(IEnumerable<HashDigest<SHA256>> hashes)
+        public BlockHashes(long? startIndex, IEnumerable<HashDigest<SHA256>> hashes)
         {
+            StartIndex = startIndex;
             Hashes = hashes.ToList();
+
+            if (StartIndex is null && Hashes.Any())
+            {
+                throw new ArgumentNullException(
+                    nameof(startIndex),
+                    "The startIndex can be null iff hashes are empty."
+                );
+            }
+            else if (!Hashes.Any() && !(StartIndex is null))
+            {
+                throw new ArgumentException(
+                    "The startIndex has to be null if hashes are empty.",
+                    nameof(startIndex)
+                );
+            }
         }
 
         public BlockHashes(NetMQFrame[] frames)
         {
             int hashCount = frames[0].ConvertToInt32();
-            Hashes = frames.Skip(1).Take(hashCount)
-                .Select(f => f.ConvertToHashDigest<SHA256>())
-                .ToList();
+            var hashes = new List<HashDigest<SHA256>>(hashCount);
+            if (hashCount > 0)
+            {
+                StartIndex = frames[1].ConvertToInt64();
+                for (int i = 2, end = hashCount + 2; i < end; i++)
+                {
+                    hashes.Add(frames[i].ConvertToHashDigest<SHA256>());
+                }
+            }
+
+            Hashes = hashes;
         }
 
+        /// <summary>
+        /// The block index of the first hash in <see cref="Hashes"/>.
+        /// It is <c>null</c> iff <see cref="Hashes"/> are empty.
+        /// </summary>
+        public long? StartIndex { get; }
+
+        /// <summary>
+        /// The continuous block hashes, from the lowest index to the highest index.
+        /// </summary>
         public IEnumerable<HashDigest<SHA256>> Hashes { get; }
 
         protected override MessageType Type => MessageType.BlockHashes;
@@ -30,10 +64,15 @@ namespace Libplanet.Net.Messages
             {
                 yield return new NetMQFrame(
                     NetworkOrderBitsConverter.GetBytes(Hashes.Count()));
-
-                foreach (var hash in Hashes)
+                if (StartIndex is long offset)
                 {
-                    yield return new NetMQFrame(hash.ToByteArray());
+                    yield return new NetMQFrame(
+                        NetworkOrderBitsConverter.GetBytes(offset));
+
+                    foreach (HashDigest<SHA256> hash in Hashes)
+                    {
+                        yield return new NetMQFrame(hash.ToByteArray());
+                    }
                 }
             }
         }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -29,11 +29,6 @@ namespace Libplanet.Net.Messages
             GetBlockHashes = 0x04,
 
             /// <summary>
-            /// Inventory to transfer blocks.
-            /// </summary>
-            BlockHashes = 0x05,
-
-            /// <summary>
             /// Inventory to transfer transactions.
             /// </summary>
             TxIds = 0x06,
@@ -83,6 +78,11 @@ namespace Libplanet.Net.Messages
             /// Message containing a single <see cref="BlockHeader"/>.
             /// </summary>
             BlockHeaderMessage = 0x0d,
+
+            /// <summary>
+            /// Message containing demand block hashes with their index numbers.
+            /// </summary>
+            BlockHashes = 0x0e,
         }
 
         public byte[] Identity { get; set; }

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -474,15 +474,10 @@ namespace Libplanet.Net
                 );
                 var tcs = new TaskCompletionSource<IEnumerable<Message>>();
                 Interlocked.Increment(ref _requestCount);
+                cancellationToken.Register(() => tcs.TrySetCanceled());
                 await _requests.AddAsync(
-                    new MessageRequest(
-                        reqId,
-                        message,
-                        peer,
-                        now,
-                        timeout,
-                        expectedResponses,
-                        tcs)
+                    new MessageRequest(reqId, message, peer, now, timeout, expectedResponses, tcs),
+                    cancellationToken
                 );
                 _logger.Verbose(
                     "Enqueued a request {RequestId} to {PeerAddress}: {Message}; " +

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Dasync.Collections;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
@@ -622,7 +621,7 @@ namespace Libplanet.Net
                 var peers = Protocol.PeersToBroadcast(except).ToList();
                 _logger.Debug($"Broadcasting message [{msg}]");
                 _logger.Debug($"Peers to broadcast : {peers.Count}");
-                peers.ParallelForEachAsync(async peer =>
+                Parallel.ForEach(peers, async peer =>
                 {
                     await SendMessageAsync(peer, msg);
                 });

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Async;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -7,6 +6,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -731,7 +731,10 @@ namespace Libplanet.Net
                 }
                 catch (OperationCanceledException)
                 {
-                    _logger.Information("Cancellation requsted; shutdown runtime...");
+                    _logger.Information(
+                        $"Cancellation requested; shut down {nameof(NetMQTransport)}." +
+                        $"{nameof(ProcessRuntime)}()..."
+                    );
                     throw;
                 }
                 catch (Exception e)

--- a/Libplanet/Net/PreloadState.cs
+++ b/Libplanet/Net/PreloadState.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Net
         /// <summary>
         /// The number of total phases.
         /// </summary>
-        public const int TotalPhase = 4;
+        public const int TotalPhase = 5;
 
         /// <summary>
         /// The current phase.

--- a/Libplanet/Net/StateDownloadState.cs
+++ b/Libplanet/Net/StateDownloadState.cs
@@ -16,6 +16,6 @@ namespace Libplanet.Net
         public int ReceivedIterationCount { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 2;
+        public override int CurrentPhase => 3;
     }
 }

--- a/Libplanet/Net/StateDownloadState.cs
+++ b/Libplanet/Net/StateDownloadState.cs
@@ -16,6 +16,6 @@ namespace Libplanet.Net
         public int ReceivedIterationCount { get; internal set; }
 
         /// <inheritdoc />
-        public override int CurrentPhase => 3;
+        public override int CurrentPhase => 4;
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -549,14 +549,14 @@ namespace Libplanet.Net
                             // TODO: catch exceptions
                             return new AsyncEnumerable<Block<T>>(async yield =>
                             {
-                                cancellationToken.ThrowIfCancellationRequested();
+                                yield.CancellationToken.ThrowIfCancellationRequested();
                                 await GetBlocksAsync(peer, hashes).ForEachAsync(
                                     async block =>
                                     {
-                                        cancellationToken.ThrowIfCancellationRequested();
+                                        yield.CancellationToken.ThrowIfCancellationRequested();
                                         await yield.ReturnAsync(block);
                                     },
-                                    cancellationToken: cancellationToken
+                                    cancellationToken: yield.CancellationToken
                                 );
                             });
                         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -12,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AsyncIO;
 using Bencodex.Types;
+using Dasync.Collections;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -841,8 +841,7 @@ namespace Libplanet.Net
         }
 
         // FIXME: This would be better if it's merged with GetDemandBlockHashes
-        internal System.Collections.Async.IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>>
-        GetBlockHashes(
+        internal IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>> GetBlockHashes(
             BoundPeer peer,
             BlockLocator locator,
             HashDigest<SHA256>? stop,
@@ -890,7 +889,7 @@ namespace Libplanet.Net
                 );
             });
 
-        internal System.Collections.Async.IAsyncEnumerable<Block<T>> GetBlocksAsync(
+        internal IAsyncEnumerable<Block<T>> GetBlocksAsync(
             BoundPeer peer,
             IEnumerable<HashDigest<SHA256>> blockHashes)
         {
@@ -947,7 +946,7 @@ namespace Libplanet.Net
             });
         }
 
-        internal System.Collections.Async.IAsyncEnumerable<Transaction<T>> GetTxsAsync(
+        internal IAsyncEnumerable<Transaction<T>> GetTxsAsync(
             BoundPeer peer,
             IEnumerable<TxId> txIds,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -1010,7 +1009,7 @@ namespace Libplanet.Net
             Transport.BroadcastMessage(except, message);
         }
 
-        private System.Collections.Async.IAsyncEnumerable<(BoundPeer, Pong)> DialToExistingPeers(
+        private IAsyncEnumerable<(BoundPeer, Pong)> DialToExistingPeers(
             TimeSpan? dialTimeout,
             CancellationToken cancellationToken)
         {
@@ -1052,8 +1051,7 @@ namespace Libplanet.Net
             });
         }
 
-        private System.Collections.Async.IAsyncEnumerable<(long, HashDigest<SHA256>)>
-        GetDemandBlockHashes(
+        private IAsyncEnumerable<(long, HashDigest<SHA256>)> GetDemandBlockHashes(
             BlockChain<T> blockChain,
             IList<(BoundPeer, long?)> peersWithHeight,
             IProgress<PreloadState> progress = null,
@@ -1649,8 +1647,8 @@ namespace Libplanet.Net
                     _logger.Debug("Trying to find branchpoint...");
                     BlockLocator locator = workspace.GetBlockLocator();
                     _logger.Debug("Locator's count: {LocatorCount}", locator.Count());
-                    System.Collections.Async.IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>>
-                        hashesAsync = GetBlockHashes(peer, locator, stop, cancellationToken);
+                    IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>> hashesAsync =
+                        GetBlockHashes(peer, locator, stop, cancellationToken);
                     IEnumerable<Tuple<long, HashDigest<SHA256>>> hashes =
                         await hashesAsync.ToArrayAsync();
 
@@ -2089,9 +2087,8 @@ namespace Libplanet.Net
                 var tasks = new List<Task<List<Transaction<T>>>>();
                 foreach (var kv in demands)
                 {
-                    System.Collections.Async.IAsyncEnumerable<Transaction<T>> fetched =
-                        GetTxsAsync(
-                            kv.Key, kv.Value, cancellationToken);
+                    IAsyncEnumerable<Transaction<T>> fetched =
+                        GetTxsAsync(kv.Key, kv.Value, cancellationToken);
                     tasks.Add(fetched.ToListAsync(cancellationToken));
                 }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -3,6 +3,7 @@ using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -28,6 +29,7 @@ namespace Libplanet.Net
     public class Swarm<T> : IDisposable
         where T : IAction, new()
     {
+        private const int InitialBlockDownloadWindow = 100;
         private static readonly TimeSpan MaxTimeout = TimeSpan.FromSeconds(150);
         private static readonly TimeSpan BlockRecvTimeout = TimeSpan.FromSeconds(15);
         private static readonly TimeSpan TxRecvTimeout = TimeSpan.FromSeconds(3);
@@ -369,7 +371,6 @@ namespace Libplanet.Net
             return Transport is null ? string.Empty : (Transport as NetMQTransport)?.Trace();
         }
 
-#pragma warning disable MEN002 // Line is too long
         /// <summary>
         /// Preemptively downloads blocks from registered <see cref="Peer"/>s.
         /// </summary>
@@ -399,9 +400,14 @@ namespace Libplanet.Net
         /// A task without value.
         /// You only can <c>await</c> until the method is completed.
         /// </returns>
+        /// <remarks>This does not render downloaded <see cref="IAction"/>s, but fills states only.
+        /// </remarks>
         /// <exception cref="AggregateException">Thrown when the given the block downloading is
         /// failed and if <paramref name="blockDownloadFailed "/> is <c>null</c>.</exception>
-#pragma warning restore MEN002 // Line is too long
+        [SuppressMessage(
+            "Microsoft.StyleCop.CSharp.ReadabilityRules",
+            "MEN003",
+            Justification = "Many lines are just for writing logs.")]
         public async Task PreloadAsync(
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
@@ -414,7 +420,7 @@ namespace Libplanet.Net
 
             Block<T> initialTip = BlockChain.Tip;
             BlockLocator initialLocator = BlockChain.GetBlockLocator();
-            _logger.Debug($"initialTip? : {BlockChain.Tip}");
+            _logger.Debug("The tip before preloading begins: {Tip}", BlockChain.Tip);
 
             IList<(BoundPeer, long?)> peersWithHeight =
                 await DialToExistingPeers(dialTimeout, cancellationToken)
@@ -440,82 +446,282 @@ namespace Libplanet.Net
             BlockChain<T> workspace = initialTip is Block<T> tip
                 ? BlockChain.Fork(tip.Hash)
                 : new BlockChain<T>(BlockChain.Policy, _store, Guid.NewGuid(), BlockChain.Genesis);
+            Guid wId = workspace.Id;
+            IStore wStore = workspace.Store;
 
             var complete = false;
 
             try
             {
-                var exceptions = new List<Exception>();
-                var blockDownloadComplete = false;
-                foreach ((BoundPeer Peer, long? Height) peerWithHeight in peersWithHeight)
+                FillBlocksAsyncStarted.Set();
+
+                var blockCompletion = new BlockCompletion<BoundPeer, T>(
+                    completionPredicate: workspace.ContainsBlock,
+                    window: InitialBlockDownloadWindow
+                );
+
+                long totalBlocksToDownload = 0L;
+                long receivedBlockCount = 0L;
+                short lapCount = 0;
+                Block<T> tipCandidate = initialTip;
+
+                while (true)
                 {
+                    Block<T> tempTip = tipCandidate;
+
                     try
                     {
-                        _logger.Information(
-                            "Try to download blocks from {EndPoint}@{Address}.",
-                            peerWithHeight.Peer.EndPoint,
-                            peerWithHeight.Peer.Address.ToHex());
+                        // From the second lap, as it's catching up the latest blocks made
+                        // in very short time, do not report the progress.  Even if it's reported,
+                        // it can be very confusing, because it looks like BlockHashDownloadState
+                        // recurring after later phases like BlockDownloadState.
+                        IProgress<PreloadState> demandProgress = lapCount++ < 1 ? progress : null;
 
-                        // FIXME: It is not guaranteed that states will be reported in order.
-                        // see issue #436, #430
-                        await SyncBehindsBlocksFromPeerAsync(
+                        await GetDemandBlockHashes(
                             workspace,
-                            peerWithHeight,
-                            progress,
-                            cancellationToken,
-                            false
+                            peersWithHeight,
+                            demandProgress,
+                            cancellationToken
+                        ).ForEachAsync(
+                            pair =>
+                            {
+                                (long index, HashDigest<SHA256> hash) = pair;
+                                cancellationToken.ThrowIfCancellationRequested();
+
+                                if (index == 0 && !hash.Equals(workspace.Genesis.Hash))
+                                {
+                                    // FIXME: This behavior can unexpectedly terminate the swarm
+                                    // (and the game app) if it encounters a peer having a different
+                                    // blockchain, and therefore can be exploited to remotely shut
+                                    // down other nodes as well.
+                                    // Since the intention of this behavior is to prevent mistakes
+                                    // to try to connect incorrect seeds (by a user),
+                                    // this behavior should be limited for only seed peers.
+                                    var msg =
+                                        $"Since the genesis block is fixed to {workspace.Genesis}" +
+                                        " protocol-wise, the blockchain which does not share " +
+                                        "any mutual block is not acceptable.";
+                                    throw new InvalidGenesisBlockException(
+                                        hash,
+                                        workspace.Genesis.Hash,
+                                        msg);
+                                }
+
+                                _logger.Verbose(
+                                    "Enqueue #{BlockIndex} {BlockHash} to demands queue...",
+                                    index,
+                                    hash
+                                );
+                                blockCompletion.Demand(hash);
+                                totalBlocksToDownload++;
+                            },
+                            cancellationToken
                         );
                     }
-                    catch (Exception e)
+                    catch (SwarmAggregateException e)
                     {
-                        _logger.Error(
-                            "Exception was thrown during downloading blocks from "
-                            + "{EndPoint}@{Address}.\n{Exception}",
-                            peerWithHeight.Peer.EndPoint,
-                            peerWithHeight.Peer.Address.ToHex(),
-                            e);
-                        exceptions.Add(e);
-                        continue;
-                    }
+                        if (blockDownloadFailed is null)
+                        {
+                            throw new AggregateException(e.Message, e.InnerExceptions);
+                        }
 
-                    _logger.Information(
-                        "Finished to download blocks from {EndPoint}@{Address}.",
-                        peerWithHeight.Peer.EndPoint,
-                        peerWithHeight.Peer.Address.ToHex());
-                    blockDownloadComplete = true;
-                    break;
-                }
-
-                if (!blockDownloadComplete)
-                {
-                    if (blockDownloadFailed is null)
-                    {
-                        throw new AggregateException(
-                            "Failed to download blocks from peers.",
-                            exceptions);
-                    }
-                    else
-                    {
                         blockDownloadFailed.Invoke(
                             this,
-                            new PreloadBlockDownloadFailEventArgs { InnerExceptions = exceptions });
+                            new PreloadBlockDownloadFailEventArgs
+                            {
+                                InnerExceptions = e.InnerExceptions,
+                            }
+                        );
+                        break;
                     }
+
+                    await blockCompletion.Complete(
+                        peers: peersWithHeight.Select(pair => pair.Item1).ToList(),
+                        blockFetcher: (peer, hashes) =>
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            _logger.Information(
+                                "Try to download blocks from {EndPoint}@{Address}...",
+                                peer.EndPoint,
+                                peer.Address.ToHex()
+                            );
+
+                            // TODO: catch exceptions
+                            return new AsyncEnumerable<Block<T>>(async yield =>
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                await GetBlocksAsync(peer, hashes).ForEachAsync(
+                                    async block =>
+                                    {
+                                        cancellationToken.ThrowIfCancellationRequested();
+                                        await yield.ReturnAsync(block);
+                                    },
+                                    cancellationToken: cancellationToken
+                                );
+                            });
+                        }
+                    ).ForEachAsync(
+                        pair =>
+                        {
+                            pair.Deconstruct(out Block<T> block, out BoundPeer sourcePeer);
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            if (block.Index == 0 && !block.Hash.Equals(workspace.Genesis.Hash))
+                            {
+                                // FIXME: This behavior can unexpectedly terminate the swarm
+                                // (and the game app) if it encounters a peer having a different
+                                // blockchain, and therefore can be exploited to remotely shut
+                                // down other nodes as well.
+                                // Since the intention of this behavior is to prevent mistakes
+                                // to try to connect incorrect seeds (by a user),
+                                // this behavior should be limited for only seed peers.
+                                var msg =
+                                    $"Since the genesis block is fixed to {workspace.Genesis} " +
+                                    "protocol-wise, the blockchain which does not share " +
+                                    "any mutual block is not acceptable.";
+
+                                // Although it's actually not aggregated, but to be consistent with
+                                // above code throwing InvalidGenesisBlockException, makes this
+                                // to wrap an exception with AggregateException... Not sure if
+                                // it show be wrapped from the very beginning.
+                                throw new AggregateException(
+                                    msg,
+                                    new InvalidGenesisBlockException(
+                                        block.Hash,
+                                        workspace.Genesis.Hash,
+                                        msg
+                                    )
+                                );
+                            }
+
+                            _logger.Verbose(
+                                "Add a block #{BlockIndex} {BlockHash}...",
+                                block.Index,
+                                block.Hash
+                            );
+                            wStore.PutBlock(block);
+                            if (tempTip is null || block.Index > tempTip.Index)
+                            {
+                                tempTip = block;
+                            }
+
+                            receivedBlockCount++;
+                            progress?.Report(new BlockDownloadState
+                            {
+                                TotalBlockCount = Math.Max(
+                                    totalBlocksToDownload,
+                                    receivedBlockCount),
+                                ReceivedBlockCount = receivedBlockCount,
+                                ReceivedBlockHash = block.Hash,
+                                SourcePeer = sourcePeer,
+                            });
+                            _logger.Debug(
+                                "Appended a block #{BlockIndex} {BlockHash} " +
+                                "to the workspace chain.",
+                                block.Index,
+                                block.Hash
+                            );
+                        },
+                        cancellationToken: cancellationToken
+                    );
+
+                    if (tempTip.Equals(tipCandidate))
+                    {
+                        break;
+                    }
+
+                    tipCandidate = tempTip;
                 }
 
-                if (workspace.Tip is null)
+                if (tipCandidate is null)
                 {
                     // If there is no blocks in the network (or no consensus at least)
                     // it doesn't need to receive states from other peers at all.
                     return;
                 }
 
+                var deltaBlocks = new LinkedList<Block<T>>();
+                while (true)
+                {
+                    Block<T> blockToAdd;
+                    if (deltaBlocks.First is LinkedListNode<Block<T>> node)
+                    {
+                        Block<T> b = node.Value;
+                        if (b.PreviousHash is HashDigest<SHA256> p)
+                        {
+                            blockToAdd = wStore.GetBlock<T>(p);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        blockToAdd = tipCandidate;
+                    }
+
+                    if (!(initialTip is null) &&
+                        blockToAdd.Index <= initialTip.Index &&
+                        wStore.IndexBlockHash(wId, blockToAdd.Index).Equals(blockToAdd.Hash))
+                    {
+                        break;
+                    }
+
+                    deltaBlocks.AddFirst(blockToAdd);
+                }
+
+                if (deltaBlocks.First is LinkedListNode<Block<T>> deltaBottom)
+                {
+                    Block<T> bottomBlock = deltaBottom.Value;
+                    if (bottomBlock.PreviousHash is HashDigest<SHA256> bp)
+                    {
+                        BlockChain<T> fork = workspace.Fork(bp);
+                        try
+                        {
+                            foreach (Block<T> deltaBlock in deltaBlocks)
+                            {
+                                fork.Append(
+                                    deltaBlock,
+                                    DateTimeOffset.UtcNow,
+                                    evaluateActions: false,
+                                    renderActions: false
+                                );
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.Error(
+                                e,
+                                "An exception occurred during appending blocks: {Exception}",
+                                e
+                            );
+                            fork.Store.DeleteChainId(fork.Id);
+                            throw;
+                        }
+
+                        workspace.Swap(fork, render: false);
+                        wId = fork.Id;
+                    }
+                    else
+                    {
+                        Block<T> first = deltaBlocks.First.Value, last = deltaBlocks.Last.Value;
+                        HashDigest<SHA256> g = wStore.IndexBlockHash(wId, 0L).Value;
+                        throw new SwarmException(
+                            $"Downloaded blocks (#{first.Index} {first.Hash}\u2013" +
+                            $"#{last.Index} {last.Hash}) are incompatible with the existing " +
+                            $"chain (#0 {g}\u2013#{initialTip.Index} {initialTip.Hash})."
+                        );
+                    }
+                }
+
                 long height = workspace.Tip.Index;
 
                 IEnumerable<(BoundPeer, HashDigest<SHA256> Hash)> trustedPeersWithTip =
                     peersWithHeight.Where(pair =>
-                        trustedStateValidators.Contains(pair.Item1.Address) &&
-                        !(pair.Item2 is null) &&
-                        pair.Item2 <= height)
+                            trustedStateValidators.Contains(pair.Item1.Address) &&
+                            !(pair.Item2 is null) &&
+                            pair.Item2 <= height)
                         .OrderByDescending(pair => pair.Item2)
                         .Select(pair => (pair.Item1, workspace[pair.Item2.Value].Hash));
 
@@ -555,12 +761,12 @@ namespace Libplanet.Net
                     _logger.Debug(
                         "Preloading is aborted; delete the temporary working chain ({0}: {1}), " +
                         "and make the existing chain ({2}: {3}) remains.",
-                        workspace.Id,
+                        wId,
                         workspace.Tip,
                         BlockChain.Id,
                         BlockChain.Tip
                     );
-                    _store.DeleteChainId(workspace.Id);
+                    _store.DeleteChainId(wId);
                 }
                 else
                 {
@@ -569,7 +775,7 @@ namespace Libplanet.Net
                         "the working chain ({2}: {3}).",
                         BlockChain.Id,
                         BlockChain.Tip,
-                        workspace.Id,
+                        wId,
                         workspace.Tip
                     );
                     BlockChain.Swap(workspace, render: false);
@@ -634,32 +840,55 @@ namespace Libplanet.Net
             await ((NetMQTransport)Transport).AddPeersAsync(peers, timeout, cancellationToken);
         }
 
-        internal async Task<IEnumerable<HashDigest<SHA256>>>
-            GetBlockHashesAsync(
-                BoundPeer peer,
-                BlockLocator locator,
-                HashDigest<SHA256>? stop,
-                CancellationToken token = default(CancellationToken)
-            )
-        {
-            var request = new GetBlockHashes(locator, stop);
-
-            Message parsedMessage = await Transport.SendMessageWithReplyAsync(
-                peer,
-                request,
-                timeout: BlockHashRecvTimeout,
-                cancellationToken: token
-            );
-
-            if (parsedMessage is BlockHashes blockHashes)
+        // FIXME: This would be better if it's merged with GetDemandBlockHashes
+        internal System.Collections.Async.IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>>
+        GetBlockHashes(
+            BoundPeer peer,
+            BlockLocator locator,
+            HashDigest<SHA256>? stop,
+            CancellationToken token = default
+        ) =>
+            new AsyncEnumerable<Tuple<long, HashDigest<SHA256>>>(async yield =>
             {
-                return blockHashes.Hashes;
-            }
+                var request = new GetBlockHashes(locator, stop);
 
-            throw new InvalidMessageException(
-                $"The response of GetBlockHashes isn't BlockHashes. " +
-                $"but {parsedMessage}");
-        }
+                Message parsedMessage = await Transport.SendMessageWithReplyAsync(
+                    peer,
+                    request,
+                    timeout: BlockHashRecvTimeout,
+                    cancellationToken: token
+                );
+
+                if (parsedMessage is BlockHashes blockHashes)
+                {
+                    if (blockHashes.StartIndex is long idx)
+                    {
+                        _logger.Debug(
+                            $"Received a {nameof(BlockHashes)} message with an offset index " +
+                            "{OffsetIndex}.",
+                            idx
+                        );
+                        foreach (var hash in blockHashes.Hashes)
+                        {
+                            await yield.ReturnAsync(new Tuple<long, HashDigest<SHA256>>(idx, hash));
+                            idx++;
+                        }
+                    }
+                    else
+                    {
+                        _logger.Debug(
+                            $"Received a {nameof(BlockHashes)} message, but it has zero hashes."
+                        );
+                    }
+
+                    return;
+                }
+
+                throw new InvalidMessageException(
+                    $"The response of {nameof(GetBlockHashes)} is expected to be " +
+                    $"{nameof(BlockHashes)}, not {parsedMessage.GetType().Name}: {parsedMessage}"
+                );
+            });
 
         internal System.Collections.Async.IAsyncEnumerable<Block<T>> GetBlocksAsync(
             BoundPeer peer,
@@ -823,33 +1052,132 @@ namespace Libplanet.Net
             });
         }
 
-        private async Task SyncBehindsBlocksFromPeerAsync(
+        private System.Collections.Async.IAsyncEnumerable<(long, HashDigest<SHA256>)>
+        GetDemandBlockHashes(
             BlockChain<T> blockChain,
-            (BoundPeer, long?) peerWithLength,
-            IProgress<BlockDownloadState> progress,
-            CancellationToken cancellationToken,
-            bool render
+            IList<(BoundPeer, long?)> peersWithHeight,
+            IProgress<PreloadState> progress = null,
+            CancellationToken cancellationToken = default
         )
         {
-            if (peerWithLength.Item1 != null &&
-                !(blockChain.Tip?.Index >= (peerWithLength.Item2 ?? -1)))
+            long currentTipIndex = blockChain.Tip?.Index ?? -1;
+            return new AsyncEnumerable<(long, HashDigest<SHA256>)>(async yield =>
             {
-                long currentTipIndex = blockChain.Tip?.Index ?? -1;
-                long peerIndex = peerWithLength.Item2 ?? -1;
-                long totalBlockCount = peerIndex - currentTipIndex;
+                BlockLocator locator = blockChain.GetBlockLocator();
+                int peersCount = peersWithHeight.Count;
+                int i = 0;
+                var exceptions = new List<Exception>();
+                foreach ((BoundPeer peer, long? peerHeight) in peersWithHeight)
+                {
+                    i++;
+                    long peerIndex = peerHeight ?? -1;
 
-                _logger.Debug("Synchronizing previous blocks from " +
-                    $"[{peerWithLength.Item1.Address.ToHex()}]");
-                await SyncPreviousBlocksAsync(
-                    blockChain,
-                    peerWithLength.Item1,
-                    null,
-                    progress,
-                    totalBlockCount,
-                    evaluateActions: render,
-                    cancellationToken: cancellationToken
-                );
-            }
+                    if (peer is null || currentTipIndex >= peerIndex)
+                    {
+                        continue;
+                    }
+
+                    long totalBlocksToDownload = peerIndex - currentTipIndex;
+                    try
+                    {
+                        var downloaded = new List<HashDigest<SHA256>>();
+                        while (downloaded.Count < totalBlocksToDownload)
+                        {
+                            _logger.Verbose(
+                                "Request block hashes to {Peer} using the locator {@Locator}... " +
+                                "({CurrentIndex}/{EstimatedTotalCount})",
+                                peer,
+                                locator,
+                                downloaded.Count,
+                                totalBlocksToDownload
+                            );
+                            await GetBlockHashes(
+                                peer,
+                                locator,
+                                null,
+                                cancellationToken
+                            ).ForEachAsync(
+                                async pair =>
+                                {
+                                    _logger.Verbose(
+                                        "Received a block hash from {Peer}: " +
+                                        "#{BlockIndex} {BlockHash}",
+                                        peer,
+                                        pair.Item1,
+                                        pair.Item2
+                                    );
+
+                                    if (pair.Item1 - currentTipIndex - 1 != downloaded.Count)
+                                    {
+                                        return;
+                                    }
+
+                                    downloaded.Add(pair.Item2);
+                                    await yield.ReturnAsync(pair.ToValueTuple());
+                                    progress?.Report(
+                                        new BlockHashDownloadState
+                                        {
+                                            EstimatedTotalBlockHashCount = Math.Max(
+                                                totalBlocksToDownload,
+                                                downloaded.Count),
+                                            ReceivedBlockHashCount = downloaded.Count,
+                                            SourcePeer = peer,
+                                        }
+                                    );
+                                },
+                                cancellationToken
+                            );
+
+                            locator = new BlockLocator(
+                                idx =>
+                                {
+                                    if (idx < 0)
+                                    {
+                                        idx = currentTipIndex + downloaded.Count + 1 + idx;
+                                    }
+
+                                    if (idx <= currentTipIndex)
+                                    {
+                                        return blockChain.Store.IndexBlockHash(blockChain.Id, idx);
+                                    }
+
+                                    int relIdx = (int)(idx - currentTipIndex - 1);
+                                    return downloaded[relIdx];
+                                },
+                                hash => blockChain.Store.GetBlock<T>(hash) is Block<T> b
+                                    ? b.Index
+                                    : currentTipIndex + 1 + downloaded.IndexOf(hash)
+                            );
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                        if (i == peersCount)
+                        {
+                            BoundPeer[] peers = peersWithHeight.Select(p => p.Item1).ToArray();
+                            _logger.Warning(
+                                e,
+                                "Failed to fetch demand block hashes from peers: {Peers}",
+                                peers
+                            );
+                            throw new SwarmAggregateException(
+                                "Failed to fetch demand block hashes from peers: " +
+                                string.Join(", ", peers.Select(p => p.ToString())),
+                                exceptions
+                            );
+                        }
+
+                        const string message =
+                            "Failed to fetch demand block hashes from {Peer}; " +
+                            "retry with another peer...\n";
+                        _logger.Debug(e, message, peer, e);
+                        continue;
+                    }
+
+                    break;
+                }
+            });
         }
 
         private async Task<long?> SyncRecentStatesFromTrustedPeersAsync(
@@ -1115,12 +1443,15 @@ namespace Libplanet.Net
 
                 case GetBlockHashes getBlockHashes:
                     {
-                        IEnumerable<HashDigest<SHA256>> hashes =
-                            BlockChain.FindNextHashes(
-                                getBlockHashes.Locator,
-                                getBlockHashes.Stop,
-                                FindNextHashesChunkSize);
-                        var reply = new BlockHashes(hashes)
+                        BlockChain.FindNextHashes(
+                            getBlockHashes.Locator,
+                            getBlockHashes.Stop,
+                            FindNextHashesChunkSize
+                        ).Deconstruct(
+                            out long? offset,
+                            out IReadOnlyList<HashDigest<SHA256>> hashes
+                        );
+                        var reply = new BlockHashes(offset, hashes)
                         {
                             Identity = getBlockHashes.Identity,
                         };
@@ -1318,9 +1649,10 @@ namespace Libplanet.Net
                     _logger.Debug("Trying to find branchpoint...");
                     BlockLocator locator = workspace.GetBlockLocator();
                     _logger.Debug("Locator's count: {LocatorCount}", locator.Count());
-                    IEnumerable<HashDigest<SHA256>> hashes = (
-                        await GetBlockHashesAsync(peer, locator, stop, cancellationToken)
-                    ).ToArray();
+                    System.Collections.Async.IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>>
+                        hashesAsync = GetBlockHashes(peer, locator, stop, cancellationToken);
+                    IEnumerable<Tuple<long, HashDigest<SHA256>>> hashes =
+                        await hashesAsync.ToArrayAsync();
 
                     if (!hashes.Any())
                     {
@@ -1331,9 +1663,16 @@ namespace Libplanet.Net
                         return workspace;
                     }
 
-                    HashDigest<SHA256> branchPoint = hashes.First();
+                    hashes.First().Deconstruct(
+                        out long branchIndex,
+                        out HashDigest<SHA256> branchPoint
+                    );
 
-                    _logger.Debug("Branchpoint is {0}.", ByteUtil.Hex(branchPoint.ToByteArray()));
+                    _logger.Debug(
+                        "Branch point is #{BranchIndex} {BranchHash}.",
+                        branchIndex,
+                        branchPoint
+                    );
 
                     if (tip is null || branchPoint.Equals(tip.Hash))
                     {
@@ -1344,11 +1683,16 @@ namespace Libplanet.Net
                     // same genesis block...
                     else if (!BlockChain.ContainsBlock(branchPoint))
                     {
+                        // FIXME: This behavior can unexpectedly terminate the swarm (and the game
+                        // app) if it encounters a peer having a different blockchain, and therefore
+                        // can be exploited to remotely shut down other nodes as well.
+                        // Since the intention of this behavior is to prevent mistakes to try to
+                        // connect incorrect seeds (by a user), this behavior should be limited for
+                        // only seed peers.
                         var msg =
                             $"Since the genesis block is fixed to {BlockChain.Genesis} " +
                             "protocol-wise, the blockchain which does not share " +
                             "any mutual block is not acceptable.";
-                        _logger.Debug(msg);
                         throw new InvalidGenesisBlockException(
                             branchPoint,
                             workspace.Genesis.Hash,
@@ -1370,7 +1714,7 @@ namespace Libplanet.Net
                     _logger.Debug("Trying to fill up previous blocks...");
 
                     var hashesAsArray =
-                        hashes as HashDigest<SHA256>[] ?? hashes.ToArray();
+                        hashes as Tuple<long, HashDigest<SHA256>>[] ?? hashes.ToArray();
                     if (!hashesAsArray.Any())
                     {
                         break;
@@ -1384,7 +1728,7 @@ namespace Libplanet.Net
 
                     totalBlockCount = Math.Max(totalBlockCount, receivedBlockCount + hashCount);
 
-                    await GetBlocksAsync(peer, hashesAsArray)
+                    await GetBlocksAsync(peer, hashesAsArray.Select(pair => pair.Item2))
                         .ForEachAsync(
                             block =>
                             {
@@ -1781,6 +2125,27 @@ namespace Libplanet.Net
                     _demandTxIds.TryRemove(kv.Key, out BoundPeer value);
                 }
             }
+        }
+
+        /// <summary>
+        /// As Dasync's <see cref="ForEachAsyncExtensions"/> catch <see cref="AggregateException"/>
+        /// by itself and throw only its first <see cref="Exception.InnerException"/>,
+        /// we define a distinct exception class that mimics <see cref="AggregateException"/>
+        /// without subclassing it.
+        /// </summary>
+        [SuppressMessage(
+            "SonarAnalyzer",
+            "S3871",
+            Justification = "This exception is always caught inside Swarm.")]
+        private class SwarmAggregateException : Exception
+        {
+            public SwarmAggregateException(string message, IReadOnlyList<Exception> innerExceptions)
+                : base(message, innerExceptions.FirstOrDefault())
+            {
+                InnerExceptions = innerExceptions;
+            }
+
+            public IReadOnlyList<Exception> InnerExceptions { get; }
         }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -876,7 +876,9 @@ namespace Libplanet.Net
 
         internal IAsyncEnumerable<Block<T>> GetBlocksAsync(
             BoundPeer peer,
-            IEnumerable<HashDigest<SHA256>> blockHashes)
+            IEnumerable<HashDigest<SHA256>> blockHashes,
+            CancellationToken cancellationToken = default
+        )
         {
             return new AsyncEnumerable<Block<T>>(async yield =>
             {

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>3000</MaxFileLines>
+  <MaxFileLines>3100</MaxFileLines>
 </Menees.Analyzers.Settings>

--- a/Menees.Analyzers.Settings.xml
+++ b/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>200</MaxMethodLines>
-  <MaxFileLines>2920</MaxFileLines>
+  <MaxFileLines>3000</MaxFileLines>
 </Menees.Analyzers.Settings>


### PR DESCRIPTION
The first commit is a commit squashed from the PR #707, except for some adjustments to resolve conflicts and make the build to pass.

This also introduces C# 8's new [async streams syntax][1] to replace Dasync's *[AsyncEnumerator]* package with it.  Although this removed the dependency on *AsyncEnumerator* package and introduce the new syntax into *Libplanet* project, note *Libplanet.Tests* project still uses C# 7.2 and the third-party package, which is intended.

Instead of *AsyncEnumerator*, *Libplanet* project has a new dependency on the *[System.Linq.Async]* package, which provides several LINQ extension methods laid on `IAsyncEnumerator<T>`.

The key changes over the reverted PR #707 in this patch are of course fixing #707's bugs and more `PreloadState`s.  See also each commit message.

[1]: https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/generate-consume-asynchronous-stream
[AsyncEnumerator]: https://www.nuget.org/packages/AsyncEnumerator/
[System.Linq.Async]: https://www.nuget.org/packages/System.Linq.Async/