### PR TITLE
Make CLI tools installable through npm

### DIFF
--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -4,5 +4,18 @@
 projects=("Libplanet" "Libplanet.RocksDBStore" "Libplanet.Tools")
 configuration=Release
 executables=("Libplanet.Tools")
-rids=(linux-x64 osx-x64 win-x64)
+
 # https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
+rids=(linux-x64 osx-x64 win-x64)
+
+# Publish a package only if the repository is upstream (planetarium/libplanet)
+# and the branch is for releases (master or *-maintenance or 9c-*).
+# shellcheck disable=SC2235
+if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
+    "$GITHUB_REF" = refs/tags/* || \
+    "$GITHUB_REF" = refs/heads/master || \
+    "$GITHUB_REF" = refs/heads/*-maintenance || \
+    "$GITHUB_REF" = refs/heads/9c-* \
+  ]]; then
+  publish_package=true
+fi

--- a/.github/bin/dist-npm.sh
+++ b/.github/bin/dist-npm.sh
@@ -12,16 +12,8 @@ if [ "$NODE_AUTH_TOKEN" = "" ]; then
   exit 1
 fi
 
-# Publish a package only if the repository is upstream (planetarium/libplanet)
-# and the branch is for releases (master or *-maintenance or 9c-*).
-# shellcheck disable=SC2235
-if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
-    "$GITHUB_REF" = refs/tags/* || \
-    "$GITHUB_REF" = refs/heads/master || \
-    "$GITHUB_REF" = refs/heads/*-maintenance || \
-    "$GITHUB_REF" = refs/heads/9c-* \
-  ]]; then
-  dry_run=
+if [ "$publish_package" = "" ]; then
+  dry_run=--dry-run
 else
   dry_run=--dry-run
 fi

--- a/.github/bin/dist-npm.sh
+++ b/.github/bin/dist-npm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Submit npm packages to npmjs.org.
+# Note that this script is intended to be run by GitHub Actions.
+set -e
+
+# shellcheck source=constants.sh
+. "$(dirname "$0")/constants.sh"
+
+if [ "$NODE_AUTH_TOKEN" = "" ]; then
+  echo "This script requires NODE_AUTH_TOKEN envrionment variable." \
+    > /dev/stderr
+  exit 1
+fi
+
+# Publish a package only if the repository is upstream (planetarium/libplanet)
+# and the branch is for releases (master or *-maintenance or 9c-*).
+# shellcheck disable=SC2235
+if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
+    "$GITHUB_REF" = refs/tags/* || \
+    "$GITHUB_REF" = refs/heads/master || \
+    "$GITHUB_REF" = refs/heads/*-maintenance || \
+    "$GITHUB_REF" = refs/heads/9c-* \
+  ]]; then
+  dry_run=
+else
+  dry_run=--dry-run
+fi
+
+set -x
+
+for project in "${executables[@]}"; do
+  pushd "./$project/"
+    # shellcheck disable=SC2086
+    npm publish --access=public $dry_run
+  popd
+done

--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -19,21 +19,13 @@ if [ "$NUGET_API_KEY" = "" ]; then
   exit 1
 fi
 
-# Publish a package only if the repository is upstream (planetarium/libplanet)
-# and the branch is for releases (master or *-maintenance or 9c-*).
-# shellcheck disable=SC2235
-if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && [[ \
-    "$GITHUB_REF" = refs/tags/* || \
-    "$GITHUB_REF" = refs/heads/master || \
-    "$GITHUB_REF" = refs/heads/*-maintenance || \
-    "$GITHUB_REF" = refs/heads/9c-* \
-  ]]; then
+if [ "$publish_package" = "" ]; then
   function dotnet-nuget {
-    dotnet nuget "$@"
+    echo "DRY-RUN: dotnet nuget" "$@"
   }
 else
   function dotnet-nuget {
-    echo "DRY-RUN: dotnet nuget" "$@"
+    dotnet nuget "$@"
   }
 fi
 

--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -36,6 +36,14 @@ for project in "${executables[@]}"; do
     popd
     rm -rf "$output_dir"
   done
+
+  if [[ -f "./$project/package.json" ]]; then
+    pushd "./$project/"
+    jq --arg v "$version" 'del(.private) | .version = $v' package.json \
+      > .package.json.tmp
+    mv .package.json.tmp package.json
+    popd
+  fi
 done
 
 for project in "${projects[@]}"; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.100
+    - uses: actions/setup-node@v1
+      with:
+        registry-url: 'https://registry.npmjs.org'
+        scope: '@planetarium'
     - run: .github/bin/dist-version.ps1
       shell: pwsh
     - run: .github/bin/dist-release-note.sh CHANGES.md obj/release_note.txt
@@ -52,6 +56,13 @@ jobs:
       run: .github/bin/dist-nuget.sh
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    - if: >-
+        github.event_name != 'pull_request' &&
+        startsWith(github.ref, 'refs/tags/') &&
+        env.NODE_AUTH_TOKEN != ''
+      run: .github/bin/dist-npm.sh
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
   docs:
     if: github.event_name != 'schedule' || github.repository == 'planetarium/libplanet'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,8 +105,9 @@ To be released.
  -  Fixed a bug where `TurnClient` hadn't applied cancellation token to its
     connections.  [[#916]]
 
-
 ### CLI tools
+
+ -  The `planet` command became installable using `npm`.
 
 [#404]: https://github.com/planetarium/libplanet/issues/404
 [#459]: https://github.com/planetarium/libplanet/issues/459

--- a/Libplanet.Tools/.gitignore
+++ b/Libplanet.Tools/.gitignore
@@ -1,0 +1,4 @@
+# npm
+!bin/
+node_modules/
+package-lock.json

--- a/Libplanet.Tools/README.md
+++ b/Libplanet.Tools/README.md
@@ -1,13 +1,18 @@
 `planet`: Libplanet CLI Tools
 =============================
 
-[![NuGet](https://img.shields.io/nuget/v/Libplanet.Tools.svg?style=flat)][NuGet]
-[![NuGet (prerelease)](https://img.shields.io/nuget/vpre/Libplanet.Tools.svg?style=flat)][NuGet]
+[![npm][npm-badge]][npm]
+[![NuGet][nuget-badge]][NuGet]
+[![NuGet (prerelease)][nuget-prerelease-badge]][NuGet]
 
 This CLI app is a collection of utilities for application programmers who
 create decentralized games powered by [Libplanet].
 
+[npm]: https://www.npmjs.com/package/@planetarium/cli
+[npm-badge]: https://img.shields.io/npm/v/@planetarium/cli
 [NuGet]: https://www.nuget.org/packages/Libplanet.Tools/
+[nuget-badge]: https://img.shields.io/nuget/v/Libplanet.Tools.svg?style=flat
+[nuget-prerelease-badge]: https://img.shields.io/nuget/vpre/Libplanet.Tools.svg?style=flat
 [Libplanet]: https://libplanet.io/
 
 
@@ -17,7 +22,7 @@ Installation
 There are three ways to install the `planet` command.  Pick the most handy
 one for you.
 
-### `npm`
+### `npm` [![npm][npm-badge]][npm]
 
 Install as an `npm` package if `npm` is installed on your system:
 
@@ -25,7 +30,7 @@ Install as an `npm` package if `npm` is installed on your system:
 npm install @planetarium/cli
 ~~~~
 
-### .NET Core tool
+### .NET Core tool [![NuGet][nuget-badge]][NuGet]
 
 Install as a [.NET Core tool] if .NET Core SDK is installed on your system:
 
@@ -35,12 +40,15 @@ dotnet tool install -g Libplanet.Tools
 
 [.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
 
-### Manual installation
+### Manual installation [![GitHub Releases][releases-badge]][releases page]
 
 Or you could just download an executable binary for your platform from
 the [releases page]: *planet-\*-{linux,osx,win}-x64.{tar.xz,zip}* files are
 CLI tools.  Linux (x64), macOS (x64), and Windows (x64) are supported.
 Extract the binary to an appropriate directory in your `PATH`.
+
+[releases page]: https://github.com/planetarium/libplanet/releases
+[releases-badge]: https://img.shields.io/github/v/release/planetarium/libplanet?sort=semver
 
 
 Usage
@@ -64,4 +72,3 @@ use `dotnet planet` command instead:
 dotnet planet --help
 ~~~~
 
-[releases page]: https://github.com/planetarium/libplanet/releases

--- a/Libplanet.Tools/README.md
+++ b/Libplanet.Tools/README.md
@@ -14,18 +14,33 @@ create decentralized games powered by [Libplanet].
 Installation
 ------------
 
+There are three ways to install the `planet` command.  Pick the most handy
+one for you.
+
+### `npm`
+
+Install as an `npm` package if `npm` is installed on your system:
+
+~~~~ bash
+npm install @planetarium/cli
+~~~~
+
+### .NET Core tool
+
 Install as a [.NET Core tool] if .NET Core SDK is installed on your system:
 
 ~~~~ bash
 dotnet tool install -g Libplanet.Tools
 ~~~~
 
+[.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
+
+### Manual installation
+
 Or you could just download an executable binary for your platform from
 the [releases page]: *planet-\*-{linux,osx,win}-x64.{tar.xz,zip}* files are
 CLI tools.  Linux (x64), macOS (x64), and Windows (x64) are supported.
 Extract the binary to an appropriate directory in your `PATH`.
-
-[.NET Core tool]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
 
 
 Usage
@@ -35,7 +50,14 @@ Usage
 planet --help
 ~~~~
 
-If you installed it using .NET Core SDK *without `-g`/`--global` option*
+If you installed it using `npm` *without `-g`/`--global` option*
+use `npx planet` command instead:
+
+~~~~ bash
+npx planet --help
+~~~~
+
+Or if you installed it using .NET Core SDK *without `-g`/`--global` option*
 use `dotnet planet` command instead:
 
 ~~~~ bash

--- a/Libplanet.Tools/bin/planet
+++ b/Libplanet.Tools/bin/planet
@@ -1,5 +1,17 @@
 #!/usr/bin/env node
 "use strict";
+// About this script: this script has two purposes:
+//
+// - Some users could pass --ignore-scripts option to "npm install" command,
+//   which ignores the install.js script.  In such case, "npx planet" will
+//   invoke this script at first time, and this downloads the actual ELF binary
+//   and overwrites this scripts with the ELF binary.  After the first invoke,
+//   "npx planet" becomes to directly invoke the ELF binary instead.
+//
+// - On Windows, npm creates a fake executable named "planet.cmd" to invoke
+//   this script, regardless of --ignore-scripts option.  There is likely no way
+//   to avoid this node.js script being invoked before the actual planet.exe
+//   is invoked.
 const child_process = require("child_process");
 const fs = require("fs");
 const path = require("path");
@@ -12,9 +24,22 @@ function runExe() {
     .on("exit", process.exit);
 }
 
-fs.stat(exePath, (err, stats) => {
-  if (!err && stats.isFile() && stats.size > 64 * 1024) return runExe();
-  return download({ log: console.warn }).then(runExe).catch(console.error);
-});
+if (process.platform === "win32") {
+  // On Windows, this script is never overwritten even after download() was
+  // executed, as on Windows executables always have suffixes,
+  // e.g., "planet.exe".  Therefore, this script is always called on Windows
+  // regardless of presence of planet.exe, so this script has to check if
+  // planet.exe exists every time.
+  fs.access(exePath, fs.constants.R_OK, err => {
+    if (!err) return runExe();
+    return download({ log: console.warn }).then(runExe).catch(console.error);
+  });
+} else {
+  // On the other hand, on POSIX platforms other than Windows, this script
+  // is overwritten after download() executed, which means if the below code is
+  // executed there must *not* be the actual ELF binary of the "planet" command.
+  // Therefore, download() should be invoked first.
+  download({ log: console.warn }).then(runExe).catch(console.error);
+}
 
 // vim: ts=2 sw=2 et ft=javascript

--- a/Libplanet.Tools/bin/planet
+++ b/Libplanet.Tools/bin/planet
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+"use strict";
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { BIN_PATH, BIN_NAME, download } = require("../download.js");
+
+const exePath = path.join(BIN_PATH, BIN_NAME);
+
+function runExe() {
+  child_process.spawn(exePath, process.argv.slice(2), { stdio: "inherit" })
+    .on("exit", process.exit);
+}
+
+fs.stat(exePath, (err, stats) => {
+  if (!err && stats.isFile() && stats.size > 64 * 1024) return runExe();
+  return download({ log: console.warn }).then(runExe).catch(console.error);
+});
+
+// vim: ts=2 sw=2 et ft=javascript

--- a/Libplanet.Tools/download.js
+++ b/Libplanet.Tools/download.js
@@ -1,0 +1,86 @@
+// The planet binary downloader for npm.
+// Inspired by Elm's npm packaging: <https://www.npmjs.com/package/elm>.
+"use strict";
+const child_process = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const fetch = require("node-fetch");
+const unzipper = require("unzipper");
+const packageMetadata = require("./package.json");
+
+const URL_BASE = "https://github.com/planetarium/libplanet/releases/download";
+const SUFFIXES = {
+  darwin: {x64: "osx-x64.tar.xz"},
+  linux: {x64: "linux-x64.tar.xz"},
+  win32: {x64: "win-x64.zip"},
+};
+const BIN_NAME = process.platform == "win32" ? "planet.exe" : "planet";
+const BIN_PATH = path.join(__dirname, "bin");
+
+function download(options = {}) {
+  const { binPath = BIN_PATH, binName = BIN_NAME, log = console.log } = options;
+  const ver = packageMetadata.version;
+  const platform = os.platform();
+  const platformSuffixes = SUFFIXES[platform];
+  if (platformSuffixes == null) {
+    throw new Error(`Unsupported platform: ${platform}`);
+  }
+  const arch = os.arch();
+  const suffix = platformSuffixes[arch];
+  if (suffix == null) {
+    throw new Error(`Unsupported architecture: ${platform}-${arch}`);
+  }
+  const url = `${URL_BASE}/${ver}/planet-${ver}-${suffix}`;
+  return new Promise((resolve, reject) => {
+    fs.mkdtemp(path.join(os.tmpdir(), "planet-"), (err, dirPath) => {
+      if (err) return reject(err);
+      const finalize = () => {
+        const src = path.join(dirPath, BIN_NAME);
+        const dst = path.join(binPath, binName);
+        fs.copyFile(src, dst, err => {
+          if (err) return reject(err);
+          if (platform === "win32") return resolve();
+          fs.chmod(dst, 0o755, err => err ? reject(err) : resolve());
+        });
+      };
+      let unarchive;
+      if (suffix.toLowerCase().endsWith(".zip")) {
+        unarchive = unzipper.Extract({ path: dirPath });
+        unarchive.on("close", err => {
+          if (err) return reject(err);
+          return finalize();
+        });
+      } else {
+        const subproc = child_process.spawn("tar", ["xvJ"], {
+          cwd: dirPath,
+          stdio: ["pipe", "ignore", "ignore"]
+        });
+        subproc.on("close", code => {
+          if (code !== 0) return reject(code);
+          return finalize();
+        });
+        unarchive = subproc.stdin;
+      }
+      unarchive.on("error", reject);
+      if (log != null) log(`
+-------------------------------------------------------------------------------
+Downloaing Libplanet CLI Tools ${ver} from GitHub...
+
+NOTE: You can avoid npm entirely by downloading directly from:
+
+  ${url}
+
+All this package does is downloading that file and put it somewhere.
+-------------------------------------------------------------------------------
+`);
+      fetch(url).catch(reject).then(res => res.body.pipe(unarchive));
+    });
+  });
+}
+
+module.exports = {
+  BIN_NAME,
+  BIN_PATH,
+  download
+};

--- a/Libplanet.Tools/install.js
+++ b/Libplanet.Tools/install.js
@@ -1,0 +1,7 @@
+// Post-install hook for npm.
+"use strict";
+const { download } = require("./download.js");
+
+download().then(console.debug).catch(console.error);
+
+// vim: ts=2 sw=2 et ft=javascript

--- a/Libplanet.Tools/package.json
+++ b/Libplanet.Tools/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@planetarium/cli",
+  "version": "0.0.0",
+  "private": true,
+  "description": "This CLI app is a collection of utilities for application programmers who create decentralized games powered by Libplanet.",
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "README.md",
+    "bin/planet",
+    "download.js",
+    "install.js"
+  ],
+  "dependencies": {
+    "node-fetch": "^2.6.0",
+    "unzipper": "^0.10.11"
+  },
+  "scripts": {
+    "install": "node install.js"
+  },
+  "bin": {
+    "planet": "bin/planet"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/planetarium/libplanet.git",
+    "directory": "Libplanet.Tools"
+  },
+  "keywords": [
+    "planetarium",
+    "libplanet",
+    "blockchain",
+    "p2p",
+    "game"
+  ],
+  "author": "Planetarium",
+  "license": "LGPL-2.1-or-later",
+  "bugs": {
+    "url": "https://github.com/planetarium/libplanet/labels/tools"
+  },
+  "homepage": "https://github.com/planetarium/libplanet/tree/master/Libplanet.Tools"
+}


### PR DESCRIPTION
To make Libplanet CLI tools easily installable without .NET Core SDK, I packaged it using `npm`: [@planetarium/cli](https://www.npmjs.com/package/@planetarium/cli).  The `npm` package in itself actually does not contain any executable binary/code for CLI tools, but includes downloader/installer for the `planet` command.  FYI [Elm's npm installer][1] inspired this approach.

Here's a demo session:

[![asciicast](https://asciinema.org/a/347262.svg)](https://asciinema.org/a/347262)

[1]: https://github.com/elm/compiler/tree/master/installers/npm