### PR TITLE
Enable null checker on Libplanet project's top-level files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,8 @@ To be released.
     constructor.  [[#1012]]
  -  Added `cacheSize` optional parameter to `BlockSet<T>()` constructor.
     [[#1013]]
+ -  Removed `Address(SerializationInfo, StreamingContext)` constructor.
+    [[#1022]]
  -  Removed constructors from `InvalidMessageException` class.  [[#1021]]
 
 ### Backward-incompatible network protocol changes
@@ -366,6 +368,7 @@ To be released.
 [#1012]: https://github.com/planetarium/libplanet/pull/1012
 [#1013]: https://github.com/planetarium/libplanet/pull/1013
 [#1021]: https://github.com/planetarium/libplanet/pull/1021
+[#1022]: https://github.com/planetarium/libplanet/pull/1022
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -42,7 +42,7 @@
     </IncludeAssets>
   </PackageReference>
   <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.2.3-planetarium" />
-  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+  <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>
       runtime; build; native; contentfiles; analyzers

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/Libplanet.Stun/Libplanet.Stun.csproj
@@ -30,7 +30,7 @@
         runtime; build; native; contentfiles; analyzers; buildtransitive
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -115,21 +115,21 @@ namespace Libplanet.Stun.Messages
                     MessageMethod.Binding => new BindingSuccessResponse(),
                     MessageMethod.CreatePermission => new CreatePermissionSuccessResponse(),
                     MessageMethod.Refresh => new RefreshSuccessResponse(),
-                    _ => rv
+                    _ => rv,
                 },
                 MessageClass.ErrorResponse => method switch
                 {
                     MessageMethod.Allocate => new AllocateErrorResponse(),
                     MessageMethod.CreatePermission => new CreatePermissionErrorResponse(),
                     MessageMethod.Refresh => new RefreshErrorResponse(),
-                    _ => rv
+                    _ => rv,
                 },
                 MessageClass.Indication => method switch
                 {
                     MessageMethod.ConnectionAttempt => new ConnectionAttempt(),
-                    _ => rv
+                    _ => rv,
                 },
-                _ => rv
+                _ => rv,
             };
 
             if (rv is null)
@@ -252,7 +252,7 @@ namespace Libplanet.Stun.Messages
                         XorRelayedAddress.Parse(payload, transactionId),
                     Attribute.AttributeType.ConnectionId => new ConnectionId(payload),
                     Attribute.AttributeType.Lifetime => new Lifetime((int)payload.ToUInt()),
-                    _ => null
+                    _ => null,
                 };
 
                 if (!(attr is null))

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -12,6 +12,10 @@
     <Rule Id="SA1005" Action="None" />
     <!-- Closing parenthesis should be on line of opening parenthesis -->
     <Rule Id="SA1112" Action="None" />
+    <!-- Allow tuple types in signatures omit element names. -->
+    <Rule Id="SA1414" Action="None" />
+    <!-- Allow tuple fields to be referred by index (i.e. ItemN). -->
+    <Rule Id="SA1142" Action="None" />
     <!-- Single-line comment should be preceded by blank line. -->
     <Rule Id="SA1515" Action="None" />
     <!-- TODO: Write copyright -->

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void RandomShouldBeDeterministic()
         {
-            (int seed, int expected)[] testCases =
+            (int Seed, int Expected)[] testCases =
             {
                 (0, 1559595546),
                 (1, 534011718),
@@ -60,7 +60,7 @@ namespace Libplanet.Tests.Action
                 randomSeed: 1
             );
 
-            (Guid expected, Guid diff)[] testCases =
+            (Guid Expected, Guid Diff)[] testCases =
             {
                 (
                     new Guid("6f460c1a-755d-48e4-ad67-65d5f519dbc8"),

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2248,7 +2248,7 @@ namespace Libplanet.Tests.Blockchain
         ///     10   addresses[4]       Present
         /// </code>
         /// </summary>
-        internal static (Address, Address[] addresses, BlockChain<DumbAction> chain)
+        internal static (Address, Address[] Addresses, BlockChain<DumbAction> Chain)
         MakeIncompleteBlockStates(
             IStore store,
             IBlockStatesStore blockStatesStore,
@@ -2333,7 +2333,7 @@ namespace Libplanet.Tests.Blockchain
             return (signer, addresses, chain);
         }
 
-        private (Address, Address[] addresses, BlockChain<DumbAction> chain)
+        private (Address, Address[] Addresses, BlockChain<DumbAction> Chain)
         MakeIncompleteBlockStates() =>
             MakeIncompleteBlockStates(_fx.Store, _fx.BlockStatesStore);
 

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.ruleset
+++ b/Libplanet.ruleset
@@ -15,6 +15,10 @@
     <Rule Id="SA1309" Action="None" />
     <!-- Allow an expression not to declare parenthese. -->
     <Rule Id="SA1407" Action="None" />
+    <!-- Allow tuple types in signatures omit element names. -->
+    <Rule Id="SA1414" Action="None" />
+    <!-- Allow tuple fields to be referred by index (i.e. ItemN). -->
+    <Rule Id="SA1142" Action="None" />
     <!-- Allow a rich text in a XML doc comment's <summary>. -->
     <Rule Id="SA1462" Action="None" />
     <Rule Id="SA1642" Action="None" />

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
@@ -93,13 +94,6 @@ namespace Libplanet
         {
         }
 
-        public Address(
-            SerializationInfo info,
-            StreamingContext context)
-            : this(info.GetValue<byte[]>("address"))
-        {
-        }
-
         /// <summary>
         /// Derives the corresponding <see cref="Address"/> from a <see
         /// cref="PublicKey"/>.
@@ -135,6 +129,14 @@ namespace Libplanet
         /// >EIP 55</a>.</param>
         public Address(string hex)
             : this(DeriveAddress(hex))
+        {
+        }
+
+        private Address(
+            SerializationInfo info,
+            StreamingContext context)
+            : this(info?.GetValue<byte[]>("address") ??
+                throw new SerializationException("Missing the address field."))
         {
         }
 
@@ -223,9 +225,7 @@ namespace Libplanet
         }
 
         /// <inheritdoc />
-        public void GetObjectData(
-            SerializationInfo info,
-            StreamingContext context)
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("address", ToByteArray());
         }
@@ -246,7 +246,7 @@ namespace Libplanet
             return 0;
         }
 
-        int IComparable.CompareTo(object obj)
+        int IComparable.CompareTo(object? obj)
         {
             if (obj is Address other)
             {

--- a/Libplanet/AddressExtensions.cs
+++ b/Libplanet/AddressExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Libplanet.Crypto;
 
 namespace Libplanet

--- a/Libplanet/ByteArrayExtensions.cs
+++ b/Libplanet/ByteArrayExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Diagnostics.Contracts;
 
@@ -22,7 +23,7 @@ namespace Libplanet
         /// <paramref name="bytes"/> or <paramref name="prefix"/> is null.
         /// </exception>
         [Pure]
-        public static bool StartsWith(this byte[] bytes, byte[] prefix)
+        public static bool StartsWith(this byte[]? bytes, byte[]? prefix)
         {
             if (bytes is null)
             {

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
@@ -74,7 +75,6 @@ namespace Libplanet
             }
 
             string s = BitConverter.ToString(bytes);
-
             return s.Replace("-", string.Empty).ToLower(CultureInfo.InvariantCulture);
         }
 

--- a/Libplanet/FixedSizedQueue.cs
+++ b/Libplanet/FixedSizedQueue.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Concurrent;
 
 namespace Libplanet

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -1,8 +1,10 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Security.Cryptography;
 
 namespace Libplanet
@@ -35,8 +37,9 @@ namespace Libplanet
 
         static HashDigest()
         {
-            var thunk = (T)typeof(T).GetMethod("Create", new Type[0]).Invoke(
-                null, new object[0]);
+            MethodInfo? method = typeof(T).GetMethod("Create", new Type[0]);
+            T thunk = method?.Invoke(null, new object[0]) as T
+                ?? throw new InvalidCastException($"Failed to instantiate {typeof(T).FullName}.");
             Size = thunk.HashSize / 8;
 
             _defaultByteArray = new byte[Size];
@@ -206,7 +209,7 @@ namespace Libplanet
         }
 
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is IEquatable<HashDigest<T>> other
                 ? other.Equals(this)

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Security.Cryptography;
 using System.Threading;

--- a/Libplanet/KeyStore/Kdfs/Pbkdf2.cs
+++ b/Libplanet/KeyStore/Kdfs/Pbkdf2.cs
@@ -195,7 +195,7 @@ namespace Libplanet.KeyStore.Kdfs
                     throw new InvalidKeyJsonException(
                         "The \"prf\" field must not be null, but a string."),
                 _ =>
-                    throw new UnsupportedKeyJsonException($"Unsupported \"prf\" type: \"{prf}\".")
+                    throw new UnsupportedKeyJsonException($"Unsupported \"prf\" type: \"{prf}\"."),
             };
         }
     }

--- a/Libplanet/KeyStore/ProtectedPrivateKey.cs
+++ b/Libplanet/KeyStore/ProtectedPrivateKey.cs
@@ -270,7 +270,7 @@ namespace Libplanet.KeyStore
                 "aes-128-ctr" => Aes128Ctr.FromJson(cipherParamsElement),
                 _ =>
                     throw new UnsupportedKeyJsonException(
-                        $"Unsupported cipher type: \"{cipherType}\".")
+                        $"Unsupported cipher type: \"{cipherType}\"."),
             };
 
             IKdf kdf;
@@ -282,7 +282,7 @@ namespace Libplanet.KeyStore
                     "scrypt" => Scrypt.FromJson(kdfParamsElement),
                     _ =>
                         throw new UnsupportedKeyJsonException(
-                            $"Unsupported cipher type: \"{kdfType}\".")
+                            $"Unsupported cipher type: \"{kdfType}\"."),
                 };
             }
             catch (ArgumentException e)

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -81,7 +81,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.260-planetarium" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet/Nonce.cs
+++ b/Libplanet/Nonce.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;


### PR DESCRIPTION
This enables null checker on Libplanet project's top-level files to contribute to #458.

Also upgraded StyleCop.Analyzers to 1.2.0-beta.205 in order to avoid <https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2927>.

Total files:

```console
$ find Libplanet/ -name '*.cs' | wc -l
187
```

Files that enable null checker (43%):

```console
$ git grep '#nullable enable' Libplanet/ | wc -l
81
```

Note that it was before (39%):

```console
$ git grep '#nullable enable' Libplanet/ | wc -l
73
```