### PR TITLE
Move block validation code to BlockChain<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,7 +112,7 @@ To be released.
     `BlockHeader` constructor.  [[#986]]
  -  Added `HashDigest<SHA256>`-typed `stateRootHash` parameter to
     `Block<T>()` constructor.  [[#986]]
- -  `BlockPolicy<T>` methods became to virtual. [[#1010]]
+ -  Methods in `BlockPolicy<T>` class became `virtual`. [[#1010]]
 
 ### Backward-incompatible network protocol changes
 
@@ -248,8 +248,9 @@ To be released.
     different genesis block.  [[#1003], [#1004]]
  -  `Swarm<T>` became to ignore `BlockHeaderMessage` from the peers with
     different genesis block.  [[#1003], [#1004]]
- -  The code for validating the next block had been moved to `BlockChain<T>` from
-    `BlockPolicy<T>`.  [[#1010]]
+ -  `BlockChain<T>` instead of `BlockPolicy<T>` became to validate `Block<T>`s to append
+    so that even if an empty implementation of `IBlockPolicy<T>` is used `Block<T>`s are
+    unable to be appended to `BlockChain<T>`.  [[#1010]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@ To be released.
     `BlockHeader` constructor.  [[#986]]
  -  Added `HashDigest<SHA256>`-typed `stateRootHash` parameter to
     `Block<T>()` constructor.  [[#986]]
+ -  `BlockPolicy<T>` methods became to virtual. [[#1010]]
 
 ### Backward-incompatible network protocol changes
 
@@ -247,6 +248,8 @@ To be released.
     different genesis block.  [[#1003], [#1004]]
  -  `Swarm<T>` became to ignore `BlockHeaderMessage` from the peers with
     different genesis block.  [[#1003], [#1004]]
+ -  The code for validating the next block had been moved to `BlockChain<T>` from
+    `BlockPolicy<T>`.  [[#1010]]
 
 ### Bug fixes
 
@@ -347,6 +350,7 @@ To be released.
 [#1002]: https://github.com/planetarium/libplanet/pull/1002
 [#1003]: https://github.com/planetarium/libplanet/issues/1003
 [#1004]: https://github.com/planetarium/libplanet/pull/1004
+[#1010]: https://github.com/planetarium/libplanet/pull/1010
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Security.Cryptography;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store.Trie;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public partial class BlockChainTest
+    {
+        [Fact]
+        public void ValidateNextBlock()
+        {
+            var validNextBlock = Block<DumbAction>.Mine(
+                1,
+                1024,
+                _fx.GenesisBlock.TotalDifficulty,
+                _fx.GenesisBlock.Miner.Value,
+                _fx.GenesisBlock.Hash,
+                _fx.GenesisBlock.Timestamp.AddDays(1),
+                _emptyTransaction);
+            _blockChain.Append(validNextBlock);
+            Assert.Equal(_blockChain.Tip, validNextBlock);
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidIndex()
+        {
+            _blockChain.Append(_validNext);
+
+            var invalidIndexBlock = Block<DumbAction>.Mine(
+                1,
+                1,
+                _fx.GenesisBlock.TotalDifficulty,
+                _fx.GenesisBlock.Miner.Value,
+                _validNext.Hash,
+                _validNext.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            Assert.Throws<InvalidBlockIndexException>(() =>
+                _blockChain.Append(invalidIndexBlock));
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidDifficulty()
+        {
+            _blockChain.Append(_validNext);
+
+            var invalidDifficultyBlock = Block<DumbAction>.Mine(
+                2,
+                1,
+                _validNext.TotalDifficulty,
+                _fx.GenesisBlock.Miner.Value,
+                _validNext.Hash,
+                _validNext.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            Assert.Throws<InvalidBlockDifficultyException>(() =>
+                    _blockChain.Append(invalidDifficultyBlock));
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidTotalDifficulty()
+        {
+            _blockChain.Append(_validNext);
+
+            var invalidTotalDifficultyBlock = Block<DumbAction>.Mine(
+                2,
+                _policy.GetNextBlockDifficulty(_blockChain),
+                _validNext.TotalDifficulty - 1,
+                _fx.GenesisBlock.Miner.Value,
+                _validNext.Hash,
+                _validNext.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
+                    _blockChain.Append(invalidTotalDifficultyBlock));
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidPreviousHash()
+        {
+            _blockChain.Append(_validNext);
+
+            var invalidPreviousHashBlock = Block<DumbAction>.Mine(
+                2,
+                1032,
+                _validNext.TotalDifficulty,
+                _fx.GenesisBlock.Miner.Value,
+                new HashDigest<SHA256>(new byte[32]),
+                _validNext.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            Assert.Throws<InvalidBlockPreviousHashException>(() =>
+                    _blockChain.Append(invalidPreviousHashBlock));
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidTimestamp()
+        {
+            _blockChain.Append(_validNext);
+
+            var invalidPreviousTimestamp = Block<DumbAction>.Mine(
+                2,
+                1032,
+                _validNext.TotalDifficulty,
+                _fx.GenesisBlock.Miner.Value,
+                _validNext.Hash,
+                _validNext.Timestamp.Subtract(TimeSpan.FromSeconds(1)),
+                _emptyTransaction);
+            Assert.Throws<InvalidBlockTimestampException>(() =>
+                    _blockChain.Append(invalidPreviousTimestamp));
+        }
+
+        [Fact]
+        private void ValidateNextBlockInvalidStateRootHash()
+        {
+            IKeyValueStore stateKeyValueStore = new MemoryKeyValueStore(),
+                stateHashKeyValueStore = new MemoryKeyValueStore();
+            var policy = new BlockPolicy<DumbAction>(
+                null,
+                TimeSpan.FromHours(3),
+                1024,
+                128);
+            var stateStore = new TrieStateStore(stateKeyValueStore, stateHashKeyValueStore);
+            // FIXME: It assumes that _fx.GenesisBlock doesn't update any states with transactions.
+            //        Actually, it depends on BlockChain<T> to update states and it makes hard to
+            //        calculate state root hash. To resolve this problem,
+            //        it should be moved into StateStore.
+            var genesisBlock = TestUtils.MineGenesis<DumbAction>(
+                blockAction: policy.BlockAction, checkStateRootHash: true);
+            var store = new DefaultStore(null);
+            var chain = new BlockChain<DumbAction>(
+                policy,
+                store,
+                stateStore,
+                genesisBlock);
+
+            var validNext = Block<DumbAction>.Mine(
+                1,
+                1024,
+                genesisBlock.TotalDifficulty,
+                genesisBlock.Miner.Value,
+                genesisBlock.Hash,
+                genesisBlock.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            chain.ExecuteActions(validNext);
+            validNext =
+                new Block<DumbAction>(validNext, stateStore.GetRootHash(validNext.Hash));
+            chain.Append(validNext);
+
+            var invalidStateRootHash = Block<DumbAction>.Mine(
+                2,
+                1032,
+                validNext.TotalDifficulty,
+                genesisBlock.Miner.Value,
+                validNext.Hash,
+                validNext.Timestamp.AddSeconds(1),
+                _emptyTransaction);
+            var actionEvaluations = _blockChain.BlockEvaluator.EvaluateActions(
+                invalidStateRootHash,
+                StateCompleterSet<DumbAction>.Recalculate);
+            chain.SetStates(invalidStateRootHash, actionEvaluations, false);
+            invalidStateRootHash = new Block<DumbAction>(
+                invalidStateRootHash,
+                new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
+            Assert.Throws<InvalidBlockStateRootHashException>(() =>
+                    chain.Append(invalidStateRootHash));
+        }
+    }
+}

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,6 +1,4 @@
-<Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-  Sdk="Microsoft.NET.Sdk">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -19,13 +17,11 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
-                             '$(MSBuildVersion)'&gt;='16.3.0'">
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And '$(MSBuildVersion)'&gt;='16.3.0'">
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
-                             '$(BuildingByReSharper)'!='true'">
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And '$(BuildingByReSharper)'!='true'">
     <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -807,11 +807,11 @@ namespace Libplanet.Tests.Store
             );
 
             var chain = TestUtils.MakeBlockChain(new NullPolicy<DumbAction>(), Fx.Store);
-            chain.Append(Fx.Block1);
+            var block = chain.MineBlock(address).Result;
 
             // Even if state references in a chain are empty it should not throw
             // ChainIdNotFoundException unless the chain in itself does not exist.
-            Fx.BlockStatesStore.ForkStateReferences(chain.Id, targetChainId, Fx.Block1);
+            Fx.BlockStatesStore.ForkStateReferences(chain.Id, targetChainId, block);
         }
 
         [SkippableFact]

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1686,23 +1686,23 @@ namespace Libplanet.Blockchain
             if (nextBlock.Index != index)
             {
                 return new InvalidBlockIndexException(
-                    $"the expected block index is {index}, but its index" +
-                    $" is {nextBlock.Index}'");
+                    $"The expected block index is #{index}, but its index " +
+                    $"is #{nextBlock.Index}.");
             }
 
             if (nextBlock.Difficulty < difficulty)
             {
                 return new InvalidBlockDifficultyException(
-                    $"the expected difficulty of the block #{index} " +
+                    $"The expected difficulty of the block #{index} " +
                     $"is {difficulty}, but its difficulty is " +
-                    $"{nextBlock.Difficulty}'");
+                    $"{nextBlock.Difficulty}.");
             }
 
             if (nextBlock.TotalDifficulty != totalDifficulty)
             {
                 var msg = $"The expected total difficulty of the block #{index} " +
                           $"is {totalDifficulty}, but its difficulty is " +
-                          $"{nextBlock.TotalDifficulty}'";
+                          $"{nextBlock.TotalDifficulty}.";
                 return new InvalidBlockTotalDifficultyException(
                     nextBlock.Difficulty,
                     nextBlock.TotalDifficulty,
@@ -1718,19 +1718,19 @@ namespace Libplanet.Blockchain
                 }
 
                 return new InvalidBlockPreviousHashException(
-                    $"the block #{index} is not continuous from the " +
+                    $"The block #{index} is not continuous from the " +
                     $"block #{index - 1}; while previous block's hash is " +
                     $"{prevHash}, the block #{index}'s pointer to " +
                     "the previous hash refers to " +
-                    (nextBlock.PreviousHash?.ToString() ?? "nothing"));
+                    (nextBlock.PreviousHash?.ToString() ?? "nothing") + ".");
             }
 
             if (nextBlock.Timestamp < prevTimestamp)
             {
                 return new InvalidBlockTimestampException(
-                    $"the block #{index}'s timestamp " +
+                    $"The block #{index}'s timestamp " +
                     $"({nextBlock.Timestamp}) is earlier than" +
-                    $" the block #{index - 1}'s ({prevTimestamp})");
+                    $" the block #{index - 1}'s ({prevTimestamp}).");
             }
 
             if (StateStore is TrieStateStore trieStateStore)
@@ -1741,9 +1741,9 @@ namespace Libplanet.Blockchain
 
                 if (!rootHash.Equals(nextBlock.StateRootHash))
                 {
-                    var message = $"the block #{index}'s state root hash is " +
+                    var message = $"The block #{index}'s state root hash is " +
                                   $"{nextBlock.StateRootHash?.ToString()}, but the execution " +
-                                  $"result is {rootHash.ToString()}";
+                                  $"result is {rootHash.ToString()}.";
                     return new InvalidBlockStateRootHashException(
                         nextBlock.StateRootHash,
                         rootHash,

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -121,6 +121,7 @@ namespace Libplanet.Blockchain.Policies
 
         private int DifficultyBoundDivisor { get; }
 
+        /// <inheritdoc cref="IBlockPolicy{T}.DoesTransactionFollowsPolicy(Transaction{T})"/>
         public virtual bool DoesTransactionFollowsPolicy(Transaction<T> transaction)
         {
             return _doesTransactionFollowPolicy(transaction);

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -121,7 +121,7 @@ namespace Libplanet.Blockchain.Policies
 
         private int DifficultyBoundDivisor { get; }
 
-        public bool DoesTransactionFollowsPolicy(Transaction<T> transaction)
+        public virtual bool DoesTransactionFollowsPolicy(Transaction<T> transaction)
         {
             return _doesTransactionFollowPolicy(transaction);
         }
@@ -129,7 +129,7 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc/>
         /// <exception cref="InvalidBlockStateRootHashException">It will be thrown when the
         /// given block has incorrect <see cref="Block{T}.StateRootHash"/>.</exception>
-        public InvalidBlockException ValidateNextBlock(
+        public virtual InvalidBlockException ValidateNextBlock(
             BlockChain<T> blocks,
             Block<T> nextBlock)
         {
@@ -137,7 +137,7 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc />
-        public long GetNextBlockDifficulty(BlockChain<T> blocks)
+        public virtual long GetNextBlockDifficulty(BlockChain<T> blocks)
         {
             long index = blocks.Count;
 


### PR DESCRIPTION
This moves block validation code to `BlockChain<T>` from `BlockPolicy<T>` and also the methods of `BlockPolicy<T>` became to virtual so that it can be overridden.