### PR TITLE
Fix unexpected error on non-ASCII passphrases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,9 @@ To be released.
     [[#839]]
  -  Fixed a bug where actions had been evaluated twice when receiving blocks.
     [[#843], [#844]]
+ -  Fixed `OverflowException` being thrown when a `passphrase` containing
+    any non-ASCII characters was passed to `Pbkdf2.Derive()` method or
+    `ProtectedPrivateKey.Protect()` method.  [[#845]]
 
 ### CLI tools
 
@@ -146,6 +149,7 @@ To be released.
 [#839]: https://github.com/planetarium/libplanet/pull/839
 [#843]: https://github.com/planetarium/libplanet/issues/843
 [#844]: https://github.com/planetarium/libplanet/pull/844
+[#845]: https://github.com/planetarium/libplanet/pull/845
 
 
 Version 0.8.0

--- a/Libplanet.Tests/KeyStore/Kdfs/KdfTest.cs
+++ b/Libplanet.Tests/KeyStore/Kdfs/KdfTest.cs
@@ -10,10 +10,11 @@ namespace Libplanet.Tests.KeyStore.Kdfs
     {
         public abstract T MakeInstance(byte[] randomBytes);
 
-        [InlineData(16)]
-        [InlineData(32)]
+        [InlineData(16, "foo")]
+        [InlineData(32, "foo")]
+        [InlineData(32, "unicode-暗號")]
         [Theory]
-        public void Derive(int size)
+        public void Derive(int size, string passphrase)
         {
             var randomBytes = new byte[size];
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
@@ -22,11 +23,11 @@ namespace Libplanet.Tests.KeyStore.Kdfs
             }
 
             T kdf = MakeInstance(randomBytes);
-            ImmutableArray<byte> dFoo = kdf.Derive("foo");
+            ImmutableArray<byte> dFoo = kdf.Derive(passphrase);
             Assert.Equal(size, dFoo.Length);
-            ImmutableArray<byte> dBar = kdf.Derive("bar");
+            ImmutableArray<byte> dBar = kdf.Derive($"diffrent-{passphrase}");
             Assert.NotEqual(dFoo, dBar);
-            TestUtils.AssertBytesEqual(dFoo, kdf.Derive("foo"));
+            TestUtils.AssertBytesEqual(dFoo, kdf.Derive(passphrase));
         }
     }
 }

--- a/Libplanet.Tests/KeyStore/ProtectedPrivateKeyTest.cs
+++ b/Libplanet.Tests/KeyStore/ProtectedPrivateKeyTest.cs
@@ -131,15 +131,18 @@ namespace Libplanet.Tests.KeyStore
             Assert.Equal(AddressFixture, mismatchedAddressException.ActualAddress);
         }
 
-        [Fact]
-        public void Protect()
+        [Theory]
+        [InlineData("foobar")]
+        [InlineData("unicode-暗號")]
+        public void Protect(string passphrase)
         {
             PrivateKey privKey = new PrivateKey();
-            ProtectedPrivateKey protectedKey = ProtectedPrivateKey.Protect(privKey, "foobar");
+            ProtectedPrivateKey protectedKey = ProtectedPrivateKey.Protect(privKey, passphrase);
             AssertBytesEqual(
                 privKey.ByteArray,
-                protectedKey.Unprotect("foobar").ByteArray
+                protectedKey.Unprotect(passphrase).ByteArray
             );
+            Assert.Throws<IncorrectPassphraseException>(() => protectedKey.Unprotect("WRONG"));
         }
 
         [Fact]

--- a/Libplanet/KeyStore/Kdfs/Pbkdf2.cs
+++ b/Libplanet/KeyStore/Kdfs/Pbkdf2.cs
@@ -75,7 +75,7 @@ namespace Libplanet.KeyStore.Kdfs
         {
             var pdb = new Pkcs5S2ParametersGenerator(new T());
             pdb.Init(
-                PbeParametersGenerator.Pkcs5PasswordToBytes(passphrase.ToCharArray()),
+                PbeParametersGenerator.Pkcs5PasswordToUtf8Bytes(passphrase.ToCharArray()),
                 Salt.ToArray(),
                 Iterations
             );

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -59,7 +59,7 @@ https://docs.libplanet.io/</Description>
 
   <ItemGroup>
     <PackageReference Include="Bencodex" Version="0.3.0-dev.1b62adcbf3bf91d1a96787f4447dc6cc518d9734" />
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />
     <PackageReference Include="Fody" Version="6.1.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
See also the changelog.  Also upgraded Bouncy Castle to the latest version.