### PR TITLE
feat(mpt): log state root hash also when an action throws exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -236,6 +236,8 @@ To be released.
  -  Added `MerkleTrieExtensions` static class.  [[#1023]]
  -  Added `IAccountStateDelta.PreviousStateRootHash` property to
     calculate states until previous action as state root hash.  [[#1030]]
+ -  Added `UnexpectedlyTerminatedActionException.PreviousStateRootHash`
+    property.  [[#1032]]
 
 ### Behavioral changes
 
@@ -400,6 +402,7 @@ To be released.
 [#1026]: https://github.com/planetarium/libplanet/pull/1026
 [#1029]: https://github.com/planetarium/libplanet/pull/1029
 [#1030]: https://github.com/planetarium/libplanet/pull/1030
+[#1032]: https://github.com/planetarium/libplanet/pull/1032
 [#1034]: https://github.com/planetarium/libplanet/pull/1034
 [#1037]: https://github.com/planetarium/libplanet/pull/1037
 [#1039]: https://github.com/planetarium/libplanet/pull/1039

--- a/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
+++ b/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
@@ -20,6 +20,9 @@ namespace Libplanet.Tests.Action
             );
             long blockIndex = 100;
             var txId = new TxId(TestUtils.GetRandomBytes(TxId.Size));
+            var previousStateRootHash = new HashDigest<SHA256>(
+                TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)
+            );
             var action = new Sleep()
             {
                 ZoneId = 1,
@@ -29,6 +32,7 @@ namespace Libplanet.Tests.Action
                 blockHash,
                 blockIndex,
                 txId,
+                previousStateRootHash,
                 action,
                 "for testing",
                 innerExc
@@ -48,6 +52,7 @@ namespace Libplanet.Tests.Action
                 Assert.Equal(blockHash, deserialized.BlockHash);
                 Assert.Equal(blockIndex, deserialized.BlockIndex);
                 Assert.Equal(txId, deserialized.TxId);
+                Assert.Equal(previousStateRootHash, deserialized.PreviousStateRootHash);
 
                 Assert.IsType<Sleep>(deserialized.Action);
                 Assert.Equal(action.PlainValue, deserialized.Action.PlainValue);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2198,7 +2198,8 @@ namespace Libplanet.Tests.Blockchain
             var blockActionEvaluation = _blockChain.BlockEvaluator.EvaluateBlockAction(
                 genesis,
                 null,
-                StateCompleterSet<DumbAction>.Recalculate
+                StateCompleterSet<DumbAction>.Recalculate,
+                null
             );
             Assert.Equal(_blockChain.Policy.BlockAction, blockActionEvaluation.Action);
             Assert.Equal(
@@ -2219,7 +2220,8 @@ namespace Libplanet.Tests.Blockchain
             blockActionEvaluation = _blockChain.BlockEvaluator.EvaluateBlockAction(
                 block1,
                 txEvaluations,
-                StateCompleterSet<DumbAction>.Recalculate
+                StateCompleterSet<DumbAction>.Recalculate,
+                null
             );
 
             Assert.Equal((Integer)2, (Integer)blockActionEvaluation.OutputStates.GetState(miner));

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -140,31 +140,32 @@ namespace Libplanet.Action
                 }
                 catch (Exception e)
                 {
-                    string msg;
-                    if (!rehearsal)
+                    if (rehearsal)
                     {
-                        // FIXME: The below "exc" object seems never used; Hong Minhee believes
-                        // this code's behavior does not follow the intention.
-                        msg = $"The action {action} (block #{blockIndex} {blockHash}, tx {txid}) " +
-                              "threw an exception during execution.  See also this exception's " +
-                              "InnerException property.";
+                        var msg =
+                            $"The action {action} threw an exception during its " +
+                            "rehearsal.  It is probably because the logic of the " +
+                            $"action {action} is not enough generic so that it " +
+                            "can cover every case including rehearsal mode.\n" +
+                            "The IActionContext.Rehearsal property also might be " +
+                            "useful to make the action can deal with the case of " +
+                            "rehearsal mode.\n" +
+                            "See also this exception's InnerException property.";
                         exc = new UnexpectedlyTerminatedActionException(
-                            blockHash, blockIndex, txid, action, msg, e
+                            null, null, null, null, action, msg, e
                         );
                     }
-
-                    msg =
-                        $"The action {action} threw an exception during its " +
-                        "rehearsal.  It is probably because the logic of the " +
-                        $"action {action} is not enough generic so that it " +
-                        "can cover every case including rehearsal mode.\n" +
-                        "The IActionContext.Rehearsal property also might be " +
-                        "useful to make the action can deal with the case of " +
-                        "rehearsal mode.\n" +
-                        "See also this exception's InnerException property.";
-                    exc = new UnexpectedlyTerminatedActionException(
-                        null, null, null, action, msg, e
-                    );
+                    else
+                    {
+                        var stateRootHash = context.PreviousStateRootHash;
+                        var msg =
+                            $"The action {action} (block #{blockIndex} {blockHash}, tx {txid}, " +
+                            $"state root hash {stateRootHash}) threw an exception " +
+                            "during execution.  See also this exception's InnerException property.";
+                        exc = new UnexpectedlyTerminatedActionException(
+                            blockHash, blockIndex, txid, stateRootHash, action, msg, e
+                        );
+                    }
                 }
 
                 // As IActionContext.Random is stateful, we cannot reuse

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -352,6 +352,8 @@ namespace Libplanet.Blocks
         /// get previous account balance.
         /// A <c>null</c> value, which is default, means a constant function that returns zero.
         /// </param>
+        /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
+        /// </param>
         /// <returns>Enumerates pair of a transaction, and
         /// <see cref="ActionEvaluation"/> for each action.
         /// The order of pairs are the same to
@@ -366,7 +368,8 @@ namespace Libplanet.Blocks
         public
         IEnumerable<Tuple<Transaction<T>, ActionEvaluation>> EvaluateActionsPerTx(
             AccountStateGetter accountStateGetter = null,
-            AccountBalanceGetter accountBalanceGetter = null
+            AccountBalanceGetter accountBalanceGetter = null,
+            ITrie previousBlockStatesTrie = null
         )
         {
             accountStateGetter ??= a => null;
@@ -385,7 +388,8 @@ namespace Libplanet.Blocks
                         PreEvaluationHash,
                         Index,
                         delta,
-                        Miner.Value);
+                        Miner.Value,
+                        previousBlockStatesTrie: previousBlockStatesTrie);
                 foreach (var evaluation in evaluations)
                 {
                     yield return Tuple.Create(tx, evaluation);
@@ -419,6 +423,8 @@ namespace Libplanet.Blocks
         /// A <c>null</c> value, which is default, means a constant function that returns zero.
         /// This affects the execution of <see cref="Transaction{T}.Actions"/>.
         /// </param>
+        /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
+        /// </param>
         /// <returns>An <see cref="ActionEvaluation"/> for each
         /// <see cref="IAction"/>.</returns>
         /// <exception cref="InvalidBlockTimestampException">Thrown when
@@ -450,7 +456,8 @@ namespace Libplanet.Blocks
         public IEnumerable<ActionEvaluation> Evaluate(
             DateTimeOffset currentTime,
             AccountStateGetter accountStateGetter = null,
-            AccountBalanceGetter accountBalanceGetter = null
+            AccountBalanceGetter accountBalanceGetter = null,
+            ITrie previousBlockStatesTrie = null
         )
         {
             accountStateGetter ??= a => null;
@@ -458,7 +465,8 @@ namespace Libplanet.Blocks
 
             Validate(currentTime);
             Tuple<Transaction<T>, ActionEvaluation>[] txEvaluations =
-                EvaluateActionsPerTx(accountStateGetter, accountBalanceGetter).ToArray();
+                EvaluateActionsPerTx(
+                    accountStateGetter, accountBalanceGetter, previousBlockStatesTrie).ToArray();
 
             var txUpdatedAddressesPairs = txEvaluations
                     .GroupBy(tuple => tuple.Item1)

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -10,6 +10,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Crypto;
+using Libplanet.Store.Trie;
 
 namespace Libplanet.Tx
 {
@@ -520,6 +521,8 @@ namespace Libplanet.Tx
         /// <param name="rehearsal">Pass <c>true</c> if it is intended
         /// to be dry-run (i.e., the returned result will be never used).
         /// The default value is <c>false</c>.</param>
+        /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
+        /// </param>
         /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
         /// <see cref="Actions"/>.
         /// The order is the same to the <see cref="Actions"/>.
@@ -533,7 +536,8 @@ namespace Libplanet.Tx
             long blockIndex,
             IAccountStateDelta previousStates,
             Address minerAddress,
-            bool rehearsal = false
+            bool rehearsal = false,
+            ITrie previousBlockStatesTrie = null
         )
         {
             return ActionEvaluation.EvaluateActionsGradually(
@@ -545,7 +549,8 @@ namespace Libplanet.Tx
                 Signer,
                 Signature,
                 Actions.Cast<IAction>().ToImmutableList(),
-                rehearsal);
+                rehearsal,
+                previousBlockStatesTrie);
        }
 
         /// <summary>


### PR DESCRIPTION
This must be merged after #1030 merged.

This fixed an issue that it throws an exception with a message like rehearsal mode though it was not on rehearsal mode. Also the message became to provide the state root hash also.