### PR TITLE
Improve performance of `BlockSet<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,8 @@ To be released.
  -  `doesTransactionFollowPolicy` parameter became 
     `Func<Transaction<T>, BlockChain<T>, bool>` on `BlockPolicy<T>()`
     constructor.  [[#1012]]
+ -  Added `cacheSize` optional parameter to `BlockSet<T>()` constructor.
+    [[#1013]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -257,6 +257,8 @@ To be released.
  -  `BlockChain<T>` instead of `BlockPolicy<T>` became to validate `Block<T>`s to append
     so that even if an empty implementation of `IBlockPolicy<T>` is used `Block<T>`s are
     unable to be appended to `BlockChain<T>`.  [[#1010]]
+ -  Improved performance of `BlockSet<T>[HashDigest<SHA256>]` and `BlockChain<T>.Genesis`
+    by caching.  [[#1013]]
 
 ### Bug fixes
 
@@ -359,6 +361,7 @@ To be released.
 [#1004]: https://github.com/planetarium/libplanet/pull/1004
 [#1010]: https://github.com/planetarium/libplanet/pull/1010
 [#1012]: https://github.com/planetarium/libplanet/pull/1012
+[#1013]: https://github.com/planetarium/libplanet/pull/1013
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -259,8 +259,8 @@ To be released.
  -  `BlockChain<T>` instead of `BlockPolicy<T>` became to validate `Block<T>`s to append
     so that even if an empty implementation of `IBlockPolicy<T>` is used `Block<T>`s are
     unable to be appended to `BlockChain<T>`.  [[#1010]]
- -  Improved performance of `BlockSet<T>[HashDigest<SHA256>]` and `BlockChain<T>.Genesis`
-    by caching.  [[#1013]]
+ -  `BlockSet<T>[HashDigest<SHA256>]` and `BlockChain<T>.Genesis` became cached
+    so that they become faster to get.  [[#1013]]
 
 ### Bug fixes
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -63,6 +63,11 @@ namespace Libplanet.Blockchain
         private IDictionary<TxId, Transaction<T>> _transactions;
 
         /// <summary>
+        /// Cached genesis block.
+        /// </summary>
+        private Block<T> _genesis;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BlockChain{T}"/> class.
         /// </summary>
         /// <param name="policy"><see cref="IBlockPolicy{T}"/> to use in the
@@ -235,7 +240,7 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// The first <see cref="Block{T}"/> in the <see cref="BlockChain{T}"/>.
         /// </summary>
-        public Block<T> Genesis => this[0];
+        public Block<T> Genesis => _genesis ??= this[0];
 
         public Guid Id { get; private set; }
 

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -95,7 +95,15 @@ namespace Libplanet.Store
         {
             if (_cache.TryGetValue(key, out Block<T> cached))
             {
-                return cached;
+                if (Store.ContainsBlock(key))
+                {
+                    return cached;
+                }
+                else
+                {
+                    // The cached block had been deleted on Store...
+                    _cache.Remove(key);
+                }
             }
 
             Block<T> fetched = Store.GetBlock<T>(key);

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -11,14 +11,12 @@ namespace Libplanet.Store
     public class BlockSet<T> : BaseIndex<HashDigest<SHA256>, Block<T>>
         where T : IAction, new()
     {
-        // FIXME it should be configurable
-        private const int DefaultCacheSize = 4096;
         private readonly LruCache<HashDigest<SHA256>, Block<T>> _cache;
 
-        public BlockSet(IStore store)
+        public BlockSet(IStore store, int cacheSize = 4096)
             : base(store)
         {
-            _cache = new LruCache<HashDigest<SHA256>, Block<T>>(DefaultCacheSize);
+            _cache = new LruCache<HashDigest<SHA256>, Block<T>>(cacheSize);
         }
 
         public override ICollection<HashDigest<SHA256>> Keys =>

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -83,10 +83,7 @@ namespace Libplanet.Store
         {
             bool deleted = Store.DeleteBlock(key);
 
-            if (deleted)
-            {
-                _cache.Remove(key);
-            }
+            _cache.Remove(key);
 
             return deleted;
         }


### PR DESCRIPTION
This PR adds a cache to `BlockSet<T>` to improve its fetching performance. (it can be useful when blocks contain huge and complex actions.)