### PR TITLE
Make BlockChain<T>.Swap() without reorg not to invoke IRenderer<T>.RenderReorg()

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1440,6 +1440,20 @@ namespace Libplanet.Tests.Blockchain
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public async Task SwapWithoutReorg(bool render)
+        {
+            BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
+            await fork.MineBlock(default);
+            var prevRecords = _renderer.ReorgRecords;
+            _blockChain.Swap(fork, render: render);
+
+            // RenderReorg() should be invoked if and only if the actual reorg happens
+            Assert.Equal(prevRecords, _renderer.ReorgRecords);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task ReorgIsUnableToHeterogenousChain(bool render)
         {
             using (var fx2 = new DefaultStoreFixture(memory: true))

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1445,7 +1445,7 @@ namespace Libplanet.Tests.Blockchain
             BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
             await fork.MineBlock(default);
             var prevRecords = _renderer.ReorgRecords;
-            _blockChain.Swap(fork, render: render);
+            _blockChain.Swap(fork, renderActions: render);
 
             // RenderReorg() should be invoked if and only if the actual reorg happens
             Assert.Equal(prevRecords, _renderer.ReorgRecords);

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -199,8 +199,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> no confirms
             // #5' -> no confirms
             renderer.RenderReorg(_chainA[5], _chainB[5], _branchpoint);
-            renderer.RenderBlock(_chainA[5], _chainB[5]);
             renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainA[5], _chainB[5]);
             renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
             renderer.RenderActionError(
                 new DumbAction(default, "#5'.2"),
@@ -216,13 +216,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 1 confirm;  #6 -> no confirm
             // #5' -> no confirms
             renderer.RenderReorg(_chainB[5], _chainA[6], _branchpoint);
-            renderer.RenderBlock(_chainB[5], _chainA[6]);
             renderer.UnrenderActionError(
                 new DumbAction(default, "#5'.2"),
                 FakeContext(5),
                 new ThrowException.SomeException("#5'.2")
             );
             renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainB[5], _chainA[6]);
             renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
             renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             Assert.Equal(_chainA[4], renderer.Tip);
@@ -234,9 +234,9 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 1 confirm; #6  -> no confirm
             // #5' -> 1 confirm; #6' -> no confirm
             renderer.RenderReorg(_chainA[6], _chainB[6], _branchpoint);
-            renderer.RenderBlock(_chainA[6], _chainB[6]);
             renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainA[6], _chainB[6]);
             renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
             renderer.RenderActionError(
                 new DumbAction(default, "#5'.2"),
@@ -253,7 +253,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 2 confirms; #6  -> 1 confirm; #7 -> no confirm
             // #5' -> 1 confirm;  #6' -> no confirm
             renderer.RenderReorg(_chainB[6], _chainA[7], _branchpoint);
-            renderer.RenderBlock(_chainB[6], _chainA[7]);
             renderer.UnrenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
             renderer.UnrenderActionError(
                 new DumbAction(default, "#5'.2"),
@@ -261,6 +260,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 new ThrowException.SomeException("#5'.2")
             );
             renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainB[6], _chainA[7]);
             renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
             renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             renderer.RenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
@@ -273,10 +273,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 2 confirms; #6  -> 1 confirm; #7  -> no confirm
             // #5' -> 2 confirms; #6' -> 1 confirm; #7' -> no confirm
             renderer.RenderReorg(_chainA[7], _chainB[7], _branchpoint);
-            renderer.RenderBlock(_chainA[7], _chainB[7]);
             renderer.UnrenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainA[7], _chainB[7]);
             renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
             renderer.RenderActionError(
                 new DumbAction(default, "#5'.2"),
@@ -294,7 +294,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8 -> no confirm
             // #5' -> 2 confirms; #6' -> 1 confirm;  #7' -> no confirm
             renderer.RenderReorg(_chainB[7], _chainA[8], _branchpoint);
-            renderer.RenderBlock(_chainB[7], _chainA[8]);
             renderer.UnrenderAction(new DumbAction(default, "#7'.1"), FakeContext(7), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#6'.1"), FakeContext(6), _emptyStates);
             renderer.UnrenderActionError(
@@ -303,6 +302,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 new ThrowException.SomeException("#5'.2")
             );
             renderer.UnrenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainB[7], _chainA[8]);
             renderer.RenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
             renderer.RenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             renderer.RenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
@@ -319,11 +319,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
             // #5  -> 3 confirms; #6  -> 2 confirms; #7  -> 1 confirm; #8  -> no confirm
             // #5' -> 3 confirms; #6' -> 2 confirms; #7' -> 1 confirm; #8' -> no confirm
             renderer.RenderReorg(_chainA[8], _chainB[8], _branchpoint);
-            renderer.RenderBlock(_chainA[8], _chainB[8]);
             renderer.UnrenderAction(new DumbAction(default, "#8.1"), FakeContext(8), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#7.1"), FakeContext(7), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#6.1"), FakeContext(6), _emptyStates);
             renderer.UnrenderAction(new DumbAction(default, "#5.1"), FakeContext(5), _emptyStates);
+            renderer.RenderBlock(_chainA[8], _chainB[8]);
             renderer.RenderAction(new DumbAction(default, "#5'.1"), FakeContext(5), _emptyStates);
             renderer.RenderActionError(
                 new DumbAction(default, "#5'.2"),

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -1329,7 +1329,7 @@ namespace Libplanet.Tests.Net
                         s.ReceivedBlockHashCount > minerChain.Count / 2)
                     {
                         receivedCount = s.ReceivedBlockHashCount;
-                        minerChain.Swap(forked, render: false);
+                        minerChain.Swap(forked, renderActions: false);
                     }
                 }),
                 cancellationToken: CancellationToken.None

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1487,9 +1487,12 @@ namespace Libplanet.Blockchain
                 Store.SetCanonicalChainId(Id);
                 _blocks = new BlockSet<T>(Store);
                 TipChanged?.Invoke(this, (oldTip, newTip));
-                foreach (IRenderer<T> renderer in Renderers)
+                if (!oldTip.Equals(topmostCommon))
                 {
-                    renderer.RenderReorg(oldTip, newTip, branchpoint: topmostCommon);
+                    foreach (IRenderer<T> renderer in Renderers)
+                    {
+                        renderer.RenderReorg(oldTip, newTip, branchpoint: topmostCommon);
+                    }
                 }
 
                 foreach (IRenderer<T> renderer in Renderers)

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -171,8 +171,8 @@ namespace Libplanet.Blockchain.Renderers
             if (lower.Index >= upper.Index)
             {
                 throw new ArgumentException(
-                    $"The {nameof(upper)} block must has the greater index than " +
-                    $"the {nameof(lower)} block.",
+                    $"The {nameof(upper)} block (#{upper.Index} {upper}) must has the greater " +
+                    $"index than the {nameof(lower)} block (#{lower.Index} {lower}).",
                     nameof(upper)
                 );
             }

--- a/Libplanet/Blockchain/Renderers/IRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IRenderer.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Blockchain.Renderers
         void RenderBlock(Block<T> oldTip, Block<T> newTip);
 
         /// <summary>
-        /// Does things that should be done right after reorg has happened to a <see
+        /// Does things that should be done right before reorg happens to a <see
         /// cref="BlockChain{T}"/>.
         /// </summary>
         /// <remarks>For every call to this method, a call to <see

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -910,7 +910,7 @@ namespace Libplanet.Net
                         wId,
                         workspace.Tip
                     );
-                    BlockChain.Swap(workspace, render: false);
+                    BlockChain.Swap(workspace, renderActions: false);
                 }
 
                 foreach (Guid chainId in chainIds)


### PR DESCRIPTION
As `BlockChain<T>.Swap()` method has used for several purposes besides reorg, fix `IRenderer<T>.RenderReorg()` to be invoked if and only if an actual reorg happens.  Also reorder the timing of `IActionRenderer<T>.UnrenderAction()` & `UnrenderActionError()` being invoked so that they are called before `IRenderer<T>.RenderBlock()` and after `IRenderer<T>.RenderReorg()`.