### PR TITLE
Fix swarm test

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -2,7 +2,7 @@ parameters:
   configuration: Debug
   testArguments: ""
   locale: "en_US.UTF8"
-  testTimeoutInMinutes: 12
+  testTimeoutInMinutes: 16
   useDotnetTest: false
 
 steps:

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -3,7 +3,7 @@ parameters:
   testDisplayName: xunit.console.exe *.Tests.dll
   testCommand: "mono --server xunit.runner.console.*/tools/net471/xunit.console.exe"
   testArguments: -verbose -parallel none
-  testTimeoutInMinutes: 12
+  testTimeoutInMinutes: 16
   excludeTests: ""
   publicTestResult: true
 

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -1,7 +1,7 @@
 parameters:
   configuration: Debug
   testArguments: -verbose
-  testTimeoutInMinutes: 12
+  testTimeoutInMinutes: 16
   copySQLitePCLRaw: false
 
 steps:

--- a/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
@@ -17,15 +17,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task DetectAppProtocolVersion()
         {
-            var blockChain = _blockchains[0];
-
             var signer = new PrivateKey();
             AppProtocolVersion v2 = AppProtocolVersion.Sign(signer, 2);
             AppProtocolVersion v3 = AppProtocolVersion.Sign(signer, 3);
-            var a = CreateSwarm(blockChain, appProtocolVersion: v2);
-            var b = CreateSwarm(blockChain, appProtocolVersion: v3);
-            var c = CreateSwarm(blockChain, appProtocolVersion: v2);
-            var d = CreateSwarm(blockChain, appProtocolVersion: v3);
+            var a = CreateSwarm(appProtocolVersion: v2);
+            var b = CreateSwarm(appProtocolVersion: v3);
+            var c = CreateSwarm(appProtocolVersion: v2);
+            var d = CreateSwarm(appProtocolVersion: v3);
 
             try
             {
@@ -64,7 +62,6 @@ namespace Libplanet.Tests.Net
             AppProtocolVersion v1 = AppProtocolVersion.Sign(signer, 1);
             AppProtocolVersion v2 = AppProtocolVersion.Sign(signer, 2);
             var a = CreateSwarm(
-                _blockchains[0],
                 appProtocolVersion: v1,
                 differentAppProtocolVersionEncountered: (_, ver, __) =>
                 {
@@ -72,7 +69,7 @@ namespace Libplanet.Tests.Net
                     return false;
                 }
             );
-            var b = CreateSwarm(_blockchains[1], appProtocolVersion: v2);
+            var b = CreateSwarm(appProtocolVersion: v2);
 
             try
             {
@@ -95,8 +92,6 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task IgnoreUntrustedAppProtocolVersion()
         {
-            var blockChain = _blockchains[0];
-
             var signer = new PrivateKey();
             AppProtocolVersion older = AppProtocolVersion.Sign(signer, 2);
             AppProtocolVersion newer = AppProtocolVersion.Sign(signer, 3);
@@ -121,33 +116,27 @@ namespace Libplanet.Tests.Net
             }
 
             var a = CreateSwarm(
-                blockChain,
                 appProtocolVersion: older,
                 trustedAppProtocolVersionSigners: new[] { signer.PublicKey },
                 differentAppProtocolVersionEncountered: DifferentAppProtocolVersionEncountered
             );
             var b = CreateSwarm(
-                blockChain,
                 appProtocolVersion: newer,
                 trustedAppProtocolVersionSigners: new[] { signer.PublicKey }
             );
             var c = CreateSwarm(
-                blockChain,
                 appProtocolVersion: older,
                 trustedAppProtocolVersionSigners: new[] { signer.PublicKey }
             );
             var d = CreateSwarm(
-                blockChain,
                 appProtocolVersion: newer,
                 trustedAppProtocolVersionSigners: new[] { signer.PublicKey }
             );
             var e = CreateSwarm(
-                blockChain,
                 appProtocolVersion: untrustedOlder,
                 trustedAppProtocolVersionSigners: new[] { untrustedSigner.PublicKey }
             );
             var f = CreateSwarm(
-                blockChain,
                 appProtocolVersion: untrustedNewer,
                 trustedAppProtocolVersionSigners: new[] { untrustedSigner.PublicKey }
             );

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -9,7 +9,6 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
-using Libplanet.Tests.Common;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
@@ -20,20 +19,6 @@ namespace Libplanet.Tests.Net
     {
         private static Block<DumbAction>[] _fixtureBlocksForPreloadAsyncCancellationTest;
 
-        private readonly StoreFixture _fx1;
-        private readonly StoreFixture _fx2;
-        private readonly StoreFixture _fx3;
-        private readonly StoreFixture _fx4;
-
-        private readonly StoreFixture _mptFx1;
-        private readonly StoreFixture _mptFx2;
-        private readonly StoreFixture _mptFx3;
-
-        private readonly List<BlockChain<DumbAction>> _blockchains;
-        private readonly List<BlockChain<DumbAction>> _mptBlockchains;
-        private readonly List<RecordingRenderer<DumbAction>> _renderers;
-        private readonly List<Swarm<DumbAction>> _swarms;
-        private readonly List<Swarm<DumbAction>> _mptSwarms;
         private readonly List<Func<Task>> _finalizers;
 
         private static async Task<(Address, Block<DumbAction>[])>
@@ -79,6 +64,37 @@ namespace Libplanet.Tests.Net
             }
 
             return (blocks[1].Transactions.First().Actions.First().TargetAddress, blocks);
+        }
+
+        private Swarm<DumbAction> CreateSwarm(
+            PrivateKey privateKey = null,
+            AppProtocolVersion? appProtocolVersion = null,
+            int? tableSize = null,
+            int? bucketSize = null,
+            string host = null,
+            int? listenPort = null,
+            DateTimeOffset? createdAt = null,
+            IEnumerable<IceServer> iceServers = null,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
+            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
+            SwarmOptions options = null)
+        {
+            var fx = new DefaultStoreFixture(memory: true);
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            var blockchain = TestUtils.MakeBlockChain(policy, fx.Store);
+            return CreateSwarm(
+                blockchain,
+                privateKey,
+                appProtocolVersion,
+                tableSize,
+                bucketSize,
+                host,
+                listenPort,
+                createdAt,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                trustedAppProtocolVersionSigners,
+                options);
         }
 
         private Swarm<T> CreateSwarm<T>(

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -477,7 +477,7 @@ namespace Libplanet.Tests.Net
             Swarm<DumbAction> swarm1 = CreateSwarm();
             Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            receiverSwarm.Options.BlockHashRecvTimeout = TimeSpan.FromMilliseconds(100);
+            receiverSwarm.Options.BlockHashRecvTimeout = TimeSpan.FromMilliseconds(1000);
 
             swarm0.FindNextHashesChunkSize = blockCount / 2;
             swarm1.FindNextHashesChunkSize = blockCount / 2;

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
+using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -30,15 +31,15 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task InitialBlockDownload()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await minerChain.MineBlock(_fx1.Address1);
+                await minerChain.MineBlock(minerSwarm.Address);
             }
 
             try
@@ -60,11 +61,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task InitialBlockDownloadStates()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             var key = new PrivateKey();
             var address1 = key.ToAddress();
@@ -76,13 +77,13 @@ namespace Libplanet.Tests.Net
                 transfer: Tuple.Create<Address, Address, BigInteger>(address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
-            await minerChain.MineBlock(_fx1.Address1);
+            await minerChain.MineBlock(minerSwarm.Address);
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
-            await minerChain.MineBlock(_fx1.Address1);
+            await minerChain.MineBlock(minerSwarm.Address);
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
-            await minerChain.MineBlock(_fx1.Address1);
+            await minerChain.MineBlock(minerSwarm.Address);
 
             try
             {
@@ -107,11 +108,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task Preload()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             var blocks = new List<Block<DumbAction>>();
             foreach (int i in Enumerable.Range(0, 11))
@@ -243,18 +244,17 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = 5 * 1000)]
         public async Task BlockDownloadTimeout()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-
             var options = new SwarmOptions
             {
                 BlockDownloadTimeout = TimeSpan.FromMilliseconds(1),
             };
 
-            Swarm<DumbAction> receiverSwarm = CreateSwarm(_blockchains[1], options: options);
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm(options: options);
 
             foreach (var unused in Enumerable.Range(0, 10))
             {
-                await minerSwarm.BlockChain.MineBlock(_fx1.Address1);
+                await minerSwarm.BlockChain.MineBlock(minerSwarm.Address);
             }
 
             try
@@ -303,7 +303,7 @@ namespace Libplanet.Tests.Net
 
             foreach (var unused in Enumerable.Range(0, 10))
             {
-                await minerSwarm.BlockChain.MineBlock(_fx1.Address1);
+                await minerSwarm.BlockChain.MineBlock(minerSwarm.Address);
             }
 
             try
@@ -346,8 +346,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task PreloadFromNominer()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
             var fxForNominers = new StoreFixture[2];
             fxForNominers[0] = new DefaultStoreFixture(memory: true);
             fxForNominers[1] = new DefaultStoreFixture(memory: true);
@@ -360,12 +360,12 @@ namespace Libplanet.Tests.Net
             var nominerSwarm0 = CreateSwarm(blockChainsForNominers[0]);
             var nominerSwarm1 = CreateSwarm(blockChainsForNominers[1]);
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = minerSwarm.BlockChain;
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await minerChain.MineBlock(_fx1.Address1);
+                await minerChain.MineBlock(minerSwarm.Address);
             }
 
             var actualStates = new List<PreloadState>();
@@ -473,9 +473,9 @@ namespace Libplanet.Tests.Net
         [InlineData(32)]
         public async Task PreloadRetryWithNextPeers(int blockCount)
         {
-            Swarm<DumbAction> swarm0 = _swarms[0];
-            Swarm<DumbAction> swarm1 = _swarms[1];
-            Swarm<DumbAction> receiverSwarm = _swarms[2];
+            Swarm<DumbAction> swarm0 = CreateSwarm();
+            Swarm<DumbAction> swarm1 = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
             receiverSwarm.Options.BlockHashRecvTimeout = TimeSpan.FromMilliseconds(100);
 
@@ -522,12 +522,21 @@ namespace Libplanet.Tests.Net
         [InlineData(false, true)]
         public async Task PreloadWithTrustedPeers(bool trust, bool genesisWithAction)
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            var fx = new DefaultStoreFixture();
+            var receiverRenderer = new RecordingRenderer<DumbAction>();
+            var loggedRenderer = new LoggedActionRenderer<DumbAction>(
+                receiverRenderer,
+                _logger);
+            var receiverChain = TestUtils.MakeBlockChain(
+                policy,
+                fx.Store,
+                renderers: new[] { loggedRenderer });
+            Swarm<DumbAction> receiverSwarm = CreateSwarm(receiverChain);
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
-            RecordingRenderer<DumbAction> receiverRenderer = _renderers[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+
             PrivateKey[] signers =
                 Enumerable.Repeat(0, 10).Select(_ => new PrivateKey()).ToArray();
             Address[] targets = Enumerable.Repeat(0, signers.Length).Select(_
@@ -671,11 +680,11 @@ namespace Libplanet.Tests.Net
             // Two miners; one trusts other one.  Test if it downloads the minimum range of blocks
             // (instead of the entire chain from the genesis to the tip) when there are branches.
             // See also: https://github.com/planetarium/libplanet/issues/465#issuecomment-525682219
-            Swarm<DumbAction> senderSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> senderSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            BlockChain<DumbAction> senderChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> senderChain = senderSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Block<DumbAction> g = senderChain.Genesis,
                 bp = TestUtils.MineNext(g, difficulty: 1024),
@@ -998,13 +1007,13 @@ namespace Libplanet.Tests.Net
         {
             var blockHashes = new List<HashDigest<SHA256>>();
 
-            Swarm<DumbAction> swarm0 = _swarms[0];
-            Swarm<DumbAction> swarm1 = _swarms[1];
-            Swarm<DumbAction> swarm2 = _swarms[2];
+            Swarm<DumbAction> swarm0 = CreateSwarm();
+            Swarm<DumbAction> swarm1 = CreateSwarm();
+            Swarm<DumbAction> swarm2 = CreateSwarm();
 
-            BlockChain<DumbAction> chain0 = _blockchains[0];
-            BlockChain<DumbAction> chain1 = _blockchains[1];
-            BlockChain<DumbAction> chain2 = _blockchains[2];
+            BlockChain<DumbAction> chain0 = swarm0.BlockChain;
+            BlockChain<DumbAction> chain1 = swarm1.BlockChain;
+            BlockChain<DumbAction> chain2 = swarm2.BlockChain;
 
             swarm0.FindNextStatesChunkSize = 4;
             swarm1.FindNextStatesChunkSize = 3;
@@ -1122,13 +1131,13 @@ namespace Libplanet.Tests.Net
         [InlineData(5000)]
         public async Task PreloadAsyncCancellation(int cancelAfter)
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
             Log.Logger.Information("Miner:    {0}", minerSwarm.Address);
             Log.Logger.Information("Receiver: {0}", receiverSwarm.Address);
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Guid receiverChainId = receiverChain.Id;
 
@@ -1206,13 +1215,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetDemandBlockHashes()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
             Log.Logger.Information("Miner:    {0}", minerSwarm.Address);
             Log.Logger.Information("Receiver: {0}", receiverSwarm.Address);
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             (_, IEnumerable<Block<DumbAction>> blocks) =
                 await MakeFixtureBlocksForPreloadAsyncCancellationTest();
@@ -1246,29 +1255,29 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task PreloadAfterReorg()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             foreach (int i in Enumerable.Range(0, 25))
             {
-                Block<DumbAction> block = await minerChain.MineBlock(_fx1.Address1);
+                Block<DumbAction> block = await minerChain.MineBlock(minerSwarm.Address);
                 receiverChain.Append(block);
             }
 
             var receiverForked = receiverChain.Fork(receiverChain[5].Hash);
             foreach (int i in Enumerable.Range(0, 20))
             {
-                await receiverForked.MineBlock(_fx1.Address1);
+                await receiverForked.MineBlock(minerSwarm.Address);
             }
 
             receiverChain.Swap(receiverForked, false);
 
             foreach (int i in Enumerable.Range(0, 1))
             {
-                await minerChain.MineBlock(_fx1.Address1);
+                await minerChain.MineBlock(minerSwarm.Address);
             }
 
             minerSwarm.FindNextHashesChunkSize = 1;
@@ -1291,13 +1300,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetDemandBlockHashesDuringReorg()
         {
-            Swarm<DumbAction> minerSwarm = _swarms[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
             Log.Logger.Information("Miner:    {0}", minerSwarm.Address);
             Log.Logger.Information("Receiver: {0}", receiverSwarm.Address);
 
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Block<DumbAction>[] blocks =
                 (await MakeFixtureBlocksForPreloadAsyncCancellationTest()).Item2;
@@ -1343,8 +1352,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task PreloadDeleteOnlyTempChain()
         {
-            BlockChain<DumbAction> minerChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            Swarm<DumbAction> minerSwarm = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
+            BlockChain<DumbAction> minerChain = minerSwarm.BlockChain;
+            BlockChain<DumbAction> receiverChain = minerSwarm.BlockChain;
 
             receiverChain = receiverChain.Fork(receiverChain.Genesis.Hash);
             Block<DumbAction>[] blocks =
@@ -1355,36 +1366,35 @@ namespace Libplanet.Tests.Net
                 minerChain.Append(block);
             }
 
-            using (Swarm<DumbAction> minerSwarm = CreateSwarm(minerChain))
-            using (Swarm<DumbAction> receiverSwarm = CreateSwarm(receiverChain))
+            try
             {
-                try
-                {
-                    await StartAsync(minerSwarm);
-                    await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
-                    await receiverSwarm.PreloadAsync(
-                        trustedStateValidators: new[] { minerSwarm.Address }.ToImmutableHashSet()
-                    );
-                }
-                finally
-                {
-                    await StopAsync(minerSwarm);
-                }
-
-                // Check PreloadAsync() preserves chain that forked before preloading.
-                Assert.Equal(2, receiverChain.Store.ListChainIds().Count());
+                await StartAsync(minerSwarm);
+                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                await receiverSwarm.PreloadAsync(
+                    trustedStateValidators: new[] { minerSwarm.Address }.ToImmutableHashSet()
+                );
             }
+            finally
+            {
+                await StopAsync(minerSwarm);
+            }
+
+            // Check PreloadAsync() preserves chain that forked before preloading.
+            Assert.Equal(2, receiverChain.Store.ListChainIds().Count());
         }
 
         [Fact(Timeout = Timeout)]
         public async Task PreloadFromTheMostDifficultChain()
         {
-            BlockChain<DumbAction> minerChain1 = _blockchains[0];
-            BlockChain<DumbAction> minerChain2 = _blockchains[1];
-            BlockChain<DumbAction> receiverChain = _blockchains[2];
+            Swarm<DumbAction> minerSwarm1 = CreateSwarm();
+            Swarm<DumbAction> minerSwarm2 = CreateSwarm();
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
+            BlockChain<DumbAction> minerChain1 = minerSwarm1.BlockChain;
+            BlockChain<DumbAction> minerChain2 = minerSwarm2.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
-            await minerChain1.MineBlock(_fx1.Address1);
-            await minerChain1.MineBlock(_fx1.Address1);
+            await minerChain1.MineBlock(minerSwarm1.Address);
+            await minerChain1.MineBlock(minerSwarm1.Address);
 
             long nextDifficulty = (long)minerChain1.Tip.TotalDifficulty +
                                   minerChain2.Policy.GetNextBlockDifficulty(minerChain2);
@@ -1394,44 +1404,40 @@ namespace Libplanet.Tests.Net
             Assert.True(minerChain1.Count > minerChain2.Count);
             Assert.True(minerChain1.Tip.TotalDifficulty < minerChain2.Tip.TotalDifficulty);
 
-            using (Swarm<DumbAction> minerSwarm1 = CreateSwarm(minerChain1))
-            using (Swarm<DumbAction> minerSwarm2 = CreateSwarm(minerChain2))
-            using (Swarm<DumbAction> receiverSwarm = CreateSwarm(receiverChain))
+            try
             {
-                try
-                {
-                    await StartAsync(minerSwarm1);
-                    await StartAsync(minerSwarm2);
-                    await receiverSwarm.AddPeersAsync(
-                        new[] { minerSwarm1.AsPeer, minerSwarm2.AsPeer },
-                        null);
-                    await receiverSwarm.PreloadAsync(
-                        trustedStateValidators: new[] { minerSwarm1.Address, minerSwarm2.Address }
-                            .ToImmutableHashSet()
-                    );
-                }
-                finally
-                {
-                    await StopAsync(minerSwarm1);
-                    await StopAsync(minerSwarm2);
-                    await StopAsync(receiverSwarm);
-                }
-
-                Assert.Equal(minerChain2.Count, receiverChain.Count);
-                Assert.Equal(minerChain2.Tip, receiverChain.Tip);
+                await StartAsync(minerSwarm1);
+                await StartAsync(minerSwarm2);
+                await receiverSwarm.AddPeersAsync(
+                    new[] { minerSwarm1.AsPeer, minerSwarm2.AsPeer },
+                    null);
+                await receiverSwarm.PreloadAsync(
+                    trustedStateValidators: new[] { minerSwarm1.Address, minerSwarm2.Address }
+                        .ToImmutableHashSet()
+                );
             }
+            finally
+            {
+                await StopAsync(minerSwarm1);
+                await StopAsync(minerSwarm2);
+                await StopAsync(receiverSwarm);
+            }
+
+            Assert.Equal(minerChain2.Count, receiverChain.Count);
+            Assert.Equal(minerChain2.Tip, receiverChain.Tip);
         }
 
         [Fact(Timeout = Timeout)]
         public async Task PreloadIgnorePeerWithDifferentGenesisBlock()
         {
+            var minerAddress = new PrivateKey().ToAddress();
             var policy = new BlockPolicy<DumbAction>();
             var genesisBlock1 = new Block<DumbAction>(
                 0,
                 0,
                 0,
                 new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }),
-                _fx1.Address1,
+                minerAddress,
                 null,
                 DateTimeOffset.MinValue,
                 Enumerable.Empty<Transaction<DumbAction>>());
@@ -1440,7 +1446,7 @@ namespace Libplanet.Tests.Net
                 0,
                 0,
                 new Nonce(new byte[] { 0x02, 0x00, 0x00, 0x00 }),
-                _fx1.Address1,
+                minerAddress,
                 null,
                 DateTimeOffset.MinValue,
                 Enumerable.Empty<Transaction<DumbAction>>());
@@ -1462,12 +1468,12 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 10; i++)
             {
-                await validSeedChain.MineBlock(_fx1.Address1);
+                await validSeedChain.MineBlock(minerAddress);
             }
 
             for (int i = 0; i < 20; i++)
             {
-                await invalidSeedChain.MineBlock(_fx1.Address1);
+                await invalidSeedChain.MineBlock(minerAddress);
             }
 
             try
@@ -1497,11 +1503,14 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task ReorgWhilePreloadAsync()
         {
-            BlockChain<DumbAction> seedChain = _blockchains[0];
-            BlockChain<DumbAction> receiverChain = _blockchains[1];
+            var seed = CreateSwarm();
+            var receiver = CreateSwarm();
+
+            BlockChain<DumbAction> seedChain = seed.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiver.BlockChain;
             for (int i = 0; i < 10; i++)
             {
-                await seedChain.MineBlock(_fx1.Address1);
+                await seedChain.MineBlock(seed.Address);
             }
 
             bool reorg = true;
@@ -1516,15 +1525,13 @@ namespace Libplanet.Tests.Net
                 {
                     var forked = seedChain.Fork(seedChain[9].Hash);
                     seedChain.Swap(forked, false);
-                    seedChain.MineBlock(_fx1.Address1).Wait();
-                    seedChain.MineBlock(_fx1.Address1).Wait();
+                    seedChain.MineBlock(seed.Address).Wait();
+                    seedChain.MineBlock(seed.Address).Wait();
 
                     reorg = false;
                 }
             });
 
-            var seed = _swarms[0];
-            var receiver = _swarms[1];
             seed.Options.RecentStateRecvTimeout = TimeSpan.FromDays(1);
 
             try
@@ -1558,7 +1565,7 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 10; i++)
             {
-                var block = await seedChain.MineBlock(_fx1.Address1);
+                var block = await seedChain.MineBlock(seed.Address);
                 receiverChain.Append(block);
             }
 
@@ -1568,7 +1575,7 @@ namespace Libplanet.Tests.Net
             seedChain.Swap(forked, false);
             for (int i = 0; i < 10; i++)
             {
-                await seedChain.MineBlock(_fx1.Address1);
+                await seedChain.MineBlock(seed.Address);
             }
 
             var actionExecutionCount = 0;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -52,127 +52,32 @@ namespace Libplanet.Tests.Net
                 .CreateLogger()
                 .ForContext<SwarmTest>();
 
-            Log.Logger.Debug($"Started to initialize a {nameof(SwarmTest)} instance.");
-
             _logger = Log.ForContext<SwarmTest>();
             _output = output;
 
-            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            _fx1 = new DefaultStoreFixture(memory: true);
-            _fx2 = new DefaultStoreFixture(memory: true);
-            _fx3 = new DefaultStoreFixture(memory: true);
-            _fx4 = new DefaultStoreFixture(memory: true);
-            _mptFx1 = new DefaultStoreFixture(memory: true, mpt: true);
-            _mptFx2 = new DefaultStoreFixture(memory: true, mpt: true);
-            _mptFx3 = new DefaultStoreFixture(memory: true, mpt: true);
-
-            _renderers = new List<RecordingRenderer<DumbAction>>
-            {
-                new ValidatingActionRenderer<DumbAction>(),
-                new ValidatingActionRenderer<DumbAction>(),
-                new ValidatingActionRenderer<DumbAction>(),
-                new ValidatingActionRenderer<DumbAction>(),
-            };
-
-            LoggedActionRenderer<DumbAction>[][] loggedRenderers = _renderers
-                .Select(r => new[] { new LoggedActionRenderer<DumbAction>(r, _logger) })
-                .ToArray();
-
-            _blockchains = new List<BlockChain<DumbAction>>
-            {
-                TestUtils.MakeBlockChain(policy, _fx1.Store, renderers: loggedRenderers[0]),
-                TestUtils.MakeBlockChain(policy, _fx2.Store, renderers: loggedRenderers[1]),
-                TestUtils.MakeBlockChain(policy, _fx3.Store, renderers: loggedRenderers[2]),
-                TestUtils.MakeBlockChain(policy, _fx4.Store, renderers: loggedRenderers[3]),
-            };
-
-            var genesisBlockHavingStateRoot =
-                TestUtils.MineGenesis<DumbAction>(
-                    blockAction: policy.BlockAction, checkStateRootHash: true);
-            _mptBlockchains = new List<BlockChain<DumbAction>>
-            {
-                TestUtils.MakeBlockChain(
-                    policy,
-                    _mptFx1.Store,
-                    stateStore: _mptFx1.StateStore,
-                    renderers: loggedRenderers[0],
-                    genesisBlock: genesisBlockHavingStateRoot),
-                TestUtils.MakeBlockChain(
-                    policy,
-                    _mptFx2.Store,
-                    stateStore: _mptFx2.StateStore,
-                    renderers: loggedRenderers[1],
-                    genesisBlock: genesisBlockHavingStateRoot),
-                TestUtils.MakeBlockChain(
-                    policy,
-                    _mptFx3.Store,
-                    stateStore: _mptFx3.StateStore,
-                    renderers: loggedRenderers[2],
-                    genesisBlock: genesisBlockHavingStateRoot),
-            };
-
             _finalizers = new List<Func<Task>>();
-            _swarms = new List<Swarm<DumbAction>>
-            {
-                CreateSwarm(_blockchains[0]),
-                CreateSwarm(_blockchains[1]),
-                CreateSwarm(_blockchains[2]),
-                CreateSwarm(_blockchains[3]),
-            };
-            _mptSwarms = new List<Swarm<DumbAction>>
-            {
-                CreateSwarm(_mptBlockchains[0]),
-                CreateSwarm(_mptBlockchains[1]),
-                CreateSwarm(_mptBlockchains[2]),
-            };
-
-            Log.Logger.Debug($"Finished to initialize a {nameof(SwarmTest)} instance.");
         }
 
         public void Dispose()
         {
-            try
+            Log.Logger.Debug("Starts to finalize {Resources} resources...", _finalizers.Count);
+            int i = 1;
+            foreach (Func<Task> finalize in _finalizers)
             {
-                Log.Logger.Debug("Starts to finalize {Resources} resources...", _finalizers.Count);
-                int i = 1;
-                foreach (Func<Task> finalize in _finalizers)
-                {
-                    Log.Logger.Debug("Tries to finalize the resource #{Resource}...", i++);
-                    finalize().Wait(DisposeTimeout);
-                }
-
-                Log.Logger.Debug("Finished to finalize {Resources} resources.", _finalizers.Count);
-
-                NetMQConfig.Cleanup(false);
-                Log.Logger.Debug($"Finished to clean up the {nameof(NetMQConfig)} singleton.");
-            }
-            finally
-            {
-                _fx1.Dispose();
-                _fx2.Dispose();
-                _fx3.Dispose();
-                _fx4.Dispose();
-
-                _mptFx1.Dispose();
-                _mptFx2.Dispose();
-                _mptFx3.Dispose();
+                Log.Logger.Debug("Tries to finalize the resource #{Resource}...", i++);
+                finalize().Wait(DisposeTimeout);
             }
 
-            Log.Logger.Debug($"Finished to {nameof(Dispose)}() a {nameof(SwarmTest)} instance.");
-        }
+            Log.Logger.Debug("Finished to finalize {Resources} resources.", _finalizers.Count);
 
-        [Fact]
-        public void BlockChain()
-        {
-            Assert.Same(_blockchains[0], _swarms[0].BlockChain);
-            Assert.Same(_blockchains[1], _swarms[1].BlockChain);
-            Assert.Same(_blockchains[2], _swarms[2].BlockChain);
+            NetMQConfig.Cleanup(false);
+            Log.Logger.Debug($"Finished to clean up the {nameof(NetMQConfig)} singleton.");
         }
 
         [Fact(Timeout = Timeout)]
         public async Task CanNotStartTwice()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
+            Swarm<DumbAction> swarm = CreateSwarm();
 
             Task t = await Task.WhenAny(
                 swarm.StartAsync(),
@@ -191,10 +96,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task HandleReconnection()
         {
-            Swarm<DumbAction> seed = CreateSwarm(_blockchains[0]);
+            Swarm<DumbAction> seed = CreateSwarm();
 
-            Swarm<DumbAction> swarmA = CreateSwarm(_blockchains[1]);
-            Swarm<DumbAction> swarmB = CreateSwarm(_blockchains[2]);
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
             try
             {
@@ -223,16 +128,16 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastBlockToReconnectedPeer()
         {
-            BlockChain<DumbAction> chainWithBlocks = _blockchains[0];
-            Swarm<DumbAction> seed = CreateSwarm(chainWithBlocks);
+            Swarm<DumbAction> seed = CreateSwarm();
+            BlockChain<DumbAction> chainWithBlocks = seed.BlockChain;
 
             var privateKey = new PrivateKey();
-            Swarm<DumbAction> swarmA = CreateSwarm(_blockchains[1], privateKey);
-            Swarm<DumbAction> swarmB = CreateSwarm(_blockchains[2], privateKey);
+            Swarm<DumbAction> swarmA = CreateSwarm(privateKey: privateKey);
+            Swarm<DumbAction> swarmB = CreateSwarm(privateKey: privateKey);
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await chainWithBlocks.MineBlock(_fx1.Address1);
+                await chainWithBlocks.MineBlock(seed.Address);
             }
 
             try
@@ -261,8 +166,8 @@ namespace Libplanet.Tests.Net
 
                 await swarmB.BlockAppended.WaitAsync();
 
-                Assert.NotEqual(chainWithBlocks.BlockHashes, _blockchains[1].BlockHashes);
-                Assert.Equal(chainWithBlocks.BlockHashes, _blockchains[2].BlockHashes);
+                Assert.NotEqual(chainWithBlocks.BlockHashes, swarmA.BlockChain.BlockHashes);
+                Assert.Equal(chainWithBlocks.BlockHashes, swarmB.BlockChain.BlockHashes);
             }
             finally
             {
@@ -279,19 +184,19 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastIgnoreFromDifferentGenesisHash()
         {
-            BlockChain<DumbAction> receiverChain = _blockchains[0];
-            Swarm<DumbAction> receiverSwarm = _swarms[0];
+            Swarm<DumbAction> receiverSwarm = CreateSwarm();
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
             var invalidGenesisBlock = new Block<DumbAction>(
                 0,
                 0,
                 0,
                 new Nonce(new byte[] { 0x10, 0x00, 0x00, 0x00 }),
-                _fx1.Address1,
+                receiverSwarm.Address,
                 null,
                 DateTimeOffset.MinValue,
                 Enumerable.Empty<Transaction<DumbAction>>());
             BlockChain<DumbAction> seedChain = TestUtils.MakeBlockChain(
-                    policy: _blockchains[0].Policy,
+                    policy: receiverChain.Policy,
                     store: new DefaultStore(path: null),
                     genesisBlock: invalidGenesisBlock);
             Swarm<DumbAction> seedSwarm = CreateSwarm(seedChain);
@@ -301,7 +206,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(seedSwarm);
 
                 await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
-                Block<DumbAction> block = await seedChain.MineBlock(_fx1.Address1);
+                Block<DumbAction> block = await seedChain.MineBlock(seedSwarm.Address);
                 seedSwarm.BroadcastBlock(block);
                 while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
                     .Any(msg => msg is BlockHeaderMessage))
@@ -324,8 +229,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task StopAsyncTest()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
-            BlockChain<DumbAction> chain = _blockchains[0];
+            Swarm<DumbAction> swarm = CreateSwarm();
 
             await swarm.StopAsync();
             var task = await StartAsync(swarm);
@@ -344,8 +248,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CanWaitForRunning()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
-            BlockChain<DumbAction> chain = _blockchains[0];
+            Swarm<DumbAction> swarm = CreateSwarm();
 
             Assert.False(swarm.Running);
 
@@ -372,8 +275,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task AddPeersWithoutStart()
         {
-            Swarm<DumbAction> a = _swarms[0];
-            Swarm<DumbAction> b = _swarms[1];
+            Swarm<DumbAction> a = CreateSwarm();
+            Swarm<DumbAction> b = CreateSwarm();
 
             try
             {
@@ -394,8 +297,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task AddPeersAsync()
         {
-            Swarm<DumbAction> a = _swarms[0];
-            Swarm<DumbAction> b = _swarms[1];
+            Swarm<DumbAction> a = CreateSwarm();
+            Swarm<DumbAction> b = CreateSwarm();
 
             try
             {
@@ -417,8 +320,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BootstrapException()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
             try
             {
@@ -437,9 +340,9 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BootstrapAsyncWithoutStart()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
 
             try
             {
@@ -463,8 +366,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task AutoConnectAfterStart()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
             try
             {
@@ -489,11 +392,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastWhileMining()
         {
-            Swarm<DumbAction> a = _swarms[0];
-            Swarm<DumbAction> b = _swarms[1];
+            Swarm<DumbAction> a = CreateSwarm();
+            Swarm<DumbAction> b = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction> chainA = a.BlockChain;
+            BlockChain<DumbAction> chainB = b.BlockChain;
 
             Task CreateMiner(
                 Swarm<DumbAction> swarm,
@@ -508,7 +411,7 @@ namespace Libplanet.Tests.Net
                     {
                         try
                         {
-                            var block = await chain.MineBlock(_fx1.Address1);
+                            var block = await chain.MineBlock(swarm.Address);
 
                             Log.Debug(
                                 "Block mined. [Node: {0}, Block: {1}]",
@@ -562,7 +465,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task Cancel()
         {
-            Swarm<DumbAction> swarm = _swarms[0];
+            Swarm<DumbAction> swarm = CreateSwarm();
             var cts = new CancellationTokenSource();
 
             Task task = await StartAsync(
@@ -587,18 +490,18 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetBlocks()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             // FIXME: Rename the following variables or reuse the real genesis block which
             // already exists in chainA.  These are misleading as genesis.Index is not 0 but 1.
-            Block<DumbAction> genesis = await chainA.MineBlock(_fx1.Address1);
+            Block<DumbAction> genesis = await chainA.MineBlock(swarmA.Address);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
-            Block<DumbAction> block1 = await chainA.MineBlock(_fx1.Address1);
-            Block<DumbAction> block2 = await chainA.MineBlock(_fx1.Address1);
+            Block<DumbAction> block1 = await chainA.MineBlock(swarmA.Address);
+            Block<DumbAction> block2 = await chainA.MineBlock(swarmA.Address);
 
             try
             {
@@ -654,16 +557,16 @@ namespace Libplanet.Tests.Net
         {
             var privateKey = new PrivateKey();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm(privateKey);
 
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = CreateSwarm(chainB, privateKey);
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            Block<DumbAction> genesis = await chainA.MineBlock(_fx1.Address1);
+            Block<DumbAction> genesis = await chainA.MineBlock(swarmA.Address);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
-            await chainA.MineBlock(_fx1.Address1);
-            await chainA.MineBlock(_fx1.Address1);
+            await chainA.MineBlock(swarmA.Address);
+            await chainA.MineBlock(swarmA.Address);
 
             try
             {
@@ -724,10 +627,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetTx()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -736,7 +639,7 @@ namespace Libplanet.Tests.Net
                 new DumbAction[0]
             );
             chainB.StageTransaction(tx);
-            await chainB.MineBlock(_fx1.Address1);
+            await chainB.MineBlock(swarmB.Address);
 
             try
             {
@@ -764,13 +667,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastTx()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
+            BlockChain<DumbAction> chainC = swarmC.BlockChain;
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -780,7 +683,7 @@ namespace Libplanet.Tests.Net
             );
 
             chainA.StageTransaction(tx);
-            await chainA.MineBlock(_fx1.Address1);
+            await chainA.MineBlock(swarmA.Address);
 
             try
             {
@@ -811,11 +714,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastTxWhileMining()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainC = swarmC.BlockChain;
 
             var privateKey = new PrivateKey();
             var address = privateKey.ToAddress();
@@ -840,7 +743,7 @@ namespace Libplanet.Tests.Net
                 {
                     for (var i = 0; i < 10; i++)
                     {
-                        await chainC.MineBlock(_fx1.Address1);
+                        await chainC.MineBlock(swarmC.Address);
                     }
                 });
 
@@ -862,13 +765,13 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastTxAsync()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
+            BlockChain<DumbAction> chainC = swarmC.BlockChain;
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -986,22 +889,22 @@ namespace Libplanet.Tests.Net
             var keyC = ByteUtil.ParseHex(
                 "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
 
-            var swarmA = CreateSwarm(_blockchains[0], new PrivateKey(keyA));
-            var swarmB = CreateSwarm(_blockchains[1], new PrivateKey(keyB));
-            var swarmC = CreateSwarm(_blockchains[2], new PrivateKey(keyC));
+            var swarmA = CreateSwarm(new PrivateKey(keyA));
+            var swarmB = CreateSwarm(new PrivateKey(keyB));
+            var swarmC = CreateSwarm(new PrivateKey(keyC));
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
-            BlockChain<DumbAction> chainC = _blockchains[2];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
+            BlockChain<DumbAction> chainC = swarmC.BlockChain;
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await chainA.MineBlock(_fx1.Address1);
+                await chainA.MineBlock(swarmA.Address);
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
-                await chainB.MineBlock(_fx2.Address1);
+                await chainB.MineBlock(swarmB.Address);
             }
 
             try
@@ -1050,12 +953,20 @@ namespace Libplanet.Tests.Net
         public async Task BroadcastBlockWithSkip()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var fx = new DefaultStoreFixture(memory: true);
-            var blockChain = TestUtils.MakeBlockChain(policy, fx.Store);
+            var fx1 = new DefaultStoreFixture(memory: true);
+            var blockChain = TestUtils.MakeBlockChain(policy, fx1.Store);
             var privateKey = new PrivateKey();
             var minerSwarm = CreateSwarm(blockChain, privateKey);
-            Swarm<DumbAction> receiverSwarm = _swarms[0];
-            RecordingRenderer<DumbAction> receiverRenderer = _renderers[0];
+            var fx2 = new DefaultStoreFixture(memory: true);
+            var receiverRenderer = new RecordingRenderer<DumbAction>();
+            var loggedRenderer = new LoggedActionRenderer<DumbAction>(
+                receiverRenderer,
+                _logger);
+            var receiverChain = TestUtils.MakeBlockChain(
+                policy,
+                fx2.Store,
+                renderers: new[] { loggedRenderer });
+            Swarm<DumbAction> receiverSwarm = CreateSwarm(receiverChain);
 
             int renderCount = 0;
 
@@ -1063,20 +974,20 @@ namespace Libplanet.Tests.Net
 
             Transaction<DumbAction>[] transactions =
             {
-                fx.MakeTransaction(
+                fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(fx.Address2, "foo"),
-                        new DumbAction(fx.Address2, "bar"),
+                        new DumbAction(fx1.Address2, "foo"),
+                        new DumbAction(fx1.Address2, "bar"),
                     },
                     timestamp: DateTimeOffset.MinValue,
                     nonce: 0,
                     privateKey: privateKey),
-                fx.MakeTransaction(
+                fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(fx.Address2, "baz"),
-                        new DumbAction(fx.Address2, "qux"),
+                        new DumbAction(fx1.Address2, "baz"),
+                        new DumbAction(fx1.Address2, "qux"),
                     },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(5),
                     nonce: 1,
@@ -1106,14 +1017,14 @@ namespace Libplanet.Tests.Net
                 minerSwarm.BroadcastBlock(block2);
                 await receiverSwarm.BlockAppended.WaitAsync();
 
-                Assert.Equal(3, _blockchains[0].Count);
+                Assert.Equal(3, receiverChain.Count);
                 Assert.Equal(4, renderCount);
             }
             finally
             {
                 await StopAsync(minerSwarm);
                 await StopAsync(receiverSwarm);
-                fx.Dispose();
+                fx1.Dispose();
                 minerSwarm.Dispose();
             }
         }
@@ -1121,11 +1032,11 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task BroadcastBlockWithoutGenesis()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             try
             {
@@ -1134,14 +1045,14 @@ namespace Libplanet.Tests.Net
 
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
 
-                await chainA.MineBlock(_fx1.Address1);
+                await chainA.MineBlock(swarmA.Address);
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
 
                 Assert.Equal(chainB.BlockHashes, chainA.BlockHashes);
 
-                await chainA.MineBlock(_fx1.Address1);
+                await chainA.MineBlock(swarmA.Address);
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
@@ -1158,18 +1069,18 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task IgnoreExistingBlocks()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
 
-            BlockChain<DumbAction> chainA = _blockchains[0];
-            BlockChain<DumbAction> chainB = _blockchains[1];
+            BlockChain<DumbAction> chainA = swarmA.BlockChain;
+            BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            Block<DumbAction> genesis = await chainA.MineBlock(_fx1.Address1);
+            Block<DumbAction> genesis = await chainA.MineBlock(swarmA.Address);
             chainB.Append(genesis);
 
             foreach (int i in Enumerable.Range(0, 3))
             {
-                await chainA.MineBlock(_fx1.Address1);
+                await chainA.MineBlock(swarmA.Address);
             }
 
             try
@@ -1204,6 +1115,9 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public void ThrowArgumentExceptionInConstructor()
         {
+            var fx = new DefaultStoreFixture();
+            var policy = new BlockPolicy<DumbAction>();
+            var blockchain = TestUtils.MakeBlockChain(policy, fx.Store);
             var key = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(key, 1);
             Assert.Throws<ArgumentNullException>(() =>
@@ -1213,19 +1127,19 @@ namespace Libplanet.Tests.Net
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(_blockchains[0], null, ver);
+                new Swarm<DumbAction>(blockchain, null, ver);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(_blockchains[0], key, ver);
+                new Swarm<DumbAction>(blockchain, key, ver);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(_blockchains[0], key, ver, iceServers: new IceServer[] { });
+                new Swarm<DumbAction>(blockchain, key, ver, iceServers: new IceServer[] { });
             });
         }
 
@@ -1233,8 +1147,7 @@ namespace Libplanet.Tests.Net
         public void CanResolveEndPoint()
         {
             var expected = new DnsEndPoint("1.2.3.4", 5678);
-            using (Swarm<DumbAction> s = CreateSwarm(
-                _blockchains[0], host: "1.2.3.4", listenPort: 5678))
+            using (Swarm<DumbAction> s = CreateSwarm(host: "1.2.3.4", listenPort: 5678))
             {
                 Assert.Equal(expected, s.EndPoint);
                 Assert.Equal(expected, (s.AsPeer as BoundPeer)?.EndPoint);
@@ -1244,7 +1157,7 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task StopGracefullyWhileStarting()
         {
-            Swarm<DumbAction> a = _swarms[0];
+            Swarm<DumbAction> a = CreateSwarm();
 
             Task t = await StartAsync(a);
             bool canceled = false;
@@ -1263,23 +1176,21 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task AsPeer()
         {
-            using (Swarm<DumbAction> swarm = CreateSwarm(_blockchains[0]))
-            {
-                Assert.IsNotType<BoundPeer>(swarm.AsPeer);
+            Swarm<DumbAction> swarm = CreateSwarm();
+            Assert.IsNotType<BoundPeer>(swarm.AsPeer);
 
-                await StartAsync(swarm);
-                Assert.IsType<BoundPeer>(swarm.AsPeer);
-                await StopAsync(swarm);
-            }
+            await StartAsync(swarm);
+            Assert.IsType<BoundPeer>(swarm.AsPeer);
+            await StopAsync(swarm);
         }
 
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task ExchangeWithIceServer()
         {
             var iceServers = FactOnlyTurnAvailableAttribute.IceServers;
-            var seed = CreateSwarm(_blockchains[0], host: "localhost");
-            var swarmA = CreateSwarm(_blockchains[1], iceServers: iceServers);
-            var swarmB = CreateSwarm(_blockchains[2], iceServers: iceServers);
+            var seed = CreateSwarm(host: "localhost");
+            var swarmA = CreateSwarm(iceServers: iceServers);
+            var swarmB = CreateSwarm(iceServers: iceServers);
 
             try
             {
@@ -1340,8 +1251,8 @@ namespace Libplanet.Tests.Net
             var cts = new CancellationTokenSource();
             var tasks = new List<Task> { TurnProxy(port, turnUrl, cts.Token) };
 
-            var seed = CreateSwarm(_blockchains[0], host: "localhost");
-            var swarmA = CreateSwarm(_blockchains[1], iceServers: iceServers);
+            var seed = CreateSwarm(host: "localhost");
+            var swarmA = CreateSwarm(iceServers: iceServers);
 
             async Task RefreshTableAsync(CancellationToken cancellationToken)
             {
@@ -1363,7 +1274,7 @@ namespace Libplanet.Tests.Net
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var block = await _blockchains[0].MineBlock(_fx1.Address1);
+                    var block = await seed.BlockChain.MineBlock(seed.Address);
                     seed.BroadcastBlock(block);
                     await Task.Delay(5000, cancellationToken);
                 }
@@ -1387,10 +1298,10 @@ namespace Libplanet.Tests.Net
                 cts.Cancel();
                 await Task.Delay(1000);
 
-                Assert.NotEqual(_blockchains[1].Genesis, _blockchains[1].Tip);
+                Assert.NotEqual(swarmA.BlockChain.Genesis, swarmA.BlockChain.Tip);
                 Assert.Contains(
-                    _blockchains[1].Tip.Hash,
-                    _blockchains[0].BlockHashes
+                    swarmA.BlockChain.Tip.Hash,
+                    seed.BlockChain.BlockHashes
                 );
             }
             finally
@@ -1415,10 +1326,14 @@ namespace Libplanet.Tests.Net
 
             var chain1 = TestUtils.MakeBlockChain(policy1, fx1.Store);
             var chain2 = TestUtils.MakeBlockChain(policy2, fx2.Store);
+
+            var swarm1 = CreateSwarm(chain1);
+            var swarm2 = CreateSwarm(chain2);
+
             Assert.Equal(chain1.Genesis, chain2.Genesis);
 
-            await chain1.MineBlock(_fx1.Address1);
-            await chain2.MineBlock(_fx1.Address1);
+            await chain1.MineBlock(swarm1.Address);
+            await chain2.MineBlock(swarm2.Address);
 
             // Creates a block that will make chain 2's total difficulty is higher than chain 1's.
             var block3 = TestUtils.MineNext(
@@ -1426,10 +1341,6 @@ namespace Libplanet.Tests.Net
                 difficulty: (long)chain1.Tip.TotalDifficulty + 1,
                 blockInterval: TimeSpan.FromMilliseconds(1));
             chain2.Append(block3);
-
-            var swarm1 = CreateSwarm(chain1);
-            var swarm2 = CreateSwarm(chain2);
-
             try
             {
                 await StartAsync(swarm1);
@@ -1478,7 +1389,7 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(miner2, miner1.AsPeer);
 
                 var privKey = new PrivateKey();
-                var addr = _fx1.Address1;
+                var addr = miner1.Address;
                 var item = "foo";
 
                 miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
@@ -1516,8 +1427,11 @@ namespace Libplanet.Tests.Net
             var chain1 = TestUtils.MakeBlockChain(policy, new DefaultStore(null));
             var chain2 = TestUtils.MakeBlockChain(policy, new DefaultStore(null));
 
-            await chain1.MineBlock(_fx1.Address1);
-            await chain1.MineBlock(_fx1.Address1);
+            var miner1 = CreateSwarm(chain1);
+            var miner2 = CreateSwarm(chain2);
+
+            await chain1.MineBlock(miner1.Address);
+            await chain1.MineBlock(miner2.Address);
             long nextDifficulty =
                 (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
             var block = TestUtils.MineNext(
@@ -1528,9 +1442,6 @@ namespace Libplanet.Tests.Net
 
             Assert.True(chain1.Tip.Index > chain2.Tip.Index);
             Assert.True(chain1.Tip.TotalDifficulty < chain2.Tip.TotalDifficulty);
-
-            var miner1 = CreateSwarm(chain1);
-            var miner2 = CreateSwarm(chain2);
 
             try
             {
@@ -1611,22 +1522,24 @@ namespace Libplanet.Tests.Net
         [InlineData(false)]
         public async void RestageTransactionsOnceLocallyMinedAfterReorg(bool restage)
         {
-            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var minerA = CreateSwarm(TestUtils.MakeBlockChain(policy, new DefaultStore(null)));
-            var minerB = CreateSwarm(TestUtils.MakeBlockChain(policy, new DefaultStore(null)));
+            var minerA = CreateSwarm();
+            var minerB = CreateSwarm();
 
             var privateKeyA = new PrivateKey();
             var privateKeyB = new PrivateKey();
+
+            var targetAddress1 = new PrivateKey().ToAddress();
+            var targetAddress2 = new PrivateKey().ToAddress();
 
             try
             {
                 const string dumbItem = "item0.0";
                 var txA = minerA.BlockChain.MakeTransaction(
                     privateKeyA,
-                    new[] { new DumbAction(_fx1.Address1, dumbItem), });
+                    new[] { new DumbAction(targetAddress1, dumbItem), });
                 var txB = minerB.BlockChain.MakeTransaction(
                     privateKeyB,
-                    new[] { new DumbAction(_fx1.Address2, dumbItem), });
+                    new[] { new DumbAction(targetAddress2, dumbItem), });
 
                 if (!restage)
                 {
@@ -1638,8 +1551,8 @@ namespace Libplanet.Tests.Net
                 Block<DumbAction> blockB = await minerB.BlockChain.MineBlock(minerB.Address);
                 Block<DumbAction> blockC = await minerB.BlockChain.MineBlock(minerB.Address);
 
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address1));
-                Assert.Equal((Text)dumbItem, minerB.BlockChain.GetState(_fx1.Address2));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
+                Assert.Equal((Text)dumbItem, minerB.BlockChain.GetState(targetAddress2));
 
                 await StartAsync(minerA);
                 await StartAsync(minerB);
@@ -1654,8 +1567,8 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(3, minerA.BlockChain.Count);
                 Assert.Equal(
                     restage ? null : (Text?)dumbItem,
-                    minerA.BlockChain.GetState(_fx1.Address1));
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address2));
+                    minerA.BlockChain.GetState(targetAddress1));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress2));
 
                 Log.Debug("Check if txs in unrendered blocks staged again.");
                 Assert.Equal(
@@ -1667,8 +1580,8 @@ namespace Libplanet.Tests.Net
                 await minerB.BlockAppended.WaitAsync();
 
                 Assert.Equal(minerA.BlockChain.Tip, minerB.BlockChain.Tip);
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address1));
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(_fx1.Address2));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
+                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress2));
             }
             finally
             {
@@ -1802,13 +1715,13 @@ namespace Libplanet.Tests.Net
             var keyC = ByteUtil.ParseHex(
                 "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
 
-            var minerSwarmA = CreateSwarm(_blockchains[0], new PrivateKey(keyA));
-            var minerSwarmB = CreateSwarm(_blockchains[1], new PrivateKey(keyB));
-            var receiverSwarm = CreateSwarm(_blockchains[2], new PrivateKey(keyC));
+            var minerSwarmA = CreateSwarm(new PrivateKey(keyA));
+            var minerSwarmB = CreateSwarm(new PrivateKey(keyB));
+            var receiverSwarm = CreateSwarm(new PrivateKey(keyC));
 
-            BlockChain<DumbAction> minerChainA = _blockchains[0];
-            BlockChain<DumbAction> minerChainB = _blockchains[1];
-            BlockChain<DumbAction> receiverChain = _blockchains[2];
+            BlockChain<DumbAction> minerChainA = minerSwarmA.BlockChain;
+            BlockChain<DumbAction> minerChainB = minerSwarmB.BlockChain;
+            BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             try
             {
@@ -1820,22 +1733,22 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(minerSwarmB, receiverSwarm.AsPeer);
 
                 // Broadcast SwarmA's first block.
-                var b1 = await minerChainA.MineBlock(_fx1.Address1);
-                await minerChainB.MineBlock(_fx1.Address1);
+                var b1 = await minerChainA.MineBlock(minerSwarmA.Address);
+                await minerChainB.MineBlock(minerSwarmA.Address);
                 minerSwarmA.BroadcastBlock(b1);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainA.Tip);
 
                 // Broadcast SwarmB's second block.
-                await minerChainA.MineBlock(_fx1.Address1);
-                var b2 = await minerChainB.MineBlock(_fx1.Address1);
+                await minerChainA.MineBlock(minerSwarmA.Address);
+                var b2 = await minerChainB.MineBlock(minerSwarmA.Address);
                 minerSwarmB.BroadcastBlock(b2);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainB.Tip);
 
                 // Broadcast SwarmA's third block.
-                var b3 = await minerChainA.MineBlock(_fx1.Address1);
-                await minerChainB.MineBlock(_fx1.Address1);
+                var b3 = await minerChainA.MineBlock(minerSwarmA.Address);
+                await minerChainB.MineBlock(minerSwarmA.Address);
                 minerSwarmA.BroadcastBlock(b3);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 Assert.Equal(receiverChain.Tip, minerChainA.Tip);
@@ -1854,18 +1767,18 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task DoNotDeleteCanonicalChainWhenBlockDownloadFailed()
         {
-            var chainA = _blockchains[0];
-            var chainB = _blockchains[1];
+            var swarmA = CreateSwarm();
+            var swarmB = CreateSwarm();
+            var chainA = swarmA.BlockChain;
+            var chainB = swarmB.BlockChain;
 
-            var swarmA = _swarms[0];
-            var swarmB = _swarms[1];
             swarmB.Options.BlockHashRecvTimeout = TimeSpan.FromMilliseconds(10);
 
-            var genesis = await chainA.MineBlock(_fx1.Address1);
+            var genesis = await chainA.MineBlock(swarmA.Address);
             chainB.Append(genesis);
 
-            await chainA.MineBlock(_fx1.Address1);
-            var block = await chainA.MineBlock(_fx1.Address1);
+            await chainA.MineBlock(swarmA.Address);
+            var block = await chainA.MineBlock(swarmA.Address);
 
             try
             {
@@ -1878,7 +1791,7 @@ namespace Libplanet.Tests.Net
                 await StopAsync(swarmA);
                 await swarmB.FillBlocksAsyncFailed.WaitAsync();
 
-                Assert.NotNull(chainB.GetState(_fx1.Address1));
+                Assert.NotNull(chainB.GetState(swarmA.Address));
             }
             finally
             {
@@ -1901,8 +1814,10 @@ namespace Libplanet.Tests.Net
             var privateKeyB = new PrivateKey(keyB);
             var privateKeyC = new PrivateKey(keyC);
 
-            var actionsA = new[] { new DumbAction(_fx1.Address1, "1") };
-            var actionsB = new[] { new DumbAction(_fx1.Address1, "2") };
+            var signerAddress = new PrivateKey().ToAddress();
+
+            var actionsA = new[] { new DumbAction(signerAddress, "1") };
+            var actionsB = new[] { new DumbAction(signerAddress, "2") };
 
             var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock(actionsA, privateKeyA);
             var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock(actionsB, privateKeyB);
@@ -1945,9 +1860,9 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(1, genesisChainB.Count);
                 Assert.Equal(2, genesisChainC.Count);
 
-                Assert.Equal("1", (Text)genesisChainA.GetState(_fx1.Address1));
-                Assert.Equal("2", (Text)genesisChainB.GetState(_fx1.Address1));
-                Assert.Equal("1", (Text)genesisChainC.GetState(_fx1.Address1));
+                Assert.Equal("1", (Text)genesisChainA.GetState(signerAddress));
+                Assert.Equal("2", (Text)genesisChainB.GetState(signerAddress));
+                Assert.Equal("1", (Text)genesisChainC.GetState(signerAddress));
             }
             finally
             {
@@ -1964,10 +1879,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task FindSpecificPeerAsync()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
-            Swarm<DumbAction> swarmD = _swarms[3];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
+            Swarm<DumbAction> swarmD = CreateSwarm();
             try
             {
                 await StartAsync(swarmA);
@@ -2008,9 +1923,9 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task FindSpecificPeerAsyncFail()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
             try
             {
                 await StartAsync(swarmA);
@@ -2048,10 +1963,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task FindSpecificPeerAsyncDepthFail()
         {
-            Swarm<DumbAction> swarmA = _swarms[0];
-            Swarm<DumbAction> swarmB = _swarms[1];
-            Swarm<DumbAction> swarmC = _swarms[2];
-            Swarm<DumbAction> swarmD = _swarms[3];
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmC = CreateSwarm();
+            Swarm<DumbAction> swarmD = CreateSwarm();
             try
             {
                 await StartAsync(swarmA);
@@ -2092,9 +2007,9 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task DoNotFillMultipleTimes()
         {
-            Swarm<DumbAction> receiver = _swarms[0];
-            Swarm<DumbAction> sender1 = _swarms[1];
-            Swarm<DumbAction> sender2 = _swarms[2];
+            Swarm<DumbAction> receiver = CreateSwarm();
+            Swarm<DumbAction> sender1 = CreateSwarm();
+            Swarm<DumbAction> sender2 = CreateSwarm();
 
             await StartAsync(receiver);
             await StartAsync(sender1);
@@ -2157,9 +2072,9 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task GetPeerChainStateAsync()
         {
-            Swarm<DumbAction> swarm1 = _swarms[0];
-            Swarm<DumbAction> swarm2 = _swarms[1];
-            Swarm<DumbAction> swarm3 = _swarms[2];
+            Swarm<DumbAction> swarm1 = CreateSwarm();
+            Swarm<DumbAction> swarm2 = CreateSwarm();
+            Swarm<DumbAction> swarm3 = CreateSwarm();
 
             var peerChainState = await swarm1.GetPeerChainStateAsync(
                 TimeSpan.FromSeconds(1), default);
@@ -2179,7 +2094,7 @@ namespace Libplanet.Tests.Net
                     peerChainState.First()
                 );
 
-                await swarm2.BlockChain.MineBlock(_fx1.Address1);
+                await swarm2.BlockChain.MineBlock(swarm2.Address);
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(
@@ -2209,8 +2124,8 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task LastMessageTimestamp()
         {
-            Swarm<DumbAction> swarm1 = _swarms[0];
-            Swarm<DumbAction> swarm2 = _swarms[1];
+            Swarm<DumbAction> swarm1 = CreateSwarm();
+            Swarm<DumbAction> swarm2 = CreateSwarm();
 
             Assert.Null(swarm1.LastMessageTimestamp);
 
@@ -2240,10 +2155,8 @@ namespace Libplanet.Tests.Net
         public async Task Restart()
         {
             Swarm<DumbAction> swarm1 = CreateSwarm(
-                blockChain: _blockchains[0],
-                iceServers: FactOnlyTurnAvailableAttribute.IceServers
-            );
-            Swarm<DumbAction> swarm2 = _swarms[0];
+                iceServers: FactOnlyTurnAvailableAttribute.IceServers);
+            Swarm<DumbAction> swarm2 = CreateSwarm();
 
             try
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -722,8 +722,9 @@ namespace Libplanet.Tests.Net
 
             var privateKey = new PrivateKey();
             var address = privateKey.ToAddress();
+            var txCount = 10;
 
-            var txs = Enumerable.Range(0, 10).Select(_ =>
+            var txs = Enumerable.Range(0, txCount).Select(_ =>
                 chainA.MakeTransaction(new PrivateKey(), new[] { new DumbAction(address, "foo") }))
                 .ToArray();
 
@@ -747,10 +748,14 @@ namespace Libplanet.Tests.Net
                     }
                 });
 
-                await swarmC.TxReceived.WaitAsync();
+                while (chainC.Store.CountTransactions() != txCount + 1)
+                {
+                    await swarmC.TxReceived.WaitAsync();
+                }
+
                 await t;
 
-                for (var i = 0; i < 10; i++)
+                for (var i = 0; i < txCount; i++)
                 {
                     Assert.True(chainC.Store.ContainsTransaction(txs[i].Id));
                 }

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Tests.Store
     public class DefaultStoreFixture : StoreFixture, IDisposable
     {
         public DefaultStoreFixture(
-            bool memory = false, bool mpt = false, IAction blockAction = null)
+            bool memory = true, bool mpt = false, IAction blockAction = null)
             : base(blockAction)
         {
             if (memory)

--- a/Libplanet.Tests/Store/DefaultStoreTest.cs
+++ b/Libplanet.Tests/Store/DefaultStoreTest.cs
@@ -16,8 +16,8 @@ namespace Libplanet.Tests.Store
         public DefaultStoreTest(ITestOutputHelper testOutputHelper)
         {
             TestOutputHelper = testOutputHelper;
-            Fx = _fx = new DefaultStoreFixture();
-            FxConstructor = () => new DefaultStoreFixture();
+            Fx = _fx = new DefaultStoreFixture(memory: false);
+            FxConstructor = () => new DefaultStoreFixture(memory: false);
         }
 
         public void Dispose()

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2064,13 +2064,22 @@ namespace Libplanet.Net
                     }
                 }
 
-                TxReceived.Set();
-                _logger.Debug(
-                    "Txs staged successfully: {@txIds}",
-                    txs.Select(tx => tx.Id.ToString()));
+                if (txs.Any())
+                {
+                    TxReceived.Set();
+                    _logger.Debug(
+                        "Txs staged successfully: {@txIds}",
+                        txs.Select(tx => tx.Id.ToString()));
 
-                // FIXME: Should exclude peers of source of the transaction ids.
-                BroadcastTxs(null, txs);
+                    // FIXME: Should exclude peers of source of the transaction ids.
+                    BroadcastTxs(null, txs);
+                }
+                else
+                {
+                    _logger.Information(
+                        "Failed to get transactions to stage: {@txIds}",
+                        demandTxIds.Select(txId => txId.ToString()));
+                }
 
                 foreach (var kv in demandTxIds)
                 {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
       testArguments: >-
         --logger trx
         --collect "Code coverage"
+        --logger "console;verbosity=normal"
   - task: Bash@3
     displayName: codecov
     inputs:
@@ -77,7 +78,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
 - job: macOS_Mono
@@ -88,7 +89,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
 - job: Windows_Mono
@@ -104,7 +105,7 @@ jobs:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
       testPrefix: '"$PROGRAMFILES/Mono/bin/mono.exe"'
-      testArguments: -appdomains denied -parallel none -stoponfail
+      testArguments: -appdomains denied -parallel none -stoponfail -verbose
       copySQLitePCLRaw: true
   timeoutInMinutes: 30
 
@@ -141,7 +142,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
 - job: macOS_NETCore
@@ -152,7 +153,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
 - job: Windows_NETCore
@@ -163,7 +164,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
 # Run tests with an alternative locale configuration
@@ -175,7 +176,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
       locale: ar_SA.UTF8
   timeoutInMinutes: 30
 
@@ -187,7 +188,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
       locale: he_IL.UTF8
   timeoutInMinutes: 30
 
@@ -199,7 +200,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose
       locale: fr_FR.UTF8
   timeoutInMinutes: 30
 
@@ -211,4 +212,4 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail
+      testArguments: -parallel none -stoponfail -verbose


### PR DESCRIPTION
To improve tests:
- Use in memory `DefaultStoreFixture` by default.
- Reduce the default test timeout in `SwarmTest` to 30 seconds.
- Use helper methods instead of fixtures in `SwarmTest`.
- Parallelize tests.