### PR TITLE
Ignore invalid header immediately

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ To be released.
  -  Added `Transaction<T>.GenesisHash` property.  [[#796], [#878]]
  -  `Swarm<T>` became to ignore received transaction with different
     genesis hash.  [[#796], [#878]]
+ -  `Swarm<T>` became to ignore invalid block header immediately.  [[#898]]
 
 ### Bug fixes
 
@@ -62,6 +63,7 @@ To be released.
 [#879]: https://github.com/planetarium/libplanet/pull/879
 [#883]: https://github.com/planetarium/libplanet/pull/883
 [#883]: https://github.com/planetarium/libplanet/pull/890
+[#898]: https://github.com/planetarium/libplanet/pull/898
 
 
 Version 0.9.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,7 +62,7 @@ To be released.
 [#878]: https://github.com/planetarium/libplanet/pull/878
 [#879]: https://github.com/planetarium/libplanet/pull/879
 [#883]: https://github.com/planetarium/libplanet/pull/883
-[#883]: https://github.com/planetarium/libplanet/pull/890
+[#890]: https://github.com/planetarium/libplanet/pull/890
 [#898]: https://github.com/planetarium/libplanet/pull/898
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ To be released.
  -  Added `Transaction<T>.GenesisHash` property.  [[#796], [#878]]
  -  `Swarm<T>` became to ignore received transaction with different
     genesis hash.  [[#796], [#878]]
- -  `Swarm<T>` became to ignore invalid block header immediately.  [[#898]]
+ -  `Swarm<T>` became to ignore invalid `BlockHeader`s immediately.  [[#898]]
 
 ### Bug fixes
 

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using Libplanet.Blocks;
+using Xunit;
+
+namespace Libplanet.Tests.Blocks
+{
+    public class BlockHeaderTest : IClassFixture<BlockFixture>
+    {
+        private BlockFixture _fx;
+
+        public BlockHeaderTest(BlockFixture fixture) => _fx = fixture;
+
+        [Fact]
+        public void ValidateTimestamp()
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string future = (now + TimeSpan.FromSeconds(901))
+                .ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture);
+            var header = new BlockHeader(
+                index: 0,
+                difficulty: 0,
+                nonce: ImmutableArray<byte>.Empty,
+                previousHash: ImmutableArray<byte>.Empty,
+                txHash: ImmutableArray<byte>.Empty,
+                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                miner: ImmutableArray<byte>.Empty,
+                timestamp: future
+            );
+
+            Assert.Throws<InvalidBlockTimestampException>(
+                () => { header.Validate(now); });
+
+            // it's okay because 2 seconds later.
+            header.Validate(now + TimeSpan.FromSeconds(2));
+        }
+
+        [Fact]
+        public void ValidateNonce()
+        {
+            var header = new BlockHeader(
+                index: _fx.Next.Index,
+                difficulty: long.MaxValue,
+                nonce: _fx.Next.Nonce.ByteArray,
+                miner: _fx.Next.Miner?.ByteArray ?? ImmutableArray<byte>.Empty,
+                hash: _fx.Next.Hash.ByteArray,
+                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
+                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
+                timestamp: _fx.Next.Timestamp.ToString(
+                    BlockHeader.TimestampFormat,
+                    CultureInfo.InvariantCulture
+                )
+            );
+
+            Assert.Throws<InvalidBlockNonceException>(() =>
+                header.Validate(DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public void ValidateIndex()
+        {
+            var header = new BlockHeader(
+                index: -1,
+                difficulty: _fx.Next.Difficulty,
+                nonce: _fx.Next.Nonce.ByteArray,
+                miner: _fx.Next.Miner?.ByteArray ?? ImmutableArray<byte>.Empty,
+                hash: _fx.Next.Hash.ByteArray,
+                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
+                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
+                timestamp: _fx.Next.Timestamp.ToString(
+                    BlockHeader.TimestampFormat,
+                    CultureInfo.InvariantCulture
+                )
+            );
+
+            Assert.Throws<InvalidBlockIndexException>(() =>
+                header.Validate(DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public void ValidateDifficulty()
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            var genesisHeader = new BlockHeader(
+                index: 0,
+                difficulty: 1000,
+                nonce: ImmutableArray<byte>.Empty,
+                previousHash: ImmutableArray<byte>.Empty,
+                txHash: ImmutableArray<byte>.Empty,
+                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                miner: ImmutableArray<byte>.Empty,
+                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture)
+            );
+
+            Assert.Throws<InvalidBlockDifficultyException>(() =>
+                genesisHeader.Validate(DateTimeOffset.UtcNow));
+
+            var header = new BlockHeader(
+                index: 10,
+                difficulty: 0,
+                nonce: ImmutableArray<byte>.Empty,
+                previousHash: ImmutableArray<byte>.Empty,
+                txHash: ImmutableArray<byte>.Empty,
+                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                miner: ImmutableArray<byte>.Empty,
+                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture)
+            );
+
+            Assert.Throws<InvalidBlockDifficultyException>(() =>
+                genesisHeader.Validate(DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public void ValidatePreviousHash()
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            var genesisHeader = new BlockHeader(
+                index: 0,
+                difficulty: 0,
+                nonce: ImmutableArray<byte>.Empty,
+                previousHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                txHash: ImmutableArray<byte>.Empty,
+                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                miner: ImmutableArray<byte>.Empty,
+                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture)
+            );
+
+            Assert.Throws<InvalidBlockPreviousHashException>(() =>
+                genesisHeader.Validate(DateTimeOffset.UtcNow));
+
+            var header = new BlockHeader(
+                index: 10,
+                difficulty: 1000,
+                nonce: ImmutableArray<byte>.Empty,
+                previousHash: ImmutableArray<byte>.Empty,
+                txHash: ImmutableArray<byte>.Empty,
+                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
+                miner: ImmutableArray<byte>.Empty,
+                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture)
+            );
+
+            Assert.Throws<InvalidBlockPreviousHashException>(() =>
+                genesisHeader.Validate(DateTimeOffset.UtcNow));
+        }
+    }
+}

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -423,18 +423,21 @@ namespace Libplanet.Blocks
 
         internal BlockHeader GetBlockHeader()
         {
+            string timestampAsString = Timestamp.ToString(
+                BlockHeader.TimestampFormat,
+                CultureInfo.InvariantCulture
+            );
+            ImmutableArray<byte> previousHashAsArray =
+                PreviousHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
+
             // FIXME: When hash is not assigned, should throw an exception.
             return new BlockHeader(
                 index: Index,
-#pragma warning disable MEN002 // line is too long
-                timestamp: Timestamp.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
-#pragma warning restore MEN002 // line is too long
+                timestamp: timestampAsString,
                 nonce: Nonce.ToByteArray().ToImmutableArray(),
                 miner: Miner?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
                 difficulty: Difficulty,
-#pragma warning disable MEN002 // line is too long
-                previousHash: PreviousHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
-#pragma warning restore MEN002 // line is too long
+                previousHash: previousHashAsArray,
                 txHash: TxHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
                 hash: Hash.ToByteArray().ToImmutableArray()
             );

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1614,6 +1614,20 @@ namespace Libplanet.Net
                 header.Index,
                 Address.ToHex());
 
+            try
+            {
+                header.Validate(DateTimeOffset.UtcNow);
+            }
+            catch (InvalidBlockException ibe)
+            {
+                _logger.Information(
+                    ibe,
+                    "Received header[{Hash}] seems invalid; ignore.",
+                    ByteUtil.Hex(header.Hash)
+                );
+                return;
+            }
+
             using (await _blockSyncMutex.LockAsync(cancellationToken))
             {
                 // FIXME: this should be changed into total difficulty.

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -91,7 +91,7 @@ namespace Libplanet.Store
                     previousHash: prevHash,
                     timestamp: DateTimeOffset.ParseExact(
                         blockDigest.Header.Timestamp,
-                        Block<T>.TimestampFormat,
+                        BlockHeader.TimestampFormat,
                         CultureInfo.InvariantCulture
                     ).ToUniversalTime(),
                     transactions: blockDigest.TxIds


### PR DESCRIPTION
This PR fixes `Swarm<T>` to ignore invalid block header immediately.