### PR TITLE
Fix preloading bug

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -145,7 +145,10 @@ namespace Libplanet.Tests.Blockchain
                 genesisBlock.Hash,
                 genesisBlock.Timestamp.AddSeconds(1),
                 _emptyTransaction);
-            chain.ExecuteActions(validNext);
+            var actionEvaluations = _blockChain.BlockEvaluator.EvaluateActions(
+                validNext,
+                StateCompleterSet<DumbAction>.Recalculate);
+            chain.SetStates(validNext, actionEvaluations, false);
             validNext =
                 new Block<DumbAction>(validNext, stateStore.GetRootHash(validNext.Hash));
             chain.Append(validNext);
@@ -158,7 +161,7 @@ namespace Libplanet.Tests.Blockchain
                 validNext.Hash,
                 validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction);
-            var actionEvaluations = _blockChain.BlockEvaluator.EvaluateActions(
+            actionEvaluations = _blockChain.BlockEvaluator.EvaluateActions(
                 invalidStateRootHash,
                 StateCompleterSet<DumbAction>.Recalculate);
             chain.SetStates(invalidStateRootHash, actionEvaluations, false);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -912,10 +912,6 @@ namespace Libplanet.Blockchain
                     if (evaluateActions)
                     {
                         evaluations = ExecuteActions(block);
-
-                        // FIXME we should refactoring ValidateNextBlock() to avoid affecting
-                        // the global state, then integrate with ThrowIfStateRootHashInvalid().
-                        ThrowIfStateRootHashInvalid(block);
                     }
 
                     _blocks[block.Hash] = block;
@@ -1100,6 +1096,8 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.ExitWriteLock();
             }
+
+            ThrowIfStateRootHashInvalid(block);
 
             return evaluations;
         }


### PR DESCRIPTION
This PR fixes a bug where `Swarm<T>.PreloadAsync()` hadn't caught illegal state root properly.

Also, I omitted `CHANGES.md` because we didn't release 0.10 introducing `Block<T>.StateRootHash` yet. 👀 