### PR TITLE
Fix inaccurate render events order according to documented automata

### DIFF
--- a/Libplanet.Tests/Common/RecordingRenderer.cs
+++ b/Libplanet.Tests/Common/RecordingRenderer.cs
@@ -76,6 +76,7 @@ namespace Libplanet.Tests.Common
                 Action = action,
                 Context = context,
                 Exception = exception,
+                Render = true,
             });
 
         public void UnrenderAction(

--- a/Libplanet.Tests/Common/RecordingRenderer.cs
+++ b/Libplanet.Tests/Common/RecordingRenderer.cs
@@ -9,7 +9,7 @@ using Serilog;
 
 namespace Libplanet.Tests.Common
 {
-    public sealed class RecordingRenderer<T> : IActionRenderer<T>
+    public class RecordingRenderer<T> : IActionRenderer<T>
         where T : IAction, new()
     {
         private List<RenderRecord<T>> _records;
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Common
             Log.Logger.ForContext<RecordingRenderer<T>>().Debug("Reset records.");
         }
 
-        public void RenderAction(
+        public virtual void RenderAction(
             IAction action,
             IActionContext context,
             IAccountStateDelta nextStates
@@ -56,6 +56,7 @@ namespace Libplanet.Tests.Common
             _records.Add(new RenderRecord<T>.ActionSuccess
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Action = action,
                 Context = context,
                 NextStates = nextStates,
@@ -65,7 +66,7 @@ namespace Libplanet.Tests.Common
             RenderEventHandler?.Invoke(action, action);
         }
 
-        public void RenderActionError(
+        public virtual void RenderActionError(
             IAction action,
             IActionContext context,
             Exception exception
@@ -73,13 +74,14 @@ namespace Libplanet.Tests.Common
             _records.Add(new RenderRecord<T>.ActionError
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Action = action,
                 Context = context,
                 Exception = exception,
                 Render = true,
             });
 
-        public void UnrenderAction(
+        public virtual void UnrenderAction(
             IAction action,
             IActionContext context,
             IAccountStateDelta nextStates
@@ -87,13 +89,14 @@ namespace Libplanet.Tests.Common
             _records.Add(new RenderRecord<T>.ActionSuccess
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Unrender = true,
                 Action = action,
                 Context = context,
                 NextStates = nextStates,
             });
 
-        public void UnrenderActionError(
+        public virtual void UnrenderActionError(
             IAction action,
             IActionContext context,
             Exception exception
@@ -101,48 +104,63 @@ namespace Libplanet.Tests.Common
             _records.Add(new RenderRecord<T>.ActionError
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Unrender = true,
                 Action = action,
                 Context = context,
                 Exception = exception,
             });
 
-        public void RenderBlock(Block<T> oldTip, Block<T> newTip) =>
+        public virtual void RenderBlock(Block<T> oldTip, Block<T> newTip) =>
             _records.Add(new RenderRecord<T>.Block
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Begin = true,
                 OldTip = oldTip,
                 NewTip = newTip,
             });
 
-        public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip) =>
+        public virtual void RenderBlockEnd(Block<T> oldTip, Block<T> newTip) =>
             _records.Add(new RenderRecord<T>.Block
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 End = true,
                 OldTip = oldTip,
                 NewTip = newTip,
             });
 
-        public void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint) =>
+        public virtual void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint) =>
             _records.Add(new RenderRecord<T>.Reorg
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 Begin = true,
                 OldTip = oldTip,
                 NewTip = newTip,
                 Branchpoint = branchpoint,
             });
 
-        public void RenderReorgEnd(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint) =>
+        public virtual void RenderReorgEnd(
+            Block<T> oldTip,
+            Block<T> newTip,
+            Block<T> branchpoint
+        ) =>
             _records.Add(new RenderRecord<T>.Reorg
             {
                 Index = _nextIndex++,
+                StackTrace = RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                 End = true,
                 OldTip = oldTip,
                 NewTip = newTip,
                 Branchpoint = branchpoint,
             });
+
+        private static string RemoveFirstLine(string stackTrace)
+        {
+            int pos = stackTrace.IndexOf('\n');
+            return pos < 0 ? stackTrace : stackTrace.Substring(pos + 1);
+        }
     }
 }

--- a/Libplanet.Tests/Common/RenderRecord.cs
+++ b/Libplanet.Tests/Common/RenderRecord.cs
@@ -9,6 +9,10 @@ namespace Libplanet.Tests.Common
     {
         public long Index;
 
+        public string StackTrace;
+
+        public override string ToString() => $"{Index}.";
+
         public abstract class ActionBase : RenderRecord<T>
         {
             public IAction Action;
@@ -22,16 +26,24 @@ namespace Libplanet.Tests.Common
                 get => !Render;
                 set => Render = !value;
             }
+
+            public override string ToString() =>
+                $"{base.ToString()} #{Context.BlockIndex} " +
+                (Render ? "Render" : "Unrender") + "Action";
         }
 
         public class ActionSuccess : ActionBase
         {
             public IAccountStateDelta NextStates;
+
+            public override string ToString() => $"{base.ToString()} [success]";
         }
 
         public class ActionError : ActionBase
         {
             public Exception Exception;
+
+            public override string ToString() => $"{base.ToString()} [error]";
         }
 
         public abstract class BlockBase : RenderRecord<T>
@@ -45,15 +57,26 @@ namespace Libplanet.Tests.Common
                 get => !Begin;
                 set => Begin = !value;
             }
+
+            public override string ToString() =>
+                $"{base.ToString()} " +
+                $"#{OldTip.Index} {OldTip.Hash} -> #{NewTip.Index} {NewTip.Hash} Render..." +
+                (End ? "End" : string.Empty);
         }
 
         public class Block : BlockBase
         {
+            public override string ToString() =>
+                base.ToString().Replace("Render...", "RenderBlock");
         }
 
         public class Reorg : BlockBase
         {
             public Libplanet.Blocks.Block<T> Branchpoint;
+
+            public override string ToString() =>
+                base.ToString().Replace("Render...", "RenderReorg") +
+                $" [branchpoint: #{Branchpoint.Index} {Branchpoint.Hash}]";
         }
     }
 }

--- a/Libplanet.Tests/Common/ValidatingActionRenderer.cs
+++ b/Libplanet.Tests/Common/ValidatingActionRenderer.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Action;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+
+namespace Libplanet.Tests.Common
+{
+    /// <summary>
+    /// Validates if rendering events are in the correct order according to the documented automata
+    /// (see also the docs for <see cref="IRenderer{T}"/> and <see cref="IActionRenderer{T}"/>)
+    /// using profiling-guided analysis.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
+    public class ValidatingActionRenderer<T> : RecordingRenderer<T>
+        where T : IAction, new()
+    {
+        private enum RenderState
+        {
+            Ready,
+            Reorg,
+            Block,
+            BlockEnd,
+        }
+
+        public override void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
+        {
+            base.RenderReorg(oldTip, newTip, branchpoint);
+            Validate();
+        }
+
+        public override void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        )
+        {
+            base.UnrenderAction(action, context, nextStates);
+            Validate();
+        }
+
+        public override void UnrenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        )
+        {
+            base.UnrenderActionError(action, context, exception);
+            Validate();
+        }
+
+        public override void RenderBlock(Block<T> oldTip, Block<T> newTip)
+        {
+            base.RenderBlock(oldTip, newTip);
+            Validate();
+        }
+
+        public override void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        )
+        {
+            base.RenderAction(action, context, nextStates);
+            Validate();
+        }
+
+        public override void RenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        )
+        {
+            base.RenderActionError(action, context, exception);
+            Validate();
+        }
+
+        public override void RenderBlockEnd(Block<T> oldTip, Block<T> newTip)
+        {
+            base.RenderBlockEnd(oldTip, newTip);
+            Validate();
+        }
+
+        public override void RenderReorgEnd(
+            Block<T> oldTip,
+            Block<T> newTip,
+            Block<T> branchpoint
+        )
+        {
+            base.RenderReorgEnd(oldTip, newTip, branchpoint);
+            Validate();
+        }
+
+        private void Validate()
+        {
+            var state = RenderState.Ready;
+            RenderRecord<T>.Reorg reorgState = null;
+            RenderRecord<T>.Block blockState = null;
+            long previousActionBlockIndex = -1L;
+            var records = new List<RenderRecord<T>>(Records.Count);
+
+            Exception BadRenderExc(string message) => new InvalidRenderException(records, message);
+
+#pragma warning disable S2589
+            foreach (RenderRecord<T> record in Records)
+            {
+                records.Add(record);
+                switch (state)
+                {
+                    case RenderState.Ready:
+                    {
+                        if (!(reorgState is null && blockState is null))
+                        {
+                            throw BadRenderExc(
+                                $"Unexpected reorg/block states: {reorgState}/{blockState}."
+                            );
+                        }
+                        else if (record is RenderRecord<T>.BlockBase blockBase && blockBase.Begin)
+                        {
+                            if (blockBase is RenderRecord<T>.Reorg reorg)
+                            {
+                                reorgState = reorg;
+                                state = RenderState.Reorg;
+                                break;
+                            }
+                            else if (blockBase is RenderRecord<T>.Block block)
+                            {
+                                blockState = block;
+                                state = RenderState.Block;
+                                break;
+                            }
+                        }
+
+                        throw BadRenderExc(
+                            $"Expected {nameof(IRenderer<T>.RenderReorg)} or " +
+                            $"{nameof(IRenderer<T>.RenderBlock)}."
+                        );
+                    }
+
+                    case RenderState.Reorg:
+                    {
+                        if (reorgState is null || !(blockState is null))
+                        {
+                            throw BadRenderExc(
+                                $"Unexpected reorg/block states: {reorgState}/{blockState}."
+                            );
+                        }
+                        else if (record is RenderRecord<T>.Block block && block.Begin)
+                        {
+                            if (block.OldTip != reorgState.OldTip ||
+                                block.NewTip != reorgState.NewTip)
+                            {
+                                throw BadRenderExc(
+                                    $"{nameof(IRenderer<T>.RenderReorg)} and " +
+                                    $"{nameof(IRenderer<T>.RenderBlock)} which follows it should " +
+                                    "have the same oldTip and newTip."
+                                );
+                            }
+
+                            blockState = block;
+                            state = RenderState.Block;
+                            break;
+                        }
+                        else if (record is RenderRecord<T>.ActionBase actionBase &&
+                                 actionBase.Unrender)
+                        {
+                            long idx = actionBase.Context.BlockIndex;
+                            long minIdx = reorgState.Branchpoint.Index + 1;
+                            long maxIdx = previousActionBlockIndex < 0
+                                ? reorgState.OldTip.Index
+                                : previousActionBlockIndex;
+                            if (idx < minIdx || idx > maxIdx)
+                            {
+                                throw BadRenderExc(
+                                    "An action is from a block which has an unexpected index " +
+                                    $"#{idx} (expected min: #{minIdx}; max: #{maxIdx})."
+                                );
+                            }
+
+                            previousActionBlockIndex = idx;
+                            break;
+                        }
+
+                        throw BadRenderExc(
+                            $"Expected {nameof(IRenderer<T>.RenderBlock)} or " +
+                            $"{nameof(IActionRenderer<T>.UnrenderAction)} or " +
+                            $"{nameof(IActionRenderer<T>.UnrenderActionError)}."
+                        );
+                    }
+
+                    case RenderState.Block:
+                    {
+                        if (blockState is null)
+                        {
+                            throw BadRenderExc("Unexpected block state: null.");
+                        }
+                        else if (record is RenderRecord<T>.Block block && block.End)
+                        {
+                            if (block.OldTip != blockState.OldTip ||
+                                block.NewTip != blockState.NewTip)
+                            {
+                                throw BadRenderExc(
+                                    $"{nameof(IRenderer<T>.RenderBlock)} and " +
+                                    $"{nameof(IActionRenderer<T>.RenderBlockEnd)} which matches " +
+                                    "to it should have the same oldTip and newTip."
+                                );
+                            }
+
+                            state = reorgState is null ? RenderState.Ready : RenderState.BlockEnd;
+                            blockState = null;
+                            break;
+                        }
+                        else if (record is RenderRecord<T>.ActionBase actionBase &&
+                                 actionBase.Render)
+                        {
+                            long idx = actionBase.Context.BlockIndex;
+                            if (reorgState is RenderRecord<T>.Reorg reorg)
+                            {
+                                long minIdx = previousActionBlockIndex >= 0
+                                    ? previousActionBlockIndex
+                                    : reorg.Branchpoint.Index + 1;
+                                long maxIdx = reorg.NewTip.Index;
+                                if (idx < minIdx || idx > maxIdx)
+                                {
+                                    throw BadRenderExc(
+                                        "An action is from a block which has an unexpected index " +
+                                        $"#{idx} (expected min: #{minIdx}; max: #{maxIdx})."
+                                    );
+                                }
+                            }
+                            else if (idx != blockState.NewTip.Index)
+                            {
+                                throw BadRenderExc(
+                                    "An action is from a block which has an unexpected index " +
+                                    $"#{idx} (expected: #{blockState.NewTip.Index}."
+                                );
+                            }
+
+                            previousActionBlockIndex = idx;
+                            break;
+                        }
+
+                        throw BadRenderExc(
+                            $"Expected {nameof(IActionRenderer<T>.RenderBlockEnd)} or " +
+                            $"{nameof(IActionRenderer<T>.RenderAction)} or " +
+                            $"{nameof(IActionRenderer<T>.RenderActionError)}"
+                        );
+                    }
+
+                    case RenderState.BlockEnd:
+                    {
+                        if (reorgState is null || !(blockState is null))
+                        {
+                            throw BadRenderExc(
+                                $"Unexpected reorg/block states: {reorgState}/{blockState}."
+                            );
+                        }
+                        else if (record is RenderRecord<T>.Reorg reorg && reorg.End)
+                        {
+                            if (reorg.OldTip != reorgState.OldTip ||
+                                reorg.NewTip != reorgState.NewTip ||
+                                reorg.Branchpoint != reorgState.Branchpoint)
+                            {
+                                throw BadRenderExc(
+                                    $"{nameof(IRenderer<T>.RenderReorgEnd)} should match to " +
+                                    $"{nameof(IActionRenderer<T>.RenderReorg)}; they should have " +
+                                    "the same oldTip, newTip, and branchpoint."
+                                );
+                            }
+
+                            state = RenderState.Ready;
+                            reorgState = null;
+                            break;
+                        }
+
+                        throw BadRenderExc(
+                            $"Expected {nameof(IActionRenderer<T>.RenderReorgEnd)}."
+                        );
+                    }
+                }
+            }
+#pragma warning restore S2589
+        }
+
+        public class InvalidRenderException : Exception
+        {
+            public InvalidRenderException(
+                IReadOnlyList<RenderRecord<T>> records,
+                string message
+            )
+                : base(message)
+            {
+                Records = records;
+            }
+
+            public IReadOnlyList<RenderRecord<T>> Records { get; }
+
+            public override string Message
+            {
+                get
+                {
+                    string MakeCompact(string stackTrace)
+                    {
+                        int pos = 0;
+                        for (int i = 0; pos >= 0 && i < 10; i++)
+                        {
+                            pos = stackTrace.IndexOf('\n', pos + 1);
+                        }
+
+                        return pos < 0
+                            ? stackTrace
+                            : stackTrace.Substring(0, pos);
+                    }
+
+                    string pre = base.Message;
+                    if (Records.Count < 1)
+                    {
+                        return pre + "\n(0 records.)";
+                    }
+
+                    RenderRecord<T> first = Records[Records.Count - 1];
+                    var firstLine = $"{pre}\n{first}";
+                    if (Records.Count < 2)
+                    {
+                        return $"{firstLine}\n{MakeCompact(first.StackTrace)}\n(1 record.)";
+                    }
+
+                    // Find common postfix
+                    string firstTrace = first.StackTrace;
+                    int commonPostfix = 0;
+                    for (int i = 0, end = Records.Min(r => r.StackTrace.Length); i < end; i++)
+                    {
+                        char charInFirst = firstTrace[StackTrace.Length - (i + 1)];
+                        bool allEqual = Records.Skip(1).All(r =>
+                        {
+                            string stackTrace = r.StackTrace;
+                            char charFromEnd = stackTrace[stackTrace.Length - (i + 1)];
+                            return charFromEnd.Equals(charInFirst);
+                        });
+
+                        if (!allEqual)
+                        {
+                            commonPostfix = i;
+                            break;
+                        }
+                    }
+
+                    firstTrace =
+                        MakeCompact(firstTrace.Substring(0, firstTrace.Length - commonPostfix));
+                    firstLine += $"\n{firstTrace}";
+                    RenderRecord<T> second = Records[Records.Count - 2];
+                    IEnumerable<RenderRecord<T>> rest = Records.Reverse().Skip(2);
+                    string secondTrace = second.StackTrace;
+                    string secondCompactTrace =
+                        MakeCompact(secondTrace.Substring(0, secondTrace.Length - commonPostfix));
+                    return $"{firstLine}\n{second}\n{secondCompactTrace}\n" +
+                           string.Join("\n", rest) + $"\n({Records.Count} records.)";
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Menees.Analyzers.Settings.xml
+++ b/Libplanet.Tests/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>300</MaxMethodLines>
-  <MaxFileLines>2600</MaxFileLines>
+  <MaxFileLines>2700</MaxFileLines>
 </Menees.Analyzers.Settings>

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -68,10 +68,10 @@ namespace Libplanet.Tests.Net
 
             _renderers = new List<RecordingRenderer<DumbAction>>
             {
-                new RecordingRenderer<DumbAction>(),
-                new RecordingRenderer<DumbAction>(),
-                new RecordingRenderer<DumbAction>(),
-                new RecordingRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
             };
 
             LoggedActionRenderer<DumbAction>[][] loggedRenderers = _renderers

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -322,7 +322,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 store,
                 stateStore ?? store as IStateStore,
                 genesisBlock,
-                renderers: renderers ?? new[] { new RecordingRenderer<T>() }
+                renderers: renderers ?? new[] { new ValidatingActionRenderer<T>() }
             );
         }
 

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -135,7 +135,9 @@ namespace Libplanet.Blockchain.Renderers
                         }
 
                         Logger.Debug(
-                            "Committed the buffered action unrenders from the block {BlockHash}.",
+                            "Committed {Count} buffered action unrenders from " +
+                            "the block {BlockHash}.",
+                            b?.Count ?? 0,
                             block
                         );
                     }
@@ -234,7 +236,8 @@ namespace Libplanet.Blockchain.Renderers
                 }
 
                 Logger.Debug(
-                    "Committed the buffered action renders from the block {BlockHash}.",
+                    "Committed {Count} buffered action renders from the block {BlockHash}.",
+                    b?.Count ?? 0,
                     block
                 );
             }


### PR DESCRIPTION
This fixes the inaccurate order of rendering events that `BlockChain<T>` emits so that the order conforms to the [documented rendering automata][1], i.e.:

> See also the docs on `IRenderer<T>`:
> 
> ![IRenderer<T>](https://user-images.githubusercontent.com/12431/92929971-5c4e9f80-f47c-11ea-8c46-9bda44e34889.png)
> 
> … and `IActionRenderer<T>`:
> 
> ![IActionRenderer<T>](https://user-images.githubusercontent.com/12431/92929884-3a551d00-f47c-11ea-861b-0ec7382a2269.png)

In order to find the causes of these bugs, I also added `ValidatingActionRenderer<T>` which is a profiler-guided analyzer.

[1]: https://github.com/planetarium/libplanet/pull/1000