### PR TITLE
Fix NuGet distribution condition

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -20,18 +20,20 @@ if [ "$NUGET_API_KEY" = "" ]; then
 fi
 
 # Publish a package only if the repository is upstream (planetarium/libplanet)
-# and the branch is for releases (master or maintenance-*).
+# and the branch is for releases (master or *-maintenance or 9c-*).
 # shellcheck disable=SC2235
-if [ "$GITHUB_REPOSITORY" != "planetarium/libplanet" ] || (
-    [ "$GITHUB_REF" = "${GITHUB_REF#refs/tags/}" ] &&
-    [ "$GITHUB_REF" != refs/heads/master ] &&
-    [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ] ); then
+if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
+    "$GITHUB_REF" = refs/tags/* || \
+    "$GITHUB_REF" = refs/heads/master || \
+    "$GITHUB_REF" = refs/heads/*-maintenance || \
+    "$GITHUB_REF" = refs/heads/9c-* \
+  ]]; then
   function dotnet-nuget {
-    echo "DRY-RUN: dotnet nuget" "$@"
+    dotnet nuget "$@"
   }
 else
   function dotnet-nuget {
-    dotnet nuget "$@"
+    echo "DRY-RUN: dotnet nuget" "$@"
   }
 fi
 


### PR DESCRIPTION
Made the condition to determine whether to submit *.nupkg* files to NuGet Gallery or skip easier to understand, and fixed the wrong case (*\*-maintenance*, not *maintenance-\**).  Also added the case for *9c-\** branches.

The following script a minimum test code for the new bash conditional:

```bash
#!/bin/bash

for GITHUB_REPOSITORY in {planetarium/libplanet,dahlia/libplanet}; do
  for GITHUB_REF in {refs/heads/master,refs/heads/0.9-maintenance,refs/heads/9c-beta,refs/tags/0.9.2,refs/heads/foobar}; do
    label="GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_REF=$GITHUB_REF"
    if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
        "$GITHUB_REF" = refs/tags/* || \
        "$GITHUB_REF" = refs/heads/master || \
        "$GITHUB_REF" = refs/heads/*-maintenance || \
        "$GITHUB_REF" = refs/heads/9c-* \
      ]]; then
      echo "perform: $label"
    else
      echo "skip:    $label"
    fi
  done
done
```

The above test prints as follows:

```
perform: GITHUB_REPOSITORY=planetarium/libplanet GITHUB_REF=refs/heads/master
perform: GITHUB_REPOSITORY=planetarium/libplanet GITHUB_REF=refs/heads/0.9-maintenance
perform: GITHUB_REPOSITORY=planetarium/libplanet GITHUB_REF=refs/heads/9c-beta
perform: GITHUB_REPOSITORY=planetarium/libplanet GITHUB_REF=refs/tags/0.9.2
skip:    GITHUB_REPOSITORY=planetarium/libplanet GITHUB_REF=refs/heads/foobar
skip:    GITHUB_REPOSITORY=dahlia/libplanet GITHUB_REF=refs/heads/master
skip:    GITHUB_REPOSITORY=dahlia/libplanet GITHUB_REF=refs/heads/0.9-maintenance
skip:    GITHUB_REPOSITORY=dahlia/libplanet GITHUB_REF=refs/heads/9c-beta
skip:    GITHUB_REPOSITORY=dahlia/libplanet GITHUB_REF=refs/tags/0.9.2
skip:    GITHUB_REPOSITORY=dahlia/libplanet GITHUB_REF=refs/heads/foobar
```