### PR TITLE
DelayedRenderer<T> & DelayedActionRenderer<T> for stable app-side state transfer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
     "struct",
     "unrender",
     "unrendered",
+    "unrenderer",
+    "unrendering",
+    "unrenders",
   ]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,7 @@ To be released.
  -  Added `IActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `AnonymousRenderer<T>` class.  [[#959], [#963]]
  -  Added `AnonymousActionRenderer<T>` interface.  [[#959], [#967], [#970]]
+ -  Added `DelayedRenderer<T>` class.  [[#980]]
  -  Added `LoggedRenderer<T>` class.  [[#959], [#963]]
  -  Added `LoggedActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `BlockChain<T>.Renderers` property.  [[#945], [#959], [#963]]
@@ -304,6 +305,7 @@ To be released.
 [#967]: https://github.com/planetarium/libplanet/issues/967
 [#970]: https://github.com/planetarium/libplanet/pull/970
 [#972]: https://github.com/planetarium/libplanet/pull/972
+[#980]: https://github.com/planetarium/libplanet/pull/980
 [#981]: https://github.com/planetarium/libplanet/pull/981
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,7 @@ To be released.
     BoundPeer, TimeSpan?, CancellationToken)` method with
     `Swarm<T>.FindSpecificPeerAsync(Address, int, TimeSpan?, CancellationToken)`.
     [[#981]]
+ -  Added `IActionContext.GetUnconsumedContext()` method.  [[#980]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,7 @@ To be released.
  -  Added `AnonymousRenderer<T>` class.  [[#959], [#963]]
  -  Added `AnonymousActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `DelayedRenderer<T>` class.  [[#980]]
+ -  Added `DelayedActionRenderer<T>` class.  [[#980]]
  -  Added `LoggedRenderer<T>` class.  [[#959], [#963]]
  -  Added `LoggedActionRenderer<T>` interface.  [[#959], [#967], [#970]]
  -  Added `BlockChain<T>.Renderers` property.  [[#945], [#959], [#963]]

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -101,6 +101,33 @@ namespace Libplanet.Tests.Action
             }
         }
 
+        [Fact]
+        public void GetUnconsumedContext()
+        {
+            var random = new System.Random();
+            var original = new ActionContext(
+                signer: random.NextAddress(),
+                miner: random.NextAddress(),
+                blockIndex: 1,
+                previousStates: new DumbAccountStateDelta(),
+                randomSeed: random.Next()
+            );
+
+            // Consume original's random state...
+            int[] values =
+            {
+                original.Random.Next(),
+                original.Random.Next(),
+                original.Random.Next(),
+            };
+
+            IActionContext clone = original.GetUnconsumedContext();
+            Assert.Equal(
+                values,
+                new[] { clone.Random.Next(), clone.Random.Next(), clone.Random.Next() }
+            );
+        }
+
         private class DumbAccountStateDelta : IAccountStateDelta
         {
             public IImmutableSet<Address> UpdatedAddresses =>

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -19,14 +19,16 @@ namespace Libplanet.Tests.Blockchain.Renderers
         {
         }
 
-        [Fact]
-        public override void Constructor()
+        [InlineData(0)]
+        [InlineData(-123)]
+        [Theory]
+        public override void Constructor(int invalidConfirmations)
         {
             ArgumentOutOfRangeException e = Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DelayedActionRenderer<DumbAction>(
                     new AnonymousActionRenderer<DumbAction>(),
                     _store,
-                    confirmations: 0
+                    confirmations: invalidConfirmations
                 )
             );
             Assert.Equal("confirmations", e.ParamName);

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class DelayedActionRendererTest : DelayedRendererTest
+    {
+        private static readonly IAccountStateDelta _emptyStates =
+            new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
+
+        public DelayedActionRendererTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public override void BlocksBeingAppended()
+        {
+            // FIXME: Eliminate duplication between this and DelayedRendererTest
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var actionEvaluations = new List<ActionEvaluation>();
+            uint unintendedCalls = 0;
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ActionRenderer = (action, context, nextStates) =>
+                    actionEvaluations.Add(new ActionEvaluation(action, context, nextStates)),
+                ActionErrorRenderer = (action, context, e) =>
+                    actionEvaluations.Add(
+                        new ActionEvaluation(action, context, context.PreviousStates, e)
+                    ),
+                ReorgRenderer = (oldTip, newTip, bp) =>
+                {
+                    // Note that this callback should not be invoked in this test case.
+                    unintendedCalls++;
+                },
+                ActionUnrenderer = (action, context, nextStates) =>
+                {
+                    // Note that this callback should not be invoked in this test case.
+                    unintendedCalls++;
+                },
+                ActionErrorUnrenderer = (action, context, nextStates) =>
+                {
+                    // Note that this callback should not be invoked in this test case.
+                    unintendedCalls++;
+                },
+            };
+
+            var renderer = new DelayedActionRenderer<DumbAction>(innerRenderer, _store, 3);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(actionEvaluations);
+            Assert.Equal(0U, unintendedCalls);
+
+            // #0 -> 1 confirm; #1 -> no confirms; #2 -> no confirms
+            renderer.RenderBlock(_chainA[0], _chainA[1]);
+            renderer.RenderAction(new DumbAction(default, "#1.1"), FakeContext(), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#1.2"), FakeContext(), _emptyStates);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(actionEvaluations);
+            Assert.Equal(0U, unintendedCalls);
+
+            // #0 -> 2 confirms; #1 -> 1 confirm; #2 -> no confirms
+            renderer.RenderBlock(_chainA[1], _chainA[2]);
+            renderer.RenderActionError(
+                new DumbAction(default, "#2.1"),
+                FakeContext(),
+                new ThrowException.SomeException("#2.1")
+            );
+            renderer.RenderAction(new DumbAction(default, "#2.2"), FakeContext(), _emptyStates);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(actionEvaluations);
+            Assert.Equal(0U, unintendedCalls);
+
+            // #0 -> 3 confirms; #1 -> 2 confirms; #2 -> 1 confirm; tip changed -> #0
+            renderer.RenderBlock(_chainA[2], _chainA[3]);
+            renderer.RenderAction(new DumbAction(default, "#3.1"), FakeContext(), _emptyStates);
+            Assert.Equal(_chainA[0], renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(actionEvaluations);
+            Assert.Equal(0U, unintendedCalls);
+
+            // #0 -> gone; #1 -> 3 confirms; #2 -> 2 confirms; tip changed -> #1; render(#0, #1)
+            renderer.RenderBlock(_chainA[3], _chainA[4]);
+            renderer.RenderAction(new DumbAction(default, "#4.1"), FakeContext(), _emptyStates);
+            Assert.Equal(_chainA[1], renderer.Tip);
+            Assert.Single(blockLogs);
+            Assert.Equal((_chainA[0], _chainA[1]), blockLogs[0]);
+            Assert.Equal(2, actionEvaluations.Count);
+            Assert.Equal("#1.1", ((DumbAction)actionEvaluations[0].Action).Item);
+            Assert.Null(actionEvaluations[0].Exception);
+            Assert.Equal("#1.2", ((DumbAction)actionEvaluations[1].Action).Item);
+            Assert.Null(actionEvaluations[1].Exception);
+            Assert.Equal(0U, unintendedCalls);
+
+            // #0 -> gone; #1 -> gone; #2 -> 3 confirms; tip changed -> #2; render(#1, #2)
+            renderer.RenderBlock(_chainA[4], _chainA[5]);
+            Assert.Equal(_chainA[2], renderer.Tip);
+            Assert.Equal(2, blockLogs.Count);
+            Assert.Equal((_chainA[0], _chainA[1]), blockLogs[0]);
+            Assert.Equal((_chainA[1], _chainA[2]), blockLogs[1]);
+            Assert.Equal(4, actionEvaluations.Count);
+            Assert.Equal("#1.1", ((DumbAction)actionEvaluations[0].Action).Item);
+            Assert.Null(actionEvaluations[0].Exception);
+            Assert.Equal("#1.2", ((DumbAction)actionEvaluations[1].Action).Item);
+            Assert.Null(actionEvaluations[1].Exception);
+            Assert.Equal("#2.1", ((DumbAction)actionEvaluations[2].Action).Item);
+            Assert.NotNull(actionEvaluations[2].Exception);
+            Assert.IsType<ThrowException.SomeException>(actionEvaluations[2].Exception);
+            Assert.Equal("#2.2", ((DumbAction)actionEvaluations[3].Action).Item);
+            Assert.Null(actionEvaluations[3].Exception);
+            Assert.Equal(0U, unintendedCalls);
+        }
+
+        [Fact]
+        public override void BlocksBeingAppendedInParallel()
+        {
+            // FIXME: Eliminate duplication between this and DelayedRendererTest
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var reorgLogs = new List<(
+                Block<DumbAction> OldTip,
+                Block<DumbAction> NewTip,
+                Block<DumbAction> Branchpoint
+            )>();
+            var renderLogs = new List<(bool Unrender, ActionEvaluation Evaluation)>();
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) => reorgLogs.Add((oldTip, newTip, bp)),
+                ActionRenderer = (action, context, nextStates) =>
+                    renderLogs.Add((false, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorRenderer = (act, ctx, e) =>
+                    renderLogs.Add((false, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+                ActionUnrenderer = (action, context, nextStates) =>
+                    renderLogs.Add((true, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorUnrenderer = (act, ctx, e) =>
+                    renderLogs.Add((true, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+            };
+            var renderer = new DelayedActionRenderer<DumbAction>(innerRenderer, _store, 3);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(reorgLogs);
+
+            // Some explanation on the fixture: there are two chains that shares a certain block
+            // as a branchpoint: _chainA and _chainB.  The topmost mutual block, i.e., branchpoint,
+            // between _chainA and _chainB is _chainA[4] (== _chainB[4]).
+            // In this test, we tries to simulate blocks from two parallel chains being "appended"
+            // (discovered) to a peer.  The order of discovery can be drawn as below (the prime
+            // [apostrophe] after the block index number like #N' shows it's from _chainB; the bare
+            // block index without that like #N means it's from _chainA):
+            //
+            //          #4 (1st)
+            //            |
+            //          /   \
+            //    #5 (2nd)  #5' (3rd)
+            //        |       |
+            //    #6 (3rd)  #6' (4th)
+            //        |       |
+            //    #7 (5th)  #7' (6th)
+            //        |       |
+            //    #8 (7th)  #8' (8th)
+            //                |
+            //              #9' (9th)
+
+            // #4  -> 1 confirm
+            // #5  -> no confirms
+            // #5' -> no confirms
+            renderer.RenderBlock(_chainA[4], _chainA[5]);
+            renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> 2 confirms
+            // #5  -> no confirms
+            // #5' -> no confirms
+            renderer.RenderReorg(_chainA[5], _chainB[5], _branchpoint);
+            renderer.RenderBlock(_chainA[5], _chainB[5]);
+            renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            Assert.Null(renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> 3 confirms; tip changed -> #4
+            // #5  -> 1 confirm;  #6 -> no confirm
+            // #5' -> no confirms
+            renderer.RenderReorg(_chainB[5], _chainA[6], _branchpoint);
+            renderer.RenderBlock(_chainB[5], _chainA[6]);
+            renderer.UnrenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 1 confirm; #6  -> no confirm
+            // #5' -> 1 confirm; #6' -> no confirm
+            renderer.RenderReorg(_chainA[6], _chainB[6], _branchpoint);
+            renderer.RenderBlock(_chainA[6], _chainB[6]);
+            renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.RenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 2 confirms; #6  -> 1 confirm; #7 -> no confirm
+            // #5' -> 1 confirm;  #6' -> no confirm
+            renderer.RenderReorg(_chainB[6], _chainA[7], _branchpoint);
+            renderer.RenderBlock(_chainB[6], _chainA[7]);
+            renderer.UnrenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
+            renderer.UnrenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 2 confirms; #6  -> 1 confirm; #7  -> no confirm
+            // #5' -> 2 confirms; #6' -> 1 confirm; #7' -> no confirm
+            renderer.RenderReorg(_chainA[7], _chainB[7], _branchpoint);
+            renderer.RenderBlock(_chainA[7], _chainB[7]);
+            renderer.UnrenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.RenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#7'.1"), FakeContext(7), _emptyStates);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            // #4  -> gone; tip changed -> #5; render(#4, #5)
+            // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8 -> no confirm
+            // #5' -> 2 confirms; #6' -> 1 confirm;  #7' -> no confirm
+            renderer.RenderReorg(_chainB[7], _chainA[8], _branchpoint);
+            renderer.RenderBlock(_chainB[7], _chainA[8]);
+            renderer.UnrenderAction(new DumbAction(default, "#7'.1"), FakeContext(7), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
+            renderer.UnrenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#8.1"), FakeContext(8), _emptyStates);
+            Assert.Equal(_chainA[5], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Equal(new[] { (_chainA[4], _chainA[5]) }, blockLogs);
+            Assert.Single(renderLogs);
+            Assert.False(renderLogs[0].Unrender);
+            Assert.Equal("#5.1", ((DumbAction)renderLogs[0].Evaluation.Action).Item);
+            Assert.Null(renderLogs[0].Evaluation.Exception);
+
+            // tip changed -> #5'; render(#5, #5'); reorg(#5, #5', #4)
+            // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8  -> no confirm
+            // #5' -> 3 confirms; #6' -> 2 confirms; #7' -> 1 confirm; #8' -> no confirm
+            renderer.RenderReorg(_chainA[8], _chainB[8], _branchpoint);
+            renderer.RenderBlock(_chainA[8], _chainB[8]);
+            renderer.UnrenderAction(new DumbAction(default, "#8.1"), FakeContext(8), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
+            renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderActionError(
+                new DumbAction(default, "#5'.2"),
+                FakeContext(5),
+                new ThrowException.SomeException("#5'.2")
+            );
+            renderer.RenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#7'.1"), FakeContext(7), _emptyStates);
+            renderer.RenderAction(new DumbAction(default, "#8'.1"), FakeContext(8), _emptyStates);
+            Assert.Equal(_chainB[5], renderer.Tip);
+            Assert.Equal(new[] { (_chainA[5], _chainB[5], _branchpoint) }, reorgLogs);
+            Assert.Equal(new[] { (_chainA[4], _chainA[5]), (_chainA[5], _chainB[5]) }, blockLogs);
+            Assert.Equal(1 + 1 + 2, renderLogs.Count);
+            Assert.True(renderLogs[1].Unrender);
+            Assert.Equal("#5.1", ((DumbAction)renderLogs[1].Evaluation.Action).Item);
+            Assert.Null(renderLogs[1].Evaluation.Exception);
+            Assert.False(renderLogs[2].Unrender);
+            Assert.Equal("#5'.1", ((DumbAction)renderLogs[2].Evaluation.Action).Item);
+            Assert.Null(renderLogs[2].Evaluation.Exception);
+            Assert.False(renderLogs[3].Unrender);
+            Assert.Equal("#5'.2", ((DumbAction)renderLogs[3].Evaluation.Action).Item);
+            Assert.NotNull(renderLogs[3].Evaluation.Exception);
+
+            // tip changed -> #6'; render(#5', #6')
+            // #5' -> gone; #6' -> 3 confirms; #7' -> 2 confirm; #8' -> 1 confirm; #9' -> 1 confirm
+            renderer.RenderBlock(_chainB[8], _chainB[9]);
+            renderer.RenderAction(new DumbAction(default, "#9'.1"), FakeContext(9), _emptyStates);
+            Assert.Equal(_chainB[6], renderer.Tip);
+            Assert.Single(reorgLogs);
+            Assert.Equal(
+                new[]
+                {
+                    (_chainA[4], _chainA[5]),
+                    (_chainA[5], _chainB[5]),
+                    (_chainB[5], _chainB[6]),
+                },
+                blockLogs
+            );
+            Assert.Equal(1 + 1 + 2 + 1, renderLogs.Count);
+            Assert.False(renderLogs[4].Unrender);
+            Assert.Equal("#6'.1", ((DumbAction)renderLogs[4].Evaluation.Action).Item);
+            Assert.Null(renderLogs[4].Evaluation.Exception);
+        }
+
+        [Fact]
+        public void LocateBlockPath()
+        {
+            var renderer = new DelayedActionRenderer<DumbAction>(
+                new AnonymousActionRenderer<DumbAction>(),
+                _store,
+                3
+            );
+            Assert.Equal(
+                new[] { _chainA[5].Hash, _chainA[6].Hash, _chainA[7].Hash },
+                renderer.LocateBlockPath(_chainA[4], _chainA[7])
+            );
+            Assert.Throws<ArgumentException>(
+                () => renderer.LocateBlockPath(_chainA[5], _chainA[4])
+            );
+            Assert.Throws<ArgumentException>(
+                () => renderer.LocateBlockPath(_chainA[4], _chainA[4])
+            );
+        }
+
+        private IActionContext FakeContext(long blockIndex = 1) =>
+            new ActionContext(default, default, blockIndex, _emptyStates, 0);
+    }
+}

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -20,6 +20,19 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
+        public override void Constructor()
+        {
+            ArgumentOutOfRangeException e = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new DelayedActionRenderer<DumbAction>(
+                    new AnonymousActionRenderer<DumbAction>(),
+                    _store,
+                    confirmations: 0
+                )
+            );
+            Assert.Equal("confirmations", e.ParamName);
+        }
+
+        [Fact]
         public override void BlocksBeingAppended()
         {
             // FIXME: Eliminate duplication between this and DelayedRendererTest

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Blockchain.Renderers;
@@ -63,6 +64,19 @@ namespace Libplanet.Tests.Blockchain.Renderers
             {
                 _store.PutBlock(b);
             }
+        }
+
+        [Fact]
+        public virtual void Constructor()
+        {
+            ArgumentOutOfRangeException e = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new DelayedRenderer<DumbAction>(
+                    new AnonymousRenderer<DumbAction>(),
+                    _store,
+                    confirmations: 0
+                )
+            );
+            Assert.Equal("confirmations", e.ParamName);
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -13,11 +13,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
 {
     public class DelayedRendererTest
     {
-        private static readonly IReadOnlyList<Block<DumbAction>> _chainA;
-        private static readonly IReadOnlyList<Block<DumbAction>> _chainB;
-        private static readonly Block<DumbAction> _branchpoint;
-        private IStore _store;
-        private ILogger _logger;
+        protected static readonly IReadOnlyList<Block<DumbAction>> _chainA;
+        protected static readonly IReadOnlyList<Block<DumbAction>> _chainB;
+        protected static readonly Block<DumbAction> _branchpoint;
+        protected IStore _store;
+        protected ILogger _logger;
 
 #pragma warning disable S3963
         static DelayedRendererTest()
@@ -48,7 +48,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 .Enrich.WithThreadId()
                 .WriteTo.TestOutput(output)
                 .CreateLogger()
-                .ForContext<DelayedRendererTest>();
+                .ForContext(GetType());
             Log.Logger = _logger;
             _logger.CompareBothChains(
                 LogEventLevel.Debug,
@@ -66,7 +66,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
-        public void BlocksBeingAppended()
+        public virtual void BlocksBeingAppended()
         {
             var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
             uint reorgs = 0;
@@ -119,7 +119,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
-        public void BlocksBeingAppendedInParallel()
+        public virtual void BlocksBeingAppendedInParallel()
         {
             var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
             var reorgLogs = new List<(

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tests.Common.Action;
+using Serilog;
+using Serilog.Events;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class DelayedRendererTest
+    {
+        private static readonly IReadOnlyList<Block<DumbAction>> _chainA;
+        private static readonly IReadOnlyList<Block<DumbAction>> _chainB;
+        private static readonly Block<DumbAction> _branchpoint;
+        private IStore _store;
+        private ILogger _logger;
+
+#pragma warning disable S3963
+        static DelayedRendererTest()
+        {
+            var chainA = new Block<DumbAction>[10];
+            var chainB = new Block<DumbAction>[chainA.Length];
+            chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>();
+            for (int i = 1; i < chainA.Length / 2; i++)
+            {
+                _branchpoint = chainA[i] = chainB[i] = TestUtils.MineNext(chainA[i - 1]);
+            }
+
+            for (int i = chainA.Length / 2; i < chainA.Length; i++)
+            {
+                chainA[i] = TestUtils.MineNext(chainA[i - 1]);
+                chainB[i] = TestUtils.MineNext(chainB[i - 1]);
+            }
+
+            _chainA = chainA;
+            _chainB = chainB;
+        }
+#pragma warning restore S3963
+
+        public DelayedRendererTest(ITestOutputHelper output)
+        {
+            _logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(output)
+                .CreateLogger()
+                .ForContext<DelayedRendererTest>();
+            Log.Logger = _logger;
+            _logger.CompareBothChains(
+                LogEventLevel.Debug,
+                nameof(_chainA),
+                _chainA,
+                nameof(_chainB),
+                _chainB
+            );
+
+            _store = new DefaultStore(null);
+            foreach (Block<DumbAction> b in _chainA.Concat(_chainB))
+            {
+                _store.PutBlock(b);
+            }
+        }
+
+        [Fact]
+        public void BlocksBeingAppended()
+        {
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            uint reorgs = 0;
+            var innerRenderer = new AnonymousRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) =>
+                {
+                    // Note that this callback should not be invoked in this test case.
+                    reorgs++;
+                },
+            };
+            var renderer = new DelayedRenderer<DumbAction>(innerRenderer, _store, 3);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Equal(0U, reorgs);
+
+            // #0 -> 1 confirm; #1 -> no confirms; #2 -> no confirms
+            renderer.RenderBlock(_chainA[0], _chainA[1]);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Equal(0U, reorgs);
+
+            // #0 -> 2 confirms; #1 -> 1 confirm; #2 -> no confirms
+            renderer.RenderBlock(_chainA[1], _chainA[2]);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Equal(0U, reorgs);
+
+            // #0 -> 3 confirms; #1 -> 2 confirms; #2 -> 1 confirm; tip changed -> #0
+            renderer.RenderBlock(_chainA[2], _chainA[3]);
+            Assert.Equal(_chainA[0], renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Equal(0U, reorgs);
+
+            // #0 -> gone; #1 -> 3 confirms; #2 -> 2 confirms; tip changed -> #1; render(#0, #1)
+            renderer.RenderBlock(_chainA[3], _chainA[4]);
+            Assert.Equal(_chainA[1], renderer.Tip);
+            Assert.Single(blockLogs);
+            Assert.Equal((_chainA[0], _chainA[1]), blockLogs[0]);
+            Assert.Equal(0U, reorgs);
+
+            // #0 -> gone; #1 -> gone; #2 -> 3 confirms; tip changed -> #2; render(#1, #2)
+            renderer.RenderBlock(_chainA[4], _chainA[5]);
+            Assert.Equal(_chainA[2], renderer.Tip);
+            Assert.Equal(2, blockLogs.Count);
+            Assert.Equal((_chainA[0], _chainA[1]), blockLogs[0]);
+            Assert.Equal((_chainA[1], _chainA[2]), blockLogs[1]);
+            Assert.Equal(0U, reorgs);
+        }
+
+        [Fact]
+        public void BlocksBeingAppendedInParallel()
+        {
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var reorgLogs = new List<(
+                Block<DumbAction> OldTip,
+                Block<DumbAction> NewTip,
+                Block<DumbAction> Branchpoint
+            )>();
+            var innerRenderer = new AnonymousRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) => reorgLogs.Add((oldTip, newTip, bp)),
+            };
+            var renderer = new DelayedRenderer<DumbAction>(innerRenderer, _store, 3);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(reorgLogs);
+
+            // Some explanation on the fixture: there are two chains that shares a certain block
+            // as a branchpoint: _chainA and _chainB.  The topmost mutual block, i.e., branchpoint,
+            // between _chainA and _chainB is _chainA[4] (== _chainB[4]).
+            // In this test, we tries to simulate blocks from two parallel chains being "appended"
+            // (discovered) to a peer.  The order of discovery can be drawn as below (the prime
+            // [apostrophe] after the block index number like #N' shows it's from _chainB; the bare
+            // block index without that like #N means it's from _chainA):
+            //
+            //          #4 (1st)
+            //            |
+            //          /   \
+            //    #5 (2nd)  #5' (3rd)
+            //        |       |
+            //    #6 (3rd)  #6' (4th)
+            //        |       |
+            //    #7 (5th)  #7' (6th)
+            //        |       |
+            //    #8 (7th)  #8' (8th)
+            //                |
+            //              #9' (9th)
+
+            // #4  -> 1 confirm
+            // #5  -> no confirms
+            // #5' -> no confirms
+            renderer.RenderBlock(_chainA[4], _chainA[5]);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> 2 confirms
+            // #5  -> no confirms
+            // #5' -> no confirms
+            renderer.RenderReorg(_chainA[5], _chainB[5], _branchpoint);
+            renderer.RenderBlock(_chainA[5], _chainB[5]);
+            Assert.Null(renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> 3 confirms; tip changed -> #4
+            // #5  -> 1 confirm;  #6 -> no confirm
+            // #5' -> no confirms
+            renderer.RenderReorg(_chainB[5], _chainA[6], _branchpoint);
+            renderer.RenderBlock(_chainB[5], _chainA[6]);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 1 confirm; #6  -> no confirm
+            // #5' -> 1 confirm; #6' -> no confirm
+            renderer.RenderReorg(_chainA[6], _chainB[6], _branchpoint);
+            renderer.RenderBlock(_chainA[6], _chainB[6]);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 2 confirms; #6  -> 1 confirm; #7 -> no confirm
+            // #5' -> 1 confirm;  #6' -> no confirm
+            renderer.RenderReorg(_chainB[6], _chainA[7], _branchpoint);
+            renderer.RenderBlock(_chainB[6], _chainA[7]);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> gone but still is tip
+            // #5  -> 2 confirms; #6  -> 1 confirm; #7  -> no confirm
+            // #5' -> 2 confirms; #6' -> 1 confirm; #7' -> no confirm
+            renderer.RenderReorg(_chainA[7], _chainB[7], _branchpoint);
+            renderer.RenderBlock(_chainA[7], _chainB[7]);
+            Assert.Equal(_chainA[4], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+
+            // #4  -> gone; tip changed -> #5; render(#4, #5)
+            // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8 -> no confirm
+            // #5' -> 2 confirms; #6' -> 1 confirm;  #7' -> no confirm
+            renderer.RenderReorg(_chainB[7], _chainA[8], _branchpoint);
+            renderer.RenderBlock(_chainB[7], _chainA[8]);
+            Assert.Equal(_chainA[5], renderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Equal(new[] { (_chainA[4], _chainA[5]) }, blockLogs);
+
+            // tip changed -> #5'; render(#5, #5'); reorg(#5, #5', #4)
+            // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8  -> no confirm
+            // #5' -> 3 confirms; #6' -> 2 confirms; #7' -> 1 confirm; #8' -> no confirm
+            renderer.RenderReorg(_chainA[8], _chainB[8], _branchpoint);
+            renderer.RenderBlock(_chainA[8], _chainB[8]);
+            Assert.Equal(_chainB[5], renderer.Tip);
+            Assert.Equal(new[] { (_chainA[5], _chainB[5], _branchpoint) }, reorgLogs);
+            Assert.Equal(new[] { (_chainA[4], _chainA[5]), (_chainA[5], _chainB[5]) }, blockLogs);
+
+            // tip changed -> #6'; render(#5', #6')
+            // #5' -> gone; #6' -> 3 confirms; #7' -> 2 confirm; #8' -> 1 confirm; #9' -> 1 confirm
+            renderer.RenderBlock(_chainB[8], _chainB[9]);
+            Assert.Equal(_chainB[6], renderer.Tip);
+            Assert.Single(reorgLogs);
+            Assert.Equal(
+                new[]
+                {
+                    (_chainA[4], _chainA[5]),
+                    (_chainA[5], _chainB[5]),
+                    (_chainB[5], _chainB[6]),
+                },
+                blockLogs
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -66,14 +66,16 @@ namespace Libplanet.Tests.Blockchain.Renderers
             }
         }
 
-        [Fact]
-        public virtual void Constructor()
+        [InlineData(0)]
+        [InlineData(-123)]
+        [Theory]
+        public virtual void Constructor(int invalidConfirmations)
         {
             ArgumentOutOfRangeException e = Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DelayedRenderer<DumbAction>(
                     new AnonymousRenderer<DumbAction>(),
                     _store,
-                    confirmations: 0
+                    confirmations: invalidConfirmations
                 )
             );
             Assert.Equal("confirmations", e.ParamName);

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -8,6 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
+    <NoWarn>$(NoWarn);SA1401</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/Libplanet.Tests/LoggerExtensions.cs
+++ b/Libplanet.Tests/LoggerExtensions.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Blocks;
 using Serilog;
 using Serilog.Events;
 
@@ -17,6 +20,24 @@ namespace Libplanet.Tests
             BlockChain<T> chainB
         )
             where T : IAction, new()
+        =>
+            logger.CompareBothChains(
+                logLevel,
+                labelA,
+                chainA.BlockHashes.Select(h => chainA[h]).ToArray(),
+                labelB,
+                chainB.BlockHashes.Select(h => chainB[h]).ToArray()
+            );
+
+        public static void CompareBothChains<T>(
+            this ILogger logger,
+            LogEventLevel logLevel,
+            string labelA,
+            IReadOnlyList<Block<T>> chainA,
+            string labelB,
+            IReadOnlyList<Block<T>> chainB
+        )
+            where T : IAction, new()
         {
             if (chainA is null)
             {
@@ -25,6 +46,14 @@ namespace Libplanet.Tests
             else if (chainB is null)
             {
                 throw new ArgumentNullException(nameof(chainB));
+            }
+            else if (chainA.Any(b => b is null))
+            {
+                throw new ArgumentException($"The {nameof(chainA)} contains null.", nameof(chainA));
+            }
+            else if (chainB.Any(b => b is null))
+            {
+                throw new ArgumentException($"The {nameof(chainB)} contains null.", nameof(chainB));
             }
 
             if (!logger.IsEnabled(logLevel))
@@ -38,11 +67,11 @@ namespace Libplanet.Tests
                 logger.Write(logLevel, $"{bar} {i,3} {bar} {x,-64} {bar} {y,-64} {bar}");
             }
 
-            long aTipIdx = chainA.Tip.Index;
-            long bTipIdx = chainB.Tip.Index;
+            var aTipIdx = (int)chainA[chainA.Count - 1].Index;
+            var bTipIdx = (int)chainB[chainB.Count - 1].Index;
             Print("Idx", $"{labelA} (tip: {aTipIdx})", $"{labelB} (tip: {bTipIdx})");
-            long tipIdx = Math.Max(aTipIdx, bTipIdx);
-            long idx = 0;
+            int tipIdx = Math.Max(aTipIdx, bTipIdx);
+            int idx = 0;
             while (idx <= tipIdx)
             {
                 Print(

--- a/Libplanet.sln.DotSettings
+++ b/Libplanet.sln.DotSettings
@@ -23,4 +23,7 @@
   <s:Boolean x:Key="/Default/UserDictionary/Words/=struct/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unrender/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unrendered/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=unrenderer/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=unrendering/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=unrenders/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -1,7 +1,11 @@
+using System.Diagnostics.Contracts;
+
 namespace Libplanet.Action
 {
     internal class ActionContext : IActionContext
     {
+        private readonly int _randomSeed;
+
         public ActionContext(
             Address signer,
             Address miner,
@@ -17,6 +21,7 @@ namespace Libplanet.Action
             Rehearsal = rehearsal;
             PreviousStates = previousStates;
             Random = new Random(randomSeed);
+            _randomSeed = randomSeed;
         }
 
         public Address Signer { get; }
@@ -30,5 +35,9 @@ namespace Libplanet.Action
         public IAccountStateDelta PreviousStates { get; }
 
         public IRandom Random { get; }
+
+        [Pure]
+        public IActionContext GetUnconsumedContext() =>
+            new ActionContext(Signer, Miner, BlockIndex, PreviousStates, _randomSeed, Rehearsal);
     }
 }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.Contracts;
+
 namespace Libplanet.Action
 {
     /// <summary>
@@ -10,17 +12,20 @@ namespace Libplanet.Action
         /// <see cref="Address"/> of an account who made and signed
         /// a transaction that an executed <see cref="IAction"/> belongs to.
         /// </summary>
+        [Pure]
         Address Signer { get; }
 
         /// <summary>
         /// <see cref="Address"/> of a block miner account.
         /// </summary>
+        [Pure]
         Address Miner { get; }
 
         /// <summary>
         /// Block index of a transaction that an executed <see cref="IAction"/>
         /// belongs to.
         /// </summary>
+        [Pure]
         long BlockIndex { get; }
 
         /// <summary>
@@ -29,6 +34,7 @@ namespace Libplanet.Action
         /// in <see cref="PreviousStates"/>.
         /// </summary>
         /// <seealso cref="Libplanet.Tx.Transaction{T}.Create"/>
+        [Pure]
         bool Rehearsal { get; }
 
         /// <summary>
@@ -41,6 +47,7 @@ namespace Libplanet.Action
         /// instances can be returned by <see
         /// cref="IAction.Execute(IActionContext)"/> method.</para>
         /// </summary>
+        [Pure]
         IAccountStateDelta PreviousStates { get; }
 
         /// <summary>
@@ -53,5 +60,16 @@ namespace Libplanet.Action
         /// <returns>A random object that shares interface mostly equivalent
         /// to <see cref="System.Random"/>.</returns>
         IRandom Random { get; }
+
+        /// <summary>
+        /// Returns a clone of this context, except that its <see cref="Random"/> has the unconsumed
+        /// state (with the same seed).  The clone and its original are a distinct instance
+        /// each other, in other words, one's state transfer must not affect the other one
+        /// (i.e., consuming <see cref="Random"/> source should be local to a context instance).
+        /// </summary>
+        /// <returns>A clone instance, which is distinct from its original.  Its internal state
+        /// is entirely equivalent to the original's unconsumed initial state.</returns>
+        [Pure]
+        IActionContext GetUnconsumedContext();
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -987,7 +987,7 @@ namespace Libplanet.Blockchain
                     {
                         renderer.RenderAction(
                             evaluation.Action,
-                            evaluation.InputContext,
+                            evaluation.InputContext.GetUnconsumedContext(),
                             evaluation.OutputStates
                         );
                     }
@@ -998,7 +998,7 @@ namespace Libplanet.Blockchain
                     {
                         renderer.RenderActionError(
                             evaluation.Action,
-                            evaluation.InputContext,
+                            evaluation.InputContext.GetUnconsumedContext(),
                             evaluation.Exception
                         );
                     }
@@ -1440,7 +1440,7 @@ namespace Libplanet.Blockchain
                             {
                                 renderer.UnrenderAction(
                                     evaluation.Action,
-                                    evaluation.InputContext,
+                                    evaluation.InputContext.GetUnconsumedContext(),
                                     evaluation.OutputStates
                                 );
                             }
@@ -1451,7 +1451,7 @@ namespace Libplanet.Blockchain
                             {
                                 renderer.UnrenderActionError(
                                     evaluation.Action,
-                                    evaluation.InputContext,
+                                    evaluation.InputContext.GetUnconsumedContext(),
                                     evaluation.Exception
                                 );
                             }

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -1,0 +1,392 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Store;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// An <see cref="IActionRenderer{T}"/> version of <see cref="DelayedRenderer{T}"/>.
+    /// <para>Decorates an <see cref="IActionRenderer{T}"/> instance and delays the events until
+    /// blocks are <em>confirmed</em> the certain number of blocks.  When blocks are recognized
+    /// the delayed events relevant to these blocks are relayed to the decorated
+    /// <see cref="IActionRenderer{T}"/>.</para>
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <example>
+    /// <code><![CDATA[
+    /// IStore store = GetStore();
+    /// IActionRenderer<ExampleAction> actionRenderer = new SomeActionRenderer();
+    /// // Wraps the actionRenderer with DelayedActionRenderer; the SomeActionRenderer instance
+    /// // becomes to receive event messages only after the relevent blocks are confirmed
+    /// // by 3+ blocks.
+    /// actionRenderer = new DelayedActionRenderer<ExampleAction>(
+    ///    actionRenderer,
+    ///    store,
+    ///    confirmations: 3);
+    /// // You must pass the same store to the BlockChain<T>() constructor:
+    /// var chain = new BlockChain<ExampleAction>(
+    ///    ...,
+    ///    store: store,
+    ///    renderers: new[] { actionRenderer });
+    /// ]]></code>
+    /// </example>
+    public class DelayedActionRenderer<T> : DelayedRenderer<T>, IActionRenderer<T>
+        where T : IAction, new()
+    {
+        private readonly Dictionary<HashDigest<SHA256>, List<ActionEvaluation>>
+            _bufferedActionRenders;
+
+        private readonly Dictionary<HashDigest<SHA256>, List<ActionEvaluation>>
+            _bufferedActionUnrenders;
+
+        private HashDigest<SHA256>? _eventReceivingBlock;
+        private Reorg? _eventReceivingReorg;
+
+        /// <summary>
+        /// Creates a new <see cref="DelayedRenderer{T}"/> instance decorating the given
+        /// <paramref name="renderer"/>.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives delayed events.</param>
+        /// <param name="store">The same store to what <see cref="BlockChain{T}"/> uses.</param>
+        /// <param name="confirmations">The required number of confirmations to recognize a block.
+        /// See also the <see cref="DelayedRenderer{T}.Confirmations"/> property.</param>
+        public DelayedActionRenderer(IActionRenderer<T> renderer, IStore store, uint confirmations)
+            : base(renderer, store, confirmations)
+        {
+            ActionRenderer = renderer;
+            _bufferedActionRenders =
+                new Dictionary<HashDigest<SHA256>, List<ActionEvaluation>>();
+            _bufferedActionUnrenders =
+                new Dictionary<HashDigest<SHA256>, List<ActionEvaluation>>();
+        }
+
+        /// <summary>
+        /// The inner action renderer which has the <em>actual</em> implementations and receives
+        /// delayed events.
+        /// </summary>
+        public IActionRenderer<T> ActionRenderer { get; }
+
+        /// <inheritdoc cref="DelayedRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
+        public override void RenderBlock(Block<T> oldTip, Block<T> newTip)
+        {
+            base.RenderBlock(oldTip, newTip);
+            if (_eventReceivingReorg is Reorg reorg)
+            {
+                foreach (HashDigest<SHA256> block in reorg.Unrendered)
+                {
+                    if (_bufferedActionUnrenders.TryGetValue(block, out List<ActionEvaluation>? b))
+                    {
+                        b?.Clear();
+                    }
+                }
+
+                foreach (HashDigest<SHA256> block in reorg.Rendered)
+                {
+                    if (_bufferedActionRenders.TryGetValue(block, out List<ActionEvaluation>? buf))
+                    {
+                        buf?.Clear();
+                    }
+                }
+
+                if (!(reorg.OldTip.Equals(oldTip) && reorg.NewTip.Equals(newTip)))
+                {
+                    _eventReceivingReorg = null;
+                }
+            }
+
+            _eventReceivingBlock = newTip.Hash;
+            _bufferedActionRenders[newTip.Hash] = new List<ActionEvaluation>();
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
+        public override void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
+        {
+            base.RenderReorg(oldTip, newTip, branchpoint);
+            _eventReceivingBlock = null;
+            _eventReceivingReorg = new Reorg(
+                LocateBlockPath(branchpoint, oldTip),
+                LocateBlockPath(branchpoint, newTip),
+                oldTip,
+                newTip,
+                branchpoint
+            );
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            DelayRenderingAction(new ActionEvaluation(action, context, nextStates));
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        public void RenderActionError(IAction action, IActionContext context, Exception exception)
+        {
+            var eval = new ActionEvaluation(action, context, context.PreviousStates, exception);
+            DelayRenderingAction(eval);
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            DelayUnrenderingAction(new ActionEvaluation(action, context, nextStates));
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
+        {
+            var eval = new ActionEvaluation(action, context, context.PreviousStates, exception);
+            DelayUnrenderingAction(eval);
+        }
+
+        /// <summary>
+        /// Lists all descendants from <paramref name="lower"/> (exclusive) to
+        /// <paramref name="upper"/> (inclusive).
+        /// </summary>
+        /// <param name="lower">The block to get its descendants (excluding it).</param>
+        /// <param name="upper">The block to get its ancestors (including it).</param>
+        /// <returns>Block hashes from <paramref name="lower"/> to <paramref name="upper"/>.
+        /// Lower block hashes go first, and upper block hashes go last.
+        /// Does not contain <paramref name="lower"/>'s hash but <paramref name="upper"/>'s one.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="upper"/> block's index
+        /// is not greater than <paramref name="lower"/> block's index.</exception>
+        internal ImmutableArray<HashDigest<SHA256>> LocateBlockPath(Block<T> lower, Block<T> upper)
+        {
+            if (lower.Index >= upper.Index)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(upper)} block must has the greater index than " +
+                    $"the {nameof(lower)} block.",
+                    nameof(upper)
+                );
+            }
+
+            IEnumerable<HashDigest<SHA256>> Iterate()
+            {
+                for (
+                    Block<T>? b = upper;
+                    b is Block<T> && b.Index > lower.Index;
+                    b = b.PreviousHash is HashDigest<SHA256> prev ? Store.GetBlock<T>(prev) : null
+                )
+                {
+                    yield return b.Hash;
+                }
+            }
+
+            return Iterate().Reverse().ToImmutableArray();
+        }
+
+        /// <inheritdoc cref="DelayedRenderer{T}.OnTipChanged(Block{T}?, Block{T})"/>
+        protected override Block<T>? OnTipChanged(Block<T>? oldTip, Block<T> newTip)
+        {
+            if (oldTip is null)
+            {
+                return null;
+            }
+
+            Block<T>? branchpoint = base.OnTipChanged(oldTip, newTip);
+            if (branchpoint is null)
+            {
+                RenderBufferedActionEvaluations(newTip.Hash, unrender: false);
+            }
+            else
+            {
+                var blocksToUnrender = LocateBlockPath(branchpoint, oldTip).Reverse();
+                foreach (HashDigest<SHA256> hash in blocksToUnrender)
+                {
+                    RenderBufferedActionEvaluations(hash, unrender: true);
+                }
+
+                var blocksToRender = LocateBlockPath(branchpoint, newTip);
+                foreach (HashDigest<SHA256> hash in blocksToRender)
+                {
+                    RenderBufferedActionEvaluations(hash, unrender: false);
+                }
+            }
+
+            return branchpoint;
+        }
+
+        private void DelayRenderingAction(ActionEvaluation eval)
+        {
+            if (_eventReceivingReorg is Reorg reorg)
+            {
+                long blockIndex = eval.InputContext.BlockIndex;
+                HashDigest<SHA256> blockHash = reorg.IndexHash(blockIndex, unrender: false);
+                if (!_bufferedActionRenders.TryGetValue(blockHash, out List<ActionEvaluation>? buf))
+                {
+                    _bufferedActionRenders[blockHash] = buf = new List<ActionEvaluation>();
+                }
+
+                buf.Add(eval);
+                Logger.Verbose(
+                    "Delayed an action render from #{BlockIndex} {BlockHash} (buffer: {Buffer}).",
+                    blockIndex,
+                    blockHash,
+                    buf.Count
+                );
+            }
+            else if (_eventReceivingBlock is HashDigest<SHA256> h &&
+                _bufferedActionRenders.TryGetValue(h, out List<ActionEvaluation>? b) &&
+                b is List<ActionEvaluation> buffer)
+            {
+                buffer.Add(eval);
+                Logger.Verbose(
+                    "Delayed an action render from #{BlockIndex} {BlockHash} (buffer: {Buffer}).",
+                    eval.InputContext.BlockIndex,
+                    h,
+                    buffer.Count
+                );
+            }
+            else
+            {
+                const string msg =
+                    "An action render {@Action} from the block #{BlockIndex} was ignored due " +
+                    "unexpected internal state.";
+                Logger.Warning(msg, eval.Action, eval.InputContext.BlockIndex);
+            }
+        }
+
+        private void DelayUnrenderingAction(ActionEvaluation eval)
+        {
+            if (_eventReceivingReorg is Reorg reorg)
+            {
+                long blockIndex = eval.InputContext.BlockIndex;
+                HashDigest<SHA256> blockHash = reorg.IndexHash(blockIndex, unrender: true);
+                if (!_bufferedActionUnrenders.TryGetValue(blockHash, out List<ActionEvaluation>? b))
+                {
+                    _bufferedActionUnrenders[blockHash] = b = new List<ActionEvaluation>();
+                }
+
+                b.Add(eval);
+                Logger.Verbose(
+                    "Delayed an action unrender from #{BlockIndex} {BlockHash} (buffer: {Buffer}).",
+                    blockIndex,
+                    blockHash,
+                    b.Count
+                );
+            }
+            else
+            {
+                const string msg =
+                    "An action unrender {@Action} from the block #{BlockIndex} was ignored due " +
+                    "unexpected internal state.";
+                Logger.Warning(msg, eval.Action, eval.InputContext.BlockIndex);
+            }
+        }
+
+        private void RenderBufferedActionEvaluations(HashDigest<SHA256> blockHash, bool unrender)
+        {
+            Dictionary<HashDigest<SHA256>, List<ActionEvaluation>> bufferMap
+                = unrender
+                ? _bufferedActionUnrenders
+                : _bufferedActionRenders;
+            string verb = unrender ? "unrender" : "render";
+            if (bufferMap.TryGetValue(blockHash, out List<ActionEvaluation>? b) &&
+                b is List<ActionEvaluation> buffer)
+            {
+                Logger.Debug(
+                    $"Starts to {verb} {{BufferCount}} buffered actions from the block " +
+                    "{BlockHash}...",
+                    buffer.Count,
+                    blockHash
+                );
+                RenderActionEvaluations(buffer, unrender);
+                bufferMap.Remove(blockHash);
+            }
+            else
+            {
+                Logger.Debug(
+                    $"There are no buffered actions to {verb} for the block {{BlockHash}}.",
+                    blockHash
+                );
+            }
+        }
+
+        private void RenderActionEvaluations(
+            IEnumerable<ActionEvaluation> evaluations,
+            bool unrender
+        )
+        {
+            foreach (ActionEvaluation eval in evaluations)
+            {
+                if (eval.Exception is Exception e)
+                {
+                    if (unrender)
+                    {
+                        ActionRenderer.UnrenderActionError(eval.Action, eval.InputContext, e);
+                    }
+                    else
+                    {
+                        ActionRenderer.RenderActionError(eval.Action, eval.InputContext, e);
+                    }
+                }
+                else
+                {
+                    if (unrender)
+                    {
+                        ActionRenderer.UnrenderAction(
+                            eval.Action,
+                            eval.InputContext,
+                            eval.OutputStates
+                        );
+                    }
+                    else
+                    {
+                        ActionRenderer.RenderAction(
+                            eval.Action,
+                            eval.InputContext,
+                            eval.OutputStates
+                        );
+                    }
+                }
+            }
+        }
+
+        private readonly struct Reorg
+        {
+            public readonly ImmutableArray<HashDigest<SHA256>> Unrendered;
+            public readonly ImmutableArray<HashDigest<SHA256>> Rendered;
+            public readonly Block<T> OldTip;
+            public readonly Block<T> NewTip;
+            public readonly Block<T> Branchpoint;
+
+            public Reorg(
+                ImmutableArray<HashDigest<SHA256>> unrendered,
+                ImmutableArray<HashDigest<SHA256>> rendered,
+                Block<T> oldTip,
+                Block<T> newTip,
+                Block<T> branchpoint
+            )
+            {
+                Unrendered = unrendered;
+                Rendered = rendered;
+                OldTip = oldTip;
+                NewTip = newTip;
+                Branchpoint = branchpoint;
+            }
+
+            public HashDigest<SHA256> IndexHash(long index, bool unrender)
+            {
+                int offset = (int)(index - Branchpoint.Index);
+                return (unrender ? Unrendered : Rendered)[offset - 1];
+            }
+        }
+    }
+}

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -58,7 +58,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <param name="store">The same store to what <see cref="BlockChain{T}"/> uses.</param>
         /// <param name="confirmations">The required number of confirmations to recognize a block.
         /// See also the <see cref="DelayedRenderer{T}.Confirmations"/> property.</param>
-        public DelayedActionRenderer(IActionRenderer<T> renderer, IStore store, uint confirmations)
+        public DelayedActionRenderer(IActionRenderer<T> renderer, IStore store, int confirmations)
             : base(renderer, store, confirmations)
         {
             ActionRenderer = renderer;

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -1,0 +1,267 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Serilog;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// Decorates an <see cref="IRenderer{T}"/> instance and delays the events until blocks
+    /// are <em>confirmed</em> the certain number of blocks.  When blocks are recognized
+    /// the delayed events relevant to these blocks are relayed to the decorated
+    /// <see cref="IRenderer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <example>
+    /// <code><![CDATA[
+    /// IStore store = GetStore();
+    /// IRenderer<ExampleAction> renderer = new SomeRenderer();
+    /// // Wraps the renderer with DelayedRenderer; the SomeRenderer instance becomes to receive
+    /// // event messages only after the relevent blocks are confirmed by 3+ blocks.
+    /// renderer = new DelayedRenderer<ExampleAction>(renderer, store, confirmations: 3);
+    /// // You must pass the same store to the BlockChain<T>() constructor:
+    /// var chain = new BlockChain<ExampleAction>(..., store: store, renderers: new[] { renderer });
+    /// ]]></code>
+    /// </example>
+    public class DelayedRenderer<T> : IRenderer<T>
+        where T : IAction, new()
+    {
+        private ILogger _logger;
+        private ConcurrentDictionary<HashDigest<SHA256>, uint> _confirmed;
+        private Block<T>? _tip;
+
+        /// <summary>
+        /// Creates a new <see cref="DelayedRenderer{T}"/> instance decorating the given
+        /// <paramref name="renderer"/>.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives delayed events.</param>
+        /// <param name="store">The same store to what <see cref="BlockChain{T}"/> uses.</param>
+        /// <param name="confirmations">The required number of confirmations to recognize a block.
+        /// See also the <see cref="Confirmations"/> property.</param>
+        public DelayedRenderer(IRenderer<T> renderer, IStore store, uint confirmations)
+        {
+            _logger = Log.ForContext<DelayedRenderer<T>>();
+            Renderer = renderer;
+            Store = store;
+            Confirmations = confirmations;
+            _confirmed = new ConcurrentDictionary<HashDigest<SHA256>, uint>();
+        }
+
+        /// <summary>
+        /// The inner renderer which has the <em>actual</em> implementations and receives delayed
+        /// events.
+        /// </summary>
+        public IRenderer<T> Renderer { get; }
+
+        /// <summary>
+        /// The same store to what <see cref="BlockChain{T}"/> uses.
+        /// </summary>
+        public IStore Store { get; }
+
+        /// <summary>
+        /// The required number of confirmations to recognize a block.
+        /// <para>For example, the required confirmations are 2, the block #N is recognized after
+        /// the block #N+1 and the block #N+2 are discovered.</para>
+        /// </summary>
+        public uint Confirmations { get; }
+
+        /// <summary>
+        /// The <em>recognized</em> topmost block.  If not enough blocks are discovered yet,
+        /// this property can be <c>null</c>.
+        /// </summary>
+        public Block<T>? Tip
+        {
+            get => _tip;
+            private set
+            {
+                Block<T>? newTip = value;
+                if (newTip is null || newTip.Equals(_tip))
+                {
+                    return;
+                }
+
+                if (_tip is null)
+                {
+                    _logger.Verbose(
+                        $"{nameof(DelayedRenderer<T>)}.{nameof(Tip)} is tried to be updated to " +
+                        "#{NewTipIndex} {NewTipHash} (from null).",
+                        newTip.Index,
+                        newTip.Hash
+                    );
+                }
+                else
+                {
+                    _logger.Verbose(
+                        $"{nameof(DelayedRenderer<T>)}.{nameof(Tip)} is tried to be updated to " +
+                        "#{NewTipIndex} {NewTipHash} (from #{OldTipIndex} {OldTipHash}).",
+                        newTip.Index,
+                        newTip.Hash,
+                        _tip.Index,
+                        _tip.Hash
+                    );
+                }
+
+                Block<T>? oldTip = _tip;
+                _tip = newTip;
+                if (oldTip is null)
+                {
+                    _logger.Debug(
+                        $"{nameof(DelayedRenderer<T>)}.{nameof(Tip)} was updated to " +
+                        "#{NewTipIndex} {NewTipHash} (from null).",
+                        newTip.Index,
+                        newTip.Hash
+                    );
+                }
+                else
+                {
+                    _logger.Debug(
+                        $"{nameof(DelayedRenderer<T>)}.{nameof(Tip)} was updated to " +
+                        "#{NewTipIndex} {NewTipHash} (from #{OldTipIndex} {OldTipHash}).",
+                        newTip.Index,
+                        newTip.Hash,
+                        oldTip.Index,
+                        oldTip.Hash
+                    );
+                }
+
+                OnTipChanged(oldTip, newTip);
+            }
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
+        public void RenderBlock(Block<T> oldTip, Block<T> newTip)
+        {
+            _confirmed.TryAdd(oldTip.Hash, 0);
+            DiscoverBlock(newTip);
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
+        public void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
+        {
+            _confirmed.TryAdd(branchpoint.Hash, 0);
+        }
+
+        /// <summary>
+        /// The callback method which is invoked when the new <see cref="Tip"/> is recognized and
+        /// changed.
+        /// </summary>
+        /// <param name="oldTip">The previously recognized topmost block.</param>
+        /// <param name="newTip">The topmost block recognized this time.</param>
+        protected virtual void OnTipChanged(Block<T>? oldTip, Block<T> newTip)
+        {
+            if (oldTip is null)
+            {
+                return;
+            }
+
+            if (!newTip.PreviousHash.Equals(oldTip.Hash))
+            {
+                Renderer.RenderReorg(oldTip, newTip, FindBranchpoint(oldTip, newTip));
+            }
+
+            Renderer.RenderBlock(oldTip, newTip);
+        }
+
+        private void DiscoverBlock(Block<T> block)
+        {
+            if (_confirmed.ContainsKey(block.Hash))
+            {
+                return;
+            }
+
+            _confirmed.TryAdd(block.Hash, 0);
+
+            HashDigest<SHA256>? prev = block.PreviousHash;
+            Block<T>? newTip = null;
+            do
+            {
+                if (!(prev is HashDigest<SHA256> prevHash &&
+                      Store.GetBlock<T>(prevHash) is Block<T> prevBlock))
+                {
+                    break;
+                }
+
+                uint c = _confirmed.AddOrUpdate(prevHash, k => 1U, (k, v) => v + 1U);
+                _logger.Verbose(
+                    "The block #{BlockIndex} {BlockHash} has {Confirmations} confirmations.",
+                    prevBlock.Index,
+                    prevBlock.Hash,
+                    c
+                );
+
+                if (c >= Confirmations)
+                {
+                    if (newTip is null)
+                    {
+                        newTip = prevBlock;
+                    }
+                    else
+                    {
+#pragma warning disable S1116, SA1106, SA1503
+                        // The below while statement is not "empty"; its condition has an effect.
+                        while (!_confirmed.TryRemove(prevHash, out _));
+#pragma warning restore S1116, SA1106, SA1503
+                    }
+                }
+
+                prev = prevBlock.PreviousHash;
+            }
+            while (true);
+
+            if (newTip is Block<T>)
+            {
+                Tip = newTip;
+            }
+        }
+
+        private Block<T> FindBranchpoint(Block<T> a, Block<T> b)
+        {
+            while (a is Block<T> && a.Index > b.Index && a.PreviousHash is HashDigest<SHA256> aPrev)
+            {
+                a = Store.GetBlock<T>(aPrev);
+            }
+
+            while (b is Block<T> && b.Index > a.Index && b.PreviousHash is HashDigest<SHA256> bPrev)
+            {
+                b = Store.GetBlock<T>(bPrev);
+            }
+
+            if (a is null || b is null || a.Index != b.Index)
+            {
+                throw new ArgumentException(
+                    "Some previous blocks of two blocks are orphan.",
+                    nameof(a)
+                );
+            }
+
+            while (a.Index >= 0)
+            {
+                if (a.Equals(b))
+                {
+                    return a;
+                }
+
+                if (a.PreviousHash is HashDigest<SHA256> aPrev &&
+                    b.PreviousHash is HashDigest<SHA256> bPrev)
+                {
+                    a = Store.GetBlock<T>(aPrev);
+                    b = Store.GetBlock<T>(bPrev);
+                    continue;
+                }
+
+                break;
+            }
+
+            throw new ArgumentException(
+                "Two blocks do not have any ancestors in common.",
+                nameof(a)
+            );
+        }
+    }
+}

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -47,9 +47,21 @@ namespace Libplanet.Blockchain.Renderers
         /// implementations and receives delayed events.</param>
         /// <param name="store">The same store to what <see cref="BlockChain{T}"/> uses.</param>
         /// <param name="confirmations">The required number of confirmations to recognize a block.
+        /// It must be greater than zero (note that zero <paramref name="confirmations"/> mean
+        /// nothing is delayed so that it is equivalent to the bare <paramref name="renderer"/>).
         /// See also the <see cref="Confirmations"/> property.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the argument
+        /// <paramref name="confirmations"/> is not greater than zero.</exception>
         public DelayedRenderer(IRenderer<T> renderer, IStore store, uint confirmations)
         {
+            if (confirmations < 1)
+            {
+                string msg =
+                    "Zero confirmations mean nothing is delayed so that it is equivalent to the " +
+                    $"bare {nameof(renderer)}; configure it to more than zero.";
+                throw new ArgumentOutOfRangeException(nameof(confirmations), msg);
+            }
+
             Logger = Log.ForContext(GetType());
             Renderer = renderer;
             Store = store;

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Blockchain.Renderers
     /// ]]></code>
     /// </example>
     /// <remarks>Since <see cref="IActionRenderer{T}"/> is a subtype of <see cref="IRenderer{T}"/>,
-    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IStore, uint)"/> constructor can take
+    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IStore, int)"/> constructor can take
     /// an <see cref="IActionRenderer{T}"/> instance as well.  However, even it takes an action
     /// renderer, action-level fine-grained events won't hear.  For action renderers,
     /// please use <see cref="DelayedActionRenderer{T}"/> instead.</remarks>
@@ -52,14 +52,21 @@ namespace Libplanet.Blockchain.Renderers
         /// See also the <see cref="Confirmations"/> property.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the argument
         /// <paramref name="confirmations"/> is not greater than zero.</exception>
-        public DelayedRenderer(IRenderer<T> renderer, IStore store, uint confirmations)
+        public DelayedRenderer(IRenderer<T> renderer, IStore store, int confirmations)
         {
-            if (confirmations < 1)
+            if (confirmations == 0)
             {
                 string msg =
                     "Zero confirmations mean nothing is delayed so that it is equivalent to the " +
                     $"bare {nameof(renderer)}; configure it to more than zero.";
                 throw new ArgumentOutOfRangeException(nameof(confirmations), msg);
+            }
+            else if (confirmations < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(confirmations),
+                    $"Expected more than zero {nameof(confirmations)}."
+                );
             }
 
             Logger = Log.ForContext(GetType());
@@ -85,7 +92,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <para>For example, the required confirmations are 2, the block #N is recognized after
         /// the block #N+1 and the block #N+2 are discovered.</para>
         /// </summary>
-        public uint Confirmations { get; }
+        public int Confirmations { get; }
 
         /// <summary>
         /// The <em>recognized</em> topmost block.  If not enough blocks are discovered yet,

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using Libplanet.Action;
+using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain.Renderers
 {
@@ -19,11 +20,6 @@ namespace Libplanet.Blockchain.Renderers
         /// Does things that should be done right after an <paramref name="action"/>
         /// is executed and applied to the blockchain.
         /// </summary>
-        /// <remarks>It is guaranteed to be called only once for an <paramref name="action"/>,
-        /// and only after applied to the blockchain, unless an exception is thrown during executing
-        /// the <paramref name="action"/> (in that case <see
-        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> is called instead) or
-        /// once the <paramref name="action"/> has been unrendered.</remarks>
         /// <param name="action">An executed action.</param>
         /// <param name="context">The equivalent context object to an object passed to
         /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
@@ -33,10 +29,21 @@ namespace Libplanet.Blockchain.Renderers
         /// <param name="nextStates">The states right <em>after</em> this action executed,
         /// which means it is equivalent to the states <paramref name="action"/>'s
         /// <see cref="IAction.Execute(IActionContext)"/> method returned.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <remarks>
+        /// It is guaranteed to be called only once for an <paramref name="action"/>,
+        /// and only after applied to the blockchain, unless an exception is thrown during executing
+        /// the <paramref name="action"/> (in that case <see
+        /// cref="RenderActionError(IAction, IActionContext, Exception)"/> is called instead) or
+        /// once the <paramref name="action"/> has been unrendered.
+        /// <para>Also note that this method is invoked after <see
+        /// cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/> method is called
+        /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
+        /// name="action"/> belongs to).</para>
+        /// <para>The reason why the parameter <paramref name="action"/> takes
         /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
         /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</para>
+        /// </remarks>
         void RenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
 
         /// <summary>
@@ -76,10 +83,16 @@ namespace Libplanet.Blockchain.Renderers
         /// <em>before</em> this action executed.</param>
         /// <param name="exception">The exception thrown during executing the <paramref
         /// name="action"/>.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
+        /// <remarks>
+        /// Also note that this method is invoked after <see
+        /// cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/> method is called
+        /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
+        /// name="action"/> belongs to).
+        /// <param>The reason why the parameter <paramref name="action"/> takes
         /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
         /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</param>
+        /// </remarks>
         void RenderActionError(IAction action, IActionContext context, Exception exception);
 
         /// <summary>

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -88,10 +88,10 @@ namespace Libplanet.Blockchain.Renderers
         /// cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/> method is called
         /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
         /// name="action"/> belongs to).
-        /// <param>The reason why the parameter <paramref name="action"/> takes
+        /// <para>The reason why the parameter <paramref name="action"/> takes
         /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
         /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</param>
+        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</para>
         /// </remarks>
         void RenderActionError(IAction action, IActionContext context, Exception exception);
 


### PR DESCRIPTION
This patch adds `DelayedRenderer<T>` & `DelayedActionRenderer<T>` that decorate another `IRenderer<T>` & `IActionRenderer<T>` and delay rendering events until the certain number of descendant blocks confirm a block.  See also the unit tests and XML comments.