### PR TITLE
Modify render automata

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.DelayedRenderer.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.DelayedRenderer.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Tests.Common.Action;
+using Serilog;
+using Serilog.Events;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public partial class BlockChainTest
+    {
+        [Fact]
+        public async Task DelayedRendererInReorg()
+        {
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var reorgLogs = new List<(
+                Block<DumbAction> OldTip,
+                Block<DumbAction> NewTip,
+                Block<DumbAction> Branchpoint
+            )>();
+            var renderLogs = new List<(bool Unrender, ActionEvaluation Evaluation)>();
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) => reorgLogs.Add((oldTip, newTip, bp)),
+                ActionRenderer = (action, context, nextStates) =>
+                    renderLogs.Add((false, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorRenderer = (act, ctx, e) =>
+                    renderLogs.Add((false, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+                ActionUnrenderer = (action, context, nextStates) =>
+                    renderLogs.Add((true, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorUnrenderer = (act, ctx, e) =>
+                    renderLogs.Add((true, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+            };
+            var delayedRenderer = new DelayedActionRenderer<DumbAction>(
+                innerRenderer, _fx.Store, 2);
+            var renderer = new LoggedActionRenderer<DumbAction>(
+                delayedRenderer,
+                Log.Logger,
+                LogEventLevel.Verbose
+            );
+
+            var chain = new BlockChain<DumbAction>(
+                _policy,
+                _fx.Store,
+                _fx.StateStore,
+                _fx.GenesisBlock,
+                renderers: new[] { renderer }
+            );
+
+            Assert.Null(delayedRenderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(renderLogs);
+
+            var key = new PrivateKey();
+
+            var tx1 = chain.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#1") });
+            await chain.MineBlock(_fx.Address1);
+
+            Assert.Null(delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#2") });
+            await chain.MineBlock(_fx.Address1);
+
+            Assert.Equal(chain[0], delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            var forked = chain.Fork(chain[0].Hash);
+            _fx.Store.StageTransactionIds(new[] { tx1.Id }.ToImmutableHashSet());
+            var block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+            _fx.Store.StageTransactionIds(new[] { tx2.Id }.ToImmutableHashSet());
+            block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+            forked.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#3") });
+            block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+            forked.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#4") });
+            block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+
+            chain.Swap(forked, true);
+
+            Assert.Equal(chain[2], delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Equal(new[] { (chain[0], chain[1]), (chain[1], chain[2]) }, blockLogs);
+            Assert.Equal(4, renderLogs.Count);
+        }
+
+        [Fact]
+        public async Task DelayedRendererAfterReorg()
+        {
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var reorgLogs = new List<(
+                Block<DumbAction> OldTip,
+                Block<DumbAction> NewTip,
+                Block<DumbAction> Branchpoint
+            )>();
+            var renderLogs = new List<(bool Unrender, ActionEvaluation Evaluation)>();
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) => reorgLogs.Add((oldTip, newTip, bp)),
+                ActionRenderer = (action, context, nextStates) =>
+                    renderLogs.Add((false, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorRenderer = (act, ctx, e) =>
+                    renderLogs.Add((false, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+                ActionUnrenderer = (action, context, nextStates) =>
+                    renderLogs.Add((true, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorUnrenderer = (act, ctx, e) =>
+                    renderLogs.Add((true, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+            };
+            var delayedRenderer = new DelayedActionRenderer<DumbAction>(
+                innerRenderer, _fx.Store, 2);
+            var renderer = new LoggedActionRenderer<DumbAction>(
+                delayedRenderer,
+                Log.Logger,
+                LogEventLevel.Verbose
+            );
+
+            var chain = new BlockChain<DumbAction>(
+                _policy,
+                _fx.Store,
+                _fx.StateStore,
+                _fx.GenesisBlock,
+                renderers: new[] { renderer }
+            );
+
+            Assert.Null(delayedRenderer.Tip);
+            Assert.Empty(blockLogs);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(renderLogs);
+
+            var key = new PrivateKey();
+
+            var tx1 = chain.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#1") });
+            await chain.MineBlock(_fx.Address1);
+
+            Assert.Null(delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(_fx.Address2, "#2") });
+            await chain.MineBlock(_fx.Address1);
+
+            Assert.Equal(chain[0], delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Empty(blockLogs);
+            Assert.Empty(renderLogs);
+
+            var forked = chain.Fork(chain[1].Hash);
+            _fx.Store.StageTransactionIds(new[] { tx2.Id }.ToImmutableHashSet());
+            var block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+            block = await forked.MineBlock(_fx.Address1, append: false);
+            forked.Append(
+                    block,
+                    DateTimeOffset.UtcNow,
+                    evaluateActions: true,
+                    renderBlocks: false,
+                    renderActions: false
+                );
+
+            chain.Swap(forked, true);
+
+            Assert.Equal(chain[1], delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Equal(new[] { (chain[0], chain[1]) }, blockLogs);
+            Assert.Equal(2, renderLogs.Count);
+
+            await chain.MineBlock(_fx.Address1);
+            Assert.Equal(chain[2], delayedRenderer.Tip);
+            Assert.Empty(reorgLogs);
+            Assert.Equal(new[] { (chain[0], chain[1]), (chain[1], chain[2]) }, blockLogs);
+            Assert.Equal(4, renderLogs.Count);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -914,7 +914,7 @@ namespace Libplanet.Tests.Blockchain
             await _blockChain.MineBlock(_fx.Address1);
             await _blockChain.MineBlock(_fx.Address1);
 
-            BlockChain<DumbAction> forked = _blockChain.Fork(_blockChain.Genesis.Hash);
+            BlockChain<DumbAction> forked = _blockChain.Fork(_blockChain.Genesis.Hash, false);
             await forked.MineBlock(_fx.Address1);
 
             BlockLocator locator = _blockChain.GetBlockLocator();
@@ -994,7 +994,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal((Text)"foo,bar", state);
 
-            var forked = _blockChain.Fork(b1.Hash);
+            var forked = _blockChain.Fork(b1.Hash, false);
             state = forked.GetState(address);
             Assert.Equal((Text)"foo", state);
 
@@ -1052,7 +1052,7 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.Append(b3);
 
             // Fork from genesis and append two empty blocks.
-            BlockChain<DumbAction> forked = _blockChain.Fork(genesis.Hash);
+            BlockChain<DumbAction> forked = _blockChain.Fork(genesis.Hash, false);
             Guid fId = forked.Id;
             Block<DumbAction> fb1 = TestUtils.MineNext(
                 genesis,
@@ -1074,7 +1074,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.BlockStatesStore.LookupStateReference(fId, stateKey2, forked.Tip.Index));
 
             // Fork from b1 and append a empty block.
-            forked = _blockChain.Fork(b1.Hash);
+            forked = _blockChain.Fork(b1.Hash, false);
             fId = forked.Id;
             fb2 = TestUtils.MineNext(b1, difficulty: b2.Difficulty);
             forked.Append(fb2);
@@ -1086,7 +1086,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.BlockStatesStore.LookupStateReference(fId, stateKey2, forked.Tip.Index));
 
             // Fork from b2.
-            forked = _blockChain.Fork(b2.Hash);
+            forked = _blockChain.Fork(b2.Hash, false);
             fId = forked.Id;
 
             Assert.Equal(
@@ -1299,7 +1299,7 @@ namespace Libplanet.Tests.Blockchain
             });
 
             BlockChain<DumbAction> fork =
-                _blockChain.Fork(_blockChain.Tip.Hash);
+                _blockChain.Fork(_blockChain.Tip.Hash, false);
 
             Transaction<DumbAction>[][] txsA =
             {
@@ -1486,7 +1486,7 @@ namespace Libplanet.Tests.Blockchain
         [InlineData(false)]
         public async Task SwapWithoutReorg(bool render)
         {
-            BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
+            BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash, false);
 
             // The lower  chain goes to the higher chain  [#N -> #N+1]
             await fork.MineBlock(default);
@@ -1497,12 +1497,12 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(prevRecords, _renderer.ReorgRecords);
         }
 
-        [Theory]
+        [Theory(Skip = "Exception should be thrown on blockchain level.")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TreatGoingBackwardAsReorg(bool render)
         {
-            BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
+            BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash, false);
 
             // The higher chain goes to the lower  chain  [#N -> #N-1]
             await _blockChain.MineBlock(default);
@@ -2413,7 +2413,7 @@ namespace Libplanet.Tests.Blockchain
         {
             _renderer.ResetRecords();
             var branchpoint = _blockChain.Tip;
-            var fork = _blockChain.Fork(_blockChain.Tip.Hash);
+            var fork = _blockChain.Fork(_blockChain.Tip.Hash, false);
             await fork.MineBlock(_fx.Address1);
             await fork.MineBlock(_fx.Address2);
             await _blockChain.MineBlock(_fx.Address3);

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -1258,7 +1258,7 @@ namespace Libplanet.Tests.Net
                 receiverChain.Append(block);
             }
 
-            var receiverForked = receiverChain.Fork(receiverChain[5].Hash);
+            var receiverForked = receiverChain.Fork(receiverChain[5].Hash, false);
             foreach (int i in Enumerable.Range(0, 20))
             {
                 await receiverForked.MineBlock(_fx1.Address1);
@@ -1307,7 +1307,7 @@ namespace Libplanet.Tests.Net
                 minerChain.Append(block);
             }
 
-            BlockChain<DumbAction> forked = minerChain.Fork(minerChain.Genesis.Hash);
+            BlockChain<DumbAction> forked = minerChain.Fork(minerChain.Genesis.Hash, false);
             while (forked.Count <= minerChain.Count)
             {
                 await forked.MineBlock(minerSwarm.Address);
@@ -1564,8 +1564,8 @@ namespace Libplanet.Tests.Net
 
             receiverStateStore.PruneStates(new[] { receiverChain.Tip.Hash }.ToImmutableHashSet());
 
-            var forked = seedChain.Fork(seedChain[5].Hash);
-            seedChain.Swap(forked, false);
+            var forked = seedChain.Fork(seedChain[5].Hash, false);
+            seedChain.Swap(forked, true);
             for (int i = 0; i < 10; i++)
             {
                 await seedChain.MineBlock(_fx1.Address1);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -72,6 +72,9 @@ namespace Libplanet.Tests.Net
                 new ValidatingActionRenderer<DumbAction>(),
                 new ValidatingActionRenderer<DumbAction>(),
                 new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
+                new ValidatingActionRenderer<DumbAction>(),
             };
 
             LoggedActionRenderer<DumbAction>[][] loggedRenderers = _renderers
@@ -95,19 +98,19 @@ namespace Libplanet.Tests.Net
                     policy,
                     _mptFx1.Store,
                     stateStore: _mptFx1.StateStore,
-                    renderers: loggedRenderers[0],
+                    renderers: loggedRenderers[4],
                     genesisBlock: genesisBlockHavingStateRoot),
                 TestUtils.MakeBlockChain(
                     policy,
                     _mptFx2.Store,
                     stateStore: _mptFx2.StateStore,
-                    renderers: loggedRenderers[1],
+                    renderers: loggedRenderers[5],
                     genesisBlock: genesisBlockHavingStateRoot),
                 TestUtils.MakeBlockChain(
                     policy,
                     _mptFx3.Store,
                     stateStore: _mptFx3.StateStore,
-                    renderers: loggedRenderers[2],
+                    renderers: loggedRenderers[6],
                     genesisBlock: genesisBlockHavingStateRoot),
             };
 
@@ -1013,11 +1016,19 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
                 await BootstrapAsync(swarmC, swarmA.AsPeer);
 
+                _logger.Debug("STEP1");
+
                 swarmB.BroadcastBlock(chainB[-1]);
+
+                _logger.Debug("STEP2");
 
                 // chainA ignores block header received because its index is shorter.
                 await swarmA.BlockHeaderReceived.WaitAsync();
+
+                _logger.Debug("STEP3");
                 await swarmC.BlockAppended.WaitAsync();
+
+                _logger.Debug("STEP4");
                 Assert.False(swarmA.BlockAppended.IsSet);
 
                 // chainB doesn't applied to chainA since chainB is shorter
@@ -1026,8 +1037,14 @@ namespace Libplanet.Tests.Net
 
                 swarmA.BroadcastBlock(chainA[-1]);
 
+                _logger.Debug("STEP5");
+
                 await swarmB.BlockAppended.WaitAsync();
+
+                _logger.Debug("STEP6");
                 await swarmC.BlockAppended.WaitAsync();
+
+                _logger.Debug("STEP7");
 
                 Log.Debug("Compare chainA and chainB");
                 Assert.Equal(chainA.BlockHashes, chainB.BlockHashes);
@@ -1095,13 +1112,13 @@ namespace Libplanet.Tests.Net
                     new[] { transactions[0] },
                     null,
                     policy.GetNextBlockDifficulty(blockChain));
-                blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
+                blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, true);
                 var block2 = TestUtils.MineNext(
                     block1,
                     new[] { transactions[1] },
                     null,
                     policy.GetNextBlockDifficulty(blockChain));
-                blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
+                blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, true);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);
                 await receiverSwarm.BlockAppended.WaitAsync();

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1767,7 +1767,7 @@ namespace Libplanet.Net
         {
             BlockChain<T> workspace = blockChain;
             var scope = new List<Guid>();
-            bool renderActions = evaluateActions;
+            bool render = evaluateActions;
 
             try
             {
@@ -1830,7 +1830,7 @@ namespace Libplanet.Net
                         workspace = workspace.Fork(branchPoint);
                         Guid workChainId = workspace.Id;
                         scope.Add(workChainId);
-                        renderActions = false;
+                        render = false;
                         _logger.Debug("Forking complete.");
                     }
 
@@ -1876,8 +1876,8 @@ namespace Libplanet.Net
                             block,
                             DateTimeOffset.UtcNow,
                             evaluateActions: evaluateActions,
-                            renderBlocks: true,
-                            renderActions: renderActions
+                            renderBlocks: render,
+                            renderActions: render
                         );
                         receivedBlockCount++;
                         progress?.Report(new BlockDownloadState


### PR DESCRIPTION
Automata has became:
```
`RenderReorg` > `UnrenderAction` > `RenderBlock` > `RenderAction` > `RenderBlockEnd` > `RenderBlock` > RenderAction` > `RenderBlockEnd` > `RenderBlock`> ... > `RenderBlockEnd` > `RenderReorgEnd`
```

Thus `ValidatingActionRenderer` and some of pre-existing tests were modified to fit in this new automata.