### PR TITLE
Fix NullReferenceException in TransferRecentStates

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -83,7 +83,8 @@ namespace Libplanet.Tests.Net
             DateTimeOffset? createdAt = null,
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
-            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null
+            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
+            SwarmOptions options = null
         )
             where T : IAction, new()
         {
@@ -104,7 +105,8 @@ namespace Libplanet.Tests.Net
                 createdAt,
                 iceServers,
                 differentAppProtocolVersionEncountered,
-                trustedAppProtocolVersionSigners);
+                trustedAppProtocolVersionSigners,
+                options);
         }
     }
 }

--- a/Libplanet/Net/InvalidStateTargetException.cs
+++ b/Libplanet/Net/InvalidStateTargetException.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Net
+{
+    [Serializable]
+    public class InvalidStateTargetException : SwarmException
+    {
+        public InvalidStateTargetException()
+        {
+        }
+
+        public InvalidStateTargetException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidStateTargetException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected InvalidStateTargetException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Net
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
-            SwarmOptions swarmOptions = null)
+            SwarmOptions options = null)
         {
             BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
             _store = BlockChain.Store;
@@ -161,7 +161,7 @@ namespace Libplanet.Net
                 ProcessMessageHandler,
                 _logger);
 
-            _options = swarmOptions ?? new SwarmOptions();
+            _options = options ?? new SwarmOptions();
         }
 
         ~Swarm()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2139,7 +2139,7 @@ namespace Libplanet.Net
 
             if (_logger.IsEnabled(LogEventLevel.Verbose))
             {
-                if (_store.ContainsBlock(target))
+                if (BlockChain.ContainsBlock(target))
                 {
                     var baseString = @base is HashDigest<SHA256> h
                         ? $"{BlockChain[h].Index}:{h}"
@@ -2174,7 +2174,7 @@ namespace Libplanet.Net
                 nextOffset,
                 iteration,
                 blockStates,
-                stateRefs.ToImmutableDictionary())
+                stateRefs?.ToImmutableDictionary())
             {
                 Identity = getRecentStates.Identity,
             };

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -14,16 +14,16 @@ namespace Libplanet.Net
         /// <summary>
         /// The base timeout used to receive <see cref="Block{T}"/> from other peers.
         /// </summary>
-        public TimeSpan BlockRecvTimeout { get; } = TimeSpan.FromSeconds(15);
+        public TimeSpan BlockRecvTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// The base timeout used to receive <see cref="Transaction{T}"/> from other peers.
         /// </summary>
-        public TimeSpan TxRecvTimeout { get; } = TimeSpan.FromSeconds(3);
+        public TimeSpan TxRecvTimeout { get; set; } = TimeSpan.FromSeconds(3);
 
         /// <summary>
         /// The timeout used to receive recent states from other peers.
         /// </summary>
-        public TimeSpan RecentStateRecvTimeout { get; } = TimeSpan.FromSeconds(90);
+        public TimeSpan RecentStateRecvTimeout { get; set; } = TimeSpan.FromSeconds(90);
     }
 }


### PR DESCRIPTION
This fixes `NullReferenceException` in `TransferRecentStates` when `GetRecentStates.TargetBlockHash` doesn't exist in the chain. Currently, the purpose of `ReorgWhilePreloadAsync` test case is to check if a timeout occurs and should be fixed in the following PR.