### PR TITLE
Use PreEvaluationHash (instead of Hash) as random seed

### DIFF
--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -36,6 +36,8 @@ namespace Libplanet.Blockchain
             _balanceGetter = balanceGetter;
         }
 
+        // FIXME: It needs to test whether to produce the same random seed in the same block.
+        //        See threads of planetarium/libplanet#1005.
         internal IReadOnlyList<ActionEvaluation> EvaluateActions(
             Block<T> block,
             StateCompleterSet<T> stateCompleters

--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Blockchain
             }
 
             return ActionEvaluation.EvaluateActionsGradually(
-                block.Hash,
+                block.PreEvaluationHash,
                 block.Index,
                 null,
                 lastStates,

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -382,7 +382,7 @@ namespace Libplanet.Blocks
                 );
                 IEnumerable<ActionEvaluation> evaluations =
                     tx.EvaluateActionsGradually(
-                        Hash,
+                        PreEvaluationHash,
                         Index,
                         delta,
                         Miner.Value);


### PR DESCRIPTION
Before this pull request, the evaluation methods used `Block<T>.Hash` as a random seed. Since `PreEvaluationHash` had introduced, it must replace the seed with it but it didn't. And it made indeterministic states. So it fixed those.