### PR TITLE
CLI tools (planet command)

### DIFF
--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -3,4 +3,6 @@
 # shellcheck disable=SC2034
 projects=("Libplanet" "Libplanet.RocksDBStore" "Libplanet.Tools")
 configuration=Release
-
+executables=("Libplanet.Tools")
+rids=(linux-x64 osx-x64 win-x64)
+# https://docs.microsoft.com/en-us/dotnet/core/rid-catalog

--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # shellcheck disable=SC2034
-projects=("Libplanet" "Libplanet.RocksDBStore")
+projects=("Libplanet" "Libplanet.RocksDBStore" "Libplanet.Tools")
 configuration=Release
 

--- a/.github/bin/dist-github-release.sh
+++ b/.github/bin/dist-github-release.sh
@@ -73,3 +73,16 @@ for project in "${projects[@]}"; do
     --name "$(basename "$nupkg_path")" \
     --file "$nupkg_path"
 done
+
+
+for rid in "${rids[@]}"; do
+  for exec_path in "./$project/bin/$configuration"/*-"$tag-$rid".{tar.xz,zip}
+  do
+    "$(dirname "$0")/github-release.sh" upload \
+      --user "$github_user" \
+      --repo "$github_repo" \
+      --tag "$tag" \
+      --name "$(basename "$exec_path")" \
+      --file "$exec_path"
+  done
+done

--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -11,10 +11,14 @@ if ! (env | grep '^GITHUB_'); then
   exit 1
 fi
 
+version="$(cat obj/package_version.txt)"
+version_prefix="$(cat obj/version_prefix.txt)"
+package_version="$(cat obj/package_version.txt)"
+
 for project in "${projects[@]}"; do
   rm -rf "./$project/bin/$configuration/"
 
-  dotnet_args="-p:Version=$(cat obj/package_version.txt)"
+  dotnet_args="-p:Version=$version"
   if [ -f obj/version_suffix.txt ]; then
     dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
   fi
@@ -23,11 +27,30 @@ for project in "${projects[@]}"; do
   # shellcheck disable=SC2086
   dotnet pack "$project" -c "$configuration" $dotnet_args
 
-  version_prefix="$(cat obj/version_prefix.txt)"
-  package_version="$(cat obj/package_version.txt)"
-
   ls -al "./$project/bin/$configuration/"
   if [ "$package_version" != "$version_prefix" ]; then
     rm -f "./$project/bin/$configuration/$project.$version_prefix.nupkg"
   fi
+done
+
+for project in "${executables[@]}"; do
+  for rid in "${rids[@]}"; do
+    output_dir="./$project/bin/$configuration/$rid/"
+    dotnet publish \
+      --runtime "$rid" \
+      -p:PublishSingleFile=true \
+      -p:Version="$version" \
+      --configuration "$configuration" \
+      --output "$output_dir" \
+      "$project"
+    bin_name="$(find "$output_dir" -type f -executable -exec basename {} \;)"
+    pushd "$output_dir"
+    if [[ "$rid" = win-* ]]; then
+      zip -r9 "../${bin_name%.exe}-$version-$rid.zip" ./*
+    else
+      tar cvfJ "../$bin_name-$version-$rid.tar.xz" ./*
+    fi
+    popd
+    rm -rf "$output_dir"
+  done
 done

--- a/.github/bin/dist-version.ps1
+++ b/.github/bin/dist-version.ps1
@@ -8,11 +8,17 @@ if ((Get-ChildItem env:GITHUB_*).Count -lt 1) {
   exit 1
 }
 
+# The root element could belong to the namespace.
 $Namespace = @{m = "http://schemas.microsoft.com/developer/msbuild/2003"}
-$VersionPrefix = (Select-Xml `
+$versionPrefixNode = (Select-Xml `
   -Path Libplanet/Libplanet.csproj `
   -Namespace $Namespace `
-  -XPath './m:Project/m:PropertyGroup/m:VersionPrefix/text()').Node.Value
+  -XPath './m:Project/m:PropertyGroup/m:VersionPrefix/text()')
+# The root element could belong to no namespace.
+$versionPrefixNode ??= (Select-Xml `
+  -Path ./Libplanet/Libplanet.csproj `
+  -XPath './Project/PropertyGroup/VersionPrefix/text()')
+$VersionPrefix = $versionPrefixNode.Node.Value
 
 New-Item -ItemType directory -Path obj -ErrorAction SilentlyContinue
 [Console]::Error.Write("VersionPrefix: ")

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,10 @@ To be released.
  -  Fixed a bug where `Swarm<T>` had crashed if it received invalid
     `Transaction<T>` from the nodes.  [[#820]]
 
+### CLI tools
+
+ -  Added the `planet` command and its alias `dotnet planet`.
+
 [#266]: https://github.com/planetarium/libplanet/issues/266
 [#707]: https://github.com/planetarium/libplanet/pull/707
 [#784]: https://github.com/planetarium/libplanet/pull/784

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,45 @@ builds the entire *Libplanet* solution:
     dotnet build
 
 
+Projects
+--------
+
+The [planetarium/libplanet](https://github.com/planetarium/libplanet) repository
+on GitHub consists of several projects:
+
+ -  *Libplanet*: The main project, which contains the most of implementation
+    code.  When this is  built into a [NuGet package], it consists of two
+    assemblies: *Libplanet*, and *Libplanet.Stun*, explained below.
+
+ -  *Libplanet.Stun*: The project dedicated to implement [TURN & STUN].
+    Note that the assembly built from this project is included by
+    *[Libplanet][NuGet package]* package on NuGet.
+
+ -  *Libplanet.RocksDBStore*: The `IStore` implementation built on [RocksDB].
+    As this depends on platform-dependent libraries (which is written in C/C++),
+    this is distributed as a distinct NuGet package: *[Libplanet.RocksDBStore]*.
+
+ -  *Libplanet.Tools*: The CLI tools for Libplanet.  See its own
+    [README.md](Libplanet.Tools/README.md).
+
+ -  *Libplanet.Benchmarks*: Performance benchmarks.
+    See the [*Benchmarks*](#benchmarks) section below.
+
+ -  *Libplanet.Tests*: Unit tests of the *Libplanet* project.  See the *Tests*
+    section below.
+
+ -  *Libplanet.Stun.Tests*: Unit tests of the *Libplanet.Stun* project.
+
+ -  *Libplanet.RocksDBStore.Tests*: Unit tests of the *Libplanet.RocksDBStore*
+    project.
+
+
+[NuGet package]: https://www.nuget.org/packages/Libplanet/
+[TURN & STUN]: https://snack.planetarium.dev/eng/2019/06/nat_traversal_2/
+[RocksDB]: https://rocksdb.org/
+[Libplanet.RocksDBStore]: https://www.nuget.org/packages/Libplanet.RocksDBStore/
+
+
 Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=master)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][2]
 -----
 

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-[!include[README](../CONTRIBUTING.md)]

--- a/Docs/docfx.json
+++ b/Docs/docfx.json
@@ -35,9 +35,17 @@
         ]
       },
       {
-        "src": "..",
+        "src": "../Libplanet.Tools",
+        "dest": "cli",
         "files": [
-          "CHANGES.md"
+          "*.md"
+        ]
+      },
+      {
+        "src": "../",
+        "files": [
+          "CHANGES.md",
+          "CONTRIBUTING.md"
         ]
       }
     ],
@@ -71,7 +79,10 @@
     },
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
-    "template": ["statictoc"],
+
+    "template": ["default"],
+    // "statictoc" has a bug that relative links with nested dirs in nav refer to incorrect destinations
+
     "theme": ["theme"],
     "postProcessors": [],
     "markdownEngineName": "markdig",

--- a/Docs/toc.yml
+++ b/Docs/toc.yml
@@ -7,7 +7,9 @@
 - name: API Reference
   href: api/
   homepage: api/Libplanet.yml
+- name: CLI Tools
+  href: ../Libplanet.Tools/README.md
 - name: Changelog
   href: ../CHANGES.md
 - name: Contribute
-  href: CONTRIBUTING.md
+  href: ../CONTRIBUTING.md

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -23,6 +23,7 @@
 </PropertyGroup>
 
 <ItemGroup>
+  <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
   <None Include="..\icon.png" Pack="true" PackagePath="icon.png" />
   <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
     <Link>Menees.Analyzers.Settings.xml</Link>
@@ -56,6 +57,8 @@
 
 <ItemGroup>
   <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+  <!-- FIXME: We should specify the version range when the following NuGet issue
+  is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
 </ItemGroup>
 
 </Project>

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -1,6 +1,4 @@
-<Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-  Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>

--- a/Libplanet.Tools/Apv.cs
+++ b/Libplanet.Tools/Apv.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using Bencodex;
+using Bencodex.Types;
+using Cocona;
+using Libplanet.Crypto;
+using Libplanet.Net;
+
+namespace Libplanet.Tools
+{
+    public class Apv
+    {
+        [Command(Description = "Sign a new app protocol version.")]
+        public void Sign(
+            [Argument(Name = "KEY-ID", Description = "A private key to use for signing.")]
+            Guid keyId,
+            [Argument(Name = "VERSION", Description = "A version number to sign.")]
+            int version,
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string passphrase = null,
+            [Option(
+                'E',
+                ValueName = "FILE",
+                Description = "Bencodex file to use for extra data.  " +
+                    "For standard input, use a hyphen (`-').  " +
+                    "For an actual file named a hyphen, prepend `./', i.e., `./-'."
+            )]
+            string extraFile = null
+        )
+        {
+            PrivateKey key = new Key().UnprotectKey(keyId, passphrase);
+            IValue extra = null;
+            if (extraFile is string path)
+            {
+                var codec = new Codec();
+                if (path == "-")
+                {
+                    // Stream for stdin does not support .Seek()
+                    using MemoryStream buffer = new MemoryStream();
+                    using (Stream stream = Console.OpenStandardInput())
+                    {
+                        stream.CopyTo(buffer);
+                    }
+
+                    buffer.Seek(0, SeekOrigin.Begin);
+                    extra = codec.Decode(buffer);
+                }
+                else
+                {
+                    using Stream stream = File.Open(path, FileMode.Open, FileAccess.Read);
+                    extra = codec.Decode(stream);
+                }
+            }
+
+            var v = AppProtocolVersion.Sign(key, version, extra);
+            Console.WriteLine(v.Token);
+        }
+    }
+}

--- a/Libplanet.Tools/Apv.cs
+++ b/Libplanet.Tools/Apv.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Tools
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string passphrase = null,
+            string? passphrase = null,
             [Option(
                 'E',
                 ValueName = "FILE",
@@ -29,11 +29,11 @@ namespace Libplanet.Tools
                     "For standard input, use a hyphen (`-').  " +
                     "For an actual file named a hyphen, prepend `./', i.e., `./-'."
             )]
-            string extraFile = null
+            string? extraFile = null
         )
         {
             PrivateKey key = new Key().UnprotectKey(keyId, passphrase);
-            IValue extra = null;
+            IValue? extra = null;
             if (extraFile is string path)
             {
                 var codec = new Codec();

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -227,7 +227,7 @@ namespace Libplanet.Tools
         {
             Utils.PrintTable(
                 ("Key ID", "Address"),
-                keys.Select(t => (t.Item1.ToString(), t.Item2.Address.ToString()))
+                keys.Select(t => (t.KeyId.ToString(), t.Key.Address.ToString()))
             );
         }
     }

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -9,9 +9,9 @@ using Libplanet.KeyStore;
 
 namespace Libplanet.Tools
 {
-    public class Keys
+    public class Key
     {
-        public Keys()
+        public Key()
         {
             KeyStore = Web3KeyStore.DefaultKeyStore;
         }

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -66,7 +66,7 @@ namespace Libplanet.Tools
 
         [Command(Aliases = new[] { "rm" }, Description = "Remove a private key.")]
         public void Remove(
-            [Argument(Name = "UUID", Description = "A key UUID to remove.")] Guid keyId,
+            [Argument(Name = "KEY-ID", Description = "A key UUID to remove.")] Guid keyId,
             [Option(
                 'p',
                 ValueName = "PASSPHRASE",
@@ -88,7 +88,7 @@ namespace Libplanet.Tools
 
         [Command(Description = "Export a raw private key.")]
         public void Export(
-            [Argument(Name = "UUID", Description = "A key UUID to export.")] Guid keyId,
+            [Argument(Name = "KEY-ID", Description = "A key UUID to export.")] Guid keyId,
             [Option(
                 'p',
                 ValueName = "PASSPHRASE",
@@ -152,7 +152,7 @@ namespace Libplanet.Tools
             }
         }
 
-        private PrivateKey UnprotectKey(Guid keyId, string passphrase = null)
+        public PrivateKey UnprotectKey(Guid keyId, string passphrase = null)
         {
             passphrase ??= ConsolePasswordReader.Read("Passphrase: ");
 
@@ -179,7 +179,7 @@ namespace Libplanet.Tools
         private void PrintKeys(IEnumerable<(Guid, ProtectedPrivateKey)> keys)
         {
             Utils.PrintTable(
-                ("UUID", "Address"),
+                ("Key ID", "Address"),
                 keys.Select(t => (t.Item1.ToString(), t.Item2.Address.ToString()))
             );
         }

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Tools
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string passphrase = null,
+            string? passphrase = null,
             [Option(
                 Description = "Print the created private key as Web3 Secret Storage format."
             )]
@@ -72,7 +72,7 @@ namespace Libplanet.Tools
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string passphrase = null
+            string? passphrase = null
         )
         {
             try
@@ -94,7 +94,7 @@ namespace Libplanet.Tools
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string passphrase = null,
+            string? passphrase = null,
             [Option(
                 'b',
                 Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended."
@@ -152,7 +152,7 @@ namespace Libplanet.Tools
             }
         }
 
-        public PrivateKey UnprotectKey(Guid keyId, string passphrase = null)
+        public PrivateKey UnprotectKey(Guid keyId, string? passphrase = null)
         {
             passphrase ??= ConsolePasswordReader.Read("Passphrase: ");
 

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -115,6 +115,43 @@ namespace Libplanet.Tools
             }
         }
 
+        [Command(
+            Aliases = new[] { "gen" },
+            Description = "Generate a raw private key without storing it."
+        )]
+        public void Generate(
+            [Option('A', Description = "Do not show a dervied address.")]
+            bool noAddress = false,
+            [Option('p', Description = "Show a public key as well.")]
+            bool publicKey = false
+        )
+        {
+            var key = new PrivateKey();
+            string priv = ByteUtil.Hex(key.ByteArray);
+            string addr = key.ToAddress().ToString();
+            string pub = ByteUtil.Hex(key.PublicKey.Format(compress: true));
+
+            if (!noAddress && publicKey)
+            {
+                Utils.PrintTable(
+                    ("Private key", "Address", "Public key"),
+                    new[] { (priv, addr, pub) }
+                );
+            }
+            else if (!noAddress)
+            {
+                Utils.PrintTable(("Private key", "Address"), new[] { (priv, addr) });
+            }
+            else if (publicKey)
+            {
+                Utils.PrintTable(("Private key", "Public key"), new[] { (priv, pub) });
+            }
+            else
+            {
+                Console.WriteLine(priv);
+            }
+        }
+
         private PrivateKey UnprotectKey(Guid keyId, string passphrase = null)
         {
             passphrase ??= ConsolePasswordReader.Read("Passphrase: ");

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -176,7 +176,7 @@ namespace Libplanet.Tools
             }
         }
 
-        private void PrintKeys(IEnumerable<(Guid, ProtectedPrivateKey)> keys)
+        private void PrintKeys(IEnumerable<(Guid KeyId, ProtectedPrivateKey Key)> keys)
         {
             Utils.PrintTable(
                 ("Key ID", "Address"),

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -141,7 +141,7 @@ namespace Libplanet.Tools
             Description = "Generate a raw private key without storing it."
         )]
         public void Generate(
-            [Option('A', Description = "Do not show a dervied address.")]
+            [Option('A', Description = "Do not show a derived address.")]
             bool noAddress = false,
             [Option('p', Description = "Show a public key as well.")]
             bool publicKey = false
@@ -202,10 +202,10 @@ namespace Libplanet.Tools
             if (passphrase is null)
             {
                 passphrase = ConsolePasswordReader.Read("Passphrase: ");
-                string second = ConsolePasswordReader.Read("Retype tassphrase: ");
+                string second = ConsolePasswordReader.Read("Retype passphrase: ");
                 if (!passphrase.Equals(second))
                 {
-                    throw Utils.Error("Passwords do not match.");
+                    throw Utils.Error("Passphrases do not match.");
                 }
             }
 

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -105,7 +105,7 @@ namespace Libplanet.Tools
             Add(key, passphrase, json, dryRun);
         }
 
-        [Command(Description = "Export a raw private key.")]
+        [Command(Description = "Export a raw private key (or public key).")]
         public void Export(
             [Argument("KEY-ID", Description = "A key UUID to export.")] Guid keyId,
             [Option(
@@ -114,6 +114,8 @@ namespace Libplanet.Tools
                 Description = "Take passphrase through this option instead of prompt."
             )]
             string? passphrase = null,
+            [Option('P', Description = "Export a public key instead of private key.")]
+            bool publicKey = false,
             [Option(
                 'b',
                 Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended."
@@ -122,7 +124,7 @@ namespace Libplanet.Tools
         )
         {
             PrivateKey key = UnprotectKey(keyId, passphrase);
-            byte[] rawKey = key.ByteArray;
+            byte[] rawKey = publicKey ? key.PublicKey.Format(true) : key.ByteArray;
             if (bytes)
             {
                 using Stream stdout = Console.OpenStandardOutput();

--- a/Libplanet.Tools/Keys.cs
+++ b/Libplanet.Tools/Keys.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cocona;
+using GetPass;
+using Libplanet.Crypto;
+using Libplanet.KeyStore;
+
+namespace Libplanet.Tools
+{
+    public class Keys
+    {
+        public Keys()
+        {
+            KeyStore = Web3KeyStore.DefaultKeyStore;
+        }
+
+        public IKeyStore KeyStore { get; }
+
+        [PrimaryCommand]
+        [Command(Description = "List all private keys.")]
+        public void List()
+        {
+            // TODO: -v/--verbose option to print public keys as well.
+            PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
+        }
+
+        [Command(Description = "Create a new private key.")]
+        public void Create(
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string passphrase = null,
+            [Option(
+                Description = "Print the created private key as Web3 Secret Storage format."
+            )]
+            bool json = false,
+            [Option(Description = "Do not add to the key store, but only show the created key.")]
+            bool dryRun = false
+        )
+        {
+            if (passphrase is null)
+            {
+                passphrase = ConsolePasswordReader.Read("Passphrase: ");
+                string second = ConsolePasswordReader.Read("Retype tassphrase: ");
+                if (!passphrase.Equals(second))
+                {
+                    throw Error("Passwords do not match.");
+                }
+            }
+
+            var key = new PrivateKey();
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, passphrase);
+            Guid keyId = dryRun ? Guid.NewGuid() : KeyStore.Add(ppk);
+            if (json)
+            {
+                using Stream stdout = System.Console.OpenStandardOutput();
+                ppk.WriteJson(stdout, keyId);
+                stdout.WriteByte(0x0a);  // line ending
+            }
+            else
+            {
+                PrintKeys(new[] { (keyId, ppk) });
+            }
+        }
+
+        [Command(Aliases = new[] { "rm" }, Description = "Remove a private key.")]
+        public void Remove(
+            [Argument(Name = "UUID", Description = "A key UUID to remove.")] Guid keyId,
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string passphrase = null
+        )
+        {
+            passphrase ??= ConsolePasswordReader.Read("Passphrase: ");
+            try
+            {
+                ProtectedPrivateKey ppk = KeyStore.Get(keyId);
+                ppk.Unprotect(passphrase);
+                KeyStore.Remove(keyId);
+            }
+            catch (NoKeyException)
+            {
+                throw Error($"No such key ID: {keyId}");
+            }
+            catch (IncorrectPassphraseException)
+            {
+                throw Error("The passphrase is wrong.");
+            }
+        }
+
+        private void PrintKeys(IEnumerable<(Guid, ProtectedPrivateKey)> keys)
+        {
+            Console.Error.WriteLine("{0,-36} {1,-42}", "UUID", "Address");
+            Console.Error.WriteLine($"{new string('-', 36)} {new string('-', 42)}");
+            Console.Error.Flush();
+            foreach ((Guid keyId, ProtectedPrivateKey ppk) in keys)
+            {
+                Console.WriteLine("{0,-36} {1,-42}", keyId, ppk.Address);
+            }
+        }
+
+        private CommandExitedException Error(string message, int exitCode = 128)
+        {
+            Console.Error.WriteLine("Error: {0}", message);
+            Console.Error.Flush();
+            return new CommandExitedException(exitCode);
+        }
+    }
+}

--- a/Libplanet.Tools/Keys.cs
+++ b/Libplanet.Tools/Keys.cs
@@ -20,11 +20,8 @@ namespace Libplanet.Tools
 
         [PrimaryCommand]
         [Command(Description = "List all private keys.")]
-        public void List()
-        {
-            // TODO: -v/--verbose option to print public keys as well.
+        public void List() =>
             PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
-        }
 
         [Command(Description = "Create a new private key.")]
         public void Create(
@@ -48,7 +45,7 @@ namespace Libplanet.Tools
                 string second = ConsolePasswordReader.Read("Retype tassphrase: ");
                 if (!passphrase.Equals(second))
                 {
-                    throw Error("Passwords do not match.");
+                    throw Utils.Error("Passwords do not match.");
                 }
             }
 
@@ -87,30 +84,20 @@ namespace Libplanet.Tools
             }
             catch (NoKeyException)
             {
-                throw Error($"No such key ID: {keyId}");
+                throw Utils.Error($"No such key ID: {keyId}");
             }
             catch (IncorrectPassphraseException)
             {
-                throw Error("The passphrase is wrong.");
+                throw Utils.Error("The passphrase is wrong.");
             }
         }
 
         private void PrintKeys(IEnumerable<(Guid, ProtectedPrivateKey)> keys)
         {
-            Console.Error.WriteLine("{0,-36} {1,-42}", "UUID", "Address");
-            Console.Error.WriteLine($"{new string('-', 36)} {new string('-', 42)}");
-            Console.Error.Flush();
-            foreach ((Guid keyId, ProtectedPrivateKey ppk) in keys)
-            {
-                Console.WriteLine("{0,-36} {1,-42}", keyId, ppk.Address);
-            }
-        }
-
-        private CommandExitedException Error(string message, int exitCode = 128)
-        {
-            Console.Error.WriteLine("Error: {0}", message);
-            Console.Error.Flush();
-            return new CommandExitedException(exitCode);
+            Utils.PrintTable(
+                ("UUID", "Address"),
+                keys.Select(t => (t.Item1.ToString(), t.Item2.Address.ToString()))
+            );
         }
     }
 }

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -1,0 +1,69 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Libplanet.Tools</PackageId>
+    <Title>Libplanet CLI Tools</Title>
+    <OutputType>Exe</OutputType>
+    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Authors>Planetarium</Authors>
+    <Company>Planetarium</Company>
+    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <RepositoryUrl>git://github.com/planetarium/libplanet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <RootNamespace>Libplanet.Tools</RootNamespace>
+    <AssemblyName>Libplanet.Tools</AssemblyName>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1591;S1118</NoWarn>
+    <IsTestProject>false</IsTestProject>
+    <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+    <None Include="..\icon.png" Pack="true" PackagePath="icon.png" />
+    <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
+      <Link>Menees.Analyzers.Settings.xml</Link>
+    </AdditionalFiles>
+    <AdditionalFiles Include="..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cocona.Lite" Version="1.3.*" />
+    <PackageReference Include="GetPass" Version="1.0.*" />
+    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference
+      Include="Microsoft.DotNet.Analyzers.Compatibility"
+      Version="0.2.12-alpha">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers; buildtransitive
+      </IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.5.0.15942">
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+    <!-- FIXME: We should specify the version range when the following NuGet
+    issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
+  </ItemGroup>
+</Project>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -68,7 +68,7 @@
       </IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -14,8 +14,6 @@
     <RepositoryUrl>git://github.com/planetarium/libplanet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Libplanet.Tools</RootNamespace>
-    <AssemblyName>Libplanet.Tools</AssemblyName>
-    <PackAsTool>true</PackAsTool>
     <ToolCommandName>planet</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -23,6 +21,20 @@
     <NoWarn>$(NoWarn);CS1591;S1118</NoWarn>
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
+    <PackAsTool>true</PackAsTool>
+    <AssemblyName>Libplanet.Tools</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' ">
+    <AssemblyName>planet</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' And
+                             '$(RuntimeIdentifier.Substring(0, 6))' == 'linux-' ">
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Libplanet.Tools</PackageId>
-    <Title>Libplanet CLI Tools</Title>
+    <Title>planet: Libplanet CLI Tools</Title>
     <OutputType>Exe</OutputType>
     <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
@@ -15,6 +15,8 @@
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Libplanet.Tools</RootNamespace>
     <AssemblyName>Libplanet.Tools</AssemblyName>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>planet</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -16,6 +16,7 @@
     <RootNamespace>Libplanet.Tools</RootNamespace>
     <ToolCommandName>planet</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -18,7 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591;S1118</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Cocona;
+
+namespace Libplanet.Tools
+{
+    [HasSubCommands(typeof(Keys), Description = "Manage private keys.")]
+    public class Program
+    {
+        public static Task Main(string[] args) =>
+            CoconaLiteApp.RunAsync<Program>(args);
+    }
+}

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -8,5 +8,10 @@ namespace Libplanet.Tools
     {
         public static Task Main(string[] args) =>
             CoconaLiteApp.RunAsync<Program>(args);
+
+        [PrimaryCommand]
+        public Task Help() =>
+            /* FIXME: I believe there is a better way... */
+            Main(new[] { "--help" });
     }
 }

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -8,7 +8,10 @@ namespace Libplanet.Tools
     public class Program
     {
         public static Task Main(string[] args) =>
-            CoconaLiteApp.RunAsync<Program>(args);
+            CoconaLiteApp.RunAsync<Program>(args, options =>
+            {
+                options.TreatPublicMethodsAsCommands = false;
+            });
 
         [PrimaryCommand]
         public Task Help() =>

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -3,6 +3,7 @@ using Cocona;
 
 namespace Libplanet.Tools
 {
+    [HasSubCommands(typeof(Apv), Description = "App protocol version utilities.")]
     [HasSubCommands(typeof(Key), Description = "Manage private keys.")]
     public class Program
     {

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -3,7 +3,7 @@ using Cocona;
 
 namespace Libplanet.Tools
 {
-    [HasSubCommands(typeof(Keys), Description = "Manage private keys.")]
+    [HasSubCommands(typeof(Key), Description = "Manage private keys.")]
     public class Program
     {
         public static Task Main(string[] args) =>

--- a/Libplanet.Tools/README.md
+++ b/Libplanet.Tools/README.md
@@ -1,8 +1,27 @@
-Libplanet CLI Tools
-===================
+`planet`: Libplanet CLI Tools
+=============================
 
 This CLI app is a collection of utilities for application programmers who
 create decentralized games powered by [Libplanet].
 
+Install as a [.NET Core tool]:
+
+~~~~ bash
+dotnet tool install -g Libplanet.Tools
+~~~~
+
+Run the command:
+
+~~~~ bash
+dotnet planet --help
+~~~~
+
+Or shortly (if it's installed with `-g`/`--global` option):
+
+~~~~ bash
+planet --help
+~~~~
+
 
 [Libplanet]: https://libplanet.io/
+[.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools

--- a/Libplanet.Tools/README.md
+++ b/Libplanet.Tools/README.md
@@ -1,0 +1,8 @@
+Libplanet CLI Tools
+===================
+
+This CLI app is a collection of utilities for application programmers who
+create decentralized games powered by [Libplanet].
+
+
+[Libplanet]: https://libplanet.io/

--- a/Libplanet.Tools/README.md
+++ b/Libplanet.Tools/README.md
@@ -4,24 +4,38 @@
 This CLI app is a collection of utilities for application programmers who
 create decentralized games powered by [Libplanet].
 
-Install as a [.NET Core tool]:
+[Libplanet]: https://libplanet.io/
+
+
+Installation
+------------
+
+Install as a [.NET Core tool] if .NET Core SDK is installed on your system:
 
 ~~~~ bash
 dotnet tool install -g Libplanet.Tools
 ~~~~
 
-Run the command:
+Or you could just download an executable binary for your platform from
+the [releases page]: *planet-\*-{linux,osx,win}-x64.{tar.xz,zip}* files are
+CLI tools.  Linux (x64), macOS (x64), and Windows (x64) are supported.
+Extract the binary to an appropriate directory in your `PATH`.
 
-~~~~ bash
-dotnet planet --help
-~~~~
+[.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
 
-Or shortly (if it's installed with `-g`/`--global` option):
+
+Usage
+-----
 
 ~~~~ bash
 planet --help
 ~~~~
 
+If you installed it using .NET Core SDK *without `-g`/`--global` option*
+use `dotnet planet` command instead:
 
-[Libplanet]: https://libplanet.io/
-[.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
+~~~~ bash
+dotnet planet --help
+~~~~
+
+[releases page]: https://github.com/planetarium/libplanet/releases

--- a/Libplanet.Tools/Utils.cs
+++ b/Libplanet.Tools/Utils.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Tools
             IEnumerable<(int, string)> RowToStrings(T tuple)
             {
                 return Enumerable.Range(0, tuple.Length)
-                    .Select(i => (i, tuple[i]?.ToString() ?? string.Empty));
+                    .Select(i => (i, tuple[i]?.ToString()?.Normalize() ?? string.Empty));
             }
 
             // Calculates the column lengths:

--- a/Libplanet.Tools/Utils.cs
+++ b/Libplanet.Tools/Utils.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Tools
             IEnumerable<(int, string)> RowToStrings(T tuple)
             {
                 return Enumerable.Range(0, tuple.Length)
-                    .Select(i => (i, tuple[i].ToString()));
+                    .Select(i => (i, tuple[i]?.ToString() ?? string.Empty));
             }
 
             // Calculates the column lengths:

--- a/Libplanet.Tools/Utils.cs
+++ b/Libplanet.Tools/Utils.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Cocona;
+
+namespace Libplanet.Tools
+{
+    public static class Utils
+    {
+        public static CommandExitedException Error(string message, int exitCode = 128)
+        {
+            Console.Error.WriteLine("Error: {0}", message);
+            Console.Error.Flush();
+            return new CommandExitedException(exitCode);
+        }
+
+        public static void PrintTable<T>(T header, IEnumerable<T> rows)
+            where T : ITuple
+        {
+            IEnumerable<(int, string)> RowToStrings(T tuple)
+            {
+                return Enumerable.Range(0, tuple.Length)
+                    .Select(i => (i, tuple[i].ToString()));
+            }
+
+            // Calculates the column lengths:
+            T[] rowsArray = rows.ToArray();
+            int[] columnLengths = RowToStrings(header).Select(pair => pair.Item2.Length).ToArray();
+            foreach (T row in rowsArray)
+            {
+                foreach ((int i, string col) in RowToStrings(row))
+                {
+                    int length = col.Length;
+                    if (columnLengths[i] < length)
+                    {
+                        columnLengths[i] = length;
+                    }
+                }
+            }
+
+            // Prints column names (into /dev/stderr):
+            foreach ((int i, string col) in RowToStrings(header))
+            {
+                int length = columnLengths[i];
+                Console.Error.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+            }
+
+            Console.Error.WriteLine();
+
+            // Prints horizontal lines (into /dev/stderr):
+            foreach ((int i, string col) in RowToStrings(header))
+            {
+                Console.Error.Write(i > 0 ? " {0}" : "{0}", new string('-', columnLengths[i]));
+            }
+
+            Console.Error.WriteLine();
+            Console.Error.Flush();
+
+            // Print rows:
+            foreach (T row in rowsArray)
+            {
+                foreach ((int i, string col) in RowToStrings(row))
+                {
+                    int length = columnLengths[i];
+                    Console.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+                }
+
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore", "L
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore.Tests", "Libplanet.RocksDBStore.Tests\Libplanet.RocksDBStore.Tests.csproj", "{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Tools", "Libplanet.Tools\Libplanet.Tools.csproj", "{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x64.Build.0 = Release|Any CPU
 		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x86.ActiveCfg = Release|Any CPU
 		{ADCBBAC0-0A87-45B7-BD31-314F136F74D4}.Release|x86.Build.0 = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|x64.Build.0 = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{A216C2F0-A9A6-4D7F-BF65-127EB80EA6A7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -1,6 +1,4 @@
-<Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-  Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
@@ -50,7 +48,7 @@ https://docs.libplanet.io/</Description>
 
   <ItemGroup>
     <None Include="..\CHANGES.md" Pack="true" PackagePath="CHANGES.md" />
-    <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
     <None Include="..\README.md" Pack="true" PackagePath="README.md" />
     <None Include="..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">

--- a/hooks/check-projects
+++ b/hooks/check-projects
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+SOLUTION="$(dirname "$0")/../Libplanet.sln"
+
+if ! [[ -f "$SOLUTION" ]]; then
+  echo "No such solution file: $SOLUTION" > /dev/stderr
+  exit 1
+fi
+
+list-projects() {
+  dotnet sln "$SOLUTION" list | tail -n +3 | awk -F/ '{ print $1 }'
+}
+
+check-project() {
+  if ! grep -E "^ -  \*$1\*: " CONTRIBUTING.md > /dev/null; then
+    echo "The project $1 is not documented in the CONTRIBUTING.md file." \
+      > /dev/stderr
+    exit 1
+  fi
+}
+
+for project in $(list-projects); do
+  check-project "$project" || exit 1
+done
+
+# vim: set filetype=sh ts=2 sw=2 et:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,5 +3,6 @@ set -e
 
 "$(dirname "$0")/check-bom"
 "$(dirname "$0")/check-changelog"
+"$(dirname "$0")/check-projects"
 
 # vim: set filetype=sh ts=2 sw=2 et:


### PR DESCRIPTION
In order to sign a new `AppProtocolVersion` from command-line/automated process, I added a `planet` command.  See also *Libplanet.Tools/README.md* for details.

```bash
Usage: Libplanet.Tools [command]
Usage: Libplanet.Tools [--help] [--version]

Libplanet.Tools

Commands:
  apv    App protocol version utilities.
  key    Manage private keys.

Options:
  -h, --help    Show help message
  --version     Show version
```

A sample session to sign a new `AppProtocolVersion`:

```bash
planet key create
# Suppose new key's ID is 39eaaed4-d03a-40d9-b7be-175b2ba2c1e5

planet apv sign 39eaaed4-d03a-40d9-b7be-175b2ba2c1e5 123 \
  -e macOSBinaryUrl=... \
  -e windowsBinaryUrl=...
```

Give a try in advance by downloading the following builds:

- [planet-0.9.0-dev.20200401104502-linux-x64.tar.xz](https://send.firefox.com/download/c2448eed62e282c0/#TjCESvQdQQsj79dXIOxJpw)
- [planet-0.9.0-dev.20200401104502-osx-x64.tar.xz](https://send.firefox.com/download/793e8c2f35cb1f5d/#2jGDavIK_ORlA7QPcF-XUQ)
- [planet-0.9.0-dev.20200401104502-win-x64.zip](https://send.firefox.com/download/30b9b9086bfa5a11/#ANT_c7ZEikEy4ELT83VpMA)