### PR TITLE
AppProtocolVersion tokens & PrivateKey.ToAddress()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,8 @@ To be released.
 
 ### Added APIs
 
+ -  Added `AddressExtensions.ToAddress(this PrivateKey)` overloaded extension
+    method.  [[#825]]
  -  Added `BlockHashDownloadState` class, a subclass of `PreloadState`.
     [[#707], [#798]]
  -  Added `BlockVerificationState` class, a subclass of `PreloadState`.
@@ -120,6 +122,7 @@ To be released.
 [#803]: https://github.com/planetarium/libplanet/pull/803
 [#815]: https://github.com/planetarium/libplanet/pull/815
 [#820]: https://github.com/planetarium/libplanet/pull/820
+[#825]: https://github.com/planetarium/libplanet/pull/825
 
 
 Version 0.8.0

--- a/Libplanet.Benchmarks/MineBlock.cs
+++ b/Libplanet.Benchmarks/MineBlock.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Benchmarks
         public void MakeOneTransactionWithActions()
         {
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            var address = privateKey.ToAddress();
             var actions = new[]
             {
                 new DumbAction(address, "foo"),
@@ -84,7 +84,7 @@ namespace Libplanet.Benchmarks
             for (var i = 0; i < 10; i++)
             {
                 var privateKey = new PrivateKey();
-                var address = privateKey.PublicKey.ToAddress();
+                var address = privateKey.ToAddress();
                 var actions = new[]
                 {
                     new DumbAction(address, "foo"),

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -14,7 +14,7 @@ namespace Libplanet.Tests.Action
 
         public AccountStateDeltaImplTest()
         {
-            Address Addr() => new PrivateKey().PublicKey.ToAddress();
+            Address Addr() => new PrivateKey().ToAddress();
 
             _addr = new[]
             {

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void Constructor()
         {
-            Address address = new PrivateKey().PublicKey.ToAddress();
+            Address address = new PrivateKey().ToAddress();
             var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void PlainValue()
         {
-            var addr = new PrivateKey().PublicKey.ToAddress();
+            var addr = new PrivateKey().ToAddress();
             var pa = new PolymorphicAction<BaseAction>(
                 new Attack
                 {
@@ -39,7 +39,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void LoadPlainValue()
         {
-            var addr = new PrivateKey().PublicKey.ToAddress();
+            var addr = new PrivateKey().ToAddress();
 #pragma warning disable 612
             var pa = new PolymorphicAction<BaseAction>();
 #pragma warning restore 612
@@ -66,7 +66,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void ImplicitlyCastFromInnerActionType()
         {
-            var addr = new PrivateKey().PublicKey.ToAddress();
+            var addr = new PrivateKey().ToAddress();
             var a = new Attack
             {
                 Weapon = "frying pan",

--- a/Libplanet.Tests/AddressExtensionsTest.cs
+++ b/Libplanet.Tests/AddressExtensionsTest.cs
@@ -6,14 +6,19 @@ namespace Libplanet.Tests
     public class AddressExtensionsTest
     {
         [Fact]
-        public void CanGetAddress()
+        public void ToAddress()
         {
-            PublicKey key = new PublicKey(ByteUtil.ParseHex(
-                "03438b935389a7ebf838b3ae4125bd28506aa2dd457f20afc843729d3e7d60d728"));
-            Assert.Equal(
-                new Address("d41fadf61badf5be2de60e9fc3230c0a8a4390f0"),
-                key.ToAddress()
+            var privateKey = new PrivateKey(
+                new byte[]
+                {
+                    0xbe, 0xe6, 0xf9, 0xcc, 0x62, 0x41, 0x27, 0x60, 0xb3, 0x69, 0x6e,
+                    0x05, 0xf6, 0xfb, 0x4a, 0xbe, 0xb9, 0xe8, 0x3c, 0x4f, 0x94, 0x4f,
+                    0x83, 0xfd, 0x62, 0x08, 0x1b, 0x74, 0x54, 0xcb, 0xc0, 0x38,
+                }
             );
+            var expected = new Address("f45A22dD63f6428e85eE0a6E13a763278f57626d");
+            Assert.Equal(expected, privateKey.ToAddress());
+            Assert.Equal(expected, privateKey.PublicKey.ToAddress());
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -708,7 +708,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var miner = _fx.Address1;
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            var address = privateKey.ToAddress();
             var actions1 = new[] { new DumbAction(address, "foo") };
             var actions2 = new[] { new DumbAction(address, "bar") };
 
@@ -733,8 +733,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void ForkStateReferences()
         {
-            Address addr1 = new PrivateKey().PublicKey.ToAddress();
-            Address addr2 = new PrivateKey().PublicKey.ToAddress();
+            Address addr1 = new PrivateKey().ToAddress();
+            Address addr2 = new PrivateKey().ToAddress();
 
             var actions1 = new[] { new DumbAction(addr1, "foo") };
             var actions2 = new[] { new DumbAction(addr2, "bar") };
@@ -912,12 +912,12 @@ namespace Libplanet.Tests.Blockchain
         {
             // An active account, so that its some recent transactions became "stale" due to a fork.
             var privateKey = new PrivateKey();
-            Address address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.ToAddress();
 
             // An inactive account, so that it has no recent transactions but only an old
             // transaction, so that its all transactions are stale-proof (stale-resistant).
             var lessActivePrivateKey = new PrivateKey();
-            Address lessActiveAddress = lessActivePrivateKey.PublicKey.ToAddress();
+            Address lessActiveAddress = lessActivePrivateKey.ToAddress();
 
             var actions = new[] { new DumbAction(address, "foo") };
 
@@ -1185,7 +1185,7 @@ namespace Libplanet.Tests.Blockchain
             for (int i = 0; i < addresses.Length; ++i)
             {
                 var privateKey = new PrivateKey();
-                Address address = privateKey.PublicKey.ToAddress();
+                Address address = privateKey.ToAddress();
                 addresses[i] = address;
                 DumbAction[] actions =
                 {
@@ -1236,7 +1236,7 @@ namespace Libplanet.Tests.Blockchain
             }
 
             tracker.ClearLogs();
-            Address nonexistent = new PrivateKey().PublicKey.ToAddress();
+            Address nonexistent = new PrivateKey().ToAddress();
             IValue result = chain.GetState(nonexistent);
             Assert.Null(result);
             var callCount = tracker.Logs.Where(
@@ -1377,7 +1377,7 @@ namespace Libplanet.Tests.Blockchain
         public async void GetStateReturnsLatestStatesWhenMultipleAddresses()
         {
             var privateKeys = Enumerable.Range(1, 10).Select(_ => new PrivateKey()).ToList();
-            var addresses = privateKeys.Select(k => k.PublicKey.ToAddress()).ToList();
+            var addresses = privateKeys.Select(AddressExtensions.ToAddress).ToList();
             var chain = new BlockChain<DumbAction>(
                 new NullPolicy<DumbAction>(),
                 _fx.Store,
@@ -1450,7 +1450,7 @@ namespace Libplanet.Tests.Blockchain
         public async void EvaluateActions()
         {
             PrivateKey fromPrivateKey = new PrivateKey();
-            Address fromAddress = fromPrivateKey.PublicKey.ToAddress();
+            Address fromAddress = fromPrivateKey.ToAddress();
             long blockIndex = 1;
 
             TestEvaluateAction action = new TestEvaluateAction();
@@ -1483,7 +1483,7 @@ namespace Libplanet.Tests.Blockchain
         public void GetNextTxNonce()
         {
             var privateKey = new PrivateKey();
-            Address address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.ToAddress();
             var actions = new[] { new DumbAction(_fx.Address1, "foo") };
             var genesis = _blockChain.Genesis;
 
@@ -1546,7 +1546,7 @@ namespace Libplanet.Tests.Blockchain
         public async Task GetNextTxNonceWithStaleTx()
         {
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            var address = privateKey.ToAddress();
             var actions = new[] { new DumbAction(address, "foo") };
 
             Transaction<DumbAction>[] txs =
@@ -1626,7 +1626,7 @@ namespace Libplanet.Tests.Blockchain
         public void MakeTransaction()
         {
             var privateKey = new PrivateKey();
-            Address address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.ToAddress();
             var actions = new[] { new DumbAction(address, "foo") };
 
             _blockChain.MakeTransaction(privateKey, actions);
@@ -1655,7 +1655,7 @@ namespace Libplanet.Tests.Blockchain
         public async Task MakeTransactionConcurrency()
         {
             var privateKey = new PrivateKey();
-            Address address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.ToAddress();
             var actions = new[] { new DumbAction(address, "foo") };
 
             var tasks = Enumerable.Range(0, 10)
@@ -1680,10 +1680,10 @@ namespace Libplanet.Tests.Blockchain
         public async void MineBlockWithBlockAction()
         {
             var privateKey1 = new PrivateKey();
-            var address1 = privateKey1.PublicKey.ToAddress();
+            var address1 = privateKey1.ToAddress();
 
             var privateKey2 = new PrivateKey();
-            var address2 = privateKey2.PublicKey.ToAddress();
+            var address2 = privateKey2.ToAddress();
 
             var blockAction = new DumbAction(address1, "foo");
             BlockPolicy<DumbAction> policy = new BlockPolicy<DumbAction>(blockAction);
@@ -1818,7 +1818,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock
             );
             var privateKey = new PrivateKey();
-            Address signer = privateKey.PublicKey.ToAddress();
+            Address signer = privateKey.ToAddress();
 
             IImmutableDictionary<Address, IValue> GetDirty(
                 IEnumerable<ActionEvaluation> evaluations) =>
@@ -1845,7 +1845,7 @@ namespace Libplanet.Tests.Blockchain
                 GetDirty(b.Evaluate(DateTimeOffset.UtcNow, _ => null));
             const int accountsCount = 5;
             Address[] addresses = Enumerable.Repeat<object>(null, accountsCount)
-                .Select(_ => new PrivateKey().PublicKey.ToAddress())
+                .Select(_ => new PrivateKey().ToAddress())
                 .ToArray();
             for (int i = 0; i < 2; ++i)
             {
@@ -2074,7 +2074,7 @@ namespace Libplanet.Tests.Blockchain
         private async Task IgnoreLowerNonceTxsAndMine()
         {
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            var address = privateKey.ToAddress();
             var txsA = Enumerable.Range(0, 3)
                 .Select(nonce => _fx.MakeTransaction(
                     nonce: nonce, privateKey: privateKey, timestamp: DateTimeOffset.Now))
@@ -2105,14 +2105,9 @@ namespace Libplanet.Tests.Blockchain
 
         private sealed class TestEvaluateAction : IAction
         {
-            public static readonly Address SignerKey =
-                new PrivateKey().PublicKey.ToAddress();
-
-            public static readonly Address MinerKey =
-                new PrivateKey().PublicKey.ToAddress();
-
-            public static readonly Address BlockIndexKey =
-                new PrivateKey().PublicKey.ToAddress();
+            public static readonly Address SignerKey = new PrivateKey().ToAddress();
+            public static readonly Address MinerKey = new PrivateKey().ToAddress();
+            public static readonly Address BlockIndexKey = new PrivateKey().ToAddress();
 
             public TestEvaluateAction()
             {

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             // For transactions signed by the same signer, these should be ordered by its tx nonce.
-            Address[] signers = privKeys.Select(pk => pk.PublicKey.ToAddress()).ToArray();
+            Address[] signers = privKeys.Select(AddressExtensions.ToAddress).ToArray();
             foreach (Address signer in signers)
             {
                 IEnumerable<Transaction<DumbAction>> signersTxs =
@@ -380,7 +380,7 @@ namespace Libplanet.Tests.Blocks
         {
             RawTransaction rawTxWithoutSig = new RawTransaction(
                 0,
-                new PrivateKey().PublicKey.ToAddress().ByteArray,
+                new PrivateKey().ToAddress().ByteArray,
                 ImmutableArray<ImmutableArray<byte>>.Empty,
                 _fx.TxFixture.PublicKey1.Format(false).ToImmutableArray(),
                 DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),

--- a/Libplanet.Tests/KeyStore/ProtectedPrivateKeyTest.cs
+++ b/Libplanet.Tests/KeyStore/ProtectedPrivateKeyTest.cs
@@ -106,14 +106,8 @@ namespace Libplanet.Tests.KeyStore
         public void Unprotect()
         {
             Assert.Equal(AddressFixture, Fixture.Address);
-            Assert.Equal(
-                AddressFixture,
-                Fixture.Unprotect(PassphraseFixture).PublicKey.ToAddress()
-            );
-            Assert.Equal(
-                AddressFixture2,
-                Fixture2.Unprotect(PassphraseFixture).PublicKey.ToAddress()
-            );
+            Assert.Equal(AddressFixture, Fixture.Unprotect(PassphraseFixture).ToAddress());
+            Assert.Equal(AddressFixture2, Fixture2.Unprotect(PassphraseFixture).ToAddress());
             var incorrectPassphraseException = Assert.Throws<IncorrectPassphraseException>(
                 () => Fixture.Unprotect("wrong passphrase")
             );
@@ -816,7 +810,7 @@ namespace Libplanet.Tests.KeyStore
             // TODO: More decent tests should be written.
             ProtectedPrivateKey key = ProtectedPrivateKey.FromJson(json);
             Assert.Equal(AddressFixture, key.Address);
-            Assert.Equal(AddressFixture, key.Unprotect(PassphraseFixture).PublicKey.ToAddress());
+            Assert.Equal(AddressFixture, key.Unprotect(PassphraseFixture).ToAddress());
 
             using (var stream = new MemoryStream())
             {
@@ -826,7 +820,7 @@ namespace Libplanet.Tests.KeyStore
 
             ProtectedPrivateKey key2 = ProtectedPrivateKey.FromJson(json);
             Assert.Equal(AddressFixture2, key2.Address);
-            Assert.Equal(AddressFixture2, key2.Unprotect(PassphraseFixture).PublicKey.ToAddress());
+            Assert.Equal(AddressFixture2, key2.Unprotect(PassphraseFixture).ToAddress());
         }
     }
 }

--- a/Libplanet.Tests/Net/AppProtocolVersionTest.cs
+++ b/Libplanet.Tests/Net/AppProtocolVersionTest.cs
@@ -9,6 +9,43 @@ namespace Libplanet.Tests.Net
 {
     public class AppProtocolVersionTest
     {
+        public static readonly PrivateKey SignerFixture = new PrivateKey(new byte[]
+        {
+            0x45, 0x7a, 0xfa, 0x94, 0x17, 0x78, 0x6e, 0x0c, 0xff, 0x4b, 0xa2,
+            0x5b, 0x35, 0x95, 0xe1, 0xfb, 0x2a, 0x54, 0x39, 0xf9, 0x0e, 0xd2,
+            0x9d, 0x39, 0xdf, 0x54, 0x57, 0x9b, 0x13, 0xea, 0x7c, 0x0f,
+        });
+
+        private static readonly AppProtocolVersion ValidClaimFixture = new AppProtocolVersion(
+            version: 1,
+            extra: null,
+            signer: SignerFixture.PublicKey.ToAddress(),
+            signature: new byte[]
+            {
+                0x30, 0x45, 0x02, 0x21, 0x00, 0x89, 0x95, 0x9c, 0x59, 0x25, 0x83, 0x4e,
+                0xbc, 0x45, 0x59, 0xd7, 0x9b, 0xca, 0x82, 0x4a, 0x69, 0x20, 0xe5, 0x18,
+                0xf0, 0xc5, 0xad, 0xe2, 0xb9, 0xa3, 0xa3, 0xb3, 0x29, 0xbb, 0xa3, 0x3d,
+                0xd8, 0x02, 0x20, 0x1d, 0xcb, 0x88, 0xa1, 0x3a, 0x3c, 0x19, 0x2d, 0xe1,
+                0x9e, 0x39, 0xf6, 0x58, 0x05, 0xd4, 0x06, 0xbf, 0xb2, 0x93, 0xd1, 0x64,
+                0x85, 0x75, 0xa8, 0xa2, 0xcb, 0x9f, 0x95, 0xd9, 0x90, 0xb9, 0x51,
+            }.ToImmutableArray()
+        );
+
+        private static readonly AppProtocolVersion ValidClaimWExtraFixture = new AppProtocolVersion(
+            version: 123,
+            extra: (Bencodex.Types.Text)"foo",
+            signer: SignerFixture.PublicKey.ToAddress(),
+            signature: new byte[]
+            {
+                0x30, 0x44, 0x02, 0x20, 0x08, 0x5d, 0xd4, 0x4d, 0x2f, 0xa1, 0x57, 0xe0,
+                0x01, 0xca, 0x6f, 0xca, 0x98, 0x8d, 0x7a, 0x1d, 0x13, 0x74, 0xcb, 0xc9,
+                0x26, 0xca, 0x3b, 0xc3, 0xdf, 0x14, 0x3d, 0x37, 0xe2, 0xad, 0x04, 0x88,
+                0x02, 0x20, 0x16, 0xd4, 0xae, 0x72, 0x42, 0x31, 0x63, 0xe9, 0x73, 0x99,
+                0x50, 0x0b, 0xb9, 0x19, 0x49, 0xa1, 0xf2, 0xbb, 0x63, 0x20, 0x99, 0x5a,
+                0x77, 0xd2, 0x15, 0xfd, 0xbd, 0x59, 0x99, 0xec, 0x5c, 0x51,
+            }.ToImmutableArray()
+        );
+
         [Fact]
         public void Sign()
         {
@@ -35,49 +72,29 @@ namespace Libplanet.Tests.Net
         [Fact]
         public void Verify()
         {
-            var signer = new PrivateKey(new byte[]
-            {
-                0x45, 0x7a, 0xfa, 0x94, 0x17, 0x78, 0x6e, 0x0c, 0xff, 0x4b, 0xa2,
-                0x5b, 0x35, 0x95, 0xe1, 0xfb, 0x2a, 0x54, 0x39, 0xf9, 0x0e, 0xd2,
-                0x9d, 0x39, 0xdf, 0x54, 0x57, 0x9b, 0x13, 0xea, 0x7c, 0x0f,
-            });
-            PublicKey signerPublicKey = signer.PublicKey;
+            PublicKey signerPublicKey = SignerFixture.PublicKey;
             var otherParty = new PrivateKey();
             PublicKey otherPartyPublicKey = otherParty.PublicKey;
 
-            var validClaim = new AppProtocolVersion(
-                version: 1,
-                extra: null,
-                signer: signerPublicKey.ToAddress(),
-                signature: new byte[]
-                {
-                    0x30, 0x45, 0x02, 0x21, 0x00, 0x89, 0x95, 0x9c, 0x59, 0x25, 0x83, 0x4e,
-                    0xbc, 0x45, 0x59, 0xd7, 0x9b, 0xca, 0x82, 0x4a, 0x69, 0x20, 0xe5, 0x18,
-                    0xf0, 0xc5, 0xad, 0xe2, 0xb9, 0xa3, 0xa3, 0xb3, 0x29, 0xbb, 0xa3, 0x3d,
-                    0xd8, 0x02, 0x20, 0x1d, 0xcb, 0x88, 0xa1, 0x3a, 0x3c, 0x19, 0x2d, 0xe1,
-                    0x9e, 0x39, 0xf6, 0x58, 0x05, 0xd4, 0x06, 0xbf, 0xb2, 0x93, 0xd1, 0x64,
-                    0x85, 0x75, 0xa8, 0xa2, 0xcb, 0x9f, 0x95, 0xd9, 0x90, 0xb9, 0x51,
-                }.ToImmutableArray()
-            );
-            Assert.True(validClaim.Verify(signerPublicKey));
-            Assert.False(validClaim.Verify(otherPartyPublicKey));
+            Assert.True(ValidClaimFixture.Verify(signerPublicKey));
+            Assert.False(ValidClaimFixture.Verify(otherPartyPublicKey));
 
             // A signature is no more valid for a different version.
             var invalidVersionClaim = new AppProtocolVersion(
-                version: validClaim.Version + 1,
-                extra: validClaim.Extra,
-                signer: validClaim.Signer,
-                signature: validClaim.Signature
+                version: ValidClaimFixture.Version + 1,
+                extra: ValidClaimFixture.Extra,
+                signer: ValidClaimFixture.Signer,
+                signature: ValidClaimFixture.Signature
             );
             Assert.False(invalidVersionClaim.Verify(signerPublicKey));
             Assert.False(invalidVersionClaim.Verify(otherPartyPublicKey));
 
             // A signature is no more valid for a different extra data.
             var invalidExtraClaim = new AppProtocolVersion(
-                version: validClaim.Version,
+                version: ValidClaimFixture.Version,
                 extra: (Bencodex.Types.Text)"invalid extra",
-                signer: validClaim.Signer,
-                signature: validClaim.Signature
+                signer: ValidClaimFixture.Signer,
+                signature: ValidClaimFixture.Signature
             );
             Assert.False(invalidExtraClaim.Verify(signerPublicKey));
             Assert.False(invalidExtraClaim.Verify(otherPartyPublicKey));
@@ -85,10 +102,10 @@ namespace Libplanet.Tests.Net
             // If a signer field does not correspond to an actual private key which signed
             // a signature a claim is invalid even if a signature in itself is valid.
             var invalidSigner = new AppProtocolVersion(
-                version: validClaim.Version,
-                extra: validClaim.Extra,
+                version: ValidClaimFixture.Version,
+                extra: ValidClaimFixture.Extra,
                 signer: otherPartyPublicKey.ToAddress(),
-                signature: validClaim.Signature
+                signature: ValidClaimFixture.Signature
             );
             Assert.False(invalidSigner.Verify(signerPublicKey));
             Assert.False(invalidSigner.Verify(otherPartyPublicKey));
@@ -187,6 +204,88 @@ namespace Libplanet.Tests.Net
             AppProtocolVersion claimWithExtra =
                 AppProtocolVersion.Sign(signer, 456, (Bencodex.Types.Text)"extra");
             Assert.Equal("456 (Bencodex.Types.Text \"extra\")", claimWithExtra.ToString());
+        }
+
+        [Fact]
+        public void Token()
+        {
+            var expected =
+                "1/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                "MEUCIQCJlZxZJYNOvEVZ15vKgkppIOUY8MWt4rmjo7Mpu6M92AIgHcuIoTo8GS3hnjn2WAXUBr+yk9Fk" +
+                "hXWoosufldmQuVE=";
+            Assert.Equal(expected, ValidClaimFixture.Token);
+
+            expected =
+                "123/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                "MEQCIAhd1E0voVfgAcpvypiNeh0TdMvJJso7w98UPTfirQSIAiAW1K5yQjFj6XOZUAu5GUmh8rtjIJla" +
+                "d9IV.b1ZmexcUQ==/" +
+                "dTM6Zm9v";
+            Assert.Equal(expected, ValidClaimWExtraFixture.Token);
+        }
+
+        [Fact]
+        public void FromToken()
+        {
+            Assert.Equal(
+                ValidClaimFixture,
+                AppProtocolVersion.FromToken(
+                    "1/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                    "MEUCIQCJlZxZJYNOvEVZ15vKgkppIOUY8MWt4rmjo7Mpu6M92AIgHcuIoTo8GS3hnjn2WAXUBr+y" +
+                    "k9FkhXWoosufldmQuVE="
+                )
+            );
+            Assert.Equal(
+                ValidClaimWExtraFixture,
+                AppProtocolVersion.FromToken(
+                    "123/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                    "MEQCIAhd1E0voVfgAcpvypiNeh0TdMvJJso7w98UPTfirQSIAiAW1K5yQjFj6XOZUAu5GUmh8rtj" +
+                    "IJlad9IV.b1ZmexcUQ==/" +
+                    "dTM6Zm9v"
+                )
+            );
+
+            // No first delimiter
+            Assert.Throws<FormatException>(() => AppProtocolVersion.FromToken("123"));
+
+            // No second delimiter
+            Assert.Throws<FormatException>(() =>
+                AppProtocolVersion.FromToken("123/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4")
+            );
+
+            // A version is not an integer
+            Assert.Throws<FormatException>(() =>
+                AppProtocolVersion.FromToken(
+                    "INCORRECT/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                    "MEUCIQCJlZxZJYNOvEVZ15vKgkppIOUY8MWt4rmjo7Mpu6M92AIgHcuIoTo8GS3hnjn2WAXUBr+y" +
+                    "k9FkhXWoosufldmQuVE="
+                )
+            );
+
+            // A signer address is incorrect
+            Assert.Throws<FormatException>(() =>
+                AppProtocolVersion.FromToken(
+                    "123/INCORRECT/" +
+                    "MEUCIQCJlZxZJYNOvEVZ15vKgkppIOUY8MWt4rmjo7Mpu6M92AIgHcuIoTo8GS3hnjn2WAXUBr+y" +
+                    "k9FkhXWoosufldmQuVE="
+                )
+            );
+
+            // A signature is not a valid base64 string
+            Assert.Throws<FormatException>(() =>
+                AppProtocolVersion.FromToken(
+                    "123/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/_INCORRECT_"
+                )
+            );
+
+            // An extra data is not a valid base64 string
+            Assert.Throws<FormatException>(() =>
+                AppProtocolVersion.FromToken(
+                    "123/271e00B29aeB93B2F4e30ECbebA4f72ac02f72b4/" +
+                    "MEQCIAhd1E0voVfgAcpvypiNeh0TdMvJJso7w98UPTfirQSIAiAW1K5yQjFj6XOZUAu5GUmh8rtj" +
+                    "IJlad9IV.b1ZmexcUQ==/" +
+                    "_INCORRECT_"
+                )
+            );
         }
     }
 }

--- a/Libplanet.Tests/Net/AppProtocolVersionTest.cs
+++ b/Libplanet.Tests/Net/AppProtocolVersionTest.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Tests.Net
         private static readonly AppProtocolVersion ValidClaimFixture = new AppProtocolVersion(
             version: 1,
             extra: null,
-            signer: SignerFixture.PublicKey.ToAddress(),
+            signer: SignerFixture.ToAddress(),
             signature: new byte[]
             {
                 0x30, 0x45, 0x02, 0x21, 0x00, 0x89, 0x95, 0x9c, 0x59, 0x25, 0x83, 0x4e,
@@ -34,7 +34,7 @@ namespace Libplanet.Tests.Net
         private static readonly AppProtocolVersion ValidClaimWExtraFixture = new AppProtocolVersion(
             version: 123,
             extra: (Bencodex.Types.Text)"foo",
-            signer: SignerFixture.PublicKey.ToAddress(),
+            signer: SignerFixture.ToAddress(),
             signature: new byte[]
             {
                 0x30, 0x44, 0x02, 0x20, 0x08, 0x5d, 0xd4, 0x4d, 0x2f, 0xa1, 0x57, 0xe0,
@@ -153,7 +153,7 @@ namespace Libplanet.Tests.Net
                 claim.Version,
                 claim.Extra,
                 claim.Signature,
-                new PrivateKey().PublicKey.ToAddress()
+                new PrivateKey().ToAddress()
             );
             Assert.False(((IEquatable<AppProtocolVersion>)claim).Equals(claim5));
             Assert.False(((object)claim).Equals(claim5));

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -49,7 +49,7 @@ namespace Libplanet.Tests.Net.Messages
             // This test lengthens long... Please read the brief description of the entire payload
             // structure from the comment in the RecentStates.DataFrames property code.
             ISet<Address> accounts = Enumerable.Repeat(0, 5).Select(_ =>
-                new PrivateKey().PublicKey.ToAddress()
+                new PrivateKey().ToAddress()
             ).ToHashSet();
             int accountsCount = accounts.Count;
             var privKey = new PrivateKey();

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Tests.Net.Protocols
         {
             _privateKey = privateKey;
             _blockBroadcast = blockBroadcast;
-            var loggerId = _privateKey.PublicKey.ToAddress().ToHex();
+            var loggerId = _privateKey.ToAddress().ToHex();
             _logger = Log.ForContext<TestTransport>()
                 .ForContext("Address", loggerId);
 
@@ -53,7 +53,7 @@ namespace Libplanet.Tests.Net.Protocols
             ReceivedMessages = new ConcurrentBag<Message>();
             MessageReceived = new AsyncAutoResetEvent();
             _transports = transports;
-            _transports[privateKey.PublicKey.ToAddress()] = this;
+            _transports[privateKey.ToAddress()] = this;
             _networkDelay = networkDelay ?? TimeSpan.Zero;
             _requests = new AsyncCollection<Request>();
             _ignoreTestMessageWithData = new List<string>();
@@ -72,7 +72,7 @@ namespace Libplanet.Tests.Net.Protocols
 
         public AsyncAutoResetEvent MessageReceived { get; }
 
-        public Address Address => _privateKey.PublicKey.ToAddress();
+        public Address Address => _privateKey.ToAddress();
 
         public Peer AsPeer => new BoundPeer(
             _privateKey.PublicKey,
@@ -301,7 +301,7 @@ namespace Libplanet.Tests.Net.Protocols
             message.Remote = AsPeer;
             var bytes = new byte[10];
             _random.NextBytes(bytes);
-            message.Identity = _privateKey.PublicKey.ToAddress().ByteArray.Concat(bytes).ToArray();
+            message.Identity = _privateKey.ToAddress().ByteArray.Concat(bytes).ToArray();
             var sendTime = DateTimeOffset.UtcNow;
             _logger.Debug("Adding request of {Message} of {Identity}.", message, message.Identity);
             await _requests.AddAsync(

--- a/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
@@ -105,11 +105,8 @@ namespace Libplanet.Tests.Net
             AppProtocolVersion untrustedOlder = AppProtocolVersion.Sign(untrustedSigner, 2);
             AppProtocolVersion untrustedNewer = AppProtocolVersion.Sign(untrustedSigner, 3);
 
-            _output.WriteLine("Trusted version signer: {0}", signer.PublicKey.ToAddress());
-            _output.WriteLine(
-                "Untrusted version signer: {0}",
-                untrustedSigner.PublicKey.ToAddress()
-            );
+            _output.WriteLine("Trusted version signer: {0}", signer.ToAddress());
+            _output.WriteLine("Untrusted version signer: {0}", untrustedSigner.ToAddress());
 
             var logs = new ConcurrentDictionary<Peer, AppProtocolVersion>();
 

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -38,9 +38,9 @@ namespace Libplanet.Tests.Net
                 using (var storeFx = new DefaultStoreFixture(memory: true))
                 {
                     var chain = TestUtils.MakeBlockChain(policy, storeFx.Store);
-                    Address miner = new PrivateKey().PublicKey.ToAddress();
+                    Address miner = new PrivateKey().ToAddress();
                     var signer = new PrivateKey();
-                    Address address = signer.PublicKey.ToAddress();
+                    Address address = signer.ToAddress();
                     Log.Logger.Information("Fixture blocks:");
                     for (int i = 0; i < 20; i++)
                     {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -717,7 +717,7 @@ namespace Libplanet.Tests.Net
             BlockChain<DumbAction> chainC = _blockchains[2];
 
             var privateKey = new PrivateKey();
-            var address = privateKey.PublicKey.ToAddress();
+            var address = privateKey.ToAddress();
 
             var txs = Enumerable.Range(0, 10).Select(_ =>
                 chainA.MakeTransaction(new PrivateKey(), new[] { new DumbAction(address, "foo") }))
@@ -1271,7 +1271,7 @@ namespace Libplanet.Tests.Net
             BlockChain<DumbAction> receiverChain = _blockchains[1];
 
             var key = new PrivateKey();
-            var address = key.PublicKey.ToAddress();
+            var address = key.ToAddress();
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address, "foo") });
             await minerChain.MineBlock(_fx1.Address1);
@@ -1675,14 +1675,14 @@ namespace Libplanet.Tests.Net
             PrivateKey[] signers =
                 Enumerable.Repeat(0, 10).Select(_ => new PrivateKey()).ToArray();
             Address[] targets = Enumerable.Repeat(0, signers.Length).Select(_
-                => new PrivateKey().PublicKey.ToAddress()
+                => new PrivateKey().ToAddress()
             ).ToArray();
             (PrivateKey, Address)[] fixturePairs =
                 signers.Zip(targets, ValueTuple.Create).ToArray();
 
             HashDigest<SHA256>? deepBlockHash = null;
 
-            Address genesisTarget = new PrivateKey().PublicKey.ToAddress();
+            Address genesisTarget = new PrivateKey().ToAddress();
             if (genesisWithAction)
             {
                 minerChain.MakeTransaction(
@@ -1879,7 +1879,7 @@ namespace Libplanet.Tests.Net
         public async Task PreloadWhilePeerTipIsChanging()
         {
             var key = new PrivateKey();
-            var address = key.PublicKey.ToAddress();
+            var address = key.ToAddress();
 
             var policy = new NullPolicy<DumbAction>();
 
@@ -1978,14 +1978,14 @@ namespace Libplanet.Tests.Net
             PrivateKey[] signers =
                 Enumerable.Repeat(0, 10).Select(_ => new PrivateKey()).ToArray();
             Address[] targets = Enumerable.Repeat(0, signers.Length).Select(_
-                => new PrivateKey().PublicKey.ToAddress()
+                => new PrivateKey().ToAddress()
             ).ToArray();
             (PrivateKey, Address)[] fixturePairs =
                 signers.Zip(targets, ValueTuple.Create).ToArray();
 
             HashDigest<SHA256>? deepBlockHash = null;
 
-            Address genesisTarget = new PrivateKey().PublicKey.ToAddress();
+            Address genesisTarget = new PrivateKey().ToAddress();
             minerChain.MakeTransaction(
                 signers[0],
                 new[] { new DumbAction(genesisTarget, "Genesis") }

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -63,7 +63,7 @@ namespace Libplanet.Tests.Store
         [Fact]
         public void StateRefDocBlockHash()
         {
-            var address = new PrivateKey().PublicKey.ToAddress();
+            var address = new PrivateKey().ToAddress();
             var random = new Random();
             var bytes = new byte[32];
             random.NextBytes(bytes);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -113,7 +113,7 @@ namespace Libplanet.Tests.Tx
                 tx.UpdatedAddresses
             );
 
-            Address additionalAddr = new PrivateKey().PublicKey.ToAddress();
+            Address additionalAddr = new PrivateKey().ToAddress();
             var txWithAddr = Transaction<PolymorphicAction<BaseAction>>.Create(
                 0,
                 _fx.PrivateKey1,
@@ -211,7 +211,7 @@ namespace Libplanet.Tests.Tx
             };
             var tx = new Transaction<DumbAction>(
                 0,
-                privateKey.PublicKey.ToAddress(),
+                privateKey.ToAddress(),
                 privateKey.PublicKey,
                 ImmutableHashSet<Address>.Empty,
                 timestamp,
@@ -258,7 +258,7 @@ namespace Libplanet.Tests.Tx
             Assert.Throws<ArgumentNullException>(() =>
                 new Transaction<DumbAction>(
                     0,
-                    privateKey.PublicKey.ToAddress(),
+                    privateKey.ToAddress(),
                     null,
                     ImmutableHashSet<Address>.Empty,
                     timestamp,
@@ -271,7 +271,7 @@ namespace Libplanet.Tests.Tx
             Assert.Throws<ArgumentNullException>(() =>
                 new Transaction<DumbAction>(
                     0,
-                    privateKey.PublicKey.ToAddress(),
+                    privateKey.ToAddress(),
                     privateKey.PublicKey,
                     ImmutableHashSet<Address>.Empty,
                     timestamp,
@@ -284,7 +284,7 @@ namespace Libplanet.Tests.Tx
             Assert.Throws<ArgumentNullException>(() =>
                 new Transaction<DumbAction>(
                     0,
-                    privateKey.PublicKey.ToAddress(),
+                    privateKey.ToAddress(),
                     privateKey.PublicKey,
                     ImmutableHashSet<Address>.Empty,
                     timestamp,
@@ -296,7 +296,7 @@ namespace Libplanet.Tests.Tx
             Assert.Throws<InvalidTxSignatureException>(() =>
                 new Transaction<DumbAction>(
                     0,
-                    privateKey.PublicKey.ToAddress(),
+                    privateKey.ToAddress(),
                     privateKey.PublicKey,
                     ImmutableHashSet<Address>.Empty,
                     timestamp,
@@ -551,9 +551,9 @@ namespace Libplanet.Tests.Tx
         {
             Address[] addresses =
             {
-                new PrivateKey().PublicKey.ToAddress(),
-                new PrivateKey().PublicKey.ToAddress(),
-                new PrivateKey().PublicKey.ToAddress(),
+                new PrivateKey().ToAddress(),
+                new PrivateKey().ToAddress(),
+                new PrivateKey().ToAddress(),
             };
             DumbAction[] actions =
             {
@@ -841,7 +841,7 @@ namespace Libplanet.Tests.Tx
             );
             var t2 = new Transaction<DumbAction>(
                 0,
-                _fx.PrivateKey1.PublicKey.ToAddress(),
+                _fx.PrivateKey1.ToAddress(),
                 _fx.PrivateKey1.PublicKey,
                 ImmutableHashSet<Address>.Empty,
                 t1.Timestamp,

--- a/Libplanet/AddressExtensions.cs
+++ b/Libplanet/AddressExtensions.cs
@@ -24,5 +24,20 @@ namespace Libplanet
         {
             return new Address(publicKey);
         }
+
+        /// <summary>
+        /// Derives the corresponding <see cref="Address"/> from a <see
+        /// cref="PrivateKey"/>.
+        /// <para>This enables a code like <c>privateKey.ToAddress()</c> instead
+        /// of <c>new Address(privateKey.PublicKey)</c>.</para>
+        /// </summary>
+        /// <param name="privateKey">A <see cref="PrivateKey"/> to derive
+        /// the corresponding <see cref="Address"/> from.</param>
+        /// <returns>The corresponding <see cref="Address"/> derived from
+        /// <paramref name="privateKey"/>.</returns>
+        public static Address ToAddress(this PrivateKey privateKey)
+        {
+            return new Address(privateKey.PublicKey);
+        }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -294,7 +294,7 @@ namespace Libplanet.Blockchain
             return Block<T>.Mine(
                 0,
                 0,
-                privateKey.PublicKey.ToAddress(),
+                privateKey.ToAddress(),
                 null,
                 timestamp ?? DateTimeOffset.UtcNow,
                 new[] { Transaction<T>.Create(0, privateKey, actions, timestamp: timestamp), });
@@ -700,7 +700,7 @@ namespace Libplanet.Blockchain
             lock (_txLock)
             {
                 Transaction<T> tx = Transaction<T>.Create(
-                    GetNextTxNonce(privateKey.PublicKey.ToAddress()),
+                    GetNextTxNonce(privateKey.ToAddress()),
                     privateKey,
                     actions,
                     updatedAddresses,

--- a/Libplanet/KeyStore/ProtectedPrivateKey.cs
+++ b/Libplanet/KeyStore/ProtectedPrivateKey.cs
@@ -119,7 +119,7 @@ namespace Libplanet.KeyStore
                 ImmutableArray.Create(privateKey.ByteArray)
             );
             ImmutableArray<byte> mac = CalculateMac(derivedKey, ciphertext);
-            Address address = privateKey.PublicKey.ToAddress();
+            Address address = privateKey.ToAddress();
             return new ProtectedPrivateKey(address, kdf, mac, cipher, ciphertext);
         }
 
@@ -324,7 +324,7 @@ namespace Libplanet.KeyStore
             ImmutableArray<byte> plaintext = Cipher.Decrypt(encKey, Ciphertext);
 
             var key = new PrivateKey(plaintext.ToArray());
-            Address actualAddress = key.PublicKey.ToAddress();
+            Address actualAddress = key.ToAddress();
             if (!Address.Equals(actualAddress))
             {
                 throw new MismatchedAddressException(

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -147,7 +147,7 @@ namespace Libplanet.Net
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
             Protocol = new KademliaProtocol(
                 this,
-                _privateKey.PublicKey.ToAddress(),
+                _privateKey.ToAddress(),
                 _appProtocolVersion,
                 _trustedAppProtocolVersionSigners,
                 _differentAppProtocolVersionEncountered,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -119,7 +119,7 @@ namespace Libplanet.Net
             TrustedAppProtocolVersionSigners =
                 trustedAppProtocolVersionSigners?.ToImmutableHashSet();
 
-            string loggerId = _privateKey.PublicKey.ToAddress().ToHex();
+            string loggerId = _privateKey.ToAddress().ToHex();
             _logger = Log.ForContext<Swarm<T>>()
                 .ForContext("SwarmId", loggerId);
 
@@ -153,7 +153,7 @@ namespace Libplanet.Net
 
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
-        public Address Address => _privateKey.PublicKey.ToAddress();
+        public Address Address => _privateKey.ToAddress();
 
         public Peer AsPeer => Transport.AsPeer;
 
@@ -1692,7 +1692,7 @@ namespace Libplanet.Net
                     {
                         _logger.Debug(
                             "Peer [{0}] didn't return any hashes; ignored.",
-                            peer.PublicKey.ToAddress().ToHex()
+                            peer.Address.ToHex()
                         );
                         return workspace;
                     }


### PR DESCRIPTION
In order to make `AppProtocolVersion` values easy to copy and paste, the concept of tokens is added to `AppProtocolVersion`.  Tokens consist of ASCII characters so that they can be pasted without escaping into command arguments or strings in shells and JSON/YAML etc.

As a bonus, I added the `PrivateKey.ToAddress()` extension method as well.  As this change affected many files, I recommend you to review each single commit.