### PR TITLE
Reconnect to TURN when the connection is lost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ To be released.
 
  -  Fixed a bug that `Swarm<T>` had failed to receive a request from TURN relay
     connections.  [[#404], [#871], [#890]]
- -  Fixed a bug where `Swarm<T>` had terminated when disconnected from TURN.  [[#909]]
+ -  Fixed a bug where `Swarm<T>` had been terminated when disconnected from TURN.  [[#909]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ To be released.
 
  -  Fixed a bug that `Swarm<T>` had failed to receive a request from TURN relay
     connections.  [[#404], [#871], [#890]]
+ -  Fixed a bug where `Swarm<T>` had terminated when disconnected from TURN.  [[#909]]
 
 ### CLI tools
 
@@ -67,6 +68,7 @@ To be released.
 [#890]: https://github.com/planetarium/libplanet/pull/890
 [#898]: https://github.com/planetarium/libplanet/pull/898
 [#902]: https://github.com/planetarium/libplanet/pull/902
+[#909]: https://github.com/planetarium/libplanet/pull/909
 
 
 Version 0.9.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,10 @@ To be released.
 
  -  Fixed a bug that `Swarm<T>` had failed to receive a request from TURN relay
     connections.  [[#404], [#871], [#890]]
- -  Fixed a bug where `Swarm<T>` had been terminated when disconnected from TURN.  [[#909]]
+ -  Fixed a bug where `Swarm<T>` had been terminated and never reconnected when
+    it had been once disconnected from TURN (mostly due to [sleep mode], etc.).
+    [[#909]]
+
 
 ### CLI tools
 
@@ -69,6 +72,7 @@ To be released.
 [#898]: https://github.com/planetarium/libplanet/pull/898
 [#902]: https://github.com/planetarium/libplanet/pull/902
 [#909]: https://github.com/planetarium/libplanet/pull/909
+[sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 
 Version 0.9.5

--- a/Libplanet.Stun/Stun/Messages/AllocateErrorResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/AllocateErrorResponse.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Stun.Messages
             get
             {
                 ErrorCode attr = GetAttribute<ErrorCode>();
-                return attr.Reason;
+                return attr?.Reason;
             }
         }
 
@@ -31,7 +31,7 @@ namespace Libplanet.Stun.Messages
             get
             {
                 Attributes.Nonce attr = GetAttribute<Attributes.Nonce>();
-                return attr.Value;
+                return attr?.Value;
             }
         }
 
@@ -40,7 +40,7 @@ namespace Libplanet.Stun.Messages
             get
             {
                 Realm attr = GetAttribute<Realm>();
-                return attr.Value;
+                return attr?.Value;
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -132,11 +132,13 @@ namespace Libplanet.Stun.Messages
                 _ => rv
             };
 
-            if (rv != null)
+            if (rv is null)
             {
-                rv.TransactionId = transactionId;
-                rv.Attributes = attributes;
+                throw new TurnClientException("Parsed result is null.");
             }
+
+            rv.TransactionId = transactionId;
+            rv.Attributes = attributes;
 
             return rv;
         }

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -287,10 +287,10 @@ namespace Libplanet.Stun
                             continue;
                         }
 
-                        Log.Error("Failed to parse StunMessage. {e}", e);
-                        foreach (var tcs in _responses.Values)
+                        Log.Error(e, "Failed to parse StunMessage. {e}", e);
+                        foreach (TaskCompletionSource<StunMessage> tcs in _responses.Values)
                         {
-                            tcs.SetCanceled();
+                            tcs.TrySetCanceled();
                         }
 
                         _responses.Clear();

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -17,6 +17,7 @@ namespace Libplanet.Stun
     {
         public const int TurnDefaultPort = 3478;
         private const int AllocateRetry = 5;
+        private const int StunMessageParseRetry = 3;
         private readonly string _host;
         private readonly int _port;
         private readonly IList<TcpClient> _relayedClients;
@@ -267,7 +268,7 @@ namespace Libplanet.Stun
         private async Task ProcessMessage()
         {
             NetworkStream stream = _control.GetStream();
-            int retryCount = 3;
+            int retry = 0;
 
             while (_control.Connected)
             {
@@ -280,9 +281,9 @@ namespace Libplanet.Stun
                     }
                     catch (TurnClientException e)
                     {
-                        if (retryCount > 0)
+                        if (retry < StunMessageParseRetry)
                         {
-                            retryCount -= 1;
+                            retry++;
                             await Task.Delay(1000);
                             continue;
                         }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1239,7 +1239,13 @@ namespace Libplanet.Tests.Net
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task ReconnectToTurn()
         {
-            const int port = 34567;
+            int port;
+            using (var socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                port = ((IPEndPoint)socket.LocalEndPoint).Port;
+            }
+
             Uri turnUrl = FactOnlyTurnAvailableAttribute.TurnUri;
             string username = FactOnlyTurnAvailableAttribute.Username;
             string password = FactOnlyTurnAvailableAttribute.Password;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1164,7 +1164,7 @@ namespace Libplanet.Tests.Net
                 canceled = true;
             }
 
-            Assert.True(canceled);
+            Assert.True(canceled || t.IsCompleted);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,13 +17,13 @@ using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Store;
+using Libplanet.Stun;
 using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
 using NetMQ;
 using NetMQ.Sockets;
-using Nito.AsyncEx;
 using Serilog;
 using Serilog.Events;
 using Xunit;
@@ -1235,6 +1236,82 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [FactOnlyTurnAvailable(Timeout = Timeout)]
+        public async Task ReconnectToTurn()
+        {
+            const int port = 34567;
+            Uri turnUrl = FactOnlyTurnAvailableAttribute.TurnUri;
+            string username = FactOnlyTurnAvailableAttribute.Username;
+            string password = FactOnlyTurnAvailableAttribute.Password;
+            var proxyUri = new Uri($"turn://{username}:{password}@localhost:{port}/");
+
+            IEnumerable<IceServer> iceServers = new[]
+            {
+                new IceServer(urls: new[] { proxyUri }, username: username, credential: password),
+            };
+
+            var cts = new CancellationTokenSource();
+            var tasks = new List<Task> { TurnProxy(port, turnUrl, cts.Token) };
+
+            var seed = CreateSwarm(_blockchains[0], host: "localhost");
+            var swarmA = CreateSwarm(_blockchains[1], iceServers: iceServers);
+
+            async Task RefreshTableAsync(CancellationToken cancellationToken)
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(1000, cancellationToken);
+                    try
+                    {
+                        await swarmA.Protocol.RefreshTableAsync(
+                            TimeSpan.FromSeconds(10), cancellationToken);
+                    }
+                    catch (TurnClientException)
+                    {
+                    }
+                }
+            }
+
+            async Task MineAndBroadcast(CancellationToken cancellationToken)
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var block = await _blockchains[0].MineBlock(_fx1.Address1);
+                    seed.BroadcastBlock(block);
+                    await Task.Delay(5000, cancellationToken);
+                }
+            }
+
+            try
+            {
+                await StartAsync(seed);
+                await StartAsync(swarmA);
+
+                await swarmA.AddPeersAsync(new[] { seed.AsPeer }, null);
+
+                cts.Cancel();
+                cts = new CancellationTokenSource();
+
+                tasks.Add(TurnProxy(port, turnUrl, cts.Token));
+                tasks.Add(RefreshTableAsync(cts.Token));
+                tasks.Add(MineAndBroadcast(cts.Token));
+
+                await swarmA.BlockReceived.WaitAsync();
+                cts.Cancel();
+                await Task.Delay(1000);
+
+                Assert.Equal(_blockchains[0].Tip, _blockchains[1].Tip);
+            }
+            finally
+            {
+                await StopAsync(seed);
+                await StopAsync(swarmA);
+
+                seed.Dispose();
+                swarmA.Dispose();
+            }
+        }
+
         [Fact(Timeout = Timeout)]
         public async Task RemoveForkedChainWhenFillBlocksAsyncFail()
         {
@@ -1920,6 +1997,60 @@ namespace Libplanet.Tests.Net
                 null,
                 findNeighborsTimeout: TimeSpan.FromSeconds(3),
                 cancellationToken: cancellationToken);
+        }
+
+        private async Task TurnProxy(
+            int port,
+            Uri turnUri,
+            CancellationToken cancellationToken)
+        {
+            var server = new TcpListener(IPAddress.Loopback, port);
+            server.Start();
+            var tasks = new List<Task>();
+            var clients = new List<TcpClient>();
+
+            cancellationToken.Register(() => server.Stop());
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await server.AcceptTcpClientAsync();
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+                clients.Add(client);
+
+                tasks.Add(Task.Run(
+                    async () =>
+                    {
+                        const int bufferSize = 8192;
+                        NetworkStream stream = client.GetStream();
+
+                        using (TcpClient remoteClient = new TcpClient(turnUri.Host, turnUri.Port))
+                        {
+                            var remoteStream = remoteClient.GetStream();
+                            await await Task.WhenAny(
+                                remoteStream.CopyToAsync(stream, bufferSize, cancellationToken),
+                                stream.CopyToAsync(remoteStream, bufferSize, cancellationToken));
+                        }
+
+                        client.Dispose();
+                    },
+                    cancellationToken));
+            }
+
+            foreach (var client in clients)
+            {
+                client?.Dispose();
+            }
+
+            Log.Debug("TurnProxy is canceled.");
+
+            await Task.WhenAny(tasks);
         }
 
         private class Sleep : IAction

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -993,9 +993,9 @@ namespace Libplanet.Net
                 }
                 catch (Exception e)
                 {
-                    _logger.Warning(
-                        e,
-                        $"Unexpected exception occurred during {nameof(RefreshTableAsync)}(): {{0}}", e);
+                    var msg = "Unexpected exception occurred during " +
+                        $"{nameof(RefreshTableAsync)}(): {{0}}";
+                    _logger.Warning(e, msg, e);
                 }
             }
         }
@@ -1018,11 +1018,9 @@ namespace Libplanet.Net
                 }
                 catch (Exception e)
                 {
-                    _logger.Warning(
-                        e,
-                        "Unexpected exception occurred during " +
-                        $"{nameof(RebuildConnectionAsync)}(): {{0}}",
-                        e);
+                    var msg = "Unexpected exception occurred during " +
+                              $"{nameof(RebuildConnectionAsync)}(): {{0}}";
+                    _logger.Warning(e, msg, e);
                 }
             }
         }

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -229,7 +229,7 @@ namespace Libplanet.Net
 
             if (_host is null && !(_iceServers is null))
             {
-                await ConnectToTurnClient();
+                await InitializeTurnClient();
             }
 
             _cancellationToken = cancellationToken;
@@ -918,12 +918,12 @@ namespace Libplanet.Net
                     _turnClient.Dispose();
                     _turnCancellationTokenSource.Cancel();
                     await Task.WhenAny(_turnTasks);
-                    await ConnectToTurnClient();
+                    await InitializeTurnClient();
                 }
             }
         }
 
-        private async Task ConnectToTurnClient()
+        private async Task InitializeTurnClient()
         {
             _turnCancellationTokenSource = new CancellationTokenSource();
             _turnClient = await IceServer.CreateTurnClient(_iceServers);

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -913,7 +913,7 @@ namespace Libplanet.Net
 
                 if (!(_turnClient is null))
                 {
-                    _logger.Debug("Trying to re-connect to TURN...");
+                    _logger.Debug("Trying to reconnect to the TURN server...");
 
                     _turnClient.Dispose();
                     _turnCancellationTokenSource.Cancel();
@@ -994,7 +994,8 @@ namespace Libplanet.Net
                 catch (Exception e)
                 {
                     _logger.Warning(
-                        $"Unexpected exception occurred during {nameof(RefreshTableAsync)}() {e}.");
+                        e,
+                        $"Unexpected exception occurred during {nameof(RefreshTableAsync)}(): {{0}}", e);
                 }
             }
         }
@@ -1018,8 +1019,10 @@ namespace Libplanet.Net
                 catch (Exception e)
                 {
                     _logger.Warning(
+                        e,
                         "Unexpected exception occurred during " +
-                        $"{nameof(RebuildConnectionAsync)}() {e}.");
+                        $"{nameof(RebuildConnectionAsync)}(): {{0}}",
+                        e);
                 }
             }
         }

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -53,7 +53,9 @@ namespace Libplanet.Net
         private AsyncCollection<MessageRequest> _requests;
         private long _requestCount;
         private CancellationTokenSource _runtimeCancellationTokenSource;
+        private CancellationTokenSource _turnCancellationTokenSource;
         private Task _runtimeProcessor;
+        private List<Task> _turnTasks;
 
         private TaskCompletionSource<object> _runningEvent;
         private CancellationToken _cancellationToken;
@@ -107,6 +109,7 @@ namespace Libplanet.Net
 
             _requests = new AsyncCollection<MessageRequest>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
+            _turnCancellationTokenSource = new CancellationTokenSource();
             _requestCount = 0;
             _runtimeProcessor = Task.Factory.StartNew(
                 () =>
@@ -213,11 +216,6 @@ namespace Libplanet.Net
             _router = new RouterSocket();
             _router.Options.RouterHandover = true;
 
-            if (_host is null && !(_iceServers is null))
-            {
-                _turnClient = await IceServer.CreateTurnClient(_iceServers);
-            }
-
             if (_listenPort == null)
             {
                 _listenPort = _router.BindRandomPort("tcp://*");
@@ -229,32 +227,18 @@ namespace Libplanet.Net
 
             _logger.Information($"Listen on {_listenPort}");
 
+            if (_host is null && !(_iceServers is null))
+            {
+                await ConnectToTurnClient();
+            }
+
             _cancellationToken = cancellationToken;
 
-            if (!(_turnClient is null))
+            if (!_behindNAT)
             {
-                _publicIPAddress = (await _turnClient.GetMappedAddressAsync()).Address;
-                _behindNAT = await _turnClient.IsBehindNAT();
-            }
-
-            if (_behindNAT)
-            {
-                IPEndPoint turnEp = await _turnClient.AllocateRequestAsync(
-                    TurnAllocationLifetime
-                );
-                _endPoint = new DnsEndPoint(turnEp.Address.ToString(), turnEp.Port);
-
-                List<Task> tasks = BindMultipleProxies(_listenPort.Value, 3, _cancellationToken);
-                tasks.Add(RefreshAllocate(_cancellationToken));
-                tasks.Add(RefreshPermissions(_cancellationToken));
-            }
-            else if (_host is null)
-            {
-                _endPoint = new DnsEndPoint(_publicIPAddress.ToString(), _listenPort.Value);
-            }
-            else
-            {
-                _endPoint = new DnsEndPoint(_host, _listenPort.Value);
+                _endPoint = new DnsEndPoint(
+                    _host ?? _publicIPAddress.ToString(),
+                    _listenPort.Value);
             }
 
             _replyQueue = new NetMQQueue<NetMQMessage>();
@@ -434,6 +418,7 @@ namespace Libplanet.Net
         public void Dispose()
         {
             _runtimeCancellationTokenSource.Cancel();
+            _turnCancellationTokenSource.Cancel();
             _runtimeProcessor.Wait();
         }
 
@@ -922,6 +907,44 @@ namespace Libplanet.Net
                     throw;
                 }
             }
+            catch (Exception e) when (e is SocketException || e is ObjectDisposedException)
+            {
+                _logger.Error($"Unexpected error occurred during {nameof(CreatePermission)}: {e}");
+
+                if (!(_turnClient is null))
+                {
+                    _logger.Debug("Trying to re-connect to TURN...");
+
+                    _turnClient.Dispose();
+                    _turnCancellationTokenSource.Cancel();
+                    await Task.WhenAny(_turnTasks);
+                    await ConnectToTurnClient();
+                }
+            }
+        }
+
+        private async Task ConnectToTurnClient()
+        {
+            _turnCancellationTokenSource = new CancellationTokenSource();
+            _turnClient = await IceServer.CreateTurnClient(_iceServers);
+
+            _publicIPAddress = (await _turnClient.GetMappedAddressAsync(_cancellationToken))
+                .Address;
+            _behindNAT = await _turnClient.IsBehindNAT(_cancellationToken);
+
+            if (_behindNAT)
+            {
+                IPEndPoint turnEp = await _turnClient.AllocateRequestAsync(
+                    TurnAllocationLifetime,
+                    _cancellationToken
+                );
+                _endPoint = new DnsEndPoint(turnEp.Address.ToString(), turnEp.Port);
+
+                _turnTasks = BindMultipleProxies(
+                    _listenPort.Value, 3, _turnCancellationTokenSource.Token);
+                _turnTasks.Add(RefreshAllocate(_turnCancellationTokenSource.Token));
+                _turnTasks.Add(RefreshPermissions(_turnCancellationTokenSource.Token));
+            }
         }
 
         // FIXME: This method should be in Swarm<T>
@@ -968,6 +991,11 @@ namespace Libplanet.Net
                     _logger.Warning(e, $"{nameof(RefreshTableAsync)}() is cancelled.");
                     throw;
                 }
+                catch (Exception e)
+                {
+                    _logger.Warning(
+                        $"Unexpected exception occurred during {nameof(RefreshTableAsync)}() {e}.");
+                }
             }
         }
 
@@ -986,6 +1014,12 @@ namespace Libplanet.Net
                 {
                     _logger.Warning(e, $"{nameof(RebuildConnectionAsync)}() is cancelled.");
                     throw;
+                }
+                catch (Exception e)
+                {
+                    _logger.Warning(
+                        "Unexpected exception occurred during " +
+                        $"{nameof(RebuildConnectionAsync)}() {e}.");
                 }
             }
         }


### PR DESCRIPTION
This fixes a bug where `Swarm<T>` had terminated when disconnected from TURN. The flaky `StopGracefullyWhileStarting` test was also fixed.