### PR TITLE
Ignore messages from peer with different genesis block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,11 +129,14 @@ To be released.
     15 seconds.  [[#922], [#925]]
  -  `Swarm<T>` became to have 5 more message types:
      -  `GetChainStatus` (`0x20`)  [[#920], [#930]]
-     -  `ChainStatus` (`0x21`)  [[#920], [#930]]
+     -  `ChainStatus` (`0x24`)  [[#920], [#930], [#1003], [#1004]]
      -  `GetBlockStates` (`0x22`)  [[#946]]
      -  `BlockStates` (`0x23`)  [[#946]]
      -  `DifferentVersion` (`0x30`)  [[#949]]
  -  Every message now contains app protocol version in its header.  [[#949]]
+ -  The existing `BlockHeaderMessage` message type (with the type number `0x0d`) was
+    replaced by a new `BlockHeaderMessage` message type
+    (with the type number `0x0c`).  [[#1003], [#1004]]
 
 ### Backward-incompatible storage format changes
 
@@ -237,6 +240,10 @@ To be released.
     rather than the genesis block when there is a branch point.  [[#991]]
  -  `BlockPolicy<T>` became to validate `Block<T>.StateRootHash` property
      of a `Block<T>`.  [[#986]]
+ -  `Swarm<T>` became not to sync `Block<T>`s from the peers with
+    different genesis block.  [[#1003], [#1004]]
+ -  `Swarm<T>` became to ignore `BlockHeaderMessage` from the peers with
+    different genesis block.  [[#1003], [#1004]]
 
 ### Bug fixes
 
@@ -328,6 +335,8 @@ To be released.
 [#986]: https://github.com/planetarium/libplanet/pull/986
 [#991]: https://github.com/planetarium/libplanet/pull/991
 [#996]: https://github.com/planetarium/libplanet/pull/996
+[#1003]: https://github.com/planetarium/libplanet/issues/1003
+[#1004]: https://github.com/planetarium/libplanet/pull/1004
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1915,39 +1915,6 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task ThrowInvalidGenesisException()
-        {
-            var policy = new BlockPolicy<DumbAction>();
-            BlockChain<DumbAction> MakeBlockChain() => TestUtils.MakeBlockChain(
-                policy,
-                new DefaultStore(path: null),
-                null,
-                new PrivateKey());
-
-            var chainA = MakeBlockChain();
-            var chainB = MakeBlockChain();
-            var swarmA = CreateSwarm(chainA);
-            var swarmB = CreateSwarm(chainB);
-
-            await chainB.MineBlock(_fx1.Address1);
-
-            await StartAsync(swarmA);
-            await StartAsync(swarmB);
-
-            await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
-            Assert.NotEqual(chainA.Genesis, chainB.Genesis);
-            Task t = swarmA.PreloadAsync();
-            await Assert.ThrowsAsync<AggregateException>(async () => await t);
-            var exception = t.Exception.InnerException?.InnerException;
-            Assert.IsType<InvalidGenesisBlockException>(exception);
-
-            await StopAsync(swarmA);
-            await StopAsync(swarmB);
-            swarmA.Dispose();
-            swarmB.Dispose();
-        }
-
-        [Fact(Timeout = Timeout)]
         public async Task FindSpecificPeerAsync()
         {
             Swarm<DumbAction> swarmA = _swarms[0];

--- a/Libplanet/Net/Messages/BlockHeaderMessage.cs
+++ b/Libplanet/Net/Messages/BlockHeaderMessage.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Libplanet.Blocks;
 using NetMQ;
 
@@ -6,15 +7,19 @@ namespace Libplanet.Net.Messages
 {
     internal class BlockHeaderMessage : Message
     {
-        public BlockHeaderMessage(BlockHeader header)
+        public BlockHeaderMessage(HashDigest<SHA256> genesisHash, BlockHeader header)
         {
+            GenesisHash = genesisHash;
             Header = header;
         }
 
         public BlockHeaderMessage(NetMQFrame[] frames)
         {
-            Header = BlockHeader.Deserialize(frames[0].Buffer);
+            GenesisHash = new HashDigest<SHA256>(frames[0].Buffer);
+            Header = BlockHeader.Deserialize(frames[1].Buffer);
         }
+
+        public HashDigest<SHA256> GenesisHash { get; }
 
         public BlockHeader Header { get; }
 
@@ -24,6 +29,7 @@ namespace Libplanet.Net.Messages
         {
             get
             {
+                yield return new NetMQFrame(GenesisHash.ToByteArray());
                 yield return new NetMQFrame(Header.Serialize());
             }
         }

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -96,7 +96,7 @@ namespace Libplanet.Net.Messages
             /// A reply to <see cref="GetChainStatus"/>.
             /// Contains the chain status of the peer at the moment.
             /// </summary>
-            ChainStatus = 0x21,
+            ChainStatus = 0x24,
 
             /// <summary>
             /// Request a block's delta states.

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Net.Messages
             /// <summary>
             /// Message containing a single <see cref="BlockHeader"/>.
             /// </summary>
-            BlockHeaderMessage = 0x0d,
+            BlockHeaderMessage = 0x0c,
 
             /// <summary>
             /// Message containing demand block hashes with their index numbers.

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -41,6 +41,7 @@ namespace Libplanet.Net
 
                     // This is based on the assumption that genesis block always exists.
                     var chainStatus = new ChainStatus(
+                        BlockChain.Genesis.Hash,
                         BlockChain.Tip.Index,
                         BlockChain.Tip.TotalDifficulty)
                     {

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -145,6 +145,17 @@ namespace Libplanet.Net
                 return;
             }
 
+            if (!message.GenesisHash.Equals(BlockChain.Genesis.Hash))
+            {
+                _logger.Information(
+                    "BlockHeaderMessage was sent from the peer " +
+                    "{PeerAddress} with different genesis block {hash}; ignored.",
+                    message.Remote.Address,
+                    message.GenesisHash
+                );
+                return;
+            }
+
             BlockHeaderReceived.Set();
             BlockHeader header = message.Header;
 

--- a/Libplanet/Net/Swarm.TrustedStateCompleter.cs
+++ b/Libplanet/Net/Swarm.TrustedStateCompleter.cs
@@ -59,11 +59,9 @@ namespace Libplanet.Net
 
             IReadOnlyList<BoundPeer> trustedPeers =
                 (await DialToExistingPeers(dialTimeout, cancellationToken))
-                    .Where(pair =>
-                        !(pair.Peer is null || pair.ChainStatus is null) &&
-                        pair.ChainStatus.GenesisHash.Equals(BlockChain.Genesis.Hash))
+                    .Where(pair => BlockChain.Genesis.Hash.Equals(pair.ChainStatus?.GenesisHash))
                     .Select(pair => pair.Peer)
-                    .Where(peer => trustedStateValidators.Contains(peer.Address))
+                    .Where(peer => !(peer is null) && trustedStateValidators.Contains(peer.Address))
                     .ToArray();
 
             StateCompleterSet<T> fallback = fallbackCompleterSet

--- a/Libplanet/Net/Swarm.TrustedStateCompleter.cs
+++ b/Libplanet/Net/Swarm.TrustedStateCompleter.cs
@@ -59,6 +59,9 @@ namespace Libplanet.Net
 
             IReadOnlyList<BoundPeer> trustedPeers =
                 (await DialToExistingPeers(dialTimeout, cancellationToken))
+                    .Where(pair =>
+                        !(pair.Peer is null || pair.ChainStatus is null) &&
+                        pair.ChainStatus.GenesisHash.Equals(BlockChain.Genesis.Hash))
                     .Select(pair => pair.Peer)
                     .Where(peer => trustedStateValidators.Contains(peer.Address))
                     .ToArray();

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1420,9 +1420,8 @@ namespace Libplanet.Net
         {
             var peersWithHeightAndDiff = (await DialToExistingPeers(dialTimeout, cancellationToken))
                 .Where(pp =>
-                    !(pp.Peer is null || pp.ChainStatus is null) &&
-                    pp.ChainStatus.GenesisHash.Equals(BlockChain.Genesis.Hash) &&
-                    pp.ChainStatus.TotalDifficulty > (initialTip?.TotalDifficulty ?? 0))
+                    BlockChain.Genesis.Hash.Equals(pp.ChainStatus?.GenesisHash) &&
+                    pp.ChainStatus?.TotalDifficulty > initialTip?.TotalDifficulty)
                 .Select(pp => (pp.Peer, pp.ChainStatus.TipIndex, pp.ChainStatus.TotalDifficulty))
                 .ToList();
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1331,7 +1331,7 @@ namespace Libplanet.Net
         private void BroadcastBlock(Address? except, Block<T> block)
         {
             _logger.Debug("Trying to broadcast blocks...");
-            var message = new BlockHeaderMessage(block.GetBlockHeader());
+            var message = new BlockHeaderMessage(BlockChain.Genesis.Hash, block.GetBlockHeader());
             BroadcastMessage(except, message);
             _logger.Debug("Block broadcasting complete.");
         }


### PR DESCRIPTION
`ChainStatus` and `BlockHeaderMessage` messages now contain `GenesisHash` parameter, so receiving peer ignores those messages if its value is different from hash of the genesis block of self.