### PR TITLE
Make DelayedRenderer<T> to regard total difficulty 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _UpgradeReport_Files/
 mono_crash.*.json
 FodyWeavers.xsd
 BenchmarkDotNet.Artifacts
+xunit.runner.console.*/
 
 Thumbs.db
 Desktop.ini

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,9 +128,27 @@ corresponds to one in *Libplanet&ast;* projects.
 If there's *Libplanet.Foo.Bar* class there also should be
 *Libplanet.Foo.Bar.Tests* to test it.
 
-To build and run unit tests at a time execute the below command:
+To build and run unit tests at a time with .NET Core execute the below command:
 
     dotnet test
+
+To run unit tests with .NET Framework:
+
+~~~~ pwsh
+nuget install xunit.runner.console -Version 2.4.1
+msbuild /restore /p:TestsTargetFramework=net472
+& (gci xunit.runner.console.*\tools\net472\xunit.console.exe | select -f 1) `
+  (gci *.Tests\bin\Debug\net472\*.Tests.dll)
+~~~~
+
+Or with Mono:
+
+~~~~ bash
+nuget install xunit.runner.console
+msbuild /restore /p:TestsTargetFramework=net472
+mono xunit.runner.console.*/tools/net472/xunit.console.exe \
+    *.Tests/bin/Debug/net472/*.Tests.dll
+~~~~
 
 [Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622
 [3]: https://codecov.io/gh/planetarium/libplanet

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -28,6 +28,10 @@
     <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -28,6 +28,10 @@
     <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -29,6 +29,10 @@
     <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -10,6 +10,19 @@ namespace Libplanet.Blockchain.Renderers
     /// on a <see cref="BlockChain{T}"/>.
     /// If you need more fine-grained events than <see cref="IRenderer{T}"/>,
     /// implement this interface instead.
+    /// <para>The invocation order of methods are:</para>
+    /// <list type="number">
+    /// <item><description><see cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
+    /// </description></item>
+    /// <item><description><see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+    /// &amp; <see cref="UnrenderActionError(IAction, IActionContext, Exception)"/></description>
+    /// </item>
+    /// <item><description><see cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
+    /// </description></item>
+    /// <item><description><see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+    /// &amp; <see cref="RenderActionError(IAction, IActionContext, Exception)"/></description>
+    /// </item>
+    /// </list>
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
     /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>


### PR DESCRIPTION
This fixes `DelayedRenderer<T>`'s bug that it changes its `Tip` even if a discovered block's `TotalDifficulty` is less than the existing `Tip`'s `TotalDifficulty`.