### PR TITLE
More flexible state complement

### DIFF
--- a/.idea/.idea.Libplanet/.idea/vcs.xml
+++ b/.idea/.idea.Libplanet/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,7 @@ To be released.
         `StateCompleters<T>.Reject`, respectively.
      -  Added `StateCompleter<T>` delegate.
      -  Added `FungibleAssetStateCompleter<T>` delegate.
+     -  Added `StateCompleterSet<T>` struct.
      -  Added `StateCompleters<T>` static class.
      -  Added `FungibleAssetStateCompleters<T>` static class.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,17 @@ To be released.
  -  Added `Block<T>.PreEvaluationHash` property.  [[#931], [#935]]
  -  Added `BlockHeader.PreEvaluationHash` property.  [[#931], [#935]]
  -  Added `HashDigest(ImmutableArray<byte>)` constructor.  [[#931], [#935]]
+ -  Incomplete block states became able to be handled in more flexible way.
+    [[#929], [#934]]
+     -  Replaced `BlockChain<T>.GetState(Address, HashDigest<SHA256>?, bool)`
+        method with `GetState(Address, HashDigest<SHA256>?, StateCompleter<T>)`
+        method.  Specifying `completeStates: true` and `false` can be replaced
+        by `stateCompleter: StateCompleters<T>.Recalculate` and
+        `StateCompleters<T>.Reject`, respectively.
+     -  Added `StateCompleter<T>` delegate.
+     -  Added `FungibleAssetStateCompleter<T>` delegate.
+     -  Added `StateCompleters<T>` static class.
+     -  Added `FungibleAssetStateCompleters<T>` static class.
 
 ### Behavioral changes
 
@@ -168,10 +179,12 @@ To be released.
 [#925]: https://github.com/planetarium/libplanet/pull/925
 [#926]: https://github.com/planetarium/libplanet/pull/926
 [#927]: https://github.com/planetarium/libplanet/pull/927
+[#929]: https://github.com/planetarium/libplanet/issues/929
 [#930]: https://github.com/planetarium/libplanet/pull/930
 [#931]: https://github.com/planetarium/libplanet/issues/931
 [#932]: https://github.com/planetarium/libplanet/pull/932
 [#933]: https://github.com/planetarium/libplanet/pull/933
+[#934]: https://github.com/planetarium/libplanet/pull/934
 [#935]: https://github.com/planetarium/libplanet/pull/935
 [#936]: https://github.com/planetarium/libplanet/pull/936
 [#940]: https://github.com/planetarium/libplanet/pull/940

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1930,7 +1930,11 @@ namespace Libplanet.Tests.Blockchain
             );
 
             var miner = genesis.Miner.GetValueOrDefault();
-            var blockActionEvaluation = _blockChain.EvaluateBlockAction(genesis, null);
+            var blockActionEvaluation = _blockChain.EvaluateBlockAction(
+                genesis,
+                null,
+                StateCompleterSet<DumbAction>.Recalculate
+            );
             Assert.Equal(_blockChain.Policy.BlockAction, blockActionEvaluation.Action);
             Assert.Equal(
                 (Integer)2,
@@ -1946,7 +1950,11 @@ namespace Libplanet.Tests.Blockchain
             var txEvaluations = block1.EvaluateActionsPerTx(a =>
                     _blockChain.GetState(a, block1.PreviousHash))
                 .Select(te => te.Item2).ToList();
-            blockActionEvaluation = _blockChain.EvaluateBlockAction(block1, txEvaluations);
+            blockActionEvaluation = _blockChain.EvaluateBlockAction(
+                block1,
+                txEvaluations,
+                StateCompleterSet<DumbAction>.Recalculate
+            );
 
             Assert.Equal((Integer)2, (Integer)blockActionEvaluation.OutputStates.GetState(miner));
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1468,6 +1468,31 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void GetStateWithStateCompleter()
+        {
+            (Address signer, Address[] addresses, BlockChain<DumbAction> chain)
+                = MakeIncompleteBlockStates();
+            StoreTracker store = (StoreTracker)chain.Store;
+
+            IValue value = chain.GetState(
+                addresses[4],
+                chain.Tip.Hash,
+                (bc, bh, a) => throw new Exception("This exception should not be thrown.")
+            );
+            Assert.Equal(new Text("9"), value);
+
+            value = chain.GetState(
+                addresses[4],
+                chain.BlockHashes.Skip((int)chain.Count - 2).First(),
+                (bc, hash, addr) =>
+                    new Text($"{bc.Id}/{hash}/{addr}: callback called")
+            );
+            HashDigest<SHA256> prevUpdate = chain.BlockHashes.Skip(addresses.Length).First();
+            var expected = new Text($"{chain.Id}/{prevUpdate}/{addresses[4]}: callback called");
+            Assert.Equal(expected, value);
+        }
+
+        [Fact]
         public void GetStateWithCompletingStates()
         {
             (Address signer, Address[] addresses, BlockChain<DumbAction> chain)
@@ -1510,7 +1535,10 @@ namespace Libplanet.Tests.Blockchain
             long txNonce = store.GetTxNonce(chain.Id, signer);
 
             store.ClearLogs();
-            chain.GetState(addresses.Last(), completeStates: true);
+            chain.GetState(
+                addresses.Last(),
+                stateCompleter: StateCompleters<DumbAction>.Recalculate
+            );
 
             Assert.Empty(
                 store.Logs.Where(l => l.Method == "StoreStateReference")
@@ -1524,7 +1552,10 @@ namespace Libplanet.Tests.Blockchain
             }
 
             store.ClearLogs();
-            chain.GetState(addresses[0], completeStates: true);
+            chain.GetState(
+                addresses[0],
+                stateCompleter: StateCompleters<DumbAction>.Recalculate
+            );
 
             foreach (var blockHash in chain.BlockHashes)
             {

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -599,7 +599,10 @@ namespace Libplanet.Tests.Net
                     foreach (BlockChain<DumbAction> chain in new[] { minerChain, receiverChain })
                     {
                         var chainType = ReferenceEquals(chain, minerChain) ? "M" : "R";
-                        var state = chain.GetState(target, completeStates: false);
+                        IValue state = chain.GetState(
+                            target,
+                            stateCompleter: StateCompleters<DumbAction>.Reject
+                        );
                         Assert.NotNull(state);
                         Assert.Equal(
                             $"({chainType}) Item0.{i},Item1.{i},Item2.{i}",
@@ -610,7 +613,7 @@ namespace Libplanet.Tests.Net
                     IValue TryToGetDeepStates() => receiverChain.GetState(
                         target,
                         deepBlockHash,
-                        completeStates: false
+                        StateCompleters<DumbAction>.Reject
                     );
 
                     if (trust)
@@ -633,7 +636,10 @@ namespace Libplanet.Tests.Net
                 {
                     foreach (BlockChain<DumbAction> chain in new[] { minerChain, receiverChain })
                     {
-                        var state = chain.GetState(genesisTarget, completeStates: false);
+                        IValue state = chain.GetState(
+                            genesisTarget,
+                            stateCompleter: StateCompleters<DumbAction>.Reject
+                        );
                         Assert.NotNull(state);
                         Assert.Equal((Text)"Genesis", state);
                     }
@@ -641,7 +647,10 @@ namespace Libplanet.Tests.Net
 
                 foreach (BlockChain<DumbAction> chain in new[] { minerChain, receiverChain })
                 {
-                    var minerState = chain.GetState(minerSwarm.Address, completeStates: false);
+                    IValue minerState = chain.GetState(
+                        minerSwarm.Address,
+                        stateCompleter: StateCompleters<DumbAction>.Reject
+                    );
                     Assert.NotNull(minerState);
                     Assert.Equal(
                         (Integer)((genesisWithAction ? 1 : 0) + repeat * fixturePairs.Length),
@@ -924,7 +933,10 @@ namespace Libplanet.Tests.Net
                     foreach (BlockChain<DumbAction> chain in new[] { minerChain, receiverChain })
                     {
                         var chainType = ReferenceEquals(chain, minerChain) ? "M" : "R";
-                        var state = chain.GetState(target, completeStates: false);
+                        IValue state = chain.GetState(
+                            target,
+                            stateCompleter: StateCompleters<DumbAction>.Reject
+                        );
                         Assert.NotNull(state);
                         Assert.Equal(
                             $"({chainType}) Item0.{i},Item1.{i},Item2.{i},Item3.{i},Item9.{i}",
@@ -935,7 +947,7 @@ namespace Libplanet.Tests.Net
                     IValue TryToGetDeepStates() => receiverChain.GetState(
                         target,
                         deepBlockHash,
-                        completeStates: false
+                        StateCompleters<DumbAction>.Reject
                     );
 
                     Assert.Throws<IncompleteBlockStatesException>(
@@ -947,7 +959,10 @@ namespace Libplanet.Tests.Net
 
                 foreach (BlockChain<DumbAction> chain in new[] { minerChain, receiverChain })
                 {
-                    var state = chain.GetState(genesisTarget, completeStates: false);
+                    IValue state = chain.GetState(
+                        genesisTarget,
+                        stateCompleter: StateCompleters<DumbAction>.Reject
+                    );
                     Assert.NotNull(state);
                     Assert.Equal((Text)"Genesis", state);
                 }
@@ -1014,7 +1029,10 @@ namespace Libplanet.Tests.Net
 
                 foreach (BlockChain<DumbAction> chain in new[] { chain0, chain1 })
                 {
-                    var blockActionState = chain.GetState(swarm0.Address, completeStates: false);
+                    IValue blockActionState = chain.GetState(
+                        swarm0.Address,
+                        stateCompleter: StateCompleters<DumbAction>.Reject
+                    );
                     Assert.NotNull(blockActionState);
                     Assert.Equal((Integer)repeat, (Integer)blockActionState);
                 }
@@ -1026,7 +1044,7 @@ namespace Libplanet.Tests.Net
                         var state = chain1.GetState(
                             swarm0.Address,
                             blockHashes[i],
-                            completeStates: false
+                            stateCompleter: StateCompleters<DumbAction>.Reject
                         );
                         Assert.NotNull(state);
                         Assert.Equal((Integer)i, (Integer)state);
@@ -1038,7 +1056,7 @@ namespace Libplanet.Tests.Net
                             chain1.GetState(
                                 swarm0.Address,
                                 blockHashes[i],
-                                completeStates: false
+                                stateCompleter: StateCompleters<DumbAction>.Reject
                             );
                         });
                     }
@@ -1052,7 +1070,10 @@ namespace Libplanet.Tests.Net
 
                 foreach (BlockChain<DumbAction> chain in new[] { chain1, chain2 })
                 {
-                    var blockActionState = chain.GetState(swarm0.Address, completeStates: false);
+                    IValue blockActionState = chain.GetState(
+                        swarm0.Address,
+                        stateCompleter: StateCompleters<DumbAction>.Reject
+                    );
                     Assert.NotNull(blockActionState);
                     Assert.Equal((Integer)repeat, (Integer)blockActionState);
                 }
@@ -1064,7 +1085,7 @@ namespace Libplanet.Tests.Net
                         var state = chain2.GetState(
                             swarm0.Address,
                             blockHashes[i],
-                            completeStates: false
+                            StateCompleters<DumbAction>.Reject
                         );
                         Assert.NotNull(state);
                         Assert.Equal((Integer)i, (Integer)state);
@@ -1076,7 +1097,7 @@ namespace Libplanet.Tests.Net
                             chain2.GetState(
                                 swarm0.Address,
                                 blockHashes[i],
-                                completeStates: false
+                                StateCompleters<DumbAction>.Reject
                             );
                         });
                     }

--- a/Libplanet.Tools/.gitignore
+++ b/Libplanet.Tools/.gitignore
@@ -1,4 +1,5 @@
 # npm
 !bin/
+bin/*/
 node_modules/
 package-lock.json

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -660,7 +660,7 @@ namespace Libplanet.Blockchain
                 throw new OperationCanceledException(cancellationToken);
             }
 
-            var actionEvaluations = EvaluateActions(block);
+            var actionEvaluations = EvaluateActions(block, StateCompleterSet<T>.Recalculate);
 
             block = new Block<T>(block, ActionEvaluationsToHash(actionEvaluations));
 
@@ -853,12 +853,18 @@ namespace Libplanet.Blockchain
         /// Render actions from block index of <paramref name="offset"/>.
         /// </summary>
         /// <param name="offset">Index of the block to start rendering from.</param>
-        internal void RenderBlocks(long offset)
+        /// <param name="stateCompleters">The strategy to complement incomplete block states.
+        /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.</param>
+        internal void RenderBlocks(long offset, StateCompleterSet<T>? stateCompleters = null)
         {
+            // Since rendering process requires every step's states, if required block states
+            // are incomplete they are complemented anyway:
+            stateCompleters ??= StateCompleterSet<T>.Recalculate;
+
             // FIXME: We should consider the case where block count is larger than int.MaxSize.
             foreach (var block in IterateBlocks((int)offset))
             {
-                RenderBlock(null, block);
+                RenderBlock(null, block, stateCompleters);
             }
         }
 
@@ -868,13 +874,23 @@ namespace Libplanet.Blockchain
         /// <param name="evaluations"><see cref="ActionEvaluation"/>s of the block.  If it is
         /// <c>null</c>, evaluate actions of the <paramref name="block"/> again.</param>
         /// <param name="block"><see cref="Block{T}"/> to render actions.</param>
-        internal void RenderBlock(IReadOnlyList<ActionEvaluation> evaluations, Block<T> block)
+        /// <param name="stateCompleters">The strategy to complement incomplete block states.
+        /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.</param>
+        internal void RenderBlock(
+            IReadOnlyList<ActionEvaluation> evaluations,
+            Block<T> block,
+            StateCompleterSet<T>? stateCompleters = null
+        )
         {
             _logger.Debug("Render actions in block {blockIndex}: {block}", block?.Index, block);
 
+            // Since rendering process requires every step's states, if required block states
+            // are incomplete they are complemented anyway:
+            stateCompleters ??= StateCompleterSet<T>.Recalculate;
+
             if (evaluations is null)
             {
-                evaluations = EvaluateActions(block);
+                evaluations = EvaluateActions(block, stateCompleters.Value);
             }
 
             foreach (var evaluation in evaluations)
@@ -902,9 +918,13 @@ namespace Libplanet.Blockchain
         /// </remarks>
         internal IReadOnlyList<ActionEvaluation> ExecuteActions(Block<T> block)
         {
-            _logger.Debug("Execute action in block {blockIndex}: {block}", block?.Index, block);
+            _logger.Debug(
+                "Execute actions in the block #{BlockIndex} {Block}.",
+                block.Index,
+                block
+            );
             IReadOnlyList<ActionEvaluation> evaluations = null;
-            evaluations = EvaluateActions(block);
+            evaluations = EvaluateActions(block, StateCompleterSet<T>.Recalculate);
 
             _rwlock.EnterWriteLock();
             try
@@ -919,7 +939,10 @@ namespace Libplanet.Blockchain
             return evaluations;
         }
 
-        internal IReadOnlyList<ActionEvaluation> EvaluateActions(Block<T> block)
+        internal IReadOnlyList<ActionEvaluation> EvaluateActions(
+            Block<T> block,
+            StateCompleterSet<T> stateCompleters
+        )
         {
             AccountStateGetter stateGetter;
             AccountBalanceGetter balanceGetter;
@@ -930,12 +953,16 @@ namespace Libplanet.Blockchain
             }
             else
             {
-                stateGetter = a => GetState(a, block.PreviousHash, StateCompleters<T>.Recalculate);
+                stateGetter = a => GetState(
+                    a,
+                    block.PreviousHash,
+                    stateCompleters.StateCompleter
+                );
                 balanceGetter = (address, currency) => GetBalance(
                         address,
                         currency,
                         block.PreviousHash,
-                        FungibleAssetStateCompleters<T>.Recalculate
+                        stateCompleters.FungibleAssetStateCompleter
                     );
             }
 
@@ -944,12 +971,14 @@ namespace Libplanet.Blockchain
                 .ToImmutableList();
             return Policy.BlockAction is null
                 ? txEvaluations
-                : txEvaluations.Add(EvaluateBlockAction(block, txEvaluations));
+                : txEvaluations.Add(EvaluateBlockAction(block, txEvaluations, stateCompleters));
         }
 
         internal ActionEvaluation EvaluateBlockAction(
             Block<T> block,
-            IReadOnlyList<ActionEvaluation> txActionEvaluations)
+            IReadOnlyList<ActionEvaluation> txActionEvaluations,
+            StateCompleterSet<T> stateCompleters
+        )
         {
             if (Policy.BlockAction is null)
             {
@@ -972,12 +1001,12 @@ namespace Libplanet.Blockchain
             if (lastStates is null)
             {
                 lastStates = new AccountStateDeltaImpl(
-                    a => GetState(a, block.PreviousHash, StateCompleters<T>.Recalculate),
+                    a => GetState(a, block.PreviousHash, stateCompleters.StateCompleter),
                     (address, currency) => GetBalance(
                         address,
                         currency,
                         block.PreviousHash,
-                        FungibleAssetStateCompleters<T>.Recalculate
+                        stateCompleters.FungibleAssetStateCompleter
                     ),
                     miner
                 );
@@ -1200,8 +1229,16 @@ namespace Libplanet.Blockchain
         // FIXME it's very dangerous because replacing Id means
         // ALL blocks (referenced by MineBlock(), etc.) will be changed.
         // we need to add a synchronization mechanism to handle this correctly.
-        internal void Swap(BlockChain<T> other, bool render)
+        internal void Swap(
+            BlockChain<T> other,
+            bool render,
+            StateCompleterSet<T>? stateCompleters = null
+        )
         {
+            // As render/unrender processing requires every step's states from the branchpoint
+            // to the new/stale tip, incomplete states need to be complemented anyway...
+            StateCompleterSet<T> completers = stateCompleters ?? StateCompleterSet<T>.Recalculate;
+
             if (other?.Tip is null)
             {
                 throw new ArgumentException(
@@ -1246,9 +1283,9 @@ namespace Libplanet.Blockchain
 
             if (_render && render)
             {
+                // Unrender stale actions.
                 _logger.Debug("Unrendering abandoned actions...");
 
-                // Unrender stale actions.
                 for (
                     Block<T> b = Tip;
                     !(b is null) && b.Index > (topmostCommon?.Index ?? -1) &&
@@ -1256,7 +1293,8 @@ namespace Libplanet.Blockchain
                     b = this[ph]
                 )
                 {
-                    List<ActionEvaluation> evaluations = EvaluateActions(b).ToList();
+                    List<ActionEvaluation> evaluations =
+                        EvaluateActions(b, completers).ToList();
                     evaluations.Reverse();
 
                     foreach (var evaluation in evaluations)
@@ -1328,7 +1366,7 @@ namespace Libplanet.Blockchain
                     ? branchPoint.Index + 1
                     : 0;
 
-                RenderBlocks(startToRenderIndex);
+                RenderBlocks(startToRenderIndex, completers);
                 _logger.Debug($"Render for {nameof(Swap)}() is completed.");
             }
         }
@@ -1472,23 +1510,31 @@ namespace Libplanet.Blockchain
             HashDigest<SHA256> blockHash
         )
         {
+            // Prevent recursive trial to recalculate & complement incomplete block states by
+            // mistake; if the below code works as intended, these state completers must never
+            // be invoked.
+            StateCompleterSet<T> stateCompleters = StateCompleterSet<T>.Reject;
+
             // Calculates and fills the incomplete states
             // on the fly.
             foreach (HashDigest<SHA256> hash in BlockHashes)
             {
-                Block<T> b = this[hash];
-                if (!(Store.GetBlockStates(b.Hash) is null))
+                Block<T> block = this[hash];
+                if (!(Store.GetBlockStates(block.Hash) is null))
                 {
                     continue;
                 }
 
-                IReadOnlyList<ActionEvaluation> evaluations = EvaluateActions(b);
+                IReadOnlyList<ActionEvaluation> evaluations = EvaluateActions(
+                    block,
+                    stateCompleters
+                );
 
                 _rwlock.EnterWriteLock();
 
                 try
                 {
-                    SetStates(b, evaluations, buildStateReferences: false);
+                    SetStates(block, evaluations, buildStateReferences: false);
                 }
                 finally
                 {

--- a/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
@@ -16,6 +16,7 @@ namespace Libplanet.Blockchain
     /// <param name="address">The account to query its balance.</param>
     /// <param name="currency">The currency to query.</param>
     /// <returns>A complement balance value.</returns>
+    /// <seealso cref="FungibleAssetStateCompleters{T}"/>
     public delegate BigInteger FungibleAssetStateCompleter<T>(
         BlockChain<T> blockChain,
         HashDigest<SHA256> blockHash,

--- a/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+using System.Security.Cryptography;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// A delegate to be called when <see cref="BlockChain{T}.GetBalance"/> method encounters
+    /// a block having incomplete dirty states. <see cref="BlockChain{T}.GetBalance"/> method
+    /// returns this delegate's return value instead for such case.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <param name="blockChain">The blockchain to query.</param>
+    /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
+    /// <param name="address">The account to query its balance.</param>
+    /// <param name="currency">The currency to query.</param>
+    /// <returns>A complement balance value.</returns>
+    public delegate BigInteger FungibleAssetStateCompleter<T>(
+        BlockChain<T> blockChain,
+        HashDigest<SHA256> blockHash,
+        Address address,
+        Currency currency
+    )
+        where T : IAction, new();
+}

--- a/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Numerics;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// Predefined built-in state completers that satisfy
+    /// <see cref="FungibleAssetStateCompleter{T}"/> delegate.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public static class FungibleAssetStateCompleters<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Recalculates and complements a block's incomplete states on the fly.
+        /// Incomplete states are filled with the recalculated states and the states are
+        /// permanently remained in the store.
+        /// </summary>
+        public static readonly FungibleAssetStateCompleter<T> Recalculate =
+            (blockChain, blockHash, address, currency) =>
+                blockChain.ComplementBlockStates(blockHash).TryGetValue(
+                    BlockChain<T>.ToFungibleAssetKey(address, currency),
+                    out IValue v
+                ) ? (BigInteger)(Bencodex.Types.Integer)v : 0;
+
+        /// <summary>
+        /// Rejects to complement incomplete state and throws
+        /// an <see cref="IncompleteBlockStatesException"/>.
+        /// </summary>
+        public static readonly FungibleAssetStateCompleter<T> Reject =
+            (chain, blockHash, address, currency) =>
+                throw new IncompleteBlockStatesException(blockHash);
+
+        internal static Func<BlockChain<T>, HashDigest<SHA256>, IValue> ToRawStateCompleter(
+            FungibleAssetStateCompleter<T> stateCompleter,
+            Address address,
+            Currency currency
+        ) =>
+            (blockChain, hash) =>
+                (Bencodex.Types.Integer)stateCompleter(blockChain, hash, address, currency);
+    }
+}

--- a/Libplanet/Blockchain/StateCompleter.cs
+++ b/Libplanet/Blockchain/StateCompleter.cs
@@ -15,6 +15,7 @@ namespace Libplanet.Blockchain
     /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
     /// <param name="address">The address to query its state value.</param>
     /// <returns>A complement state.  This can be <c>null</c>.</returns>
+    /// <seealso cref="StateCompleters{T}"/>
     public delegate IValue StateCompleter<T>(
         BlockChain<T> blockChain,
         HashDigest<SHA256> blockHash,

--- a/Libplanet/Blockchain/StateCompleter.cs
+++ b/Libplanet/Blockchain/StateCompleter.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// A delegate to be called when <see cref="BlockChain{T}.GetState"/> method encounters a block
+    /// having incomplete dirty states. <see cref="BlockChain{T}.GetState"/> method returns this
+    /// delegate's return value instead for such case.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <param name="blockChain">The blockchain to query.</param>
+    /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
+    /// <param name="address">The address to query its state value.</param>
+    /// <returns>A complement state.  This can be <c>null</c>.</returns>
+    public delegate IValue StateCompleter<T>(
+        BlockChain<T> blockChain,
+        HashDigest<SHA256> blockHash,
+        Address address
+    )
+        where T : IAction, new();
+}

--- a/Libplanet/Blockchain/StateCompleterSet.cs
+++ b/Libplanet/Blockchain/StateCompleterSet.cs
@@ -1,0 +1,44 @@
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// Groups two kinds of state completers.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public struct StateCompleterSet<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Recalculates and complements a block's incomplete states on the fly.
+        /// Incomplete states are filled with the recalculated states and the states are
+        /// permanently remained in the store.
+        /// </summary>
+        public static readonly StateCompleterSet<T> Recalculate = new StateCompleterSet<T>
+        {
+            StateCompleter = StateCompleters<T>.Recalculate,
+            FungibleAssetStateCompleter = FungibleAssetStateCompleters<T>.Recalculate,
+        };
+
+        /// <summary>
+        /// Rejects to complement incomplete state and throws
+        /// an <see cref="IncompleteBlockStatesException"/>.
+        /// </summary>
+        public static readonly StateCompleterSet<T> Reject = new StateCompleterSet<T>
+        {
+            StateCompleter = StateCompleters<T>.Reject,
+            FungibleAssetStateCompleter = FungibleAssetStateCompleters<T>.Reject,
+        };
+
+        /// <summary>
+        /// Holds a <see cref="StateCompleter{T}"/>.
+        /// </summary>
+        public StateCompleter<T> StateCompleter { get; set; }
+
+        /// <summary>
+        /// Holds a <see cref="FungibleAssetStateCompleter{T}"/>.
+        /// </summary>
+        public FungibleAssetStateCompleter<T> FungibleAssetStateCompleter { get; set; }
+    }
+}

--- a/Libplanet/Blockchain/StateCompleters.cs
+++ b/Libplanet/Blockchain/StateCompleters.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// Predefined built-in state completers that satisfy <see cref="StateCompleter{T}"/> delegate.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public static class StateCompleters<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Recalculates and complements a block's incomplete states on the fly.
+        /// Incomplete states are filled with the recalculated states and the states are
+        /// permanently remained in the store.
+        /// </summary>
+        public static readonly StateCompleter<T> Recalculate = (blockChain, blockHash, address) =>
+            blockChain.ComplementBlockStates(blockHash).TryGetValue(
+                BlockChain<T>.ToStateKey(address),
+                out IValue v
+            ) ? v : null;
+
+        /// <summary>
+        /// Rejects to complement incomplete state and throws
+        /// an <see cref="IncompleteBlockStatesException"/>.
+        /// </summary>
+        public static readonly StateCompleter<T> Reject = (chain, blockHash, address) =>
+            throw new IncompleteBlockStatesException(blockHash);
+
+        internal static Func<BlockChain<T>, HashDigest<SHA256>, IValue> ToRawStateCompleter(
+            StateCompleter<T> stateCompleter,
+            Address address
+        ) =>
+            (blockChain, hash) => stateCompleter(blockChain, hash, address);
+    }
+}


### PR DESCRIPTION
This changes is a prior work to address the issue #929.  The existing option `bool completeStates` on `BlockChain<T>.GetState()` and `BlockChain<T>.GetBalance()` methods had provided only two ways to handle *incomplete block states*:

- `completeStates: true` recalculates actions from scratch and fills the incomplete block states with the recalculated states.  Of course this probably takes a long time.
- `completeStates: false` rejects inquiry on a state value and throws `IncompleteBlockStatesException` instead.  This prevents high latency, but also prevents to *use* 🙄 at the same time.

However, in order to achieve the idea of #929, we need to add one more option, and make `BlockChain<T>` to depend on `Swarm<T>`, which causes circular dependency (`BlockChain<T>` → `Swarm<T>` → `BlockChain<T>`).  To avoid such circular dependency, the new way turns the `bool`ean flag into the callback named `stateCompleter`.

There are two types of delegates for `GetState()` and `GetBalance()` methods, respectively:

- `IValue StateCompleter<T>(BlockChain<T>, HashDigest<SHA256>, Address)`
- `BigInteger FungibleAssetStateCompleter<T>(BlockChain<T>, HashDigest<SHA256>, Address, Currency)`

Other higher methods than `GetState()` and `GetBalance()` need both of them, so a new `StateCompleterSet<T>` struct is introduced.  Currently two predefined built-in completer sets are provided, and they corresponds to the existing `completeStates: true` and `false` options:

- `StateCompleterSet<T>.Recalculate`
- `StateCompleterSet<T>.Reject`

I am going to submit a separated patch later, which will introduce a new completer set: `Swarm<T>.GetTrustedStateCompleter()`.