### PR TITLE
Fix bug where BootstrapAsync throw PingTimeoutException when some FindPeer fails

### DIFF
--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -664,7 +664,7 @@ namespace Libplanet.Net.Protocols
             catch (Exception)
             {
                 IEnumerable<AggregateException> exceptions = awaitables
-                    .Where(t => !(t.Exception is null))
+                    .Where(t => t.IsFaulted)
                     .Select(t => t.Exception);
                 foreach (var ae in exceptions)
                 {

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -445,6 +445,11 @@ namespace Libplanet.Net.Protocols
             }
         }
 
+        internal void ClearTable()
+        {
+            _routing.Clear();
+        }
+
         /// <summary>
         /// Validate peer by send <see cref="Ping"/> to <paramref name="peer"/>. If target peer
         /// does not responds, remove it from the table.


### PR DESCRIPTION
Since the feature that made this bug hasn't released, skip changelog.