### PR TITLE
Export all states as JSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -299,8 +299,8 @@ To be released.
  -  The `planet` command became installable using `npm`.  [[#923], [#982]]
  -  Fixed a bug that <kbd>^H</kbd> had not removed the rightmost character
     in passphrase prompts.  [[#983], [#984]]
- -  Added a new sub-command `planet mpt`.  [[#1023]]
- -  Introduced a configuration file.  It's placed in:  [[#1023]]
+ -  Added a new sub-command `planet mpt`.  [[#1023], [#1026]]
+ -  Introduced a configuration file.  It's placed in:  [[#1023], [#1026]]
      -  Linux/macOS: *<var>$XDG_CONFIG_HOME</var>/planetarium/cli.json*
      -  Windows: *<var>%AppData%</var>\planetarium\cli.json*
 
@@ -377,6 +377,7 @@ To be released.
 [#1021]: https://github.com/planetarium/libplanet/pull/1021
 [#1022]: https://github.com/planetarium/libplanet/pull/1022
 [#1023]: https://github.com/planetarium/libplanet/pull/1023
+[#1026]: https://github.com/planetarium/libplanet/pull/1026
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/ImmutableArrayEqualityComparer.cs
+++ b/Libplanet.Tests/ImmutableArrayEqualityComparer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Libplanet.Tests
+{
+    public class ImmutableArrayEqualityComparer<T> : IEqualityComparer<ImmutableArray<T>>
+    {
+        public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
+            => x.Length == y.Length && x.SequenceEqual(y);
+
+        public int GetHashCode(ImmutableArray<T> obj)
+        {
+            int code = 0;
+            unchecked
+            {
+                foreach (T el in obj)
+                {
+                    code = (code * 397) ^ el.GetHashCode();
+                }
+            }
+
+            return code;
+        }
+    }
+}

--- a/Libplanet/Store/Trie/MerkleTrieExtensions.cs
+++ b/Libplanet/Store/Trie/MerkleTrieExtensions.cs
@@ -40,6 +40,20 @@ namespace Libplanet.Store.Trie
                     group.Count() == 1 || !group.All(v => v.Value.Equals(group.First().Value)));
         }
 
+        /// <summary>
+        /// Lists the all states key and the all states in the given <paramref name="merkleTrie"/>.
+        /// </summary>
+        /// <param name="merkleTrie">A trie to discover.</param>
+        /// <returns>All state keys and the all states.</returns>
+        public static IEnumerable<KeyValuePair<ImmutableArray<byte>, IValue>> ListAllStates(
+            this MerkleTrie merkleTrie)
+        {
+            return merkleTrie.IterateNodes().Where(pair => pair.Node is ValueNode).Select(pair =>
+                new KeyValuePair<ImmutableArray<byte>, IValue>(
+                    FromKey(pair.Path),
+                    ((ValueNode)pair.Node).Value));
+        }
+
         private static ImmutableArray<byte> FromKey(ImmutableArray<byte> bytes)
         {
             if (bytes.Length % 2 == 1)


### PR DESCRIPTION
Before this pull request, #1023 MUST proceed.

This pull request introduced a new feature to export all states corresponded to the state root hash as JSON.

### Usage

```powershell
> dotnet run -- mpt export "C:\Users\moreal\AppData\Local\planetarium\9c-beta-8-rc1\states" "09dc793242a7f0932656654e01d92e5e84b58b3f52738cf0d67960e9d32951de" -t rocksdb > states.json

> cat states.json
{"39666566633833366331343965336664383436333932366232623434626431616633363734663034":"ZHU3OmFkZHJlc3MyMDqf78g2wUnj/YRjkmsrRL0a82dPBHU1Om5vbmNlM ....
....
```

### Export format

It will be exported as not pretty JSON like the below type:

```JSON
{
  "<state_key>": "<bencodexed_hexdecimal_string>"
}
```