### PR TITLE
All-in-one bundles

### DIFF
--- a/.github/bin/bundle.sh
+++ b/.github/bin/bundle.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Make "bundle" archives, include all referenced assemblies, for each
+# supported target platform.
+# Note that this script is intended to be run by GitHub Actions.
+set -e
+
+# shellcheck source=constants.sh
+. "$(dirname "$0")/constants.sh"
+
+if [[ "$1" = "" ]]; then
+  echo No the first argument.  Needs a nupkg path. > /dev/stderr
+  exit 1
+elif [[ "$2" = "" ]]; then
+  echo No the second argument.  Needs an output directory. > /dev/stderr
+  exit 1
+elif [[ "$3" = "" ]]; then
+  echo No the third argument.  Needs a target framework. > /dev/stderr
+  exit 1
+fi
+
+nupkg="$(realpath "$1")"
+outdir="$(realpath "$2")"
+target="$3"
+
+if ! [[ "$(basename "$nupkg")" =~ \.([0-9]+\.[0-9]+\.[0-9]+.*)\.nupkg$ ]]; then
+  echo No version information in the filename: "$nupkg" > /dev/stderr
+  exit 1
+fi
+
+version="${BASH_REMATCH[1]}"
+package="$(basename "$nupkg" | sed -E 's/(\.[0-9]{1,}){3}.*?\.nupkg$//')"
+workdir="$(mktemp -d)"
+
+pushd "$workdir"
+  # Prepare a local NuGet repository
+  mkdir repo/
+  nuget add "$nupkg" -Source ./repo
+
+  # Create a skeleton app to bundle assemblies
+  app="BundleApp$(head -c 1024 /dev/urandom | md5sum | head -c 10)"
+  dotnet new console -o "$app" -n "$app"
+  pushd "$app/"
+    sed \
+      -E "s|(<TargetFramework>)[^<]*(</TargetFramework>)|\1$target\2|" \
+      "$app.csproj" \
+      > "$app.csproj_"
+    mv "$app.csproj_" "$app.csproj"
+
+    dotnet add package "$package" --version "$version" --source "$workdir/repo"
+
+    if [[ "$target" =~ ^net[0-9][0-9][0-9]$ ]]; then
+      msbuild /r "/p:Configuration=$configuration"
+    else
+      dotnet build -c "$configuration"
+    fi
+
+    # All referenced assemblies would go inside the bin/ directory:
+    pushd "bin/Release/$target/"
+      # Remove unnecessary assemblies
+      find . -name "$app*" -exec rm {} +
+
+      # Archive everything in the directory using tarball + xz
+      mkdir -p "$outdir"
+      tar cvfJ "$outdir/$package-$version-$target.tar.xz" .
+    popd
+  popd
+popd

--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# shellcheck disable=SC2034
+projects=("Libplanet" "Libplanet.RocksDBStore")
+configuration=Release
+

--- a/.github/bin/dist-github-release.sh
+++ b/.github/bin/dist-github-release.sh
@@ -4,8 +4,8 @@
 # shellcheck disable=SC2169
 set -e
 
-projects=("Libplanet" "Libplanet.RocksDBStore")
-configuration=Release
+# shellcheck source=constants.sh
+. "$(dirname "$0")/constants.sh"
 
 if [ "$GITHUB_REPOSITORY" = "" ] | [ "$GITHUB_REF" = "" ]; then
   echo "This script is intended to be run by GitHub Actions." > /dev/stderr

--- a/.github/bin/dist-github-release.sh
+++ b/.github/bin/dist-github-release.sh
@@ -53,18 +53,11 @@ if command -v apk; then
   update-ca-certificates
 fi
 
-wget -O /tmp/github-release.tar.bz2 \
-  https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2
-tar xvfj /tmp/github-release.tar.bz2 -C /tmp
-rm /tmp/github-release.tar.bz2 \
-
 # Fill the description on GitHub releases with the release note
 github_user="${GITHUB_REPOSITORY%/*}"
 github_repo="${GITHUB_REPOSITORY#*/}"
 
-export PATH="/tmp/bin/linux/amd64:$PATH"
-
-github-release release \
+"$(dirname "$0")/github-release.sh" release \
   --user "$github_user" \
   --repo "$github_repo" \
   --tag "$tag" \
@@ -73,12 +66,10 @@ github-release release \
 
 for project in "${projects[@]}"; do
   nupkg_path="./$project/bin/$configuration/$project.$tag.nupkg"
-  github-release upload \
+  "$(dirname "$0")/github-release.sh" upload \
     --user "$github_user" \
     --repo "$github_repo" \
     --tag "$tag" \
     --name "$(basename "$nupkg_path")" \
     --file "$nupkg_path"
 done
-
-rm /tmp/bin/linux/amd64/github-release

--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -3,8 +3,8 @@
 # Note that this script is intended to be run by GitHub Actions.
 set -e
 
-projects=("Libplanet" "Libplanet.RocksDBStore")
-configuration=Release
+# shellcheck source=constants.sh
+. "$(dirname "$0")/constants.sh"
 
 if [ ! -f obj/package_version.txt ]; then
   {

--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -3,8 +3,8 @@
 # Note that this script is intended to be run by GitHub Actions.
 set -e
 
-projects=("Libplanet" "Libplanet.RocksDBStore")
-configuration=Release
+# shellcheck source=constants.sh
+. "$(dirname "$0")/constants.sh"
 
 if ! (env | grep '^GITHUB_'); then
   echo "This script is intended to be run by GitHub Actions." > /dev/stderr

--- a/.github/bin/github-release.sh
+++ b/.github/bin/github-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Invoke github-release <https://github.com/aktau/github-release>.
+set -e
+
+if [[ ! -f /tmp/bin/linux/amd64/github-release ]]; then
+  wget -O /tmp/github-release.tar.bz2 \
+    https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2
+  tar xvfj /tmp/github-release.tar.bz2 -C /tmp
+  rm /tmp/github-release.tar.bz2
+fi
+
+/tmp/bin/linux/amd64/github-release "$@"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,16 @@ jobs:
         name: dist-obj
         path: obj/
     - run: .github/bin/dist-pack.sh
+    - run: |
+        . .github/bin/constants.sh
+        mkdir -p /tmp/dist-bin/
+        for project in "${projects[@]}"; do
+          cp -r "$project/bin/$configuration"/* /tmp/dist-bin/
+        done
     - uses: actions/upload-artifact@master
       with:
         name: dist-bin
-        path: Libplanet/bin/Release/
+        path: /tmp/dist-bin/
     - if: >-
         github.event_name != 'pull_request' &&
         startsWith(github.ref, 'refs/tags/')
@@ -80,3 +86,32 @@ jobs:
           --url="$(cat Docs/obj/url.txt)"
           --token="$GH_CHECK_STATUS_TOKEN"
       if: github.event_name != 'pull_request'
+
+  bundle:
+    name: bundle
+    needs: [build]
+    runs-on: ubuntu-18.04
+    steps:
+    - run: sudo apt-get install nuget
+    - uses: actions/checkout@master
+      if: github.event_name != 'pull_request'
+    - uses: actions/checkout@master
+      if: github.event_name == 'pull_request'
+      with:
+        ref: ${{ github.pull_request.head.sha }}
+    - uses: actions/download-artifact@master
+      with:
+        name: dist-bin
+        path: /tmp/nupkg
+    - run: |
+        targets=(netcoreapp3.1 net472 net462 net461)
+        for target in "${targets[@]}"; do
+          find /tmp/nupkg \
+            -name '*.nupkg' \
+            -exec .github/bin/bundle.sh {} /tmp/bundles "$target" ';'
+        done
+      shell: bash
+    - uses: actions/upload-artifact@master
+      with:
+        name: bundles
+        path: /tmp/bundles

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,3 +115,20 @@ jobs:
       with:
         name: bundles
         path: /tmp/bundles
+    - if: >-
+        github.event_name != 'pull_request' &&
+        startsWith(github.ref, 'refs/tags/')
+      run: |
+        tag="${GITHUB_REF#refs/*/}"
+        github_user="${GITHUB_REPOSITORY%/*}"
+        github_repo="${GITHUB_REPOSITORY#*/}"
+        for bundle in /tmp/bundles/*; do
+          .github/bin/github-release.sh upload \
+            --user "$github_user" \
+            --repo "$github_repo" \
+            --tag "$tag" \
+            --name "$(basename "$bundle")" \
+            --file "$bundle"
+        done
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For development environments that cannot leverage NuGet like Unity, distribute all-in-one bundles that include all referenced assemblies including Libplanet in itself.

Bundles are an archive file which consists of all required assemblies (*\*.dll*) for a target framework.  Currently 4 target frameworks are supported:

<https://github.com/planetarium/libplanet/blob/4db8cd603325f75d57445a417d568cb409f07382/.github/workflows/main.yml#L107>

There are 2 types of bundle packages: *Libplanet* & *Libplanet.RocksDBStore*.  A *Libplanet.RocksDBStore* bundle consists of all assemblies in a *Libplanet* bundle with RocksDB-related assemblies.

For every push (and pull request), 2 packages × 4 target frameworks = 8 bundles are made in GitHub Actions, and these are uploaded as a single artifact named *bundles*.  You could check how bundles look like in the following GitHub Actions artifact:

<https://github.com/dahlia/libplanet/suites/499499235/artifacts/2529016>

For tag pushes, these bundles are also uploaded to GitHub Actions besides *\*.nupkg* files:

![](https://user-images.githubusercontent.com/12431/75922682-d63b1600-5ea6-11ea-8aa6-b833990a3385.png)