### PR TITLE
Fix RocksDBStore ForkBlockIndex

### DIFF
--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -248,14 +248,21 @@ namespace Libplanet.RocksDBStore
             Guid destinationChainId,
             HashDigest<SHA256> branchPoint)
         {
-            foreach (HashDigest<SHA256> hash in IterateIndexes(sourceChainId, 0, null))
+            var genesisHash = IterateIndexes(sourceChainId, 0, 1).First();
+
+            if (branchPoint.Equals(genesisHash))
             {
+                return;
+            }
+
+            foreach (HashDigest<SHA256> hash in IterateIndexes(sourceChainId, 1, null))
+            {
+                AppendIndex(destinationChainId, hash);
+
                 if (hash.Equals(branchPoint))
                 {
                     break;
                 }
-
-                AppendIndex(destinationChainId, hash);
             }
         }
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -248,9 +248,11 @@ namespace Libplanet.RocksDBStore
             Guid destinationChainId,
             HashDigest<SHA256> branchPoint)
         {
-            var genesisHash = IterateIndexes(sourceChainId, 0, 1).First();
+            HashDigest<SHA256>? genesisHash = IterateIndexes(sourceChainId, 0, 1)
+                .Cast<HashDigest<SHA256>?>()
+                .FirstOrDefault();
 
-            if (branchPoint.Equals(genesisHash))
+            if (genesisHash is null || branchPoint.Equals(genesisHash))
             {
                 return;
             }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1037,6 +1037,41 @@ namespace Libplanet.Tests.Store
             }
         }
 
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [SkippableTheory]
+        public void ForkBlockIndex(int branchPointIndex)
+        {
+            var store = Fx.Store;
+
+            var blocks = new BlockChain<DumbAction>(
+                new NullPolicy<DumbAction>(),
+                store,
+                Fx.GenesisBlock
+            );
+
+            blocks.Append(Fx.Block1);
+            blocks.Append(Fx.Block2);
+            blocks.Append(Fx.Block3);
+
+            var forked = new BlockChain<DumbAction>(
+                new NullPolicy<DumbAction>(),
+                store,
+                Guid.NewGuid(),
+                Fx.GenesisBlock
+            );
+
+            store.ForkBlockIndexes(blocks.Id, forked.Id, blocks[branchPointIndex].Hash);
+
+            Assert.Equal(
+                store.IterateIndexes(blocks.Id, 0, branchPointIndex + 1).ToList(),
+                store.IterateIndexes(forked.Id).ToList()
+            );
+
+            Assert.Equal(branchPointIndex + 1, store.CountIndex(forked.Id));
+        }
+
         [SkippableFact]
         public void Copy()
         {

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -256,13 +256,19 @@ namespace Libplanet.Store
             LiteCollection<HashDoc> srcColl = IndexCollection(sourceChainId);
             LiteCollection<HashDoc> destColl = IndexCollection(destinationChainId);
 
-            var genesisHash = IterateIndexes(sourceChainId, 0, 1).First();
+            HashDigest<SHA256>? genesisHash = IterateIndexes(sourceChainId, 0, 1)
+                .Cast<HashDigest<SHA256>?>()
+                .FirstOrDefault();
+
+            if (genesisHash is null || branchPoint.Equals(genesisHash))
+            {
+                return;
+            }
+
             destColl.InsertBulk(srcColl.FindAll()
                 .TakeWhile(i => !i.Hash.Equals(branchPoint)).Skip(1));
-            if (!branchPoint.Equals(genesisHash))
-            {
-                AppendIndex(destinationChainId, branchPoint);
-            }
+
+            AppendIndex(destinationChainId, branchPoint);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This fixes `RocksDBStore.ForkBlockIndex()` method and adds `StoreTest.ForkBlockIndex`.