### PR TITLE
Replace to use RocksDB for Tx Nonce and Canonical Chain ID 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,18 @@ To be released.
 
  -  `BaseStore` class became to implement `IDisposable`.  [[#789]]
  -  Removed `IStore.DeleteIndex(Guid, HashDigest<SHA256>)` method.  [[#802]]
+ -  Extension classes have been renamed. However, it is not affected
+    if you do not call it directly.  [[#803]]
+     -  Renamed `StunAddressExtension` class to `StunAddressExtensions`.
+     -  Renamed `BytesConvertExtension` class to `BytesConvertExtensions`.
+     -  Renamed `RandomExtension` class to `RandomExtensions`.
+     -  Renamed `AddressExtension` class to `AddressExtensions`.
+     -  Renamed `HashDigestExtension` class to `HashDigestExtensions`.
+     -  Renamed `NetMQFrameExtension` class to `NetMQFrameExtensions`.
+     -  Renamed `NetMQSocketExtension` class to `NetMQSocketExtensions`.
+     -  Renamed `SerializationInfoExtension` class to
+        `SerializationInfoExtensions`.
+     -  Renamed `StoreExtension` class to `StoreExtensions`.
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,8 @@ To be released.
 
  -  `BaseStore` class became to implement `IDisposable`.  [[#789]]
  -  Removed `IStore.DeleteIndex(Guid, HashDigest<SHA256>)` method.  [[#802]]
- -  Extension classes have been renamed. However, it is not affected
-    if you do not call it directly.  [[#803]]
+ -  Extension classes was renamed.  However, it would not be affected
+    if you have called it by using instance method syntax.  [[#803]]
      -  Renamed `StunAddressExtension` class to `StunAddressExtensions`.
      -  Renamed `BytesConvertExtension` class to `BytesConvertExtensions`.
      -  Renamed `RandomExtension` class to `RandomExtensions`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ To be released.
  -  Added `BlockHeader` struct.  [[#785]]
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
  -  Added `Block<T>.ToBlockDigest()` method.  [[#785]]
+ -  Added `ByteArrayExtensions` class.  [[#803]]
 
 ### Behavioral changes
 
@@ -63,6 +64,7 @@ To be released.
 [#791]: https://github.com/planetarium/libplanet/pull/791
 [#798]: https://github.com/planetarium/libplanet/pull/798
 [#802]: https://github.com/planetarium/libplanet/pull/802
+[#803]: https://github.com/planetarium/libplanet/pull/803
 
 
 Version 0.8.0

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -13,6 +13,7 @@ namespace Libplanet.RocksDBStore.Tests
             try
             {
                 Fx = _fx = new RocksDBStoreFixture();
+                FxConstructor = () => new RocksDBStoreFixture();
             }
             catch (TypeInitializationException)
             {

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -303,11 +303,12 @@ namespace Libplanet.RocksDBStore
         public override IEnumerable<TxId> IterateTransactionIds()
         {
             Iterator it = _blockDb.NewIterator();
+            byte[] prefix = TxKeyPrefix;
 
-            for (it.Seek(TxKeyPrefix); it.Valid(); it.Next())
+            for (it.Seek(prefix); it.Valid() && it.Key().StartsWith(prefix); it.Next())
             {
                 byte[] key = it.Key();
-                byte[] txIdBytes = key.Skip(TxKeyPrefix.Length).ToArray();
+                byte[] txIdBytes = key.Skip(prefix.Length).ToArray();
 
                 var txId = new TxId(txIdBytes);
                 yield return txId;
@@ -387,11 +388,12 @@ namespace Libplanet.RocksDBStore
         public override IEnumerable<HashDigest<SHA256>> IterateBlockHashes()
         {
             Iterator it = _blockDb.NewIterator();
+            byte[] prefix = BlockKeyPrefix;
 
-            for (it.Seek(BlockKeyPrefix); it.Valid(); it.Next())
+            for (it.Seek(prefix); it.Valid() && it.Key().StartsWith(prefix); it.Next())
             {
                 byte[] key = it.Key();
-                byte[] hashBytes = key.Skip(BlockKeyPrefix.Length).ToArray();
+                byte[] hashBytes = key.Skip(prefix.Length).ToArray();
 
                 var blockHash = new HashDigest<SHA256>(hashBytes);
                 yield return blockHash;
@@ -692,11 +694,12 @@ namespace Libplanet.RocksDBStore
         {
             ColumnFamilyHandle cf = GetColumnFamilyFromChainId(chainId);
             Iterator it = _chainDb.NewIterator(cf);
+            byte[] prefix = TxNonceKeyPrefix;
 
-            for (it.Seek(TxNonceKeyPrefix); it.Valid(); it.Next())
+            for (it.Seek(prefix); it.Valid() && it.Key().StartsWith(prefix); it.Next())
             {
                 byte[] addressBytes = it.Key()
-                    .Skip(TxNonceKeyPrefix.Length)
+                    .Skip(prefix.Length)
                     .ToArray();
                 var address = new Address(addressBytes);
                 long nonce = BitConverter.ToInt64(it.Value(), 0);

--- a/Libplanet.Stun.Tests/Stun/Attributes/StunAddressExtensionsTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Attributes/StunAddressExtensionsTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Libplanet.Stun.Tests.Attributes
 {
-    public class StunAddressExtensionTest
+    public class StunAddressExtensionsTest
     {
         public static IEnumerable<object[]> Testcases => new List<object[]>
         {

--- a/Libplanet.Stun/Stun/Attributes/StunAddressExtensions.cs
+++ b/Libplanet.Stun/Stun/Attributes/StunAddressExtensions.cs
@@ -7,7 +7,7 @@ using Libplanet.Stun.Messages;
 
 namespace Libplanet.Stun.Attributes
 {
-    internal static class StunAddressExtension
+    internal static class StunAddressExtensions
     {
         private enum StunAf : byte
         {

--- a/Libplanet.Stun/Stun/BytesConvertExtensions.cs
+++ b/Libplanet.Stun/Stun/BytesConvertExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Libplanet.Stun
 {
-    internal static class BytesConvertExtension
+    internal static class BytesConvertExtensions
     {
         public static byte[] ToBytes(this ushort value)
         {

--- a/Libplanet.Tests/AddressExtensionsTest.cs
+++ b/Libplanet.Tests/AddressExtensionsTest.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Libplanet.Tests
 {
-    public class AddressExtensionTest
+    public class AddressExtensionsTest
     {
         [Fact]
         public void CanGetAddress()

--- a/Libplanet.Tests/ByteArrayExtensionsTest.cs
+++ b/Libplanet.Tests/ByteArrayExtensionsTest.cs
@@ -1,0 +1,29 @@
+using System;
+using Xunit;
+
+namespace Libplanet.Tests
+{
+    public class ByteArrayExtensionsTest
+    {
+        [Fact]
+        public void StartsWith()
+        {
+            byte[] bytes = null;
+
+            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(new byte[] { 0 }));
+            bytes = new byte[]
+            {
+                0, 1,
+            };
+
+            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(null));
+
+            Assert.False(bytes.StartsWith(new byte[] { 0, 1, 2 }));
+            Assert.False(bytes.StartsWith(new byte[] { 0, 2 }));
+            Assert.False(bytes.StartsWith(new byte[] { 1 }));
+
+            Assert.True(bytes.StartsWith(new byte[] { 0 }));
+            Assert.True(bytes.StartsWith(new byte[] { 0, 1 }));
+        }
+    }
+}

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -60,5 +60,26 @@ namespace Libplanet.Tests
                 ByteUtil.CalculateHashCode(otherBytes)
             );
         }
+
+        [Fact]
+        public void StartsWith()
+        {
+            byte[] bytes = null;
+
+            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(new byte[] { 0 }));
+            bytes = new byte[]
+            {
+                0, 1,
+            };
+
+            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(null));
+
+            Assert.False(bytes.StartsWith(new byte[] { 0, 1, 2 }));
+            Assert.False(bytes.StartsWith(new byte[] { 0, 2 }));
+            Assert.False(bytes.StartsWith(new byte[] { 1 }));
+
+            Assert.True(bytes.StartsWith(new byte[] { 0 }));
+            Assert.True(bytes.StartsWith(new byte[] { 0, 1 }));
+        }
     }
 }

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -60,26 +60,5 @@ namespace Libplanet.Tests
                 ByteUtil.CalculateHashCode(otherBytes)
             );
         }
-
-        [Fact]
-        public void StartsWith()
-        {
-            byte[] bytes = null;
-
-            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(new byte[] { 0 }));
-            bytes = new byte[]
-            {
-                0, 1,
-            };
-
-            Assert.Throws<ArgumentNullException>(() => bytes.StartsWith(null));
-
-            Assert.False(bytes.StartsWith(new byte[] { 0, 1, 2 }));
-            Assert.False(bytes.StartsWith(new byte[] { 0, 2 }));
-            Assert.False(bytes.StartsWith(new byte[] { 1 }));
-
-            Assert.True(bytes.StartsWith(new byte[] { 0 }));
-            Assert.True(bytes.StartsWith(new byte[] { 0, 1 }));
-        }
     }
 }

--- a/Libplanet.Tests/HashSetExtensions.cs
+++ b/Libplanet.Tests/HashSetExtensions.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Libplanet.Tests
 {
-    public static class HashSetExtension
+    public static class HashSetExtensions
     {
         public static HashSet<T> ToHashSet<T>(this IEnumerable<T> l)
         {

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -17,6 +17,7 @@ namespace Libplanet.Tests.Store
         {
             TestOutputHelper = testOutputHelper;
             Fx = _fx = new DefaultStoreFixture();
+            FxConstructor = () => new DefaultStoreFixture();
         }
 
         public void Dispose()

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -882,6 +882,41 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
+        public void ListTxNonces()
+        {
+            var chainId1 = Guid.NewGuid();
+            var chainId2 = Guid.NewGuid();
+
+            Address address1 = Fx.Address1;
+            Address address2 = Fx.Address2;
+
+            Assert.Empty(Fx.Store.ListTxNonces(chainId1));
+            Assert.Empty(Fx.Store.ListTxNonces(chainId2));
+
+            Fx.Store.IncreaseTxNonce(chainId1, address1);
+            Assert.Equal(
+                new Dictionary<Address, long> { [address1] = 1, },
+                Fx.Store.ListTxNonces(chainId1));
+
+            Fx.Store.IncreaseTxNonce(chainId2, address2);
+            Assert.Equal(
+                new Dictionary<Address, long> { [address2] = 1, },
+                Fx.Store.ListTxNonces(chainId2));
+
+            Fx.Store.IncreaseTxNonce(chainId1, address1);
+            Fx.Store.IncreaseTxNonce(chainId1, address2);
+            Assert.Equal(
+                new Dictionary<Address, long> { [address1] = 2, [address2] = 1, },
+                Fx.Store.ListTxNonces(chainId1));
+
+            Fx.Store.IncreaseTxNonce(chainId2, address1);
+            Fx.Store.IncreaseTxNonce(chainId2, address2);
+            Assert.Equal(
+                new Dictionary<Address, long> { [address1] = 1, [address2] = 2, },
+                Fx.Store.ListTxNonces(chainId2));
+        }
+
+        [SkippableFact]
         public void IndexBlockHashReturnNull()
         {
             Fx.Store.PutBlock(Fx.Block1);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -24,6 +24,8 @@ namespace Libplanet.Tests.Store
 
         protected StoreFixture Fx { get; set; }
 
+        protected Func<StoreFixture> FxConstructor { get; set; }
+
         [SkippableFact]
         public void ListChainId()
         {
@@ -131,7 +133,7 @@ namespace Libplanet.Tests.Store
             string stateKey2 = address2.ToHex().ToLowerInvariant();
             string stateKey3 = address3.ToHex().ToLowerInvariant();
 
-            var store = new DefaultStore(null);
+            var store = Fx.Store;
             var chain = TestUtils.MakeBlockChain(new NullPolicy<DumbAction>(), store);
 
             var block1 = TestUtils.MineNext(chain.Genesis);
@@ -1003,8 +1005,8 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void Copy()
         {
-            using (DefaultStoreFixture fx = new DefaultStoreFixture(memory: true))
-            using (DefaultStoreFixture fx2 = new DefaultStoreFixture(memory: true))
+            using (StoreFixture fx = FxConstructor())
+            using (StoreFixture fx2 = FxConstructor())
             {
                 IStore s1 = fx.Store, s2 = fx2.Store;
                 var blocks = new BlockChain<DumbAction>(

--- a/Libplanet/Action/RandomExtensions.cs
+++ b/Libplanet/Action/RandomExtensions.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Action
     /// This extension class provides some convenient methods
     /// to deal with <see cref="IRandom"/>.
     /// </summary>
-    public static class RandomExtension
+    public static class RandomExtensions
     {
         /// <summary>
         /// Generates a UUID version 4, i.e., a random <see cref="Guid"/>.

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -104,13 +104,13 @@ namespace Libplanet
         /// Derives the corresponding <see cref="Address"/> from a <see
         /// cref="PublicKey"/>.
         /// <para>Note that there is an equivalent extension method
-        /// <see cref="AddressExtension.ToAddress(PublicKey)"/>, which enables
+        /// <see cref="AddressExtensions.ToAddress(PublicKey)"/>, which enables
         /// a code like <c>publicKey.ToAddress()</c> instead of
         /// <c>new Address(publicKey)</c>, for convenience.</para>
         /// </summary>
         /// <param name="publicKey">A <see cref="PublicKey"/> to derive
         /// the corresponding <see cref="Address"/> from.</param>
-        /// <seealso cref="AddressExtension.ToAddress(PublicKey)"/>
+        /// <seealso cref="AddressExtensions.ToAddress(PublicKey)"/>
         public Address(PublicKey publicKey)
             : this(DeriveAddress(publicKey))
         {

--- a/Libplanet/AddressExtensions.cs
+++ b/Libplanet/AddressExtensions.cs
@@ -7,7 +7,7 @@ namespace Libplanet
     /// the most part) to deal with <see cref="Address"/>.
     /// </summary>
     /// <seealso cref="Address"/>
-    public static class AddressExtension
+    public static class AddressExtensions
     {
         /// <summary>
         /// Derives the corresponding <see cref="Address"/> from a <see

--- a/Libplanet/ByteArrayExtensions.cs
+++ b/Libplanet/ByteArrayExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics.Contracts;
+
+namespace Libplanet
+{
+    /// <summary>
+    /// This extension class enables some convenient methods to deal with byte array.
+    /// </summary>
+    /// <seealso cref="Address"/>
+    public static class ByteArrayExtensions
+    {
+        /// <summary>
+        /// Determines whether the beginning of this byte array instance matches a specified string.
+        /// </summary>
+        /// <param name="bytes">A byte array to check.</param>
+        /// <param name="prefix">The prefix byte array to compare.</param>
+        /// <returns>
+        /// true if <paramref name="prefix"/> matches the beginning of <paramref name="bytes"/>;
+        /// otherwise, false.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="bytes"/> or <paramref name="prefix"/> is null.
+        /// </exception>
+        [Pure]
+        public static bool StartsWith(this byte[] bytes, byte[] prefix)
+        {
+            if (bytes is null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+
+            if (prefix is null)
+            {
+                throw new ArgumentNullException(nameof(prefix));
+            }
+
+            if (prefix.Length > bytes.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0, j = 0; i < bytes.Length && j < prefix.Length; i++, j++)
+            {
+                if (bytes[i] != prefix[j])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -118,34 +118,5 @@ namespace Libplanet
                 (current, t) => unchecked(current * (bytes.Length + 1) + t)
             );
         }
-
-        [Pure]
-        public static bool StartsWith(this byte[] bytes, byte[] prefix)
-        {
-            if (bytes == null)
-            {
-                throw new ArgumentNullException(nameof(bytes));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (prefix.Length > bytes.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0, j = 0; i < bytes.Length && j < prefix.Length; i++, j++)
-            {
-                if (bytes[i] != prefix[j])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
     }
 }

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -118,5 +118,34 @@ namespace Libplanet
                 (current, t) => unchecked(current * (bytes.Length + 1) + t)
             );
         }
+
+        [Pure]
+        public static bool StartsWith(this byte[] bytes, byte[] prefix)
+        {
+            if (bytes == null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+
+            if (prefix == null)
+            {
+                throw new ArgumentNullException(nameof(prefix));
+            }
+
+            if (prefix.Length > bytes.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0, j = 0; i < bytes.Length && j < prefix.Length; i++, j++)
+            {
+                if (bytes[i] != prefix[j])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -113,7 +113,7 @@ namespace Libplanet
         /// the <see cref="Size"/>, the hash algorithm
         /// (i.e., <typeparamref name="T"/> requires.</exception>
         /// <seealso cref="ToString()"/>
-        /// <seealso cref="HashDigestExtension.ToHashDigest{T}(string)"/>
+        /// <seealso cref="HashDigestExtensions.ToHashDigest{T}(string)"/>
         [Pure]
         public static HashDigest<T> FromString(string hexDigest)
         {
@@ -232,7 +232,7 @@ namespace Libplanet
     /// Augments types to have some shortcut methods dealing with
     /// <see cref="HashDigest{T}"/> values.
     /// </summary>
-    public static class HashDigestExtension
+    public static class HashDigestExtensions
     {
         /// <summary>
         /// Converts a given hexadecimal representation of a digest into

--- a/Libplanet/Net/NetMQFrameExtensions.cs
+++ b/Libplanet/Net/NetMQFrameExtensions.cs
@@ -6,7 +6,7 @@ using NetMQ;
 
 namespace Libplanet.Net
 {
-    internal static class NetMQFrameExtension
+    internal static class NetMQFrameExtensions
     {
         public static HashDigest<T> ConvertToHashDigest<T>(
             this NetMQFrame frame)

--- a/Libplanet/Net/NetMQSocketExtensions.cs
+++ b/Libplanet/Net/NetMQSocketExtensions.cs
@@ -5,7 +5,7 @@ using NetMQ;
 
 namespace Libplanet.Net
 {
-    internal static class NetMQSocketExtension
+    internal static class NetMQSocketExtensions
     {
         public static async Task SendMultipartMessageAsync(
             this NetMQSocket socket,

--- a/Libplanet/Serialization/SerializationInfoExtensions.cs
+++ b/Libplanet/Serialization/SerializationInfoExtensions.cs
@@ -2,7 +2,7 @@ using System.Runtime.Serialization;
 
 namespace Libplanet.Serialization
 {
-    public static class SerializationInfoExtension
+    public static class SerializationInfoExtensions
     {
         public static T GetValue<T>(this SerializationInfo info, string name)
         {

--- a/Libplanet/Store/StoreExtensions.cs
+++ b/Libplanet/Store/StoreExtensions.cs
@@ -10,7 +10,7 @@ using Libplanet.Tx;
 
 namespace Libplanet.Store
 {
-    public static class StoreExtension
+    public static class StoreExtensions
     {
         /// <summary>
         /// Makes a store, <paramref name="to"/>, logically (but not necessarily physically)


### PR DESCRIPTION
This replaces to use RocksDB for Tx Nonce and Canonical Chain ID in `Libplanet.RocksDBStore`. The remainder of using LiteDB will be replaced in the next PRs.