### PR TITLE
WIP: Fixes a bug we couldn't insert a key having another one as a prefix

### DIFF
--- a/Libplanet.Tests/Store/Trie/TrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/TrieTest.cs
@@ -114,5 +114,28 @@ namespace Libplanet.Tests.Store.Trie
             committedTrie = trie.Commit();
             Assert.NotEqual(MerkleTrie.EmptyRootHash, committedTrie.Hash);
         }
+
+        [Fact]
+        public void InsertSamePrefixNode()
+        {
+            IKeyValueStore keyValueStore = new MemoryKeyValueStore();
+            ITrie trie = new MerkleTrie(keyValueStore);
+
+            byte[] shortKey = { 0x01 },
+                longKey = { 0x01, 0x02 };
+            trie.Set(shortKey, default(Null));
+            trie.Set(longKey, Dictionary.Empty);
+
+            Assert.True(trie.TryGet(shortKey, out IValue shortKeyValue));
+            Assert.True(trie.TryGet(longKey, out IValue longKeyValue));
+            Assert.Equal(default(Null), shortKeyValue);
+            Assert.Equal(Dictionary.Empty, longKeyValue);
+
+            ITrie committedTrie = trie.Commit();
+            Assert.True(committedTrie.TryGet(shortKey, out shortKeyValue));
+            Assert.True(committedTrie.TryGet(longKey, out longKeyValue));
+            Assert.Equal(default(Null), shortKeyValue);
+            Assert.Equal(Dictionary.Empty, longKeyValue);
+        }
     }
 }

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -293,7 +293,9 @@ namespace Libplanet.Store.Trie
             }
 
             int commonPrefixLength = CommonPrefixLen(shortNode.Key, key);
-            if (commonPrefixLength == shortNode.Key.Length)
+
+            // If the node
+            if (commonPrefixLength == shortNode.Key.Length && commonPrefixLength == key.Length)
             {
                 var nn = Insert(
                     shortNode.Value,
@@ -311,13 +313,24 @@ namespace Libplanet.Store.Trie
                     prefix.AddRange(key.Take(commonPrefixLength + 1)),
                     key.Skip(commonPrefixLength + 1).ToImmutableArray(),
                     value));
-            branch = branch.SetChild(
-                shortNode.Key[commonPrefixLength],
-                Insert(
+            if (commonPrefixLength == shortNode.Key.Length)
+            {
+                branch = branch.SetValue(Insert(
                     null,
                     prefix.AddRange(shortNode.Key.Take(commonPrefixLength + 1)),
                     shortNode.Key.Skip(commonPrefixLength + 1).ToImmutableArray(),
                     shortNode.Value!));
+            }
+            else
+            {
+                branch = branch.SetChild(
+                    shortNode.Key[commonPrefixLength],
+                    Insert(
+                        null,
+                        prefix.AddRange(shortNode.Key.Take(commonPrefixLength + 1)),
+                        shortNode.Key.Skip(commonPrefixLength + 1).ToImmutableArray(),
+                        shortNode.Value!));
+            }
 
             if (commonPrefixLength == 0)
             {
@@ -359,6 +372,15 @@ namespace Libplanet.Store.Trie
                         out value);
 
                 case FullNode fullNode:
+                    if (path.Length == 0)
+                    {
+                        return TryGet(
+                            fullNode.Value,
+                            prefix,
+                            path,
+                            out value);
+                    }
+
                     INode? childNode = fullNode.Children[path[0]];
                     return TryGet(
                         childNode,

--- a/Libplanet/Store/Trie/Nodes/BaseNode.cs
+++ b/Libplanet/Store/Trie/Nodes/BaseNode.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Store.Trie.Nodes
         }
 
         // It will not support embedded node.
-        public INode? Value { get; set; }
+        public virtual INode? Value { get; }
 
         public byte[] Serialize() => _codec.Encode(ToBencodex());
 

--- a/Libplanet/Store/Trie/Nodes/BaseNode.cs
+++ b/Libplanet/Store/Trie/Nodes/BaseNode.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Store.Trie.Nodes
         }
 
         // It will not support embedded node.
-        public INode? Value { get; }
+        public INode? Value { get; set; }
 
         public byte[] Serialize() => _codec.Encode(ToBencodex());
 

--- a/Libplanet/Store/Trie/Nodes/FullNode.cs
+++ b/Libplanet/Store/Trie/Nodes/FullNode.cs
@@ -30,9 +30,16 @@ namespace Libplanet.Store.Trie.Nodes
 
         public ImmutableArray<INode?> Children { get; }
 
+        public override INode? Value => Children[ChildrenCount - 1];
+
         public FullNode SetChild(int index, INode childNode)
         {
             return new FullNode(Children.SetItem(index, childNode));
+        }
+
+        public FullNode SetValue(INode valueNode)
+        {
+            return new FullNode(Children.SetItem(ChildrenCount - 1, valueNode));
         }
 
         bool IEquatable<FullNode>.Equals(FullNode? other)


### PR DESCRIPTION
Actually, now we are using state key typed `string`, and There are no real limitations but we have stored states with specific common formatted. Because of it, it was not seen but there is a critical bug that we couldn't use the state key having another one as its prefix. For instance, the values are invalid and throw exceptions.

```
> 0000
> 00001
```

It was because `FullNode` didn't include its value correctly in serialization and there can be other reasons. We can bypass this problem by using the feature, *secure mode* after #1014  merged.