### PR TITLE
fix(tools): Do not return default when type is struct

### DIFF
--- a/Libplanet.Tools/Configuration/MptConfiguration.cs
+++ b/Libplanet.Tools/Configuration/MptConfiguration.cs
@@ -4,9 +4,9 @@ namespace Libplanet.Tools.Configuration
 {
     public struct MptConfiguration
     {
-        public MptConfiguration(Dictionary<string, string>? aliases = null)
+        public MptConfiguration(Dictionary<string, string> aliases)
         {
-            Aliases = aliases ?? new Dictionary<string, string>();
+            Aliases = aliases;
         }
 
         public Dictionary<string, string> Aliases { get; set; }

--- a/Libplanet.Tools/JsonConfigurationService.cs
+++ b/Libplanet.Tools/JsonConfigurationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using Libplanet.Tools.Configuration;
 using Zio;
@@ -20,7 +21,8 @@ namespace Libplanet.Tools
         {
             if (!_fileSystem.FileExists(UPath.Root / _configurationFileName))
             {
-                return default;
+                return new ToolConfiguration(
+                    new MptConfiguration(new Dictionary<string, string>()));
             }
 
             return JsonSerializer.Deserialize<ToolConfiguration>(


### PR DESCRIPTION
Fix these error:

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Libplanet.Tools.Mpt.Add(String alias, String uri, IConfigurationService`1 configurationService) in C:\Users\riema\Documents\Workspaces\libplanet\Libplanet.Tools\Mpt.cs:line 172
```