### PR TITLE
Improve block propagation performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,8 +28,9 @@ To be released.
 
 ### Behavioral changes
 
- -  Improved performance of `Swarm<T>` by multiplexing response and
-    broadcast.  [[#858], [#859]]
+ -  Improved performance of `Swarm<T>`.
+    - Multiplexed response and broadcast.  [[#858], [#859]]
+    - Reduced internal delays.  [[#871], [#879]]
  -  `Transaction<T>.Create()`, `Transaction<T>.EvaluateActions()` and
     `Transaction<T>.EvaluateActionsGradually()` no longer throw
     `UnexpectedlyTerminatedActionException` directly. Instead, it records
@@ -48,8 +49,10 @@ To be released.
 [#859]: https://github.com/planetarium/libplanet/pull/859
 [#860]: https://github.com/planetarium/libplanet/issues/860
 [#868]: https://github.com/planetarium/libplanet/pull/868
+[#871]: https://github.com/planetarium/libplanet/issues/871
 [#875]: https://github.com/planetarium/libplanet/pull/875
 [#878]: https://github.com/planetarium/libplanet/pull/878
+[#879]: https://github.com/planetarium/libplanet/pull/879
 
 
 Version 0.9.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,8 @@ To be released.
 ### Behavioral changes
 
  -  Improved performance of `Swarm<T>`.
-    - Multiplexed response and broadcast.  [[#858], [#859]]
-    - Reduced internal delays.  [[#871], [#879]]
+     -  Multiplexed response and broadcast.  [[#858], [#859]]
+     -  Reduced internal delays.  [[#871], [#879]]
  -  `Transaction<T>.Create()`, `Transaction<T>.EvaluateActions()` and
     `Transaction<T>.EvaluateActionsGradually()` no longer throw
     `UnexpectedlyTerminatedActionException` directly. Instead, it records

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -488,18 +488,25 @@ namespace Libplanet.Net
                     Interlocked.Read(ref _requestCount)
                 );
 
-                var reply = (await tcs.Task).ToList();
-                foreach (var msg in reply)
+                if (expectedResponses > 0)
                 {
-                    MessageHistory.Enqueue(msg);
+                    var reply = (await tcs.Task).ToList();
+                    foreach (var msg in reply)
+                    {
+                        MessageHistory.Enqueue(msg);
+                    }
+
+                    const string logMsg =
+                        "Received {ReplyMessageCount} reply messages to {RequestId} " +
+                        "from {PeerAddress}: {ReplyMessages}.";
+                    _logger.Debug(logMsg, reply.Count, reqId, peer.Address, reply);
+
+                    return reply;
                 }
-
-                const string logMsg =
-                    "Received {ReplyMessageCount} reply messages to {RequestId} " +
-                    "from {PeerAddress}: {ReplyMessages}.";
-                _logger.Debug(logMsg, reply.Count, reqId, peer.Address, reply);
-
-                return reply;
+                else
+                {
+                    return new Message[0];
+                }
             }
             catch (DifferentAppProtocolVersionException e)
             {

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -627,15 +627,15 @@ namespace Libplanet.Net
 
             // FIXME Should replace with PUB/SUB model.
             List<BoundPeer> peers = Protocol.PeersToBroadcast(except).ToList();
-            _logger.Debug($"Broadcasting message [{msg}]");
-            _logger.Debug($"Peers to broadcast : {peers.Count}");
+            _logger.Debug("Broadcasting message: {Message}", msg);
+            _logger.Debug("Peers to broadcast: {PeersCount}", peers.Count);
 
             foreach (BoundPeer peer in peers)
             {
                 _ = SendMessageAsync(peer, msg)
                     .ContinueWith(t =>
                     {
-                        string fname = nameof(DoBroadcast);
+                        const string fname = nameof(DoBroadcast);
                         switch (t.Exception?.InnerException)
                         {
                             case TimeoutException te:

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -431,10 +431,8 @@ namespace Libplanet.Net
 
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
-        public async Task SendMessageAsync(BoundPeer peer, Message message)
-        {
-            await SendMessageWithReplyAsync(peer, message, TimeSpan.FromSeconds(3), 0);
-        }
+        public Task SendMessageAsync(BoundPeer peer, Message message)
+            => SendMessageWithReplyAsync(peer, message, TimeSpan.FromSeconds(3), 0);
 
         public async Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2098,7 +2098,7 @@ namespace Libplanet.Net
                 if (_demandBlockHash is null ||
                     _demandBlockHash.Value.Item1 <= BlockChain.Tip.Index)
                 {
-                    await Task.Delay(100, cancellationToken);
+                    await Task.Delay(1, cancellationToken);
                     continue;
                 }
 
@@ -2141,7 +2141,7 @@ namespace Libplanet.Net
             {
                 if (_demandTxIds.IsEmpty)
                 {
-                    await Task.Delay(100, cancellationToken);
+                    await Task.Delay(1, cancellationToken);
                     continue;
                 }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2123,7 +2123,6 @@ namespace Libplanet.Net
                 catch (TimeoutException)
                 {
                     _logger.Debug($"Timeout occurred during {nameof(ProcessFillblock)}");
-                    await Task.Delay(100, cancellationToken);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This PR addresses #871. I've benchmarked via Libplanet.Benchmark. (it tests a scenario using 10 skewed `Swarm<T>`s.) 

# Before

```
|                    Method |    Mean |    Error |   StdDev |  Median |
|-------------------------- |--------:|---------:|---------:|--------:|
|            BroadcastBlock | 1.202 s | 0.0341 s | 0.1005 s | 1.198 s |
| BroadcastBlockWithoutFill | 1.110 s | 0.0277 s | 0.0816 s | 1.131 s |
```

# After
```
|                    Method |     Mean |    Error |   StdDev |
|-------------------------- |---------:|---------:|---------:|
|            BroadcastBlock | 820.2 ms | 20.15 ms | 57.18 ms |
| BroadcastBlockWithoutFill | 652.8 ms | 20.38 ms | 58.81 ms |
```