### PR TITLE
Make SonarAnalyzer optional

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -32,7 +32,9 @@ steps:
   displayName: dotnet build
   inputs:
     command: build
-    arguments: --configuration ${{ parameters.configuration }}
+    arguments: >-
+      --configuration ${{ parameters.configuration }}
+      -p:SkipSonar=true
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test
@@ -41,6 +43,7 @@ steps:
     projects: '**/*Tests/*.csproj'
     arguments: >-
       --configuration ${{ parameters.configuration }}
+      -p:SkipSonar=true
       ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
@@ -55,6 +58,7 @@ steps:
     projects: '**/*Tests/*.csproj'
     arguments: >-
       --configuration ${{ parameters.configuration }}
+      -p:SkipSonar=true
       ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -24,7 +24,8 @@ steps:
     script: |
       msbuild \
         /restore \
-        /p:Configuration=${{ parameters.configuration }}
+        /p:Configuration=${{ parameters.configuration }} \
+        /p:SkipSonar=true
 
 - task: CmdLine@2
   displayName: ${{ parameters.testDisplayName }}

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -31,7 +31,7 @@ steps:
     solution: Libplanet.sln
     msbuildVersion: "16.0"
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: /restore
+    msbuildArguments: /restore /p:SkipSonar=true
 
 - task: Bash@3
   displayName: xunit.console.exe *.Tests.dll

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,3 +1,11 @@
+# This workflow checks if the build (compilation) succeeds without any errors.
+# Although the build is done in Azure Pipelines as well, to speed up the build time
+# some checks are turned off in Azure Pipelines.  To conduct the complete checks
+# there should be this separated workflow.
+# See also the below issues:
+# - https://github.com/planetarium/libplanet/pull/979
+# - https://github.com/planetarium/libplanet/pull/977
+# - https://github.com/planetarium/libplanet/issues/976
 on:
   push: []
   pull_request: []

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -17,4 +17,4 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.100
-    - run: 'dotnet build'
+    - run: 'dotnet build -p:SkipSonar=false'

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,0 +1,20 @@
+on:
+  push: []
+  pull_request: []
+name: check-build
+
+jobs:
+  build:
+    name: check-build
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@main
+      if: github.event_name != 'pull_request'
+    - uses: actions/checkout@main
+      if: github.event_name == 'pull_request'
+      with:
+        ref: ${{ github.pull_request.head.sha }}
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.100
+    - run: 'dotnet build'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,13 @@ builds the entire *Libplanet* solution:
 
     dotnet build
 
+We use [SonarAnalyzer] to check our code quality but it takes longer to build.
+To skip the analyzer, you can use:
+
+    dotnet build -p:SkipSonar=true
+
+[SonarAnalyzer]: https://github.com/SonarSource/sonar-dotnet
+
 
 Projects
 --------

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -39,10 +39,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -53,6 +49,13 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -42,7 +42,7 @@
     </IncludeAssets>
   </PackageReference>
   <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.3-planetarium" />
-  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
     <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     <PrivateAssets>all</PrivateAssets>
   </PackageReference>

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -42,10 +42,6 @@
     </IncludeAssets>
   </PackageReference>
   <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.3-planetarium" />
-  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    <PrivateAssets>all</PrivateAssets>
-  </PackageReference>
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>
@@ -53,6 +49,13 @@
     </IncludeAssets>
   </PackageReference>
   <PackageReference Include="Serilog" Version="2.8.0" />
+</ItemGroup>
+
+<ItemGroup Condition="'$(SkipSonar)' != 'true'">
+  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PrivateAssets>all</PrivateAssets>
+  </PackageReference>
 </ItemGroup>
 
 <ItemGroup>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -33,10 +33,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -50,6 +46,13 @@
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -30,7 +30,7 @@
         runtime; build; native; contentfiles; analyzers; buildtransitive
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -30,10 +30,6 @@
         runtime; build; native; contentfiles; analyzers; buildtransitive
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -42,5 +38,12 @@
     </PackageReference>
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -86,5 +86,16 @@
     <Rule Id="S4035" Action="None" />
     <!-- Remove this unnecessary null check; 'is' returns false for nulls. -->
     <Rule Id="S4201" Action="None" />
+
+    <!-- Remove this parameter 'x', whose value is ignored in the method. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove this useless assignment to local variable x -->
+    <Rule Id="S1854" Action="None" />
+    <!-- Change this condition so that it does not always evaluate to 'false'; some subsequent code is never executed. -->
+    <Rule Id="S2583" Action="None" />
+    <!-- Remove this redundant jump. -->
+    <Rule Id="S3626" Action="None" />
+    <!-- Restrict types of objects allowed to be deserialized. -->
+    <Rule Id="S5773" Action="None" />
   </Rules>
 </RuleSet>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -41,10 +41,6 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -56,6 +52,13 @@
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -240,7 +240,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task PreloadFailed()
         {
             Swarm<DumbAction> minerSwarm = _swarms[0];
@@ -666,7 +666,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task PreloadWithBranchesAndTrustedPeers()
         {
             // Two miners; one trusts other one.  Test if it downloads the minimum range of blocks
@@ -736,7 +736,7 @@ namespace Libplanet.Tests.Net
             */
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task PreloadWhilePeerTipIsChanging()
         {
             var key = new PrivateKey();
@@ -1239,7 +1239,7 @@ namespace Libplanet.Tests.Net
             Assert.Equal(expectedBlocks, demands);
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task PreloadAfterReorg()
         {
             Swarm<DumbAction> minerSwarm = _swarms[0];

--- a/Libplanet.Tests/Net/SwarmTest.TrustedStateCompleter.cs
+++ b/Libplanet.Tests/Net/SwarmTest.TrustedStateCompleter.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Net
 {
     public partial class SwarmTest
     {
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task TrustedStateCompleter()
         {
             StateCompleter<DumbAction> noComplete = StateCompleters<DumbAction>.Reject;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1371,7 +1371,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task RenderInFork()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -67,17 +67,18 @@
         runtime; build; native; contentfiles; analyzers; buildtransitive
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -67,7 +67,7 @@
         runtime; build; native; contentfiles; analyzers; buildtransitive
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.5.0.15942">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>

--- a/Libplanet.ruleset
+++ b/Libplanet.ruleset
@@ -123,5 +123,12 @@
     <!-- Seal class 'Transaction' or implement 'IEqualityComparer<T>'
     instead. -->
     <Rule Id="S4035" Action="None" />
+
+    <!-- Remove this useless assignment to local variable x -->
+    <Rule Id="S1854" Action="None" />
+    <!-- Remove this redundant jump. -->
+    <Rule Id="S3626" Action="None" />
+    <!-- Restrict types of objects allowed to be deserialized. -->
+    <Rule Id="S5773" Action="None" />
   </Rules>
 </RuleSet>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -81,10 +81,6 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.260-planetarium" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -95,6 +91,13 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="System.Linq.Async" Version="4.0.*" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="Zio" Version="0.7.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- The above hacky trick is borrowed from the following Stack Overflow

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -81,7 +81,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.260-planetarium" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This is another version of #977.

This turns off Sonar Analyzer by default and checks it using in the `check-sonar` action.
In your local environment, you can skip Sonar by using `SkipSonar` option like `dotnet build -p:SkipSonar=true`.