### PR TITLE
Do not request RecentStates if IBlockStateStore is unused

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -25,9 +25,15 @@ namespace Libplanet.Tests.Net
         private readonly StoreFixture _fx3;
         private readonly StoreFixture _fx4;
 
+        private readonly StoreFixture _mptFx1;
+        private readonly StoreFixture _mptFx2;
+        private readonly StoreFixture _mptFx3;
+
         private readonly List<BlockChain<DumbAction>> _blockchains;
+        private readonly List<BlockChain<DumbAction>> _mptBlockchains;
         private readonly List<DumbRenderer<DumbAction>> _renderers;
         private readonly List<Swarm<DumbAction>> _swarms;
+        private readonly List<Swarm<DumbAction>> _mptSwarms;
         private readonly List<Func<Task>> _finalizers;
 
         private static async Task<(Address, Block<DumbAction>[])>

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -1468,5 +1468,59 @@ namespace Libplanet.Tests.Net
                 await StopAsync(seed);
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ExecuteActionsBetweenTrieStateStoreAndBlockStatesStore(bool fromMpt)
+        {
+            Swarm<DumbAction> seedSwarm = _swarms[0];
+            Swarm<DumbAction> receiverSwarm = _mptSwarms[0];
+
+            if (fromMpt)
+            {
+                (seedSwarm, receiverSwarm) = (receiverSwarm, seedSwarm);
+            }
+
+            seedSwarm.Options.RecentStateRecvTimeout = TimeSpan.FromDays(1);
+
+            var preloadStateLogs = new List<PreloadState>();
+            var progress = new Progress<PreloadState>(state =>
+            {
+                preloadStateLogs.Add(state);
+                _logger.Debug(state.GetType().ToString());
+            });
+
+            try
+            {
+                await seedSwarm.BlockChain.MineBlock(_fx1.Address1);
+
+                await StartAsync(seedSwarm);
+                await BootstrapAsync(receiverSwarm, seedSwarm.AsPeer);
+
+                Assert.Equal(2, seedSwarm.BlockChain.Count);
+                Assert.Equal(1, receiverSwarm.BlockChain.Count);
+
+                await receiverSwarm.PreloadAsync(
+                    trustedStateValidators: ImmutableHashSet<Address>.Empty.Add(seedSwarm.Address),
+                    progress: progress);
+
+                Assert.Equal(seedSwarm.BlockChain.Tip, receiverSwarm.BlockChain.Tip);
+                // NOTE: the reason to use ternary-operator is because it repeat block verification
+                //       steps one more time when it used block states store and
+                //       got recentStates.Missing.
+                Assert.Equal(fromMpt ? 5 : 4, preloadStateLogs.Count);
+                Assert.Single(preloadStateLogs.OfType<BlockHashDownloadState>());
+                Assert.Single(preloadStateLogs.OfType<BlockDownloadState>());
+                Assert.Equal(
+                    fromMpt ? 2 : 1, preloadStateLogs.OfType<BlockVerificationState>().Count());
+                Assert.Empty(preloadStateLogs.OfType<StateDownloadState>());
+                Assert.Single(preloadStateLogs.OfType<ActionExecutionState>());
+            }
+            finally
+            {
+                await StopAsync(seedSwarm);
+            }
+        }
     }
 }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -62,6 +62,9 @@ namespace Libplanet.Tests.Net
             _fx2 = new DefaultStoreFixture(memory: true);
             _fx3 = new DefaultStoreFixture(memory: true);
             _fx4 = new DefaultStoreFixture(memory: true);
+            _mptFx1 = new DefaultStoreFixture(memory: true, mpt: true);
+            _mptFx2 = new DefaultStoreFixture(memory: true, mpt: true);
+            _mptFx3 = new DefaultStoreFixture(memory: true, mpt: true);
 
             _renderers = new List<DumbRenderer<DumbAction>>
             {
@@ -83,6 +86,25 @@ namespace Libplanet.Tests.Net
                 TestUtils.MakeBlockChain(policy, _fx4.Store, renderers: loggedRenderers[3]),
             };
 
+            _mptBlockchains = new List<BlockChain<DumbAction>>
+            {
+                TestUtils.MakeBlockChain(
+                    policy,
+                    _mptFx1.Store,
+                    stateStore: _mptFx1.StateStore,
+                    renderers: loggedRenderers[0]),
+                TestUtils.MakeBlockChain(
+                    policy,
+                    _mptFx2.Store,
+                    stateStore: _mptFx2.StateStore,
+                    renderers: loggedRenderers[1]),
+                TestUtils.MakeBlockChain(
+                    policy,
+                    _mptFx3.Store,
+                    stateStore: _mptFx3.StateStore,
+                    renderers: loggedRenderers[2]),
+            };
+
             _finalizers = new List<Func<Task>>();
             _swarms = new List<Swarm<DumbAction>>
             {
@@ -90,6 +112,12 @@ namespace Libplanet.Tests.Net
                 CreateSwarm(_blockchains[1]),
                 CreateSwarm(_blockchains[2]),
                 CreateSwarm(_blockchains[3]),
+            };
+            _mptSwarms = new List<Swarm<DumbAction>>
+            {
+                CreateSwarm(_mptBlockchains[0]),
+                CreateSwarm(_mptBlockchains[1]),
+                CreateSwarm(_mptBlockchains[2]),
             };
 
             Log.Logger.Debug($"Finished to initialize a {nameof(SwarmTest)} instance.");
@@ -117,6 +145,11 @@ namespace Libplanet.Tests.Net
                 _fx1.Dispose();
                 _fx2.Dispose();
                 _fx3.Dispose();
+                _fx4.Dispose();
+
+                _mptFx1.Dispose();
+                _mptFx2.Dispose();
+                _mptFx3.Dispose();
             }
 
             Log.Logger.Debug($"Finished to {nameof(Dispose)}() a {nameof(SwarmTest)} instance.");

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -134,9 +134,9 @@ namespace Libplanet.Tests.Store
 
         public IStore Store { get; set; }
 
-        public IBlockStatesStore BlockStatesStore => Store as IBlockStatesStore;
+        public IStateStore StateStore { get; set; }
 
-        public IStateStore StateStore => Store as IStateStore;
+        public IBlockStatesStore BlockStatesStore => StateStore as IBlockStatesStore;
 
         public abstract void Dispose();
 

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -262,7 +262,8 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             IEnumerable<T> actions = null,
             PrivateKey privateKey = null,
             DateTimeOffset? timestamp = null,
-            IEnumerable<IRenderer<T>> renderers = null
+            IEnumerable<IRenderer<T>> renderers = null,
+            IStateStore stateStore = null
         )
             where T : IAction, new()
         {
@@ -295,7 +296,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return new BlockChain<T>(
                 policy,
                 store,
-                store as IStateStore,
+                stateStore ?? store as IStateStore,
                 genesisBlock,
                 renderers: renderers ?? new[] { new DumbRenderer<T>() }
             );

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -386,37 +386,39 @@ namespace Libplanet.Net
                 {
                     rwlock.ExitReadLock();
                 }
-            }
 
-            if (_logger.IsEnabled(LogEventLevel.Verbose))
-            {
-                if (BlockChain.ContainsBlock(target))
+                if (_logger.IsEnabled(LogEventLevel.Verbose))
                 {
-                    var baseString = @base is HashDigest<SHA256> h
-                        ? $"{BlockChain[h].Index}:{h}"
-                        : null;
-                    var targetString = $"{BlockChain[target].Index}:{target}";
-                    _logger.Verbose(
-                        "State references to send (preload): {StateReferences} ({Base}-{Target})",
-                        stateRefs.Select(kv =>
-                            (
-                                kv.Key,
-                                string.Join(", ", kv.Value.Select(v => v.ToString()))
-                            )
-                        ).ToArray(),
-                        baseString,
-                        targetString
-                    );
-                    _logger.Verbose(
-                        "Block states to send (preload): {BlockStates} ({Base}-{Target})",
-                        blockStates.Select(kv => (kv.Key, kv.Value)).ToArray(),
-                        baseString,
-                        targetString
-                    );
-                }
-                else
-                {
-                    _logger.Verbose("Nothing to reply because {TargetHash} doesn't exist.", target);
+                    if (BlockChain.ContainsBlock(target))
+                    {
+                        var baseString = @base is HashDigest<SHA256> h
+                            ? $"{BlockChain[h].Index}:{h}"
+                            : null;
+                        var targetString = $"{BlockChain[target].Index}:{target}";
+                        _logger.Verbose(
+                            "State references to send (preload):" +
+                            " {StateReferences} ({Base}-{Target})",
+                            stateRefs.Select(kv =>
+                                (
+                                    kv.Key,
+                                    string.Join(", ", kv.Value.Select(v => v.ToString()))
+                                )
+                            ).ToArray(),
+                            baseString,
+                            targetString
+                        );
+                        _logger.Verbose(
+                            "Block states to send (preload): {BlockStates} ({Base}-{Target})",
+                            blockStates.Select(kv => (kv.Key, kv.Value)).ToArray(),
+                            baseString,
+                            targetString
+                        );
+                    }
+                    else
+                    {
+                        _logger.Verbose(
+                            "Nothing to reply because {TargetHash} doesn't exist.", target);
+                    }
                 }
             }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1475,7 +1475,7 @@ namespace Libplanet.Net
                     }
 
                     if (reply is RecentStates recentStates
-                        && _store is IBlockStatesStore blockStatesStore)
+                        && BlockChain.StateStore is IBlockStatesStore blockStatesStore)
                     {
                         if (recentStates.Missing)
                         {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -852,13 +852,17 @@ namespace Libplanet.Net
                     // see issue #436, #430
                     try
                     {
-                        receivedStateHeight = await SyncRecentStatesFromTrustedPeersAsync(
-                            workspace,
-                            progress,
-                            trustedPeersWithTip.ToImmutableList(),
-                            initialLocator,
-                            cancellationToken
-                        );
+                        if (BlockChain.StateStore is IBlockStatesStore)
+                        {
+                            receivedStateHeight = await SyncRecentStatesFromTrustedPeersAsync(
+                                workspace,
+                                progress,
+                                trustedPeersWithTip.ToImmutableList(),
+                                initialLocator,
+                                cancellationToken
+                            );
+                        }
+
                         break;
                     }
                     catch (InvalidStateTargetException e)


### PR DESCRIPTION
Previously, nodes turned off`IBlockStateStore` had requested `RecentStates` despite these hadn't been stored.  Therefore, these requests cause unnecessary computation on seed nodes.  This pull request addresses the problem.  I skipped the changelog as `IStateStore` and `IBlockStateStore` have never released yet.