### PR TITLE
Polishing Swarm<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -249,6 +249,8 @@ To be released.
     was once called.  [[#965]]
  -  Fixed a bug that `TurnClient` had thrown `InvalidOperationException` when
     reconnecting.  [[#957], [#972]]
+ -  Fixed a bug that `Swarm<T>` had not received block headers after failing
+    to recevie previous blocks.  [[#996]]
 
 ### CLI tools
 
@@ -312,6 +314,7 @@ To be released.
 [#980]: https://github.com/planetarium/libplanet/pull/980
 [#981]: https://github.com/planetarium/libplanet/pull/981
 [#991]: https://github.com/planetarium/libplanet/pull/991
+[#996]: https://github.com/planetarium/libplanet/pull/996
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -250,9 +250,9 @@ To be released.
  -  Fixed a bug that `TurnClient` had thrown `InvalidOperationException` when
     reconnecting.  [[#957], [#972]]
  -  Fixed a bug that `Swarm<T>` had not received block headers after failing
-    to recevie previous blocks.  [[#996]]
+    to receive previous blocks.  [[#996]]
  -  Fixed a bug that `Swarm<T>` had thrown `InvalidGenesisBlockException`
-    when reorganizing repeatedly.  [[#996]]
+    when reorg its chain repeatedly.  [[#996]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -251,6 +251,8 @@ To be released.
     reconnecting.  [[#957], [#972]]
  -  Fixed a bug that `Swarm<T>` had not received block headers after failing
     to recevie previous blocks.  [[#996]]
+ -  Fixed a bug that `Swarm<T>` had thrown `InvalidGenesisBlockException`
+    when reorganizing repeatedly.  [[#996]]
 
 ### CLI tools
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1968,6 +1968,13 @@ namespace Libplanet.Net
                         $" {nameof(ProcessFillBlocks)}: {{e}}";
                     _logger.Error(e, msg, e);
                 }
+                finally
+                {
+                    using (await _blockSyncMutex.LockAsync(cancellationToken))
+                    {
+                        _demandBlockHash = null;
+                    }
+                }
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1810,10 +1810,7 @@ namespace Libplanet.Net
                     {
                         _logger.Debug("It doesn't need to fork.");
                     }
-
-                    // We can omit this clause if assume every chain shares
-                    // same genesis block...
-                    else if (!BlockChain.ContainsBlock(branchPoint))
+                    else if (!workspace.ContainsBlock(branchPoint))
                     {
                         // FIXME: This behavior can unexpectedly terminate the swarm (and the game
                         // app) if it encounters a peer having a different blockchain, and therefore


### PR DESCRIPTION
This PR addresses two bugs in `Swarm<T>` as below

1. a bug that `Swarm<T>` had not received block headers after failing to receive previous blocks.
2. a bug that  `Swarm<T>` had thrown `InvalidGenesisBlockException` when reorg chain repeatedly.