### PR TITLE
Replace to use RocksDB for Chain Index

### DIFF
--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -252,13 +252,9 @@ namespace Libplanet.RocksDBStore
             }
 
             ColumnFamilyHandle cf = GetColumnFamily(chainId);
-            byte[] indexBytes = BitConverter.GetBytes(index);
 
             // Use Big-endian to order index lexicographically.
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(indexBytes);
-            }
+            byte[] indexBytes = NetMQ.NetworkOrderBitsConverter.GetBytes(index);
 
             byte[] key = IndexKeyPrefix.Concat(indexBytes).ToArray();
             byte[] bytes = _chainDb.Get(key, cf);
@@ -271,13 +267,9 @@ namespace Libplanet.RocksDBStore
         public override long AppendIndex(Guid chainId, HashDigest<SHA256> hash)
         {
             long index = CountIndex(chainId);
-            byte[] indexBytes = BitConverter.GetBytes(index);
 
             // Use Big-endian to order index lexicographically.
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(indexBytes);
-            }
+            byte[] indexBytes = NetMQ.NetworkOrderBitsConverter.GetBytes(index);
 
             byte[] key = IndexKeyPrefix.Concat(indexBytes).ToArray();
             ColumnFamilyHandle cf = GetColumnFamily(chainId);

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -221,18 +221,11 @@ namespace Libplanet.RocksDBStore
             int offset,
             int? limit)
         {
-            int skip = 0;
             int count = 0;
             byte[] prefix = IndexKeyPrefix;
 
-            foreach (Iterator it in IterateDb(_chainDb, prefix, chainId))
+            foreach (Iterator it in IterateDb(_chainDb, prefix, chainId).Skip(offset))
             {
-                if (skip < offset)
-                {
-                    skip += 1;
-                    continue;
-                }
-
                 if (count >= limit)
                 {
                     break;

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -167,7 +167,7 @@ namespace Libplanet.RocksDBStore
 
                 try
                 {
-                    guid = new Guid(name);
+                    guid = Guid.Parse(name);
                 }
                 catch (FormatException)
                 {


### PR DESCRIPTION
This replaces to use RocksDB for chain indexes in Libplanet.RocksDBStore.