### PR TITLE
Represent fungible asset values as a distinct type and support minor units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ To be released.
  -  Added `IAction.RenderError()` and `IAction.UnrenderError()` methods.
     [[#860], [#875]]
  -  Added methods related fungible asset states to `IAccountStateDelta`:
-    [[#861], [#900]]
+    [[#861], [#900], [#954]]
      -  `UpdatedFungibleAssetsAccounts` property
      -  `MintAsset(Address, Currency, BigInteger)` method
      -  `TransferAsset(Address, Address, Currency, BigInteger)` method
@@ -118,12 +118,13 @@ To be released.
 ### Added APIs
 
  -  Added `Currency` struct.  [[#861], [#900], [#954]]
- -  Added `AccountBalanceGetter` delegate.  [[#861], [#900]]
+ -  Added `FungibleAssetValue` struct.  [[#861], [#944], [#954]]
+ -  Added `AccountBalanceGetter` delegate.  [[#861], [#900], [#954]]
  -  Added `TurnClient.BindProxies()` method. [[#756], [#868]]
  -  Added `ActionEvaluation.Exception` property.  [[#860], [[#875]]]
  -  Added `InvalidTxGenesisHashException` class.  [[#796], [#878]]
  -  Added `CurrencyPermissionException` class.  [[#861], [#900]]
- -  Added `InsufficientBalanceException` class.  [[#861], [#900]]
+ -  Added `InsufficientBalanceException` class.  [[#861], [#900], [#954]]
  -  Added `BlockChain<T>.GetBalance()` method.  [[#861], [#900]]
  -  Added `Block<T>.TotalDifficulty` property.  [[#666], [#917]]
  -  Added `SwarmOptions` class.  [[#926]]
@@ -135,12 +136,19 @@ To be released.
  -  Added `BlockHeader.PreEvaluationHash` property.  [[#931], [#935]]
  -  Added `HashDigest(ImmutableArray<byte>)` constructor.  [[#931], [#935]]
  -  Incomplete block states became able to be handled in more flexible way.
-    [[#929], [#934], [#946]]
+    [[#929], [#934], [#946], [#954]]
      -  Replaced `BlockChain<T>.GetState(Address, HashDigest<SHA256>?, bool)`
         method with `GetState(Address, HashDigest<SHA256>?, StateCompleter<T>)`
         method.  Specifying `completeStates: true` and `false` can be replaced
         by `stateCompleter: StateCompleters<T>.Recalculate` and
         `StateCompleters<T>.Reject`, respectively.
+     -  Replaced
+        `BlockChain<T>.GetBalance(Address, Currency, HashDigest<SHA256>?, bool)`
+        method with
+        `GetState(Address, Currency, HashDigest<SHA256>?, StateCompleter<T>)`
+        method.  Specifying `completeStates: true` and `false` can be replaced
+        by `stateCompleter: FungibleAssetStateCompleters<T>.Recalculate` and
+        `FungibleAssetStateCompleters<T>.Reject`, respectively.
      -  Added `StateCompleter<T>` delegate.
      -  Added `FungibleAssetStateCompleter<T>` delegate.
      -  Added `StateCompleterSet<T>` struct.
@@ -246,6 +254,7 @@ To be released.
 [#936]: https://github.com/planetarium/libplanet/pull/936
 [#940]: https://github.com/planetarium/libplanet/pull/940
 [#941]: https://github.com/planetarium/libplanet/pull/941
+[#944]: https://github.com/planetarium/libplanet/issues/944
 [#945]: https://github.com/planetarium/libplanet/pull/945
 [#946]: https://github.com/planetarium/libplanet/pull/946
 [#949]: https://github.com/planetarium/libplanet/pull/949

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,7 +117,7 @@ To be released.
 
 ### Added APIs
 
- -  Added `Currency` struct.  [[#861], [#900]]
+ -  Added `Currency` struct.  [[#861], [#900], [#954]]
  -  Added `AccountBalanceGetter` delegate.  [[#861], [#900]]
  -  Added `TurnClient.BindProxies()` method. [[#756], [#868]]
  -  Added `ActionEvaluation.Exception` property.  [[#860], [[#875]]]
@@ -250,6 +250,7 @@ To be released.
 [#946]: https://github.com/planetarium/libplanet/pull/946
 [#949]: https://github.com/planetarium/libplanet/pull/949
 [#950]: https://github.com/planetarium/libplanet/pull/950
+[#954]: https://github.com/planetarium/libplanet/pull/954
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Action/AccountStateDeltaExtensions.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaExtensions.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -22,12 +21,11 @@ namespace Libplanet.Tests.Action
             ).ToImmutableDictionary();
         }
 
-        public static IImmutableDictionary<(Address, Currency), BigInteger> GetUpdatedBalances(
-            this IAccountStateDelta delta
-        ) =>
+        public static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
+        GetUpdatedBalances(this IAccountStateDelta delta) =>
             delta.UpdatedFungibleAssets.SelectMany(kv =>
                 kv.Value.Select(currency =>
-                    new KeyValuePair<(Address, Currency), BigInteger>(
+                    new KeyValuePair<(Address, Currency), FungibleAssetValue>(
                         (kv.Key, currency),
                         delta.GetBalance(kv.Key, currency)
                     )

--- a/Libplanet.Tests/Action/AccountStateDeltaExtensions.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 
 namespace Libplanet.Tests.Action
 {

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -33,9 +33,9 @@ namespace Libplanet.Tests.Action
 
             _currencies = new[]
             {
-                new Currency("FOO", minter: _addr[0]),
-                new Currency("BAR", minters: _addr.Take(2).ToImmutableHashSet()),
-                new Currency("BAZ", minter: null),
+                new Currency("FOO", 0, minter: _addr[0]),
+                new Currency("BAR", 0, minters: _addr.Take(2).ToImmutableHashSet()),
+                new Currency("BAZ", 0, minter: null),
             };
 
             _states = new Dictionary<Address, IValue>

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Crypto;
 using Xunit;
 using Xunit.Abstractions;

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -79,15 +79,15 @@ namespace Libplanet.Tests.Action
             Assert.Equal("a", (Text)_init.GetState(_addr[0]));
             Assert.Equal("b", (Text)_init.GetState(_addr[1]));
             Assert.Null(_init.GetState(_addr[2]));
-            Assert.Equal(5, _init.GetBalance(_addr[0], _currencies[0]));
-            Assert.Equal(-10, _init.GetBalance(_addr[0], _currencies[1]));
-            Assert.Equal(0, _init.GetBalance(_addr[0], _currencies[2]));
-            Assert.Equal(0, _init.GetBalance(_addr[1], _currencies[0]));
-            Assert.Equal(15, _init.GetBalance(_addr[1], _currencies[1]));
-            Assert.Equal(20, _init.GetBalance(_addr[1], _currencies[2]));
-            Assert.Equal(0, _init.GetBalance(_addr[2], _currencies[0]));
-            Assert.Equal(0, _init.GetBalance(_addr[2], _currencies[1]));
-            Assert.Equal(0, _init.GetBalance(_addr[2], _currencies[2]));
+            Assert.Equal(Value(0, 5), _init.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(1, -10), _init.GetBalance(_addr[0], _currencies[1]));
+            Assert.Equal(Zero(2), _init.GetBalance(_addr[0], _currencies[2]));
+            Assert.Equal(Zero(0), _init.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(1, 15), _init.GetBalance(_addr[1], _currencies[1]));
+            Assert.Equal(Value(2, 20), _init.GetBalance(_addr[1], _currencies[2]));
+            Assert.Equal(Zero(0), _init.GetBalance(_addr[2], _currencies[0]));
+            Assert.Equal(Zero(1), _init.GetBalance(_addr[2], _currencies[1]));
+            Assert.Equal(Zero(2), _init.GetBalance(_addr[2], _currencies[2]));
         }
 
         [Fact]
@@ -130,16 +130,16 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void FungibleAssets()
         {
-            IAccountStateDelta a = _init.TransferAsset(_addr[1], _addr[2], _currencies[2], 5);
-            Assert.Equal(15, a.GetBalance(_addr[1], _currencies[2]));
-            Assert.Equal(5, a.GetBalance(_addr[2], _currencies[2]));
-            Assert.Equal(5, a.GetBalance(_addr[0], _currencies[0]));
-            Assert.Equal(-10, a.GetBalance(_addr[0], _currencies[1]));
-            Assert.Equal(0, a.GetBalance(_addr[0], _currencies[2]));
-            Assert.Equal(0, a.GetBalance(_addr[1], _currencies[0]));
-            Assert.Equal(15, a.GetBalance(_addr[1], _currencies[1]));
-            Assert.Equal(0, a.GetBalance(_addr[2], _currencies[0]));
-            Assert.Equal(0, a.GetBalance(_addr[2], _currencies[1]));
+            IAccountStateDelta a = _init.TransferAsset(_addr[1], _addr[2], Value(2, 5));
+            Assert.Equal(Value(2, 15), a.GetBalance(_addr[1], _currencies[2]));
+            Assert.Equal(Value(2, 5), a.GetBalance(_addr[2], _currencies[2]));
+            Assert.Equal(Value(0, 5), a.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(1, -10), a.GetBalance(_addr[0], _currencies[1]));
+            Assert.Equal(Zero(2), a.GetBalance(_addr[0], _currencies[2]));
+            Assert.Equal(Zero(0), a.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(1, 15), a.GetBalance(_addr[1], _currencies[1]));
+            Assert.Equal(Zero(0), a.GetBalance(_addr[2], _currencies[0]));
+            Assert.Equal(Zero(1), a.GetBalance(_addr[2], _currencies[1]));
             Assert.Equal(
                 new Dictionary<Address, IImmutableSet<Currency>>
                 {
@@ -159,109 +159,116 @@ namespace Libplanet.Tests.Action
         public void TransferAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.TransferAsset(_addr[0], _addr[1], _currencies[0], 0)
+                _init.TransferAsset(_addr[0], _addr[1], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.TransferAsset(_addr[0], _addr[1], _currencies[0], -1)
+                _init.TransferAsset(_addr[0], _addr[1], Value(0, -1))
             );
             Assert.Throws<InsufficientBalanceException>(() =>
-                _init.TransferAsset(_addr[0], _addr[1], _currencies[0], 6)
+                _init.TransferAsset(_addr[0], _addr[1], Value(0, 6))
             );
 
             IAccountStateDelta a = _init.TransferAsset(
                 _addr[0],
                 _addr[1],
-                _currencies[0],
-                6,
+                Value(0, 6),
                 allowNegativeBalance: true
             );
-            Assert.Equal(-1, a.GetBalance(_addr[0], _currencies[0]));
-            Assert.Equal(6, a.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(0, -1), a.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
         }
 
         [Fact]
         public void MintAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.MintAsset(_addr[0], _currencies[0], 0)
+                _init.MintAsset(_addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.MintAsset(_addr[0], _currencies[0], -1)
+                _init.MintAsset(_addr[0], Value(0, -1))
             );
 
             IAccountStateDelta delta0 = _init;
             // currencies[0] (FOO) allows only _addr[0] to mint
-            delta0 = delta0.MintAsset(_addr[0], _currencies[0], 10);
-            Assert.Equal(15, delta0.GetBalance(_addr[0], _currencies[0]));
+            delta0 = delta0.MintAsset(_addr[0], Value(0, 10));
+            Assert.Equal(Value(0, 15), delta0.GetBalance(_addr[0], _currencies[0]));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
-            delta0 = delta0.MintAsset(_addr[1], _currencies[1], 10);
-            Assert.Equal(25, delta0.GetBalance(_addr[1], _currencies[1]));
+            delta0 = delta0.MintAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 25), delta0.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to mint
-            delta0 = delta0.MintAsset(_addr[2], _currencies[2], 10);
-            Assert.Equal(10, delta0.GetBalance(_addr[2], _currencies[2]));
+            delta0 = delta0.MintAsset(_addr[2], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[2], _currencies[2]));
 
             IAccountStateDelta delta1 = new AccountStateDeltaImpl(GetState, GetBalance, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to mint
             Assert.Throws<CurrencyPermissionException>(() =>
-                delta1.MintAsset(_addr[1], _currencies[0], 10)
+                delta1.MintAsset(_addr[1], Value(0, 10))
             );
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
-            delta1 = delta1.MintAsset(_addr[0], _currencies[1], 20);
-            Assert.Equal(10, delta1.GetBalance(_addr[0], _currencies[1]));
+            delta1 = delta1.MintAsset(_addr[0], Value(1, 20));
+            Assert.Equal(Value(1, 10), delta1.GetBalance(_addr[0], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to mint
-            delta1 = delta1.MintAsset(_addr[2], _currencies[2], 10);
-            Assert.Equal(10, delta1.GetBalance(_addr[2], _currencies[2]));
+            delta1 = delta1.MintAsset(_addr[2], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[2], _currencies[2]));
         }
 
         [Fact]
         public void BurnAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.BurnAsset(_addr[0], _currencies[0], 0)
+                _init.BurnAsset(_addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _init.BurnAsset(_addr[0], _currencies[0], -1)
+                _init.BurnAsset(_addr[0], Value(0, -1))
             );
             Assert.Throws<InsufficientBalanceException>(() =>
-                _init.BurnAsset(_addr[0], _currencies[0], 6)
+                _init.BurnAsset(_addr[0], Value(0, 6))
             );
 
             IAccountStateDelta delta0 = _init;
             // currencies[0] (FOO) allows only _addr[0] to burn
-            delta0 = delta0.BurnAsset(_addr[0], _currencies[0], 4);
-            Assert.Equal(1, delta0.GetBalance(_addr[0], _currencies[0]));
+            delta0 = delta0.BurnAsset(_addr[0], Value(0, 4));
+            Assert.Equal(Value(0, 1), delta0.GetBalance(_addr[0], _currencies[0]));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
-            delta0 = delta0.BurnAsset(_addr[1], _currencies[1], 10);
-            Assert.Equal(5, delta0.GetBalance(_addr[1], _currencies[1]));
+            delta0 = delta0.BurnAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 5), delta0.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to burn
-            delta0 = delta0.BurnAsset(_addr[1], _currencies[2], 10);
-            Assert.Equal(10, delta0.GetBalance(_addr[1], _currencies[2]));
+            delta0 = delta0.BurnAsset(_addr[1], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[1], _currencies[2]));
 
             IAccountStateDelta delta1 = new AccountStateDeltaImpl(GetState, GetBalance, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to burn
             Assert.Throws<CurrencyPermissionException>(() =>
-                delta1.BurnAsset(_addr[0], _currencies[0], 5)
+                delta1.BurnAsset(_addr[0], Value(0, 5))
             );
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
-            delta1 = delta1.BurnAsset(_addr[1], _currencies[1], 10);
-            Assert.Equal(5, delta1.GetBalance(_addr[1], _currencies[1]));
+            delta1 = delta1.BurnAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 5), delta1.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to burn
-            delta1 = delta1.BurnAsset(_addr[1], _currencies[2], 10);
-            Assert.Equal(10, delta1.GetBalance(_addr[1], _currencies[2]));
+            delta1 = delta1.BurnAsset(_addr[1], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[1], _currencies[2]));
         }
+
+        private FungibleAssetValue Value(int currencyIndex, BigInteger quantity) =>
+            new FungibleAssetValue(_currencies[currencyIndex], quantity);
+
+        private FungibleAssetValue Zero(int currencyIndex) => Value(currencyIndex, 0);
 
         private IValue GetState(Address address) =>
             _states.TryGetValue(address, out IValue v) ? v : null;
 
-        private BigInteger GetBalance(Address address, Currency currency) =>
-            _assets.TryGetValue((address, currency), out BigInteger balance) ? balance : 0;
+        private FungibleAssetValue GetBalance(Address address, Currency currency) =>
+            new FungibleAssetValue(
+                currency,
+                _assets.TryGetValue((address, currency), out BigInteger balance) ? balance : 0
+            );
     }
 }

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Xunit;
 
 namespace Libplanet.Tests.Action

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -118,24 +117,20 @@ namespace Libplanet.Tests.Action
 
             public IAccountStateDelta SetState(Address address, IValue state) => this;
 
-            public BigInteger GetBalance(Address address, Currency currency) => 0;
+            public FungibleAssetValue GetBalance(Address address, Currency currency) =>
+                new FungibleAssetValue(currency);
 
-            public IAccountStateDelta MintAsset(
-                Address recipient,
-                Currency currency,
-                BigInteger amount
-            ) => this;
+            public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value) =>
+                this;
 
             public IAccountStateDelta TransferAsset(
                 Address sender,
                 Address recipient,
-                Currency currency,
-                BigInteger amount,
+                FungibleAssetValue value,
                 bool allowNegativeBalance = false
             ) => this;
 
-            public IAccountStateDelta BurnAsset(Address owner, Currency currency, BigInteger amount)
-                => this;
+            public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value) => this;
         }
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -18,11 +17,12 @@ namespace Libplanet.Tests.Action
                 (dirty, ev) => dirty.SetItems(ev.OutputStates.GetUpdatedStates())
             );
 
-        public static IImmutableDictionary<(Address, Currency), BigInteger> GetDirtyBalances(
+        public static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
+        GetDirtyBalances(
             this IEnumerable<ActionEvaluation> evaluations
         ) =>
             evaluations.Aggregate(
-                ImmutableDictionary<(Address, Currency), BigInteger>.Empty,
+                ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty,
                 (dirty, ev) => dirty.SetItems(ev.OutputStates.GetUpdatedBalances())
             );
     }

--- a/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 
 namespace Libplanet.Tests.Action
 {

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -1,5 +1,6 @@
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Xunit;
@@ -18,13 +19,17 @@ namespace Libplanet.Tests.Action
                     address,
                     address,
                     1,
-                    new AccountStateDeltaImpl(_ => null, (_, __) => 0, address),
+                    new AccountStateDeltaImpl(
+                        _ => null,
+                        (_, c) => new FungibleAssetValue(c),
+                        address
+                    ),
                     123,
                     false
                 ),
                 new AccountStateDeltaImpl(
                     a => a.Equals(address) ? (Text)"item" : null,
-                    (_, __) => 0,
+                    (_, c) => new FungibleAssetValue(c),
                     address
                 )
             );

--- a/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
+++ b/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Xunit;
 
 namespace Libplanet.Tests.Action

--- a/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
+++ b/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
@@ -23,7 +23,11 @@ namespace Libplanet.Tests.Action
             });
 
             var currency = new Currency("PLT", minter);
-            var exc = new InsufficientBalanceException(account, currency, 99, "for testing");
+            var exc = new InsufficientBalanceException(
+                account,
+                new FungibleAssetValue(currency, 99),
+                "for testing"
+            );
 
             var formatter = new BinaryFormatter();
             using (var ms = new MemoryStream())
@@ -34,8 +38,7 @@ namespace Libplanet.Tests.Action
                 var deserialized = (InsufficientBalanceException)formatter.Deserialize(ms);
                 Assert.Equal("for testing", deserialized.Message);
                 Assert.Equal(account, deserialized.Address);
-                Assert.Equal(currency.Hash, deserialized.Currency.Hash);
-                Assert.Equal(99, deserialized.Balance);
+                Assert.Equal(new FungibleAssetValue(currency, 99), deserialized.Balance);
             }
         }
     }

--- a/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
+++ b/Libplanet.Tests/Action/InsufficientBalanceExceptionTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Tests.Action
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
             });
 
-            var currency = new Currency("PLT", minter);
+            var currency = new Currency("PLT", 0, minter);
             var exc = new InsufficientBalanceException(
                 account,
                 new FungibleAssetValue(currency, 99),

--- a/Libplanet.Tests/Assets/CurrencyTest.cs
+++ b/Libplanet.Tests/Assets/CurrencyTest.cs
@@ -154,5 +154,13 @@ namespace Libplanet.Tests.Assets
             Assert.NotEqual(currencyA, currencyD);
             Assert.NotEqual(currencyA, currencyE);
         }
+
+        [Fact]
+        public void GetFungibleAssetValue()
+        {
+            var foo = new Currency(ticker: "FOO", decimalPlaces: 0, minter: null);
+            Assert.Equal(new FungibleAssetValue(foo, 123, 0), 123 * foo);
+            Assert.Equal(new FungibleAssetValue(foo, -123, 0), foo * -123);
+        }
     }
 }

--- a/Libplanet.Tests/Assets/CurrencyTest.cs
+++ b/Libplanet.Tests/Assets/CurrencyTest.cs
@@ -3,11 +3,12 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
+using Libplanet.Assets;
 using Libplanet.Crypto;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests
+namespace Libplanet.Tests.Assets
 {
     public class CurrencyTest
     {

--- a/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
+++ b/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
@@ -1,0 +1,306 @@
+#pragma warning disable S1764
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Assets;
+using Xunit;
+
+namespace Libplanet.Tests.Assets
+{
+    public class FungibleAssetValueTest
+    {
+        private static readonly Currency FOO = new Currency("FOO", minter: null);
+        private static readonly Currency BAR = new Currency("BAR", minter: null);
+
+        [Fact]
+        public void Equality()
+        {
+            FungibleAssetValue foo100a = new FungibleAssetValue(FOO, 100);
+            FungibleAssetValue foo100b = new FungibleAssetValue(FOO, 100);
+            FungibleAssetValue foo200a = new FungibleAssetValue(FOO, 200);
+            FungibleAssetValue foo200b = new FungibleAssetValue(FOO, 200);
+            FungibleAssetValue bar100a = new FungibleAssetValue(BAR, 100);
+            FungibleAssetValue bar100b = new FungibleAssetValue(BAR, 100);
+            FungibleAssetValue bar200a = new FungibleAssetValue(BAR, 200);
+            FungibleAssetValue bar200b = new FungibleAssetValue(BAR, 200);
+
+            Assert.Equal(foo100b, foo100a);
+            Assert.Equal(foo100b.GetHashCode(), foo100a.GetHashCode());
+            Assert.True(foo100b.Equals((object)foo100a));
+            Assert.True(foo100b == foo100a);
+            Assert.False(foo100b != foo100a);
+            Assert.Equal(foo200b, foo200a);
+            Assert.Equal(foo200b.GetHashCode(), foo200a.GetHashCode());
+            Assert.True(foo200b.Equals((object)foo200a));
+            Assert.True(foo200b == foo200a);
+            Assert.False(foo200b != foo200a);
+            Assert.Equal(bar100b, bar100a);
+            Assert.Equal(bar100b.GetHashCode(), bar100a.GetHashCode());
+            Assert.True(bar100b.Equals((object)bar100a));
+            Assert.True(bar100b == bar100a);
+            Assert.False(bar100b != bar100a);
+            Assert.Equal(bar200b, bar200a);
+            Assert.Equal(bar200b.GetHashCode(), bar200a.GetHashCode());
+            Assert.True(bar200b.Equals((object)bar200a));
+            Assert.True(bar200b == bar200a);
+            Assert.False(bar200b != bar200a);
+
+            Assert.NotEqual(foo100a, foo200a);
+            Assert.False(foo100a.Equals((object)foo200a));
+            Assert.False(foo100a == foo200a);
+            Assert.True(foo100a != foo200a);
+            Assert.NotEqual(foo100a, bar100a);
+            Assert.False(foo100a.Equals((object)bar100a));
+            Assert.False(foo100a == bar100a);
+            Assert.True(foo100a != bar100a);
+            Assert.NotEqual(foo100a, bar200a);
+            Assert.False(foo100a.Equals((object)bar200a));
+            Assert.False(foo100a == bar200a);
+            Assert.True(foo100a != bar200a);
+            Assert.NotEqual(bar100a, foo200a);
+            Assert.False(bar100a.Equals((object)foo200a));
+            Assert.False(bar100a == foo200a);
+            Assert.True(bar100a != foo200a);
+            Assert.NotEqual(foo100a, bar100a);
+            Assert.False(foo100a.Equals((object)bar100a));
+            Assert.False(foo100a == bar100a);
+            Assert.True(foo100a != bar100a);
+            Assert.NotEqual(foo100a, bar200a);
+            Assert.False(foo100a.Equals((object)bar200a));
+            Assert.False(foo100a == bar200a);
+            Assert.True(foo100a != bar200a);
+
+            Assert.False(foo100a.Equals(100));
+            Assert.False(foo200a.Equals(200));
+        }
+
+        [Fact]
+        public void Compare()
+        {
+            FungibleAssetValue foo100a = new FungibleAssetValue(FOO, 100);
+            FungibleAssetValue foo100b = new FungibleAssetValue(FOO, 100);
+            FungibleAssetValue foo200 = new FungibleAssetValue(FOO, 200);
+            FungibleAssetValue bar100 = new FungibleAssetValue(BAR, 100);
+
+            Assert.Equal(0, foo100a.CompareTo(foo100b));
+            Assert.Equal(0, foo100a.CompareTo((object)foo100b));
+            Assert.False(foo100a < foo100b);
+            Assert.True(foo100a <= foo100b);
+            Assert.False(foo100a > foo100b);
+            Assert.True(foo100a >= foo100b);
+
+            Assert.True(foo100a.CompareTo(foo200) < 0);
+            Assert.True(foo100a.CompareTo((object)foo200) < 0);
+            Assert.True(foo100a < foo200);
+            Assert.True(foo100a <= foo200);
+            Assert.False(foo100a > foo200);
+            Assert.False(foo100a >= foo200);
+
+            Assert.True(foo200.CompareTo(foo100b) > 0);
+            Assert.True(foo200.CompareTo((object)foo100b) > 0);
+            Assert.False(foo200 < foo100b);
+            Assert.False(foo200 <= foo100b);
+            Assert.True(foo200 > foo100b);
+            Assert.True(foo200 >= foo100b);
+
+            Assert.Throws<ArgumentException>(() => foo100a.CompareTo(bar100));
+            Assert.Throws<ArgumentException>(() => foo100a.CompareTo((object)bar100));
+            Assert.Throws<ArgumentException>(() => foo100a < bar100);
+            Assert.Throws<ArgumentException>(() => foo100a <= bar100);
+            Assert.Throws<ArgumentException>(() => foo100a > bar100);
+            Assert.Throws<ArgumentException>(() => foo100a >= bar100);
+
+            Assert.Throws<ArgumentException>(() => foo100a.CompareTo(100));
+        }
+
+        [Fact]
+        public void Negate()
+        {
+            FungibleAssetValue foo_3 = new FungibleAssetValue(FOO, -3);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue foo3 = new FungibleAssetValue(FOO, 3);
+
+            Assert.Equal(foo_3, -foo3);
+            Assert.Equal(foo3, -foo_3);
+            Assert.Equal(foo0, -foo0);
+        }
+
+        [Fact]
+        public void Add()
+        {
+            FungibleAssetValue foo_1 = new FungibleAssetValue(FOO, -1);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue foo1 = new FungibleAssetValue(FOO, 1);
+            FungibleAssetValue foo2 = new FungibleAssetValue(FOO, 2);
+            FungibleAssetValue foo3 = new FungibleAssetValue(FOO, 3);
+            FungibleAssetValue bar3 = new FungibleAssetValue(BAR, 3);
+
+            Assert.Equal(foo1, foo1 + foo0);
+            Assert.Equal(foo1, foo0 + foo1);
+            Assert.Equal(foo2, foo1 + foo1);
+            Assert.Equal(foo3, foo1 + foo2);
+            Assert.Equal(foo3, foo2 + foo1);
+            Assert.Equal(foo1, foo2 + foo_1);
+            Assert.Equal(foo1, foo_1 + foo2);
+            Assert.Equal(foo_1, foo_1 + foo0);
+            Assert.Equal(foo_1, foo0 + foo_1);
+
+            Assert.Throws<ArgumentException>(() => foo1 + bar3);
+        }
+
+        [Fact]
+        public void Subtract()
+        {
+            FungibleAssetValue foo_1 = new FungibleAssetValue(FOO, -1);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue foo1 = new FungibleAssetValue(FOO, 1);
+            FungibleAssetValue foo2 = new FungibleAssetValue(FOO, 2);
+            FungibleAssetValue bar3 = new FungibleAssetValue(BAR, 3);
+
+            Assert.Equal(foo0, foo1 - foo1);
+            Assert.Equal(foo_1, foo1 - foo2);
+            Assert.Equal(foo2, foo1 - foo_1);
+            Assert.Equal(foo0, foo_1 - foo_1);
+
+            Assert.Throws<ArgumentException>(() => bar3 - foo1);
+        }
+
+        [Fact]
+        public void Multiply()
+        {
+            FungibleAssetValue foo_2 = new FungibleAssetValue(FOO, -2);
+            FungibleAssetValue foo_1 = new FungibleAssetValue(FOO, -1);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue foo1 = new FungibleAssetValue(FOO, 1);
+            FungibleAssetValue foo2 = new FungibleAssetValue(FOO, 2);
+            FungibleAssetValue foo4 = new FungibleAssetValue(FOO, 4);
+
+            Assert.Equal(foo2, foo1 * 2);
+            Assert.Equal(foo2, 2 * foo1);
+            Assert.Equal(foo2, foo2 * 1);
+            Assert.Equal(foo2, 1 * foo2);
+            Assert.Equal(foo_2, foo2 * -1);
+            Assert.Equal(foo_2, -1 * foo2);
+            Assert.Equal(foo_2, foo_1 * 2);
+            Assert.Equal(foo_2, 2 * foo_1);
+            Assert.Equal(foo_1, foo_1 * 1);
+            Assert.Equal(foo_1, 1 * foo_1);
+            Assert.Equal(foo4, foo2 * 2);
+            Assert.Equal(foo4, 2 * foo2);
+            Assert.Equal(foo0, foo2 * 0);
+            Assert.Equal(foo0, 0 * foo2);
+            Assert.Equal(foo0, foo_1 * 0);
+            Assert.Equal(foo0, 0 * foo_1);
+        }
+
+        [Fact]
+        public void DivRem()
+        {
+            FungibleAssetValue foo7 = new FungibleAssetValue(FOO, 7);
+            FungibleAssetValue foo6 = new FungibleAssetValue(FOO, 6);
+            FungibleAssetValue foo3 = new FungibleAssetValue(FOO, 3);
+            FungibleAssetValue foo2 = new FungibleAssetValue(FOO, 2);
+            FungibleAssetValue foo1 = new FungibleAssetValue(FOO, 1);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue rem;
+
+            Assert.Equal((foo6, foo0), foo6.DivRem(1));
+            Assert.Equal(foo6, foo6.DivRem(1, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo6 % 1);
+
+            Assert.Equal((foo2, foo0), foo6.DivRem(3));
+            Assert.Equal(foo2, foo6.DivRem(3, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo6 % 3);
+
+            Assert.Equal((foo2, foo1), foo7.DivRem(3));
+            Assert.Equal(foo2, foo7.DivRem(3, out rem));
+            Assert.Equal(foo1, rem);
+            Assert.Equal(foo1, foo7 % 3);
+
+            Assert.Equal((foo0, foo6), foo6.DivRem(7));
+            Assert.Equal(foo0, foo6.DivRem(7, out rem));
+            Assert.Equal(foo6, rem);
+            Assert.Equal(foo6, foo6 % 7);
+
+            Assert.Equal((foo0, foo0), foo0.DivRem(2));
+            Assert.Equal(foo0, foo0.DivRem(2, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo0 % 2);
+
+            Assert.Equal((6, foo0), foo6.DivRem(foo1));
+            Assert.Equal(6, foo6.DivRem(foo1, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo6 % foo1);
+
+            Assert.Equal((2, foo0), foo6.DivRem(foo3));
+            Assert.Equal(2, foo6.DivRem(foo3, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo6 % foo3);
+
+            Assert.Equal((2, foo1), foo7.DivRem(foo3));
+            Assert.Equal(2, foo7.DivRem(foo3, out rem));
+            Assert.Equal(foo1, rem);
+            Assert.Equal(foo1, foo7 % foo3);
+
+            Assert.Equal((0, foo6), foo6.DivRem(foo7));
+            Assert.Equal(0, foo6.DivRem(foo7, out rem));
+            Assert.Equal(foo6, rem);
+            Assert.Equal(foo6, foo6 % foo7);
+
+            Assert.Equal((0, foo0), foo0.DivRem(foo2));
+            Assert.Equal(0, foo0.DivRem(foo2, out rem));
+            Assert.Equal(foo0, rem);
+            Assert.Equal(foo0, foo0 % foo2);
+
+            Assert.Throws<DivideByZeroException>(() => foo1.DivRem(0));
+            Assert.Throws<DivideByZeroException>(() => foo1.DivRem(0, out rem));
+            Assert.Throws<DivideByZeroException>(() => foo1 % 0);
+            Assert.Throws<DivideByZeroException>(() => foo1.DivRem(foo0));
+            Assert.Throws<DivideByZeroException>(() => foo1.DivRem(foo0, out rem));
+            Assert.Throws<DivideByZeroException>(() => foo1 % foo0);
+
+            FungibleAssetValue bar1 = new FungibleAssetValue(BAR, 1);
+            Assert.Throws<ArgumentException>(() => bar1.DivRem(foo1));
+            Assert.Throws<ArgumentException>(() => bar1.DivRem(foo1, out rem));
+            Assert.Throws<ArgumentException>(() => bar1 % foo1);
+        }
+
+        [Fact]
+        public void Abs()
+        {
+            FungibleAssetValue foo_3 = new FungibleAssetValue(FOO, -3);
+            FungibleAssetValue foo0 = new FungibleAssetValue(FOO);
+            FungibleAssetValue foo3 = new FungibleAssetValue(FOO, 3);
+
+            Assert.Equal(foo3, foo3.Abs());
+            Assert.Equal(foo3, foo_3.Abs());
+            Assert.Equal(foo0, foo0.Abs());
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            FungibleAssetValue foo100 = new FungibleAssetValue(FOO, 100);
+            var f = new BinaryFormatter();
+            var s = new MemoryStream();
+            f.Serialize(s, foo100);
+            s.Seek(0, SeekOrigin.Begin);
+            var deserialized = f.Deserialize(s);
+            Assert.IsType<FungibleAssetValue>(deserialized);
+            Assert.Equal(foo100, (FungibleAssetValue)deserialized);
+        }
+
+        [Fact]
+        public void String()
+        {
+            FungibleAssetValue foo100 = new FungibleAssetValue(FOO, 100);
+            FungibleAssetValue bar90000000 = new FungibleAssetValue(BAR, 90000000);
+            Assert.Equal("100 FOO", foo100.ToString());
+            Assert.Equal("90000000 BAR", bar90000000.ToString());
+        }
+    }
+}
+
+#pragma warning restore S1764

--- a/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
+++ b/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
@@ -9,8 +9,81 @@ namespace Libplanet.Tests.Assets
 {
     public class FungibleAssetValueTest
     {
-        private static readonly Currency FOO = new Currency("FOO", minter: null);
-        private static readonly Currency BAR = new Currency("BAR", minter: null);
+        private static readonly Currency FOO = new Currency("FOO", 2, minter: null);
+        private static readonly Currency BAR = new Currency("BAR", 0, minter: null);
+
+        [Fact]
+        public void Constructor()
+        {
+            FungibleAssetValue v;
+            v = new FungibleAssetValue(FOO, 123, 45);
+            Assert.Equal(new FungibleAssetValue(FOO, 1, 123, 45), v);
+            Assert.Equal(12345, v.RawValue);
+            Assert.Equal(123, v.MajorUnit);
+            Assert.Equal(45, v.MinorUnit);
+            Assert.Equal(1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 456, 9);
+            Assert.Equal(new FungibleAssetValue(FOO, 1, 456, 9), v);
+            Assert.Equal(45609, v.RawValue);
+            Assert.Equal(456, v.MajorUnit);
+            Assert.Equal(9, v.MinorUnit);
+            Assert.Equal(1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 0, 10);
+            Assert.Equal(new FungibleAssetValue(FOO, 1, 0, 10), v);
+            Assert.Equal(10, v.RawValue);
+            Assert.Equal(0, v.MajorUnit);
+            Assert.Equal(10, v.MinorUnit);
+            Assert.Equal(1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 0, 9);
+            Assert.Equal(new FungibleAssetValue(FOO, 1, 0, 9), v);
+            Assert.Equal(9, v.RawValue);
+            Assert.Equal(0, v.MajorUnit);
+            Assert.Equal(9, v.MinorUnit);
+            Assert.Equal(1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, -789, 1);
+            Assert.Equal(new FungibleAssetValue(FOO, -1, 789, 1), v);
+            Assert.Equal(-78901, v.RawValue);
+            Assert.Equal(789, v.MajorUnit);
+            Assert.Equal(1, v.MinorUnit);
+            Assert.Equal(-1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 0, -2);
+            Assert.Equal(new FungibleAssetValue(FOO, -1, 0, 2), v);
+            Assert.Equal(-2, v.RawValue);
+            Assert.Equal(0, v.MajorUnit);
+            Assert.Equal(2, v.MinorUnit);
+            Assert.Equal(-1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 123, 0);
+            Assert.Equal(new FungibleAssetValue(FOO, 1, 123, 0), v);
+            Assert.Equal(12300, v.RawValue);
+            Assert.Equal(123, v.MajorUnit);
+            Assert.Equal(0, v.MinorUnit);
+            Assert.Equal(1, v.Sign);
+
+            v = new FungibleAssetValue(FOO, 0, 0);
+            Assert.Equal(new FungibleAssetValue(FOO, 0, 0, 0), v);
+            Assert.Equal(new FungibleAssetValue(FOO), v);
+            Assert.Equal(0, v.RawValue);
+            Assert.Equal(0, v.MajorUnit);
+            Assert.Equal(0, v.MinorUnit);
+            Assert.Equal(0, v.Sign);
+
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, -2, 1, 0));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 2, 1, 0));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 0, 1, 0));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 0, 0, 1));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 1, -1, 0));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 1, 1, -1));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 1, 1, 100));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 10, -10));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, -10, -10));
+            Assert.Throws<ArgumentException>(() => new FungibleAssetValue(FOO, 1, 100));
+        }
 
         [Fact]
         public void Equality()
@@ -293,11 +366,48 @@ namespace Libplanet.Tests.Assets
         }
 
         [Fact]
+        public void GetQuantityString()
+        {
+            FungibleAssetValue v;
+            v = new FungibleAssetValue(FOO, 123, 45);
+            Assert.Equal("123.45", v.GetQuantityString());
+            Assert.Equal("123.45", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 456, 9);
+            Assert.Equal("456.09", v.GetQuantityString());
+            Assert.Equal("456.09", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 0, 10);
+            Assert.Equal("0.1", v.GetQuantityString());
+            Assert.Equal("0.10", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 0, 9);
+            Assert.Equal("0.09", v.GetQuantityString());
+            Assert.Equal("0.09", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, -789, 1);
+            Assert.Equal("-789.01", v.GetQuantityString());
+            Assert.Equal("-789.01", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 0, -2);
+            Assert.Equal("-0.02", v.GetQuantityString());
+            Assert.Equal("-0.02", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 123, 0);
+            Assert.Equal("123", v.GetQuantityString());
+            Assert.Equal("123.00", v.GetQuantityString(true));
+
+            v = new FungibleAssetValue(FOO, 0, 0);
+            Assert.Equal("0", v.GetQuantityString());
+            Assert.Equal("0.00", v.GetQuantityString(true));
+        }
+
+        [Fact]
         public void String()
         {
             FungibleAssetValue foo100 = new FungibleAssetValue(FOO, 100);
             FungibleAssetValue bar90000000 = new FungibleAssetValue(BAR, 90000000);
-            Assert.Equal("100 FOO", foo100.ToString());
+            Assert.Equal("1 FOO", foo100.ToString());
             Assert.Equal("90000000 BAR", bar90000000.ToString());
         }
     }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Numerics;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
@@ -2139,10 +2138,13 @@ namespace Libplanet.Tests.Blockchain
 
             // Build the store has incomplete states
             Block<DumbAction> b = chain.Genesis;
-            ActionEvaluation[] evals =
-                b.Evaluate(DateTimeOffset.UtcNow, _ => null, (a, c) => 0).ToArray();
+            ActionEvaluation[] evals = b.Evaluate(
+                DateTimeOffset.UtcNow,
+                _ => null,
+                (a, c) => new FungibleAssetValue(c)
+            ).ToArray();
             IImmutableDictionary<Address, IValue> dirty = evals.GetDirtyStates();
-            IImmutableDictionary<(Address, Currency), BigInteger> balances =
+            IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances =
                 evals.GetDirtyBalances();
             const int accountsCount = 5;
             Address[] addresses = Enumerable.Repeat<object>(null, accountsCount)

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tests.Action;

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Threading;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Boolean = Bencodex.Types.Boolean;
 
 namespace Libplanet.Tests.Common.Action

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Tests.Common.Action
         public static readonly Address RandomRecordsAddress =
             new Address("7811C3fAa0f9Cc41F7971c3d9b031B1095b20AB2");
 
-        public static readonly Currency DumbCurrency = new Currency("DUMB", minters: null);
+        public static readonly Currency DumbCurrency = new Currency("DUMB", 0, minters: null);
 
         public DumbAction()
         {

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -183,8 +183,7 @@ namespace Libplanet.Tests.Common.Action
                 nextState = nextState.TransferAsset(
                     sender: Transfer.Item1,
                     recipient: Transfer.Item2,
-                    currency: DumbCurrency,
-                    amount: Transfer.Item3,
+                    value: new FungibleAssetValue(DumbCurrency, Transfer.Item3),
                     allowNegativeBalance: true
                 );
             }

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -644,14 +644,14 @@ namespace Libplanet.Tests.Tx
                         prevEval is null
                             ? initBalances
                             : addresses.Select(a =>
-                                prevEval.OutputStates.GetBalance(a, currency).Quantity),
+                                prevEval.OutputStates.GetBalance(a, currency).RawValue),
                         addresses.Select(
-                            a => eval.InputContext.PreviousStates.GetBalance(a, currency).Quantity
+                            a => eval.InputContext.PreviousStates.GetBalance(a, currency).RawValue
                         )
                     );
                     Assert.Equal(
                         expectedBalances[i],
-                        addresses.Select(a => eval.OutputStates.GetBalance(a, currency).Quantity)
+                        addresses.Select(a => eval.OutputStates.GetBalance(a, currency).RawValue)
                     );
                 }
 

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -586,7 +586,11 @@ namespace Libplanet.Tests.Tx
                 var evaluations = tx.EvaluateActionsGradually(
                     default,
                     1,
-                    new AccountStateDeltaImpl(address => null, (a, c) => 0, tx.Signer),
+                    new AccountStateDeltaImpl(
+                        address => null,
+                        (a, c) => new FungibleAssetValue(c),
+                        tx.Signer
+                    ),
                     addresses[0],
                     rehearsal: rehearsal
                 ).ToImmutableArray();
@@ -639,14 +643,15 @@ namespace Libplanet.Tests.Tx
                     Assert.Equal(
                         prevEval is null
                             ? initBalances
-                            : addresses.Select(a => prevEval.OutputStates.GetBalance(a, currency)),
+                            : addresses.Select(a =>
+                                prevEval.OutputStates.GetBalance(a, currency).Quantity),
                         addresses.Select(
-                            a => eval.InputContext.PreviousStates.GetBalance(a, currency)
+                            a => eval.InputContext.PreviousStates.GetBalance(a, currency).Quantity
                         )
                     );
                     Assert.Equal(
                         expectedBalances[i],
-                        addresses.Select(a => eval.OutputStates.GetBalance(a, currency))
+                        addresses.Select(a => eval.OutputStates.GetBalance(a, currency).Quantity)
                     );
                 }
 
@@ -670,7 +675,11 @@ namespace Libplanet.Tests.Tx
                 IAccountStateDelta delta = tx.EvaluateActions(
                     default,
                     1,
-                    new AccountStateDeltaImpl(address => null, (a, c) => 0, tx.Signer),
+                    new AccountStateDeltaImpl(
+                        address => null,
+                        (a, c) => new FungibleAssetValue(c),
+                        tx.Signer
+                    ),
                     addresses[0],
                     rehearsal: rehearsal
                 );
@@ -712,7 +721,11 @@ namespace Libplanet.Tests.Tx
             var nextStates = tx.EvaluateActions(
                 blockHash: hash,
                 blockIndex: 123,
-                previousStates: new AccountStateDeltaImpl(_ => null, (_, __) => 0, tx.Signer),
+                previousStates: new AccountStateDeltaImpl(
+                    _ => null,
+                    (_, c) => new FungibleAssetValue(c),
+                    tx.Signer
+                ),
                 minerAddress: GenesisMinerAddress,
                 rehearsal: false
             );

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Crypto;
 using Libplanet.Tests.Action;
 using Libplanet.Tests.Common.Action;

--- a/Libplanet/Action/AccountBalanceGetter.cs
+++ b/Libplanet/Action/AccountBalanceGetter.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Numerics;
+using Libplanet.Assets;
 
 namespace Libplanet.Action
 {

--- a/Libplanet/Action/AccountBalanceGetter.cs
+++ b/Libplanet/Action/AccountBalanceGetter.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System.Numerics;
 using Libplanet.Assets;
 
 namespace Libplanet.Action
@@ -16,5 +15,5 @@ namespace Libplanet.Action
     /// <returns>
     /// The <paramref name="address"/>'s balance of the <paramref name="currency"/>.
     /// </returns>
-    public delegate BigInteger AccountBalanceGetter(Address address, Currency currency);
+    public delegate FungibleAssetValue AccountBalanceGetter(Address address, Currency currency);
 }

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -76,23 +76,25 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
-        public BigInteger GetBalance(Address address, Currency currency) =>
+        public FungibleAssetValue GetBalance(Address address, Currency currency) =>
             _updatedFungibleAssets.TryGetValue((address, currency), out BigInteger balance)
-                ? balance
+                ? new FungibleAssetValue(currency, balance)
                 : _accountBalanceGetter(address, currency);
 
         /// <inheritdoc/>
         [Pure]
-        public IAccountStateDelta MintAsset(Address recipient, Currency currency, BigInteger amount)
+        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
         {
-            if (amount <= 0)
+            if (value.Quantity <= 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(amount),
-                    "The amount to mint has to be greater than 0."
+                    nameof(value),
+                    "The value to mint has to be greater than zero."
                 );
             }
-            else if (!currency.AllowsToMint(_signer))
+
+            Currency currency = value.Currency;
+            if (!currency.AllowsToMint(_signer))
             {
                 throw new CurrencyPermissionException(
                     _signer,
@@ -101,9 +103,9 @@ namespace Libplanet.Action
                 );
             }
 
-            BigInteger balance = GetBalance(recipient, currency);
+            FungibleAssetValue balance = GetBalance(recipient, currency);
             return UpdateFungibleAssets(
-                _updatedFungibleAssets.SetItem((recipient, currency), balance + amount)
+                _updatedFungibleAssets.SetItem((recipient, currency), (balance + value).Quantity)
             );
         }
 
@@ -112,67 +114,69 @@ namespace Libplanet.Action
         public IAccountStateDelta TransferAsset(
             Address sender,
             Address recipient,
-            Currency currency,
-            BigInteger amount,
+            FungibleAssetValue value,
             bool allowNegativeBalance = false
         )
         {
-            if (amount <= 0)
+            if (value.Quantity <= 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(amount),
-                    "The amount to transfer has to be greater than 0."
+                    nameof(value),
+                    "The value to transfer has to be greater than zero."
                 );
             }
 
-            BigInteger senderBalance = GetBalance(sender, currency),
-                       recipientBalance = GetBalance(recipient, currency);
+            Currency currency = value.Currency;
+            FungibleAssetValue senderBalance = GetBalance(sender, currency);
+            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
 
-            if (!allowNegativeBalance && senderBalance < amount)
+            if (!allowNegativeBalance && senderBalance < value)
             {
                 var msg = $"The account {sender}'s balance of {currency} is insufficient to " +
-                          $"transfer: {senderBalance} {currency} < {amount} {currency}.";
-                throw new InsufficientBalanceException(sender, currency, senderBalance, msg);
+                          $"transfer: {senderBalance} < {value}.";
+                throw new InsufficientBalanceException(sender, senderBalance, msg);
             }
 
             return UpdateFungibleAssets(
                 _updatedFungibleAssets
-                    .SetItem((sender, currency), senderBalance - amount)
-                    .SetItem((recipient, currency), recipientBalance + amount)
+                    .SetItem((sender, currency), (senderBalance - value).Quantity)
+                    .SetItem((recipient, currency), (recipientBalance + value).Quantity)
             );
         }
 
         /// <inheritdoc/>
         [Pure]
-        public IAccountStateDelta BurnAsset(Address owner, Currency currency, BigInteger amount)
+        public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
         {
             string msg;
 
-            if (amount <= 0)
+            if (value.Quantity <= 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(amount),
-                    "The amount to burn has to be greater than 0."
+                    nameof(value),
+                    "The value to burn has to be greater than zero."
                 );
             }
-            else if (!currency.AllowsToMint(_signer))
+
+            Currency currency = value.Currency;
+            if (!currency.AllowsToMint(_signer))
             {
                 msg = $"The account {_signer} has no permission to burn assets of " +
                       $"the currency {currency}.";
                 throw new CurrencyPermissionException(_signer, currency, msg);
             }
 
-            BigInteger balance = GetBalance(owner, currency);
+            FungibleAssetValue balance = GetBalance(owner, currency);
 
-            if (balance < amount)
+            if (balance < value)
             {
                 msg = $"The account {owner}'s balance of {currency} is insufficient to burn: " +
-                      $"{balance} {currency} < {amount} {currency}.";
-                throw new InsufficientBalanceException(owner, currency, balance, msg);
+                      $"{balance} < {value}.";
+                throw new InsufficientBalanceException(owner, balance, msg);
             }
 
             return UpdateFungibleAssets(
-                _updatedFungibleAssets.SetItem((owner, currency), balance - amount)
+                _updatedFungibleAssets.SetItem((owner, currency), (balance - value).Quantity)
             );
         }
 

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Numerics;
 using Bencodex.Types;
+using Libplanet.Assets;
 
 namespace Libplanet.Action
 {

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -85,7 +85,7 @@ namespace Libplanet.Action
         [Pure]
         public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
         {
-            if (value.Quantity <= 0)
+            if (value.Sign <= 0)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(value),
@@ -105,7 +105,7 @@ namespace Libplanet.Action
 
             FungibleAssetValue balance = GetBalance(recipient, currency);
             return UpdateFungibleAssets(
-                _updatedFungibleAssets.SetItem((recipient, currency), (balance + value).Quantity)
+                _updatedFungibleAssets.SetItem((recipient, currency), (balance + value).RawValue)
             );
         }
 
@@ -118,7 +118,7 @@ namespace Libplanet.Action
             bool allowNegativeBalance = false
         )
         {
-            if (value.Quantity <= 0)
+            if (value.Sign <= 0)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(value),
@@ -139,8 +139,8 @@ namespace Libplanet.Action
 
             return UpdateFungibleAssets(
                 _updatedFungibleAssets
-                    .SetItem((sender, currency), (senderBalance - value).Quantity)
-                    .SetItem((recipient, currency), (recipientBalance + value).Quantity)
+                    .SetItem((sender, currency), (senderBalance - value).RawValue)
+                    .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
         }
 
@@ -150,7 +150,7 @@ namespace Libplanet.Action
         {
             string msg;
 
-            if (value.Quantity <= 0)
+            if (value.Sign <= 0)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(value),
@@ -176,7 +176,7 @@ namespace Libplanet.Action
             }
 
             return UpdateFungibleAssets(
-                _updatedFungibleAssets.SetItem((owner, currency), (balance - value).Quantity)
+                _updatedFungibleAssets.SetItem((owner, currency), (balance - value).RawValue)
             );
         }
 

--- a/Libplanet/Action/CurrencyPermissionException.cs
+++ b/Libplanet/Action/CurrencyPermissionException.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using Libplanet.Assets;
 
 namespace Libplanet.Action
 {
@@ -18,7 +19,7 @@ namespace Libplanet.Action
         /// <param name="transactionSigner"> The address of the account who tried to mint or burn
         /// assets of a <paramref name="currency"/>.  Corresponds to
         /// the <see cref="TransactionSigner"/> property.</param>
-        /// <param name="currency"> The <see cref="Libplanet.Currency"/> to be tried to be minted
+        /// <param name="currency"> The <see cref="Assets.Currency"/> to be tried to be minted
         /// or burned by the <paramref name="transactionSigner"/>.  Corresponds to
         /// the <see cref="Currency"/> property.</param>
         /// <param name="message">Specifies a <see cref="Exception.Message"/>.</param>
@@ -39,7 +40,7 @@ namespace Libplanet.Action
         public Address TransactionSigner { get; }
 
         /// <summary>
-        /// The <see cref="Libplanet.Currency"/> to be tried to be minted or burned by
+        /// The <see cref="Assets.Currency"/> to be tried to be minted or burned by
         /// the <see cref="TransactionSigner"/>.
         /// </summary>
         public Currency Currency { get; }

--- a/Libplanet/Action/IAccountStateDelta.cs
+++ b/Libplanet/Action/IAccountStateDelta.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Numerics;
 using Bencodex.Types;
+using Libplanet.Assets;
 
 namespace Libplanet.Action
 {

--- a/Libplanet/Action/IAccountStateDelta.cs
+++ b/Libplanet/Action/IAccountStateDelta.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Assets;
 
@@ -104,75 +103,67 @@ namespace Libplanet.Action
         /// The <paramref name="address"/>'s balance of the <paramref name="currency"/>.
         /// </returns>
         [Pure]
-        BigInteger GetBalance(Address address, Currency currency);
+        FungibleAssetValue GetBalance(Address address, Currency currency);
 
         /// <summary>
-        /// Mints the <paramref name="amount"/> of a new <paramref name="currency"/>, fungible asset
-        /// (i.e., in-game monetary), and give it to the <paramref name="recipient"/>.
+        /// Mints the fungible asset <paramref name="value"/> (i.e., in-game monetary),
+        /// and give it to the <paramref name="recipient"/>.
         /// </summary>
         /// <param name="recipient">The address who receives the minted asset.</param>
-        /// <param name="currency">The currency type to mint.</param>
-        /// <param name="amount">The amount of the <paramref name="currency"/> to mint.</param>
-        /// <returns>A new <see cref="IAccountStateDelta"/> instance that
-        /// the given <paramref name="amount"/> of the <paramref name="currency"/> is added to
-        /// <paramref name="recipient"/>'s balance.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amount"/>
+        /// <param name="value">The asset value to mint.</param>
+        /// <returns>A new <see cref="IAccountStateDelta"/> instance that the given <paramref
+        /// name="value"/> is added to <paramref name="recipient"/>'s balance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/>
         /// is less than or equal to 0.</exception>
         /// <exception cref="CurrencyPermissionException">Thrown when a transaction signer
-        /// (or a miner in case of block actions) is not a member of <paramref name="currency"/>'s
-        /// <see cref="Currency.Minters"/>.</exception>
+        /// (or a miner in case of block actions) is not a member of the <see
+        /// cref="FungibleAssetValue.Currency"/>'s <see cref="Currency.Minters"/>.</exception>
         [Pure]
-        IAccountStateDelta MintAsset(Address recipient, Currency currency, BigInteger amount);
+        IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value);
 
         /// <summary>
-        /// Transfers the <paramref name="amount"/> of a new <paramref name="currency"/>,
-        /// fungible asset (i.e., in-game monetary), from the <paramref name="sender"/>
-        /// to the <paramref name="recipient"/>.
+        /// Transfers the fungible asset <paramref name="value"/> (i.e., in-game monetary)
+        /// from the <paramref name="sender"/> to the <paramref name="recipient"/>.
         /// </summary>
         /// <param name="sender">The address who sends the fungible asset to
         /// the <paramref name="recipient"/>.</param>
         /// <param name="recipient">The address who receives the fungible asset from
         /// the <paramref name="sender"/>.</param>
-        /// <param name="currency">The currency type to transfer.</param>
-        /// <param name="amount">The amount of the <paramref name="currency"/> to transfer.</param>
+        /// <param name="value">The asset value to transfer.</param>
         /// <param name="allowNegativeBalance">Turn on to allow <paramref name="sender"/>'s balance
-        /// less than zero of the <paramref name="currency"/>.  Turned off by default.</param>
-        /// <returns>A new <see cref="IAccountStateDelta"/> instance that
-        /// the given <paramref name="amount"/> of the <paramref name="currency"/> is subtracted
-        /// from <paramref name="sender"/>'s balance and added to <paramref name="recipient"/>'s
-        /// balance.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amount"/>
-        /// is less than or equal to 0.</exception>
+        /// less than zero.  Turned off by default.</param>
+        /// <returns>A new <see cref="IAccountStateDelta"/> instance that the given <paramref
+        /// name="value"/>  is subtracted from <paramref name="sender"/>'s balance and added to
+        /// <paramref name="recipient"/>'s balance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/>
+        /// is less than or equal to zero.</exception>
         /// <exception cref="InsufficientBalanceException">Thrown when the <paramref name="sender"/>
-        /// has insufficient balance than <paramref name="amount"/> to transfer and
+        /// has insufficient balance than <paramref name="value"/> to transfer and
         /// the <paramref name="allowNegativeBalance"/> option is turned off.</exception>
         [Pure]
         IAccountStateDelta TransferAsset(
             Address sender,
             Address recipient,
-            Currency currency,
-            BigInteger amount,
+            FungibleAssetValue value,
             bool allowNegativeBalance = false
         );
 
         /// <summary>
-        /// Burns the <paramref name="amount"/> of the <paramref name="currency"/>, fungible asset
-        /// (i.e., in-game monetary), from <paramref name="owner"/>'s balance.
+        /// Burns the fungible asset <paramref name="value"/> (i.e., in-game monetary) from
+        /// <paramref name="owner"/>'s balance.
         /// </summary>
         /// <param name="owner">The address who owns the fungible asset to burn.</param>
-        /// <param name="currency">The currency type to burn.</param>
-        /// <param name="amount">The amount of the <paramref name="currency"/> to burn.</param>
-        /// <returns>A new <see cref="IAccountStateDelta"/> instance that
-        /// the given <paramref name="amount"/> of the <paramref name="currency"/> is subtracted
-        /// from <paramref name="owner"/>'s balance.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amount"/>
-        /// is less than or equal to 0.</exception>
+        /// <param name="value">The fungible asset <paramref name="value"/> to burn.</param>
+        /// <returns>A new <see cref="IAccountStateDelta"/> instance that the given <paramref
+        /// name="value"/> is subtracted from <paramref name="owner"/>'s balance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/>
+        /// is less than or equal to zero.</exception>
         /// <exception cref="CurrencyPermissionException">Thrown when a transaction signer
-        /// (or a miner in case of block actions) is not a member of <paramref name="currency"/>'s
-        /// <see cref="Currency.Minters"/>.</exception>
+        /// (or a miner in case of block actions) is not a member of the <see
+        /// cref="FungibleAssetValue.Currency"/>'s <see cref="Currency.Minters"/>.</exception>
         /// <exception cref="InsufficientBalanceException">Thrown when the <paramref name="owner"/>
-        /// has insufficient balance than <paramref name="amount"/> to burn.</exception>
+        /// has insufficient balance than <paramref name="value"/> to burn.</exception>
         [Pure]
-        IAccountStateDelta BurnAsset(Address owner, Currency currency, BigInteger amount);
+        IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value);
     }
 }

--- a/Libplanet/Action/InsufficientBalanceException.cs
+++ b/Libplanet/Action/InsufficientBalanceException.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Numerics;
 using System.Runtime.Serialization;
 using Libplanet.Assets;
 using Libplanet.Serialization;
@@ -21,21 +20,17 @@ namespace Libplanet.Action
         /// </summary>
         /// <param name="address">The owner of the insufficient <paramref name="balance"/>.
         /// Corresponds to the <see cref="Address"/> property.</param>
-        /// <param name="currency">The <see cref="Assets.Currency"/> of the insufficient
-        /// <paramref name="balance"/>.  Corresponds to the <see cref="Currency"/> property.</param>
-        /// <param name="balance">The account's current balance of the <paramref name="currency"/>.
+        /// <param name="balance">The account's current balance.
         /// Corresponds to the <see cref="Balance"/> property.</param>
         /// <param name="message">Specifies a <see cref="Exception.Message"/>.</param>
         public InsufficientBalanceException(
             Address address,
-            Currency currency,
-            BigInteger balance,
+            FungibleAssetValue balance,
             string? message
         )
             : base(message)
         {
             Address = address;
-            Currency = currency;
             Balance = balance;
         }
 
@@ -43,8 +38,7 @@ namespace Libplanet.Action
             : base(info, context)
         {
             Address = info.GetValue<Address>(nameof(Address));
-            Balance = info.GetValue<BigInteger>(nameof(Balance));
-            Currency = info.GetValue<Currency>(nameof(Currency));
+            Balance = info.GetValue<FungibleAssetValue>(nameof(Balance));
         }
 
         /// <summary>
@@ -53,14 +47,9 @@ namespace Libplanet.Action
         public Address Address { get; }
 
         /// <summary>
-        /// The <see cref="Assets.Currency"/> of the insufficient <see cref="Balance"/>.
+        /// The account's current balance.
         /// </summary>
-        public Currency Currency { get; }
-
-        /// <summary>
-        /// The account's current balance of the <see cref="Currency"/>.
-        /// </summary>
-        public BigInteger Balance { get; }
+        public FungibleAssetValue Balance { get; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -68,7 +57,6 @@ namespace Libplanet.Action
 
             info.AddValue(nameof(Address), Address);
             info.AddValue(nameof(Balance), Balance);
-            info.AddValue(nameof(Currency), Currency);
         }
     }
 }

--- a/Libplanet/Action/InsufficientBalanceException.cs
+++ b/Libplanet/Action/InsufficientBalanceException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Numerics;
 using System.Runtime.Serialization;
+using Libplanet.Assets;
 using Libplanet.Serialization;
 
 namespace Libplanet.Action
@@ -20,7 +21,7 @@ namespace Libplanet.Action
         /// </summary>
         /// <param name="address">The owner of the insufficient <paramref name="balance"/>.
         /// Corresponds to the <see cref="Address"/> property.</param>
-        /// <param name="currency">The <see cref="Libplanet.Currency"/> of the insufficient
+        /// <param name="currency">The <see cref="Assets.Currency"/> of the insufficient
         /// <paramref name="balance"/>.  Corresponds to the <see cref="Currency"/> property.</param>
         /// <param name="balance">The account's current balance of the <paramref name="currency"/>.
         /// Corresponds to the <see cref="Balance"/> property.</param>
@@ -52,7 +53,7 @@ namespace Libplanet.Action
         public Address Address { get; }
 
         /// <summary>
-        /// The <see cref="Libplanet.Currency"/> of the insufficient <see cref="Balance"/>.
+        /// The <see cref="Assets.Currency"/> of the insufficient <see cref="Balance"/>.
         /// </summary>
         public Currency Currency { get; }
 

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -12,7 +12,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Serialization;
 
-namespace Libplanet
+namespace Libplanet.Assets
 {
     /// <summary>
     /// Represents a currency type.  Every single value of <see cref="Currency"/> defines
@@ -21,7 +21,7 @@ namespace Libplanet
     /// EUR (Euro), <em>not values</em> like $100 or €100.
     /// </summary>
     [Serializable]
-    public readonly struct Currency : ISerializable, IEquatable<Currency>
+    public readonly struct Currency : IEquatable<Currency>, ISerializable
     {
         /// <summary>
         /// The ticker symbol, e.g., <c>&quot;USD&quot;</c>.
@@ -110,7 +110,7 @@ namespace Libplanet
         [Pure]
         public bool AllowsToMint(Address address) => Minters is null || Minters.Contains(address);
 
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue(nameof(Ticker), Ticker);
 

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -20,6 +20,7 @@ namespace Libplanet.Assets
     /// each <see cref="Currency"/> value represents such currencies as USD (US Dollar) or
     /// EUR (Euro), <em>not values</em> like $100 or €100.
     /// </summary>
+    /// <seealso cref="FungibleAssetValue"/>
     [Serializable]
     public readonly struct Currency : IEquatable<Currency>, ISerializable
     {

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Bencodex;
@@ -25,6 +26,9 @@ namespace Libplanet.Assets
     /// <code>
     /// var USMint = new PrivateKey();
     /// var USD = new Currency(ticker: "USD", decimalPlace: 2, minter: USMint.ToAddress());
+    /// var twentyThreeBucks = 23 * USD;
+    /// // Or alternatively: USD * 23;
+    /// // Or explicitly: new FungibleAssetValue(USD, 23, 0)
     /// </code>
     /// </example>
     /// <seealso cref="FungibleAssetValue"/>
@@ -123,6 +127,38 @@ namespace Libplanet.Assets
 
             Hash = GetHash();
         }
+
+        /// <summary>
+        /// Gets a fungible asset value with the given <paramref name="quantity"/> of the
+        /// specified <paramref name="currency"/>.
+        /// </summary>
+        /// <param name="currency">The currency to get a value.</param>
+        /// <param name="quantity">The major unit of the fungible asset value,
+        /// i.e., digits <em>before</em> the decimal separator.</param>
+        /// <returns>A fungible asset value with the given <paramref name="quantity"/> of the
+        /// specified <paramref name="currency"/>.</returns>
+        /// <remarks>This cannot specify <see cref="FungibleAssetValue.MinorUnit"/> but only
+        /// <see cref="FungibleAssetValue.MajorUnit"/>.  For more precision, directly use <see
+        /// cref="FungibleAssetValue"/>'s constructors instead.</remarks>
+        [Pure]
+        public static FungibleAssetValue operator *(Currency currency, BigInteger quantity) =>
+            new FungibleAssetValue(currency, majorUnit: quantity, minorUnit: 0);
+
+        /// <summary>
+        /// Gets a fungible asset value with the given <paramref name="quantity"/> of the
+        /// specified <paramref name="currency"/>.
+        /// </summary>
+        /// <param name="quantity">The major unit of the fungible asset value,
+        /// i.e., digits <em>before</em> the decimal separator.</param>
+        /// <param name="currency">The currency to get a value.</param>
+        /// <returns>A fungible asset value with the given <paramref name="quantity"/> of the
+        /// specified <paramref name="currency"/>.</returns>
+        /// <remarks>This cannot specify <see cref="FungibleAssetValue.MinorUnit"/> but only
+        /// <see cref="FungibleAssetValue.MajorUnit"/>.  For more precision, directly use <see
+        /// cref="FungibleAssetValue"/>'s constructors instead.</remarks>
+        [Pure]
+        public static FungibleAssetValue operator *(BigInteger quantity, Currency currency) =>
+            new FungibleAssetValue(currency, majorUnit: quantity, minorUnit: 0);
 
         /// <summary>
         /// Returns <c>true</c> if and only if the given <paramref name="address"/> is allowed

--- a/Libplanet/Assets/FungibleAssetValue.cs
+++ b/Libplanet/Assets/FungibleAssetValue.cs
@@ -1,0 +1,376 @@
+#nullable enable
+using System;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.Serialization;
+using Libplanet.Serialization;
+
+namespace Libplanet.Assets
+{
+    /// <summary>
+    /// Holds a fungible asset value which holds its <see cref="Currency"/> together.
+    /// <para>It behaves like numbers except for division operator (<c>/</c>) to prevent to forget
+    /// to handle its remainder; use <see cref="DivRem(FungibleAssetValue)"/> and <see
+    /// cref="DivRem(BigInteger)"/> methods instead.</para>
+    /// </summary>
+    [Serializable]
+    public readonly struct FungibleAssetValue :
+        IEquatable<FungibleAssetValue>,
+        IComparable<FungibleAssetValue>,
+        IComparable,
+        ISerializable
+    {
+        /// <summary>
+        /// The currency of the fungible asset.
+        /// </summary>
+        public readonly Currency Currency;
+
+        internal readonly BigInteger Quantity;
+
+        /// <summary>
+        /// Creates a zero value of the <paramref name="currency"/>.
+        /// </summary>
+        /// <param name="currency">The currency to create a zero value.</param>
+        public FungibleAssetValue(Currency currency)
+            : this(currency, BigInteger.Zero)
+        {
+        }
+
+        /// <summary>
+        /// Creates a value of the <paramref name="currency"/> with the specified <paramref
+        /// name="quantity"/>.
+        /// </summary>
+        /// <param name="currency">The currency to create a value.</param>
+        /// <param name="quantity">The quantity of the value to create.</param>
+        internal FungibleAssetValue(Currency currency, BigInteger quantity)
+        {
+            Currency = currency;
+            Quantity = quantity;
+        }
+
+        /// <summary>
+        /// Deserializes a fungible asset value.
+        /// </summary>
+        /// <param name="info">A serialization information.</param>
+        /// <param name="context">A streaming context.</param>
+        private FungibleAssetValue(SerializationInfo info, StreamingContext context)
+            : this(
+                info.GetValue<Currency>(nameof(Currency)),
+                info.GetValue<BigInteger>(nameof(Quantity))
+            )
+        {
+        }
+
+        /// <summary>
+        /// Tests if two values are equal.
+        /// </summary>
+        /// <param name="obj">A value.</param>
+        /// <param name="other">Another value.</param>
+        /// <returns><c>true</c> if two values are equal.  Otherwise <c>false</c>.</returns>
+        [Pure]
+        public static bool operator ==(FungibleAssetValue obj, FungibleAssetValue other) =>
+            obj.Equals(other);
+
+        /// <summary>
+        /// Tests if two values are unequal.
+        /// </summary>
+        /// <param name="obj">A value.</param>
+        /// <param name="other">Another value.</param>
+        /// <returns><c>false</c> if two values are equal.  Otherwise <c>true</c>.</returns>
+        [Pure]
+        public static bool operator !=(FungibleAssetValue obj, FungibleAssetValue other) =>
+            !(obj == other);
+
+        /// <summary>
+        /// Tests if the left operand (<paramref name="obj"/>) is less than the right operand
+        /// (<paramref name="other"/>).
+        /// </summary>
+        /// <param name="obj">The left operand to compare.</param>
+        /// <param name="other">The right operand to compare.</param>
+        /// <returns><c>true</c> if the left operand (<paramref name="obj"/>) is less than the right
+        /// operand (<paramref name="other"/>).  Otherwise (even if two operands are equal)
+        /// <c>false</c>.</returns>
+        [Pure]
+        public static bool operator <(FungibleAssetValue obj, FungibleAssetValue other) =>
+            obj.CompareTo(other) < 0;
+
+        /// <summary>
+        /// Tests if the left operand (<paramref name="obj"/>) is less than or equal to the right
+        /// operand (<paramref name="other"/>).
+        /// </summary>
+        /// <param name="obj">The left operand to compare.</param>
+        /// <param name="other">The right operand to compare.</param>
+        /// <returns><c>true</c> if the left operand (<paramref name="obj"/>) is less than or equal
+        /// to the right operand (<paramref name="other"/>).  Otherwise <c>false</c>.</returns>
+        [Pure]
+        public static bool operator <=(FungibleAssetValue obj, FungibleAssetValue other) =>
+            obj.CompareTo(other) <= 0;
+
+        /// <summary>
+        /// Tests if the left operand (<paramref name="obj"/>) is greater than the right operand
+        /// (<paramref name="other"/>).
+        /// </summary>
+        /// <param name="obj">The left operand to compare.</param>
+        /// <param name="other">The right operand to compare.</param>
+        /// <returns><c>true</c> if the left operand (<paramref name="obj"/>) is greater than
+        /// the right operand (<paramref name="other"/>).  Otherwise (even if two operands are
+        /// equal) <c>false</c>.</returns>
+        [Pure]
+        public static bool operator >(FungibleAssetValue obj, FungibleAssetValue other) =>
+            other < obj;
+
+        /// <summary>
+        /// Tests if the left operand (<paramref name="obj"/>) is greater than or equal to the right
+        /// operand (<paramref name="other"/>).
+        /// </summary>
+        /// <param name="obj">The left operand to compare.</param>
+        /// <param name="other">The right operand to compare.</param>
+        /// <returns><c>true</c> if the left operand (<paramref name="obj"/>) is greater than or
+        /// equal to the right operand (<paramref name="other"/>). Otherwise <c>false</c>.</returns>
+        [Pure]
+        public static bool operator >=(FungibleAssetValue obj, FungibleAssetValue other) =>
+            other <= obj;
+
+        /// <summary>
+        /// Negates a <paramref name="value"/>.
+        /// <para>Adds a negative sign to the <paramref name="value"/> if it's positive.
+        /// Removes a negative sign from the <paramref name="value"/> if it's already negative.
+        /// Does nothing if the <paramref name="value"/> is zero.</para>
+        /// </summary>
+        /// <param name="value">A value to negate.</param>
+        /// <returns>A negated <paramref name="value"/>.</returns>
+        [Pure]
+        public static FungibleAssetValue operator -(FungibleAssetValue value) =>
+            new FungibleAssetValue(value.Currency, -value.Quantity);
+
+        /// <summary>
+        /// Adds two values and returns the result.
+        /// </summary>
+        /// <param name="left">The first value to add.</param>
+        /// <param name="right">The second value to add.</param>
+        /// <returns>The sum of <paramref name="left"/> and <paramref name="right"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when two values do not have the same
+        /// <see cref="Currency"/>.</exception>
+        [Pure]
+        public static FungibleAssetValue operator +(
+            FungibleAssetValue left,
+            FungibleAssetValue right
+        ) => left.Currency.Equals(right.Currency)
+            ? new FungibleAssetValue(left.Currency, left.Quantity + right.Quantity)
+            : throw new ArgumentException(
+                "Unable to add heterogeneous currencies: " +
+                $"{left.Currency} \u2260 {right.Currency}.",
+                nameof(right));
+
+        /// <summary>
+        /// Subtracts the <paramref name="right"/> value from the <paramref name="left"/> value.
+        /// </summary>
+        /// <param name="left">The value to subtract from (the minuend).</param>
+        /// <param name="right">The value to subtract (the subtrahend).</param>
+        /// <returns>The result of subtracting <paramref name="right"/> from
+        /// <paramref name="left"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when two values do not have the same
+        /// <see cref="Currency"/>.</exception>
+        [Pure]
+        public static FungibleAssetValue operator -(
+            FungibleAssetValue left,
+            FungibleAssetValue right
+        ) => left.Currency.Equals(right.Currency)
+            ? new FungibleAssetValue(left.Currency, left.Quantity - right.Quantity)
+            : throw new ArgumentException(
+                "Unable to subtract heterogeneous currencies: " +
+                $"{left.Currency} \u2260 {right.Currency}.",
+                nameof(right));
+
+        /// <summary>
+        /// Multiplies <paramref name="right"/> times the <paramref name="left"/> value.
+        /// </summary>
+        /// <param name="left">The value to multiply.</param>
+        /// <param name="right">The times to multiply.</param>
+        /// <returns>The multiplied value.</returns>
+        [Pure]
+        public static FungibleAssetValue operator *(FungibleAssetValue left, BigInteger right) =>
+            new FungibleAssetValue(left.Currency, left.Quantity * right);
+
+        /// <summary>
+        /// Multiplies <paramref name="left"/> times the <paramref name="right"/> value.
+        /// </summary>
+        /// <param name="left">The times to multiply.</param>
+        /// <param name="right">The value to multiply.</param>
+        /// <returns>The multiplied value.</returns>
+        [Pure]
+        public static FungibleAssetValue operator *(BigInteger left, FungibleAssetValue right) =>
+            new FungibleAssetValue(right.Currency, left * right.Quantity);
+
+        /// <summary>
+        /// Divides the value (<paramref name="dividend"/>) by <paramref name="divisor"/>,
+        /// and returns the remainder.
+        /// </summary>
+        /// <param name="dividend">The value to be divided.</param>
+        /// <param name="divisor">The number to divide by.</param>
+        /// <returns>The remainder after dividing <paramref name="dividend"/>
+        /// by <paramref name="divisor"/>.</returns>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// <c>0</c> (zero).</exception>
+        [Pure]
+        public static FungibleAssetValue operator %(FungibleAssetValue dividend, BigInteger divisor)
+            => new FungibleAssetValue(dividend.Currency, dividend.Quantity % divisor);
+
+        /// <summary>
+        /// Divides the value (<paramref name="dividend"/>) by <paramref name="divisor"/>,
+        /// and returns the remainder.
+        /// </summary>
+        /// <param name="dividend">The value to be divided.</param>
+        /// <param name="divisor">The value to divide by.</param>
+        /// <returns>The remainder after dividing <paramref name="dividend"/>
+        /// by <paramref name="divisor"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when two values do not have the same
+        /// <see cref="Currency"/>.</exception>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// zero.</exception>
+        [Pure]
+        public static FungibleAssetValue operator %(
+            FungibleAssetValue dividend,
+            FungibleAssetValue divisor)
+        {
+            if (!dividend.Currency.Equals(divisor.Currency))
+            {
+                throw new ArgumentException(
+                    "Cannot be divided by a heterogeneous currency: " +
+                    $"{dividend.Currency} \u2260 {divisor.Currency}."
+                );
+            }
+
+            return new FungibleAssetValue(dividend.Currency, dividend.Quantity % divisor.Quantity);
+        }
+
+        /// <summary>
+        /// Divides the value by <paramref name="divisor"/>, returns the quotient, and returns
+        /// the <paramref name="remainder"/> in an output parameter.
+        /// </summary>
+        /// <param name="divisor">The number to divide by.</param>
+        /// <param name="remainder">When this method returns (without any exception), the remainder
+        /// after dividing the value by <paramref name="divisor"/>.  This parameter is passed
+        /// uninitialized.</param>
+        /// <returns>The quotient of the division.</returns>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// <c>0</c> (zero).</exception>
+        [Pure]
+        public FungibleAssetValue DivRem(BigInteger divisor, out FungibleAssetValue remainder)
+        {
+            BigInteger q = BigInteger.DivRem(Quantity, divisor, out BigInteger rem);
+            remainder = new FungibleAssetValue(Currency, rem);
+            return new FungibleAssetValue(Currency, q);
+        }
+
+        /// <summary>
+        /// Divides the value by <paramref name="divisor"/>, returns the quotient, and returns
+        /// the <paramref name="remainder"/> in an output parameter.
+        /// </summary>
+        /// <param name="divisor">The value to divide by.</param>
+        /// <param name="remainder">When this method returns (without any exception), the remainder
+        /// after dividing the value by <paramref name="divisor"/>.  This parameter is passed
+        /// uninitialized.</param>
+        /// <returns>The quotient of the division.</returns>
+        /// <exception cref="ArgumentException">Thrown when two values do not have the same
+        /// <see cref="Currency"/>.</exception>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// zero.</exception>
+        [Pure]
+        public BigInteger DivRem(FungibleAssetValue divisor, out FungibleAssetValue remainder)
+        {
+            if (!Currency.Equals(divisor.Currency))
+            {
+                throw new ArgumentException(
+                    "Cannot be divided by a heterogeneous currency: " +
+                    $"{Currency} \u2260 {divisor.Currency}."
+                );
+            }
+
+            BigInteger d = BigInteger.DivRem(Quantity, divisor.Quantity, out BigInteger rem);
+            remainder = new FungibleAssetValue(Currency, rem);
+            return d;
+        }
+
+        /// <summary>
+        /// Divides the value by <paramref name="divisor"/>, and returns a pair of the quotient
+        /// and the remainder.
+        /// </summary>
+        /// <param name="divisor">The number to divide by.</param>
+        /// <returns>A tuple of the <c>Quotient</c> and <c>Remainder</c> of the division.</returns>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// <c>0</c> (zero).</exception>
+        [Pure]
+        public (FungibleAssetValue Quotient, FungibleAssetValue Remainder)
+        DivRem(BigInteger divisor) =>
+            (DivRem(divisor, out FungibleAssetValue remainder), remainder);
+
+        /// <summary>
+        /// Divides the value by <paramref name="divisor"/>, and returns a pair of the quotient
+        /// and the remainder.
+        /// </summary>
+        /// <param name="divisor">The value to divide by.</param>
+        /// <returns>A tuple of the <c>Quotient</c> and <c>Remainder</c> of the division.</returns>
+        /// <exception cref="ArgumentException">Thrown when two values do not have the same
+        /// <see cref="Currency"/>.</exception>
+        /// <exception cref="DivideByZeroException">Thrown when the <paramref name="divisor"/> is
+        /// zero.</exception>
+        [Pure]
+        public (BigInteger Quotient, FungibleAssetValue Remainder)
+        DivRem(FungibleAssetValue divisor) =>
+            (DivRem(divisor, out FungibleAssetValue remainder), remainder);
+
+        /// <summary>
+        /// Gets the absolute value.
+        /// <para>Removes the negative sign if it's negative.  Otherwise does nothing.</para>
+        /// </summary>
+        /// <returns>Its absolute value.</returns>
+        [Pure]
+        public FungibleAssetValue Abs()
+            => new FungibleAssetValue(Currency, BigInteger.Abs(Quantity));
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        [Pure]
+        public bool Equals(FungibleAssetValue other) =>
+            Currency.Equals(other.Currency) && Quantity.Equals(other.Quantity);
+
+        /// <inheritdoc cref="object.Equals(object)"/>
+        [Pure]
+        public override bool Equals(object? obj) =>
+            obj is FungibleAssetValue other && Equals(other);
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        [Pure]
+        public override int GetHashCode() =>
+            unchecked((Currency.GetHashCode() * 397) ^ Quantity.GetHashCode());
+
+        /// <inheritdoc cref="IComparable.CompareTo(object)"/>
+        [Pure]
+        public int CompareTo(object? obj) => obj is FungibleAssetValue o
+            ? CompareTo(o)
+            : throw new ArgumentException(
+                $"Unable to compare with other than {nameof(FungibleAssetValue)}",
+                nameof(obj));
+
+        /// <inheritdoc cref="IComparable{T}.CompareTo(T)"/>
+        [Pure]
+        public int CompareTo(FungibleAssetValue other) => Currency.Equals(other.Currency)
+            ? Quantity.CompareTo(other.Quantity)
+            : throw new ArgumentException(
+                $"Unable to compare heterogeneous currencies: {Currency} \u2260 {other.Currency}.",
+                nameof(other));
+
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Currency), Currency);
+            info.AddValue(nameof(Quantity), Quantity);
+        }
+
+        /// <inheritdoc cref="object.ToString()"/>
+        [Pure]
+        public override string ToString() =>
+            $"{Quantity.ToString(CultureInfo.InvariantCulture)} {Currency.Ticker}";
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1535,9 +1535,7 @@ namespace Libplanet.Blockchain
                             new KeyValuePair<string, IValue>(
                                 ToFungibleAssetKey(pair),
                                 new Bencodex.Types.Integer(
-                                    lastStates is null
-                                        ? 0
-                                        : lastStates.GetBalance(pair.Item1, pair.Item2).Quantity
+                                    lastStates?.GetBalance(pair.Item1, pair.Item2).RawValue ?? 0
                                 )
                             )
                         )

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;

--- a/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Assets;
 
 namespace Libplanet.Blockchain
 {

--- a/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -16,9 +15,10 @@ namespace Libplanet.Blockchain
     /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
     /// <param name="address">The account to query its balance.</param>
     /// <param name="currency">The currency to query.</param>
-    /// <returns>A complement balance value.</returns>
+    /// <returns>A complement balance value.  <em>Its <see cref="FungibleAssetValue.Currency"/>
+    /// must match to the given <paramref name="currency"/>.</em></returns>
     /// <seealso cref="FungibleAssetStateCompleters{T}"/>
-    public delegate BigInteger FungibleAssetStateCompleter<T>(
+    public delegate FungibleAssetValue FungibleAssetStateCompleter<T>(
         BlockChain<T> blockChain,
         HashDigest<SHA256> blockHash,
         Address address,

--- a/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Blockchain
             (blockChain, hash) =>
             {
                 FungibleAssetValue balance = stateCompleter(blockChain, hash, address, currency);
-                return (Bencodex.Types.Integer)balance.Quantity;
+                return (Bencodex.Types.Integer)balance.RawValue;
             };
     }
 }

--- a/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 
 namespace Libplanet.Blockchain
 {

--- a/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
@@ -41,6 +41,9 @@ namespace Libplanet.Blockchain
             Currency currency
         ) =>
             (blockChain, hash) =>
-                (Bencodex.Types.Integer)stateCompleter(blockChain, hash, address, currency);
+            {
+                FungibleAssetValue balance = stateCompleter(blockChain, hash, address, currency);
+                return (Bencodex.Types.Integer)balance.Quantity;
+            };
     }
 }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Tx;
 
@@ -370,7 +371,7 @@ namespace Libplanet.Blocks
         )
         {
             accountStateGetter ??= a => null;
-            accountBalanceGetter ??= (a, c) => 0;
+            accountBalanceGetter ??= (a, c) => new FungibleAssetValue(c);
 
             IAccountStateDelta delta;
             foreach (Transaction<T> tx in Transactions)
@@ -454,7 +455,7 @@ namespace Libplanet.Blocks
         )
         {
             accountStateGetter ??= a => null;
-            accountBalanceGetter ??= (a, c) => 0;
+            accountBalanceGetter ??= (a, c) => new FungibleAssetValue(c);
 
             Validate(currentTime);
             Tuple<Transaction<T>, ActionEvaluation>[] txEvaluations =

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Crypto;
 
 namespace Libplanet.Tx
@@ -435,7 +436,11 @@ namespace Libplanet.Tx
                 ).EvaluateActions(
                     default(HashDigest<SHA256>),
                     0,
-                    new AccountStateDeltaImpl(_ => null, (_, __) => 0, signer),
+                    new AccountStateDeltaImpl(
+                        _ => null,
+                        (_, c) => new FungibleAssetValue(c),
+                        signer
+                    ),
                     signer,
                     rehearsal: true
                 );


### PR DESCRIPTION
This pull request adds `Currency.DecimalPlaces` property and `FungibleAssetValue` type to address the issue #944.

From this changes, fungible asset values are no more represented as `BigInteger`, which does not hold any decimal places, but `FungibleAssetValue` instead.  The introduced `FungibleAssetValue` type is essentially a pair of `(Currency, BigInteger)`.  It cannot mix heterogeneous currencies.  `FungibleAssetValue`s can be made like below:

```csharp
var gold = new Currency(ticker: "GOLD", decimalPlaces: 2, minter: null);
FungibleAssetValue value;

value = new FungibleAssetValue(gold, majorUnit: 123, minorUnit: 0);
// Or alternatively:
value = 123 * gold;
// Or:
value = gold * 123;
```

This patch also introduces a new property named `DecimalPlaces` to `Currency`.  This defines how precise can currency values be, like 2 decimal places for cents of US Dollar.  Continued from the above example, you can represent 123.45 GOLD like below:

```csharp
var v = new FungibleAssetValue(gold, 123, 45);
```

On the other hand, it does not allow more decimal places than it's specified in `DecimalPlaces`.  For example, the following code causes `ArgumentException`:

```csharp
new FungibleAssetValue(gold, 123, 456);
// ArgumentException: Since the currency GOLD (dfc2eebfd2bfb1fc31d921d665d9210b9ea8ebb3) allows upto 2 decimal places, the given minor unit 456 is too big.
```

`FungibleAssetValue` type mimics other integral types like `BigInteger`; it provides `+`, `-`, `*`, `%`, `.DivRem()`, `.Abs()`, `.Sign` and so on, except for division operator (`/`) which is bug-prone IMHO.  For the rationale, see also the XML comment on `FungibleAssetValue` struct.

In order to print the value, simply use `.ToString()` method or if you want only quantity without currency use `.GetQuantityString()` method.

Besides, this patch adds a new namespace `Libplanet.Assets` and `Currency` is also moved into that.