### PR TITLE
WIP: Add “write mode” to state completers

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1525,14 +1525,14 @@ namespace Libplanet.Tests.Blockchain
             IValue value = chain.GetState(
                 addresses[4],
                 chain.Tip.Hash,
-                (bc, bh, a) => throw new Exception("This exception should not be thrown.")
+                (bc, bh, a, _) => throw new Exception("This exception should not be thrown.")
             );
             Assert.Equal(new Text("9"), value);
 
             value = chain.GetState(
                 addresses[4],
                 chain.BlockHashes.Skip((int)chain.Count - 2).First(),
-                (bc, hash, addr) =>
+                (bc, hash, addr, _) =>
                     new Text($"{bc.Id}/{hash}/{addr}: callback called")
             );
             HashDigest<SHA256> prevUpdate = chain.BlockHashes.Skip(addresses.Length).First();

--- a/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Action;
@@ -15,13 +16,18 @@ namespace Libplanet.Blockchain
     /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
     /// <param name="address">The account to query its balance.</param>
     /// <param name="currency">The currency to query.</param>
+    /// <param name="enterWriteMode">An optional function to enter the <em>write mode</em> and
+    /// returns an <see cref="IDisposable"/> to exit it.  If the delegate tries to update
+    /// the <paramref name="blockChain"/> such operation has to be done in the <em>write mode</em>
+    /// in order to prevent race condition.</param>
     /// <returns>A complement balance value.</returns>
     /// <seealso cref="FungibleAssetStateCompleters{T}"/>
     public delegate BigInteger FungibleAssetStateCompleter<T>(
         BlockChain<T> blockChain,
         HashDigest<SHA256> blockHash,
         Address address,
-        Currency currency
+        Currency currency,
+        Func<IDisposable> enterWriteMode
     )
         where T : IAction, new();
 }

--- a/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
+++ b/Libplanet/Blockchain/FungibleAssetStateCompleters.cs
@@ -21,8 +21,8 @@ namespace Libplanet.Blockchain
         /// permanently remained in the store.
         /// </summary>
         public static readonly FungibleAssetStateCompleter<T> Recalculate =
-            (blockChain, blockHash, address, currency) =>
-                blockChain.ComplementBlockStates(blockHash).TryGetValue(
+            (blockChain, blockHash, address, currency, enterWriteMode) =>
+                blockChain.ComplementBlockStates(blockHash, enterWriteMode).TryGetValue(
                     BlockChain<T>.ToFungibleAssetKey(address, currency),
                     out IValue v
                 ) ? (BigInteger)(Bencodex.Types.Integer)v : 0;
@@ -32,15 +32,22 @@ namespace Libplanet.Blockchain
         /// an <see cref="IncompleteBlockStatesException"/>.
         /// </summary>
         public static readonly FungibleAssetStateCompleter<T> Reject =
-            (chain, blockHash, address, currency) =>
+            (chain, blockHash, address, currency, enterWriteMode) =>
                 throw new IncompleteBlockStatesException(blockHash);
 
-        internal static Func<BlockChain<T>, HashDigest<SHA256>, IValue> ToRawStateCompleter(
+        internal static Func<BlockChain<T>, HashDigest<SHA256>, Func<IDisposable>, IValue>
+        ToRawStateCompleter(
             FungibleAssetStateCompleter<T> stateCompleter,
             Address address,
             Currency currency
         ) =>
-            (blockChain, hash) =>
-                (Bencodex.Types.Integer)stateCompleter(blockChain, hash, address, currency);
+            (blockChain, hash, enterWriteMode) =>
+                (Bencodex.Types.Integer)stateCompleter(
+                    blockChain,
+                    hash,
+                    address,
+                    currency,
+                    enterWriteMode
+                );
     }
 }

--- a/Libplanet/Blockchain/StateCompleter.cs
+++ b/Libplanet/Blockchain/StateCompleter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -14,12 +15,17 @@ namespace Libplanet.Blockchain
     /// <param name="blockChain">The blockchain to query.</param>
     /// <param name="blockHash">The hash of a block to lacks its dirty states.</param>
     /// <param name="address">The address to query its state value.</param>
+    /// <param name="enterWriteMode">An optional function to enter the <em>write mode</em> and
+    /// returns an <see cref="IDisposable"/> to exit it.  If the delegate tries to update
+    /// the <paramref name="blockChain"/> such operation has to be done in the <em>write mode</em>
+    /// in order to prevent race condition.</param>
     /// <returns>A complement state.  This can be <c>null</c>.</returns>
     /// <seealso cref="StateCompleters{T}"/>
     public delegate IValue StateCompleter<T>(
         BlockChain<T> blockChain,
         HashDigest<SHA256> blockHash,
-        Address address
+        Address address,
+        Func<IDisposable> enterWriteMode
     )
         where T : IAction, new();
 }

--- a/Libplanet/Blockchain/StateCompleters.cs
+++ b/Libplanet/Blockchain/StateCompleters.cs
@@ -18,23 +18,26 @@ namespace Libplanet.Blockchain
         /// Incomplete states are filled with the recalculated states and the states are
         /// permanently remained in the store.
         /// </summary>
-        public static readonly StateCompleter<T> Recalculate = (blockChain, blockHash, address) =>
-            blockChain.ComplementBlockStates(blockHash).TryGetValue(
-                BlockChain<T>.ToStateKey(address),
-                out IValue v
-            ) ? v : null;
+        public static readonly StateCompleter<T> Recalculate =
+            (blockChain, blockHash, address, enterWriteMode) =>
+                blockChain.ComplementBlockStates(blockHash, enterWriteMode).TryGetValue(
+                    BlockChain<T>.ToStateKey(address),
+                    out IValue v
+                ) ? v : null;
 
         /// <summary>
         /// Rejects to complement incomplete state and throws
         /// an <see cref="IncompleteBlockStatesException"/>.
         /// </summary>
-        public static readonly StateCompleter<T> Reject = (chain, blockHash, address) =>
+        public static readonly StateCompleter<T> Reject = (chain, blockHash, address, _) =>
             throw new IncompleteBlockStatesException(blockHash);
 
-        internal static Func<BlockChain<T>, HashDigest<SHA256>, IValue> ToRawStateCompleter(
+        internal static Func<BlockChain<T>, HashDigest<SHA256>, Func<IDisposable>, IValue>
+        ToRawStateCompleter(
             StateCompleter<T> stateCompleter,
             Address address
         ) =>
-            (blockChain, hash) => stateCompleter(blockChain, hash, address);
+            (blockChain, hash, enterWriteMode) =>
+                stateCompleter(blockChain, hash, address, enterWriteMode);
     }
 }


### PR DESCRIPTION
Continued from the pull request #946.  This addresses the problem @longfin mentioned in the previous pull request: <https://github.com/planetarium/libplanet/pull/946#discussion_r469104685>.