### PR TITLE
CI: Use -stoponfail on .NET Core tests

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -3,6 +3,7 @@ parameters:
   testArguments: ""
   locale: "en_US.UTF8"
   testTimeoutInMinutes: 12
+  useDotnetTest: false
 
 steps:
 
@@ -29,6 +30,14 @@ steps:
   inputs:
     command: restore
 
+- ${{ if eq(parameters.useDotnetTest, false) }}:
+  - task: DotNetCoreCLI@2
+    displayName: dotnet tool install xunit-cli
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --global xunit-cli --version 0.1.12
+
 - task: DotNetCoreCLI@2
   displayName: dotnet build
   inputs:
@@ -37,23 +46,46 @@ steps:
       --configuration ${{ parameters.configuration }}
       -p:SkipSonar=true
 
-- task: DotNetCoreCLI@2
-  displayName: dotnet test
-  inputs:
-    command: test
-    projects: '**/*Tests/*.csproj'
-    arguments: >-
-      --configuration ${{ parameters.configuration }}
-      -p:SkipSonar=true
-      ${{ parameters.testArguments }}
-  env:
-    TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
-    LANG: ${{ parameters.locale }}
-    LANGUAGE: ${{ parameters.locale }}
-    LC_ALL: ${{ parameters.locale }}
-  timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+- ${{ if eq(parameters.useDotnetTest, false) }}:
+  - task: Bash@3
+    displayName: List all test assemblies
+    inputs:
+      targetType: inline
+      script: |
+        echo -n '##vso[task.setvariable variable=testAssemblies]'
+        for f in *.Tests; do
+          printf '%q ' \
+            "$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
+        done
+  - task: Bash@3
+    displayName: xunit *.Tests.dll
+    inputs:
+      targetType: inline
+      script: xunit $(testAssemblies) ${{ parameters.testArguments }}
+    env:
+      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      LANG: ${{ parameters.locale }}
+      LANGUAGE: ${{ parameters.locale }}
+      LC_ALL: ${{ parameters.locale }}
+    timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
 
-- task: PublishTestResults@2
-  inputs:
-    testRunner: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/*.trx'
+- ${{ if eq(parameters.useDotnetTest, true) }}:
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: '**/*Tests/*.csproj'
+      arguments: >-
+        --configuration ${{ parameters.configuration }}
+        -p:SkipSonar=true
+        ${{ parameters.testArguments }}
+    env:
+      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      LANG: ${{ parameters.locale }}
+      LANGUAGE: ${{ parameters.locale }}
+      LC_ALL: ${{ parameters.locale }}
+    timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '$(Agent.TempDirectory)/*.trx'

--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -48,26 +48,31 @@ steps:
 
 - ${{ if eq(parameters.useDotnetTest, false) }}:
   - task: Bash@3
-    displayName: List all test assemblies
-    inputs:
-      targetType: inline
-      script: |
-        echo -n '##vso[task.setvariable variable=testAssemblies]'
-        for f in *.Tests; do
-          printf '%q ' \
-            "$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
-        done
-  - task: Bash@3
     displayName: xunit *.Tests.dll
     inputs:
       targetType: inline
-      script: xunit $(testAssemblies) ${{ parameters.testArguments }}
+      script: |
+        set -vx
+        declare -a assemblies
+        for f in *.Tests; do
+          path="$(find "$f" \
+            -wholename "$f/bin/${{ parameters.configuration }}/net*/"$f".dll")"
+          assemblies+=("`pwd`/$path")
+        done
+        xunit \
+          "${assemblies[@]}" \
+          ${{ parameters.testArguments }} \
+          -xml "$(Agent.TempDirectory)/xunit.xml"
     env:
       TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
       LANG: ${{ parameters.locale }}
       LANGUAGE: ${{ parameters.locale }}
       LC_ALL: ${{ parameters.locale }}
     timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: XUnit
+      testResultsFiles: '$(Agent.TempDirectory)/xunit.xml'
 
 - ${{ if eq(parameters.useDotnetTest, true) }}:
   - task: DotNetCoreCLI@2

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -28,17 +28,24 @@ steps:
         /p:Configuration=${{ parameters.configuration }} \
         /p:SkipSonar=true
 
+- task: Bash@3
+  displayName: List all test assemblies
+  inputs:
+    targetType: inline
+    script: |
+      echo -n '##vso[task.setvariable variable=testAssemblies]'
+      for f in *.Tests; do
+        printf '%q ' \
+          "`pwd`/$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
+      done
+
 - task: CmdLine@2
   displayName: ${{ parameters.testDisplayName }}
   inputs:
     script: |
-      # Because Libplanet.RocksDBStore.Tests has Libplanet.Tests as a dependency,
-      # Libplanet.Tests is executed twice without this.
-      for f in *.Tests; do
-        ${{ parameters.testCommand }} \
-          $(pwd)/"$f"/bin/${{ parameters.configuration }}/net*/"$f".dll \
-          ${{ parameters.testArguments }}
-      done
+      ${{ parameters.testCommand }} \
+        $(testAssemblies) \
+        ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -4,6 +4,7 @@ parameters:
   testCommand: "mono --server xunit.runner.console.*/tools/net471/xunit.console.exe"
   testArguments: -verbose -parallel none
   testTimeoutInMinutes: 12
+  publicTestResult: true
 
 steps:
 
@@ -28,25 +29,47 @@ steps:
         /p:Configuration=${{ parameters.configuration }} \
         /p:SkipSonar=true
 
-- task: Bash@3
-  displayName: List all test assemblies
-  inputs:
-    targetType: inline
-    script: |
-      echo -n '##vso[task.setvariable variable=testAssemblies]'
-      for f in *.Tests; do
-        printf '%q ' \
-          "`pwd`/$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
-      done
+- ${{ if eq(parameters.publicTestResult, false) }}:
+  - task: CmdLine@2
+    displayName: ${{ parameters.testDisplayName }}
+    inputs:
+      script: |
+        set -vx
+        declare -a assemblies
+        for f in *.Tests; do
+          path="$(find "$f" \
+            -wholename "$f/bin/${{ parameters.configuration }}/net*/"$f".dll")"
+          assemblies+=("`pwd`/$path")
+        done
+        ${{ parameters.testCommand }} \
+          "${assemblies[@]}" \
+          ${{ parameters.testArguments }}
+    env:
+      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      MONO_THREADS_SUSPEND: preemptive
+    timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
 
-- task: CmdLine@2
-  displayName: ${{ parameters.testDisplayName }}
-  inputs:
-    script: |
-      ${{ parameters.testCommand }} \
-        $(testAssemblies) \
-        ${{ parameters.testArguments }}
-  env:
-    TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
-    MONO_THREADS_SUSPEND: preemptive
-  timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+- ${{ if eq(parameters.publicTestResult, true) }}:
+  - task: CmdLine@2
+    displayName: ${{ parameters.testDisplayName }}
+    inputs:
+      script: |
+        set -vx
+        declare -a assemblies
+        for f in *.Tests; do
+          path="$(find "$f" \
+            -wholename "$f/bin/${{ parameters.configuration }}/net*/"$f".dll")"
+          assemblies+=("`pwd`/$path")
+        done
+        ${{ parameters.testCommand }} \
+          "${assemblies[@]}" \
+          ${{ parameters.testArguments }} \
+          -xml "$(Agent.TempDirectory)/xunit.xml"
+    env:
+      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      MONO_THREADS_SUSPEND: preemptive
+    timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: XUnit
+      testResultsFiles: '$(Agent.TempDirectory)/xunit.xml'

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -35,18 +35,25 @@ steps:
     msbuildArguments: /restore /p:SkipSonar=true
 
 - task: Bash@3
+  displayName: List all test assemblies
+  inputs:
+    targetType: inline
+    script: |
+      echo -n '##vso[task.setvariable variable=testAssemblies]'
+      for f in *.Tests; do
+        printf '%q ' \
+          "$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
+      done
+
+- task: Bash@3
   displayName: xunit.console.exe *.Tests.dll
   inputs:
     targetType: inline
     script: |
-      # Because Libplanet.RocksDBStore.Tests has Libplanet.Tests as a dependency,
-      # Libplanet.Tests is executed twice without this.
-      for f in *.Tests; do
-        ${{ parameters.testPrefix }} \
-          xunit.runner.console.*/tools/net471/xunit.console.exe \
-            $(pwd)/"$f"/bin/${{ parameters.configuration }}/net*/"$f".dll \
-            ${{ parameters.testArguments }}
-      done
+      ${{ parameters.testPrefix }} \
+        xunit.runner.console.*/tools/net471/xunit.console.exe \
+          $(testAssemblies) \
+          ${{ parameters.testArguments }}
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -35,26 +35,28 @@ steps:
     msbuildArguments: /restore /p:SkipSonar=true
 
 - task: Bash@3
-  displayName: List all test assemblies
-  inputs:
-    targetType: inline
-    script: |
-      echo -n '##vso[task.setvariable variable=testAssemblies]'
-      for f in *.Tests; do
-        printf '%q ' \
-          "$f"/bin/${{ parameters.configuration }}/net*/"$f".dll
-      done
-
-- task: Bash@3
   displayName: xunit.console.exe *.Tests.dll
   inputs:
     targetType: inline
     script: |
+      set -vx
+      declare -a assemblies
+      for f in *.Tests; do
+        path="$(find "$f" \
+          -wholename "$f/bin/${{ parameters.configuration }}/net*/"$f".dll")"
+        assemblies+=("`pwd`/$path")
+      done
       ${{ parameters.testPrefix }} \
         xunit.runner.console.*/tools/net471/xunit.console.exe \
-          $(testAssemblies) \
-          ${{ parameters.testArguments }}
+          "${assemblies[@]}" \
+          ${{ parameters.testArguments }} \
+          -xml "$(Agent.TempDirectory)/xunit.xml"
   env:
     TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
     MONO_THREADS_SUSPEND: preemptive
   timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+
+- task: PublishTestResults@2
+  inputs:
+    testRunner: XUnit
+    testResultsFiles: '$(Agent.TempDirectory)/xunit.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,7 @@ jobs:
       testCommand: |-
         /tmp/StandaloneOSX.app/Contents/MacOS/StandaloneOSX
       testArguments: ""
+      publicTestResult: false
   timeoutInMinutes: 30
 
 - job: Linux_NETCore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
       script: dotnet tool install --global Codecov.Tool --version 1.10.0
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
+      useDotnetTest: true
       configuration: Debug
       turnServerUrl: $(turnServerUrl)
       testArguments: >-
@@ -76,7 +77,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -stoponfail
+      testArguments: -parallel none -stoponfail
   timeoutInMinutes: 30
 
 - job: macOS_Mono
@@ -87,7 +88,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -stoponfail
+      testArguments: -parallel none -stoponfail
   timeoutInMinutes: 30
 
 - job: Windows_Mono
@@ -103,7 +104,7 @@ jobs:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
       testPrefix: '"$PROGRAMFILES/Mono/bin/mono.exe"'
-      testArguments: -appdomains denied -stoponfail
+      testArguments: -appdomains denied -parallel none -stoponfail
   timeoutInMinutes: 30
 
 - job: macOS_Unity
@@ -137,6 +138,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
+      testArguments: -parallel none -stoponfail
   timeoutInMinutes: 30
 
 - job: macOS_NETCore
@@ -147,6 +149,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
+      testArguments: -parallel none -stoponfail
   timeoutInMinutes: 30
 
 - job: Windows_NETCore
@@ -157,7 +160,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: '-v n'
+      testArguments: -parallel none -stoponfail
   timeoutInMinutes: 30
 
 # Run tests with an alternative locale configuration
@@ -169,6 +172,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
+      testArguments: -parallel none -stoponfail
       locale: ar_SA.UTF8
   timeoutInMinutes: 30
 
@@ -180,6 +184,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
+      testArguments: -parallel none -stoponfail
       locale: he_IL.UTF8
   timeoutInMinutes: 30
 
@@ -191,7 +196,7 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: '-v n'
+      testArguments: -parallel none -stoponfail
       locale: fr_FR.UTF8
   timeoutInMinutes: 30
 
@@ -203,4 +208,4 @@ jobs:
     parameters:
       configuration: $(configuration)
       turnServerUrl: $(turnServerUrl)
-      testArguments: -stoponfail
+      testArguments: -parallel none -stoponfail


### PR DESCRIPTION
In the pull request #992, I applied `-stoponfail` option to Xunit, but it's only Mono and .NET Framework, because .NET Core jobs used `dotnet test` instead.  This replaces `dotnet test` with [xunit-cli][1] which can support all options `xunit.console.exe` provides.  Meanwhile, for coverage it still uses `dotnet test` because all tests should be run anyway even if some fails.

[1]: https://github.com/natemcmaster/xunit-cli