### PR TITLE
Clean up only temporary chains only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,7 +42,7 @@ To be released.
  -  `Swarm<T>` became to ignore received transaction with different
     genesis hash.  [[#796], [#878]]
  -  `Swarm<T>` became to ignore invalid `BlockHeader`s immediately.  [[#898]]
- -  `Swarm<T>.PreloadAsync()` became to only clean up temporary chains only.
+ -  `Swarm<T>.PreloadAsync()` became to clean up only temporary chains.
     [[#902]]
 
 ### Bug fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@ To be released.
  -  `Swarm<T>` became to ignore received transaction with different
     genesis hash.  [[#796], [#878]]
  -  `Swarm<T>` became to ignore invalid `BlockHeader`s immediately.  [[#898]]
+ -  `Swarm<T>.PreloadAsync()` became to only clean up temporary chains only.
+    [[#902]]
 
 ### Bug fixes
 
@@ -64,6 +66,7 @@ To be released.
 [#883]: https://github.com/planetarium/libplanet/pull/883
 [#890]: https://github.com/planetarium/libplanet/pull/890
 [#898]: https://github.com/planetarium/libplanet/pull/898
+[#902]: https://github.com/planetarium/libplanet/pull/902
 
 
 Version 0.9.4

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -490,6 +490,11 @@ namespace Libplanet.Net
                     false);
             Guid wId = workspace.Id;
             IStore wStore = workspace.Store;
+            var chainIds = new HashSet<Guid>
+            {
+                BlockChain.Id,
+                workspace.Id,
+            };
 
             var complete = false;
 
@@ -702,6 +707,7 @@ namespace Libplanet.Net
                     if (bottomBlock.PreviousHash is HashDigest<SHA256> bp)
                     {
                         workspace = workspace.Fork(bp);
+                        chainIds.Add(workspace.Id);
                         try
                         {
                             long verifiedBlockCount = 0;
@@ -811,7 +817,7 @@ namespace Libplanet.Net
                     BlockChain.Swap(workspace, render: false);
                 }
 
-                foreach (Guid chainId in wStore.ListChainIds().ToList())
+                foreach (Guid chainId in chainIds)
                 {
                     if (!chainId.Equals(BlockChain.Id))
                     {


### PR DESCRIPTION
This PR fixes `Swarm<T>.Preload` to clean up temporary chains only.