### PR TITLE
Fix Backspace not working in create new key in CLI.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -273,8 +273,9 @@ To be released.
 
 ### CLI tools
 
- -  The `planet` command became installable using `npm`.
- -  Fixed a bug that Backspace Key not working when input Passphrase.
+ -  The `planet` command became installable using `npm`.  [[#923], [#982]]
+ -  Fixed a bug that <kbd>^H</kbd> had not removed the rightmost character
+    in passphrase prompts.  [[#983], [#984]]
 
 [#404]: https://github.com/planetarium/libplanet/issues/404
 [#459]: https://github.com/planetarium/libplanet/issues/459
@@ -303,6 +304,7 @@ To be released.
 [#919]: https://github.com/planetarium/libplanet/pull/919
 [#920]: https://github.com/planetarium/libplanet/issues/920
 [#922]: https://github.com/planetarium/libplanet/issues/922
+[#923]: https://github.com/planetarium/libplanet/pull/923
 [#925]: https://github.com/planetarium/libplanet/pull/925
 [#926]: https://github.com/planetarium/libplanet/pull/926
 [#927]: https://github.com/planetarium/libplanet/pull/927
@@ -333,6 +335,9 @@ To be released.
 [#972]: https://github.com/planetarium/libplanet/pull/972
 [#980]: https://github.com/planetarium/libplanet/pull/980
 [#981]: https://github.com/planetarium/libplanet/pull/981
+[#982]: https://github.com/planetarium/libplanet/pull/982
+[#983]: https://github.com/planetarium/libplanet/issues/983
+[#984]: https://github.com/planetarium/libplanet/pull/984
 [#986]: https://github.com/planetarium/libplanet/pull/986
 [#991]: https://github.com/planetarium/libplanet/pull/991
 [#996]: https://github.com/planetarium/libplanet/pull/996

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -274,6 +274,7 @@ To be released.
 ### CLI tools
 
  -  The `planet` command became installable using `npm`.
+ -  Fixed a bug that Backspace Key not working when input Passphrase.
 
 [#404]: https://github.com/planetarium/libplanet/issues/404
 [#459]: https://github.com/planetarium/libplanet/issues/459

--- a/Libplanet.Tools/ConsolePasswordReader.cs
+++ b/Libplanet.Tools/ConsolePasswordReader.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+
+namespace Libplanet.Tools
+{
+    public class ConsolePasswordReader
+    {
+        public static string Read(string prompt)
+        {
+            var password = new StringBuilder();
+
+            Console.Write(prompt);
+            do
+            {
+                var key = Console.ReadKey(true).KeyChar;
+
+                if (key == '\b')
+                {
+                    if (password.Length <= 0)
+                    {
+                        continue;
+                    }
+
+                    password.Remove(password.Length - 1, 1);
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    Console.Write(' ');
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                }
+                else if (key == '\r')
+                {
+                    Console.WriteLine();
+                    break;
+                }
+                else if (!char.IsControl(key))
+                {
+                    password.Append(key);
+                    Console.Write('*');
+                }
+            }
+            while (true);
+
+            Console.WriteLine(password.ToString());
+            return password.ToString();
+        }
+    }
+}

--- a/Libplanet.Tools/ConsolePasswordReader.cs
+++ b/Libplanet.Tools/ConsolePasswordReader.cs
@@ -39,7 +39,6 @@ namespace Libplanet.Tools
             }
             while (true);
 
-            Console.WriteLine(password.ToString());
             return password.ToString();
         }
     }

--- a/Libplanet.Tools/Key.cs
+++ b/Libplanet.Tools/Key.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Cocona;
-using GetPass;
 using Libplanet.Crypto;
 using Libplanet.KeyStore;
 

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -55,7 +55,6 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.*" />
-    <PackageReference Include="GetPass" Version="1.0.*" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR resolves Issue #983.
Tested in WSL2 Ubuntu 18.04, Windows 10 CMD and Powershell, macOS 10.15.
Feel free to review this. Thanks. :) 