### PR TITLE
Report progress synchronously in test

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -126,7 +126,7 @@ namespace Libplanet.Tests.Net
             }
 
             var actualStates = new List<PreloadState>();
-            var progress = new Progress<PreloadState>(state =>
+            var progress = new ActionProgress<PreloadState>(state =>
             {
                 _logger.Information("Received a progress event: {@State}", state);
                 lock (actualStates)
@@ -372,7 +372,7 @@ namespace Libplanet.Tests.Net
             }
 
             var actualStates = new List<PreloadState>();
-            var progress = new Progress<PreloadState>(state =>
+            var progress = new ActionProgress<PreloadState>(state =>
             {
                 lock (actualStates)
                 {
@@ -505,7 +505,7 @@ namespace Libplanet.Tests.Net
             var shouldStopSwarm =
                 swarm0.AsPeer.Equals(receiverSwarm.Peers.First()) ? swarm0 : swarm1;
             await receiverSwarm.PreloadAsync(
-                progress: new Progress<PreloadState>(async (state) =>
+                progress: new ActionProgress<PreloadState>(async (state) =>
                 {
                     if (!startedStop && state is BlockDownloadState)
                     {
@@ -915,7 +915,7 @@ namespace Libplanet.Tests.Net
                 int currentCount = 0;
                 var allProgressesReported = new AsyncAutoResetEvent();
                 await receiverSwarm.PreloadAsync(
-                    progress: new Progress<PreloadState>(state =>
+                    progress: new ActionProgress<PreloadState>(state =>
                     {
                         if (state is StateDownloadState srds)
                         {
@@ -1433,7 +1433,7 @@ namespace Libplanet.Tests.Net
 
             bool reorg = true;
 
-            var progress = new Progress<PreloadState>(state =>
+            var progress = new ActionProgress<PreloadState>(state =>
             {
                 _logger.Information("Received a progress event: {@State}", state);
 
@@ -1500,7 +1500,7 @@ namespace Libplanet.Tests.Net
 
             var actionExecutionCount = 0;
 
-            var progress = new Progress<PreloadState>(state =>
+            var progress = new ActionProgress<PreloadState>(state =>
             {
                 if (state is ActionExecutionState)
                 {


### PR DESCRIPTION
Actually, it is possible not to report all of them because it reports them asynchronously. So it became to report synchronously by using `ActionProgress`.