### PR TITLE
IKeyStore & Web3KeyStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,8 @@ To be released.
  -  Added `BlockVerificationState` class, a subclass of `PreloadState`.
     [[#798]]
  -  Added `AppProtocolVersion` struct.  [[#266], [#815]]
+ -  Added `IKeyStore` interface.  [[#831]]
+ -  Added `Web3KeyStore` class.  [[#831]]
  -  Added `BlockDigest` struct.  [[#785]]
  -  Added `BlockHeader` struct.  [[#785]]
  -  Added `IStore.GetBlockDigest(HashDigest<SHA256>)` method.  [[#785]]
@@ -86,6 +88,8 @@ To be released.
     [[#266], [#815]]
  -  Added `Peer.IsCompatibleWith()` method.  [[#266], [#815]]
  -  Added `TxViolatingBlockPolicyException` class.  [[#827]]
+ -  Added `KeyStoreException` class.  [[#831]]
+ -  Added `NoKeyException` class.  [[#831]]
 
 ### Behavioral changes
 
@@ -126,6 +130,7 @@ To be released.
 [#815]: https://github.com/planetarium/libplanet/pull/815
 [#820]: https://github.com/planetarium/libplanet/pull/820
 [#825]: https://github.com/planetarium/libplanet/pull/825
+[#831]: https://github.com/planetarium/libplanet/pull/831
 
 
 Version 0.8.0

--- a/Libplanet.Tests/KeyStore/KeyStoreTest.cs
+++ b/Libplanet.Tests/KeyStore/KeyStoreTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using Libplanet.Crypto;
+using Libplanet.KeyStore;
+using Xunit;
+
+namespace Libplanet.Tests.KeyStore
+{
+    public abstract class KeyStoreTest<T>
+        where T : IKeyStore
+    {
+        public abstract T KeyStore { get; }
+
+        [Fact]
+        public void List()
+        {
+            Assert.Empty(KeyStore.List());
+            Assert.Empty(KeyStore.ListIds());
+
+            var key = new PrivateKey();
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, "pass");
+            Guid id = KeyStore.Add(ppk);
+
+            Assert.Single(KeyStore.List());
+            Tuple<Guid, ProtectedPrivateKey> pair = KeyStore.List().First();
+            Assert.Equal(id, pair.Item1);
+            Assert.Equal(ppk.Address, pair.Item2.Address);
+            Assert.Equal(new[] { id }, KeyStore.ListIds());
+
+            var key2 = new PrivateKey();
+            ProtectedPrivateKey ppk2 = ProtectedPrivateKey.Protect(key2, "pass");
+            Guid id2 = KeyStore.Add(ppk2);
+
+            Assert.Equal(
+                new[] { (id, ppk.Address), (id2, ppk2.Address) }.ToHashSet(),
+                KeyStore.List().Select(tuple => (tuple.Item1, tuple.Item2.Address)).ToHashSet()
+            );
+            Assert.Equal(
+                new[] { id, id2 }.ToHashSet(),
+                KeyStore.ListIds().ToHashSet()
+            );
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var key = new PrivateKey();
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, "pass");
+            Guid id = KeyStore.Add(ppk);
+
+            Assert.Equal(ppk.Address, KeyStore.Get(id).Address);
+            Assert.Equal(key, KeyStore.Get(id).Unprotect("pass"));
+            Assert.Throws<NoKeyException>(() => KeyStore.Get(Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void Add()
+        {
+            var key = new PrivateKey();
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, "pass");
+            Guid id = KeyStore.Add(ppk);
+            var key2 = new PrivateKey();
+            ProtectedPrivateKey ppk2 = ProtectedPrivateKey.Protect(key2, "pass");
+            Guid id2 = KeyStore.Add(ppk2);
+
+            // Key ids should be unique.
+            Assert.NotEqual(id, id2);
+
+            Assert.Equal(ppk.Address, KeyStore.Get(id).Address);
+            Assert.Equal(ppk2.Address, KeyStore.Get(id2).Address);
+
+            (Guid, Address Address) ToSimplePair(Tuple<Guid, ProtectedPrivateKey> pair) =>
+                (pair.Item1, pair.Item2.Address);
+
+            Assert.Contains((id, ppk.Address), KeyStore.List().Select(ToSimplePair));
+            Assert.Contains((id2, ppk2.Address), KeyStore.List().Select(ToSimplePair));
+        }
+
+        [Fact]
+        public void Remove()
+        {
+            var key = new PrivateKey();
+            Guid id = KeyStore.Add(ProtectedPrivateKey.Protect(key, "pass"));
+
+            Assert.Throws<NoKeyException>(() => KeyStore.Remove(Guid.NewGuid()));
+            Assert.Equal(new[] { id }, KeyStore.ListIds());
+
+            KeyStore.Remove(id);
+            Assert.Throws<NoKeyException>(() => KeyStore.Get(id));
+            Assert.Empty(KeyStore.ListIds());
+        }
+    }
+}

--- a/Libplanet.Tests/KeyStore/Web3KeyStoreTest.cs
+++ b/Libplanet.Tests/KeyStore/Web3KeyStoreTest.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Libplanet.Crypto;
+using Libplanet.KeyStore;
+using Xunit;
+
+namespace Libplanet.Tests.KeyStore
+{
+    public class Web3KeyStoreTest : KeyStoreTest<Web3KeyStore>, IDisposable
+    {
+        public Web3KeyStoreTest()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            KeyStore = new Web3KeyStore(tempDir);
+        }
+
+        public override Web3KeyStore KeyStore { get; }
+
+        [Fact]
+        public void Constructor()
+        {
+            // Constructor creates a directory if needed.
+            Assert.True(Directory.Exists(KeyStore.Path));
+        }
+
+        [Fact]
+        public void DefaultKeyStore()
+        {
+            string path = Web3KeyStore.DefaultKeyStore.Path;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Equal(
+                    Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".config",
+                        "planetarium",
+                        "keystore"
+                    ),
+                    path
+                );
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal(
+                    Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        "planetarium",
+                        "keystore"
+                    ),
+                    path
+                );
+            }
+        }
+
+        [Fact]
+        public void Load()
+        {
+            string idStr = "c8b0c0b1-82a0-41cd-9528-a22a0f208dee";
+            Guid id = Guid.Parse(idStr);
+            var path = Path.Combine(KeyStore.Path, $"UTC--2020-03-23T00-00-00Z--{idStr}");
+            var key = new PrivateKey();
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, "pass");
+            using (var f = new FileStream(path, FileMode.Create))
+            {
+                ppk.WriteJson(f, id);
+            }
+
+            Assert.Equal(new[] { id }, KeyStore.ListIds());
+            Assert.Equal(ppk.Address, KeyStore.Get(id).Address);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(KeyStore.Path, true);
+        }
+    }
+}

--- a/Libplanet/KeyStore/IKeyStore.cs
+++ b/Libplanet/KeyStore/IKeyStore.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Libplanet.KeyStore
+{
+    /// <summary>
+    /// The interface to store <see cref="ProtectedPrivateKey"/>s.  An appropriate implementation
+    /// should be used according to a running platform.
+    /// </summary>
+    public interface IKeyStore
+    {
+        /// <summary>
+        /// Lists all keys IDs in the key store.
+        /// </summary>
+        /// <returns>All keys IDs in the key store.  The order is undefined and not deterministic.
+        /// </returns>
+        public IEnumerable<Guid> ListIds();
+
+        /// <summary>
+        /// Lists all keys in the key store.
+        /// </summary>
+        /// <returns>All keys in the key store.  The order is undefined and not deterministic.
+        /// </returns>
+        public IEnumerable<Tuple<Guid, ProtectedPrivateKey>> List();
+
+        /// <summary>
+        /// Looks for a key having the requested <paramref name="id"/> in the key store.
+        /// </summary>
+        /// <param name="id">The key ID to look for.</param>
+        /// <returns>The found key.</returns>
+        /// <exception cref="NoKeyException">Thrown when there are no key of the given
+        /// <paramref name="id"/>.</exception>
+        public ProtectedPrivateKey Get(Guid id);
+
+        /// <summary>
+        /// Adds a new <paramref name="key"/> into the key store.
+        /// </summary>
+        /// <param name="key">A key to add.</param>
+        /// <returns>The id of the added <paramref name="key"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <c>null</c> is passed to
+        /// <paramref name="key"/>.</exception>
+        public Guid Add(ProtectedPrivateKey key);
+
+        /// <summary>
+        /// Removes a key having the given <pramref name="id"/> from the key store.
+        /// </summary>
+        /// <param name="id">The key ID to remove.</param>
+        /// <exception cref="NoKeyException">Thrown when there is no key having
+        /// the given <paramref name="id"/>.</exception>
+        public void Remove(Guid id);
+    }
+}

--- a/Libplanet/KeyStore/KeyStoreException.cs
+++ b/Libplanet/KeyStore/KeyStoreException.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Libplanet.KeyStore
+{
+    /// <summary>
+    /// Serves as the base class for exceptions thrown by <see cref="IKeyStore"/>
+    /// implementations.
+    /// </summary>
+    public abstract class KeyStoreException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance with the given <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">A descriptive error message for programmers.
+        /// Goes to <see cref="System.Exception.Message"/>.</param>
+        public KeyStoreException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Libplanet/KeyStore/NoKeyException.cs
+++ b/Libplanet/KeyStore/NoKeyException.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Libplanet.KeyStore
+{
+    /// <summary>
+    /// The exception that is thrown when there is no <see cref="ProtectedPrivateKey"/>
+    /// with a given key ID in an <see cref="IKeyStore"/>.
+    /// </summary>
+    public class NoKeyException : KeyStoreException
+    {
+        /// <summary>
+        /// Instantiates a new exception object with proper metadata.
+        /// </summary>
+        /// <param name="keyId">The key ID tried to look for.
+        /// It is automatically included to the <see cref="System.Exception.Message"/>
+        /// string.
+        /// </param>
+        /// <param name="message">A descriptive error message for programmers.
+        /// Goes to <see cref="System.Exception.Message"/>.</param>
+        public NoKeyException(Guid keyId, string message)
+            : base($"{message}: {keyId}")
+        {
+            KeyId = keyId;
+        }
+
+        /// <summary>
+        /// The key ID tried to look for.
+        /// </summary>
+        public Guid KeyId { get; }
+    }
+}

--- a/Libplanet/KeyStore/Web3KeyStore.cs
+++ b/Libplanet/KeyStore/Web3KeyStore.cs
@@ -1,0 +1,187 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Serilog;
+
+namespace Libplanet.KeyStore
+{
+    /// <summary>
+    /// <a href="https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition">Web3 Secret
+    /// Storage</a> (i.e., Ethereum-style key store) compliant <see cref="IKeyStore"/>
+    /// implementation.  Key files are placed in a directory of the <see cref="Path"/>.
+    /// <para>Use <see cref="DefaultKeyStore"/> property to get an instance.</para>
+    /// <para>In order to get an instance with a customized directory,
+    /// use the <see cref="Web3KeyStore(string)"/> constructor.</para>
+    /// </summary>
+    public class Web3KeyStore : IKeyStore
+    {
+        private static readonly string DefaultPath = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "planetarium",
+            "keystore"
+        );
+
+        private static readonly string NameFormat =
+            "UTC--{0:yyyy-MM-dd}T{0:HH-mm-ss}Z--{1:D}";
+
+        private static readonly Regex NamePattern = new Regex(
+            @"^UTC--\d{4}-\d\d-\d\dT\d\d-\d\d-\d\dZ--([\da-f]{8}-?(?:[\da-f]{4}-?){3}[\da-f]{12})$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
+        );
+
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a <see cref="Web3KeyStore"/> instance with a custom directory
+        /// <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">A path of the directory to store key files.  A new directory is
+        /// created if not exists.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>null</c> is passed to
+        /// <paramref name="path"/>.</exception>
+        /// <seealso cref="DefaultKeyStore"/>
+        public Web3KeyStore(string path)
+        {
+            _logger = Log.ForContext<Web3KeyStore>().ForContext("DirectoryPath", path);
+
+            if (path is null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            else if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+                _logger.Debug(
+                    "Created a directory {DirectoryPath} as it did not exist.",
+                    path
+                );
+            }
+
+            Path = path;
+        }
+
+        /// <summary>
+        /// A default <see cref="Web3KeyStore"/> instance which refers to a user-local directory.
+        /// The <see cref="Path"/> differs on the platform:
+        /// <list type="table">
+        /// <listheader>
+        /// <term>OS</term>
+        /// <description>Directory path</description>
+        /// </listheader>
+        /// <item>
+        /// <term>Linux/macOS</term>
+        /// <description><var>$HOME</var>/.config/planetarium/keystore</description>
+        /// </item>
+        /// <item>
+        /// <term>Windows</term>
+        /// <description><var>%AppData%</var>\planetarium\keystore</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <seealso cref="Web3KeyStore(string)"/>
+        public static Web3KeyStore DefaultKeyStore =>
+            new Web3KeyStore(DefaultPath);
+
+        /// <summary>
+        /// The path of the directory key files are placed.
+        /// </summary>
+        public string Path { get; }
+
+        /// <inheritdoc/>
+        public IEnumerable<Tuple<Guid, ProtectedPrivateKey>> List() =>
+            ListFiles().Select(pair => Tuple.Create(pair.Item1, Get(pair.Item2)));
+
+        /// <inheritdoc/>
+        public IEnumerable<Guid> ListIds() =>
+            ListFiles().Select(pair => pair.Item1);
+
+        /// <inheritdoc/>
+        public ProtectedPrivateKey Get(Guid id)
+        {
+            IEnumerable<(Guid, string)> files = ListFiles();
+            string name;
+            try
+            {
+                (_, name) = files.First(pair => pair.Item1.Equals(id));
+            }
+            catch (InvalidOperationException)
+            {
+                throw new NoKeyException(id, "There is no key with such ID");
+            }
+
+            return Get(name);
+        }
+
+        /// <inheritdoc/>
+        public Guid Add(ProtectedPrivateKey key)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            Guid keyId = Guid.NewGuid();
+            string filename = string.Format(
+                CultureInfo.InvariantCulture,
+                NameFormat,
+                DateTimeOffset.UtcNow,
+                keyId
+            );
+            var keyPath = System.IO.Path.Combine(Path, filename);
+            using Stream f = new FileStream(keyPath, FileMode.CreateNew);
+            key.WriteJson(f, keyId);
+            return keyId;
+        }
+
+        /// <inheritdoc/>
+        public void Remove(Guid id)
+        {
+            foreach ((Guid keyId, string keyPath) in ListFiles())
+            {
+                if (keyId.Equals(id))
+                {
+                    System.IO.File.Delete(keyPath);
+                    return;
+                }
+            }
+
+            throw new NoKeyException(id, "No key have such ID");
+        }
+
+        private IEnumerable<(Guid, string)> ListFiles()
+        {
+            IEnumerable<string> keyPaths = Directory.EnumerateFiles(Path);
+            foreach (string keyPath in keyPaths)
+            {
+                if (System.IO.Path.GetFileName(keyPath) is string f)
+                {
+                    Match m = NamePattern.Match(f);
+                    if (m.Success)
+                    {
+                        if (!Guid.TryParse(m.Groups[1].Value, out Guid id))
+                        {
+                            _logger.Debug(
+                                "Failed to parse the file name due to invalid UUID: {keyPath}"
+                            );
+                            continue;
+                        }
+
+                        yield return (id, keyPath);
+                    }
+                }
+            }
+        }
+
+        private ProtectedPrivateKey Get(string name)
+        {
+            using (StreamReader reader = new StreamReader(System.IO.Path.Combine(Path, name)))
+            {
+                return ProtectedPrivateKey.FromJson(reader.ReadToEnd());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch finally implements the complete [Web3 Secret Storage][1].

I also experimented with C# 8's [nullable reference types][2].  We could gradually adopt it by enabling [nullable context][3] per file (instead of the whole project, i.e., #458).

[1]: https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
[2]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
[3]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts