### PR TITLE
Promoting the most difficult chain as canonical chain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,10 @@ To be released.
     constructor.  [[#666], [#917]]
  -  Added `BigInteger`-typed `previousTotalDifficulty` parameter to
     `Block<T>.Mine()` static method.  [[#666], [#917]]
+ -  `Pong()` constructor has changed:  [[459], [#919]]
+     -  Added `Pong()` constructor with no any parameter.
+     -  Removed `Pong(long?)` constructor.
+     -  Added `Pong(long, BigInteger)` constructor.
 
 ### Backward-incompatible network protocol changes
 
@@ -41,6 +45,9 @@ To be released.
     replaced by a new `RecentStates` message type
     (with the type number `0x13`).  [[#912]]
  -  Added `BlockHeader.TotalDifficulty` property.  [[#666], [#917]]
+ -  The existing `Pong` message type (with the type number `0x02`) was
+    replaced by a new `Pong` message type
+    (with the type number `0x14`).  [[#459]. [#919]]
 
 ### Backward-incompatible storage format changes
 
@@ -78,6 +85,10 @@ To be released.
     [[#902]]
  -  `BlockPolicy<T>` became to validate `Block<T>.TotalDifficulty` property
     of a `Block<T>`.  [[#666], [#917]]
+ -  `Swarm<T>` became to preload from peer that has the most difficult chain.
+    [[#459], [#919]]
+ -  `Swarm<T>` became to promote the most difficult chain as a canonical chain
+    instead of the longest chain.  [[#459], [#919]]
 
 ### Bug fixes
 
@@ -97,6 +108,7 @@ To be released.
 ### CLI tools
 
 [#404]: https://github.com/planetarium/libplanet/issues/404
+[#459]: https://github.com/planetarium/libplanet/issues/459
 [#666]: https://github.com/planetarium/libplanet/issues/666
 [#756]: https://github.com/planetarium/libplanet/issues/756
 [#796]: https://github.com/planetarium/libplanet/issues/796
@@ -119,6 +131,7 @@ To be released.
 [#913]: https://github.com/planetarium/libplanet/pull/913
 [#916]: https://github.com/planetarium/libplanet/pull/916
 [#917]: https://github.com/planetarium/libplanet/pull/917
+[#919]: https://github.com/planetarium/libplanet/pull/919
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,10 +31,6 @@ To be released.
     constructor.  [[#666], [#917]]
  -  Added `BigInteger`-typed `previousTotalDifficulty` parameter to
     `Block<T>.Mine()` static method.  [[#666], [#917]]
- -  `Pong()` constructor has changed:  [[459], [#919]]
-     -  Added `Pong()` constructor with no any parameter.
-     -  Removed `Pong(long?)` constructor.
-     -  Added `Pong(long, BigInteger)` constructor.
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -448,7 +448,7 @@ namespace Libplanet.Tests.Net.Protocols
 
             if (message is Ping)
             {
-                ReplyMessage(new Pong((long?)null)
+                ReplyMessage(new Pong
                 {
                     Identity = message.Identity,
                     Remote = AsPeer,

--- a/Libplanet/Net/BlockHashDemand.cs
+++ b/Libplanet/Net/BlockHashDemand.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    internal readonly struct BlockHashDemand
+    {
+        public readonly BlockHeader Header;
+
+        public readonly BoundPeer Peer;
+
+        public BlockHashDemand(BlockHeader header, BoundPeer peer)
+        {
+            Header = header;
+            Peer = peer;
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Net.Messages
             /// <summary>
             /// A reply to <see cref="Ping"/>.
             /// </summary>
-            Pong = 0x02,
+            Pong = 0x14,
 
             /// <summary>
             /// Request to query block hashes.

--- a/Libplanet/Net/Messages/Pong.cs
+++ b/Libplanet/Net/Messages/Pong.cs
@@ -1,13 +1,19 @@
 using System.Collections.Generic;
+using System.Numerics;
 using NetMQ;
 
 namespace Libplanet.Net.Messages
 {
     internal class Pong : Message
     {
-        public Pong(long? tipIndex)
+        public Pong()
+        {
+        }
+
+        public Pong(long tipIndex, BigInteger totalDifficulty)
         {
             TipIndex = tipIndex;
+            TotalDifficulty = totalDifficulty;
         }
 
         public Pong(NetMQFrame[] body)
@@ -18,9 +24,13 @@ namespace Libplanet.Net.Messages
             {
                 TipIndex = null;
             }
+
+            TotalDifficulty = new BigInteger(body[1].ToByteArray());
         }
 
         public long? TipIndex { get; set; }
+
+        public BigInteger? TotalDifficulty { get; set; }
 
         protected override MessageType Type => MessageType.Pong;
 
@@ -30,6 +40,7 @@ namespace Libplanet.Net.Messages
             {
                 yield return new NetMQFrame(
                     NetworkOrderBitsConverter.GetBytes(TipIndex ?? -1));
+                yield return new NetMQFrame((TotalDifficulty ?? 0).ToByteArray());
             }
         }
     }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1609,6 +1609,13 @@ namespace Libplanet.Net
             }
         }
 
+        private bool IsDemandNeeded(BlockHeader target)
+        {
+            return target.TotalDifficulty > BlockChain.Tip.TotalDifficulty &&
+                   (_demandBlockHash is null ||
+                    _demandBlockHash.Value.Header.TotalDifficulty < target.TotalDifficulty);
+        }
+
         private async Task ProcessBlockHeader(
             BlockHeaderMessage message,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -1647,9 +1654,7 @@ namespace Libplanet.Net
 
             using (await _blockSyncMutex.LockAsync(cancellationToken))
             {
-                if (header.TotalDifficulty > BlockChain.Tip.TotalDifficulty &&
-                    (_demandBlockHash is null ||
-                     _demandBlockHash.Value.Header.TotalDifficulty < header.TotalDifficulty))
+                if (IsDemandNeeded(header))
                 {
                     _demandBlockHash = new BlockHashDemand(header, peer);
                 }


### PR DESCRIPTION
Includes:
- Select the peer with the most difficult chain to preload.
- Demand only more difficult chain than current.

Closes #459.