### PR TITLE
Fix two bugs from GitHub Actions scripts

### DIFF
--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -15,24 +15,6 @@ version="$(cat obj/package_version.txt)"
 version_prefix="$(cat obj/version_prefix.txt)"
 package_version="$(cat obj/package_version.txt)"
 
-for project in "${projects[@]}"; do
-  rm -rf "./$project/bin/$configuration/"
-
-  dotnet_args="-p:Version=$version"
-  if [ -f obj/version_suffix.txt ]; then
-    dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
-  fi
-  # shellcheck disable=SC2086
-  dotnet build -c "$configuration" $dotnet_args
-  # shellcheck disable=SC2086
-  dotnet pack "$project" -c "$configuration" $dotnet_args
-
-  ls -al "./$project/bin/$configuration/"
-  if [ "$package_version" != "$version_prefix" ]; then
-    rm -f "./$project/bin/$configuration/$project.$version_prefix.nupkg"
-  fi
-done
-
 for project in "${executables[@]}"; do
   for rid in "${rids[@]}"; do
     output_dir="./$project/bin/$configuration/$rid/"
@@ -53,4 +35,22 @@ for project in "${executables[@]}"; do
     popd
     rm -rf "$output_dir"
   done
+done
+
+for project in "${projects[@]}"; do
+  rm -rf "./$project/bin/$configuration/"
+
+  dotnet_args="-p:Version=$version"
+  if [ -f obj/version_suffix.txt ]; then
+    dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
+  fi
+  # shellcheck disable=SC2086
+  dotnet build -c "$configuration" $dotnet_args
+  # shellcheck disable=SC2086
+  dotnet pack "$project" -c "$configuration" $dotnet_args
+
+  ls -al "./$project/bin/$configuration/"
+  if [ "$package_version" != "$version_prefix" ]; then
+    rm -f "./$project/bin/$configuration/$project.$version_prefix.nupkg"
+  fi
 done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - run: mkdir -p Docs/obj/
     - run: Docs/build.ps1
       shell: pwsh


### PR DESCRIPTION
### Make *Libplanet.Tools* package as a .NET Core Tool

There had been a bug in *dist-pack.sh* that made *Libplanet.Tools.\*.nupkg* lacks a `<packageType name="DotnetTool" />` metadata.  This bug had been happened because the second-pass build of the *Libplanet.Tools* project for making a single-file executables had overwritten the *Libplanet.Tools.nuspec* file.  I fixed it by reversing the order of two build passes each other.

![Intended](https://user-images.githubusercontent.com/12431/80225529-286a0d80-8686-11ea-97de-c03a72ca6631.png)

![Unintended](https://user-images.githubusercontent.com/12431/80225553-315adf00-8686-11ea-9c45-07b3a6844950.png)


### Make the entrance of docs.libplanet.io updated only when a new tag is made

There had been a bug in *Docs/publish.sh* that every push to the master branch updates the root *index.html*, while the intention was to update it only for a new tag.  The bug was due to the empty output of `git tag -l`.  To fix this, I added an explicit instruction to fetch tags into the `docs` job of the *main.yml* workflow.