### PR TITLE
Add empty action test case

### DIFF
--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -209,6 +209,12 @@ namespace Libplanet.Tests.Blocks
                     new[] { MakeAction(addresses[2], 'C') },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(2)
                 ),
+                Transaction<DumbAction>.Create(
+                    0,
+                    _fx.TxFixture.PrivateKey3,
+                    new DumbAction[0],
+                    timestamp: DateTimeOffset.MinValue.AddSeconds(3)
+                ),
             };
             Block<DumbAction> blockIdx1 = MineNext(genesis, blockIdx1Txs, new byte[] { });
             var pairs = blockIdx1


### PR DESCRIPTION
This PR resolve #754.
In the original issue, it wanted to make the test case random so that all cases could be examined.

But rather because it would harm the deterministic action, we made additional PR for the empty case.
- Add cases _'if a transaction has empty action list'_