### PR TITLE
Fix serialization bug on UnexpectedlyTerminatedActionException

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,8 @@ To be released.
     [[#909]]
  -  Fixed a bug in which pre-computed state delivery had failed when a state
     key is not an `Address` when preloading.  [[#912]]
+ -  Fixed a bug where `UnexpectedlyTerminatedException` hadn't been serialized
+    with `BinaryFormatter`.  [[#913]]
 
 ### CLI tools
 
@@ -101,6 +103,7 @@ To be released.
 [#902]: https://github.com/planetarium/libplanet/pull/902
 [#909]: https://github.com/planetarium/libplanet/pull/909
 [#912]: https://github.com/planetarium/libplanet/pull/912
+[#913]: https://github.com/planetarium/libplanet/pull/913
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
+++ b/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Action
+{
+    public class UnexpectedlyTerminatedActionExceptionTest
+    {
+        [Fact]
+        public void Serializable()
+        {
+            var innerExc = new Exception("inner");
+            var exc = new UnexpectedlyTerminatedActionException(
+                default, default, null, null, "for testing", innerExc
+            );
+
+            var formatter = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                formatter.Serialize(ms, exc);
+
+                ms.Seek(0, SeekOrigin.Begin);
+                var deserialized = (UnexpectedlyTerminatedActionException)formatter.Deserialize(ms);
+                Assert.Equal("for testing", deserialized.Message);
+                Assert.IsType<Exception>(deserialized.InnerException);
+                Assert.Equal(innerExc.Message, deserialized.InnerException.Message);
+            }
+        }
+    }
+}

--- a/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
+++ b/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -46,6 +47,14 @@ namespace Libplanet.Action
             BlockIndex = blockIndex;
             TxId = txid;
             Action = action;
+        }
+
+        private UnexpectedlyTerminatedActionException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes a problem that `UnexpectedlyTerminatedActionException` hadn't been compatible with .NET serialization.