### PR TITLE
Fix a bug that TrieStateStore.SetStates(…) couldn't get previous hash successfully

### DIFF
--- a/Libplanet.Tests/Store/StateStoreTracker.cs
+++ b/Libplanet.Tests/Store/StateStoreTracker.cs
@@ -18,13 +18,12 @@ namespace Libplanet.Tests.Store
         }
 
         public void SetStates<T>(
-            HashDigest<SHA256> blockHash,
-            IImmutableDictionary<string, IValue> states,
-            Func<HashDigest<SHA256>, Block<T>> blockGetter)
+            Block<T> blockHash,
+            IImmutableDictionary<string, IValue> states)
             where T : IAction, new()
         {
-            Log(nameof(SetStates), blockHash, states, blockGetter);
-            _stateStore.SetStates(blockHash, states, blockGetter);
+            Log(nameof(SetStates), blockHash, states);
+            _stateStore.SetStates(blockHash, states);
         }
 
         public IValue GetState(

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -1,12 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Bencodex.Types;
-using Libplanet.Blocks;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
-using Libplanet.Tests.Common.Action;
 using Xunit;
 
 namespace Libplanet.Tests.Store
@@ -20,35 +17,10 @@ namespace Libplanet.Tests.Store
         private readonly IImmutableDictionary<string, IValue> _prestoredValues;
 
         private readonly DefaultStoreFixture _fx;
-        private readonly Func<HashDigest<SHA256>, Block<DumbAction>> _fxBlockGetter;
 
         public TrieStateStoreTest()
         {
             _fx = new DefaultStoreFixture();
-            _fxBlockGetter = (blockHash) =>
-            {
-                if (blockHash.Equals(_fx.Hash1))
-                {
-                    return _fx.Block1;
-                }
-
-                if (blockHash.Equals(_fx.Hash2))
-                {
-                    return _fx.Block2;
-                }
-
-                if (blockHash.Equals(_fx.Hash3))
-                {
-                    return _fx.Block3;
-                }
-
-                if (blockHash.Equals(_fx.GenesisBlock.Hash))
-                {
-                    return _fx.GenesisBlock;
-                }
-
-                return null;
-            };
 
             _stateKeyValueStore = new DefaultKeyValueStore(null);
             _stateHashKeyValueStore = new DefaultKeyValueStore(null);
@@ -60,31 +32,31 @@ namespace Libplanet.Tests.Store
                 .Add("qux", Bencodex.Types.Dictionary.Empty);
 
             _stateStore = new TrieStateStore(_stateKeyValueStore, _stateHashKeyValueStore);
-            _stateStore.SetStates(_fx.GenesisBlock.Hash, _prestoredValues, _fxBlockGetter);
+            _stateStore.SetStates(_fx.GenesisBlock, _prestoredValues);
         }
 
         [Fact]
         public void SetStates()
         {
             // Check to set and to get.
-            Assert.Throws<KeyNotFoundException>(() => _stateStore.GetRootHash(_fx.Hash1));
-            Assert.False(_stateStore.ContainsBlockStates(_fx.Hash1));
+            Assert.Throws<KeyNotFoundException>(() => _stateStore.GetRootHash(_fx.Block1.Hash));
+            Assert.False(_stateStore.ContainsBlockStates(_fx.Block1.Hash));
             var states = ImmutableDictionary<string, IValue>.Empty
                 .Add("foo", (Text)"value");
-            _stateStore.SetStates(_fx.Hash1, states, _fxBlockGetter);
-            Assert.Equal((Text)"value", _stateStore.GetState("foo", _fx.Hash1));
-            Assert.IsType<HashDigest<SHA256>>(_stateStore.GetRootHash(_fx.Hash1));
-            Assert.True(_stateStore.ContainsBlockStates(_fx.Hash1));
+            _stateStore.SetStates(_fx.Block1, states);
+            Assert.Equal((Text)"value", _stateStore.GetState("foo", _fx.Block1.Hash));
+            Assert.IsType<HashDigest<SHA256>>(_stateStore.GetRootHash(_fx.Block1.Hash));
+            Assert.True(_stateStore.ContainsBlockStates(_fx.Block1.Hash));
 
-            _stateStore.SetStates(_fx.Hash2, _prestoredValues, _fxBlockGetter);
+            _stateStore.SetStates(_fx.Block2, _prestoredValues);
 
             // Check same states have same state hash.
             Assert.NotEqual(
                 _stateStore.GetRootHash(_fx.GenesisBlock.Hash),
-                _stateStore.GetRootHash(_fx.Hash1));
+                _stateStore.GetRootHash(_fx.Block1.Hash));
             Assert.Equal(
                 _stateStore.GetRootHash(_fx.GenesisBlock.Hash),
-                _stateStore.GetRootHash(_fx.Hash2));
+                _stateStore.GetRootHash(_fx.Block2.Hash));
         }
 
         [Fact]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1559,7 +1559,7 @@ namespace Libplanet.Blockchain
                         )
                     );
 
-                StateStore.SetStates(blockHash, totalDelta, blockHash => this[blockHash]);
+                StateStore.SetStates(block, totalDelta);
             }
 
             if (buildStateReferences && StateStore is IBlockStatesStore blockStatesStore)

--- a/Libplanet/Store/BaseBlockStatesStore.cs
+++ b/Libplanet/Store/BaseBlockStatesStore.cs
@@ -11,12 +11,11 @@ namespace Libplanet.Store
     public abstract class BaseBlockStatesStore : BaseStore, IBlockStatesStore
     {
         public void SetStates<T>(
-            HashDigest<SHA256> blockHash,
-            IImmutableDictionary<string, IValue> states,
-            Func<HashDigest<SHA256>, Block<T>> blockGetter)
+            Block<T> block,
+            IImmutableDictionary<string, IValue> states)
             where T : IAction, new()
         {
-            SetBlockStates(blockHash, states);
+            SetBlockStates(block.Hash, states);
         }
 
         public IValue GetState(

--- a/Libplanet/Store/IStateStore.cs
+++ b/Libplanet/Store/IStateStore.cs
@@ -16,19 +16,15 @@ namespace Libplanet.Store
         /// <summary>
         /// Sets states mapped as relation <see cref="Block{T}.Hash"/> → states.
         /// It guarantees <see cref="GetState"/> will return the same state if you passed same
-        /// <paramref name="blockHash"/> unless it has overwritten.
+        /// <paramref name="block"/> unless it has overwritten.
         /// </summary>
-        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> to set states.</param>
+        /// <param name="block">The <see cref="Block{T}"/> to set states.</param>
         /// <param name="states">The dictionary of state keys to states.</param>
-        /// <param name="blockGetter">The getter returns the block corresponded to
-        /// <see cref="HashDigest{T}"/>-typed parameter.</param>
         /// <typeparam name="T">An <see cref="IAction"/> type. It should match to
-        /// <paramref name="blockGetter"/>'s <see cref="Block{T}"/>-typed return value's
-        /// type parameter.</typeparam>
+        /// <paramref name="block"/>'s type parameter.</typeparam>
         void SetStates<T>(
-            HashDigest<SHA256> blockHash,
-            IImmutableDictionary<string, IValue> states,
-            Func<HashDigest<SHA256>, Block<T>> blockGetter = null)
+            Block<T> block,
+            IImmutableDictionary<string, IValue> states)
             where T : IAction, new();
 
         /// <summary>


### PR DESCRIPTION
Before this bugfix, `TrieStateStore` couldn't store states properly because of [this line](https://github.com/planetarium/libplanet/blob/4d080b547c7c6bc4616d15de9d345c9f747f6196/Libplanet/Blockchain/BlockChain.cs#L1562).

Also, the changes in `TrieStateStore` and `IStateStore`, were introduced in this version 0.11.0. So, the changelog was skipped.