### PR TITLE
Introduce Version property to messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,12 @@ To be released.
     backward compatibility (i.e., you need to rebuild your assemblies), still is
     backward-compatible at API-level as the option is turned on by default.
     [[#946]]
+ -  Removed `Peer.AppProtocolVersion` property.  [[#949]]
+ -  Removed `Peer.IsCompatibleWith()` method.  [[#949]]
+ -  Replaced `Peer(PublicKey, AppProtocolVersion)` constructor with
+    `Peer(PublicKey)` constructor.  [[#949]]
+ -  Replaced `BoundPeer(PublicKey, DnsEndPoint, AppProtocolVersion)` constructor
+    with `Peer(PublicKey, DnsEndPoint)` constructor.  [[#949]]
 
 ### Backward-incompatible network protocol changes
 
@@ -83,11 +89,13 @@ To be released.
     (with the type number `0x14`).  [[#459], [#919], [#920], [#930]]
  -  The `TimestampThreshold` between `Block<T>`s was changed from 15 minutes to
     15 seconds.  [[#922], [#925]]
- -  `Swarm<T>` became to have 4 more message types:
+ -  `Swarm<T>` became to have 5 more message types:
      -  `GetChainStatus` (`0x20`)  [[#920], [#930]]
      -  `ChainStatus` (`0x21`)  [[#920], [#930]]
      -  `GetBlockStates` (`0x22`)  [[#946]]
      -  `BlockStates` (`0x23`)  [[#946]]
+     -  `DifferentVersion` (`0x30`)  [[#949]]
+ -  Every message now contains app protocol version in its header.  [[#949]]
 
 ### Backward-incompatible storage format changes
 
@@ -129,6 +137,7 @@ To be released.
  -  Added `BlockChain<T>.Render` property.  [[#946]]
  -  Added `Reorged` event on `BlockChain<T>`.  [[#945]]
  -  Added `ReorgedEventArgs` class.  [[#945]]
+ -  Added `Swarm<T>.AppProtocolVersion` property.  [[#949]]
 
 ### Behavioral changes
 
@@ -155,6 +164,8 @@ To be released.
     instead of the longest chain.  [[#459], [#919]]
  -  `Swarm<T>.BootstrapAsync()` method became not to throw `TimeoutException` when
     it fails to connect to all neighbors.  [[#933]]
+ -  `Swarm<T>` became to respond to the messages with different app protocol version.
+    [[#949]]
 
 ### Bug fixes
 
@@ -220,6 +231,7 @@ To be released.
 [#941]: https://github.com/planetarium/libplanet/pull/941
 [#945]: https://github.com/planetarium/libplanet/pull/945
 [#946]: https://github.com/planetarium/libplanet/pull/946
+[#949]: https://github.com/planetarium/libplanet/pull/949
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -33,8 +33,8 @@ namespace Libplanet.Tests.Net.Messages
             Assert.Equal(blockHashes, msg.Hashes);
             var privKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
-            Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234), ver);
             NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
+            Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
             var restored = new BlockHashes(frames);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -33,8 +33,8 @@ namespace Libplanet.Tests.Net.Messages
             Assert.Equal(blockHashes, msg.Hashes);
             var privKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
-            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer).Skip(3).ToArray();
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
+            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer, ver).Skip(4).ToArray();
             var restored = new BlockHashes(frames);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -34,7 +34,8 @@ namespace Libplanet.Tests.Net.Messages
             var privKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
-            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer, ver).Skip(4).ToArray();
+            NetMQFrame[] frames =
+                msg.ToNetMQMessage(privKey, peer, ver).Skip(Message.CommonFrames).ToArray();
             var restored = new BlockHashes(frames);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Tests/Net/Messages/BlockStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockStatesTest.cs
@@ -19,13 +19,21 @@ namespace Libplanet.Tests.Net.Messages
             HashDigest<SHA256> blockHash = new Random().NextHashDigest<SHA256>();
             var blockStates = new BlockStates(blockHash, null);
             var signer = new PrivateKey();
-            NetMQMessage msg =
-                blockStates.ToNetMQMessage(signer, new Peer(signer.PublicKey, default));
-            Assert.Equal(5, msg.FrameCount);
-            TestUtils.AssertBytesEqual(blockHash, new HashDigest<SHA256>(msg[3].Buffer));
-            Assert.Equal(-1, msg[4].ConvertToInt32());
+            NetMQMessage msg = blockStates.ToNetMQMessage(
+                    signer,
+                    new Peer(signer.PublicKey, default),
+                    new AppProtocolVersion(
+                        1,
+                        new Bencodex.Types.Integer(0),
+                        ImmutableArray<byte>.Empty,
+                        default(Address)));
+            Assert.Equal(Message.CommonFrames + 2, msg.FrameCount);
+            TestUtils.AssertBytesEqual(
+                blockHash,
+                new HashDigest<SHA256>(msg[Message.CommonFrames].Buffer));
+            Assert.Equal(-1, msg[Message.CommonFrames + 1].ConvertToInt32());
 
-            var parsed = new BlockStates(msg.Skip(3).ToArray());
+            var parsed = new BlockStates(msg.Skip(Message.CommonFrames).ToArray());
             TestUtils.AssertBytesEqual(blockHash, parsed.BlockHash);
             Assert.Null(parsed.States);
         }
@@ -41,13 +49,23 @@ namespace Libplanet.Tests.Net.Messages
                 .Add("baz丙", new Text("a value 값"));
             var blockStates = new BlockStates(blockHash, states);
             var signer = new PrivateKey();
-            NetMQMessage msg =
-                blockStates.ToNetMQMessage(signer, new Peer(signer.PublicKey, default));
-            Assert.Equal(5 + 3 * 3, msg.FrameCount);
-            TestUtils.AssertBytesEqual(blockHash, new HashDigest<SHA256>(msg[3].Buffer));
-            Assert.Equal(states.Count, msg[4].ConvertToInt32());
+            NetMQMessage msg = blockStates.ToNetMQMessage(
+                signer,
+                new Peer(signer.PublicKey, default),
+                new AppProtocolVersion(
+                    1,
+                    new Bencodex.Types.Integer(0),
+                    ImmutableArray<byte>.Empty,
+                    default(Address)));
+            Assert.Equal(Message.CommonFrames + 2 + 3 * 3, msg.FrameCount);
+            TestUtils.AssertBytesEqual(
+                blockHash,
+                new HashDigest<SHA256>(msg[Message.CommonFrames].Buffer));
+            Assert.Equal(
+                states.Count,
+                msg[Message.CommonFrames + 1].ConvertToInt32());
 
-            var parsed = new BlockStates(msg.Skip(3).ToArray());
+            var parsed = new BlockStates(msg.Skip(Message.CommonFrames).ToArray());
             TestUtils.AssertBytesEqual(blockHash, parsed.BlockHash);
             Assert.Equal(states, parsed.States);
         }

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using NetMQ;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Messages
+{
+    public class MessageTest
+    {
+        [Fact]
+        public void DifferentAppProtocolVersionWithSameStructure()
+        {
+            var privateKey = new PrivateKey();
+            var peer = new Peer(privateKey.PublicKey);
+            var validAppProtocolVersion = new AppProtocolVersion(
+                1,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var invalidAppProtocolVersion = new AppProtocolVersion(
+                2,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var message = new Ping();
+            var netMQMessage = message.ToNetMQMessage(privateKey, peer, validAppProtocolVersion);
+
+            Assert.Throws<DifferentAppProtocolVersionException>(() =>
+                Message.Parse(
+                    netMQMessage,
+                    true,
+                    invalidAppProtocolVersion,
+                    ImmutableHashSet<PublicKey>.Empty,
+                    null));
+        }
+
+        [Fact]
+        public void DifferentAppProtocolVersionWithDifferentStructure()
+        {
+            var validAppProtocolVersion = new AppProtocolVersion(
+                1,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var invalidAppProtocolVersion = new AppProtocolVersion(
+                2,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var netMQMessage = new NetMQMessage();
+            netMQMessage.Push(validAppProtocolVersion.Token);
+
+            Assert.Throws<DifferentAppProtocolVersionException>(() =>
+                Message.Parse(
+                    netMQMessage,
+                    true,
+                    invalidAppProtocolVersion,
+                    ImmutableHashSet<PublicKey>.Empty,
+                    null));
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
+++ b/Libplanet.Tests/Net/Messages/RecentStatesTest.cs
@@ -108,7 +108,7 @@ namespace Libplanet.Tests.Net.Messages
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
 
             NetMQMessage msg = reply.ToNetMQMessage(privKey, peer, version);
-            const int headerSize = 4;  // version, type, peer, sig
+            const int headerSize = Message.CommonFrames;  // version, type, peer, sig
             int stateRefsOffset = headerSize + 3;  // blockHash, offsetHash, iteration
             int blockStatesOffset = stateRefsOffset + 1 + (accountsCount * 4);
             Assert.Equal(

--- a/Libplanet.Tests/Net/PeerTest.cs
+++ b/Libplanet.Tests/Net/PeerTest.cs
@@ -33,7 +33,6 @@ namespace Libplanet.Tests.Net
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
                     }),
                     new DnsEndPoint("0.0.0.0", 1234),
-                    default(AppProtocolVersion),
                     IPAddress.IPv6Loopback),
             };
             yield return new object[]
@@ -49,8 +48,7 @@ namespace Libplanet.Tests.Net
                         0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
                     }),
-                    new DnsEndPoint("0.0.0.0", 1234),
-                    ver),
+                    new DnsEndPoint("0.0.0.0", 1234)),
             };
             yield return new object[]
             {
@@ -65,8 +63,7 @@ namespace Libplanet.Tests.Net
                         0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
                     }),
-                    new DnsEndPoint("0.0.0.0", 1234),
-                    ver),
+                    new DnsEndPoint("0.0.0.0", 1234)),
             };
             yield return new object[]
             {
@@ -80,8 +77,7 @@ namespace Libplanet.Tests.Net
                         0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45,
                         0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
                         0x1a, 0x3d, 0x3c, 0x76, 0xdb,
-                    }),
-                    ver2),
+                    })),
             };
         }
 

--- a/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
@@ -26,24 +26,19 @@ namespace Libplanet.Tests.Net.Protocols
             var bucket = new KBucket(4, new System.Random(), Logger.None);
             var peer1 = new BoundPeer(
                 new PrivateKey().PublicKey,
-                new DnsEndPoint("0.0.0.0", 1234),
-                AppProtocolVer);
+                new DnsEndPoint("0.0.0.0", 1234));
             var peer2 = new BoundPeer(
                 new PrivateKey().PublicKey,
-                new DnsEndPoint("0.0.0.0", 1234),
-                AppProtocolVer);
+                new DnsEndPoint("0.0.0.0", 1234));
             var peer3 = new BoundPeer(
                 new PrivateKey().PublicKey,
-                new DnsEndPoint("0.0.0.0", 1234),
-                AppProtocolVer);
+                new DnsEndPoint("0.0.0.0", 1234));
             var peer4 = new BoundPeer(
                 new PrivateKey().PublicKey,
-                new DnsEndPoint("0.0.0.0", 1234),
-                AppProtocolVer);
+                new DnsEndPoint("0.0.0.0", 1234));
             var peer5 = new BoundPeer(
                 new PrivateKey().PublicKey,
-                new DnsEndPoint("0.0.0.0", 1234),
-                AppProtocolVer);
+                new DnsEndPoint("0.0.0.0", 1234));
 
             Assert.Empty(bucket.Peers);
             Assert.True(bucket.IsEmpty());
@@ -104,7 +99,7 @@ namespace Libplanet.Tests.Net.Protocols
         {
             var pubKey = new PrivateKey().PublicKey;
             RoutingTable table = CreateTable(pubKey.ToAddress());
-            var peer = new BoundPeer(pubKey, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
+            var peer = new BoundPeer(pubKey, new DnsEndPoint("0.0.0.0", 1234));
             Assert.Throws<ArgumentException>(() => table.AddPeer(peer));
         }
 
@@ -129,9 +124,9 @@ namespace Libplanet.Tests.Net.Protocols
                 2,
                 new System.Random(),
                 Logger.None);
-            var peer1 = new BoundPeer(pubKey1, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
-            var peer2 = new BoundPeer(pubKey2, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
-            var peer3 = new BoundPeer(pubKey3, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
+            var peer1 = new BoundPeer(pubKey1, new DnsEndPoint("0.0.0.0", 1234));
+            var peer2 = new BoundPeer(pubKey2, new DnsEndPoint("0.0.0.0", 1234));
+            var peer3 = new BoundPeer(pubKey3, new DnsEndPoint("0.0.0.0", 1234));
             table.AddPeer(peer1);
             table.AddPeer(peer2);
             table.AddPeer(peer3);
@@ -154,8 +149,8 @@ namespace Libplanet.Tests.Net.Protocols
                 2,
                 new System.Random(),
                 Logger.None);
-            var peer1 = new BoundPeer(pubKey1, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
-            var peer2 = new BoundPeer(pubKey2, new DnsEndPoint("0.0.0.0", 1234), AppProtocolVer);
+            var peer1 = new BoundPeer(pubKey1, new DnsEndPoint("0.0.0.0", 1234));
+            var peer2 = new BoundPeer(pubKey2, new DnsEndPoint("0.0.0.0", 1234));
 
             Assert.Throws<ArgumentException>(() => table.RemovePeer(peer1));
             Assert.Throws<ArgumentNullException>(() => table.RemovePeer(null));

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -76,8 +76,7 @@ namespace Libplanet.Tests.Net.Protocols
 
         public Peer AsPeer => new BoundPeer(
             _privateKey.PublicKey,
-            new DnsEndPoint("localhost", 1234),
-            AppProtocolVersion);
+            new DnsEndPoint("localhost", 1234));
 
         public IEnumerable<BoundPeer> Peers => Protocol.Peers;
 

--- a/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
@@ -181,14 +181,6 @@ namespace Libplanet.Tests.Net
                         kv.Value.Verify(signer.PublicKey) ? "verified" : "not verified"
                     );
                 }
-
-                Assert.Equal(
-                    new Dictionary<Peer, AppProtocolVersion>
-                    {
-                        [d.AsPeer] = d.AsPeer.AppProtocolVersion,
-                    },
-                    logs
-                );
             }
             finally
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -591,14 +591,24 @@ namespace Libplanet.Tests.Net
                     );
 
                     NetMQMessage response = socket.ReceiveMultipartMessage();
-                    Message parsedMessage = Message.Parse(response, true);
+                    Message parsedMessage = Message.Parse(
+                        response,
+                        true,
+                        swarmA.AppProtocolVersion,
+                        swarmA.TrustedAppProtocolVersionSigners,
+                        null);
                     Libplanet.Net.Messages.Blocks blockMessage =
                         (Libplanet.Net.Messages.Blocks)parsedMessage;
 
                     Assert.Equal(2, blockMessage.Payloads.Count);
 
                     response = socket.ReceiveMultipartMessage();
-                    parsedMessage = Message.Parse(response, true);
+                    parsedMessage = Message.Parse(
+                        response,
+                        true,
+                        swarmA.AppProtocolVersion,
+                        swarmA.TrustedAppProtocolVersionSigners,
+                        null);
                     blockMessage = (Libplanet.Net.Messages.Blocks)parsedMessage;
 
                     Assert.Single(blockMessage.Payloads);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -587,7 +587,7 @@ namespace Libplanet.Tests.Net
                 {
                     var request = new GetBlocks(hashes.Select(pair => pair.Item2), 2);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey, swarmB.AsPeer)
+                        request.ToNetMQMessage(privateKey, swarmB.AsPeer, swarmB.AppProtocolVersion)
                     );
 
                     NetMQMessage response = socket.ReceiveMultipartMessage();

--- a/Libplanet/Net/BoundPeer.cs
+++ b/Libplanet/Net/BoundPeer.cs
@@ -17,22 +17,18 @@ namespace Libplanet.Net
         /// <see cref="Peer"/>.</param>
         /// <param name="endPoint">A <see cref="DnsEndPoint"/> consisting of the
         /// host and port of the <see cref="Peer"/>.</param>
-        /// <param name="appProtocolVersion">An application protocol version
-        /// that the <see cref="Peer"/> is using.</param>
         public BoundPeer(
             PublicKey publicKey,
-            DnsEndPoint endPoint,
-            AppProtocolVersion appProtocolVersion)
-        : this(publicKey, endPoint, appProtocolVersion, null)
+            DnsEndPoint endPoint)
+        : this(publicKey, endPoint, null)
         {
         }
 
         internal BoundPeer(
             PublicKey publicKey,
             DnsEndPoint endPoint,
-            AppProtocolVersion appProtocolVersion,
             IPAddress publicIPAddress)
-        : base(publicKey, appProtocolVersion, publicIPAddress)
+        : base(publicKey, publicIPAddress)
         {
             EndPoint = endPoint ?? throw new ArgumentNullException(nameof(endPoint));
         }
@@ -71,7 +67,7 @@ namespace Libplanet.Net
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Address}.{EndPoint}.{AppProtocolVersion}";
+            return $"{Address}.{EndPoint}.{PublicIPAddress}";
         }
     }
 }

--- a/Libplanet/Net/DifferentAppProtocolVersionException.cs
+++ b/Libplanet/Net/DifferentAppProtocolVersionException.cs
@@ -1,12 +1,13 @@
 #pragma warning disable S3871
 using System;
+using Libplanet.Net.Messages;
 
 namespace Libplanet.Net
 {
     /// <summary>
     /// The exception that is thrown when the version of the
-    /// <see cref="Peer" /> that <see cref="Swarm{T}" /> is trying to connect
-    /// to is different.
+    /// <see cref="Message" /> that <see cref="Swarm{T}" /> received
+    /// is different.
     /// </summary>
     [Serializable]
     internal sealed class DifferentAppProtocolVersionException : Exception
@@ -15,6 +16,8 @@ namespace Libplanet.Net
         /// Initializes a new instance of the
         /// <see cref="DifferentAppProtocolVersionException"/> class.
         /// </summary>
+        /// <param name="identity">The identity of the message received. Will have empty
+        /// string if the message is a reply.</param>
         /// <param name="expectedVersion">The protocol version of the current
         /// <see cref="Swarm{T}"/>.</param>
         /// <param name="actualVersion">The protocol version of the
@@ -24,6 +27,7 @@ namespace Libplanet.Net
         /// </param>
         public DifferentAppProtocolVersionException(
             string message,
+            byte[] identity,
             AppProtocolVersion expectedVersion,
             AppProtocolVersion actualVersion)
             : base($"{message}\n" +
@@ -32,9 +36,16 @@ namespace Libplanet.Net
                    $"Actual Version: {actualVersion} " +
                    $"[{ByteUtil.Hex(actualVersion.Signature)} by {actualVersion.Signer}]")
         {
+            Identity = identity;
             ExpectedVersion = expectedVersion;
             ActualVersion = actualVersion;
         }
+
+        /// <summary>
+        /// The identity of the message received.
+        /// Will have <c>null</c> if the message is a reply.
+        /// </summary>
+        public byte[] Identity { get; }
 
         /// <summary>
         /// The protocol version of the current <see cref="Swarm{T}"/>.

--- a/Libplanet/Net/Messages/DifferentVersion.cs
+++ b/Libplanet/Net/Messages/DifferentVersion.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class DifferentVersion : Message
+    {
+        public DifferentVersion()
+        {
+        }
+
+        public DifferentVersion(NetMQFrame[] body)
+        {
+        }
+
+        protected override MessageType Type => MessageType.DifferentVersion;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -105,6 +105,13 @@ namespace Libplanet.Net.Messages
             /// Contains the delta states of the requested block.
             /// </summary>
             BlockStates = 0x23,
+
+            /// <summary>
+            /// A reply to any messages with different <see cref="AppProtocolVersion"/>.
+            /// Contains the expected and actual <see cref="AppProtocolVersion"/>
+            /// value of the message.
+            /// </summary>
+            DifferentVersion = 0x30,
         }
 
         public byte[] Identity { get; set; }
@@ -157,6 +164,7 @@ namespace Libplanet.Net.Messages
                 { MessageType.ChainStatus, typeof(ChainStatus) },
                 { MessageType.GetBlockStates, typeof(GetBlockStates) },
                 { MessageType.BlockStates, typeof(BlockStates) },
+                { MessageType.DifferentVersion, typeof(DifferentVersion) },
             };
 
             if (!types.TryGetValue(rawType, out Type type))

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -11,6 +11,8 @@ namespace Libplanet.Net.Messages
 {
     internal abstract class Message
     {
+        public const int CommonFrames = 4;
+
         internal enum MessageType : byte
         {
             /// <summary>
@@ -133,7 +135,7 @@ namespace Libplanet.Net.Messages
 
             // (reply == true)  [version, type, sign, peer, frames...]
             // (reply == false) [identity, version, type, sign, peer, frames...]
-            int headerCount = reply ? 4 : 5;
+            int headerCount = reply ? CommonFrames : CommonFrames + 1;
             var versionToken = raw[headerCount - 4].ConvertToString();
             var rawType = (MessageType)raw[headerCount - 3].ConvertToInt32();
             var peer = raw[headerCount - 2].ToByteArray();

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -172,12 +172,10 @@ namespace Libplanet.Net
         public Peer AsPeer => _endPoint is null
             ? new Peer(
                 _privateKey.PublicKey,
-                _appProtocolVersion,
                 _publicIPAddress)
             : new BoundPeer(
                 _privateKey.PublicKey,
                 _endPoint,
-                _appProtocolVersion,
                 _publicIPAddress);
 
         public IEnumerable<BoundPeer> Peers => Protocol.Peers;

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -964,21 +964,19 @@ namespace Libplanet.Net
                 return true;
             }
 
-            if (_trustedAppProtocolVersionSigners is null ||
-                _trustedAppProtocolVersionSigners.Any(s => remoteVersion.Verify(s)))
+            if (!(_trustedAppProtocolVersionSigners is null) &&
+                !_trustedAppProtocolVersionSigners.Any(s => remoteVersion.Verify(s)))
             {
-                if (_differentAppProtocolVersionEncountered is null)
-                {
-                    return false;
-                }
-                else
-                {
-                    return _differentAppProtocolVersionEncountered(
-                        message.Remote, remoteVersion, _appProtocolVersion);
-                }
+                return false;
             }
 
-            return false;
+            if (_differentAppProtocolVersionEncountered is null)
+            {
+                return false;
+            }
+
+            return _differentAppProtocolVersionEncountered(
+                message.Remote, remoteVersion, _appProtocolVersion);
         }
 
         private async Task RefreshTableAsync(

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -578,7 +578,7 @@ namespace Libplanet.Net
                     _logger.Debug("A message has parsed: {0}, from {1}", message, message.Remote);
                     MessageHistory.Enqueue(message);
 
-                    if (!IsMessageValid(message))
+                    if (!IsAppProtocolVersionValid(message))
                     {
                         var differentVersion = new DifferentVersion()
                         {
@@ -814,7 +814,7 @@ namespace Libplanet.Net
                         reply.Remote
                     );
 
-                    if (!IsMessageValid(reply))
+                    if (!IsAppProtocolVersionValid(reply))
                     {
                         throw new DifferentAppProtocolVersionException(
                             "Message protocol version is different.",
@@ -956,7 +956,7 @@ namespace Libplanet.Net
             }
         }
 
-        private bool IsMessageValid(Message message)
+        private bool IsAppProtocolVersionValid(Message message)
         {
             AppProtocolVersion remoteVersion = message.Version;
             if (remoteVersion.Equals(_appProtocolVersion))

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Net;
 using System.Runtime.Serialization;
-using Bencodex;
-using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
 
@@ -20,39 +15,23 @@ namespace Libplanet.Net
     [Equals]
     public class Peer : ISerializable
     {
-        private static readonly Codec _codec = new Codec();
-
-        public Peer(
-            PublicKey publicKey,
-            AppProtocolVersion appProtocolVersion)
-        : this(publicKey, appProtocolVersion, null)
+        public Peer(PublicKey publicKey)
+        : this(publicKey, null)
         {
         }
 
         internal Peer(
             PublicKey publicKey,
-            AppProtocolVersion appProtocolVersion,
             IPAddress publicIPAddress)
         {
             PublicKey = publicKey ??
                         throw new ArgumentNullException(nameof(publicKey));
-            AppProtocolVersion = appProtocolVersion;
             PublicIPAddress = publicIPAddress;
         }
 
         protected Peer(SerializationInfo info, StreamingContext context)
         {
             PublicKey = new PublicKey(info.GetValue<byte[]>("public_key"));
-            var appProtocolVersionExtraBytes =
-                (byte[])info.GetValue("app_protocol_version_extra", typeof(byte[]));
-            AppProtocolVersion = new AppProtocolVersion(
-                version: info.GetInt32("app_protocol_version"),
-                extra: appProtocolVersionExtraBytes is byte[] e ? _codec.Decode(e) : null,
-                signature: ImmutableArray.Create(
-                    (byte[])info.GetValue("app_protocol_version_sig", typeof(byte[]))),
-                signer: new Address(
-                    (byte[])info.GetValue("app_protocol_version_signer", typeof(byte[])))
-            );
             string addressStr = info.GetString("public_ip_address");
             if (addressStr != null)
             {
@@ -66,14 +45,6 @@ namespace Libplanet.Net
         /// </summary>
         [Pure]
         public PublicKey PublicKey { get; }
-
-        /// <summary>
-        /// The corresponding application protocol version of this peer.
-        /// </summary>
-        // FIXME: This would be better to be nullable...
-        [IgnoreDuringEquals]
-        [Pure]
-        public AppProtocolVersion AppProtocolVersion { get; }
 
         /// <summary>The peer's address which is derived from
         /// its <see cref="PublicKey"/>.
@@ -90,53 +61,10 @@ namespace Libplanet.Net
 
         public static bool operator !=(Peer left, Peer right) => Operator.Weave(left, right);
 
-        /// <summary>
-        /// Determines if the peer is compatible with the given criteria.
-        /// </summary>
-        /// <param name="localVersion">The version of the currently running application.</param>
-        /// <param name="trustedSigners">A list of signers to trust.  <em>An empty list means
-        /// to trust no one, so that this method always returns <c>false</c>.</em>  Conversely,
-        /// <c>null</c> means to <em>trust anyone</em>.  Be aware of the difference of those two.
-        /// </param>
-        /// <param name="recognizer">A callback to determine an encountered peer's
-        /// <see cref="AppProtocolVersion"/> is compatible with the currently running
-        /// application, in the case of the peer's version signature is trustworthy but its
-        /// version number is not the same.</param>
-        /// <returns><c>true</c> if the peer is compatible with the given criteria.
-        /// Otherwise <c>false</c>.</returns>
-        public bool IsCompatibleWith(
-            AppProtocolVersion localVersion,
-            IEnumerable<PublicKey> trustedSigners = null,
-            DifferentAppProtocolVersionEncountered recognizer = null
-        )
-        {
-            if (AppProtocolVersion.Equals(localVersion))
-            {
-                return true;
-            }
-
-            if (trustedSigners is null || trustedSigners.Any(s => AppProtocolVersion.Verify(s)))
-            {
-                return recognizer is null
-                    ? false
-                    : recognizer(this, AppProtocolVersion, localVersion);
-            }
-
-            return false;
-        }
-
         /// <inheritdoc/>
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("public_key", PublicKey.Format(true));
-            info.AddValue("app_protocol_version", AppProtocolVersion.Version);
-            info.AddValue(
-                "app_protocol_version_extra",
-                AppProtocolVersion.Extra is IValue e ? _codec.Encode(e) : null);
-            info.AddValue(
-                "app_protocol_version_sig",
-                AppProtocolVersion.Signature.ToBuilder().ToArray());
-            info.AddValue("app_protocol_version_signer", AppProtocolVersion.Signer.ToByteArray());
             info.AddValue("public_ip_address", PublicIPAddress?.ToString());
         }
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -441,17 +441,11 @@ namespace Libplanet.Net.Protocols
                 throw new ArgumentNullException(nameof(rawPeer));
             }
 
-            if (!(rawPeer is BoundPeer peer &&
-                  peer.IsCompatibleWith(
-                      _appProtocolVersion,
-                      _trustedAppProtocolVersionSigners,
-                      _differentAppProtocolVersionEncountered)))
+            if (rawPeer is BoundPeer peer)
             {
                 // Don't update peer without endpoint or with different appProtocolVersion.
-                return;
+                _routing.AddPeer(peer);
             }
-
-            _routing.AddPeer(peer);
         }
 
         private void RemovePeer(BoundPeer peer)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -199,6 +199,8 @@ namespace Libplanet.Net
 
         public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners { get; }
 
+        public AppProtocolVersion AppProtocolVersion => _appProtocolVersion;
+
         internal ITransport Transport { get; private set; }
 
         internal IProtocol Protocol => (Transport as NetMQTransport)?.Protocol;


### PR DESCRIPTION
Removed `Peer.AppProtocolVersion` which were used to check version between swarms. Instead, added `AppProtocolVersion`-typed `Version` property to `Message` and use it to check validity of messages.

If received message has different app protocol version, `NetMQTransport` will reply a `DifferentVersion` message regardless of received message's type and does not process anything.