### PR TITLE
Short-circuit evaluation of stale actions on reorg

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
     "secp256k1",
     "struct",
     "unrender",
+    "unrendered",
   ]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ To be released.
      -  Removed `BlockChain<T>.TipChanged` event, which was replaced by
         `IRenderer<T>.RenderBlock()`.
      -  Removed `PolymorphicAction<T>.Render()` and `Unrender()` methods.
+     -  Removed `BlockChain<T>.TipChangedEventArgs` class.
  -  Added methods related fungible asset states to `IAccountStateDelta`:
     [[#861], [#900], [#954]]
      -  `UpdatedFungibleAssetsAccounts` property
@@ -171,7 +172,6 @@ To be released.
      -  Added `FungibleAssetStateCompleters<T>` static class.
      -  Added `Swarm<T>.GetTrustedStateCompleterAsync()` method.
  -  Added `IRenderer<T>` interface.  [[#959], [#963]]
- -  Added `PolymorphicRenderer<T>` class.  [[#959], [#963]]
  -  Added `AnonymousRenderer<T>` class.  [[#959], [#963]]
  -  Added `LoggedRenderer<T>` class.  [[#959], [#963]]
  -  Added `BlockChain<T>.Renderers` property.  [[#945], [#959], [#963]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -172,9 +172,13 @@ To be released.
      -  Added `FungibleAssetStateCompleters<T>` static class.
      -  Added `Swarm<T>.GetTrustedStateCompleterAsync()` method.
  -  Added `IRenderer<T>` interface.  [[#959], [#963]]
+ -  Added `IActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `AnonymousRenderer<T>` class.  [[#959], [#963]]
+ -  Added `AnonymousActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `LoggedRenderer<T>` class.  [[#959], [#963]]
+ -  Added `LoggedActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `BlockChain<T>.Renderers` property.  [[#945], [#959], [#963]]
+ -  Added `BlockChain<T>.ActionRenderers` property.  [[#959], [#967], [#970]]
  -  Added `Swarm<T>.AppProtocolVersion` property.  [[#949]]
  -  `DefaultStore` became to implement `IBlockStatesStore`.  [[#950]]
  -  Added `IStateStore` interface.  [[#950]]
@@ -293,6 +297,8 @@ To be released.
 [#963]: https://github.com/planetarium/libplanet/pull/963
 [#964]: https://github.com/planetarium/libplanet/pull/964
 [#965]: https://github.com/planetarium/libplanet/pull/965
+[#967]: https://github.com/planetarium/libplanet/issues/967
+[#970]: https://github.com/planetarium/libplanet/pull/970
 [#972]: https://github.com/planetarium/libplanet/pull/972
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 

--- a/Docs/articles/overview.md
+++ b/Docs/articles/overview.md
@@ -205,15 +205,16 @@ Although this method works, there are still some problems because reflecting the
 - If multiple actions were executed in a short period of time, they would not be handled accurately.
 
 Libplanet provides a rendering mechanism called
-@"Libplanet.Blockchain.Renderers.IRenderer`1" to solve this problem.
-@"Libplanet.Blockchain.Renderers.IRenderer`1.RenderAction(Libplanet.Action.IAction,Libplanet.Action.IActionContext,Libplanet.Action.IAccountStateDelta)"
+@"Libplanet.Blockchain.Renderers.IRenderer`1" and its subtype
+@"Libplanet.Blockchain.Renderers.IActionRenderer`1" to solve this problem.
+@"Libplanet.Blockchain.Renderers.IActionRenderer`1.RenderAction(Libplanet.Action.IAction,Libplanet.Action.IActionContext,Libplanet.Action.IAccountStateDelta)"
 is called after a @"Libplanet.Blocks.Block`1" with the corresponding
 @"Libplanet.Action.IAction"s is confirmed and the state is transitioned.
 The following code has been re-implemented using
-@"Libplanet.Blockchain.Renderers.IRenderer`1.RenderAction(Libplanet.Action.IAction,Libplanet.Action.IActionContext,Libplanet.Action.IAccountStateDelta)".
+@"Libplanet.Blockchain.Renderers.IActionRenderer`1.RenderAction(Libplanet.Action.IAction,Libplanet.Action.IActionContext,Libplanet.Action.IAccountStateDelta)".
 
 ```csharp
-public class WinRenderer : IRenderer<Win>
+public class WinRenderer : IActionRenderer<Win>
 {
     // ...
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -398,6 +398,58 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void ShortCircuitActionEvaluationForUnrenderWithNoActionRenderers()
+        {
+            IEnumerable<ExecuteRecord> NonRehearsalExecutions() =>
+                DumbAction.ExecuteRecords.Value.Where(r => !r.Rehearsal);
+
+            var policy = new BlockPolicy<DumbAction>();
+            var key = new PrivateKey();
+            Address miner = key.ToAddress();
+
+            using (var fx = new DefaultStoreFixture(memory: true))
+            {
+                var emptyRenderer = new AnonymousRenderer<DumbAction>();
+                var chain = new BlockChain<DumbAction>(
+                    policy,
+                    fx.Store,
+                    fx.StateStore,
+                    fx.GenesisBlock,
+                    renderers: new[] { emptyRenderer }
+                );
+                var actions = new[] { new DumbAction(miner, "foo") };
+                var tx = chain.MakeTransaction(key, actions);
+                var block = TestUtils.MineNext(
+                    chain.Genesis,
+                    new[] { tx },
+                    miner: miner,
+                    difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain));
+                chain.Append(block);
+                var forked = chain.Fork(chain.Genesis.Hash);
+                forked.Append(block);
+
+                DumbAction.ExecuteRecords.Value = ImmutableList<ExecuteRecord>.Empty;
+                Assert.Empty(DumbAction.ExecuteRecords.Value);
+
+                // Stale actions shouldn't be evaluated because the "renderer" here is not an
+                // IActionRenderer<T> but a vanilla IRenderer<T> which means they don't have to
+                // be unrendered.
+                var renderer = new DumbRenderer<DumbAction>();
+                var newChain = new BlockChain<DumbAction>(
+                    policy,
+                    fx.Store,
+                    fx.StateStore,
+                    Guid.NewGuid(),
+                    fx.GenesisBlock,
+                    renderers: new[] { renderer }
+                );
+                chain.Swap(newChain, true);
+                Assert.Empty(renderer.ActionRecords);
+                Assert.Empty(NonRehearsalExecutions());
+            }
+        }
+
+        [Fact]
         public void Append()
         {
             (Address[] addresses, Transaction<DumbAction>[] txs) =

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.Store,
                 _fx.StateStore,
                 _fx.GenesisBlock,
-                renderers: new[] { new LoggedRenderer<DumbAction>(_renderer, Log.Logger) }
+                renderers: new[] { new LoggedActionRenderer<DumbAction>(_renderer, Log.Logger) }
             );
             _renderer.ResetRecords();
         }
@@ -653,16 +653,16 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async Task RenderAfterAppendComplete()
+        public async Task RenderActionsAfterAppendComplete()
         {
              var policy = new NullPolicy<DumbAction>();
              var store = new DefaultStore(null);
-             IRenderer<DumbAction> renderer = new AnonymousRenderer<DumbAction>
+             IActionRenderer<DumbAction> renderer = new AnonymousActionRenderer<DumbAction>
              {
                  ActionRenderer = (_, __, nextStates) =>
                      throw new SomeException("thrown by renderer"),
              };
-             renderer = new LoggedRenderer<DumbAction>(renderer, Log.Logger);
+             renderer = new LoggedActionRenderer<DumbAction>(renderer, Log.Logger);
              BlockChain<DumbAction> blockChain =
                  TestUtils.MakeBlockChain(policy, store, renderers: new[] { renderer });
              var privateKey = new PrivateKey();

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -1,0 +1,194 @@
+using System;
+using Libplanet.Action;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class AnonymousActionRendererTest
+    {
+        private static IAction _action = new DumbAction();
+
+        private static IAccountStateDelta _stateDelta =
+            new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
+
+        private static IActionContext _actionContext =
+            new ActionContext(default, default, default, _stateDelta, default);
+
+        private static Exception _exception = new Exception();
+
+        private static Block<DumbAction> _genesis =
+            TestUtils.MineGenesis<DumbAction>(default(Address));
+
+        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis);
+
+        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis);
+
+        [Fact]
+        public void ActionRenderer()
+        {
+            (IAction, IActionContext, IAccountStateDelta)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                ActionRenderer = (action, context, nextStates) =>
+                    record = (action, context, nextStates),
+            };
+
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.Null(record);
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.Null(record);
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.NotNull(record);
+            Assert.Same(_action, record?.Item1);
+            Assert.Same(_actionContext, record?.Item2);
+            Assert.Same(_stateDelta, record?.Item3);
+        }
+
+        [Fact]
+        public void ActionUnrenderer()
+        {
+            (IAction, IActionContext, IAccountStateDelta)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                ActionUnrenderer = (action, context, nextStates) =>
+                    record = (action, context, nextStates),
+            };
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.Null(record);
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.Null(record);
+
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.NotNull(record);
+            Assert.Same(_action, record?.Item1);
+            Assert.Same(_actionContext, record?.Item2);
+            Assert.Same(_stateDelta, record?.Item3);
+        }
+
+        [Fact]
+        public void ActionErrorRenderer()
+        {
+            (IAction, IActionContext, Exception)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                ActionErrorRenderer = (action, context, exception) =>
+                    record = (action, context, exception),
+            };
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.Null(record);
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.Null(record);
+
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.NotNull(record);
+            Assert.Same(_action, record?.Item1);
+            Assert.Same(_actionContext, record?.Item2);
+            Assert.Same(_exception, record?.Item3);
+        }
+
+        [Fact]
+        public void ActionErrorUnrenderer()
+        {
+            (IAction, IActionContext, Exception)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                ActionErrorUnrenderer = (action, context, exception) =>
+                    record = (action, context, exception),
+            };
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.Null(record);
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.Null(record);
+
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.NotNull(record);
+            Assert.Same(_action, record?.Item1);
+            Assert.Same(_actionContext, record?.Item2);
+            Assert.Same(_exception, record?.Item3);
+        }
+
+        [Fact]
+        public void BlockRenderer()
+        {
+            (Block<DumbAction> Old, Block<DumbAction> New)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => record = (oldTip, newTip),
+            };
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.Null(record);
+
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.NotNull(record);
+            Assert.Same(_genesis, record?.Old);
+            Assert.Same(_blockA, record?.New);
+        }
+
+        [Fact]
+        public void BlockReorg()
+        {
+            (Block<DumbAction> Old, Block<DumbAction> New, Block<DumbAction> Bp)? record = null;
+            var renderer = new AnonymousActionRenderer<DumbAction>
+            {
+                ReorgRenderer = (oldTip, newTip, bp) => record = (oldTip, newTip, bp),
+            };
+
+            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            Assert.Null(record);
+            renderer.RenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            Assert.Null(record);
+            renderer.RenderBlock(_genesis, _blockA);
+            Assert.Null(record);
+
+            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            Assert.NotNull(record);
+            Assert.Same(_blockA, record?.Old);
+            Assert.Same(_blockB, record?.New);
+            Assert.Same(_genesis, record?.Bp);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -1,5 +1,3 @@
-using System;
-using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
@@ -9,134 +7,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
 {
     public class AnonymousRendererTest
     {
-        private static IAction _action = new DumbAction();
-
-        private static IAccountStateDelta _stateDelta =
-            new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
-
-        private static IActionContext _actionContext =
-            new ActionContext(default, default, default, _stateDelta, default);
-
-        private static Exception _exception = new Exception();
-
         private static Block<DumbAction> _genesis =
             TestUtils.MineGenesis<DumbAction>(default(Address));
 
         private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis);
 
         private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis);
-
-        [Fact]
-        public void ActionRenderer()
-        {
-            (IAction, IActionContext, IAccountStateDelta)? record = null;
-            var renderer = new AnonymousRenderer<DumbAction>
-            {
-                ActionRenderer = (action, context, nextStates) =>
-                    record = (action, context, nextStates),
-            };
-
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.RenderBlock(_genesis, _blockA);
-            Assert.Null(record);
-            renderer.RenderReorg(_blockA, _blockB, _genesis);
-            Assert.Null(record);
-
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.NotNull(record);
-            Assert.Same(_action, record?.Item1);
-            Assert.Same(_actionContext, record?.Item2);
-            Assert.Same(_stateDelta, record?.Item3);
-        }
-
-        [Fact]
-        public void ActionUnrenderer()
-        {
-            (IAction, IActionContext, IAccountStateDelta)? record = null;
-            var renderer = new AnonymousRenderer<DumbAction>
-            {
-                ActionUnrenderer = (action, context, nextStates) =>
-                    record = (action, context, nextStates),
-            };
-
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.RenderBlock(_genesis, _blockA);
-            Assert.Null(record);
-            renderer.RenderReorg(_blockA, _blockB, _genesis);
-            Assert.Null(record);
-
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.NotNull(record);
-            Assert.Same(_action, record?.Item1);
-            Assert.Same(_actionContext, record?.Item2);
-            Assert.Same(_stateDelta, record?.Item3);
-        }
-
-        [Fact]
-        public void ActionErrorRenderer()
-        {
-            (IAction, IActionContext, Exception)? record = null;
-            var renderer = new AnonymousRenderer<DumbAction>
-            {
-                ActionErrorRenderer = (action, context, exception) =>
-                    record = (action, context, exception),
-            };
-
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.RenderBlock(_genesis, _blockA);
-            Assert.Null(record);
-            renderer.RenderReorg(_blockA, _blockB, _genesis);
-            Assert.Null(record);
-
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.NotNull(record);
-            Assert.Same(_action, record?.Item1);
-            Assert.Same(_actionContext, record?.Item2);
-            Assert.Same(_exception, record?.Item3);
-        }
-
-        [Fact]
-        public void ActionErrorUnrenderer()
-        {
-            (IAction, IActionContext, Exception)? record = null;
-            var renderer = new AnonymousRenderer<DumbAction>
-            {
-                ActionErrorUnrenderer = (action, context, exception) =>
-                    record = (action, context, exception),
-            };
-
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.RenderBlock(_genesis, _blockA);
-            Assert.Null(record);
-            renderer.RenderReorg(_blockA, _blockB, _genesis);
-            Assert.Null(record);
-
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.NotNull(record);
-            Assert.Same(_action, record?.Item1);
-            Assert.Same(_actionContext, record?.Item2);
-            Assert.Same(_exception, record?.Item3);
-        }
 
         [Fact]
         public void BlockRenderer()
@@ -147,14 +23,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 BlockRenderer = (oldTip, newTip) => record = (oldTip, newTip),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
             renderer.RenderReorg(_blockA, _blockB, _genesis);
             Assert.Null(record);
 
@@ -173,14 +41,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 ReorgRenderer = (oldTip, newTip, bp) => record = (oldTip, newTip, bp),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
-            Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
-            Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
@@ -13,8 +14,15 @@ using Constants = Serilog.Core.Constants;
 
 namespace Libplanet.Tests.Blockchain.Renderers
 {
-    public class LoggedRendererTest : IDisposable
+    public class LoggedActionRendererTest : IDisposable
     {
+        private static IAction _action = new DumbAction();
+
+        private static IAccountStateDelta _stateDelta =
+            new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
+
+        private static Exception _exception = new Exception();
+
         private static Block<DumbAction> _genesis =
             TestUtils.MineGenesis<DumbAction>(default(Address));
 
@@ -26,7 +34,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private ITestCorrelatorContext _context;
 
-        public LoggedRendererTest()
+        public LoggedActionRendererTest()
         {
             _logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -44,6 +52,223 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Theory]
+        [InlineData(false, false, false, false)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, true, false, false)]
+        [InlineData(true, true, false, false)]
+        [InlineData(false, false, true, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(false, true, true, false)]
+        [InlineData(true, true, true, false)]
+        [InlineData(false, false, false, true)]
+        [InlineData(true, false, false, true)]
+        [InlineData(false, true, false, true)]
+        [InlineData(true, true, false, true)]
+        [InlineData(false, false, true, true)]
+        [InlineData(true, false, true, true)]
+        [InlineData(false, true, true, true)]
+        [InlineData(true, true, true, true)]
+        public void ActionRenderings(bool unrender, bool error, bool rehearsal, bool exception)
+        {
+            bool called = false;
+            LogEvent firstLog = null;
+            IActionContext actionContext =
+                new ActionContext(default, default, 123, _stateDelta, default, rehearsal);
+            Exception actionError = new Exception();
+            IActionRenderer<DumbAction> actionRenderer;
+            if (error)
+            {
+                Action<IAction, IActionContext, Exception> render = (action, cxt, e) =>
+                {
+                    LogEvent[] logs = LogEvents.ToArray();
+                    Assert.Single(logs);
+                    firstLog = logs[0];
+                    Assert.Same(_action, action);
+                    Assert.Same(actionContext, cxt);
+                    Assert.Same(actionError, e);
+                    called = true;
+                    if (exception)
+                    {
+                        throw new ThrowException.SomeException(string.Empty);
+                    }
+                };
+                actionRenderer = new AnonymousActionRenderer<DumbAction>
+                {
+                    ActionErrorRenderer = unrender ? null : render,
+                    ActionErrorUnrenderer = unrender ? render : null,
+                };
+            }
+            else
+            {
+                Action<IAction, IActionContext, IAccountStateDelta> render = (action, cxt, next) =>
+                {
+                    LogEvent[] logs = LogEvents.ToArray();
+                    Assert.Single(logs);
+                    firstLog = logs[0];
+                    Assert.Same(_action, action);
+                    Assert.Same(actionContext, cxt);
+                    Assert.Same(_stateDelta, next);
+                    called = true;
+                    if (exception)
+                    {
+                        throw new ThrowException.SomeException(string.Empty);
+                    }
+                };
+                actionRenderer = new AnonymousActionRenderer<DumbAction>
+                {
+                    ActionRenderer = unrender ? null : render,
+                    ActionUnrenderer = unrender ? render : null,
+                };
+            }
+
+            actionRenderer = new LoggedActionRenderer<DumbAction>(
+                actionRenderer,
+                _logger,
+                LogEventLevel.Information
+            );
+            Assert.False(called);
+            Assert.Empty(LogEvents);
+
+            actionRenderer.RenderBlock(_genesis, _blockA);
+            Assert.False(called);
+            Assert.Equal(2, LogEvents.Count());
+            ResetContext();
+
+            ThrowException.SomeException thrownException = null;
+            try
+            {
+                if (error)
+                {
+                    if (unrender)
+                    {
+                        actionRenderer.UnrenderActionError(_action, actionContext, actionError);
+                    }
+                    else
+                    {
+                        actionRenderer.RenderActionError(_action, actionContext, actionError);
+                    }
+                }
+                else
+                {
+                    if (unrender)
+                    {
+                        actionRenderer.UnrenderAction(_action, actionContext, _stateDelta);
+                    }
+                    else
+                    {
+                        actionRenderer.RenderAction(_action, actionContext, _stateDelta);
+                    }
+                }
+            }
+            catch (ThrowException.SomeException e)
+            {
+                thrownException = e;
+            }
+
+            if (exception)
+            {
+                Assert.NotNull(thrownException);
+                Assert.IsType<ThrowException.SomeException>(thrownException);
+            }
+            else
+            {
+                Assert.Null(thrownException);
+            }
+
+            Assert.True(called);
+            LogEvent[] logEvents = LogEvents.ToArray();
+            Assert.Equal(2, logEvents.Length);
+            Assert.Equal(firstLog, logEvents[0]);
+            Assert.Equal(LogEventLevel.Information, firstLog.Level);
+            const string expected1stLog =
+                "Invoking {MethodName}() for an action {ActionType} at block #{BlockIndex}...";
+            Assert.Equal(
+                expected1stLog + (rehearsal ? " (rehearsal: {Rehearsal})" : string.Empty),
+                firstLog.MessageTemplate.Text
+            );
+            string methodName =
+                (unrender ? "Unrender" : "Render") +
+                "Action" + (error ? "Error" : string.Empty);
+            Assert.Equal($"\"{methodName}\"", firstLog.Properties["MethodName"].ToString());
+            Assert.Equal(
+                $"\"{typeof(DumbAction).FullName}\"",
+                firstLog.Properties["ActionType"].ToString()
+            );
+            Assert.Equal(
+                actionContext.BlockIndex.ToString(CultureInfo.InvariantCulture),
+                firstLog.Properties["BlockIndex"].ToString()
+            );
+            Assert.Equal(
+                $"\"{typeof(AnonymousActionRenderer<DumbAction>).FullName}\"",
+                firstLog.Properties[Constants.SourceContextPropertyName].ToString()
+            );
+            Assert.Null(firstLog.Exception);
+            if (rehearsal)
+            {
+                Assert.Equal("True", firstLog.Properties["Rehearsal"].ToString());
+            }
+            else
+            {
+                Assert.False(firstLog.Properties.ContainsKey("Rehearsal"));
+            }
+
+            LogEvent secondLog = logEvents[1];
+            Assert.Equal(
+                exception ? LogEventLevel.Error : LogEventLevel.Information,
+                secondLog.Level
+            );
+            string expected2ndLog;
+            if (exception)
+            {
+                expected2ndLog =
+                    "An exception was thrown during {MethodName}() for an action {ActionType} at " +
+                    "block #{BlockIndex}" +
+                    (rehearsal ? " (rehearsal: {Rehearsal})" : string.Empty) +
+                    ": {Exception}";
+            }
+            else
+            {
+                expected2ndLog =
+                    "Invoked {MethodName}() for an action {ActionType} at block #{BlockIndex}" +
+                    (rehearsal ? " (rehearsal: {Rehearsal})." : ".");
+            }
+
+            Assert.Equal(
+                expected2ndLog,
+                secondLog.MessageTemplate.Text
+            );
+            Assert.Equal(firstLog.Properties["MethodName"], secondLog.Properties["MethodName"]);
+            Assert.Equal(firstLog.Properties["ActionType"], secondLog.Properties["ActionType"]);
+            Assert.Equal(firstLog.Properties["BlockIndex"], secondLog.Properties["BlockIndex"]);
+            Assert.Equal(
+                firstLog.Properties[Constants.SourceContextPropertyName],
+                secondLog.Properties[Constants.SourceContextPropertyName]
+            );
+            if (exception)
+            {
+                Assert.StartsWith(
+                    $"\"{typeof(ThrowException.SomeException).FullName}",
+                    secondLog.Properties["Exception"].ToString()
+                );
+                Assert.NotNull(secondLog.Exception);
+                Assert.IsType<ThrowException.SomeException>(secondLog.Exception);
+            }
+            else
+            {
+                Assert.Null(secondLog.Exception);
+            }
+
+            if (rehearsal)
+            {
+                Assert.Equal("True", firstLog.Properties["Rehearsal"].ToString());
+            }
+            else
+            {
+                Assert.False(firstLog.Properties.ContainsKey("Rehearsal"));
+            }
+        }
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void RenderBlock(bool exception)
@@ -51,7 +276,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             bool called = false;
             LogEvent firstLog = null;
 
-            IRenderer<DumbAction> renderer = new AnonymousRenderer<DumbAction>
+            IActionRenderer<DumbAction> actionRenderer = new AnonymousActionRenderer<DumbAction>
             {
                 BlockRenderer = (oldTip, newTip) =>
                 {
@@ -67,12 +292,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     }
                 },
             };
-            renderer = new LoggedRenderer<DumbAction>(renderer, _logger);
+            actionRenderer = new LoggedActionRenderer<DumbAction>(actionRenderer, _logger);
 
             Assert.False(called);
             Assert.Empty(LogEvents);
 
-            renderer.RenderReorg(_blockA, _blockB, _genesis);
+            actionRenderer.RenderReorg(_blockA, _blockB, _genesis);
             Assert.False(called);
             Assert.Equal(2, LogEvents.Count());
             ResetContext();
@@ -80,12 +305,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
             if (exception)
             {
                 Assert.Throws<ThrowException.SomeException>(
-                    () => renderer.RenderBlock(_genesis, _blockA)
+                    () => actionRenderer.RenderBlock(_genesis, _blockA)
                 );
             }
             else
             {
-                renderer.RenderBlock(_genesis, _blockA);
+                actionRenderer.RenderBlock(_genesis, _blockA);
             }
 
             Assert.True(called);
@@ -109,7 +334,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             Assert.Equal($"\"{_genesis.Hash}\"", firstLog.Properties["OldHash"].ToString());
             Assert.Equal(
-                $"\"{typeof(AnonymousRenderer<DumbAction>).FullName}\"",
+                $"\"{typeof(AnonymousActionRenderer<DumbAction>).FullName}\"",
                 firstLog.Properties[Constants.SourceContextPropertyName].ToString()
             );
             Assert.Null(firstLog.Exception);
@@ -159,7 +384,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             bool called = false;
             LogEvent firstLog = null;
 
-            IRenderer<DumbAction> renderer = new AnonymousRenderer<DumbAction>
+            IActionRenderer<DumbAction> actionRenderer = new AnonymousActionRenderer<DumbAction>
             {
                 ReorgRenderer = (oldTip, newTip, branchpoint) =>
                 {
@@ -176,12 +401,16 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     }
                 },
             };
-            renderer = new LoggedRenderer<DumbAction>(renderer, _logger, LogEventLevel.Verbose);
+            actionRenderer = new LoggedActionRenderer<DumbAction>(
+                actionRenderer,
+                _logger,
+                LogEventLevel.Verbose
+            );
 
             Assert.False(called);
             Assert.Empty(LogEvents);
 
-            renderer.RenderBlock(_genesis, _blockA);
+            actionRenderer.RenderBlock(_genesis, _blockA);
             Assert.False(called);
             Assert.Equal(2, LogEvents.Count());
             ResetContext();
@@ -189,12 +418,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
             if (exception)
             {
                 Assert.Throws<ThrowException.SomeException>(
-                    () => renderer.RenderReorg(_blockA, _blockB, _genesis)
+                    () => actionRenderer.RenderReorg(_blockA, _blockB, _genesis)
                 );
             }
             else
             {
-                renderer.RenderReorg(_blockA, _blockB, _genesis);
+                actionRenderer.RenderReorg(_blockA, _blockB, _genesis);
             }
 
             Assert.True(called);
@@ -224,7 +453,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             Assert.Equal($"\"{_genesis.Hash}\"", firstLog.Properties["BranchpointHash"].ToString());
             Assert.Equal(
-                $"\"{typeof(AnonymousRenderer<DumbAction>).FullName}\"",
+                $"\"{typeof(AnonymousActionRenderer<DumbAction>).FullName}\"",
                 firstLog.Properties[Constants.SourceContextPropertyName].ToString()
             );
             Assert.Null(firstLog.Exception);

--- a/Libplanet.Tests/Common/Action/ExecuteRecord.cs
+++ b/Libplanet.Tests/Common/Action/ExecuteRecord.cs
@@ -9,5 +9,9 @@ namespace Libplanet.Tests.Common.Action
         public IAccountStateDelta NextState { get; set; }
 
         public bool Rehearsal { get; set; }
+
+        public override string ToString() =>
+            $"{nameof(ExecuteRecord)} {{ {nameof(Action)} = {Action}, {nameof(NextState)} = " +
+            $"{NextState}, {nameof(Rehearsal)} = {Rehearsal} }}";
     }
 }

--- a/Libplanet.Tests/Common/DumbRenderer.cs
+++ b/Libplanet.Tests/Common/DumbRenderer.cs
@@ -7,7 +7,7 @@ using Serilog;
 
 namespace Libplanet.Tests.Common
 {
-    public sealed class DumbRenderer<T> : IRenderer<T>
+    public sealed class DumbRenderer<T> : IActionRenderer<T>
         where T : IAction, new()
     {
         public DumbRenderer()

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -71,8 +71,8 @@ namespace Libplanet.Tests.Net
                 new DumbRenderer<DumbAction>(),
             };
 
-            LoggedRenderer<DumbAction>[][] loggedRenderers = _renderers
-                .Select(r => new[] { new LoggedRenderer<DumbAction>(r, _logger) })
+            LoggedActionRenderer<DumbAction>[][] loggedRenderers = _renderers
+                .Select(r => new[] { new LoggedActionRenderer<DumbAction>(r, _logger) })
                 .ToArray();
 
             _blockchains = new List<BlockChain<DumbAction>>

--- a/Libplanet.sln.DotSettings
+++ b/Libplanet.sln.DotSettings
@@ -22,4 +22,5 @@
   <s:Boolean x:Key="/Default/UserDictionary/Words/=secp256k1/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=struct/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unrender/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=unrendered/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Action
     /// an instance of <see cref="PolymorphicAction{T}"/> is passed instead of its
     /// <see cref="InnerAction"/>:
     /// <code>
-    /// public class Renderer : IRenderer&lt;PolymorphicAction&lt;ActionBase&gt;&gt;
+    /// public class Renderer : IActionRenderer&lt;PolymorphicAction&lt;ActionBase&gt;&gt;
     /// {
     ///     public void RenderAction(IAction action,
     ///                              IActionContext context,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -143,6 +143,7 @@ namespace Libplanet.Blockchain
             Renderers = renderers is IEnumerable<IRenderer<T>> r
                 ? r.ToImmutableArray()
                 : ImmutableArray<IRenderer<T>>.Empty;
+            ActionRenderers = Renderers.OfType<IActionRenderer<T>>().ToImmutableArray();
             _rwlock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             _txLock = new object();
 
@@ -199,6 +200,12 @@ namespace Libplanet.Blockchain
         /// constructor instead.
         /// </remarks>
         public IImmutableList<IRenderer<T>> Renderers { get; }
+
+        /// <summary>
+        /// A filtered list, from <see cref="Renderers"/>, which contains only <see
+        /// cref="IActionRenderer{T}"/> instances.
+        /// </summary>
+        public IImmutableList<IActionRenderer<T>> ActionRenderers { get; }
 
         public IBlockPolicy<T> Policy { get; }
 
@@ -974,7 +981,7 @@ namespace Libplanet.Blockchain
             {
                 if (evaluation.Exception is null)
                 {
-                    foreach (IRenderer<T> renderer in Renderers)
+                    foreach (IActionRenderer<T> renderer in ActionRenderers)
                     {
                         renderer.RenderAction(
                             evaluation.Action,
@@ -985,7 +992,7 @@ namespace Libplanet.Blockchain
                 }
                 else
                 {
-                    foreach (IRenderer<T> renderer in Renderers)
+                    foreach (IActionRenderer<T> renderer in ActionRenderers)
                     {
                         renderer.RenderActionError(
                             evaluation.Action,
@@ -1427,7 +1434,7 @@ namespace Libplanet.Blockchain
                         _logger.Debug("Unrender an action: {Action}.", evaluation.Action);
                         if (evaluation.Exception is null)
                         {
-                            foreach (IRenderer<T> renderer in Renderers)
+                            foreach (IActionRenderer<T> renderer in ActionRenderers)
                             {
                                 renderer.UnrenderAction(
                                     evaluation.Action,
@@ -1438,7 +1445,7 @@ namespace Libplanet.Blockchain
                         }
                         else
                         {
-                            foreach (IRenderer<T> renderer in Renderers)
+                            foreach (IActionRenderer<T> renderer in ActionRenderers)
                             {
                                 renderer.UnrenderActionError(
                                     evaluation.Action,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -815,6 +815,8 @@ namespace Libplanet.Blockchain
                 );
             }
 
+            renderActions = renderActions && ActionRenderers.Any();
+
             // Since rendering process requires every step's states, if required block states
             // are incomplete they are complemented anyway:
             stateCompleters ??= StateCompleterSet<T>.Recalculate;
@@ -1412,7 +1414,7 @@ namespace Libplanet.Blockchain
                 topmostCommon
             );
 
-            if (render)
+            if (render && ActionRenderers.Any())
             {
                 // Unrender stale actions.
                 _logger.Debug("Unrendering abandoned actions...");
@@ -1503,7 +1505,7 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitWriteLock();
             }
 
-            if (render)
+            if (render && ActionRenderers.Any())
             {
                 _logger.Debug("Rendering actions in new chain.");
 

--- a/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// An <see cref="IActionRenderer{T}"/> that invokes its callbacks.
+    /// In other words, this is an <see cref="IActionRenderer{T}"/> version of
+    /// <see cref="AnonymousRenderer{T}"/>.
+    /// <para>This class is useful when you want an one-use ad-hoc implementation (i.e., Java-style
+    /// anonymous class) of <see cref="IActionRenderer{T}"/> interface.</para>
+    /// </summary>
+    /// <example>
+    /// With object initializers, you can easily make an one-use action renderer:
+    /// <code>
+    /// var actionRenderer = new AnonymousActionRenderer&lt;ExampleAction&gt;
+    /// {
+    ///     ActionRenderer = (action, context, nextStates) =>
+    ///     {
+    ///         // Implement RenderAction() here.
+    ///     };
+    /// };
+    /// </code>
+    /// </example>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public sealed class AnonymousActionRenderer<T> : AnonymousRenderer<T>, IActionRenderer<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// A callback function to be invoked together with
+        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
+        /// </summary>
+        public Action<IAction, IActionContext, IAccountStateDelta>? ActionRenderer { get; set; }
+
+        /// <summary>
+        /// A callback function to be invoked together with
+        /// <see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
+        /// </summary>
+        public Action<IAction, IActionContext, IAccountStateDelta>? ActionUnrenderer { get; set; }
+
+        /// <summary>
+        /// A callback function to be invoked together with
+        /// <see cref="RenderActionError(IAction, IActionContext, Exception)"/>.
+        /// </summary>
+        public Action<IAction, IActionContext, Exception>? ActionErrorRenderer { get; set; }
+
+        /// <summary>
+        /// A callback function to be invoked together with
+        /// <see cref="UnrenderActionError(IAction, IActionContext, Exception)"/>.
+        /// </summary>
+        public Action<IAction, IActionContext, Exception>? ActionErrorUnrenderer { get; set; }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            ActionRenderer?.Invoke(action, context, nextStates);
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            ActionUnrenderer?.Invoke(action, context, nextStates);
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        public void RenderActionError(IAction action, IActionContext context, Exception exception)
+            => ActionErrorRenderer?.Invoke(action, context, exception);
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
+            => ActionErrorUnrenderer?.Invoke(action, context, exception);
+    }
+}

--- a/Libplanet/Blockchain/Renderers/AnonymousRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousRenderer.cs
@@ -15,42 +15,18 @@ namespace Libplanet.Blockchain.Renderers
     /// <code>
     /// var renderer = new AnonymousRenderer&lt;ExampleAction&gt;
     /// {
-    ///     ActionRenderer = (action, context, nextStates) =>
+    ///     BlockRenderer = (oldTip, newTip) =>
     ///     {
-    ///         // Implement RenderAction() here.
+    ///         // Implement RenderBlock() here.
     ///     };
     /// };
     /// </code>
     /// </example>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
     /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public sealed class AnonymousRenderer<T> : IRenderer<T>
+    public class AnonymousRenderer<T> : IRenderer<T>
         where T : IAction, new()
     {
-        /// <summary>
-        /// A callback function to be invoked together with
-        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
-        /// </summary>
-        public Action<IAction, IActionContext, IAccountStateDelta>? ActionRenderer { get; set; }
-
-        /// <summary>
-        /// A callback function to be invoked together with
-        /// <see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
-        /// </summary>
-        public Action<IAction, IActionContext, IAccountStateDelta>? ActionUnrenderer { get; set; }
-
-        /// <summary>
-        /// A callback function to be invoked together with
-        /// <see cref="RenderActionError(IAction, IActionContext, Exception)"/>.
-        /// </summary>
-        public Action<IAction, IActionContext, Exception>? ActionErrorRenderer { get; set; }
-
-        /// <summary>
-        /// A callback function to be invoked together with
-        /// <see cref="UnrenderActionError(IAction, IActionContext, Exception)"/>.
-        /// </summary>
-        public Action<IAction, IActionContext, Exception>? ActionErrorUnrenderer { get; set; }
-
         /// <summary>
         /// A callback function to be invoked together with
         /// <see cref="RenderBlock(Block{T}, Block{T})"/>.
@@ -62,33 +38,6 @@ namespace Libplanet.Blockchain.Renderers
         /// <see cref="RenderReorg(Block{T}, Block{T}, Block{T})"/>.
         /// </summary>
         public Action<Block<T>, Block<T>, Block<T>>? ReorgRenderer { get; set; }
-
-        /// <inheritdoc
-        /// cref="IRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
-        public void RenderAction(
-            IAction action,
-            IActionContext context,
-            IAccountStateDelta nextStates
-        ) =>
-            ActionRenderer?.Invoke(action, context, nextStates);
-
-        /// <inheritdoc
-        /// cref="IRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
-        public void UnrenderAction(
-            IAction action,
-            IActionContext context,
-            IAccountStateDelta nextStates
-        ) =>
-            ActionUnrenderer?.Invoke(action, context, nextStates);
-
-        /// <inheritdoc cref="IRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
-        public void RenderActionError(IAction action, IActionContext context, Exception exception)
-            => ActionErrorRenderer?.Invoke(action, context, exception);
-
-        /// <inheritdoc
-        /// cref="IRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
-        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
-            => ActionErrorUnrenderer?.Invoke(action, context, exception);
 
         /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
         public void RenderBlock(Block<T> oldTip, Block<T> newTip) =>

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -1,0 +1,105 @@
+#nullable enable
+using System;
+using Libplanet.Action;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// Listens state changes of every step of actions, besides blocks,
+    /// on a <see cref="BlockChain{T}"/>.
+    /// If you need more fine-grained events than <see cref="IRenderer{T}"/>,
+    /// implement this interface instead.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public interface IActionRenderer<T> : IRenderer<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Does things that should be done right after an <paramref name="action"/>
+        /// is executed and applied to the blockchain.
+        /// </summary>
+        /// <remarks>It is guaranteed to be called only once for an <paramref name="action"/>,
+        /// and only after applied to the blockchain, unless an exception is thrown during executing
+        /// the <paramref name="action"/> (in that case <see
+        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> is called instead) or
+        /// once the <paramref name="action"/> has been unrendered.</remarks>
+        /// <param name="action">An executed action.</param>
+        /// <param name="context">The equivalent context object to an object passed to
+        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
+        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// <em>before</em> this action executed.  For the states after this action executed,
+        /// use the <paramref name="nextStates"/> argument instead.</param>
+        /// <param name="nextStates">The states right <em>after</em> this action executed,
+        /// which means it is equivalent to the states <paramref name="action"/>'s
+        /// <see cref="IAction.Execute(IActionContext)"/> method returned.</param>
+        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
+        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        void RenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
+
+        /// <summary>
+        /// Does things that should be undone right after the given <paramref name="action"/> is
+        /// invalidated (mostly due to reorg, i.e., a block which the action has belonged to becomes
+        /// considered stale).
+        /// <para>This method takes the equivalent arguments to <see
+        /// cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/> method.</para>
+        /// </summary>
+        /// <param name="action">A stale action.</param>
+        /// <param name="context">The equivalent context object to an object passed to
+        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
+        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// <em>before</em> this action executed.  For the states after this action executed,
+        /// use the <paramref name="nextStates"/> argument instead.</param>
+        /// <param name="nextStates">The states right <em>after</em> this action executed,
+        /// which means it is equivalent to the states <paramref name="action"/>'s
+        /// <see cref="IAction.Execute(IActionContext)"/> method returned.</param>
+        /// <remarks>As a rule of thumb, this should be the inverse of
+        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/> method
+        /// with redrawing the graphics on the display at the finish.</remarks>
+        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
+        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        void UnrenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
+
+        /// <summary>
+        /// Does the similar things to <see cref=
+        /// "RenderAction(IAction, IActionContext, IAccountStateDelta)"/>, except that this method
+        /// is invoked when <paramref name="action"/> has terminated with an exception.
+        /// </summary>
+        /// <param name="action">An action which threw an exception during execution.</param>
+        /// <param name="context">The equivalent context object to an object passed to
+        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
+        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// <em>before</em> this action executed.</param>
+        /// <param name="exception">The exception thrown during executing the <paramref
+        /// name="action"/>.</param>
+        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
+        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        void RenderActionError(IAction action, IActionContext context, Exception exception);
+
+        /// <summary>
+        /// Does the similar things to <see
+        /// cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>, except that
+        /// this method is invoked when <paramref name="action"/> has terminated with an exception.
+        /// <para>This method takes the equivalent arguments to <see
+        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> method.</para>
+        /// </summary>
+        /// <param name="action">An action which threw an exception during execution.</param>
+        /// <param name="context">The equivalent context object to an object passed to
+        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
+        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// <em>before</em> this action executed.</param>
+        /// <param name="exception">The exception thrown during executing the <paramref
+        /// name="action"/>.</param>
+        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
+        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        void UnrenderActionError(IAction action, IActionContext context, Exception exception);
+    }
+}

--- a/Libplanet/Blockchain/Renderers/IRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IRenderer.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using Libplanet.Action;
 using Libplanet.Blocks;
 
@@ -16,93 +15,6 @@ namespace Libplanet.Blockchain.Renderers
     public interface IRenderer<T>
         where T : IAction, new()
     {
-        /// <summary>
-        /// Does things that should be done right after an <paramref name="action"/>
-        /// is executed and applied to the blockchain.
-        /// </summary>
-        /// <remarks>It is guaranteed to be called only once for an <paramref name="action"/>,
-        /// and only after applied to the blockchain, unless an exception is thrown during executing
-        /// the <paramref name="action"/> (in that case <see
-        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> is called instead) or
-        /// once the <paramref name="action"/> has been unrendered.</remarks>
-        /// <param name="action">An executed action.</param>
-        /// <param name="context">The equivalent context object to an object passed to
-        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
-        /// <em>before</em> this action executed.  For the states after this action executed,
-        /// use the <paramref name="nextStates"/> argument instead.</param>
-        /// <param name="nextStates">The states right <em>after</em> this action executed,
-        /// which means it is equivalent to the states <paramref name="action"/>'s
-        /// <see cref="IAction.Execute(IActionContext)"/> method returned.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
-        void RenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
-
-        /// <summary>
-        /// Does things that should be undone right after the given <paramref name="action"/> is
-        /// invalidated (mostly due to reorg, i.e., a block which the action has belonged to becomes
-        /// considered stale).
-        /// <para>This method takes the equivalent arguments to <see
-        /// cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/> method.</para>
-        /// </summary>
-        /// <param name="action">A stale action.</param>
-        /// <param name="context">The equivalent context object to an object passed to
-        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
-        /// <em>before</em> this action executed.  For the states after this action executed,
-        /// use the <paramref name="nextStates"/> argument instead.</param>
-        /// <param name="nextStates">The states right <em>after</em> this action executed,
-        /// which means it is equivalent to the states <paramref name="action"/>'s
-        /// <see cref="IAction.Execute(IActionContext)"/> method returned.</param>
-        /// <remarks>As a rule of thumb, this should be the inverse of
-        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/> method
-        /// with redrawing the graphics on the display at the finish.</remarks>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
-        void UnrenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
-
-        /// <summary>
-        /// Does the similar things to <see cref=
-        /// "RenderAction(IAction, IActionContext, IAccountStateDelta)"/>, except that this method
-        /// is invoked when <paramref name="action"/> has terminated with an exception.
-        /// </summary>
-        /// <param name="action">An action which threw an exception during execution.</param>
-        /// <param name="context">The equivalent context object to an object passed to
-        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
-        /// <em>before</em> this action executed.</param>
-        /// <param name="exception">The exception thrown during executing the <paramref
-        /// name="action"/>.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
-        void RenderActionError(IAction action, IActionContext context, Exception exception);
-
-        /// <summary>
-        /// Does the similar things to <see
-        /// cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>, except that
-        /// this method is invoked when <paramref name="action"/> has terminated with an exception.
-        /// <para>This method takes the equivalent arguments to <see
-        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> method.</para>
-        /// </summary>
-        /// <param name="action">An action which threw an exception during execution.</param>
-        /// <param name="context">The equivalent context object to an object passed to
-        /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
-        /// <em>before</em> this action executed.</param>
-        /// <param name="exception">The exception thrown during executing the <paramref
-        /// name="action"/>.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
-        void UnrenderActionError(IAction action, IActionContext context, Exception exception);
-
         /// <summary>
         /// Does things that should be done right after a new <see cref="Block{T}"/> is appended to
         /// a <see cref="BlockChain{T}"/> (so that its <see cref="BlockChain{T}.Tip"/> has changed).

--- a/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
@@ -1,0 +1,209 @@
+#nullable enable
+using System;
+using Libplanet.Action;
+using Serilog;
+using Serilog.Events;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// Decorates an <see cref="IActionRenderer{T}"/> so that all event messages are logged.
+    /// In other words, this is an <see cref="IActionRenderer{T}"/> version of
+    /// <see cref="LoggedRenderer{T}"/>.
+    /// <para>Every single event message causes two log messages: one is logged <em>before</em>
+    /// rendering, and other one is logged <em>after</em> rendering.  If any exception is thrown
+    /// it is also logged with the log level <see cref="LogEventLevel.Error"/> (regardless of
+    /// <see cref="LoggedRenderer{T}.Level"/> configuration).</para>
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <example>
+    /// <code>
+    /// IActionRenderer&lt;ExampleAction&gt; actionRenderer = new SomeActionRenderer();
+    /// // Wraps the action renderer with LoggedActionRenderer:
+    /// actionRenderer = new LoggedActionRenderer&lt;ExampleAction&gt;(
+    ///     actionRenderer,
+    ///     Log.Logger,
+    ///     LogEventLevel.Information,
+    /// );
+    /// </code>
+    /// </example>
+    public class LoggedActionRenderer<T> : LoggedRenderer<T>, IActionRenderer<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Creates a new <see cref="LoggedActionRenderer{T}"/> instance which decorates the given
+        /// action <paramref name="renderer"/>.
+        /// </summary>
+        /// <param name="renderer">The actual action renderer to forward all event messages to and
+        /// actually render things.</param>
+        /// <param name="logger">The logger to write log messages to.  Note that all log messages
+        /// this decorator writes become in the context of the <paramref name="renderer"/>'s
+        /// type (with the context property <c>SourceContext</c>).</param>
+        /// <param name="level">The log event level.  All log messages become this level.</param>
+        public LoggedActionRenderer(
+            IActionRenderer<T> renderer,
+            ILogger logger,
+            LogEventLevel level = LogEventLevel.Debug
+        )
+            : base(renderer, logger, level)
+        {
+            ActionRenderer = renderer;
+        }
+
+        /// <summary>
+        /// The inner action renderer to forward all event messages to and actually render things.
+        /// </summary>
+        public IActionRenderer<T> ActionRenderer { get; }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            LogActionRendering(
+                nameof(RenderAction),
+                action,
+                context,
+                () => ActionRenderer.RenderAction(action, context, nextStates)
+            );
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            LogActionRendering(
+                nameof(UnrenderAction),
+                action,
+                context,
+                () => ActionRenderer.UnrenderAction(action, context, nextStates)
+            );
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        public void RenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        ) =>
+            LogActionRendering(
+                nameof(RenderActionError),
+                action,
+                context,
+                () => ActionRenderer.RenderActionError(action, context, exception)
+            );
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+        public void UnrenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        ) =>
+            LogActionRendering(
+                nameof(UnrenderActionError),
+                action,
+                context,
+                () => ActionRenderer.UnrenderActionError(action, context, exception)
+            );
+
+        private void LogActionRendering(
+            string methodName,
+            IAction action,
+            IActionContext context,
+            System.Action callback
+        )
+        {
+            Type actionType = action.GetType();
+            const string startMessage =
+                "Invoking {MethodName}() for an action {ActionType} at block #{BlockIndex}...";
+            if (context.Rehearsal)
+            {
+                Logger.Write(
+                    Level,
+                    startMessage + " (rehearsal: {Rehearsal})",
+                    methodName,
+                    actionType,
+                    context.BlockIndex,
+                    context.Rehearsal
+                );
+            }
+            else
+            {
+                Logger.Write(
+                    Level,
+                    startMessage,
+                    methodName,
+                    actionType,
+                    context.BlockIndex
+                );
+            }
+
+            try
+            {
+                callback();
+            }
+            catch (Exception e)
+            {
+                const string errorMessage =
+                    "An exception was thrown during {MethodName}() for an action {ActionType} at " +
+                    "block #{BlockIndex}";
+                if (context.Rehearsal)
+                {
+                    Logger.Error(
+                        e,
+                        errorMessage + " (rehearsal: {Rehearsal}): {Exception}",
+                        methodName,
+                        actionType,
+                        context.BlockIndex,
+                        context.Rehearsal,
+                        e
+                    );
+                }
+                else
+                {
+                    Logger.Error(
+                        e,
+                        errorMessage + ": {Exception}",
+                        methodName,
+                        actionType,
+                        context.BlockIndex,
+                        e
+                    );
+                }
+
+                throw;
+            }
+
+            const string endMessage =
+                "Invoked {MethodName}() for an action {ActionType} at block #{BlockIndex}";
+
+            if (context.Rehearsal)
+            {
+                Logger.Write(
+                    Level,
+                    endMessage + " (rehearsal: {Rehearsal}).",
+                    methodName,
+                    actionType,
+                    context.BlockIndex,
+                    context.Rehearsal
+                );
+            }
+            else
+            {
+                Logger.Write(
+                    Level,
+                    endMessage + ".",
+                    methodName,
+                    actionType,
+                    context.BlockIndex
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This addresses #967.

The previous patch #963 unified two types of events into one: one is for rendering/unrendering actions, and other one is for watching new tips & reorgs.  At the same time, it also threw away the `BlockChain<T>()` constructor's Boolean option `render` because I thought it's redundant as `render: false` seemed equivalent to `renderers: null`.

However, those two changes regressed the performance of reorg, because the optimization made by the patch #883 was thrown away together.  The disappeared optimization was a short-circuit evaluation option for stale actions to be unrendered.  As the option `render: false` was removed, stale actions became evaluated even if there is no renderers, or all renderers do nothing for `UnrenderAction()`/`UnrenderActionError()` events…

In order to fix this performance regression, I reverted (with some adjusts and new name) `ShortCircuitActionEvaluationForUnrenderWithNoActionRenderers` (was `Render`) test, I removed in the previous patch #963, and refactored the renderer interface(s) according to the conclusion made in the issue #967.  Now we have a new interface named `IActionRenderer<T>`, is basically equivalent to the previous `IRenderer<T>`, and `IRenderer<T>` became to have only block-related events.  `BlockChain<T>.Swap()` now omits evaluation of stale actions if there is no `IActionRenderer<T>` at all.