### PR TITLE
Replace StagedTx to use RocksDB

### DIFF
--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -348,8 +348,8 @@ namespace Libplanet.RocksDBStore
             byte[] prefix = StagedTxKeyPrefix;
             foreach (var it in IterateDb(_stagedTxDb, prefix))
             {
-                var key = it.Key();
-                var txIdBytes = key.Skip(prefix.Length).ToArray();
+                byte[] key = it.Key();
+                byte[] txIdBytes = key.Skip(prefix.Length).ToArray();
                 yield return new TxId(txIdBytes);
             }
         }

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -325,7 +325,7 @@ namespace Libplanet.RocksDBStore
         /// <inheritdoc/>
         public override void StageTransactionIds(IImmutableSet<TxId> txids)
         {
-            foreach (var txId in txids)
+            foreach (TxId txId in txids)
             {
                 byte[] key = StagedTxKey(txId);
                 _stagedTxDb.Put(key, EmptyBytes);
@@ -335,7 +335,7 @@ namespace Libplanet.RocksDBStore
         /// <inheritdoc/>
         public override void UnstageTransactionIds(ISet<TxId> txids)
         {
-            foreach (var txId in txids)
+            foreach (TxId txId in txids)
             {
                 byte[] key = StagedTxKey(txId);
                 _stagedTxDb.Remove(key);


### PR DESCRIPTION
This replaces to use RocksDB for staged transactions in Libplanet.RocksDBStore and split tx and state from block database.