### PR TITLE
Separate timeouts in Swarm<T> to SwarmOptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@ To be released.
     constructor.  [[#666], [#917]]
  -  Added `BigInteger`-typed `previousTotalDifficulty` parameter to
     `Block<T>.Mine()` static method.  [[#666], [#917]]
+ -  Added `options` optional parameter to `Swarm<T>()` constructor.
+    [[#926]]
 
 ### Backward-incompatible network protocol changes
 
@@ -63,6 +65,7 @@ To be released.
  -  Added `InsufficientBalanceException` class.  [[#861], [#900]]
  -  Added `BlockChain<T>.GetBalance()` method.  [[#861], [#900]]
  -  Added `Block<T>.TotalDifficulty` property.  [[#666], [#917]]
+ -  Added `SwarmOptions` class.  [[#926]]
 
 ### Behavioral changes
 
@@ -132,6 +135,7 @@ To be released.
 [#919]: https://github.com/planetarium/libplanet/pull/919
 [#922]: https://github.com/planetarium/libplanet/issues/922
 [#925]: https://github.com/planetarium/libplanet/pull/925
+[#926]: https://github.com/planetarium/libplanet/pull/926
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Net
         private static readonly TimeSpan MaxTimeout = TimeSpan.FromSeconds(150);
         private static readonly TimeSpan BlockRecvTimeout = TimeSpan.FromSeconds(15);
         private static readonly TimeSpan TxRecvTimeout = TimeSpan.FromSeconds(3);
-        private static readonly TimeSpan RecentStateRecvTimeout = TimeSpan.FromSeconds(150);
+        private static readonly TimeSpan RecentStateRecvTimeout = TimeSpan.FromSeconds(90);
         private readonly PrivateKey _privateKey;
         private readonly AppProtocolVersion _appProtocolVersion;
 

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -1,0 +1,29 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+
+namespace Libplanet.Net
+{
+    public class SwarmOptions
+    {
+        /// <summary>
+        /// The maximum timeout used in <see cref="Swarm{T}"/>.
+        /// </summary>
+        public TimeSpan MaxTimeout { get; set; } = TimeSpan.FromSeconds(150);
+
+        /// <summary>
+        /// The base timeout used to receive <see cref="Block{T}"/> from other peers.
+        /// </summary>
+        public TimeSpan BlockRecvTimeout { get; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// The base timeout used to receive <see cref="Transaction{T}"/> from other peers.
+        /// </summary>
+        public TimeSpan TxRecvTimeout { get; } = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// The timeout used to receive recent states from other peers.
+        /// </summary>
+        public TimeSpan RecentStateRecvTimeout { get; } = TimeSpan.FromSeconds(90);
+    }
+}


### PR DESCRIPTION
Separate timeouts in `Swarm<T>` to `SwarmOptions` to be configurable.