### PR TITLE
Update .editorconfig for YAML config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,3 +41,7 @@ quote_type = double
 
 [*.sln]
 indent_style = tab
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR forces 2 spaces indent on YAML config file. Previously it forces 4 spaces for indent and 8 spaces for tab while using VS Code. 
 Since there is no requirement for indent size in YAML spec—see [SO](https://stackoverflow.com/a/42248984)—, but I think it might be better to specify an indent size in a`.editorconfig`.