### PR TITLE
Bump Planetarium.RocksDbSharp to 6.2.2.3-planetarium

### DIFF
--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -40,7 +40,7 @@
       runtime; build; native; contentfiles; analyzers; buildtransitive
     </IncludeAssets>
   </PackageReference>
-  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.1-planetarium" />
+  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.3-planetarium" />
   <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
     <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This fixes an issue where an `ExecutionEngineException: String conversion error` occurred when `RocksDbException` occurred.