### PR TITLE
Add ICryptoBackend.Sign

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ To be released.
     `Block<T>.Mine()` static method.  [[#666], [#917]]
  -  Added `options` optional parameter to `Swarm<T>()` constructor.
     [[#926]]
+ -  Added `Sign(HashDigest<SHA256>, PrivateKey)` method to `ICryptoBackend`
+    interface.  [[#932]]
 
 ### Backward-incompatible network protocol changes
 
@@ -141,6 +143,7 @@ To be released.
 [#925]: https://github.com/planetarium/libplanet/pull/925
 [#926]: https://github.com/planetarium/libplanet/pull/926
 [#930]: https://github.com/planetarium/libplanet/pull/930
+[#932]: https://github.com/planetarium/libplanet/pull/932
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,12 @@ To be released.
     `Block<T>.Mine()` static method.  [[#666], [#917]]
  -  Added `options` optional parameter to `Swarm<T>()` constructor.
     [[#926]]
- -  Added `ICryptoBackend.Sign(HashDigest<SHA256>, PrivateKey)` method.
+ -  `ICryptoBackend` became to `ICryptoBackend<T>`.  [[#932]]
+ -  `ICryptoBackend.Verify(HashDigest<SHA256>, byte[], PublicKey)` became to
+    `ICryptoBackend<T>.Verify(HashDigest<T>, byte[], PublicKey)` [[#932]]
+ -  Added `ICryptoBackend<T>.Sign(HashDigest<T>, PrivateKey)` method.
     [[#932]]
+ -  `DefaultCryptoBackend` became to `DefaultCryptoBackend<T>`.  [[#932]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,8 @@ To be released.
     `Block<T>.Mine()` static method.  [[#666], [#917]]
  -  Added `options` optional parameter to `Swarm<T>()` constructor.
     [[#926]]
- -  Added `Sign(HashDigest<SHA256>, PrivateKey)` method to `ICryptoBackend`
-    interface.  [[#932]]
+ -  Added `ICryptoBackend.Sign(HashDigest<SHA256>, PrivateKey)` method.
+    [[#932]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet/Crypto/CryptoConfig.cs
+++ b/Libplanet/Crypto/CryptoConfig.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Libplanet.Crypto
 {
     /// <summary>
@@ -5,14 +7,14 @@ namespace Libplanet.Crypto
     /// </summary>
     public static class CryptoConfig
     {
-        private static ICryptoBackend _cryptoBackend;
+        private static ICryptoBackend<SHA256> _cryptoBackend;
 
         /// <summary>
         /// Global cryptography backend to sign and verify messages.
         /// </summary>
-        public static ICryptoBackend CryptoBackend
+        public static ICryptoBackend<SHA256> CryptoBackend
         {
-            get => _cryptoBackend ?? (_cryptoBackend = new DefaultCryptoBackend());
+            get => _cryptoBackend ??= new DefaultCryptoBackend<SHA256>();
             set => _cryptoBackend = value;
         }
     }

--- a/Libplanet/Crypto/DefaultCryptoBackend.cs
+++ b/Libplanet/Crypto/DefaultCryptoBackend.cs
@@ -7,9 +7,10 @@ using Org.BouncyCastle.Math;
 
 namespace Libplanet.Crypto
 {
-    public class DefaultCryptoBackend : ICryptoBackend
+    public class DefaultCryptoBackend<T> : ICryptoBackend<T>
+        where T : HashAlgorithm
     {
-        public byte[] Sign(HashDigest<SHA256> messageHash, PrivateKey privateKey)
+        public byte[] Sign(HashDigest<T> messageHash, PrivateKey privateKey)
         {
             var h = new Sha256Digest();
             var kCalculator = new HMacDsaKCalculator(h);
@@ -34,7 +35,7 @@ namespace Libplanet.Crypto
         }
 
         public bool Verify(
-            HashDigest<SHA256> messageHash,
+            HashDigest<T> messageHash,
             byte[] signature,
             PublicKey publicKey)
         {

--- a/Libplanet/Crypto/ICryptoBackend.cs
+++ b/Libplanet/Crypto/ICryptoBackend.cs
@@ -8,6 +8,20 @@ namespace Libplanet.Crypto
     public interface ICryptoBackend
     {
         /// <summary>
+        /// Creates a signature from <paramref name="messageHash"/> with the corresponding
+        /// <paramref name="privateKey"/>.
+        /// </summary>
+        /// <param name="messageHash">A 32 bytes message hash digest hashed with SHA256 to sign.
+        /// </param>
+        /// <param name="privateKey"><see cref="PrivateKey"/> to sign
+        /// <paramref name="messageHash"/>.
+        /// </param>
+        /// <returns> Created a signature from <paramref name="messageHash"/> with the corresponding
+        /// <paramref name="privateKey"/>.
+        /// </returns>
+        byte[] Sign(HashDigest<SHA256> messageHash, PrivateKey privateKey);
+
+        /// <summary>
         /// Verifies whether a <paramref name="signature"/> was created from
         /// a <paramref name="messageHash"/> with the corresponding <see cref="PrivateKey"/>.
         /// </summary>

--- a/Libplanet/Crypto/ICryptoBackend.cs
+++ b/Libplanet/Crypto/ICryptoBackend.cs
@@ -5,7 +5,10 @@ namespace Libplanet.Crypto
     /// <summary>
     /// Cryptography backend interface.
     /// </summary>
-    public interface ICryptoBackend
+    /// <typeparam name="T">A <see cref="HashAlgorithm"/> which corresponds to a digest.</typeparam>
+    /// <seealso cref="HashAlgorithm"/>
+    public interface ICryptoBackend<T>
+        where T : HashAlgorithm
     {
         /// <summary>
         /// Creates a signature from <paramref name="messageHash"/> with the corresponding
@@ -19,7 +22,7 @@ namespace Libplanet.Crypto
         /// <returns> Created a signature from <paramref name="messageHash"/> with the corresponding
         /// <paramref name="privateKey"/>.
         /// </returns>
-        byte[] Sign(HashDigest<SHA256> messageHash, PrivateKey privateKey);
+        byte[] Sign(HashDigest<T> messageHash, PrivateKey privateKey);
 
         /// <summary>
         /// Verifies whether a <paramref name="signature"/> was created from
@@ -33,7 +36,7 @@ namespace Libplanet.Crypto
         /// from the <paramref name="messageHash"/> with the corresponding
         /// <see cref="PrivateKey"/>. Otherwise <c>false</c>.</returns>
         bool Verify(
-            HashDigest<SHA256> messageHash,
+            HashDigest<T> messageHash,
             byte[] signature,
             PublicKey publicKey);
     }

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -1,17 +1,16 @@
 using System;
 using System.Diagnostics.Contracts;
-using System.IO;
 using System.Linq;
-using Org.BouncyCastle.Asn1;
+using System.Security.Cryptography;
 using Org.BouncyCastle.Asn1.Sec;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto.Digests;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Crypto.Signers;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Math.EC;
 using Org.BouncyCastle.Security;
+using ECPoint = Org.BouncyCastle.Math.EC.ECPoint;
 
 namespace Libplanet.Crypto
 {
@@ -40,8 +39,6 @@ namespace Libplanet.Crypto
     [Equals]
     public class PrivateKey
     {
-        private readonly ECPrivateKeyParameters keyParam;
-
         /// <summary>
         /// Generates a new unique <see cref="PrivateKey"/> instance.
         /// It can be analogous to creating a new account in a degree.
@@ -75,7 +72,7 @@ namespace Libplanet.Crypto
 
         private PrivateKey(ECPrivateKeyParameters keyParam)
         {
-            this.keyParam = keyParam;
+            KeyParam = keyParam;
         }
 
         /// <summary>
@@ -89,7 +86,7 @@ namespace Libplanet.Crypto
             get
             {
                 ECDomainParameters ecParams = GetECParameters();
-                ECPoint q = ecParams.G.Multiply(this.keyParam.D);
+                ECPoint q = ecParams.G.Multiply(KeyParam.D);
                 var kp = new ECPublicKeyParameters("ECDSA", q, ecParams);
                 return new PublicKey(kp);
             }
@@ -116,7 +113,9 @@ namespace Libplanet.Crypto
         /// </remarks>
         /// <seealso cref="PrivateKey(byte[])"/>
         [Pure]
-        public byte[] ByteArray => keyParam.D.ToByteArrayUnsigned();
+        public byte[] ByteArray => KeyParam.D.ToByteArrayUnsigned();
+
+        internal ECPrivateKeyParameters KeyParam { get; }
 
         public static bool operator ==(PrivateKey left, PrivateKey right) =>
             Operator.Weave(left, right);
@@ -163,25 +162,7 @@ namespace Libplanet.Crypto
             h.DoFinal(hashed, 0);
             h.Reset();
 
-            var kCalculator = new HMacDsaKCalculator(h);
-            var signer = new ECDsaSigner(kCalculator);
-            signer.Init(true, keyParam);
-            BigInteger[] rs = signer.GenerateSignature(hashed);
-            var r = rs[0];
-            var s = rs[1];
-
-            BigInteger otherS = keyParam.Parameters.N.Subtract(s);
-            if (s.CompareTo(otherS) == 1)
-            {
-                s = otherS;
-            }
-
-            var bos = new MemoryStream(72);
-            var seq = new DerSequenceGenerator(bos);
-            seq.AddObject(new DerInteger(r));
-            seq.AddObject(new DerInteger(s));
-            seq.Close();
-            return bos.ToArray();
+            return CryptoConfig.CryptoBackend.Sign(new HashDigest<SHA256>(hashed), this);
         }
 
         /// <summary>
@@ -287,7 +268,7 @@ namespace Libplanet.Crypto
 
         private ECPoint CalculatePoint(ECPublicKeyParameters pubKeyParams)
         {
-            ECDomainParameters dp = keyParam.Parameters;
+            ECDomainParameters dp = KeyParam.Parameters;
             if (!dp.Equals(pubKeyParams.Parameters))
             {
                 throw new InvalidOperationException(
@@ -295,7 +276,7 @@ namespace Libplanet.Crypto
                 );
             }
 
-            BigInteger d = keyParam.D;
+            BigInteger d = KeyParam.D;
 
             ECPoint q = dp.Curve.DecodePoint(pubKeyParams.Q.GetEncoded(true));
             if (q.IsInfinity)

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -39,6 +39,8 @@ namespace Libplanet.Crypto
     [Equals]
     public class PrivateKey
     {
+        private PublicKey _publicKey;
+
         /// <summary>
         /// Generates a new unique <see cref="PrivateKey"/> instance.
         /// It can be analogous to creating a new account in a degree.
@@ -79,16 +81,20 @@ namespace Libplanet.Crypto
         /// The corresponding <see cref="Libplanet.Crypto.PublicKey"/> of
         /// this private key.
         /// </summary>
-        [Pure]
         [IgnoreDuringEquals]
         public PublicKey PublicKey
         {
             get
             {
-                ECDomainParameters ecParams = GetECParameters();
-                ECPoint q = ecParams.G.Multiply(KeyParam.D);
-                var kp = new ECPublicKeyParameters("ECDSA", q, ecParams);
-                return new PublicKey(kp);
+                if (_publicKey is null)
+                {
+                    ECDomainParameters ecParams = GetECParameters();
+                    ECPoint q = ecParams.G.Multiply(KeyParam.D);
+                    var kp = new ECPublicKeyParameters("ECDSA", q, ecParams);
+                    _publicKey = new PublicKey(kp);
+                }
+
+                return _publicKey;
             }
         }
 


### PR DESCRIPTION
This adds `ICryptoBackend.Sign()` method to enable signing library changes. Also, this modifies `PrivateKey` to store `PublicKey` instead of generating it every time.