### PR TITLE
Serializable InsufficientBalanceException

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,8 +128,9 @@ To be released.
     [[#909]]
  -  Fixed a bug in which pre-computed state delivery had failed when a state
     key is not an `Address` when preloading.  [[#912]]
- -  Fixed a bug where `UnexpectedlyTerminatedException` hadn't been serialized
-    with `BinaryFormatter`.  [[#913]]
+ -  Fixed a bug where `UnexpectedlyTerminatedException` and
+    `InsufficientBalanceException` hadn't been serialized with
+    `BinaryFormatter`.  [[#913], [#940]]
  -  Fixed a bug where `TurnClient` hadn't applied cancellation token to its
     connections.  [[#916]]
  -  Fixed a bug where `BlockChain<T>.GetRawState()` had overwritten block states

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,7 @@ To be released.
     instead of the longest chain.  [[#459], [#919]]
  -  `Swarm<T>.BootstrapAsync()` method became not to throw `TimeoutException` when
     it fails to connect to all neighbors.  [[#933]]
+ -  `Currency` is now serializable.  [[#940]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,7 +117,6 @@ To be released.
     instead of the longest chain.  [[#459], [#919]]
  -  `Swarm<T>.BootstrapAsync()` method became not to throw `TimeoutException` when
     it fails to connect to all neighbors.  [[#933]]
- -  `Currency` is now serializable.  [[#940]]
 
 ### Bug fixes
 
@@ -128,9 +127,8 @@ To be released.
     [[#909]]
  -  Fixed a bug in which pre-computed state delivery had failed when a state
     key is not an `Address` when preloading.  [[#912]]
- -  Fixed a bug where `UnexpectedlyTerminatedException` and
-    `InsufficientBalanceException` hadn't been serialized with
-    `BinaryFormatter`.  [[#913], [#940]]
+ -  Fixed a bug where `UnexpectedlyTerminatedException` hadn't been serialized
+    with `BinaryFormatter`.  [[#913]]
  -  Fixed a bug where `TurnClient` hadn't applied cancellation token to its
     connections.  [[#916]]
  -  Fixed a bug where `BlockChain<T>.GetRawState()` had overwritten block states
@@ -176,6 +174,7 @@ To be released.
 [#933]: https://github.com/planetarium/libplanet/pull/933
 [#935]: https://github.com/planetarium/libplanet/pull/935
 [#936]: https://github.com/planetarium/libplanet/pull/936
+[#940]: https://github.com/planetarium/libplanet/pull/940
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ To be released.
     `BlockHeader` constructor. [[#931], [#935]]
  -  Added `HashDigest<SHA256>`-typed `preEvaluationHash` parameter to
     `Block<T>()` constructor. [[#931], [#935]]
+ -  Replaced `SerializationInfoExtensions.GetValueOrDefault<T>()` to
+    `SerializationInfoExtensions.TryGetValue<T>()`.  [[#940]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
+++ b/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Action
+{
+    public class InsufficientBalanceExceptionTest
+    {
+        [Fact]
+        public void Serializable()
+        {
+            var minter = new Address(new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            });
+            var account = new Address(new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            });
+
+            var currency = new Currency("PLT", minter);
+            var exc = new InsufficientBalanceException(account, currency, 99, "for testing");
+
+            var formatter = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                formatter.Serialize(ms, exc);
+
+                ms.Seek(0, SeekOrigin.Begin);
+                var deserialized = (InsufficientBalanceException)formatter.Deserialize(ms);
+                Assert.Equal("for testing", deserialized.Message);
+                Assert.Equal(account, deserialized.Address);
+                Assert.Equal(currency.Hash, deserialized.Currency.Hash);
+                Assert.Equal(99, deserialized.Balance);
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
+++ b/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
@@ -1,7 +1,10 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
 using Xunit;
 
 namespace Libplanet.Tests.Action
@@ -12,8 +15,23 @@ namespace Libplanet.Tests.Action
         public void Serializable()
         {
             var innerExc = new Exception("inner");
+            var blockHash = new HashDigest<SHA256>(
+                TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)
+            );
+            long blockIndex = 100;
+            var txId = new TxId(TestUtils.GetRandomBytes(TxId.Size));
+            var action = new Sleep()
+            {
+                ZoneId = 1,
+            };
+
             var exc = new UnexpectedlyTerminatedActionException(
-                default, default, null, null, "for testing", innerExc
+                blockHash,
+                blockIndex,
+                txId,
+                action,
+                "for testing",
+                innerExc
             );
 
             var formatter = new BinaryFormatter();
@@ -26,6 +44,13 @@ namespace Libplanet.Tests.Action
                 Assert.Equal("for testing", deserialized.Message);
                 Assert.IsType<Exception>(deserialized.InnerException);
                 Assert.Equal(innerExc.Message, deserialized.InnerException.Message);
+
+                Assert.Equal(blockHash, deserialized.BlockHash);
+                Assert.Equal(blockIndex, deserialized.BlockIndex);
+                Assert.Equal(txId, deserialized.TxId);
+
+                Assert.IsType<Sleep>(deserialized.Action);
+                Assert.Equal(action.PlainValue, deserialized.Action.PlainValue);
             }
         }
     }

--- a/Libplanet.Tests/CurrencyTest.cs
+++ b/Libplanet.Tests/CurrencyTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Immutable;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using Libplanet.Crypto;
 using Xunit;
@@ -106,6 +108,22 @@ namespace Libplanet.Tests
         {
             Currency currency = new Currency(ticker: "GOLD", minter: AddressA);
             Assert.Equal("GOLD (2ce0b92ff1c5e5631d73370ad2c45920c1ba9755)", currency.ToString());
+        }
+
+        [Fact]
+        public void Serializable()
+        {
+            var currency = new Currency(ticker: "GOLD", minter: AddressA);
+
+            var formatter = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                formatter.Serialize(ms, currency);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                var deserialized = (Currency)formatter.Deserialize(ms);
+                Assert.Equal(currency.Hash, deserialized.Hash);
+            }
         }
     }
 }

--- a/Libplanet/Action/InsufficientBalanceException.cs
+++ b/Libplanet/Action/InsufficientBalanceException.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
 using System.Numerics;
+using System.Runtime.Serialization;
+using Libplanet.Serialization;
 
 namespace Libplanet.Action
 {
@@ -36,6 +38,14 @@ namespace Libplanet.Action
             Balance = balance;
         }
 
+        private InsufficientBalanceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            Address = info.GetValue<Address>(nameof(Address));
+            Balance = info.GetValue<BigInteger>(nameof(Balance));
+            Currency = info.GetValue<Currency>(nameof(Currency));
+        }
+
         /// <summary>
         /// The owner of the insufficient <see cref="Balance"/>.
         /// </summary>
@@ -50,5 +60,14 @@ namespace Libplanet.Action
         /// The account's current balance of the <see cref="Currency"/>.
         /// </summary>
         public BigInteger Balance { get; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue(nameof(Address), Address);
+            info.AddValue(nameof(Balance), Balance);
+            info.AddValue(nameof(Currency), Currency);
+        }
     }
 }

--- a/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
+++ b/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Action
                 );
 
                 Action = (IAction)Activator.CreateInstance(Type.GetType(actionType, true, true));
-                Action.LoadPlainValue(values);
+                Action?.LoadPlainValue(values);
             }
         }
 

--- a/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
+++ b/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
+using Bencodex;
+using Bencodex.Types;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Serialization;
 using Libplanet.Tx;
 
 namespace Libplanet.Action
@@ -55,6 +58,30 @@ namespace Libplanet.Action
         )
             : base(info, context)
         {
+            if (info.TryGetValue(nameof(BlockHash), out byte[] blockHash))
+            {
+                BlockHash = new HashDigest<SHA256>(blockHash);
+            }
+
+            if (info.TryGetValue(nameof(BlockIndex), out long blockIndex))
+            {
+                BlockIndex = blockIndex;
+            }
+
+            if (info.TryGetValue(nameof(TxId), out byte[] txId))
+            {
+                TxId = new TxId(txId);
+            }
+
+            if (info.TryGetValue($"{nameof(Action)}_type", out string actionType))
+            {
+                var values = (Dictionary)new Codec().Decode(
+                    info.GetValue<byte[]>($"{nameof(Action)}_values")
+                );
+
+                Action = (IAction)Activator.CreateInstance(Type.GetType(actionType, true, true));
+                Action.LoadPlainValue(values);
+            }
         }
 
         /// <summary>
@@ -80,5 +107,31 @@ namespace Libplanet.Action
         /// The <see cref="IAction"/> object which threw an exception.
         /// </summary>
         public IAction Action { get; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            if (BlockHash is HashDigest<SHA256> blockHash)
+            {
+                info.AddValue(nameof(BlockHash), blockHash.ToByteArray());
+            }
+
+            if (BlockIndex is long blockIndex)
+            {
+                info.AddValue(nameof(BlockIndex), blockIndex);
+            }
+
+            if (TxId is TxId txId)
+            {
+                info.AddValue(nameof(TxId), txId.ToByteArray());
+            }
+
+            if (!(Action is null))
+            {
+                info.AddValue($"{nameof(Action)}_type", Action.GetType().AssemblyQualifiedName);
+                info.AddValue($"{nameof(Action)}_values", new Codec().Encode(Action.PlainValue));
+            }
+        }
     }
 }

--- a/Libplanet/Serialization/SerializationInfoExtensions.cs
+++ b/Libplanet/Serialization/SerializationInfoExtensions.cs
@@ -9,18 +9,20 @@ namespace Libplanet.Serialization
             return (T)info.GetValue(name, typeof(T));
         }
 
-        public static T GetValueOrDefault<T>(
+        public static bool TryGetValue<T>(
             this SerializationInfo serializationInfo,
             string name,
-            T defaultValue)
+            out T value)
         {
             try
             {
-                return serializationInfo.GetValue<T>(name);
+                value = serializationInfo.GetValue<T>(name);
+                return true;
             }
             catch (SerializationException)
             {
-                return defaultValue;
+                value = default;
+                return false;
             }
         }
     }


### PR DESCRIPTION
This PR fixes `InsufficientBalanceException` to be serialized properly by .NET serialization mechanism.

And more, it also fixes a bug that `UnexpectedlyTerminatedActionExceptions` doesn't contain its properties after de-serialization.