### PR TITLE
Enable null checker on exception files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,11 +116,12 @@ To be released.
  -  `BlockPolicy<T>.DoesTransactionFollowPolicy()` method and
     `IBlockPolicy.DoesTransactionFollowPolicy()` method became to take
     additional `BlockChain<T>` parameter as its context.  [[#1012]]
- -  `doesTransactionFollowPolicy` parameter became 
+ -  `doesTransactionFollowPolicy` parameter became
     `Func<Transaction<T>, BlockChain<T>, bool>` on `BlockPolicy<T>()`
     constructor.  [[#1012]]
  -  Added `cacheSize` optional parameter to `BlockSet<T>()` constructor.
     [[#1013]]
+ -  Removed constructors from `InvalidMessageException` class.  [[#1021]]
 
 ### Backward-incompatible network protocol changes
 
@@ -364,6 +365,7 @@ To be released.
 [#1010]: https://github.com/planetarium/libplanet/pull/1010
 [#1012]: https://github.com/planetarium/libplanet/pull/1012
 [#1013]: https://github.com/planetarium/libplanet/pull/1013
+[#1021]: https://github.com/planetarium/libplanet/pull/1021
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet/Action/MissingActionTypeException.cs
+++ b/Libplanet/Action/MissingActionTypeException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Action

--- a/Libplanet/Blockchain/IncompleteBlockStatesException.cs
+++ b/Libplanet/Blockchain/IncompleteBlockStatesException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
@@ -21,7 +22,7 @@ namespace Libplanet.Blockchain
         /// </param>
         public IncompleteBlockStatesException(
             HashDigest<SHA256> blockHash,
-            string message = null)
+            string? message = null)
             : base(
                 message is null
                     ? $"The block {blockHash} lacks its states"

--- a/Libplanet/Blocks/InvalidBlockDifficultyException.cs
+++ b/Libplanet/Blocks/InvalidBlockDifficultyException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Blocks

--- a/Libplanet/Blocks/InvalidBlockException.cs
+++ b/Libplanet/Blocks/InvalidBlockException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Blocks/InvalidBlockHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockHashException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Blocks

--- a/Libplanet/Blocks/InvalidBlockIndexException.cs
+++ b/Libplanet/Blocks/InvalidBlockIndexException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Blocks

--- a/Libplanet/Blocks/InvalidBlockPreviousHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockPreviousHashException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Blocks

--- a/Libplanet/Blocks/InvalidBlockTimestampException.cs
+++ b/Libplanet/Blocks/InvalidBlockTimestampException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Blocks

--- a/Libplanet/Blocks/InvalidGenesisBlockException.cs
+++ b/Libplanet/Blocks/InvalidGenesisBlockException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using Libplanet.Blockchain;

--- a/Libplanet/Crypto/InvalidCiphertextException.cs
+++ b/Libplanet/Crypto/InvalidCiphertextException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/KeyStore/IncorrectPassphraseException.cs
+++ b/Libplanet/KeyStore/IncorrectPassphraseException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 

--- a/Libplanet/KeyStore/InvalidKeyJsonException.cs
+++ b/Libplanet/KeyStore/InvalidKeyJsonException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Libplanet.KeyStore
 {
     /// <summary>

--- a/Libplanet/KeyStore/KeyJsonException.cs
+++ b/Libplanet/KeyStore/KeyJsonException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.KeyStore

--- a/Libplanet/KeyStore/KeyStoreException.cs
+++ b/Libplanet/KeyStore/KeyStoreException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.KeyStore

--- a/Libplanet/KeyStore/MismatchedAddressException.cs
+++ b/Libplanet/KeyStore/MismatchedAddressException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.KeyStore

--- a/Libplanet/KeyStore/NoKeyException.cs
+++ b/Libplanet/KeyStore/NoKeyException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.KeyStore

--- a/Libplanet/KeyStore/UnsupportedKeyJsonException.cs
+++ b/Libplanet/KeyStore/UnsupportedKeyJsonException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Libplanet.KeyStore
 {
     /// <summary>

--- a/Libplanet/Net/DifferentAppProtocolVersionException.cs
+++ b/Libplanet/Net/DifferentAppProtocolVersionException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 #pragma warning disable S3871
 using System;
 using Libplanet.Net.Messages;

--- a/Libplanet/Net/IceServerException.cs
+++ b/Libplanet/Net/IceServerException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Net

--- a/Libplanet/Net/InvalidMessageException.cs
+++ b/Libplanet/Net/InvalidMessageException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 using Libplanet.Net.Messages;
@@ -7,18 +8,14 @@ namespace Libplanet.Net
     [Serializable]
     public class InvalidMessageException : Exception
     {
-        public InvalidMessageException()
-        {
-        }
-
-        public InvalidMessageException(string message)
-            : base(message)
-        {
-        }
-
-        public InvalidMessageException(string message, Exception innerException)
+        internal InvalidMessageException(
+            string message,
+            Message receivedMessage,
+            Exception innerException
+        )
             : base(message, innerException)
         {
+            ReceivedMessage = receivedMessage;
         }
 
         internal InvalidMessageException(string message, Message receivedMessage)
@@ -33,8 +30,19 @@ namespace Libplanet.Net
         )
             : base(info, context)
         {
+            ReceivedMessage = info.GetValue(nameof(ReceivedMessage), typeof(Message)) is Message m
+                ? m
+                : throw new SerializationException(
+                    $"{nameof(ReceivedMessage)} is expected to be a non-null {nameof(Message)}.");
         }
 
         internal Message ReceivedMessage { get; }
+
+        public override void GetObjectData(
+            SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(ReceivedMessage), ReceivedMessage);
+        }
     }
 }

--- a/Libplanet/Net/InvalidStateTargetException.cs
+++ b/Libplanet/Net/InvalidStateTargetException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -230,8 +230,10 @@ namespace Libplanet.Net.Messages
 
             if (!types.TryGetValue(rawType, out Type type))
             {
-                throw new InvalidMessageException(
-                    $"Can't determine NetMQMessage. [type: {rawType}]");
+                throw new ArgumentException(
+                    $"Can't determine NetMQMessage. [type: {rawType}]",
+                    nameof(raw)
+                );
             }
 
             var message = (Message)Activator.CreateInstance(
@@ -241,9 +243,7 @@ namespace Libplanet.Net.Messages
 
             if (!message.Remote.PublicKey.Verify(body.ToByteArray(), signature))
             {
-                throw new InvalidMessageException(
-                    "The message signature is invalid"
-                );
+                throw new InvalidMessageException("The message signature is invalid", message);
             }
 
             if (!reply)

--- a/Libplanet/Net/NoSwarmContextException.cs
+++ b/Libplanet/Net/NoSwarmContextException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Net/PeerNotFoundException.cs
+++ b/Libplanet/Net/PeerNotFoundException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -423,20 +423,20 @@ namespace Libplanet.Net.Protocols
             try
             {
                 _logger.Debug("Trying to ping async to {Peer}.", target);
-                if (!(await _transport.SendMessageWithReplyAsync(
+                Message reply = await _transport.SendMessageWithReplyAsync(
                     target,
                     new Ping(),
                     timeout,
-                    cancellationToken) is Pong pong))
+                    cancellationToken
+                );
+                if (!(reply is Pong pong))
                 {
-                    throw new InvalidMessageException(
-                        "Received pong is invalid.");
+                    throw new InvalidMessageException("Received pong is invalid.", reply);
                 }
 
                 if (pong.Remote.Address.Equals(_address))
                 {
-                    throw new InvalidMessageException(
-                        "Cannot receive pong from self");
+                    throw new InvalidMessageException("Cannot receive pong from self", pong);
                 }
             }
             catch (TimeoutException)
@@ -592,13 +592,18 @@ namespace Libplanet.Net.Protocols
             var findPeer = new FindNeighbors(target);
             try
             {
-                if (!(await _transport.SendMessageWithReplyAsync(
+                Message reply = await _transport.SendMessageWithReplyAsync(
                     addressee,
                     findPeer,
                     timeout,
-                    cancellationToken) is Neighbors neighbors))
+                    cancellationToken
+                );
+                if (!(reply is Neighbors neighbors))
                 {
-                    throw new InvalidMessageException("Reply of FindNeighbors is invalid.");
+                    throw new InvalidMessageException(
+                        $"Reply to {nameof(FindNeighbors)} is invalid.",
+                        reply
+                    );
                 }
 
                 return neighbors.Found;

--- a/Libplanet/Net/Protocols/PeerDiscoveryException.cs
+++ b/Libplanet/Net/Protocols/PeerDiscoveryException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Net/Protocols/PingTimeoutException.cs
+++ b/Libplanet/Net/Protocols/PingTimeoutException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 
@@ -27,7 +28,10 @@ namespace Libplanet.Net.Protocols
         protected PingTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Target = (BoundPeer)info.GetValue("Target", typeof(BoundPeer));
+            Target = info.GetValue(nameof(Target), typeof(BoundPeer)) is BoundPeer target
+                ? target
+                : throw new SerializationException(
+                    $"{nameof(Target)} is expected to be a non-null {nameof(BoundPeer)}.");
         }
 
         public BoundPeer Target { get; private set; }
@@ -41,7 +45,7 @@ namespace Libplanet.Net.Protocols
             }
 
             base.GetObjectData(info, context);
-            info.AddValue("Target", Target);
+            info.AddValue(nameof(Target), Target);
         }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1034,10 +1034,10 @@ namespace Libplanet.Net
                 yield break;
             }
 
-            throw new InvalidMessageException(
+            string errorMessage =
                 $"The response of {nameof(GetBlockHashes)} is expected to be " +
-                $"{nameof(BlockHashes)}, not {parsedMessage.GetType().Name}: {parsedMessage}"
-            );
+                $"{nameof(BlockHashes)}, not {parsedMessage.GetType().Name}: {parsedMessage}";
+            throw new InvalidMessageException(errorMessage, parsedMessage);
         }
 
         internal async IAsyncEnumerable<Block<T>> GetBlocksAsync(
@@ -1097,11 +1097,11 @@ namespace Libplanet.Net
                 }
                 else
                 {
-                    throw new InvalidMessageException(
+                    string errorMessage =
                         $"Expected a {nameof(Blocks)} message as a response of " +
                         $"the {nameof(GetBlocks)} message, but got a {message.GetType().Name} " +
-                        $"message instead: {message}"
-                    );
+                        $"message instead: {message}";
+                    throw new InvalidMessageException(errorMessage, message);
                 }
             }
 
@@ -1146,11 +1146,11 @@ namespace Libplanet.Net
                 }
                 else
                 {
-                    throw new InvalidMessageException(
+                    string errorMessage =
                         $"Expected {nameof(Tx)} messages as response of " +
                         $"the {nameof(GetTxs)} message, but got a {message.GetType().Name} " +
-                        $"message instead: {message}"
-                    );
+                        $"message instead: {message}";
+                    throw new InvalidMessageException(errorMessage, message);
                 }
             }
         }

--- a/Libplanet/Net/SwarmException.cs
+++ b/Libplanet/Net/SwarmException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.Serialization;
 

--- a/Libplanet/Store/ChainIdNotFoundException.cs
+++ b/Libplanet/Store/ChainIdNotFoundException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Store

--- a/Libplanet/Tx/InvalidTxException.cs
+++ b/Libplanet/Tx/InvalidTxException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Tx

--- a/Libplanet/Tx/InvalidTxGenesisHashException.cs
+++ b/Libplanet/Tx/InvalidTxGenesisHashException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/Libplanet/Tx/InvalidTxIdException.cs
+++ b/Libplanet/Tx/InvalidTxIdException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Tx

--- a/Libplanet/Tx/InvalidTxNonceException.cs
+++ b/Libplanet/Tx/InvalidTxNonceException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Libplanet.Blockchain;

--- a/Libplanet/Tx/InvalidTxPublicKeyException.cs
+++ b/Libplanet/Tx/InvalidTxPublicKeyException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Tx

--- a/Libplanet/Tx/InvalidTxSignatureException.cs
+++ b/Libplanet/Tx/InvalidTxSignatureException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Tx

--- a/Libplanet/Tx/InvalidTxUpdatedAddressesException.cs
+++ b/Libplanet/Tx/InvalidTxUpdatedAddressesException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;

--- a/Libplanet/Tx/TxViolatingBlockPolicyException.cs
+++ b/Libplanet/Tx/TxViolatingBlockPolicyException.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Libplanet.Tx


### PR DESCRIPTION
Enable null checker on exceptions files.  This contributes to #458.

Total files:

```console
$ find Libplanet/ -name '*.cs' | wc -l
187
```

Files that enable null checker (39%):

```console
$ git grep '#nullable enable' Libplanet/ | wc -l
73
```

Note that it was before (19%):

```console
$ git grep '#nullable enable' Libplanet/ | wc -l
37
```