### PR TITLE
Fix for deleting chain ID

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -492,7 +492,6 @@ namespace Libplanet.Net
             IStore wStore = workspace.Store;
             var chainIds = new HashSet<Guid>
             {
-                BlockChain.Id,
                 workspace.Id,
             };
 


### PR DESCRIPTION
This fixes an issue that attempted to delete the chain multiple times. Also, in order to facilitate debugging, the deletion log of  `_chainDb` and the `_stateRefDb`  are separated.