### PR TITLE
Fix TimestampThreshold to 15s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@ To be released.
  -  The existing `Pong` message type (with the type number `0x02`) was
     replaced by a new `Pong` message type
     (with the type number `0x14`).  [[#459]. [#919]]
+ -  The `TimestampThreshold` for future block has been changed from 900s to 15s.
+    [[#922], [#925]]
 
 ### Backward-incompatible storage format changes
 
@@ -128,6 +130,8 @@ To be released.
 [#916]: https://github.com/planetarium/libplanet/pull/916
 [#917]: https://github.com/planetarium/libplanet/pull/917
 [#919]: https://github.com/planetarium/libplanet/pull/919
+[#922]: https://github.com/planetarium/libplanet/issues/922
+[#925]: https://github.com/planetarium/libplanet/pull/925
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,8 +44,8 @@ To be released.
  -  The existing `Pong` message type (with the type number `0x02`) was
     replaced by a new `Pong` message type
     (with the type number `0x14`).  [[#459]. [#919]]
- -  The `TimestampThreshold` for future block has been changed from 900s to 15s.
-    [[#922], [#925]]
+ -  The `TimestampThreshold` between `Block<T>`s was changed from 15 minutes to
+    15 seconds.  [[#922], [#925]]
 
 ### Backward-incompatible storage format changes
 

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Tests.Blocks
         public void ValidateTimestamp()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            string future = (now + TimeSpan.FromSeconds(901))
+            string future = (now + TimeSpan.FromSeconds(16))
                 .ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture);
             var header = new BlockHeader(
                 index: 0,

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -536,7 +536,7 @@ namespace Libplanet.Tests.Blocks
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,
                 _fx.Genesis.Hash,
-                now + TimeSpan.FromSeconds(901),
+                now + TimeSpan.FromSeconds(16),
                 new Transaction<DumbAction>[] { }
             );
 

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Blocks
         private static readonly byte[] HashKey = { 0x68 }; // 'h'
 
         private static readonly TimeSpan TimestampThreshold =
-            TimeSpan.FromSeconds(900);
+            TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// Creates a <see cref="BlockHeader"/> instance.


### PR DESCRIPTION
This fixes `BlockHeader.TimestampThreshold` to 15s to mitigate #922. It should be changed later to be the same as `BlockPolicy.BlockInterval`.