### PR TITLE
Add Swarm<T>.LastMessageTimestamp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,7 @@ To be released.
  -  Added `SwarmOptions` class.  [[#926]]
  -  Added `PeerChainState` struct.  [[#936]]
  -  Added `Swarm<T>.GetPeerChainStateAsync()` method.  [[#936]]
+ -  Added `Swarm<T>.LastMessageTimestamp` property.  [[#964]]
  -  Added `Block<T>.EvaluationDigest` property.  [[#931], [#935]]
  -  Added `BlockHeader.EvaluationDigest` property.  [[#931], [#935]]
  -  Added `Block<T>.PreEvaluationHash` property.  [[#931], [#935]]
@@ -285,6 +286,7 @@ To be released.
 [#959]: https://github.com/planetarium/libplanet/issues/959
 [#954]: https://github.com/planetarium/libplanet/pull/954
 [#963]: https://github.com/planetarium/libplanet/pull/963
+[#964]: https://github.com/planetarium/libplanet/pull/964
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -241,7 +241,7 @@ namespace Libplanet.Tests.Net.Protocols
 
             Task.Run(() =>
             {
-                (Protocol as KademliaProtocol).PingAsync(
+                _ = (Protocol as KademliaProtocol).PingAsync(
                     boundPeer,
                     timeSpan,
                     default(CancellationToken));

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -80,6 +80,8 @@ namespace Libplanet.Tests.Net.Protocols
 
         public IEnumerable<BoundPeer> Peers => Protocol.Peers;
 
+        public DateTimeOffset? LastMessageTimestamp { get; private set; }
+
         internal ConcurrentBag<Message> ReceivedMessages { get; }
 
         internal IProtocol Protocol { get; }
@@ -341,6 +343,7 @@ namespace Libplanet.Tests.Net.Protocols
                     "Received reply {Reply} of message with identity {identity}.",
                     reply,
                     message.Identity);
+                LastMessageTimestamp = DateTimeOffset.UtcNow;
                 ReceivedMessages.Add(reply);
                 Protocol.ReceiveMessage(reply);
                 MessageReceived.Set();
@@ -454,6 +457,7 @@ namespace Libplanet.Tests.Net.Protocols
                 });
             }
 
+            LastMessageTimestamp = DateTimeOffset.UtcNow;
             ReceivedMessages.Add(message);
             Protocol.ReceiveMessage(message);
             MessageReceived.Set();

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2080,6 +2080,36 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [Fact(Timeout = Timeout)]
+        public async Task LastMessageTimestamp()
+        {
+            Swarm<DumbAction> swarm1 = _swarms[0];
+            Swarm<DumbAction> swarm2 = _swarms[1];
+
+            Assert.Null(swarm1.LastMessageTimestamp);
+
+            try
+            {
+                await StartAsync(swarm1);
+                Assert.Null(swarm1.LastMessageTimestamp);
+                DateTimeOffset bootstrappedAt = DateTimeOffset.UtcNow;
+                await BootstrapAsync(swarm2, swarm1.AsPeer);
+                await StartAsync(swarm2);
+
+                Assert.NotNull(swarm1.LastMessageTimestamp);
+                Assert.InRange(
+                    swarm1.LastMessageTimestamp.Value,
+                    bootstrappedAt,
+                    DateTimeOffset.UtcNow
+                );
+            }
+            finally
+            {
+                await StopAsync(swarm1);
+                await StopAsync(swarm2);
+            }
+        }
+
         private async Task<Task> StartAsync<T>(
             Swarm<T> swarm,
             IImmutableSet<Address> trustedStateValidators = null,

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -12,6 +12,8 @@ namespace Libplanet.Net
 
         IEnumerable<BoundPeer> Peers { get; }
 
+        DateTimeOffset? LastMessageTimestamp { get; }
+
         Task StartAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         Task RunAsync(CancellationToken cancellationToken = default(CancellationToken));

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -180,6 +180,8 @@ namespace Libplanet.Net
 
         public IEnumerable<BoundPeer> Peers => Protocol.Peers;
 
+        public DateTimeOffset? LastMessageTimestamp { get; private set; }
+
         /// <summary>
         /// Whether this <see cref="NetMQTransport"/> instance is running.
         /// </summary>
@@ -582,6 +584,7 @@ namespace Libplanet.Net
                         _differentAppProtocolVersionEncountered);
                     _logger.Debug("A message has parsed: {0}, from {1}", message, message.Remote);
                     MessageHistory.Enqueue(message);
+                    LastMessageTimestamp = DateTimeOffset.UtcNow;
 
                     try
                     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -182,7 +182,8 @@ namespace Libplanet.Net
         public Peer AsPeer => Transport.AsPeer;
 
         /// <summary>
-        /// The time the message was last received.
+        /// The last time when any message was arrived.
+        /// It can be <c>null</c> if no message has been arrived yet.
         /// </summary>
         public DateTimeOffset? LastMessageTimestamp =>
             Running ? Transport.LastMessageTimestamp : (DateTimeOffset?)null;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -129,7 +129,6 @@ namespace Libplanet.Net
 
             DateTimeOffset now = createdAt.GetValueOrDefault(
                 DateTimeOffset.UtcNow);
-            LastReceived = now;
             TxReceived = new AsyncAutoResetEvent();
             BlockHeaderReceived = new AsyncAutoResetEvent();
             BlockAppended = new AsyncAutoResetEvent();
@@ -182,7 +181,11 @@ namespace Libplanet.Net
 
         public Peer AsPeer => Transport.AsPeer;
 
-        public DateTimeOffset LastReceived { get; private set; }
+        /// <summary>
+        /// The time the message was last received.
+        /// </summary>
+        public DateTimeOffset? LastMessageTimestamp =>
+            Running ? Transport.LastMessageTimestamp : (DateTimeOffset?)null;
 
         public IDictionary<Peer, DateTimeOffset> LastSeenTimestamps
         {


### PR DESCRIPTION
This PR adds `LastMessageTimestamp` to `Swarm<T>`  so that library users can take appropriate action. (e.g. restarting `Swarm<T>`)

Also, I didn't mention deleted `Swarm<T>.LastReceived` because it hadn't been in the previous documentation.