### PR TITLE
Don't Swap to a chain of lower total difficulty

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1742,7 +1742,9 @@ namespace Libplanet.Net
             finally
             {
                 if (synced is BlockChain<T> syncedNotNull
-                    && !syncedNotNull.Id.Equals(blockChain?.Id))
+                    && !syncedNotNull.Id.Equals(blockChain?.Id)
+                    && (blockChain.Tip is null
+                        || blockChain.Tip.TotalDifficulty < syncedNotNull.Tip.TotalDifficulty))
                 {
                     blockChain.Swap(
                         synced,


### PR DESCRIPTION
This fixes a bug where the `BlockChain` was reorged into a chain with lower total difficulty. I skipped the changelog because the total difficulty is introduced in 0.10.0.