### PR TITLE
Do not run upstream specific workfolows in forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ name: main
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || github.repository == 'planetarium/libplanet'
     name: dist
     runs-on: ubuntu-18.04
     steps:
@@ -47,12 +48,13 @@ jobs:
       run: .github/bin/dist-github-release.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - if: github.event_name != 'pull_request'
+    - if: github.event_name != 'pull_request' && env.NUGET_API_KEY != ''
       run: .github/bin/dist-nuget.sh
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   docs:
+    if: github.event_name != 'schedule' || github.repository == 'planetarium/libplanet'
     name: docs
     runs-on: ubuntu-18.04
     steps:
@@ -85,7 +87,7 @@ jobs:
           --state=success
           --url="$(cat Docs/obj/url.txt)"
           --token="$GH_CHECK_STATUS_TOKEN"
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && env.GH_CHECK_STATUS_TOKEN != ''
 
   bundle:
     name: bundle


### PR DESCRIPTION
This PR changes the scheduled jobs and publishing artifact to be allowed only upstream. It was motivated by nightly builds on my forked repo that trigger email notifications for failed runs.