### PR TITLE
More log for the reorg

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1252,7 +1252,15 @@ namespace Libplanet.Blockchain
             }
 
             _logger.Debug(
-                "Swapping block chain. (from: {fromChainId}) (to: {toChainId})", Id, other.Id);
+                "Swapping block chain." +
+                " (from: {fromChainId}, TipIndex - {fromTipIndex}, TipHash - {fromTipHash})" +
+                " (to: {toChainId}, TipIndex - {toTipIndex}, TipHash - {toTipHash})",
+                Id,
+                Tip.Index,
+                Tip.Hash,
+                other.Id,
+                other.Tip.Index,
+                other.Tip.Hash);
 
             // Finds the branch point.
             Block<T> topmostCommon = null;

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1252,9 +1252,9 @@ namespace Libplanet.Blockchain
             }
 
             _logger.Debug(
-                "Swapping block chain." +
-                " (from: {fromChainId}, TipIndex - {fromTipIndex}, TipHash - {fromTipHash})" +
-                " (to: {toChainId}, TipIndex - {toTipIndex}, TipHash - {toTipHash})",
+                "The blockchain was reorged from " +
+                "{OldChainId} (#{OldTipIndex} {OldTipHash}) " +
+                "to {NewChainId} (#{NewTipIndex} {NewTipHash}).",
                 Id,
                 Tip.Index,
                 Tip.Hash,


### PR DESCRIPTION
This adds logs for the reorg.

Before:
```
16:43:50:115234Z[@][15] - Swapping block chain. (from: 31fd07a8-df6d-48c3-bffe-c1f1d148eaca) (to: a91b78aa-83d8-49fd-a6c9-f78db2e7e277)
```

After:
```
16:43:50:115234Z[@][15] - Swapping block chain. (from: 31fd07a8-df6d-48c3-bffe-c1f1d148eaca, TipIndex - 10, TipHash - "2fe9bdf8026ffc4a0da658adeab7689a698c03157c502af63ceff422f7d18152") (to: a91b78aa-83d8-49fd-a6c9-f78db2e7e277, TipIndex - 9, TipHash - "4360218110c4dab3d32b6c7ff83a0c6004c45c7a94f081e116e38ca5f254018e")
```