### PR TITLE
Even backward tip change shouldn't invoke RenderReorg

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1457,12 +1457,17 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task SwapWithoutReorg(bool render)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task SwapWithoutReorg(bool direction, bool render)
         {
             BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
-            await fork.MineBlock(default);
+
+            // When direction == true:  the higher chain goes to the lower  chain  [#N -> #N-1]
+            // When direction == false: the lower  chain goes to the higher chain  [#N -> #N+1]
+            await (direction ? _blockChain : fork).MineBlock(default);
             var prevRecords = _renderer.ReorgRecords;
             _blockChain.Swap(fork, renderActions: render);
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1426,7 +1426,7 @@ namespace Libplanet.Blockchain
                 topmostCommon
             );
 
-            if (renderBlocks && !Tip.Equals(topmostCommon))
+            if (renderBlocks && !Tip.Equals(topmostCommon) && !other.Tip.Equals(topmostCommon))
             {
                 foreach (IRenderer<T> renderer in Renderers)
                 {

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -197,7 +197,14 @@ namespace Libplanet.Blockchain.Renderers
             if (!newTip.PreviousHash.Equals(oldTip.Hash))
             {
                 branchpoint = FindBranchpoint(oldTip, newTip);
-                Renderer.RenderReorg(oldTip, newTip, branchpoint);
+                if (!branchpoint.Equals(oldTip) && !branchpoint.Equals(newTip))
+                {
+                    Renderer.RenderReorg(oldTip, newTip, branchpoint);
+                }
+                else
+                {
+                    branchpoint = null;
+                }
             }
 
             Renderer.RenderBlock(oldTip, newTip);


### PR DESCRIPTION
I'm going to add more accurate unit test later.