### PR TITLE
Change StateReference key to string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
+ -  `RecentStates.StateReferences` became to
+    `IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>` from
+    `IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>`.  [[#912]]
+ -  The existing `RecentStates` message type (with the type number `0x0f`) was
+    replaced by a new `RecentStates` message type (with type number `0x13`).  [[#912]]
+
 ### Backward-incompatible storage format changes
 
  -  Added `RawTransaction<T>.GenesisHash` property.  [[#796], [#878]]
@@ -70,7 +76,8 @@ To be released.
  -  Fixed a bug where `Swarm<T>` had been terminated and never reconnected when
     it had been once disconnected from TURN (mostly due to [sleep mode], etc.).
     [[#909]]
-
+ -  Fixed a bug in which pre-computed state delivery had failed when a state
+    key is not an `Address` when preloading.  [[#912]]
 
 ### CLI tools
 
@@ -92,6 +99,7 @@ To be released.
 [#900]: https://github.com/planetarium/libplanet/pull/900
 [#902]: https://github.com/planetarium/libplanet/pull/902
 [#909]: https://github.com/planetarium/libplanet/pull/909
+[#912]: https://github.com/planetarium/libplanet/pull/912
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,11 +30,12 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
- -  `RecentStates.StateReferences` became to
+ -  The message field `RecentStates.StateReferences` became to
     `IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>` from
     `IImmutableDictionary<Address, IImmutableList<HashDigest<SHA256>>>`.  [[#912]]
  -  The existing `RecentStates` message type (with the type number `0x0f`) was
-    replaced by a new `RecentStates` message type (with type number `0x13`).  [[#912]]
+    replaced by a new `RecentStates` message type
+    (with the type number `0x13`).  [[#912]]
 
 ### Backward-incompatible storage format changes
 

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -262,11 +262,11 @@ namespace Libplanet.Tests.Common.Action
             TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").Value);
             RecordRehearsal = plainValue.GetValue<Boolean>("record_rehearsal").Value;
             RecordRandom =
-                plainValue.ContainsKey((Text)"record_random") &&
+                plainValue.ContainsKey((IKey)(Text)"record_random") &&
                 plainValue["record_random"] is Boolean r &&
                 r.Value;
 
-            if (plainValue.ContainsKey((Text)"idempotent"))
+            if (plainValue.ContainsKey((IKey)(Text)"idempotent"))
             {
                 Idempotent = plainValue.GetValue<Boolean>("idempotent");
             }

--- a/Libplanet/Blocks/BlockDigest.cs
+++ b/Libplanet/Blocks/BlockDigest.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Blocks
         public BlockDigest(Bencodex.Types.Dictionary dict)
         {
             Header = new BlockHeader(dict.GetValue<Bencodex.Types.Dictionary>(HeaderKey));
-            TxIds = dict.ContainsKey((Binary)TransactionIdsKey)
+            TxIds = dict.ContainsKey((IKey)(Binary)TransactionIdsKey)
                 ? dict.GetValue<Bencodex.Types.List>(TransactionIdsKey)
                     .Select(txId => ((Binary)txId).ToImmutableArray()).ToImmutableArray()
                 : ImmutableArray<ImmutableArray<byte>>.Empty;

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -81,19 +81,19 @@ namespace Libplanet.Blocks
             Difficulty = dict.GetValue<Integer>(DifficultyKey);
             Nonce = dict.GetValue<Binary>(NonceKey).ToImmutableArray();
 
-            Miner = dict.ContainsKey((Binary)MinerKey)
+            Miner = dict.ContainsKey((IKey)(Binary)MinerKey)
                 ? dict.GetValue<Binary>(MinerKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
 
-            PreviousHash = dict.ContainsKey((Binary)PreviousHashKey)
+            PreviousHash = dict.ContainsKey((IKey)(Binary)PreviousHashKey)
                 ? dict.GetValue<Binary>(PreviousHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
 
-            TxHash = dict.ContainsKey((Binary)TxHashKey)
+            TxHash = dict.ContainsKey((IKey)(Binary)TxHashKey)
                 ? dict.GetValue<Binary>(TxHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
 
-            Hash = dict.ContainsKey((Binary)HashKey)
+            Hash = dict.ContainsKey((IKey)(Binary)HashKey)
                 ? dict.GetValue<Binary>(HashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
         }

--- a/Libplanet/Blocks/RawBlock.cs
+++ b/Libplanet/Blocks/RawBlock.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Blocks
         public RawBlock(Bencodex.Types.Dictionary dict)
         {
             Header = new BlockHeader(dict.GetValue<Bencodex.Types.Dictionary>(HeaderKey));
-            Transactions = dict.ContainsKey((Binary)TransactionsKey)
+            Transactions = dict.ContainsKey((IKey)(Binary)TransactionsKey)
                 ? dict.GetValue<Bencodex.Types.List>(TransactionsKey)
                     .Select(tx => ((Binary)tx).ToImmutableArray()).ToImmutableArray()
                 : ImmutableArray<ImmutableArray<byte>>.Empty;

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -58,7 +58,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.3.0-dev.1b62adcbf3bf91d1a96787f4447dc6cc518d9734" />
+    <PackageReference Include="Bencodex" Version="0.3.0-dev.caf675965004555b8d52e39a5e6a76a6b0772127" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />
     <PackageReference Include="Fody" Version="6.1.1">

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -72,7 +72,7 @@ namespace Libplanet.Net.Messages
             /// A reply to <see cref="GetRecentStates"/>.
             /// Contains the calculated recent states and state references.
             /// </summary>
-            RecentStates = 0x0f,
+            RecentStates = 0x13,
 
             /// <summary>
             /// Message containing a single <see cref="BlockHeader"/>.

--- a/Libplanet/Tx/RawTransaction.cs
+++ b/Libplanet/Tx/RawTransaction.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Tx
         {
             Nonce = dict.GetValue<Integer>(NonceKey);
             Signer = dict.GetValue<Binary>(SignerKey).ToImmutableArray();
-            GenesisHash = dict.ContainsKey((Binary)GenesisHashKey)
+            GenesisHash = dict.ContainsKey((IKey)(Binary)GenesisHashKey)
                 ? dict.GetValue<Binary>(GenesisHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
             UpdatedAddresses = dict.GetValue<Bencodex.Types.List>(UpdatedAddressesKey)
@@ -80,7 +80,7 @@ namespace Libplanet.Tx
             Timestamp = dict.GetValue<Text>(TimestampKey);
             Actions = dict.GetValue<Bencodex.Types.List>(ActionsKey).ToImmutableArray();
 
-            Signature = dict.ContainsKey((Binary)SignatureKey)
+            Signature = dict.ContainsKey((IKey)(Binary)SignatureKey)
                 ? dict.GetValue<Binary>(SignatureKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
         }


### PR DESCRIPTION
This changes `StateReference` key to string to fix a bug in which pre-computed state delivery had failed when a state key is not an `Address` when preloading.