### PR TITLE
feat(mpt): provide API to calculate state root hash in the action execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -226,6 +226,8 @@ To be released.
  -  Added `Block<T>.StateRootHash` property.  [[#986]]
  -  Added `BlockHeader.StateRootHash` property.  [[#986]]
  -  Added `MerkleTrieExtensions` static class.  [[#1023]]
+ -  Added `IAccountStateDelta.PreviousStateRootHash` property to
+    calculate states until previous action as state root hash.  [[#1030]]
 
 ### Behavioral changes
 
@@ -378,6 +380,7 @@ To be released.
 [#1022]: https://github.com/planetarium/libplanet/pull/1022
 [#1023]: https://github.com/planetarium/libplanet/pull/1023
 [#1026]: https://github.com/planetarium/libplanet/pull/1026
+[#1030]: https://github.com/planetarium/libplanet/pull/1030
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Libplanet.Store.Trie;
 using Libplanet.Tests.Store.Trie;
 using Xunit;
 
@@ -136,8 +137,8 @@ namespace Libplanet.Tests.Action
         public void LazyPreviousStateRootHash(bool callPreviousStateRootHash)
         {
             var keyValueStore = new MemoryKeyValueStore();
-            var previousBlockStatesTrie = new Libplanet.Store.Trie.MerkleTrie(keyValueStore);
-            previousBlockStatesTrie.Set(new byte[0], default(Null));
+            ITrie previousBlockStatesTrie = new MerkleTrie(keyValueStore);
+            previousBlockStatesTrie = previousBlockStatesTrie.Set(new byte[0], default(Null));
             var random = new System.Random();
             var actionContext = new ActionContext(
                 signer: random.NextAddress(),

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Libplanet.Tests.Store.Trie;
 using Xunit;
 
 namespace Libplanet.Tests.Action
@@ -126,6 +128,32 @@ namespace Libplanet.Tests.Action
                 values,
                 new[] { clone.Random.Next(), clone.Random.Next(), clone.Random.Next() }
             );
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LazyPreviousStateRootHash(bool callPreviousStateRootHash)
+        {
+            var keyValueStore = new MemoryKeyValueStore();
+            var previousBlockStatesTrie = new Libplanet.Store.Trie.MerkleTrie(keyValueStore);
+            previousBlockStatesTrie.Set(new byte[0], default(Null));
+            var random = new System.Random();
+            var actionContext = new ActionContext(
+                signer: random.NextAddress(),
+                miner: random.NextAddress(),
+                blockIndex: 1,
+                previousStates: new DumbAccountStateDelta(),
+                randomSeed: random.Next(),
+                previousBlockStatesTrie: previousBlockStatesTrie
+            );
+
+            if (callPreviousStateRootHash)
+            {
+                _ = actionContext.PreviousStateRootHash;
+            }
+
+            Assert.Equal(callPreviousStateRootHash ? 1 : 0, keyValueStore.ListKeys().Count());
         }
 
         private class DumbAccountStateDelta : IAccountStateDelta

--- a/Libplanet.Tests/Blockchain/BlockEvaluatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockEvaluatorTest.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Tests.Blockchain
                 transactions: txs,
                 checkStateRootHash: true);
             var blockEvaluator =
-                new BlockEvaluator<RandomAction>(null, NullStateGetter, NullBalanceGetter);
+                new BlockEvaluator<RandomAction>(null, NullStateGetter, NullBalanceGetter, null);
             var generatedRandomNumbers = new List<int>();
 
             Assert.NotEqual(stateRootBlock.Hash, noStateRootBlock.Hash);

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -47,11 +47,11 @@ namespace Libplanet.Tests.Store.Trie
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             MerkleTrie trie = new MerkleTrie(keyValueStore);
 
-            trie.Set(new byte[] { 0x01, }, default(Null));
-            trie.Set(new byte[] { 0x02, }, default(Null));
-            trie.Set(new byte[] { 0x03, }, default(Null));
-            trie.Set(new byte[] { 0x04, }, default(Null));
-            trie.Set(new byte[] { 0xbe, 0xef }, Dictionary.Empty);
+            trie = (MerkleTrie)trie.Set(new byte[] { 0x01, }, default(Null))
+                    .Set(new byte[] { 0x02, }, default(Null))
+                    .Set(new byte[] { 0x03, }, default(Null))
+                    .Set(new byte[] { 0x04, }, default(Null))
+                    .Set(new byte[] { 0xbe, 0xef }, Dictionary.Empty);
 
             Dictionary<ImmutableArray<byte>, IValue> states =
                 trie.ListAllStates().ToDictionary(

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -17,14 +17,14 @@ namespace Libplanet.Tests.Store.Trie
             MerkleTrie trieA = new MerkleTrie(keyValueStore),
                 trieB = new MerkleTrie(keyValueStore);
 
-            trieA.Set(new byte[] { 0x01, }, default(Null));
-            trieA.Set(new byte[] { 0x02, }, default(Null));
-            trieA.Set(new byte[] { 0x03, }, default(Null));
-            trieB.Set(new byte[] { 0x01, }, Dictionary.Empty);
-            trieB.Set(new byte[] { 0x02, }, default(Null));
-            trieB.Set(new byte[] { 0x04, }, default(Null));
-            trieA = (MerkleTrie)trieA.Commit();
-            trieB = (MerkleTrie)trieB.Commit();
+            trieA = (MerkleTrie)trieA.Set(new byte[] { 0x01, }, default(Null))
+                .Set(new byte[] { 0x02, }, default(Null))
+                .Set(new byte[] { 0x03, }, default(Null))
+                .Commit();
+            trieB = (MerkleTrie)trieB.Set(new byte[] { 0x01, }, Dictionary.Empty)
+                .Set(new byte[] { 0x02, }, default(Null))
+                .Set(new byte[] { 0x04, }, default(Null))
+                .Commit();
 
             Dictionary<string, (HashDigest<SHA256> Root, IValue Value)[]> differentNodes =
                 trieA.DifferentNodes(trieB).ToDictionary(

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -35,13 +35,13 @@ namespace Libplanet.Tests.Store.Trie
             // There is nothing.
             Assert.Empty(merkleTrie.IterateNodes());
 
-            merkleTrie.Set(
+            merkleTrie = (MerkleTrie)merkleTrie.Set(
                 new byte[] { 0xbe, 0xef, },
                 Dictionary.Empty.Add(TestUtils.GetRandomBytes(32), default(Null)));
             // There are (ShortNode, ValueNode)
             Assert.Equal(2, merkleTrie.IterateNodes().Count());
 
-            merkleTrie = merkleTrie.Commit() as MerkleTrie;
+            merkleTrie = (MerkleTrie)merkleTrie.Commit();
             // There are (HashNode, ShortNode, HashNode, ValueNode)
             Assert.Equal(4, merkleTrie.IterateNodes().Count());
         }

--- a/Libplanet.Tests/Store/Trie/TrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/TrieTest.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Tests.Store.Trie
             foreach (var address in addresses)
             {
                 states[address] = (Text)address.ToHex();
-                trie.Set(address.ToByteArray(), states[address]);
+                trie = trie.Set(address.ToByteArray(), states[address]);
                 CheckAddressStates();
             }
         }
@@ -71,11 +71,11 @@ namespace Libplanet.Tests.Store.Trie
                 addresses[i] = new PrivateKey().ToAddress();
                 states[i] = (Binary)TestUtils.GetRandomBytes(128);
 
-                trieA.Set(addresses[i].ToByteArray(), states[i]);
+                trieA = trieA.Set(addresses[i].ToByteArray(), states[i]);
             }
 
             byte[] path = TestUtils.GetRandomBytes(32);
-            trieA.Set(path, (Text)"foo");
+            trieA = trieA.Set(path, (Text)"foo");
             HashDigest<SHA256> rootHash = trieA.Hash;
             Assert.True(trieA.TryGet(path, out IValue stateA));
             Assert.Equal((Text)"foo", stateA);
@@ -85,7 +85,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.True(trieB.TryGet(path, out IValue stateB));
             Assert.Equal((Text)"foo", stateB);
 
-            trieB.Set(path, (Text)"bar");
+            trieB = trieB.Set(path, (Text)"bar");
 
             Assert.True(trieA.TryGet(path, out stateA));
             Assert.Equal((Text)"foo", stateA);
@@ -111,7 +111,7 @@ namespace Libplanet.Tests.Store.Trie
             var committedTrie = trie.Commit();
             Assert.Equal(MerkleTrie.EmptyRootHash, committedTrie.Hash);
 
-            trie.Set(default(Address).ToByteArray(), Dictionary.Empty);
+            trie = trie.Set(default(Address).ToByteArray(), Dictionary.Empty);
             committedTrie = trie.Commit();
             Assert.NotEqual(MerkleTrie.EmptyRootHash, committedTrie.Hash);
         }
@@ -124,7 +124,7 @@ namespace Libplanet.Tests.Store.Trie
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                trie.Set(new byte[] { 0xbe, 0xef }, null);
+                _ = trie.Set(new byte[] { 0xbe, 0xef }, null);
             });
         }
     }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -206,7 +206,8 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 var blockEvaluator = new BlockEvaluator<T>(
                     blockAction,
                     (address, digest, arg3) => null,
-                    (address, currency, arg3, arg4) => new FungibleAssetValue(currency));
+                    (address, currency, arg3, arg4) => new FungibleAssetValue(currency),
+                    null);
                 var actionEvaluationResult = blockEvaluator
                     .EvaluateActions(block, StateCompleterSet<T>.Reject)
                     .GetTotalDelta(ToStateKey, ToFungibleAssetKey);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -18,6 +18,7 @@ using Libplanet.Store.Trie;
 using Libplanet.Tests.Common;
 using Libplanet.Tx;
 using Xunit;
+using static Libplanet.Blockchain.KeyConverters;
 using Random = System.Random;
 
 namespace Libplanet.Tests
@@ -208,7 +209,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                     (address, currency, arg3, arg4) => new FungibleAssetValue(currency));
                 var actionEvaluationResult = blockEvaluator
                     .EvaluateActions(block, StateCompleterSet<T>.Reject)
-                    .GetTotalDelta(BlockChain<T>.ToStateKey, BlockChain<T>.ToFungibleAssetKey);
+                    .GetTotalDelta(ToStateKey, ToFungibleAssetKey);
                 var trie = new MerkleTrie(new DefaultKeyValueStore(null));
                 foreach (var pair in actionEvaluationResult)
                 {

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -211,10 +211,10 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 var actionEvaluationResult = blockEvaluator
                     .EvaluateActions(block, StateCompleterSet<T>.Reject)
                     .GetTotalDelta(ToStateKey, ToFungibleAssetKey);
-                var trie = new MerkleTrie(new DefaultKeyValueStore(null));
+                ITrie trie = new MerkleTrie(new DefaultKeyValueStore(null));
                 foreach (var pair in actionEvaluationResult)
                 {
-                    trie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
+                    trie = trie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
                 }
 
                 var stateRootHash = trie.Commit(rehearsal: true).Hash;

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -9,7 +9,6 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Crypto;
-using Libplanet.Tests.Action;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -42,14 +42,11 @@ namespace Libplanet.Action
 
         public IRandom Random { get; }
 
-        public HashDigest<SHA256>? PreviousStateRootHash
-        {
-            get
-            {
-                _previousBlockStatesTrie?.Set(PreviousStates.GetUpdatedRawStates());
-                return _previousBlockStatesTrie?.Commit().Hash;
-            }
-        }
+        public HashDigest<SHA256>? PreviousStateRootHash =>
+            _previousBlockStatesTrie?
+                .Set(PreviousStates.GetUpdatedRawStates())
+                .Commit()
+                .Hash;
 
         [Pure]
         public IActionContext GetUnconsumedContext() =>

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -10,6 +10,8 @@ namespace Libplanet.Action
         private readonly int _randomSeed;
         private readonly ITrie? _previousBlockStatesTrie;
 
+        private HashDigest<SHA256>? _previousStateRootHash;
+
         public ActionContext(
             Address signer,
             Address miner,
@@ -42,11 +44,16 @@ namespace Libplanet.Action
 
         public IRandom Random { get; }
 
-        public HashDigest<SHA256>? PreviousStateRootHash =>
-            _previousBlockStatesTrie?
-                .Set(PreviousStates.GetUpdatedRawStates())
-                .Commit()
-                .Hash;
+        public HashDigest<SHA256>? PreviousStateRootHash
+        {
+            get
+            {
+                return _previousStateRootHash ??= _previousBlockStatesTrie?
+                    .Set(PreviousStates.GetUpdatedRawStates())
+                    .Commit()
+                    .Hash;
+            }
+        }
 
         [Pure]
         public IActionContext GetUnconsumedContext() =>

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Store.Trie;
 using Libplanet.Tx;
 
 namespace Libplanet.Action
@@ -84,6 +85,8 @@ namespace Libplanet.Action
         /// <param name="rehearsal">Pass <c>true</c> if it is intended
         /// to be dry-run (i.e., the returned result will be never used).
         /// The default value is <c>false</c>.</param>
+        /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
+        /// </param>
         /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
         /// <paramref name="actions"/>.  The order is the same to the <paramref name="actions"/>.
         /// Note that each <see cref="IActionContext.Random"/> object
@@ -98,7 +101,8 @@ namespace Libplanet.Action
             Address signer,
             byte[] signature,
             IImmutableList<IAction> actions,
-            bool rehearsal = false)
+            bool rehearsal = false,
+            ITrie previousBlockStatesTrie = null)
         {
             ActionContext CreateActionContext(
                 IAccountStateDelta prevStates,
@@ -110,7 +114,8 @@ namespace Libplanet.Action
                     blockIndex: blockIndex,
                     previousStates: prevStates,
                     randomSeed: randomSeed,
-                    rehearsal: rehearsal
+                    rehearsal: rehearsal,
+                    previousBlockStatesTrie: previousBlockStatesTrie
                 );
 
             byte[] hashedSignature;

--- a/Libplanet/Action/IAccountStateDeltaExtensions.cs
+++ b/Libplanet/Action/IAccountStateDeltaExtensions.cs
@@ -1,28 +1,28 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
-using Libplanet.Action;
 using Libplanet.Assets;
 
-namespace Libplanet.Tests.Action
+namespace Libplanet.Action
 {
-    public static class AccountStateDeltaExtensions
+    internal static class IAccountStateDeltaExtensions
     {
-        public static IImmutableDictionary<Address, IValue> GetUpdatedStates(
+        internal static IImmutableDictionary<Address, IValue> GetUpdatedStates(
             this IAccountStateDelta delta
         )
         {
             return delta.StateUpdatedAddresses.Select(address =>
                 new KeyValuePair<Address, IValue>(
                     address,
-                    delta.GetState(address)
+                    delta.GetState(address)!
                 )
             ).ToImmutableDictionary();
         }
 
-        public static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
-        GetUpdatedBalances(this IAccountStateDelta delta) =>
+        internal static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
+            GetUpdatedBalances(this IAccountStateDelta delta) =>
             delta.UpdatedFungibleAssets.SelectMany(kv =>
                 kv.Value.Select(currency =>
                     new KeyValuePair<(Address, Currency), FungibleAssetValue>(

--- a/Libplanet/Action/IAccountStateDeltaExtensions.cs
+++ b/Libplanet/Action/IAccountStateDeltaExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
 using Libplanet.Assets;
+using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Action
 {
@@ -31,5 +32,18 @@ namespace Libplanet.Action
                     )
                 )
             ).ToImmutableDictionary();
+
+        internal static IImmutableDictionary<string, IValue> GetUpdatedRawStates(
+            this IAccountStateDelta delta) =>
+            delta.GetUpdatedStates()
+                .Select(pair =>
+                    new KeyValuePair<string, IValue>(
+                        ToStateKey(pair.Key),
+                        pair.Value))
+                .Union(
+                    delta.GetUpdatedBalances().Select(pair =>
+                        new KeyValuePair<string, IValue>(
+                            ToFungibleAssetKey(pair.Key),
+                            (Integer)pair.Value.RawValue))).ToImmutableDictionary();
     }
 }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System.Diagnostics.Contracts;
+using System.Security.Cryptography;
 
 namespace Libplanet.Action
 {
@@ -60,6 +62,13 @@ namespace Libplanet.Action
         /// <returns>A random object that shares interface mostly equivalent
         /// to <see cref="System.Random"/>.</returns>
         IRandom Random { get; }
+
+        /// <summary>
+        /// A state root hash at the <see cref="PreviousStates"/>.  It can cause file I/O interrupt.
+        /// It will be return null if the implementation or your chain didn't support
+        /// the state root hash feature.
+        /// </summary>
+        HashDigest<SHA256>? PreviousStateRootHash { get; }
 
         /// <summary>
         /// Returns a clone of this context, except that its <see cref="Random"/> has the unconsumed

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -385,8 +385,8 @@ namespace Libplanet.Blockchain
             var actionEvaluationResult = blockEvaluator
                 .EvaluateActions(block, StateCompleterSet<T>.Reject)
                 .GetTotalDelta(ToStateKey, ToFungibleAssetKey);
-            var trie = new MerkleTrie(new DefaultKeyValueStore(null));
-            trie.Set(actionEvaluationResult);
+            ITrie trie = new MerkleTrie(new DefaultKeyValueStore(null));
+            trie = trie.Set(actionEvaluationResult);
             var stateRootHash = trie.Commit(rehearsal: true).Hash;
 
             return new Block<T>(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -19,6 +19,7 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Serilog;
+using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Blockchain
 {
@@ -825,15 +826,6 @@ namespace Libplanet.Blockchain
                 return tx;
             }
         }
-
-        internal static string ToStateKey(Address address) => address.ToHex().ToLowerInvariant();
-
-        internal static string ToFungibleAssetKey(Address address, Currency currency) =>
-            "_" + address.ToHex().ToLowerInvariant() +
-            "_" + ByteUtil.Hex(currency.Hash.ByteArray).ToLowerInvariant();
-
-        internal static string ToFungibleAssetKey((Address, Currency) pair) =>
-            ToFungibleAssetKey(pair.Item1, pair.Item2);
 
         internal void Append(
             Block<T> block,

--- a/Libplanet/Blockchain/KeyConverters.cs
+++ b/Libplanet/Blockchain/KeyConverters.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using Libplanet.Assets;
+
+namespace Libplanet.Blockchain
+{
+    internal static class KeyConverters
+    {
+        internal static string ToStateKey(Address address) => address.ToHex().ToLowerInvariant();
+
+        internal static string ToFungibleAssetKey(Address address, Currency currency) =>
+            "_" + address.ToHex().ToLowerInvariant() +
+            "_" + ByteUtil.Hex(currency.Hash.ByteArray).ToLowerInvariant();
+
+        internal static string ToFungibleAssetKey((Address, Currency) pair) =>
+            ToFungibleAssetKey(pair.Item1, pair.Item2);
+    }
+}

--- a/Libplanet/Store/Trie/ITrie.cs
+++ b/Libplanet/Store/Trie/ITrie.cs
@@ -23,7 +23,8 @@ namespace Libplanet.Store.Trie
         /// <param name="value">The value to store.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when the given
         /// <paramref name="value"/> is <c>null</c>.</exception>
-        void Set(byte[] key, IValue value);
+        /// <returns>Returns new updated <see cref="ITrie"/>.</returns>
+        ITrie Set(byte[] key, IValue value);
 
         /// <summary>
         /// Gets the value stored with <paramref name="key"/> in <see cref="Set"/>.

--- a/Libplanet/Store/Trie/ITrieExtensions.cs
+++ b/Libplanet/Store/Trie/ITrieExtensions.cs
@@ -6,17 +6,19 @@ namespace Libplanet.Store.Trie
 {
     internal static class ITrieExtensions
     {
-        public static void Set(this ITrie trie, IImmutableDictionary<byte[], IValue> values)
+        public static ITrie Set(this ITrie trie, IImmutableDictionary<byte[], IValue> values)
         {
             foreach (var pair in values)
             {
-                trie.Set(pair.Key, pair.Value);
+                trie = trie.Set(pair.Key, pair.Value);
             }
+
+            return trie;
         }
 
-        public static void Set(this ITrie trie, IImmutableDictionary<string, IValue> values)
+        public static ITrie Set(this ITrie trie, IImmutableDictionary<string, IValue> values)
         {
-            trie.Set(values.ToImmutableDictionary(
+            return trie.Set(values.ToImmutableDictionary(
                 pair => Encoding.UTF8.GetBytes(pair.Key),
                 pair => pair.Value));
         }

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Store.Trie
 
         public HashDigest<SHA256> Hash => Root?.Hash() ?? EmptyRootHash;
 
-        private INode? Root { get; set; }
+        private INode? Root { get; }
 
         private IKeyValueStore KeyValueStore { get; }
 
@@ -80,18 +80,20 @@ namespace Libplanet.Store.Trie
             Operator.Weave(left, right);
 
         /// <inheritdoc/>
-        public void Set(byte[] key, IValue value)
+        public ITrie Set(byte[] key, IValue value)
         {
             if (value is null)
             {
                 throw new ArgumentNullException(nameof(value));
             }
 
-            Root = Insert(
+            INode newRootNode = Insert(
                 Root,
                 ImmutableArray<byte>.Empty,
                 ToKey(key).ToImmutableArray(),
                 new ValueNode(value));
+
+            return new MerkleTrie(KeyValueStore, newRootNode, _secure);
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -190,5 +190,13 @@ namespace Libplanet.Store
         /// <paramref name="blockHash"/>.</exception>
         public HashDigest<SHA256> GetRootHash(HashDigest<SHA256> blockHash)
             => new HashDigest<SHA256>(_stateHashKeyValueStore.Get(blockHash.ToByteArray()));
+
+        internal ITrie GetTrie(HashDigest<SHA256> blockHash)
+            =>
+                new MerkleTrie(
+                    _stateKeyValueStore,
+                    new HashNode(
+                        new HashDigest<SHA256>(
+                            _stateHashKeyValueStore.Get(blockHash.ToByteArray()))));
     }
 }

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Store
             IImmutableDictionary<string, IValue> states)
             where T : IAction, new()
         {
-            MerkleTrie prevStatesTrie;
+            ITrie prevStatesTrie;
             var previousBlockStateHashBytes = block.PreviousHash is null
                 ? null
                 : _stateHashKeyValueStore.Get(block.PreviousHash.Value.ToByteArray());
@@ -59,7 +59,7 @@ namespace Libplanet.Store
 
             foreach (var pair in states)
             {
-                prevStatesTrie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
+                prevStatesTrie = prevStatesTrie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
             }
 
             var newStateTrie = prevStatesTrie.Commit();


### PR DESCRIPTION
It was hard to debug when an error or some situations occurred during action execution because there was no API to know the state root hash. This pull request resolves it by providing the API.

There is one which I want to ask for your advice. The pattern which passes the getter function through the constructor is a good pattern? It can make difference between the real code and the test code and I'm not sure that the real code is testing well because of the difference. So is there another pattern to resolve it? or does it seem like wrong to worry?