### PR TITLE
Fix a bug where nupkg is not submitted to NuGet

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -27,12 +27,10 @@ if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ] || (
     [ "$GITHUB_REF" != refs/heads/master ] &&
     [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ] ); then
   function dotnet-nuget {
-    shift
     echo "DRY-RUN: dotnet nuget" "$@"
   }
 else
   function dotnet-nuget {
-    shift
     dotnet nuget "$@"
   }
 fi


### PR DESCRIPTION
This patch fixes a bug, where nupkg is not submitted to NuGet Gallery, made by my previous PR #809.  In Bash, `$@` does not contain `$0` from the outset, so `shift` is unnecessary.