### PR TITLE
Improve reply throughput of `Swarm<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@ To be released.
     creation.  [[#817], [#837]]
  -  Improved performance of `Swarm<T>.PreloadAsync()` by parallelizing
     connections.  [[#846]]
+ -  Improved response throughput of `Swarm<T>`.  [[#849]]
 
 ### Bug fixes
 
@@ -154,6 +155,7 @@ To be released.
 [#844]: https://github.com/planetarium/libplanet/pull/844
 [#845]: https://github.com/planetarium/libplanet/pull/845
 [#846]: https://github.com/planetarium/libplanet/pull/846
+[#849]: https://github.com/planetarium/libplanet/pull/849
 
 
 Version 0.8.0

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -337,20 +337,19 @@ namespace Libplanet.Net
             }
         }
 
-        public async Task BootstrapAsync(
+        public Task BootstrapAsync(
             IEnumerable<BoundPeer> bootstrapPeers,
             TimeSpan? pingSeedTimeout,
             TimeSpan? findNeighborsTimeout,
             int depth = Kademlia.MaxDepth,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            await Protocol.BootstrapAsync(
-                bootstrapPeers.ToImmutableList(),
-                pingSeedTimeout,
-                findNeighborsTimeout,
-                depth,
-                cancellationToken);
-        }
+            CancellationToken cancellationToken = default(CancellationToken)
+        ) => Protocol.BootstrapAsync(
+            bootstrapPeers.ToImmutableList(),
+            pingSeedTimeout,
+            findNeighborsTimeout,
+            depth,
+            cancellationToken
+        );
 
         public async Task AddPeersAsync(
             IEnumerable<Peer> peers,


### PR DESCRIPTION
This PR improves response throughput of `Swarm<T>` by arranging the timing of `.ToNetMQMessage()`. Moving it to the outside of `DoReply()` can help with its concurrency.