### PR TITLE
Remove IStore.DeleteIndex method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ To be released.
 ### Backward-incompatible API changes
 
  -  `BaseStore` class became to implement `IDisposable`.  [[#789]]
+ -  Removed `IStore.DeleteIndex(Guid, HashDigest<SHA256>)` method.  [[#802]]
 
 ### Backward-incompatible network protocol changes
 
@@ -61,6 +62,7 @@ To be released.
 [#789]: https://github.com/planetarium/libplanet/pull/789
 [#791]: https://github.com/planetarium/libplanet/pull/791
 [#798]: https://github.com/planetarium/libplanet/pull/798
+[#802]: https://github.com/planetarium/libplanet/pull/802
 
 
 Version 0.8.0

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -224,13 +224,6 @@ namespace Libplanet.RocksDBStore
         }
 
         /// <inheritdoc/>
-        public override bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash)
-        {
-            int deleted = IndexCollection(chainId).Delete(i => i.Hash.Equals(hash));
-            return deleted > 0;
-        }
-
-        /// <inheritdoc/>
         public override void ForkBlockIndexes(
             Guid sourceChainId,
             Guid destinationChainId,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -376,16 +376,6 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
-        public void DeleteIndex()
-        {
-            Assert.False(Fx.Store.DeleteIndex(Fx.StoreChainId, Fx.Hash1));
-            Fx.Store.AppendIndex(Fx.StoreChainId, Fx.Hash1);
-            Assert.NotEmpty(Fx.Store.IterateIndexes(Fx.StoreChainId));
-            Assert.True(Fx.Store.DeleteIndex(Fx.StoreChainId, Fx.Hash1));
-            Assert.Empty(Fx.Store.IterateIndexes(Fx.StoreChainId));
-        }
-
-        [SkippableFact]
         public void IterateIndexes()
         {
             var ns = Fx.StoreChainId;

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -63,12 +63,6 @@ namespace Libplanet.Tests.Store
             return _store.ContainsBlock(blockHash);
         }
 
-        public bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash)
-        {
-            Log(nameof(DeleteIndex), chainId, hash);
-            return _store.DeleteIndex(chainId, hash);
-        }
-
         public IEnumerable<string> ListStateKeys(Guid chainId)
         {
             Log(nameof(ListStateKeys), chainId);

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -176,8 +176,6 @@ namespace Libplanet.Store
             return IterateBlockHashes().LongCount();
         }
 
-        public abstract bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash);
-
         /// <inheritdoc />
         public abstract bool ContainsTransaction(TxId txId);
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -248,13 +248,6 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public override bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash)
-        {
-            int deleted = IndexCollection(chainId).Delete(i => i.Hash.Equals(hash));
-            return deleted > 0;
-        }
-
-        /// <inheritdoc/>
         public override void ForkBlockIndexes(
             Guid sourceChainId,
             Guid destinationChainId,

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -63,8 +63,6 @@ namespace Libplanet.Store
 
         long AppendIndex(Guid chainId, HashDigest<SHA256> hash);
 
-        bool DeleteIndex(Guid chainId, HashDigest<SHA256> hash);
-
         /// <summary>
         /// Forks block indexes from
         /// <paramref name="sourceChainId"/> to


### PR DESCRIPTION
This removes `IStore.DeleteIndex()` method.