### PR TITLE
Make RocksDBStore.DeleteChainId() idempotent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.9.4
 
 To be released.
 
+ -  (Libplanet.RocksDBStore) Fixed a bug that  `RocksDBStore.DeleteChainId()`
+    method had thrown `KeyNotFoundException` when there's no such chain ID.
+    [[#891]]
+
+[#891]: https://github.com/planetarium/libplanet/pull/891
+
 
 Version 0.9.3
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ To be released.
  -  (Libplanet.RocksDBStore) Fixed a bug that  `RocksDBStore.DeleteChainId()`
     method had thrown `KeyNotFoundException` when there's no such chain ID.
     [[#891]]
+ -  (Libplanet.RocksDBStore) Fixed a bug that `RocksDBStore` had written logs
+    into the incorrect context `DefaultContext`, not `RocksDBStore`
+    the correct one.  [[#891]]
 
 [#891]: https://github.com/planetarium/libplanet/pull/891
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -141,11 +141,18 @@ namespace Libplanet.RocksDBStore
         /// <inheritdoc/>
         public override void DeleteChainId(Guid chainId)
         {
-            _lastStateRefCaches.Remove(chainId);
+            try
+            {
+                _lastStateRefCaches.Remove(chainId);
 
-            var cfName = chainId.ToString();
-            _chainDb.DropColumnFamily(cfName);
-            _stateRefDb.DropColumnFamily(cfName);
+                var cfName = chainId.ToString();
+                _chainDb.DropColumnFamily(cfName);
+                _stateRefDb.DropColumnFamily(cfName);
+            }
+            catch (KeyNotFoundException)
+            {
+                // Do nothing according to the specification: DeleteChainId() should be idempotent.
+            }
         }
 
         /// <inheritdoc />

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -76,7 +76,7 @@ namespace Libplanet.RocksDBStore
             int statesCacheSize = 10000
         )
         {
-            _logger = Log.ForContext<DefaultStore>();
+            _logger = Log.ForContext<RocksDBStore>();
 
             if (path is null)
             {
@@ -152,6 +152,7 @@ namespace Libplanet.RocksDBStore
             catch (KeyNotFoundException)
             {
                 // Do nothing according to the specification: DeleteChainId() should be idempotent.
+                _logger.Debug("No such chain ID: {ChainId}.", chainId);
             }
         }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -74,6 +74,14 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
+        public void DeleteChainIdIsIdempotent()
+        {
+            Assert.Empty(Fx.Store.ListChainIds());
+            Fx.Store.DeleteChainId(Guid.NewGuid());
+            Assert.Empty(Fx.Store.ListChainIds());
+        }
+
+        [SkippableFact]
         public void CanonicalChainId()
         {
             Assert.Null(Fx.Store.GetCanonicalChainId());


### PR DESCRIPTION
According to `IStore.DeleteChainId()` method's XML comment:

> If there is no such `chainId` it does nothing.

Howver, `RocksDBStore.DeleteChainId()` hadn't been like that.  This fixed the bug.