### PR TITLE
Check whether BlockEvaluator evaluates blocks idempotently

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockEvaluatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockEvaluatorTest.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public class BlockEvaluatorTest
+    {
+        [Fact]
+        public void Idempotent()
+        {
+            // NOTE: This test checks that blocks can be evaluated idempotently. Also it checks
+            // the action results in pre-evaluation step and in evaluation step are equal.
+            const int repeatCount = 2;
+            var signer = new PrivateKey();
+            Address address = signer.ToAddress();
+            var timestamp = DateTimeOffset.UtcNow;
+            var txs = new[]
+            {
+                Transaction<RandomAction>.Create(
+                    0,
+                    signer,
+                    null,
+                    new[] { new RandomAction(address), }),
+            };
+            Block<RandomAction> noStateRootBlock = TestUtils.MineGenesis(
+                timestamp: timestamp,
+                transactions: txs);
+            Block<RandomAction> stateRootBlock = TestUtils.MineGenesis(
+                timestamp: timestamp,
+                transactions: txs,
+                checkStateRootHash: true);
+            var blockEvaluator =
+                new BlockEvaluator<RandomAction>(null, NullStateGetter, NullBalanceGetter);
+            var generatedRandomNumbers = new List<int>();
+
+            Assert.NotEqual(stateRootBlock.Hash, noStateRootBlock.Hash);
+            Assert.Equal(stateRootBlock.PreEvaluationHash, noStateRootBlock.PreEvaluationHash);
+
+            for (int i = 0; i < repeatCount; ++i)
+            {
+                var actionEvaluations = blockEvaluator.EvaluateActions(
+                    noStateRootBlock,
+                    StateCompleterSet<RandomAction>.Reject);
+                generatedRandomNumbers.Add(
+                    (Integer)actionEvaluations[0].OutputStates.GetState(address));
+                actionEvaluations = blockEvaluator.EvaluateActions(
+                    stateRootBlock,
+                    StateCompleterSet<RandomAction>.Reject);
+                generatedRandomNumbers.Add(
+                    (Integer)actionEvaluations[0].OutputStates.GetState(address));
+            }
+
+            for (int i = 1; i < generatedRandomNumbers.Count; ++i)
+            {
+                Assert.Equal(generatedRandomNumbers[0], generatedRandomNumbers[i]);
+            }
+        }
+
+        private IValue NullStateGetter<T>(
+            Address address,
+            HashDigest<SHA256>? hashDigest,
+            StateCompleter<T> stateCompleter)
+            where T : IAction, new() => null;
+
+        private FungibleAssetValue NullBalanceGetter<T>(
+            Address address,
+            Currency currency,
+            HashDigest<SHA256>? hashDigest,
+            FungibleAssetStateCompleter<T> fungibleAssetStateCompleter)
+            where T : IAction, new() => new FungibleAssetValue(currency);
+    }
+}

--- a/Libplanet.Tests/Common/Action/RandomAction.cs
+++ b/Libplanet.Tests/Common/Action/RandomAction.cs
@@ -1,0 +1,39 @@
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public class RandomAction : IAction
+    {
+        public RandomAction()
+        {
+        }
+
+        public RandomAction(Address address)
+        {
+            Address = address;
+        }
+
+        public IValue PlainValue => Bencodex.Types.Dictionary.Empty
+            .Add("address", Address.ToHex());
+
+        private Address Address { get; set; }
+
+        public void LoadPlainValue(IValue plainValue)
+        {
+            var dictionary = (Bencodex.Types.Dictionary)plainValue;
+            Address = new Address(dictionary.GetValue<Text>("address"));
+        }
+
+        public IAccountStateDelta Execute(IActionContext context)
+        {
+            IAccountStateDelta states = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return states.SetState(Address, default(Null));
+            }
+
+            return states.SetState(Address, (Integer)context.Random.Next());
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -36,8 +36,6 @@ namespace Libplanet.Blockchain
             _balanceGetter = balanceGetter;
         }
 
-        // FIXME: It needs to test whether to produce the same random seed in the same block.
-        //        See threads of planetarium/libplanet#1005.
         internal IReadOnlyList<ActionEvaluation> EvaluateActions(
             Block<T> block,
             StateCompleterSet<T> stateCompleters


### PR DESCRIPTION
It is continued from #1005. It contains a test to check whether `BlockEvaluator` evaluates blocks idempotently.
I'm not sure it can cover all of the issues in #1005 properly. Please review this hard and leave your opinions.