### PR TITLE
Fix the outdated branch name in the docs build script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ on GitHub consists of several projects:
 [Libplanet.RocksDBStore]: https://www.nuget.org/packages/Libplanet.RocksDBStore/
 
 
-Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=master)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][2]
+Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][2]
 -----
 
 We write as complete tests as possible to the corresponding implementation code.
@@ -125,7 +125,7 @@ To build and run unit tests at a time execute the below command:
 
     dotnet test
 
-[Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build/latest?definitionId=1&branchName=master
+[Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622
 [3]: https://codecov.io/gh/planetarium/libplanet
 [Xunit]: https://xunit.github.io/
 

--- a/Docs/publish.sh
+++ b/Docs/publish.sh
@@ -41,10 +41,10 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
   pr_number="$(jq '.pull_request.number' "$GITHUB_EVENT_PATH")"
   slug="pulls/$pr_number"
 else
-  if [ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ] && \
-     [ "$GITHUB_REF" = "${GITHUB_REF#refs/tags/}" ] &&
-     [ "$GITHUB_REF" != refs/heads/master ] && \
-     [ "$GITHUB_REF" = "${GITHUB_REF#refs/heads/maintenance-}" ]; then
+  if [[ "$GITHUB_REPOSITORY" = "planetarium/libplanet" ]] && \
+     [[ "$GITHUB_REF" != refs/tags/* ]] &&
+     [[ "$GITHUB_REF" != refs/heads/main ]] && \
+     [[ "$GITHUB_REF" != refs/heads/maintenance-* ]]; then
     echo "This branch is not for releases, so docs won't be published." >&2
     exit 0
   fi

--- a/Libplanet.Tools/package.json
+++ b/Libplanet.Tools/package.json
@@ -44,5 +44,5 @@
   "bugs": {
     "url": "https://github.com/planetarium/libplanet/labels/tools"
   },
-  "homepage": "https://github.com/planetarium/libplanet/tree/master/Libplanet.Tools"
+  "homepage": "https://github.com/planetarium/libplanet/tree/main/Libplanet.Tools"
 }

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -26,7 +26,7 @@ https://docs.libplanet.io/</Description>
     <Company>Planetarium</Company>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/master/CHANGES.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>
     <RepositoryUrl>git://github.com/planetarium/libplanet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Libplanet
 =========
 
 [![Discord](https://img.shields.io/discord/539405872346955788.svg?color=7289da&logo=discord&logoColor=white)][Discord]
-[![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=master)][Azure Pipelines]
-[![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/master/graph/badge.svg)][Codecov]
+[![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines]
+[![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][Codecov]
 [![NuGet](https://img.shields.io/nuget/v/Libplanet.svg?style=flat)][NuGet]
 [![NuGet (prerelease)](https://img.shields.io/nuget/vpre/Libplanet.svg?style=flat)][NuGet]
 
@@ -31,7 +31,7 @@ To learn more about why Planetarium is creating technology for fully
 decentralized games, please refer to our [blog post].
 
 [Discord]: https://discord.gg/planetarium
-[Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build/latest?definitionId=1&branchName=master
+[Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622
 [Codecov]: https://codecov.io/gh/planetarium/libplanet
 [NuGet]: https://www.nuget.org/packages/Libplanet/
 [digital signature]: https://en.wikipedia.org/wiki/Digital_signature


### PR DESCRIPTION
Because of this, <https://docs.libplanet.io/main/> hadn't updated for several days.