### PR TITLE
Restartable Swarm<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -232,7 +232,8 @@ To be released.
     without read lock.  [[#927]]
  -  Fixed a bug that `Swarm<T>` had not respond to `GetRecentStates` message
     when the target block does not exist in the chain.  [[#941]]
- -  Fixed a bug that `Swarm<T>` had not started after `.StopAsync()`.  [[#965]]
+ -  Fixed a bug that `Swarm<T>.StartAsync()` had not worked after `Swarm<T>.StopAsync()`
+    was once called.  [[#965]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -232,6 +232,7 @@ To be released.
     without read lock.  [[#927]]
  -  Fixed a bug that `Swarm<T>` had not respond to `GetRecentStates` message
     when the target block does not exist in the chain.  [[#941]]
+ -  Fixed a bug that `Swarm<T>` had not started after `.StopAsync()`.  [[#965]]
 
 ### CLI tools
 
@@ -287,6 +288,7 @@ To be released.
 [#954]: https://github.com/planetarium/libplanet/pull/954
 [#963]: https://github.com/planetarium/libplanet/pull/963
 [#964]: https://github.com/planetarium/libplanet/pull/964
+[#965]: https://github.com/planetarium/libplanet/pull/965
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/FactOnlyTurnAvailableAttribute.cs
+++ b/Libplanet.Tests/Net/FactOnlyTurnAvailableAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using Libplanet.Net;
 using Xunit;
 
 namespace Libplanet.Tests.Net
@@ -19,6 +20,14 @@ namespace Libplanet.Tests.Net
 
                 Username = userInfo[0];
                 Password = userInfo[1];
+
+                IceServers = new[]
+                {
+                    new IceServer(
+                        urls: new[] { TurnUri },
+                        username: Username,
+                        credential: Password),
+                };
             }
             catch (ArgumentNullException)
             {
@@ -38,5 +47,7 @@ namespace Libplanet.Tests.Net
         public static string Username { get; }
 
         public static string Password { get; }
+
+        public static IceServer[] IceServers { get; }
     }
 }

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -279,7 +279,6 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
-            _runtimeCancellationTokenSource?.Cancel();
             if (Running)
             {
                 await Task.Delay(waitFor, cancellationToken);
@@ -287,6 +286,7 @@ namespace Libplanet.Net
                 _broadcastQueue.ReceiveReady -= DoBroadcast;
                 _replyQueue.ReceiveReady -= DoReply;
                 _router.ReceiveReady -= ReceiveMessage;
+                _router.Unbind($"tcp://*:{_listenPort}");
 
                 if (_routerPoller.IsRunning)
                 {
@@ -307,6 +307,8 @@ namespace Libplanet.Net
                 {
                     dealer.Dispose();
                 }
+
+                _dealers.Clear();
 
                 Running = false;
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -241,6 +241,7 @@ namespace Libplanet.Net
 
         public void Dispose()
         {
+            _workerCancellationTokenSource?.Cancel();
             Transport.Dispose();
         }
 
@@ -256,7 +257,6 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
-            _workerCancellationTokenSource?.Cancel();
             _logger.Debug($"Stopping {nameof(Swarm<T>)}...");
             using (await _runningMutex.LockAsync())
             {


### PR DESCRIPTION
This PR fixes a bug that `Swarm<T>` hadn't started after `Swarm<T>.StopAsync()`.