### PR TITLE
Avoid overwrapped SetResult and SetException

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,14 @@ To be released.
 
 ### Bug fixes
 
- -  Fixed a bug where the canonical chain had changed if any actions had thrown an exception
-    during `Swarm<T>.PreloadAsync()`.  [[#862]]
+ -  Fixed a bug where the canonical chain had changed if any actions had thrown
+    an exception during `Swarm<T>.PreloadAsync()`.  [[#862]]
+ -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that it had hung forever and
+    raisen `InvalidOperationException`.  [[#847], [#864]]
 
+[#847]: https://github.com/planetarium/libplanet/issues/847
 [#862]: https://github.com/planetarium/libplanet/pull/862
+[#864]: https://github.com/planetarium/libplanet/pull/864
 
 Version 0.9.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ To be released.
  -  Fixed a bug where the canonical chain had changed if any actions had thrown
     an exception during `Swarm<T>.PreloadAsync()`.  [[#862]]
  -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that it had hung forever and
-    raisen `InvalidOperationException`.  [[#847], [#864]]
+    raised `InvalidOperationException`.  [[#847], [#864]]
 
 [#847]: https://github.com/planetarium/libplanet/issues/847
 [#862]: https://github.com/planetarium/libplanet/pull/862

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -491,6 +491,8 @@ namespace Libplanet.Net
                 );
                 var tcs = new TaskCompletionSource<IEnumerable<Message>>();
                 Interlocked.Increment(ref _requestCount);
+
+                // FIXME should we also cacel tcs sender side too?
                 cancellationToken.Register(() => tcs.TrySetCanceled());
                 await _requests.AddAsync(
                     new MessageRequest(reqId, message, peer, now, timeout, expectedResponses, tcs),
@@ -836,15 +838,15 @@ namespace Libplanet.Net
                     Protocol.ReceiveMessage(result[0]);
                 }
 
-                tcs.SetResult(result);
+                tcs.TrySetResult(result);
             }
             catch (DifferentAppProtocolVersionException dape)
             {
-                tcs.SetException(dape);
+                tcs.TrySetException(dape);
             }
             catch (TimeoutException te)
             {
-                tcs.SetException(te);
+                tcs.TrySetException(te);
             }
 
             // Delaying dealer disposing to avoid ObjectDisposedException on NetMQPoller

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -492,7 +492,7 @@ namespace Libplanet.Net
                 var tcs = new TaskCompletionSource<IEnumerable<Message>>();
                 Interlocked.Increment(ref _requestCount);
 
-                // FIXME should we also cacel tcs sender side too?
+                // FIXME should we also cancel tcs sender side too?
                 cancellationToken.Register(() => tcs.TrySetCanceled());
                 await _requests.AddAsync(
                     new MessageRequest(reqId, message, peer, now, timeout, expectedResponses, tcs),


### PR DESCRIPTION
This PR addresses #847 by ignoring `InvalidOperationException` during `tcs.SetResult()` and `tcs.SetException()`.