### PR TITLE
Make default(AppProtocolVersion) to have an empty Signature

### DIFF
--- a/Libplanet.Tests/Net/AppProtocolVersionTest.cs
+++ b/Libplanet.Tests/Net/AppProtocolVersionTest.cs
@@ -287,5 +287,13 @@ namespace Libplanet.Tests.Net
                 )
             );
         }
+
+        [Fact]
+        public void DefaultConstructor()
+        {
+            ImmutableArray<byte> defaultSig = default(AppProtocolVersion).Signature;
+            Assert.False(defaultSig.IsDefault);
+            Assert.True(defaultSig.IsEmpty);
+        }
     }
 }

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -14,6 +14,11 @@ namespace Libplanet.Tests.Net
         {
             var signer = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(signer, 1);
+            AppProtocolVersion ver2 = AppProtocolVersion.Sign(
+                signer: signer,
+                version: 2,
+                extra: Bencodex.Types.Dictionary.Empty.Add("foo", 123).Add("bar", 456)
+            );
             yield return new object[]
             {
                 new BoundPeer(
@@ -28,7 +33,7 @@ namespace Libplanet.Tests.Net
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
                     }),
                     new DnsEndPoint("0.0.0.0", 1234),
-                    ver,
+                    default(AppProtocolVersion),
                     IPAddress.IPv6Loopback),
             };
             yield return new object[]
@@ -76,7 +81,7 @@ namespace Libplanet.Tests.Net
                         0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
                     }),
-                    ver),
+                    ver2),
             };
         }
 

--- a/Libplanet/Net/AppProtocolVersion.cs
+++ b/Libplanet/Net/AppProtocolVersion.cs
@@ -35,16 +35,13 @@ namespace Libplanet.Net
         public readonly IValue Extra;
 
         /// <summary>
-        /// A signature which verifies <seealso cref="Signer"/>'s claim of a version.
-        /// </summary>
-        public readonly ImmutableArray<byte> Signature;
-
-        /// <summary>
         /// A signer who claims presence of a version.
         /// </summary>
         public readonly Address Signer;
 
         private static readonly Codec _codec = new Codec();
+
+        private readonly ImmutableArray<byte> _signature;
 
         /// <summary>
         /// Initializes an <see cref="AppProtocolVersion"/> value with field values.
@@ -62,9 +59,15 @@ namespace Libplanet.Net
         {
             Version = version;
             Extra = extra;
-            Signature = signature;
+            _signature = signature;
             Signer = signer;
         }
+
+        /// <summary>
+        /// A signature which verifies <seealso cref="Signer"/>'s claim of a version.
+        /// </summary>
+        public ImmutableArray<byte> Signature =>
+            _signature.IsDefault ? ImmutableArray<byte>.Empty : _signature;
 
         /// <summary>
         /// A token string which serializes an <see cref="AppProtocolVersion"/>.

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -70,6 +70,7 @@ namespace Libplanet.Net
         /// <summary>
         /// The corresponding application protocol version of this peer.
         /// </summary>
+        // FIXME: This would be better to be nullable...
         [IgnoreDuringEquals]
         [Pure]
         public AppProtocolVersion AppProtocolVersion { get; }


### PR DESCRIPTION
This patch makes `default(AppProtocolVersion)` to have an empty `Signature` (instead of `default(ImmutableArray<byte>)` so that `Peer` values can be serialized with `default(AppProtocolVersion)`.