### PR TITLE
Do not render genesis block during fork

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -565,6 +565,7 @@ namespace Libplanet.Tests.Blockchain
                     block,
                     DateTimeOffset.UtcNow,
                     evaluateActions: false,
+                    renderBlocks: true,
                     renderActions: true
                 )
             );
@@ -575,6 +576,7 @@ namespace Libplanet.Tests.Blockchain
                 block,
                 DateTimeOffset.UtcNow,
                 evaluateActions: false,
+                renderBlocks: true,
                 renderActions: false
             );
             Assert.Equal(block, _blockChain.Tip);
@@ -834,6 +836,7 @@ namespace Libplanet.Tests.Blockchain
                 block1,
                 DateTimeOffset.UtcNow,
                 evaluateActions: false,
+                renderBlocks: true,
                 renderActions: false
             );
 
@@ -1378,6 +1381,7 @@ namespace Libplanet.Tests.Blockchain
                 forkTip,
                 DateTimeOffset.UtcNow,
                 evaluateActions: true,
+                renderBlocks: true,
                 renderActions: false
             );
 
@@ -2134,6 +2138,7 @@ namespace Libplanet.Tests.Blockchain
                 block1,
                 DateTimeOffset.UtcNow,
                 evaluateActions: false,
+                renderBlocks: true,
                 renderActions: false);
 
             var txEvaluations = block1.EvaluateActionsPerTx(a =>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1121,14 +1121,18 @@ namespace Libplanet.Tests.Blockchain
                 );
 
                 Assert.Equal(1, renderer.ActionRecords.Count(r => r.Action is DumbAction));
+                Assert.Single(renderer.BlockRecords);
                 Assert.Single(DumbAction.ExecuteRecords.Value.Where(r => !r.Rehearsal));
 
                 await blockChain.MineBlock(miner, DateTimeOffset.UtcNow);
                 await blockChain.MineBlock(miner, DateTimeOffset.UtcNow);
 
+                int blockRecordsBeforeFork = renderer.BlockRecords.Count;
+
                 blockChain.Fork(blockChain.Tip.Hash);
 
                 Assert.Equal(1, renderer.ActionRecords.Count(r => r.Action is DumbAction));
+                Assert.Equal(blockRecordsBeforeFork, renderer.BlockRecords.Count);
                 Assert.Single(DumbAction.ExecuteRecords.Value.Where(r => !r.Rehearsal));
             }
         }

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -333,7 +333,7 @@ namespace Libplanet.Tests.Net
                     new[] { tx },
                     difficulty: policy.GetNextBlockDifficulty(minerChain),
                     blockInterval: TimeSpan.FromSeconds(1));
-                minerSwarm.BlockChain.Append(block, DateTimeOffset.UtcNow, false, false);
+                minerSwarm.BlockChain.Append(block, DateTimeOffset.UtcNow, false, true, false);
 
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
 
@@ -864,6 +864,7 @@ namespace Libplanet.Tests.Net
                 genesis,
                 DateTimeOffset.UtcNow,
                 evaluateActions: true,
+                renderBlocks: true,
                 renderActions: true);
 
             const int repeat = 10;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1050,13 +1050,13 @@ namespace Libplanet.Tests.Net
                     new[] { transactions[0] },
                     null,
                     policy.GetNextBlockDifficulty(blockChain));
-                blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, false);
+                blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
                 var block2 = TestUtils.MineNext(
                     block1,
                     new[] { transactions[1] },
                     null,
                     policy.GetNextBlockDifficulty(blockChain));
-                blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, false);
+                blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);
                 await receiverSwarm.BlockAppended.WaitAsync();

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -162,6 +162,7 @@ namespace Libplanet.Blockchain
                 Append(
                     genesisBlock,
                     currentTime: genesisBlock.Timestamp,
+                    renderBlocks: !inFork,
                     renderActions: !inFork,
                     evaluateActions: !inFork
                 );
@@ -551,6 +552,7 @@ namespace Libplanet.Blockchain
                 block,
                 currentTime,
                 evaluateActions: true,
+                renderBlocks: true,
                 renderActions: true,
                 stateCompleters: stateCompleters
             );
@@ -831,6 +833,7 @@ namespace Libplanet.Blockchain
             Block<T> block,
             DateTimeOffset currentTime,
             bool evaluateActions,
+            bool renderBlocks,
             bool renderActions,
             StateCompleterSet<T>? stateCompleters = null
         )
@@ -935,9 +938,12 @@ namespace Libplanet.Blockchain
                         .ToImmutableHashSet();
                     Store.UnstageTransactionIds(txIds);
                     TipChanged?.Invoke(this, (prevTip, block));
-                    foreach (IRenderer<T> renderer in Renderers)
+                    if (renderBlocks)
                     {
-                        renderer.RenderBlock(oldTip: prevTip ?? Genesis, newTip: block);
+                        foreach (IRenderer<T> renderer in Renderers)
+                        {
+                            renderer.RenderBlock(oldTip: prevTip ?? Genesis, newTip: block);
+                        }
                     }
 
                     _logger.Debug("Block {blockIndex}: {block} is appended.", block?.Index, block);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -803,10 +803,13 @@ namespace Libplanet.Net
                                 foreach (Block<T> deltaBlock in deltaBlocks)
                                 {
                                     cancellationToken.ThrowIfCancellationRequested();
+
+                                    // FIXME: Shouldn't we turn off renderBlocks option in IBD?
                                     workspace.Append(
                                         deltaBlock,
                                         DateTimeOffset.UtcNow,
                                         evaluateActions: false,
+                                        renderBlocks: true,
                                         renderActions: false
                                     );
                                     progress?.Report(new BlockVerificationState
@@ -1880,6 +1883,7 @@ namespace Libplanet.Net
                             block,
                             DateTimeOffset.UtcNow,
                             evaluateActions: evaluateActions,
+                            renderBlocks: true,
                             renderActions: renderActions
                         );
                         receivedBlockCount++;


### PR DESCRIPTION
I added `renderBlocks` parameter to `BlockChain.Append()` internal method.

Since the method is internal and `IRenderer` isn't released yet, I omitted changelog.