### PR TITLE
Omit state root hash check when evaluateActions is disabled

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -866,7 +866,7 @@ namespace Libplanet.Blockchain
             Block<T> prevTip = Tip;
             try
             {
-                InvalidBlockException e = ValidateNextBlock(block);
+                InvalidBlockException e = ValidateNextBlock(block, evaluateActions);
 
                 if (!(e is null))
                 {
@@ -1669,7 +1669,10 @@ namespace Libplanet.Blockchain
             }
         }
 
-        private InvalidBlockException ValidateNextBlock(Block<T> nextBlock)
+        private InvalidBlockException ValidateNextBlock(
+            Block<T> nextBlock,
+            bool validateStateRootHash
+        )
         {
             InvalidBlockException e = Policy.ValidateNextBlock(this, nextBlock);
 
@@ -1738,7 +1741,7 @@ namespace Libplanet.Blockchain
                     $" the block #{index - 1}'s ({prevTimestamp}).");
             }
 
-            if (StateStore is TrieStateStore trieStateStore)
+            if (validateStateRootHash && StateStore is TrieStateStore trieStateStore)
             {
                 ExecuteActions(nextBlock, StateCompleterSet<T>.Recalculate);
                 HashDigest<SHA256> rootHash =

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -912,6 +912,9 @@ namespace Libplanet.Blockchain
                     if (evaluateActions)
                     {
                         evaluations = ExecuteActions(block);
+
+                        // FIXME we should refactoring ValidateNextBlock() to avoid affecting
+                        // the global state, then integrate with ThrowIfStateRootHashInvalid().
                         ThrowIfStateRootHashInvalid(block);
                     }
 


### PR DESCRIPTION
This PR omits a check for `Block<T>.StateRootHash` when `evaluateActions` is `false` to avoid unexpected evaluation.

I also skip the changelog because we didn't release 0.10.0 that introduced MPT yet(!).