### PR TITLE
Fix Swarm<T>.Preload()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,8 @@ To be released.
     if `cancellationToken` was requested.  [[#798]]
  -  Fixed a bug where `Swarm<T>` had crashed if it received invalid
     `Transaction<T>` from the nodes.  [[#820]]
+ -  Fixed a bug where `Swarm<T>` hadn't reported preload states correctly.
+    [[#TBD]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,8 @@ To be released.
     `Transaction<T>` from the nodes.  [[#820]]
  -  Fixed a bug where `Swarm<T>` hadn't reported preload states correctly.
     [[#TBD]]
+ -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that it had hung forever
+    when a block fetch failed due to an unexpected error.  [[#TBD]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,10 +113,11 @@ To be released.
     if `cancellationToken` was requested.  [[#798]]
  -  Fixed a bug where `Swarm<T>` had crashed if it received invalid
     `Transaction<T>` from the nodes.  [[#820]]
- -  Fixed a bug where `Swarm<T>` hadn't reported preload states correctly.
-    [[#TBD]]
+ -  Fixed a bug where `Swarm<T>` hadn't reported `IProgress<PreloadState>`s
+    correctly.[[#839]]
  -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that it had hung forever
-    when a block fetch failed due to an unexpected error.  [[#TBD]]
+    when a block failed to be fetched due to an unexpected inner exception.
+    [[#839]]
 
 ### CLI tools
 
@@ -140,6 +141,7 @@ To be released.
 [#831]: https://github.com/planetarium/libplanet/pull/831
 [#837]: https://github.com/planetarium/libplanet/pull/837
 [#838]: https://github.com/planetarium/libplanet/pull/838
+[#839]: https://github.com/planetarium/libplanet/pull/839
 
 
 Version 0.8.0

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -346,7 +346,11 @@ namespace Libplanet.Tests.Net
                 });
 
             Tuple<Block<DumbAction>, char>[] result =
-                await AsyncEnumerable.ToArrayAsync(bc.Complete(new[] { 'A', 'B' }, blockFetcher));
+                await AsyncEnumerable.ToArrayAsync(
+                    bc.Complete(
+                        new[] { 'A', 'B' }, blockFetcher, millisecondsSingleSessionTimeout: 3000
+                    )
+                );
             Assert.Equal(
                 fixture.Select(b => Tuple.Create(b, 'B')).ToHashSet(),
                 result.ToHashSet()

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -357,6 +357,40 @@ namespace Libplanet.Tests.Net
             );
         }
 
+        [Fact(Timeout = Timeout)]
+        public async Task CompleteWithCrashingPeers()
+        {
+            ImmutableArray<Block<DumbAction>> fixture =
+                GenerateBlocks<DumbAction>(15).ToImmutableArray();
+            var bc = new BlockCompletion<char, DumbAction>(_ => false, 5);
+            bc.Demand(fixture.Select(b => b.Hash));
+
+            BlockCompletion<char, DumbAction>.BlockFetcher blockFetcher =
+                (peer, blockHashes, token) => new AsyncEnumerable<Block<DumbAction>>(async yield =>
+                {
+                    // Peer A does crash and Peer B does respond.
+                    if (peer == 'A')
+                    {
+                        throw new Exception("Peer A can't respond.");
+                    }
+
+                    foreach (Block<DumbAction> b in fixture)
+                    {
+                        if (blockHashes.Contains(b.Hash))
+                        {
+                            await yield.ReturnAsync(b);
+                        }
+                    }
+                });
+
+            Tuple<Block<DumbAction>, char>[] result =
+                await AsyncEnumerable.ToArrayAsync(bc.Complete(new[] { 'A', 'B' }, blockFetcher));
+            Assert.Equal(
+                fixture.Select(b => Tuple.Create(b, 'B')).ToHashSet(),
+                result.ToHashSet()
+            );
+        }
+
         private IEnumerable<Block<T>> GenerateBlocks<T>(int count)
             where T : IAction, new()
         {

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -318,6 +318,10 @@ namespace Libplanet.Net
                                 peer
                             );
                         }
+                        catch (Exception e)
+                        {
+                            _logger.Error(e, "A blockFetcher job (peer: {Peer}) is failed.", peer);
+                        }
                     }
                     finally
                     {


### PR DESCRIPTION
This PR addresses two problems of `Swarm<T>.Preload()`.

- Fixed a bug where `Swarm<T>` hadn't reported preload states correctly.
- Fixed a `Swarm<T>.PreloadAsync()` method's bug that it had hung forever when a block fetch failed due to an unexpected error. 