### PR TITLE
Don't throw exception when connecting to all neighbors fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,8 +98,8 @@ To be released.
     [[#459], [#919]]
  -  `Swarm<T>` became to promote the most difficult chain as a canonical chain
     instead of the longest chain.  [[#459], [#919]]
- -  Changed to not throw an exception in `Swarm.BootstrapAsync()` when
-    connecting to all neighbors fails.  [[#933]]
+ -  `Swarm<T>.BootstrapAsync()` method became not to throw `TimeoutException` when
+    it fails to connect to all neighbors.  [[#933]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,8 @@ To be released.
     [[#459], [#919]]
  -  `Swarm<T>` became to promote the most difficult chain as a canonical chain
     instead of the longest chain.  [[#459], [#919]]
+ -  Changed to not throw an exception in `Swarm.BootstrapAsync()` when
+    connecting to all neighbors fails.  [[#933]]
 
 ### Bug fixes
 
@@ -151,6 +153,7 @@ To be released.
 [#927]: https://github.com/planetarium/libplanet/pull/927
 [#930]: https://github.com/planetarium/libplanet/pull/930
 [#932]: https://github.com/planetarium/libplanet/pull/932
+[#933]: https://github.com/planetarium/libplanet/pull/933
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -127,15 +127,6 @@ namespace Libplanet.Net.Protocols
             }
             catch (Exception e)
             {
-                if (findPeerTasks.All(task =>
-                    task.IsFaulted &&
-                    !(task.Exception is null) &&
-                    task.Exception.InnerExceptions.All(ex => ex is TimeoutException)))
-                {
-                    throw new TimeoutException(
-                        $"Timeout exception occurred during {nameof(BootstrapAsync)}().");
-                }
-
                 var msg = $"An unexpected exception occurred during {nameof(BootstrapAsync)}()." +
                           " {Exception}";
                 _logger.Error(e, msg, e);
@@ -640,16 +631,6 @@ namespace Libplanet.Net.Protocols
             }
             catch (Exception e)
             {
-                if (awaitables.All(task =>
-                    task.IsFaulted &&
-                    !(task.Exception is null) &&
-                    task.Exception.InnerExceptions.All(ex => ex is TimeoutException)))
-                {
-                    throw new TimeoutException(
-                        $"All neighbors found do not respond in {_requestTimeout}."
-                    );
-                }
-
                 _logger.Error(
                     e,
                     "Some responses from neighbors found unexpectedly terminated: {Exception}",
@@ -695,16 +676,6 @@ namespace Libplanet.Net.Protocols
             }
             catch (Exception e)
             {
-                if (findPeerTasks.All(task =>
-                    task.IsFaulted &&
-                    !(task.Exception is null) &&
-                    task.Exception.InnerExceptions.All(ex => ex is TimeoutException)))
-                {
-                    throw new TimeoutException(
-                        "All FindPeer tasks caused timeout during " +
-                        $"{nameof(ProcessFoundAsync)}().");
-                }
-
                 _logger.Error(
                     e,
                     "Some FindPeer tasks were unexpectedly terminated: {Exception}",


### PR DESCRIPTION
This PR changes to not throw an exception in `Swarm.BootstrapAsync()` when connecting to all neighbors fails.