### PR TITLE
Fix `Swarm<T>` halting 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,10 @@ To be released.
  -  Added `IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null`
     parameter to `Swarm()` constructor.  [[#266], [#815]]
  -  Removed `DifferentProtocolVersionEventArgs` class.  [[#266], [#815]]
+ -  Replaced `BlockChain<T>.StageTransactions()` with `.StageTransaction()`
+    that receives only one transaction.  [[#820]]
+ -  Replaced `BlockChain<T>.UnstageTransactions()` with `.UnstageTransaction()`
+    that receives only one transaction.  [[#820]]
 
 ### Backward-incompatible network protocol changes
 
@@ -100,6 +104,8 @@ To be released.
  -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that temporary chain IDs
     in the store had been completely cleaned up in some corner cases
     if `cancellationToken` was requested.  [[#798]]
+ -  Fixed a bug where `Swarm<T>` had crashed if it received invalid
+    `Transaction<T>` from the nodes.  [[#820]]
 
 [#266]: https://github.com/planetarium/libplanet/issues/266
 [#707]: https://github.com/planetarium/libplanet/pull/707
@@ -113,6 +119,7 @@ To be released.
 [#802]: https://github.com/planetarium/libplanet/pull/802
 [#803]: https://github.com/planetarium/libplanet/pull/803
 [#815]: https://github.com/planetarium/libplanet/pull/815
+[#820]: https://github.com/planetarium/libplanet/pull/820
 
 
 Version 0.8.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -96,7 +96,8 @@ namespace Libplanet.Tests.Blockchain
                     new DumbAction[] { }),
             };
 
-            _blockChain.StageTransactions(txs.ToImmutableHashSet());
+            StageTransactions(txs);
+
             Block<DumbAction> block = await _blockChain.MineBlock(_fx.Address1);
 
             Assert.True(_blockChain.ContainsBlock(block.Hash));
@@ -165,7 +166,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void StageTransactions()
+        public void StageTransaction()
         {
             var txs = new HashSet<Transaction<DumbAction>>()
             {
@@ -174,7 +175,8 @@ namespace Libplanet.Tests.Blockchain
             };
             Assert.Empty(txs.Where(tx => _fx.Store.ContainsTransaction(tx.Id)));
 
-            _blockChain.StageTransactions(txs.ToImmutableHashSet());
+            StageTransactions(txs);
+
             Assert.Equal(
                 txs,
                 txs.Where(tx => _fx.Store.ContainsTransaction(tx.Id)).ToHashSet()
@@ -182,19 +184,21 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void UnstageTransactions()
+        public void UnstageTransaction()
         {
             Assert.Empty(_blockChain.GetStagedTransactionIds());
-            var txs = new HashSet<Transaction<DumbAction>>()
-            {
-                _fx.Transaction1,
-                _fx.Transaction2,
-            };
-            _blockChain.StageTransactions(txs.ToImmutableHashSet());
-            HashSet<TxId> txIds = txs.Select(tx => tx.Id).ToHashSet();
+
+            _blockChain.StageTransaction(_fx.Transaction1);
+            _blockChain.StageTransaction(_fx.Transaction2);
+
+            HashSet<TxId> txIds = new[] { _fx.Transaction1.Id, _fx.Transaction2.Id }.ToHashSet();
             HashSet<TxId> stagedTxIds = _blockChain.GetStagedTransactionIds().ToHashSet();
+
             Assert.Equal(txIds, stagedTxIds);
-            _blockChain.UnstageTransactions(txs);
+
+            _blockChain.UnstageTransaction(_fx.Transaction1);
+            _blockChain.UnstageTransaction(_fx.Transaction2);
+
             Assert.Empty(_blockChain.GetStagedTransactionIds());
         }
 
@@ -235,9 +239,7 @@ namespace Libplanet.Tests.Blockchain
                 store,
                 genesisBlock
             );
-            chain.StageTransactions(
-                ImmutableHashSet<Transaction<PolymorphicAction<BaseAction>>>.Empty.Add(tx1)
-            );
+            chain.StageTransaction(tx1);
             await chain.MineBlock(_fx.Address1);
 
             IValue state = chain.GetState(_fx.Address1);
@@ -264,9 +266,7 @@ namespace Libplanet.Tests.Blockchain
                 actions2
             );
 
-            chain.StageTransactions(
-                ImmutableHashSet<Transaction<PolymorphicAction<BaseAction>>>.Empty.Add(tx2)
-            );
+            chain.StageTransaction(tx2);
             await chain.MineBlock(_fx.Address1);
 
             state = chain.GetState(_fx.Address1);
@@ -286,9 +286,7 @@ namespace Libplanet.Tests.Blockchain
                     },
                 }
             );
-            chain.StageTransactions(
-                ImmutableHashSet<Transaction<PolymorphicAction<BaseAction>>>.Empty.Add(tx3)
-            );
+            chain.StageTransaction(tx3);
             await chain.MineBlock(_fx.Address1);
             state = chain.GetState(_fx.Address1);
 
@@ -480,7 +478,9 @@ namespace Libplanet.Tests.Blockchain
                     blockInterval: TimeSpan.FromSeconds(10));
                 _blockChain.Append(block1);
                 Assert.Empty(_blockChain.GetStagedTransactionIds());
-                _blockChain.StageTransactions(txs.ToImmutableHashSet());
+
+                StageTransactions(txs);
+
                 Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
                 Block<DumbAction> block2 = TestUtils.MineNext(
@@ -491,7 +491,7 @@ namespace Libplanet.Tests.Blockchain
                 );
                 _blockChain.Append(block2);
                 Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
-                _blockChain.StageTransactions(txs.ToImmutableHashSet());
+                StageTransactions(txs);
                 Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
 
                 var actions = new[] { new DumbAction(addresses[0], "foobar") };
@@ -499,7 +499,7 @@ namespace Libplanet.Tests.Blockchain
                 {
                     _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
                 };
-                _blockChain.StageTransactions(txs2.ToImmutableHashSet());
+                StageTransactions(txs2);
                 Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
                 Block<DumbAction> block3 = TestUtils.MineNext(
@@ -1461,9 +1461,7 @@ namespace Libplanet.Tests.Blockchain
                 new BlockPolicy<TestEvaluateAction>(),
                 store
             );
-            chain.StageTransactions(
-                ImmutableHashSet<Transaction<TestEvaluateAction>>.Empty.Add(tx1)
-            );
+            chain.StageTransaction(tx1);
             await chain.MineBlock(_fx.Address1);
 
             Assert.Equal(
@@ -1508,7 +1506,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 2),
             };
 
-            _blockChain.StageTransactions(txsB.ToImmutableHashSet());
+            StageTransactions(txsB);
 
             Assert.Equal(3, _blockChain.GetNextTxNonce(address));
 
@@ -1517,7 +1515,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 3),
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 3),
             };
-            _blockChain.StageTransactions(txsC.ToImmutableHashSet());
+            StageTransactions(txsC);
 
             Assert.Equal(4, _blockChain.GetNextTxNonce(address));
 
@@ -1525,7 +1523,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 5),
             };
-            _blockChain.StageTransactions(txsD.ToImmutableHashSet());
+            StageTransactions(txsD);
 
             Assert.Equal(4, _blockChain.GetNextTxNonce(address));
 
@@ -1535,7 +1533,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 5),
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 7),
             };
-            _blockChain.StageTransactions(txsE.ToImmutableHashSet());
+            StageTransactions(txsE);
 
             Assert.Equal(6, _blockChain.GetNextTxNonce(address));
         }
@@ -1553,7 +1551,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
             };
 
-            _blockChain.StageTransactions(txs.ToImmutableHashSet());
+            StageTransactions(txs);
             await _blockChain.MineBlock(address);
 
             Transaction<DumbAction>[] staleTxs =
@@ -1561,7 +1559,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
             };
-            _blockChain.StageTransactions(staleTxs.ToImmutableHashSet());
+            StageTransactions(staleTxs);
 
             Assert.Equal(2, _blockChain.GetNextTxNonce(address));
 
@@ -2077,7 +2075,7 @@ namespace Libplanet.Tests.Blockchain
                 .Select(nonce => _fx.MakeTransaction(
                     nonce: nonce, privateKey: privateKey, timestamp: DateTimeOffset.Now))
                 .ToArray();
-            _blockChain.StageTransactions(txsA.ToImmutableHashSet());
+            StageTransactions(txsA);
             Block<DumbAction> b1 = await _blockChain.MineBlock(address);
             Assert.Equal(txsA, b1.Transactions);
 
@@ -2085,12 +2083,20 @@ namespace Libplanet.Tests.Blockchain
                 .Select(nonce => _fx.MakeTransaction(
                     nonce: nonce, privateKey: privateKey, timestamp: DateTimeOffset.Now))
                 .ToArray();
-            _blockChain.StageTransactions(txsB.ToImmutableHashSet());
+            StageTransactions(txsB);
 
             // Mine only txs having higher or equal with nonce than expected nonce.
             Block<DumbAction> b2 = await _blockChain.MineBlock(address);
             Assert.Single(b2.Transactions);
             Assert.Contains(txsB[3], b2.Transactions);
+        }
+
+        private void StageTransactions(IEnumerable<Transaction<DumbAction>> txs)
+        {
+            foreach (Transaction<DumbAction> tx in txs)
+            {
+                _blockChain.StageTransaction(tx);
+            }
         }
 
         private sealed class TestEvaluateAction : IAction

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -186,12 +186,16 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void UnstageTransaction()
         {
+            Transaction<DumbAction>[] txs = new[]
+            {
+                _fx.Transaction1,
+                _fx.Transaction2,
+            };
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
-            _blockChain.StageTransaction(_fx.Transaction1);
-            _blockChain.StageTransaction(_fx.Transaction2);
+            StageTransactions(txs);
 
-            HashSet<TxId> txIds = new[] { _fx.Transaction1.Id, _fx.Transaction2.Id }.ToHashSet();
+            HashSet<TxId> txIds = txs.Select(tx => tx.Id).ToHashSet();
             HashSet<TxId> stagedTxIds = _blockChain.GetStagedTransactionIds().ToHashSet();
 
             Assert.Equal(txIds, stagedTxIds);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -635,7 +635,7 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 new DumbAction[0]
             );
-            chainB.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
+            chainB.StageTransaction(tx);
             await chainB.MineBlock(_fx1.Address1);
 
             try
@@ -678,7 +678,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[] { }
             );
 
-            chainA.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
+            chainA.StageTransaction(tx);
             await chainA.MineBlock(_fx1.Address1);
 
             try
@@ -775,7 +775,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[] { }
             );
 
-            chainA.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
+            chainA.StageTransaction(tx);
 
             try
             {
@@ -832,8 +832,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[] { }
             );
 
-            blockChains[size - 1]
-                .StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
+            blockChains[size - 1].StageTransaction(tx);
 
             try
             {
@@ -2380,15 +2379,12 @@ namespace Libplanet.Tests.Net
 
             foreach (var i in Enumerable.Range(0, 8))
             {
-                miner1.BlockChain.StageTransactions(
-                    new[]
-                    {
-                        Transaction<Sleep>.Create(
-                            0,
-                            new PrivateKey(),
-                            actions: new[] { new Sleep() }
-                        ),
-                    }.ToImmutableHashSet()
+                miner1.BlockChain.StageTransaction(
+                    Transaction<Sleep>.Create(
+                        0,
+                        new PrivateKey(),
+                        actions: new[] { new Sleep() }
+                    )
                 );
                 var b = await miner1.BlockChain.MineBlock(miner1.Address);
                 miner2.BlockChain.Append(b);
@@ -2448,8 +2444,7 @@ namespace Libplanet.Tests.Net
 
                 if (!restage)
                 {
-                    minerB.BlockChain.StageTransactions(
-                        ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(txA));
+                    minerB.BlockChain.StageTransaction(txA);
                 }
 
                 Log.Debug("Make minerB's chain longer than minerA's chain.");
@@ -2788,10 +2783,8 @@ namespace Libplanet.Tests.Net
                     new PrivateKey(),
                     new DumbAction[] { }
                 );
-                sender1.BlockChain.StageTransactions(
-                    ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
-                sender2.BlockChain.StageTransactions(
-                    ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx));
+                sender1.BlockChain.StageTransaction(tx);
+                sender2.BlockChain.StageTransaction(tx);
 
                 // Make sure that receiver swarm only filled once for same transaction
                 // that were broadcasted simultaneously.

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1111,11 +1111,11 @@ namespace Libplanet.Tests.Store
                     2,
                     privKey,
                     new[] { new DumbAction(fx.Address1, "item2") });
-                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx1));
+                blocks.StageTransaction(tx1);
                 var block1 = await blocks.MineBlock(fx.Address2);
-                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx2));
+                blocks.StageTransaction(tx2);
                 var block2 = await blocks.MineBlock(fx.Address2);
-                blocks.StageTransactions(ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(tx3));
+                blocks.StageTransaction(tx3);
                 var block3 = await blocks.MineBlock(fx.Address2);
                 Assert.Equal(
                     (Text)"item0",

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -540,7 +540,7 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Removes <paramref name="transaction"/> from the pending list.
+        /// Removes a <paramref name="transaction"/> from the pending list.
         /// </summary>
         /// <param name="transaction">A <see cref="Transaction{T}"/>
         /// to remove from the pending list.</param>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2150,9 +2150,13 @@ namespace Libplanet.Net
                         $"Some tasks faulted during {nameof(GetTxsAsync)}().");
                 }
 
-                foreach (var task in tasks.Where(task => !task.IsFaulted))
+                foreach (Task<List<Transaction<T>>> task in tasks)
                 {
-                    txs.AddRange(task.Result);
+                    if (!task.IsFaulted)
+                    {
+                        // `task.Result` is okay because we've already waited.
+                        txs.AddRange(task.Result);
+                    }
                 }
 
                 foreach (Transaction<T> tx in txs)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2155,7 +2155,22 @@ namespace Libplanet.Net
                     txs.AddRange(task.Result);
                 }
 
-                BlockChain.StageTransactions(txs.ToImmutableHashSet());
+                foreach (Transaction<T> tx in txs)
+                {
+                    try
+                    {
+                        BlockChain.StageTransaction(tx);
+                    }
+                    catch (InvalidTxException ite)
+                    {
+                        _logger.Error(
+                            ite,
+                            "{TxId} will not be staged since it is invalid.",
+                            tx.Id
+                        );
+                    }
+                }
+
                 TxReceived.Set();
                 _logger.Debug(
                     "Txs staged successfully: {@txIds}",


### PR DESCRIPTION
This PR fixes a bug where `Swarm<T>` had stopped if received invalid tx from the network.

To fix it, I changed some API in `BlockChain<T>`.

- `StageTransactions()` → `StageTransaction()`
- `UnstageTransactions()` → `UnstageTransaction()`