### PR TITLE
Fix release script bugs

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -26,13 +26,21 @@ if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ] || (
     [ "$GITHUB_REF" = "${GITHUB_REF#refs/tags/}" ] &&
     [ "$GITHUB_REF" != refs/heads/master ] &&
     [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ] ); then
-  alias dotnet="echo DRY-RUN: dotnet"
+  function dotnet-nuget {
+    shift
+    echo "DRY-RUN: dotnet nuget" "$@"
+  }
+else
+  function dotnet-nuget {
+    shift
+    dotnet nuget "$@"
+  }
 fi
 
 package_version="$(cat obj/package_version.txt)"
 
 for project in "${projects[@]}"; do
-  dotnet nuget push \
+  dotnet-nuget push \
     "./$project/bin/$configuration/$project.$package_version.nupkg" \
     --api-key "$NUGET_API_KEY" \
     --source https://api.nuget.org/v3/index.json

--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -14,8 +14,8 @@ fi
 for project in "${projects[@]}"; do
   rm -rf "./$project/bin/$configuration/"
 
+  dotnet_args="-p:Version=$(cat obj/package_version.txt)"
   if [ -f obj/version_suffix.txt ]; then
-    dotnet_args="-p:Version=$(cat obj/package_version.txt)"
     dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
   fi
   # shellcheck disable=SC2086

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 on:
-  push: []
+  push:
+    branches-ignore:
+    - gh-pages
+    tags:
+    - "*"
   schedule:
   - cron: 59 14 * * *
   pull_request: []

--- a/hooks/validate-release
+++ b/hooks/validate-release
@@ -27,7 +27,10 @@ fi
 csproj="$root/Libplanet/Libplanet.csproj"
 if command -v xmllint > /dev/null; then
   csproj_version="$(xmllint \
-    --xpath './Project/PropertyGroup/VersionPrefix/text()' \
+    --xpath '/*[local-name()="Project"]
+             /*[local-name()="PropertyGroup"]
+             /*[local-name()="VersionPrefix"]
+             /text()' \
     "$csproj")"
 else
   regex='<VersionPrefix>([0-9]+\.[0-9]+\.[0-9]+)</VersionPrefix>'


### PR DESCRIPTION
- Fixed a bug that tag pushes hadn't triggered the `build` job on GitHub Actions. (GitHub Actions recently changed `on:`'s behavior.)
- Fixed a bug that *Libplanet.RocksDBStore* package hadn't properly versioned for stable releases.
- Fixed a bug that *Libplanet.RocksDBStore.\*.nupkg* hadn't uploaded to GitHub releases.
- Fixed an XPath bug on pre-commit hook made due to XML namespaces.