### PR TITLE
Find specific peer from network

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,10 @@ To be released.
  -  The signature of `IStore.LookupStateReference<T>(Guid, string, Block<T>)` method was
     changed to `LookupStateReference(Guid, string, long)`.  [[#950]]
  -  Added `IStateStore`-typed `stateStore` to `BlockChain<T>` constructor.  [[#950]]
+ -  Replaced `Swarm<T>.FindSpecificPeerAsync(Address, Address, int,
+    BoundPeer, TimeSpan?, CancellationToken)` method with
+    `Swarm<T>.FindSpecificPeerAsync(Address, int, TimeSpan?, CancellationToken)`.
+    [[#981]]
 
 ### Backward-incompatible network protocol changes
 
@@ -300,6 +304,7 @@ To be released.
 [#967]: https://github.com/planetarium/libplanet/issues/967
 [#970]: https://github.com/planetarium/libplanet/pull/970
 [#972]: https://github.com/planetarium/libplanet/pull/972
+[#981]: https://github.com/planetarium/libplanet/pull/981
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -207,11 +207,12 @@ namespace Libplanet.Tests.Net.Protocols
                 {
                     _logger.Debug("Different version encountered during AddPeersAsync().");
                 }
-                catch (TimeoutException)
+                catch (PingTimeoutException)
                 {
-                    _logger.Debug(
-                        $"Timeout occurred during {nameof(AddPeersAsync)}() after {timeout}.");
-                    throw;
+                    var msg =
+                        $"Timeout occurred during {nameof(AddPeersAsync)}() after {timeout}.";
+                    _logger.Debug(msg);
+                    throw new TimeoutException(msg);
                 }
                 catch (TaskCanceledException)
                 {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1953,6 +1953,46 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
+        public async Task FindSpecificPeerAsyncFail()
+        {
+            Swarm<DumbAction> swarmA = _swarms[0];
+            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmC = _swarms[2];
+            try
+            {
+                await StartAsync(swarmA);
+                await StartAsync(swarmB);
+                await StartAsync(swarmC);
+
+                await swarmA.AddPeersAsync(new Peer[] { swarmB.AsPeer }, null);
+                await swarmB.AddPeersAsync(new Peer[] { swarmC.AsPeer }, null);
+
+                await StopAsync(swarmB);
+
+                BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
+                    swarmB.AsPeer.Address,
+                    -1,
+                    TimeSpan.FromMilliseconds(3000));
+
+                Assert.Null(foundPeer);
+
+                foundPeer = await swarmA.FindSpecificPeerAsync(
+                    swarmC.AsPeer.Address,
+                    -1,
+                    TimeSpan.FromMilliseconds(3000));
+
+                Assert.Null(foundPeer);
+                Assert.DoesNotContain(swarmC.AsPeer, swarmA.Peers);
+            }
+            finally
+            {
+                await StopAsync(swarmA);
+                await StopAsync(swarmB);
+                await StopAsync(swarmC);
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
         public async Task DoNotFillMultipleTimes()
         {
             Swarm<DumbAction> receiver = _swarms[0];

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1915,7 +1915,6 @@ namespace Libplanet.Tests.Net
             Swarm<DumbAction> swarmB = _swarms[1];
             Swarm<DumbAction> swarmC = _swarms[2];
             Swarm<DumbAction> swarmD = _swarms[3];
-            BoundPeer foundPeer;
             try
             {
                 await StartAsync(swarmA);
@@ -1927,25 +1926,22 @@ namespace Libplanet.Tests.Net
                 await swarmB.AddPeersAsync(new Peer[] { swarmC.AsPeer }, null);
                 await swarmC.AddPeersAsync(new Peer[] { swarmD.AsPeer }, null);
 
-                foundPeer = await swarmA.FindSpecificPeerAsync(
-                    swarmA.AsPeer.Address,
+                BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmB.AsPeer.Address,
                     -1,
-                    null,
-                    TimeSpan.FromMilliseconds(3000),
-                    default(CancellationToken));
+                    TimeSpan.FromMilliseconds(3000));
 
                 Assert.Equal(swarmB.AsPeer.Address, foundPeer.Address);
+                Assert.DoesNotContain(swarmC.AsPeer, swarmA.Peers);
 
                 foundPeer = await swarmA.FindSpecificPeerAsync(
-                    swarmA.AsPeer.Address,
                     swarmD.AsPeer.Address,
                     -1,
-                    null,
-                    TimeSpan.FromMilliseconds(3000),
-                    default(CancellationToken));
+                    TimeSpan.FromMilliseconds(3000));
 
                 Assert.Equal(swarmD.AsPeer.Address, foundPeer.Address);
+                Assert.Contains(swarmC.AsPeer, swarmA.Peers);
+                Assert.Contains(swarmD.AsPeer, swarmA.Peers);
             }
             finally
             {

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -404,9 +404,7 @@ namespace Libplanet.Net
         {
             var kp = (KademliaProtocol)Protocol;
             return await kp.FindSpecificPeerAsync(
-                null,
                 target,
-                null,
                 depth,
                 timeout,
                 cancellationToken);

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -398,9 +398,7 @@ namespace Libplanet.Net
 
         public async Task<BoundPeer> FindSpecificPeerAsync(
             Address target,
-            Address searchAddress,
             int depth,
-            BoundPeer viaPeer,
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
@@ -408,9 +406,8 @@ namespace Libplanet.Net
             return await kp.FindSpecificPeerAsync(
                 null,
                 target,
-                viaPeer,
+                null,
                 depth,
-                searchAddress,
                 timeout,
                 cancellationToken);
         }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -357,16 +357,15 @@ namespace Libplanet.Net.Protocols
                 }
 
                 history.Add(viaPeer);
-                List<BoundPeer> foundPeers =
-                    (await GetNeighbors(viaPeer, target, timeout, cancellationToken)).ToList();
-
-                int count = 0;
+                IEnumerable<BoundPeer> foundPeers =
+                    await GetNeighbors(viaPeer, target, timeout, cancellationToken);
                 IEnumerable<BoundPeer> filteredPeers = foundPeers
                     .Where(peer =>
                         !history.Contains(peer) &&
                         !peersToFind.Contains(peer) &&
                         !peer.Address.Equals(_address))
                     .Take(_findConcurrency);
+                int count = 0;
                 foreach (var found in filteredPeers)
                 {
                     try
@@ -391,7 +390,7 @@ namespace Libplanet.Net.Protocols
                     }
                     catch (PingTimeoutException)
                     {
-                        continue;
+                        history.Add(found);
                     }
                 }
             }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -307,7 +307,8 @@ namespace Libplanet.Net.Protocols
         /// <see cref="FindNeighbors"/>.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
-        /// <returns>A BoundPeer with <see cref="Address"/> of <paramref name="target"/>.</returns>
+        /// <returns>A <see cref="BoundPeer"/> with <see cref="Address"/> of
+        /// <paramref name="target"/>.</returns>
         public async Task<BoundPeer> FindSpecificPeerAsync(
             ConcurrentBag<BoundPeer> history,
             Address target,
@@ -327,7 +328,9 @@ namespace Libplanet.Net.Protocols
             {
                 if (_routing.ContainsAddress(target) is BoundPeer boundPeer)
                 {
-                    _logger.Debug("Target peer was in routing table. {BoundPeer}", boundPeer);
+                    _logger.Debug(
+                        "{BoundPeer}, a target peer, is in the routing table.",
+                        boundPeer);
                     return boundPeer;
                 }
 
@@ -697,7 +700,7 @@ namespace Libplanet.Net.Protocols
 
             if (peers.Count == 0)
             {
-                _logger.Debug("No any neighbor received.");
+                _logger.Debug("Received no neighbors at all.");
                 return null;
             }
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -331,6 +331,18 @@ namespace Libplanet.Net.Protocols
             {
                 if (_routing.ContainsAddress(target) is BoundPeer boundPeer)
                 {
+                    try
+                    {
+                        await PingAsync(boundPeer, _requestTimeout, cancellationToken);
+                    }
+                    catch (PingTimeoutException)
+                    {
+                        var msg =
+                            "{BoundPeer}, a target peer, is in the routing table does not respond.";
+                        _logger.Debug(msg, boundPeer);
+                        return null;
+                    }
+
                     _logger.Debug(
                         "{BoundPeer}, a target peer, is in the routing table.",
                         boundPeer);

--- a/Libplanet/Net/Protocols/PingTimeoutException.cs
+++ b/Libplanet/Net/Protocols/PingTimeoutException.cs
@@ -24,14 +24,24 @@ namespace Libplanet.Net.Protocols
             Target = target;
         }
 
-        protected PingTimeoutException(
-            SerializationInfo info,
-            StreamingContext context
-        )
+        protected PingTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            Target = (BoundPeer)info.GetValue("Target", typeof(BoundPeer));
         }
 
         public BoundPeer Target { get; private set; }
+
+        public override void GetObjectData(
+            SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new System.ArgumentNullException(nameof(info));
+            }
+
+            base.GetObjectData(info, context);
+            info.AddValue("Target", Target);
+        }
     }
 }

--- a/Libplanet/Net/Protocols/PingTimeoutException.cs
+++ b/Libplanet/Net/Protocols/PingTimeoutException.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Net.Protocols
+{
+    [Serializable]
+    public class PingTimeoutException : TimeoutException
+    {
+        public PingTimeoutException(BoundPeer target)
+            : base()
+        {
+            Target = target;
+        }
+
+        public PingTimeoutException(BoundPeer target, string message)
+            : base(message)
+        {
+            Target = target;
+        }
+
+        public PingTimeoutException(BoundPeer target, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Target = target;
+        }
+
+        protected PingTimeoutException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
+        }
+
+        public BoundPeer Target { get; private set; }
+    }
+}

--- a/Libplanet/Net/Protocols/PingTimeoutException.cs
+++ b/Libplanet/Net/Protocols/PingTimeoutException.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Net.Protocols
         public override void GetObjectData(
             SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
+            if (info is null)
             {
                 throw new System.ArgumentNullException(nameof(info));
             }

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -168,14 +168,32 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        public IEnumerable<BoundPeer> Neighbors(Peer target, int k)
+        /// <summary>
+        /// Returns <paramref name="k"/> nearest peers to given parameter peer from routing table.
+        /// Return value is already sorted with respect to target.
+        /// </summary>
+        /// <param name="target"><see cref="Peer"/> to look up.</param>
+        /// <param name="k">Number of peers to return.</param>
+        /// <param name="includeTarget">A boolean value indicates to include a peer with
+        /// <see cref="Address"/> of <paramref name="target"/> in return value or not.</param>
+        /// <returns>An enumerable of <see cref="BoundPeer"/>.</returns>
+        public IEnumerable<BoundPeer> Neighbors(Peer target, int k, bool includeTarget)
         {
-            return Neighbors(target.Address, k);
+            return Neighbors(target.Address, k, includeTarget);
         }
 
-        // returns k nearest peers to given parameter peer from routing table.
-        // return value is already sorted with respect to target.
-        public IEnumerable<BoundPeer> Neighbors(Address target, int k)
+        /// <summary>
+        /// Returns at most 2 * <paramref name="k"/> (2 * <paramref name="k"/> + 1 if
+        /// <paramref name="includeTarget"/> is <c>true</c>) nearest peers to given parameter peer
+        /// from routing table. Return value is sorted with respect to target.
+        /// <seealso cref="Kademlia.SortByDistance(IEnumerable{BoundPeer}, Address)"/>
+        /// </summary>
+        /// <param name="target"><see cref="Address"/> to look up.</param>
+        /// <param name="k">Number of peers to return.</param>
+        /// <param name="includeTarget">A boolean value indicates to include a peer with
+        /// <see cref="Address"/> of <paramref name="target"/> in return value or not.</param>
+        /// <returns>An enumerable of <see cref="BoundPeer"/>.</returns>
+        public IEnumerable<BoundPeer> Neighbors(Address target, int k, bool includeTarget)
         {
             var sorted = _buckets
                 .Where(b => !b.IsEmpty())
@@ -184,10 +202,17 @@ namespace Libplanet.Net.Protocols
 
             sorted = Kademlia.SortByDistance(sorted, target);
             var peers = new List<BoundPeer>();
-            foreach (var peer in sorted.Where(peer => !peer.Address.Equals(target)))
+
+            // Select maximum k * 2 peers excluding the target itself.
+            bool containsTarget = sorted.Any(peer => peer.Address.Equals(target));
+            int maxCount = (includeTarget && containsTarget) ? k * 2 + 1 : k * 2;
+
+            foreach (var peer in includeTarget
+                ? sorted
+                : sorted.Where(peer => !peer.Address.Equals(target)))
             {
                 peers.Add(peer);
-                if (peers.Count >= k * 2)
+                if (peers.Count >= maxCount)
                 {
                     break;
                 }

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -207,24 +207,16 @@ namespace Libplanet.Net.Protocols
                 .ToList();
 
             sorted = Kademlia.SortByDistance(sorted, target);
-            var peers = new List<BoundPeer>();
 
             // Select maximum k * 2 peers excluding the target itself.
             bool containsTarget = sorted.Any(peer => peer.Address.Equals(target));
             int maxCount = (includeTarget && containsTarget) ? k * 2 + 1 : k * 2;
 
-            foreach (var peer in includeTarget
+            IEnumerable<BoundPeer> peers = includeTarget
                 ? sorted
-                : sorted.Where(peer => !peer.Address.Equals(target)))
-            {
-                peers.Add(peer);
-                if (peers.Count >= maxCount)
-                {
-                    break;
-                }
-            }
+                : sorted.Where(peer => !peer.Address.Equals(target));
 
-            return peers;
+            return peers.Take(maxCount);
         }
 
         public void Check(BoundPeer peer, DateTimeOffset start, DateTimeOffset end)

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -160,7 +160,7 @@ namespace Libplanet.Net.Protocols
             return BucketOf(peer).Contains(peer);
         }
 
-        public BoundPeer ContainsAddress(Address addr) =>
+        public BoundPeer GetPeer(Address addr) =>
             _buckets
                 .Where(b => !b.IsEmpty())
                 .SelectMany(b => b.Peers)

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -160,6 +160,12 @@ namespace Libplanet.Net.Protocols
             return BucketOf(peer).Contains(peer);
         }
 
+        public BoundPeer ContainsAddress(Address addr) =>
+            _buckets
+                .Where(b => !b.IsEmpty())
+                .SelectMany(b => b.Peers)
+                .FirstOrDefault(peer => peer.Address.Equals(addr));
+
         public void Clear()
         {
             foreach (KBucket bucket in _buckets)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -926,20 +926,32 @@ namespace Libplanet.Net
             }
         }
 
+        /// <summary>
+        /// Use <see cref="FindNeighbors"/> messages to to find a <see cref="BoundPeer"/> with
+        /// <see cref="Address"/> of <paramref name="target"/>.
+        /// </summary>
+        /// <param name="target">The <see cref="Address"/> to find.</param>
+        /// <param name="depth">Target depth of recursive operation. If -1 is given,
+        /// will recursive until the closest <see cref="BoundPeer"/> to the
+        /// <paramref name="target"/> is found.</param>
+        /// <param name="timeout">
+        /// <see cref="TimeSpan"/> for waiting reply of <see cref="FindNeighbors"/>.
+        /// If <c>null</c> is given, <see cref="TimeoutException"/> will not be thrown.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token used to propagate notification
+        /// that this operation should be canceled.</param>
+        /// <returns>A BoundPeer with <see cref="Address"/> of <paramref name="target"/>.
+        /// Returns <c>null</c> if the peer with address does not exist.</returns>
         public async Task<BoundPeer> FindSpecificPeerAsync(
             Address target,
-            Address searchAddress,
-            int depth,
-            BoundPeer viaPeer,
-            TimeSpan? timeout,
-            CancellationToken cancellationToken)
+            int depth = 3,
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             NetMQTransport netMQTransport = (NetMQTransport)Transport;
             return await netMQTransport.FindSpecificPeerAsync(
                 target,
-                searchAddress,
                 depth,
-                viaPeer,
                 timeout,
                 cancellationToken);
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -940,8 +940,10 @@ namespace Libplanet.Net
         /// </param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
-        /// <returns>A BoundPeer with <see cref="Address"/> of <paramref name="target"/>.
-        /// Returns <c>null</c> if the peer with address does not exist.</returns>
+        /// <returns>
+        /// A <see cref="BoundPeer"/> with <see cref="Address"/> of <paramref name="target"/>.
+        /// Returns <c>null</c> if the peer with address does not exist.
+        /// </returns>
         public async Task<BoundPeer> FindSpecificPeerAsync(
             Address target,
             int depth = 3,


### PR DESCRIPTION
There was `Swarm<T>.FindSpecificPeerAsync()` method but it was not precise. This PR makes it to work more precisely.