### PR TITLE
Separate Ping/Pong message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,9 +45,12 @@ To be released.
  -  Added `BlockHeader.TotalDifficulty` property.  [[#666], [#917]]
  -  The existing `Pong` message type (with the type number `0x02`) was
     replaced by a new `Pong` message type
-    (with the type number `0x14`).  [[#459]. [#919]]
+    (with the type number `0x15`).  [[#459], [#919], [#920], [#930]]
  -  The `TimestampThreshold` between `Block<T>`s was changed from 15 minutes to
     15 seconds.  [[#922], [#925]]
+ -  Added new message types:
+     -  Added `GetChainStatus` message.  [[#920], [#930]]
+     -  Added `ChainStatus` message.  [[#920], [#930]]
 
 ### Backward-incompatible storage format changes
 
@@ -134,9 +137,11 @@ To be released.
 [#916]: https://github.com/planetarium/libplanet/pull/916
 [#917]: https://github.com/planetarium/libplanet/pull/917
 [#919]: https://github.com/planetarium/libplanet/pull/919
+[#920]: https://github.com/planetarium/libplanet/issues/920
 [#922]: https://github.com/planetarium/libplanet/issues/922
 [#925]: https://github.com/planetarium/libplanet/pull/925
 [#926]: https://github.com/planetarium/libplanet/pull/926
+[#930]: https://github.com/planetarium/libplanet/pull/930
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,12 +45,11 @@ To be released.
  -  Added `BlockHeader.TotalDifficulty` property.  [[#666], [#917]]
  -  The existing `Pong` message type (with the type number `0x02`) was
     replaced by a new `Pong` message type
-    (with the type number `0x15`).  [[#459], [#919], [#920], [#930]]
+    (with the type number `0x14`).  [[#459], [#919], [#920], [#930]]
  -  The `TimestampThreshold` between `Block<T>`s was changed from 15 minutes to
     15 seconds.  [[#922], [#925]]
- -  Added new message types:
-     -  Added `GetChainStatus` message.  [[#920], [#930]]
-     -  Added `ChainStatus` message.  [[#920], [#930]]
+ -  `Swarm<T>` became to have two more message types: `GetChainStatus` (`0x20`)
+     and `ChainStatus` (`0x21`).  [[#920], [#930]]
 
 ### Backward-incompatible storage format changes
 

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -1198,7 +1198,7 @@ namespace Libplanet.Tests.Net
             minerSwarm.FindNextHashesChunkSize = 2;
             await StartAsync(minerSwarm);
 
-            (BoundPeer, long?)[] peers =
+            (BoundPeer, long)[] peers =
             {
                 ((BoundPeer)minerSwarm.AsPeer, minerChain.Count - 1),
             };
@@ -1289,7 +1289,7 @@ namespace Libplanet.Tests.Net
             minerSwarm.FindNextHashesChunkSize = 2;
             await StartAsync(minerSwarm);
 
-            (BoundPeer, long?)[] peers =
+            (BoundPeer, long)[] peers =
             {
                 ((BoundPeer)minerSwarm.AsPeer, minerChain.Count - 1),
             };

--- a/Libplanet/Net/Messages/ChainStatus.cs
+++ b/Libplanet/Net/Messages/ChainStatus.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Numerics;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class ChainStatus : Message
+    {
+        public ChainStatus(long tipIndex, BigInteger totalDifficulty)
+        {
+            TipIndex = tipIndex;
+            TotalDifficulty = totalDifficulty;
+        }
+
+        public ChainStatus(NetMQFrame[] body)
+        {
+            TipIndex = body[0].ConvertToInt64();
+            TotalDifficulty = new BigInteger(body[1].ToByteArray());
+        }
+
+        public long TipIndex { get; }
+
+        public BigInteger TotalDifficulty { get; }
+
+        protected override MessageType Type => MessageType.ChainStatus;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(
+                    NetworkOrderBitsConverter.GetBytes(TipIndex));
+                yield return new NetMQFrame(TotalDifficulty.ToByteArray());
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/GetChainStatus.cs
+++ b/Libplanet/Net/Messages/GetChainStatus.cs
@@ -3,17 +3,17 @@ using NetMQ;
 
 namespace Libplanet.Net.Messages
 {
-    internal class Pong : Message
+    internal class GetChainStatus : Message
     {
-        public Pong()
+        public GetChainStatus()
         {
         }
 
-        public Pong(NetMQFrame[] body)
+        public GetChainStatus(NetMQFrame[] body)
         {
         }
 
-        protected override MessageType Type => MessageType.Pong;
+        protected override MessageType Type => MessageType.GetChainStatus;
 
         protected override IEnumerable<NetMQFrame> DataFrames
         {

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Net.Messages
             /// <summary>
             /// A reply to <see cref="Ping"/>.
             /// </summary>
-            Pong = 0x15,
+            Pong = 0x14,
 
             /// <summary>
             /// Request to query block hashes.

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Net.Messages
             /// <summary>
             /// A reply to <see cref="Ping"/>.
             /// </summary>
-            Pong = 0x14,
+            Pong = 0x15,
 
             /// <summary>
             /// Request to query block hashes.
@@ -83,6 +83,17 @@ namespace Libplanet.Net.Messages
             /// Message containing demand block hashes with their index numbers.
             /// </summary>
             BlockHashes = 0x0e,
+
+            /// <summary>
+            /// Request current chain status of the peer.
+            /// </summary>
+            GetChainStatus = 0x20,
+
+            /// <summary>
+            /// A reply to <see cref="GetChainStatus"/>.
+            /// Contains the chain status of the peer at the moment.
+            /// </summary>
+            ChainStatus = 0x21,
         }
 
         public byte[] Identity { get; set; }
@@ -125,6 +136,8 @@ namespace Libplanet.Net.Messages
                 { MessageType.GetRecentStates, typeof(GetRecentStates) },
                 { MessageType.RecentStates, typeof(RecentStates) },
                 { MessageType.BlockHeaderMessage, typeof(BlockHeaderMessage) },
+                { MessageType.GetChainStatus, typeof(GetChainStatus) },
+                { MessageType.ChainStatus, typeof(ChainStatus) },
             };
 
             if (!types.TryGetValue(rawType, out Type type))


### PR DESCRIPTION
`Ping` and `Pong` messages were used in both health checks and chain status checking. Thus, added new messages `GetChainStatus` and `ChainStatus` for the case of chain status checking. Now `Ping` and `Pong` used in health checks only.

Closes #920.