### PR TITLE
Prevent Swarm<T>.GetDemandBlockHashes() from being hanged when a peer's chain is during reorg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.9.3
 
 To be released.
 
+ -  Fixed a `Swarm<T>.PreloadAsync()` method's bug that had hanged in a state
+    downloading block hashes and finally unexpectedly terminated when a peer's
+    chain had gotten reorged.   [[#880], [#884]]
+
+[#880]: https://github.com/planetarium/libplanet/issues/880
+[#884]: https://github.com/planetarium/libplanet/pull/884
+
 
 Version 0.9.2
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@ Version 0.9.2
 
 Released on May 20, 2020.
 
- -  (Libplanet.RocksDBStore) Fixed a memory leak bug in `RocksDBStore`.  [[#870]]
+ -  (Libplanet.RocksDBStore) Fixed a memory leak bug in `RocksDBStore`.
+    [[#870]]
 
 [#870]: https://github.com/planetarium/libplanet/pull/870
 
@@ -85,8 +86,8 @@ Released on April 27, 2020.
     that receives only one transaction.  [[#820]]
  -  Replaced `BlockChain<T>.UnstageTransactions()` with `.UnstageTransaction()`
     that receives only one transaction.  [[#820]]
- -  Added `IBlockPolicy.DoesTransactionFollowPolicy()` method which is a method to
-    determine if a transaction follows the block policy.  [[#827]]
+ -  Added `IBlockPolicy.DoesTransactionFollowPolicy()` method which is a method
+    to determine if a transaction follows the block policy.  [[#827]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Tests/ActionProgress.cs
+++ b/Libplanet.Tests/ActionProgress.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Libplanet.Tests
+{
+    public sealed class ActionProgress<T> : IProgress<T>
+    {
+        private Action<T> _action;
+
+        public ActionProgress(Action<T> action) =>
+            _action = action ?? throw new ArgumentNullException(nameof(action));
+
+        public void Report(T value) =>
+            _action(value);
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -1167,5 +1167,45 @@ namespace Libplanet.Tests.Net
                 );
             }
         }
+
+        [Fact(Timeout = Timeout)]
+        public async Task GetDemandBlockHashes()
+        {
+            Swarm<DumbAction> minerSwarm = _swarms[0];
+            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Log.Logger.Information("Miner:    {0}", minerSwarm.Address);
+            Log.Logger.Information("Receiver: {0}", receiverSwarm.Address);
+
+            BlockChain<DumbAction> minerChain = _blockchains[0];
+            BlockChain<DumbAction> receiverChain = _blockchains[1];
+
+            (_, IEnumerable<Block<DumbAction>> blocks) =
+                await MakeFixtureBlocksForPreloadAsyncCancellationTest();
+
+            foreach (Block<DumbAction> block in blocks)
+            {
+                minerChain.Append(block);
+            }
+
+            minerSwarm.FindNextHashesChunkSize = 2;
+            await StartAsync(minerSwarm);
+
+            (BoundPeer, long?)[] peers =
+            {
+                ((BoundPeer)minerSwarm.AsPeer, minerChain.Count - 1),
+            };
+
+            (long, HashDigest<SHA256>)[] demands = await receiverSwarm.GetDemandBlockHashes(
+                receiverChain,
+                peers,
+                progress: null,
+                cancellationToken: CancellationToken.None
+            ).ToArrayAsync();
+
+            IEnumerable<(long, HashDigest<SHA256>)> expectedBlocks = minerChain.IterateBlocks()
+                .Where(b => b.Index >= receiverChain.Count)
+                .Select(b => (b.Index, b.Hash));
+            Assert.Equal(expectedBlocks, demands);
+        }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1055,6 +1055,8 @@ namespace Libplanet.Net
                 i++;
                 long peerIndex = peerHeight ?? -1;
 
+                // FIXME: The following condition should be fixed together when the issue #459 is
+                // fixed.  https://github.com/planetarium/libplanet/issues/459
                 if (peer is null || currentTipIndex >= peerIndex)
                 {
                     continue;
@@ -1066,8 +1068,18 @@ namespace Libplanet.Net
                 try
                 {
                     var downloaded = new List<HashDigest<SHA256>>();
+                    int previousDownloadedCount = -1;
+                    int stagnant = 0;
+                    const int stagnationLimit = 3;
                     while (downloaded.Count < totalBlocksToDownload)
                     {
+                        if (previousDownloadedCount == downloaded.Count &&
+                            ++stagnant > stagnationLimit)
+                        {
+                            break;
+                        }
+
+                        previousDownloadedCount = downloaded.Count;
                         _logger.Verbose(
                             "Request block hashes to {Peer} (height: {PeerHeight}) using " +
                             "the locator {@Locator}... ({CurrentIndex}/{EstimatedTotalCount})",


### PR DESCRIPTION
This fixes the bug #880.

- Make `Swarm<T>.GetDemandBlockHashes()` method `internal` (was `private`) and add unit tests on it.
- Prevent `Swarm<T>.GetDemandBlockHashes()` method from being hanged when a peer's chain is during reorg.