### PR TITLE
Skip broadcasting invalid txs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -301,6 +301,8 @@ To be released.
     to receive previous blocks.  [[#996]]
  -  Fixed a bug that `Swarm<T>` had thrown `InvalidGenesisBlockException`
     when reorg its chain repeatedly.  [[#996]]
+ -  Fixed a bug that `Swarm<T>` had propagated invalid transactions.
+    [[#1043]]
 
 ### Static analyzer
 
@@ -398,6 +400,7 @@ To be released.
 [#1034]: https://github.com/planetarium/libplanet/pull/1034
 [#1037]: https://github.com/planetarium/libplanet/pull/1037
 [#1039]: https://github.com/planetarium/libplanet/pull/1039
+[#1043]: https://github.com/planetarium/libplanet/pull/1043
 [sleep mode]: https://en.wikipedia.org/wiki/Sleep_mode
 
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1715,7 +1715,9 @@ namespace Libplanet.Tests.Net
                 await swarmB.TxReceived.WaitAsync();
 
                 Assert.Equal(swarmB.BlockChain.GetTransaction(validTx.Id), validTx);
-                Assert.Equal(swarmB.BlockChain.GetTransaction(invalidTx.Id), invalidTx);
+                Assert.Throws<KeyNotFoundException>(
+                    () => swarmB.BlockChain.GetTransaction(invalidTx.Id)
+                );
 
                 Assert.Contains(validTx.Id, swarmB.BlockChain.GetStagedTransactionIds());
                 Assert.DoesNotContain(invalidTx.Id, swarmB.BlockChain.GetStagedTransactionIds());

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -2037,6 +2037,10 @@ namespace Libplanet.Net
                     }
                 }
 
+                txs = new HashSet<Transaction<T>>(
+                    txs.Where(tx => BlockChain.Policy.DoesTransactionFollowsPolicy(tx, BlockChain))
+                );
+
                 foreach (Transaction<T> tx in txs)
                 {
                     try
@@ -2050,11 +2054,6 @@ namespace Libplanet.Net
                             "{TxId} will not be staged since it is invalid.",
                             tx.Id
                         );
-                    }
-
-                    if (!BlockChain.Policy.DoesTransactionFollowsPolicy(tx, BlockChain))
-                    {
-                        BlockChain.UnstageTransaction(tx);
                     }
                 }
 


### PR DESCRIPTION
This PR adjusts the order of re-broadcast tx from the network to avoid sending invalid transactions.