### PR TITLE
Expose exception in IAction.Execute()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  Added `IAction.RenderError()` and `IAction.UnrenderError()`.
+ -  Added `IAction.RenderError()` and `IAction.UnrenderError()` methods.
     [[#860], [#875]]
 
 ### Backward-incompatible network protocol changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,18 +8,26 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Added `IAction.RenderError()` and `IAction.UnrenderError()`.
+    [[#860], [#875]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
 
-- Added `TurnClient.BindProxies()` method. [[#756], [#868]]
+ -  Added `TurnClient.BindProxies()` method. [[#756], [#868]]
+ -  Added `ActionEvaluation.Exception` property.  [[#860], [[#875]]]
 
 ### Behavioral changes
 
  -  Improved performance of `Swarm<T>` by multiplexing response and
     broadcast.  [[#858], [#859]]
+ -  `Transaction<T>.Create()`, `Transaction<T>.EvaluateActions()` and
+    `Transaction<T>.EvaluateActionsGradually()` no longer throw
+    `UnexpectedlyTerminatedActionException` directly. Instead, it records
+    an exception to `ActionEvalution`s.  [[#860], [#875]]
 
 ### Bug fixes
 
@@ -28,7 +36,9 @@ To be released.
 [#756]: https://github.com/planetarium/libplanet/issues/756
 [#858]: https://github.com/planetarium/libplanet/issues/858
 [#859]: https://github.com/planetarium/libplanet/pull/859
+[#860]: https://github.com/planetarium/libplanet/issues/860
 [#868]: https://github.com/planetarium/libplanet/pull/868
+[#875]: https://github.com/planetarium/libplanet/pull/875
 
 
 Version 0.9.2

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -120,6 +121,14 @@ namespace Libplanet.Tests.Action
             public void Unrender(
                 IActionContext context,
                 IAccountStateDelta nextStates)
+            {
+            }
+
+            public void RenderError(IActionContext context, Exception exception)
+            {
+            }
+
+            public void UnrenderError(IActionContext context, Exception exception)
             {
             }
         }

--- a/Libplanet.Tests/Common/Action/BaseAction.cs
+++ b/Libplanet.Tests/Common/Action/BaseAction.cs
@@ -1,3 +1,4 @@
+using System;
 using Bencodex.Types;
 using Libplanet.Action;
 
@@ -22,5 +23,13 @@ namespace Libplanet.Tests.Common.Action
         }
 
         public abstract void LoadPlainValue(IValue plainValue);
+
+        public virtual void RenderError(IActionContext context, Exception exception)
+        {
+        }
+
+        public virtual void UnrenderError(IActionContext context, Exception exception)
+        {
+        }
     }
 }

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -189,6 +189,14 @@ namespace Libplanet.Tests.Common.Action
             });
         }
 
+        public void RenderError(IActionContext context, Exception exception)
+        {
+        }
+
+        public void UnrenderError(IActionContext context, Exception exception)
+        {
+        }
+
         public void LoadPlainValue(IValue plainValue)
         {
             LoadPlainValue((Bencodex.Types.Dictionary)plainValue);

--- a/Libplanet.Tests/Common/Action/MinerReward.cs
+++ b/Libplanet.Tests/Common/Action/MinerReward.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -90,6 +91,14 @@ namespace Libplanet.Tests.Common.Action
                 Context = context,
                 NextStates = nextStates,
             });
+        }
+
+        public void RenderError(IActionContext context, Exception exception)
+        {
+        }
+
+        public void UnrenderError(IActionContext context, Exception exception)
+        {
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/ThrowException.cs
+++ b/Libplanet.Tests/Common/Action/ThrowException.cs
@@ -18,6 +18,10 @@ namespace Libplanet.Tests.Common.Action
 
         public bool ThrowOnRendering { get; set; }
 
+        public Action<IActionContext, Exception> OnRenderError { get; set; }
+
+        public Action<IActionContext, Exception> OnUnrenderError { get; set; }
+
         public IValue PlainValue =>
             new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
@@ -62,6 +66,22 @@ namespace Libplanet.Tests.Common.Action
             IActionContext context,
             IAccountStateDelta nextStates)
         {
+        }
+
+        public void RenderError(IActionContext context, Exception exception)
+        {
+            if (!(OnRenderError is null))
+            {
+                OnRenderError(context, exception);
+            }
+        }
+
+        public void UnrenderError(IActionContext context, Exception exception)
+        {
+            if (!(OnUnrenderError is null))
+            {
+                OnUnrenderError(context, exception);
+            }
         }
 
         public class SomeException : Exception

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
-using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -283,7 +282,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task PreloadFailureWhileExecuteActions()
+        public async Task PreloadWithFailedActions()
         {
             var policy = new BlockPolicy<ThrowException>();
             var fx1 = new DefaultStoreFixture(memory: true);
@@ -324,9 +323,10 @@ namespace Libplanet.Tests.Net
                     blockInterval: TimeSpan.FromSeconds(1));
                 minerSwarm.BlockChain.Append(block, DateTimeOffset.UtcNow, false, false);
 
-                await Assert.ThrowsAsync<UnexpectedlyTerminatedActionException>(async () =>
-                    await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1)));
-                Assert.Equal(chainId, fx2.Store.GetCanonicalChainId());
+                await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
+
+                // Preloading should succeed even if action throws exception.
+                Assert.Equal(minerChain.Tip, receiverChain.Tip);
             }
             finally
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1879,7 +1879,15 @@ namespace Libplanet.Tests.Net
             {
             }
 
+            public void RenderError(IActionContext context, Exception exception)
+            {
+            }
+
             public void Unrender(IActionContext context, IAccountStateDelta nextStates)
+            {
+            }
+
+            public void UnrenderError(IActionContext context, Exception exception)
             {
             }
         }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1219,6 +1219,14 @@ namespace Libplanet.Tests.Store
             public void Unrender(IActionContext context, IAccountStateDelta nextStates)
             {
             }
+
+            public void RenderError(IActionContext context, Exception exception)
+            {
+            }
+
+            public void UnrenderError(IActionContext context, Exception exception)
+            {
+            }
         }
     }
 }

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Action
         /// evaluate <paramref name="action"/>.</param>
         /// <param name="outputStates">The result states that
         /// <paramref name="action"/> makes.</param>
-        /// <param name="exception">An exception that has raised during evaluating a given
+        /// <param name="exception">An exception that has risen during evaluating a given
         /// <paramref name="action"/>.</param>
         public ActionEvaluation(
             IAction action,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -24,15 +24,19 @@ namespace Libplanet.Action
         /// evaluate <paramref name="action"/>.</param>
         /// <param name="outputStates">The result states that
         /// <paramref name="action"/> makes.</param>
+        /// <param name="exception">An exception that has raised during evaluating a given
+        /// <paramref name="action"/>.</param>
         public ActionEvaluation(
             IAction action,
             IActionContext inputContext,
-            IAccountStateDelta outputStates
+            IAccountStateDelta outputStates,
+            Exception exception = null
         )
         {
             Action = action;
             InputContext = inputContext;
             OutputStates = outputStates;
+            Exception = exception;
         }
 
         /// <summary>
@@ -52,6 +56,11 @@ namespace Libplanet.Action
         /// The result states that <see cref="Action"/> makes.
         /// </summary>
         public IAccountStateDelta OutputStates { get; }
+
+        /// <summary>
+        /// An exception that had risen during evaluation.
+        /// </summary>
+        public Exception Exception { get; }
 
         /// <summary>
         /// Executes the <paramref name="actions"/> step by step, and emits
@@ -80,11 +89,6 @@ namespace Libplanet.Action
         /// Note that each <see cref="IActionContext.Random"/> object
         /// has a unconsumed state.
         /// </returns>
-        /// <exception cref="UnexpectedlyTerminatedActionException">
-        /// Thrown when one of <paramref name="actions"/> throws some exception.
-        /// The actual exception that an <see cref="IAction"/> threw
-        /// is stored in its <see cref="Exception.InnerException"/> property.
-        /// </exception>
         internal static IEnumerable<ActionEvaluation> EvaluateActionsGradually(
             HashDigest<SHA256> blockHash,
             long blockIndex,
@@ -120,11 +124,11 @@ namespace Libplanet.Action
                 (signature.Any() ? BitConverter.ToInt32(hashedSignature, 0) : 0);
 
             IAccountStateDelta states = previousStates;
+            Exception exc = null;
             foreach (IAction action in actions)
             {
-                ActionContext context =
-                    CreateActionContext(states, seed);
-                IAccountStateDelta nextStates;
+                ActionContext context = CreateActionContext(states, seed);
+                IAccountStateDelta nextStates = context.PreviousStates;
                 try
                 {
                     nextStates = action.Execute(context);
@@ -137,7 +141,7 @@ namespace Libplanet.Action
                         msg = $"The action {action} (block #{blockIndex} {blockHash}, tx {txid}) " +
                               "threw an exception during execution.  See also this exception's " +
                               "InnerException property.";
-                        throw new UnexpectedlyTerminatedActionException(
+                        exc = new UnexpectedlyTerminatedActionException(
                             blockHash, blockIndex, txid, action, msg, e
                         );
                     }
@@ -151,21 +155,22 @@ namespace Libplanet.Action
                         "useful to make the action can deal with the case of " +
                         "rehearsal mode.\n" +
                         "See also this exception's InnerException property.";
-                    throw new UnexpectedlyTerminatedActionException(
+                    exc = new UnexpectedlyTerminatedActionException(
                         null, null, null, action, msg, e
                     );
                 }
 
                 // As IActionContext.Random is stateful, we cannot reuse
                 // the context which is once consumed by Execute().
-                ActionContext equivalentContext =
-                    CreateActionContext(states, seed);
+                ActionContext equivalentContext = CreateActionContext(states, seed);
 
                 yield return new ActionEvaluation(
                     action,
                     equivalentContext,
-                    nextStates
+                    nextStates,
+                    exc
                 );
+
                 states = nextStates;
                 unchecked
                 {

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -1,3 +1,4 @@
+using System;
 using Bencodex.Types;
 
 namespace Libplanet.Action
@@ -314,6 +315,20 @@ namespace Libplanet.Action
         void Render(IActionContext context, IAccountStateDelta nextStates);
 
         /// <summary>
+        /// Does things that should be doen right after this action is
+        /// spread to the network or is &#x201c;confirmed&#x201d; (kind of)
+        /// by each peer node.
+        /// </summary>
+        /// <param name="context">The equivalent context object to
+        /// what <see cref="Execute(IActionContext)"/> method had received.
+        /// That means <see cref="IActionContext.PreviousStates"/> are
+        /// the states right <em>before</em> this action executed.
+        /// </param>
+        /// <param name="exception">The exception that had raised during excuting this action.
+        /// </param>
+        void RenderError(IActionContext context, Exception exception);
+
+        /// <summary>
         /// Does things that should be undone right after this action is
         /// invalidated (mostly due to a block which this action has belonged
         /// to becoming considered a stale).
@@ -336,5 +351,22 @@ namespace Libplanet.Action
         /// <see cref="Render(IActionContext, IAccountStateDelta)"/> method
         /// with redrawing the graphics on the display at the finish.</remarks>
         void Unrender(IActionContext context, IAccountStateDelta nextStates);
+
+        /// <summary>
+        /// Does things that should be undone right after this action is
+        /// invalidated (mostly due to a block which this action has belonged
+        /// to becoming considered a stale).
+        /// <para>This method takes the equivalent arguments to
+        /// <see cref="Render(IActionContext, IAccountStateDelta)"/> method.
+        /// </para>
+        /// </summary>
+        /// <param name="context">The equivalent context object to
+        /// what <see cref="Execute(IActionContext)"/> method had received.
+        /// That means <see cref="IActionContext.PreviousStates"/> are
+        /// the states right <em>before</em> this action executed.
+        /// </param>
+        /// <param name="exception">The exception that had raised during excuting this action.
+        /// </param>
+        void UnrenderError(IActionContext context, Exception exception);
     }
 }

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -316,7 +316,7 @@ namespace Libplanet.Action
 
         /// <summary>
         /// Does the similar things to <see cref="Render(IActionContext, IAccountStateDelta)"/>,
-        /// except that this method is invoked when see cref="Execute(IActionContext)"/> method
+        /// except that this method is invoked when <see cref="Execute(IActionContext)"/> method
         /// has terminated with an exception.
         /// </summary>
         /// <param name="context">The equivalent context object to

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -315,9 +315,9 @@ namespace Libplanet.Action
         void Render(IActionContext context, IAccountStateDelta nextStates);
 
         /// <summary>
-        /// Does things that should be doen right after this action is
-        /// spread to the network or is &#x201c;confirmed&#x201d; (kind of)
-        /// by each peer node.
+        /// Does the similar things to <see cref="Render(IActionContext, IAccountStateDelta)"/>,
+        /// except that this method is invoked when see cref="Execute(IActionContext)"/> method
+        /// has terminated with an exception.
         /// </summary>
         /// <param name="context">The equivalent context object to
         /// what <see cref="Execute(IActionContext)"/> method had received.
@@ -353,11 +353,11 @@ namespace Libplanet.Action
         void Unrender(IActionContext context, IAccountStateDelta nextStates);
 
         /// <summary>
-        /// Does things that should be undone right after this action is
-        /// invalidated (mostly due to a block which this action has belonged
-        /// to becoming considered a stale).
+        /// Does the similar things to <see cref="Unrender(IActionContext, IAccountStateDelta)"/>,
+        /// except that this method is invoked when see cref="Execute(IActionContext)"/> method
+        /// has terminated with an exception.
         /// <para>This method takes the equivalent arguments to
-        /// <see cref="Render(IActionContext, IAccountStateDelta)"/> method.
+        /// <see cref="RenderError(IActionContext, Exception)"/> method.
         /// </para>
         /// </summary>
         /// <param name="context">The equivalent context object to

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -316,5 +316,13 @@ namespace Libplanet.Action
         /// <inheritdoc/>
         public override string ToString() =>
             $"{nameof(PolymorphicAction<T>)}<{InnerAction.GetType().FullName}>({InnerAction})";
+
+        /// <inheritdoc/>
+        public void RenderError(IActionContext context, Exception exception)
+            => InnerAction.RenderError(context, exception);
+
+        /// <inheritdoc/>
+        public void UnrenderError(IActionContext context, Exception exception)
+            => InnerAction.UnrenderError(context, exception);
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -877,7 +877,14 @@ namespace Libplanet.Blockchain
 
             foreach (var evaluation in evaluations)
             {
-                evaluation.Action.Render(evaluation.InputContext, evaluation.OutputStates);
+                if (evaluation.Exception is null)
+                {
+                    evaluation.Action.Render(evaluation.InputContext, evaluation.OutputStates);
+                }
+                else
+                {
+                    evaluation.Action.RenderError(evaluation.InputContext, evaluation.Exception);
+                }
             }
         }
 
@@ -1235,10 +1242,20 @@ namespace Libplanet.Blockchain
                     foreach (var evaluation in evaluations)
                     {
                         _logger.Debug("Unrender action {action}", evaluation.Action);
-                        evaluation.Action.Unrender(
-                            evaluation.InputContext,
-                            evaluation.OutputStates
-                        );
+                        if (evaluation.Exception is null)
+                        {
+                            evaluation.Action.Unrender(
+                                evaluation.InputContext,
+                                evaluation.OutputStates
+                            );
+                        }
+                        else
+                        {
+                            evaluation.Action.UnrenderError(
+                                evaluation.InputContext,
+                                evaluation.Exception
+                            );
+                        }
                     }
                 }
 

--- a/Libplanet/Store/StoreExtensions.cs
+++ b/Libplanet/Store/StoreExtensions.cs
@@ -104,7 +104,19 @@ namespace Libplanet.Store
             }
 
             /// <inheritdoc/>
+            public void RenderError(IActionContext context, Exception exception)
+            {
+                // Does nothing.
+            }
+
+            /// <inheritdoc/>
             public void Unrender(IActionContext context, IAccountStateDelta nextStates)
+            {
+                // Does nothing.
+            }
+
+            /// <inheritdoc/>
+            public void UnrenderError(IActionContext context, Exception exception)
             {
                 // Does nothing.
             }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -358,19 +358,6 @@ namespace Libplanet.Tx
         /// is passed to <paramref name="privateKey"/> or
         /// or <paramref name="actions"/>.
         /// </exception>
-        /// <exception cref="UnexpectedlyTerminatedActionException">
-        /// Thrown when one of <paramref name="actions"/> throws some
-        /// exception during their rehearsal.
-        /// <para>This exception is thrown probably because the logic of some of
-        /// the <paramref name="actions"/> is not enough generic so that
-        /// it can cover every case including &#x201c;rehearsal mode.&#x201d;
-        /// The <see cref="IActionContext.Rehearsal"/> property also might be
-        /// useful to make the <see cref="IAction"/> can deal with the case of
-        /// rehearsal mode.</para>
-        /// <para>The actual exception that an <see cref="IAction"/> threw
-        /// is stored in its <see cref="Exception.InnerException"/> property.
-        /// </para>
-        /// </exception>
         public static Transaction<T> Create(
             long nonce,
             PrivateKey privateKey,
@@ -500,14 +487,6 @@ namespace Libplanet.Tx
         /// Note that each <see cref="IActionContext.Random"/> object has
         /// a unconsumed state.
         /// </returns>
-        /// <exception cref="UnexpectedlyTerminatedActionException">
-        /// Thrown when one of <see cref="Actions"/> throws some
-        /// exception during <paramref name="rehearsal"/> mode.
-        /// The actual exception that an <see cref="IAction"/> threw
-        /// is stored in its <see cref="Exception.InnerException"/> property.
-        /// It is never thrown if the <paramref name="rehearsal"/> option is
-        /// <c>false</c>.
-        /// </exception>
         [Pure]
         public IEnumerable<ActionEvaluation>
         EvaluateActionsGradually(
@@ -553,14 +532,6 @@ namespace Libplanet.Tx
         /// being executed.  Note that it maintains
         /// <see cref="IAccountStateDelta.UpdatedAddresses"/> of the given
         /// <paramref name="previousStates"/> as well.</returns>
-        /// <exception cref="UnexpectedlyTerminatedActionException">
-        /// Thrown when one of <see cref="Actions"/> throws some
-        /// exception during <paramref name="rehearsal"/> mode.
-        /// The actual exception that an <see cref="IAction"/> threw
-        /// is stored in its <see cref="Exception.InnerException"/> property.
-        /// It is never thrown if the <paramref name="rehearsal"/> option is
-        /// <c>false</c>.
-        /// </exception>
         [Pure]
         public IAccountStateDelta EvaluateActions(
             HashDigest<SHA256> blockHash,


### PR DESCRIPTION
This PR addresses #860. specifically, it has the following changes.

- Added `IAction.RenderError()` and `IAction.UnrenderError()` to report an exception raised by `IAction.Execute()` to game developer.
- Added `ActionEvalution.Exception` to record whether an exception occurred while executing an action.
- `ActionEvalution.EvaluateActionsGradually()` (and related methods) no longer throw `UnexpectedlyTerminatedActionException`. instead, they record it to `ActionEvaluation`s.
