### PR TITLE
Execute actions from branch point when preloading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -225,6 +225,8 @@ To be released.
     it fails to connect to all neighbors.  [[#933]]
  -  `Swarm<T>` became to respond to the messages with different app protocol version.
     [[#949]]
+ -  `Swarm<T>.PreloadAsync()` became to execute the actions from the branch point
+    rather than the genesis block when there is a branch point.  [[#991]]
 
 ### Bug fixes
 
@@ -309,6 +311,7 @@ To be released.
 [#972]: https://github.com/planetarium/libplanet/pull/972
 [#980]: https://github.com/planetarium/libplanet/pull/980
 [#981]: https://github.com/planetarium/libplanet/pull/981
+[#991]: https://github.com/planetarium/libplanet/pull/991
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -520,11 +520,6 @@ namespace Libplanet.Blocks
             ImmutableArray<byte> actionsHashAsArray =
                 EvaluationDigest?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
 
-            if (PreviousHash.Equals(EvaluationDigest))
-            {
-                Console.WriteLine();
-            }
-
             // FIXME: When hash is not assigned, should throw an exception.
             return new BlockHeader(
                 index: Index,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -581,6 +581,7 @@ namespace Libplanet.Net
                 Block<T> tipCandidate = initialTip;
 
                 Block<T> tempTip = tipCandidate;
+                Block<T> branchpoint = null;
 
                 long? receivedStateHeight = null;
                 long height = 0;
@@ -793,6 +794,7 @@ namespace Libplanet.Net
                         Block<T> bottomBlock = deltaBottom.Value;
                         if (bottomBlock.PreviousHash is HashDigest<SHA256> bp)
                         {
+                            branchpoint = workspace[bp];
                             workspace = workspace.Fork(bp);
                             chainIds.Add(workspace.Id);
                             try
@@ -876,7 +878,7 @@ namespace Libplanet.Net
                 {
                     PreloadExecuteActions(
                         workspace,
-                        initialTip,
+                        branchpoint,
                         receivedStateHeight,
                         progress,
                         cancellationToken);
@@ -1582,7 +1584,7 @@ namespace Libplanet.Net
 
         private void PreloadExecuteActions(
             BlockChain<T> workspace,
-            Block<T> initialTip,
+            Block<T> branchpoint,
             long? receivedStateHeight,
             IProgress<PreloadState> progress,
             CancellationToken cancellationToken)
@@ -1590,9 +1592,7 @@ namespace Libplanet.Net
             long initHeight;
             if (receivedStateHeight is null)
             {
-                initHeight = initialTip is null || !workspace[initialTip.Index].Equals(initialTip)
-                    ? 0
-                    : initialTip.Index + 1;
+                initHeight = branchpoint?.Index + 1 ?? 0;
             }
             else
             {


### PR DESCRIPTION
This changes `Swarm<T>.PreloadAsync()` to execute the actions from the branch point rather than the genesis block when there is a branch point.