### PR TITLE
LAA1002: DictionariesOrSetsShouldBeOrderedToEnumerate

### DIFF
--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -53,29 +53,57 @@ namespace Libplanet.Analyzers.Tests
         [Theory]
         [InlineData(
             false,
+            null,
+            "int",
             "System.Collections.Generic.HashSet<int>",
             "new HashSet<int> { 1, 2, 3 }"
         )]
         [InlineData(
             false,
+            "string, int",
+            "System.Collections.Generic.KeyValuePair<string, int>",
             "System.Collections.Generic.Dictionary<string, int>",
-            "new Dictionary<string, int> { [\"foo\"] = 1, [\"bar\"] = 2}"
+            "new Dictionary<string, int> { [\"foo\"] = 1, [\"bar\"] = 2 }"
         )]
         [InlineData(
             true,
+            null,
+            "int",
             "System.Collections.Generic.List<int>",
             "new List<int> { 1, 2, 3 }"
         )]
-        [InlineData(true, "char[]", "new char[] { 'a', 'b', 'c' }")]
+        [InlineData(true, null, "char", "char[]", "new char[] { 'a', 'b', 'c' }")]
+        [InlineData(
+            false,
+            "Bencodex.Types.IKey, Bencodex.Types.IValue",
+            "System.Collections.Generic.KeyValuePair<Bencodex.Types.IKey, Bencodex.Types.IValue>",
+            "Bencodex.Types.Dictionary",
+            "new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue> { })"
+        )]
         public void LAA1002_DictionariesOrSetsShouldBeOrderedToEnumerate(
             bool pass,
+            string kvTypes,
+            string elemType,
             string typeName,
             string expr
         )
         {
+            string dictCode = string.Empty;
+
+            if (!(kvTypes is null))
+            {
+                dictCode = @"
+                    // should pass:
+                    v.ToDictionary(key => key, val => val);
+                    v.ToImmutableDictionary();
+                    var newDict = new Dictionary<" + kvTypes + @">(v);
+";
+            }
+
             var test = @"
                 using System;
                 using System.Collections.Generic;
+                using System.Collections.Immutable;
                 using System.Linq;
                 using System.Security.Cryptography;
                 using Bencodex.Types;
@@ -87,19 +115,26 @@ namespace Libplanet.Analyzers.Tests
                         public IValue PlainValue => default(Null);
                         public void LoadPlainValue(IValue plainValue) {}
                         public IAccountStateDelta Execute(IActionContext context) {
+                            // Following code should all fail:
                             var v = " + expr + @";
                             ConsumeEnumerable(v);
                             var a = v.ToArray();
+                            var randomlySorted = new List<" + elemType + @">(v);
                             foreach (var e in v) Console.WriteLine(e.ToString());
+
                             // Following code should all pass:
                             ConsumeEnumerable(v.OrderBy(e => e));
                             var orderedArray = v.OrderBy(e => e).ToArray();
                             foreach (var e in v.OrderBy(e => e)) {
                                 Console.WriteLine(e.ToString());
                             }
+                            v.ToHashSet();
+                            v.ToImmutableHashSet();
+                            var newSet = new HashSet<" + elemType + @">(v);
+                            " + dictCode + @"
                             return context.PreviousStates;
                         }
-                        public void ConsumeEnumerable<T>(IEnumerable<T> it) {}
+                        public void ConsumeEnumerable(IEnumerable<" + elemType + @"> it) {}
                         public static void Main() {}
                     }
                 }
@@ -112,30 +147,41 @@ namespace Libplanet.Analyzers.Tests
             }
 
             string message = $"Enumerating an instance of {typeName} is indeterministic since " +
-                $"the order of {typeName} is unspecified; explicitly sort them before " +
-                "enumerating.";
+                $"the order of {typeName} is unspecified; explicitly sort them before";
             DiagnosticResult[] expected =
             {
                 new DiagnosticResult
                 {
                     Id = "LAA1002",
-                    Message = message,
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations = new[] { new DiagnosticResultLocation(16, 47) },
-                },
-                new DiagnosticResult
-                {
-                    Id = "LAA1002",
-                    Message = message,
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations = new[] { new DiagnosticResultLocation(17, 37) },
-                },
-                new DiagnosticResult
-                {
-                    Id = "LAA1002",
-                    Message = message,
+                    Message =
+                        $"{message} passing to SampleGame.SampleAction.ConsumeEnumerable(" +
+                        $"System.Collections.Generic.IEnumerable<{elemType}>) method.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation(18, 47) },
+                },
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message = $"{message} passing to System.Linq.Enumerable.ToArray<{elemType}>(" +
+                        $"System.Collections.Generic.IEnumerable<{elemType}>) method.",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(19, 37) },
+                },
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message =
+                        $"{message} passing to System.Collections.Generic.List<{elemType}>." +
+                        $"List(System.Collections.Generic.IEnumerable<{elemType}>) constructor.",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(20, 61 + elemType.Length) },
+                },
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message = $"{message} iterating via foreach.",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(21, 47) },
                 },
             };
 

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -96,7 +96,7 @@ namespace Libplanet.Analyzers.Tests
                     // should pass:
                     v.ToDictionary(key => key, val => val);
                     v.ToImmutableDictionary();
-                    var newDict = new Dictionary<" + kvTypes + @">(v);
+                    var newDict = new Dict(v);
 ";
             }
 
@@ -139,6 +139,19 @@ namespace Libplanet.Analyzers.Tests
                     }
                 }
             ";
+
+            if (!(kvTypes is null))
+            {
+                test += @"
+                    public class Dict : Dictionary<" + kvTypes + @"> {
+                        public Dict(IEnumerable<" + elemType + @"> kvs) : base() {
+                            foreach (var kv in kvs) {
+                                Add(kv.Key, kv.Value);
+                            }
+                        }
+                    }
+                ";
+            }
 
             if (pass)
             {

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -1,4 +1,3 @@
-using System;
 using Libplanet.Analyzers.Tests.Helpers;
 using Libplanet.Analyzers.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
@@ -12,7 +11,11 @@ namespace Libplanet.Analyzers.Tests
         [Fact]
         public void EmptyCode()
         {
-            VerifyDiagnostic(" ");
+            VerifyDiagnostic(@"
+                public class Sample {
+                    public static void Main() {}
+                }
+            ");
         }
 
         [Fact]
@@ -20,16 +23,18 @@ namespace Libplanet.Analyzers.Tests
         {
             var test = @"
                 using System;
-                using Bencodex;
+                using Bencodex.Types;
                 using Libplanet.Action;
                 namespace SampleGame {
                     public class SampleAction : IAction {
-                        IValue PlainValue => default(Null);
-                        public void LoadPlainValue(IValue plainValue) { }
+                        public SampleAction() {}
+                        public IValue PlainValue => default(Null);
+                        public void LoadPlainValue(IValue plainValue) {}
                         public IAccountStateDelta Execute(IActionContext context) {
                             new Random().Next();
                             return context.PreviousStates;
                         }
+                        public static void Main() {}
                     }
                 }
             ";
@@ -39,7 +44,99 @@ namespace Libplanet.Analyzers.Tests
                 Message = "The System.Random makes an IAction indeterministic; " +
                     "use IActionContext.Random property instead.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation(10, 29) },
+                Locations = new[] { new DiagnosticResultLocation(11, 29) },
+            };
+
+            VerifyDiagnostic(test, expected);
+        }
+
+        [Theory]
+        [InlineData(
+            false,
+            "System.Collections.Generic.HashSet<int>",
+            "new HashSet<int> { 1, 2, 3 }"
+        )]
+        [InlineData(
+            false,
+            "System.Collections.Generic.Dictionary<string, int>",
+            "new Dictionary<string, int> { [\"foo\"] = 1, [\"bar\"] = 2}"
+        )]
+        [InlineData(
+            true,
+            "System.Collections.Generic.List<int>",
+            "new List<int> { 1, 2, 3 }"
+        )]
+        [InlineData(true, "char[]", "new char[] { 'a', 'b', 'c' }")]
+        public void LAA1002_DictionariesOrSetsShouldBeOrderedToEnumerate(
+            bool pass,
+            string typeName,
+            string expr
+        )
+        {
+            var test = @"
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+                using System.Security.Cryptography;
+                using Bencodex.Types;
+                using Libplanet;
+                using Libplanet.Action;
+                namespace SampleGame {
+                    public class SampleAction : IAction {
+                        public SampleAction() {}
+                        public IValue PlainValue => default(Null);
+                        public void LoadPlainValue(IValue plainValue) {}
+                        public IAccountStateDelta Execute(IActionContext context) {
+                            var v = " + expr + @";
+                            ConsumeEnumerable(v);
+                            var a = v.ToArray();
+                            foreach (var e in v) Console.WriteLine(e.ToString());
+                            // Following code should all pass:
+                            ConsumeEnumerable(v.OrderBy(e => e));
+                            var orderedArray = v.OrderBy(e => e).ToArray();
+                            foreach (var e in v.OrderBy(e => e)) {
+                                Console.WriteLine(e.ToString());
+                            }
+                            return context.PreviousStates;
+                        }
+                        public void ConsumeEnumerable<T>(IEnumerable<T> it) {}
+                        public static void Main() {}
+                    }
+                }
+            ";
+
+            if (pass)
+            {
+                VerifyDiagnostic(test);
+                return;
+            }
+
+            string message = $"Enumerating an instance of {typeName} is indeterministic since " +
+                $"the order of {typeName} is unspecified; explicitly sort them before " +
+                "enumerating.";
+            DiagnosticResult[] expected =
+            {
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message = message,
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(16, 47) },
+                },
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message = message,
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(17, 37) },
+                },
+                new DiagnosticResult
+                {
+                    Id = "LAA1002",
+                    Message = message,
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation(18, 47) },
+                },
             };
 
             VerifyDiagnostic(test, expected);

--- a/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.Helper.cs
@@ -224,7 +224,17 @@ namespace Libplanet.Analyzers.Tests.Verifiers
                 {
                     if (!registry.ContainsKey(@ref.FullName))
                     {
-                        Register(Assembly.Load(@ref));
+                        Assembly dep;
+                        try
+                        {
+                            dep = Assembly.Load(@ref);
+                        }
+                        catch (FileNotFoundException)
+                        {
+                            continue;
+                        }
+
+                        Register(dep);
                     }
                 }
             }

--- a/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.Helper.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Libplanet.Analyzers.Tests.Verifiers
@@ -15,22 +17,10 @@ namespace Libplanet.Analyzers.Tests.Verifiers
     /// </summary>
     public abstract partial class DiagnosticVerifier
     {
-        internal static string DefaultFilePathPrefix = "Test";
-        internal static string CSharpDefaultFileExt = "cs";
-        internal static string VisualBasicDefaultExt = "vb";
-        internal static string TestProjectName = "TestProject";
-
-        private static readonly MetadataReference CorlibReference =
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-
-        private static readonly MetadataReference SystemCoreReference =
-            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
-
-        private static readonly MetadataReference CSharpSymbolsReference =
-            MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
-
-        private static readonly MetadataReference CodeAnalysisReference =
-            MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        internal const string DefaultFilePathPrefix = "Test";
+        internal const string CSharpDefaultFileExt = "cs";
+        internal const string VisualBasicDefaultExt = "vb";
+        internal const string TestProjectName = "TestProject";
 
         /// <summary>
         /// Given an analyzer and a document to apply it to, run the analyzer and gather an array of
@@ -55,7 +45,19 @@ namespace Libplanet.Analyzers.Tests.Verifiers
             var diagnostics = new List<Diagnostic>();
             foreach (var project in projects)
             {
-                var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(
+                Compilation result = project.GetCompilationAsync().Result;
+                EmitResult emitted = result.Emit(new MemoryStream());
+                if (!emitted.Success)
+                {
+                    throw new InvalidOperationException(
+                        "Failed to compile:\n" + string.Join(
+                            "\n",
+                            emitted.Diagnostics.Select(d => $"\t{d.ToString()}")
+                        )
+                    );
+                }
+
+                var compilationWithAnalyzers = result.WithAnalyzers(
                     ImmutableArray.Create(analyzer));
                 var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
                 foreach (var diag in diags)
@@ -172,11 +174,19 @@ namespace Libplanet.Analyzers.Tests.Verifiers
 
             var solution = new AdhocWorkspace()
                 .CurrentSolution
-                .AddProject(projectId, TestProjectName, TestProjectName, language)
-                .AddMetadataReference(projectId, CorlibReference)
-                .AddMetadataReference(projectId, SystemCoreReference)
-                .AddMetadataReference(projectId, CSharpSymbolsReference)
-                .AddMetadataReference(projectId, CodeAnalysisReference);
+                .AddProject(projectId, TestProjectName, TestProjectName, language);
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.IsDynamic)
+                {
+                    continue;
+                }
+
+                solution = solution.AddMetadataReference(
+                    projectId,
+                    MetadataReference.CreateFromFile(assembly.Location)
+                );
+            }
 
             int count = 0;
             foreach (var source in sources)

--- a/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/Libplanet.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
@@ -158,8 +158,8 @@ namespace Libplanet.Analyzers.Tests.Verifiers
             Assert.True(
                 actualSpan.Path == expected.Path || (
                     actualSpan.Path != null &&
-                    actualSpan.Path.Contains("Test0.") &&
-                    expected.Path.Contains("Test.")
+                    actualSpan.Path.Contains($"{DefaultFilePathPrefix}0.") &&
+                    expected.Path.Contains($"{DefaultFilePathPrefix}.")
                 ),
                 msg
             );

--- a/Libplanet.Analyzers/ActionAnalyzer.cs
+++ b/Libplanet.Analyzers/ActionAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Libplanet.Action;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -42,6 +43,16 @@ namespace Libplanet.Analyzers
                 isEnabledByDefault: true,
                 helpLinkUri: $"{HelpLinkUriPrefix}1001.md"
             ),
+            new DiagnosticDescriptor(
+                id: $"{IdPrefix}1002",
+                title: "DictionariesOrSetsShouldBeOrderedToEnumerate",
+                messageFormat: "Enumerating an instance of {0} is indeterministic since " +
+                    "the order of {0} is unspecified; explicitly sort them before enumerating.",
+                category: "Determinism",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: $"{HelpLinkUriPrefix}1002.md"
+            ),
         };
 #pragma warning restore SA1118
 
@@ -56,21 +67,112 @@ namespace Libplanet.Analyzers
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
             context.RegisterOperationAction(LAA1001_SystemRandom, OperationKind.ObjectCreation);
+            context.RegisterOperationAction(
+                LAA1002_DictionarySetEnumeration,
+                OperationKind.Conversion,
+                OperationKind.Loop
+            );
         }
 
         private static void LAA1001_SystemRandom(OperationAnalysisContext context)
         {
-            if (context.Operation is IObjectCreationOperation op)
+            if (context.Operation is IObjectCreationOperation op &&
+                context.Compilation.GetTypeByMetadataName("System.Random") is ITypeSymbol ts &&
+                op.Type is ITypeSymbol opType &&
+                SymbolEqualityComparer.Default.Equals(opType, ts))
             {
-                string cls = op.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                if (cls.Equals("global::System.Random"))
-                {
-                    Diagnostic diag = Diagnostic.Create(
-                        Rules[$"{IdPrefix}1001"],
-                        op.Syntax.GetLocation(),
-                        cls.Substring(8)
+                Diagnostic diag = Diagnostic.Create(
+                    Rules[$"{IdPrefix}1001"],
+                    op.Syntax.GetLocation(),
+                    ts.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                );
+                context.ReportDiagnostic(diag);
+            }
+        }
+
+        private static void LAA1002_DictionarySetEnumeration(OperationAnalysisContext context)
+        {
+            const string ns = "System.Collections";
+            Compilation comp = context.Compilation;
+            SymbolEqualityComparer comparer = SymbolEqualityComparer.Default;
+
+            bool TypeEquals(ITypeSymbol? valType, string metadataName) => valType is ITypeSymbol a
+                && comp.GetTypeByMetadataName(metadataName) is INamedTypeSymbol b
+                && comparer.Equals(a, b);
+
+            string[] dictOrSets =
+            {
+                $"{ns}.Generic.IDictionary`2",
+                $"{ns}.Generic.IReadOnlyDictionary`2",
+                $"{ns}.Immutable.IImmutableDictionary`2",
+                $"{ns}.IDictionary",
+                $"{ns}.Generic.ISet`1",
+                $"{ns}.Immutable.IImmutableSet`1",
+            };
+
+            bool IsDictOrSet(ITypeSymbol? valType) => valType is ITypeSymbol t &&
+                t.OriginalDefinition.AllInterfaces
+                    .OfType<ITypeSymbol>()
+                    .Select(ifce => ifce.OriginalDefinition)
+                    .OfType<ITypeSymbol>()
+                    .Any(i => dictOrSets.Any(dst => TypeEquals(i, dst))
                     );
-                    context.ReportDiagnostic(diag);
+
+            switch (context.Operation)
+            {
+                case IConversionOperation conv:
+                {
+                    ITypeSymbol? endType = conv.Type;
+                    if (!TypeEquals(endType?.OriginalDefinition, $"{ns}.Generic.IEnumerable`1") &&
+                        !TypeEquals(endType, $"{ns}.IEnumerable"))
+                    {
+                        return;
+                    }
+
+                    if (conv.Parent is IArgumentOperation arg &&
+                        arg.Parent is IInvocationOperation invoke &&
+                        invoke.TargetMethod.IsGenericMethod &&
+                        invoke.TargetMethod.Name.StartsWith("OrderBy") &&
+                        invoke.TargetMethod.OriginalDefinition is IMethodSymbol proto &&
+                        TypeEquals(proto.ContainingType, "System.Linq.Enumerable") &&
+                        TypeEquals(
+                            proto.ReturnType.OriginalDefinition,
+                            "System.Linq.IOrderedEnumerable`1"
+                        ))
+                    {
+                        // Ignores Linq's .OrderBy()/OrderByDescending() methods.
+                        return;
+                    }
+
+                    ITypeSymbol? valType = conv.Operand?.Type;
+                    if (IsDictOrSet(valType))
+                    {
+                        Diagnostic diag = Diagnostic.Create(
+                            Rules[$"{IdPrefix}1002"],
+                            conv.Syntax.GetLocation(),
+                            valType!.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                        );
+                        context.ReportDiagnostic(diag);
+                    }
+
+                    break;
+                }
+
+                case IForEachLoopOperation loop:
+                {
+                    IOperation collection = loop.Collection;
+                    ITypeSymbol? collType = collection.Type;
+                    if (IsDictOrSet(collType))
+                    {
+                        Diagnostic diag = Diagnostic.Create(
+                            Rules[$"{IdPrefix}1002"],
+                            collection.Syntax.GetLocation(),
+                            collType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                        );
+                        context.ReportDiagnostic(diag);
+                    }
+
+                    break;
                 }
             }
         }

--- a/Libplanet.Analyzers/README.md
+++ b/Libplanet.Analyzers/README.md
@@ -33,3 +33,4 @@ Rules
 | Rule                        |                                                |
 |-----------------------------|------------------------------------------------|
 | [LAA1001](rules/LAA1001.md) | SystemRandomBreaksActionDeterminism            |
+| [LAA1002](rules/LAA1002.md) | DictionariesOrSetsShouldBeOrderedToEnumerate   |

--- a/Libplanet.Analyzers/rules/LAA1002.md
+++ b/Libplanet.Analyzers/rules/LAA1002.md
@@ -1,0 +1,53 @@
+<def>LAA1002</def>: DictionariesOrSetsShouldBeOrderedToEnumerate
+================================================================
+
+Since there is no explicit order to enumerate dictionaries or sets,
+enumerating them breaks `IAction`'s determinism.  They should be explicitly
+ordered before being enumerated.
+
+Applied interfaces are:
+
+ -  `System.Collections.Generic.IDictionary<K, V>`
+ -  `System.Collections.Generic.IReadOnlyDictionary<K, V>`
+ -  `System.Collections.Generic.ISet<V>`
+ -  `System.Collections.Immutable.IImmutableSet<V>`
+ -  `System.Collections.IDictionary`
+
+
+Examples
+--------
+
+The following code is warned by the rule LAA1002:
+
+~~~~ csharp
+public IAccountStateDelta Execute(IActionContext context)
+{
+    var states = context.PreviousStates;
+    if (states.GetState(_address) is Bencodex.Types.Dictionary d)
+    {
+        string list = d.Keys
+            .OfType<Bencodex.Types.Text>(k => k.Value);  // LAA1002
+        states.SetState(_targetAddress, (Bencodex.Types.Text)list);
+    }
+
+    return states;
+}
+~~~~
+
+This can be addressed like below:
+
+~~~~ csharp
+public IAccountStateDelta Execute(IActionContext context)
+{
+    var states = context.PreviousStates;
+    if (states.GetState(_address) is Bencodex.Types.Dictionary d)
+    {
+        string list = d.Keys
+            .OfType<Bencodex.Types.Text>(k => k.Value)
+            .OrderBy(k => k);  // Fixed
+        states.SetState(_targetAddress, (Bencodex.Types.Text)list);
+    }
+
+    return states;
+}
+~~~~


### PR DESCRIPTION
Added a new rule to ensure if dictionaries or sets are ordered before they are enumerated.  See also the docs in *LAA1002.md* file.

FYI, with this rule, Lib9c has the below warnings (though there are quite many false alarms yet):

```
Action/SellCancellation.cs(50,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/AttachmentActionResult.cs(47,43): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/Sell.cs(24,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/SellCancellation.cs(43,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/Buy.cs(87,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/ChargeActionPoint.cs(53,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/Buy.cs(51,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/RewardGold.cs(17,43): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/CombinationConsumable.cs(84,24): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/CombinationConsumable.cs(53,32): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/Buy.cs(79,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
ReorgMiner.cs(89,43): error LAA1002: Enumerating an instance of System.Collections.Generic.HashSet<Libplanet.Tx.Transaction<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>> is indeterministic since the order of System.Collections.Generic.HashSet<Libplanet.Tx.Transaction<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>> is unspecified; explicitly sort them before enumerating.
Action/CreateAvatar.cs(31,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/CombinationEquipment.cs(221,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/DailyReward.cs(46,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/WorldInformation.cs(215,50): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.WorldInformation.World> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.WorldInformation.World> is unspecified; explicitly sort them before enumerating.
Model/WorldInformation.cs(282,21): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.WorldInformation.World> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.WorldInformation.World> is unspecified; explicitly sort them before enumerating.
Action/RedeemCode.cs(113,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Miner.cs(68,43): error LAA1002: Enumerating an instance of System.Collections.Generic.HashSet<Libplanet.Tx.Transaction<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>> is indeterministic since the order of System.Collections.Generic.HashSet<Libplanet.Tx.Transaction<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>> is unspecified; explicitly sort them before enumerating.
Action/HackAndSlash.cs(33,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/RapidCombination.cs(113,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/RapidCombination.cs(36,32): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Character/CharacterBase.cs(394,18): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, int> is indeterministic since the order of System.Collections.Generic.Dictionary<int, int> is unspecified; explicitly sort them before enumerating.
Model/Character/CharacterBase.cs(106,34): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Buff.Buff> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Buff.Buff> is unspecified; explicitly sort them before enumerating.
Model/Character/CharacterBase.cs(156,34): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Buff.Buff> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Buff.Buff> is unspecified; explicitly sort them before enumerating.
Action/RankingBattle.cs(162,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/WorldInformation.cs(78,54): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
TableData/Item/CostumeItemSheet.cs(32,81): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/CollectionMap.cs(56,20): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, int> is indeterministic since the order of System.Collections.Generic.Dictionary<int, int> is unspecified; explicitly sort them before enumerating.
TableData/Item/ConsumableItemSheet.cs(46,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/QuestReward.cs(68,87): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/InitializeStates.cs(168,51): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, string> is indeterministic since the order of System.Collections.Generic.Dictionary<string, string> is unspecified; explicitly sort them before enumerating.
Action/InitializeStates.cs(87,26): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, string> is indeterministic since the order of System.Collections.Generic.Dictionary<string, string> is unspecified; explicitly sort them before enumerating.
Action/InitializeStates.cs(90,26): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is unspecified; explicitly sort them before enumerating.
Action/InitializeStates.cs(117,22): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, string> is indeterministic since the order of System.Collections.Generic.Dictionary<string, string> is unspecified; explicitly sort them before enumerating.
Action/InitializeStates.cs(120,22): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is unspecified; explicitly sort them before enumerating.
TableData/Item/EquipmentItemSetEffectSheet.cs(53,24): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Stat.StatModifier> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Stat.StatModifier> is unspecified; explicitly sort them before enumerating.
Model/Quest/TradeQuest.cs(48,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/ShopItem.cs(46,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/QuestReward.cs(17,23): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, int> is indeterministic since the order of System.Collections.Generic.Dictionary<int, int> is unspecified; explicitly sort them before enumerating.
Model/Quest/CollectQuest.cs(57,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/CombinationEquipmentQuest.cs(66,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Mail/AttachmentMail.cs(29,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Material.cs(66,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
TableData/RedeemRewardSheet.cs(59,39): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/ItemEnhancement.cs(55,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/WeeklyArenaState.cs(398,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Mail/Mail.cs(56,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/ItemUsable.cs(117,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Action/ItemEnhancement.cs(302,24): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<string, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/CombinationQuest.cs(61,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/WeeklyArenaState.cs(73,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/WeeklyArenaState.cs(75,48): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.ArenaInfo> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.ArenaInfo> is unspecified; explicitly sort them before enumerating.
TableData/Item/EquipmentItemSetEffectSheet.cs(78,41): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, int> is indeterministic since the order of System.Collections.Generic.Dictionary<int, int> is unspecified; explicitly sort them before enumerating.
TableData/Item/EquipmentItemSetEffectSheet.cs(83,50): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Stat.StatModifier> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Nekoyume.Model.Stat.StatModifier> is unspecified; explicitly sort them before enumerating.
TableData/Item/EquipmentItemSheet.cs(46,81): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/QuestReward.cs(31,13): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, int> is indeterministic since the order of System.Collections.Generic.Dictionary<int, int> is unspecified; explicitly sort them before enumerating.
TableData/Quest/QuestSheet.cs(28,47): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Skill/Skill.cs(84,43): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/GeneralQuest.cs(77,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Consumable.cs(32,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Chest.cs(36,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/GoldQuest.cs(65,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/ItemEnhancementQuest.cs(66,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/WeeklyArenaState.cs(225,20): error LAA1002: Enumerating an instance of System.Collections.Generic.HashSet<Libplanet.Address> is indeterministic since the order of System.Collections.Generic.HashSet<Libplanet.Address> is unspecified; explicitly sort them before enumerating.
Model/State/WeeklyArenaState.cs(254,20): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.ArenaInfo> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.ArenaInfo> is unspecified; explicitly sort them before enumerating.
Model/Quest/ItemTypeCollectQuest.cs(67,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/ItemGradeQuest.cs(65,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Costume.cs(34,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/Quest.cs(356,53): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Equipment.cs(66,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Item/Inventory.cs(83,54): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/Quest.cs(90,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Quest/MonsterQuest.cs(57,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/StateExtensions.cs(249,17): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.HashDigest<System.Security.Cryptography.SHA256>, int> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.HashDigest<System.Security.Cryptography.SHA256>, int> is unspecified; explicitly sort them before enumerating.
Model/Stat/StatsMap.cs(153,17): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Nekoyume.Model.Stat.StatType, Nekoyume.Model.Stat.StatMapEx> is indeterministic since the order of System.Collections.Generic.Dictionary<Nekoyume.Model.Stat.StatType, Nekoyume.Model.Stat.StatMapEx> is unspecified; explicitly sort them before enumerating.
Model/State/ActivatedAccountsState.cs(54,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Stat/StatMapEx.cs(69,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/Stat/StatMap.cs(66,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/AdminState.cs(37,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/State.cs(33,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/ShopState.cs(34,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/ShopState.cs(37,21): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<System.Guid, Nekoyume.Model.Item.ShopItem> is indeterministic since the order of System.Collections.Generic.Dictionary<System.Guid, Nekoyume.Model.Item.ShopItem> is unspecified; explicitly sort them before enumerating.
Model/State/RedeemCodeState.cs(47,39): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/AgentState.cs(44,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/AgentState.cs(47,21): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<int, Libplanet.Address> is indeterministic since the order of System.Collections.Generic.Dictionary<int, Libplanet.Address> is unspecified; explicitly sort them before enumerating.
Model/State/AgentState.cs(54,45): error LAA1002: Enumerating an instance of System.Collections.Generic.HashSet<int> is indeterministic since the order of System.Collections.Generic.HashSet<int> is unspecified; explicitly sort them before enumerating.
Model/State/RankingState.cs(23,41): error LAA1002: Enumerating an instance of System.Collections.Generic.HashSet<Libplanet.Address> is indeterministic since the order of System.Collections.Generic.HashSet<Libplanet.Address> is unspecified; explicitly sort them before enumerating.
Model/State/RedeemCodeState.cs(77,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/RedeemCodeState.cs(79,49): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Crypto.PublicKey, Nekoyume.Model.State.RedeemCodeState.Reward> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Crypto.PublicKey, Nekoyume.Model.State.RedeemCodeState.Reward> is unspecified; explicitly sort them before enumerating.
Model/State/RankingState.cs(57,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/RankingState.cs(59,56): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, System.Collections.Immutable.ImmutableHashSet<Libplanet.Address>> is unspecified; explicitly sort them before enumerating.
Model/State/RankingState.cs(63,34): error LAA1002: Enumerating an instance of System.Collections.Immutable.ImmutableHashSet<Libplanet.Address> is indeterministic since the order of System.Collections.Immutable.ImmutableHashSet<Libplanet.Address> is unspecified; explicitly sort them before enumerating.
Model/State/RankingMapState.cs(58,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/RankingMapState.cs(60,49): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.RankingInfo> is indeterministic since the order of System.Collections.Generic.Dictionary<Libplanet.Address, Nekoyume.Model.State.RankingInfo> is unspecified; explicitly sort them before enumerating.
Model/State/PendingActivationState.cs(54,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/RankingMapState.cs(138,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/GoldCurrencyState.cs(42,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/DeletedAvatarState.cs(26,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/CreditsState.cs(35,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/GameConfigState.cs(68,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/CombinationSlotState.cs(85,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/AvatarState.cs(441,39): error LAA1002: Enumerating an instance of System.Collections.Immutable.ImmutableHashSet<Nekoyume.Model.Item.Equipment> is indeterministic since the order of System.Collections.Immutable.ImmutableHashSet<Nekoyume.Model.Item.Equipment> is unspecified; explicitly sort them before enumerating.
Model/State/AvatarState.cs(416,37): error LAA1002: Enumerating an instance of System.Collections.Immutable.ImmutableHashSet<Nekoyume.Model.Item.Costume> is indeterministic since the order of System.Collections.Immutable.ImmutableHashSet<Nekoyume.Model.Item.Costume> is unspecified; explicitly sort them before enumerating.
Model/State/AuthorizedMinersState.cs(42,51): error LAA1002: Enumerating an instance of System.Collections.Immutable.ImmutableHashSet<Libplanet.Address> is indeterministic since the order of System.Collections.Immutable.ImmutableHashSet<Libplanet.Address> is unspecified; explicitly sort them before enumerating.
Model/State/AuthorizedMinersState.cs(46,35): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
Model/State/AvatarState.cs(467,28): error LAA1002: Enumerating an instance of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is indeterministic since the order of System.Collections.Generic.Dictionary<Bencodex.Types.IKey, Bencodex.Types.IValue> is unspecified; explicitly sort them before enumerating.
```