### PR TITLE
Make ITransport public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ To be released.
 
 ### Added APIs
 
+ -  Added `ITransport` interface.  [[#1052]]
+ -  Added `NetMQTransport` which implements `ITransport`.  [[#1052]]
+ -  Added `Message` abstract class.  [[#1052]]
  -  Added `BlockExceedingTransactionsException` class.  [[#1104], [#1110]]
  -  Added `BlockChain<T>.GetStagedTransactionIds()` method.  [[#1089]]
  -  (Libplanet.RocksDBStore) Added `maxTotalWalSize` and `keepLogFileNum`
@@ -50,6 +53,7 @@ To be released.
 
 ### CLI tools
 
+[#1052]: https://github.com/planetarium/libplanet/pull/1052
 [#1061]: https://github.com/planetarium/libplanet/pull/1061
 [#1062]: https://github.com/planetarium/libplanet/pull/1062
 [#1065]: https://github.com/planetarium/libplanet/pull/1065

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ To be released.
 ### Added APIs
 
  -  Added `ITransport` interface.  [[#1052]]
- -  Added `NetMQTransport` which implements `ITransport`.  [[#1052]]
+ -  Added `NetMQTransport` class which implements `ITransport`.  [[#1052]]
  -  Added `Message` abstract class.  [[#1052]]
  -  Added `BlockExceedingTransactionsException` class.  [[#1104], [#1110]]
  -  Added `BlockChain<T>.GetStagedTransactionIds()` method.  [[#1089]]

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -178,7 +178,16 @@ namespace Libplanet.Tests.Net.Protocols
                 Kademlia.MaxDepth,
                 cancellationToken);
         }
-#pragma warning restore S4457 // Cannot split the method since method is in interface
+
+        public Task SendMessageAsync(
+            BoundPeer peer,
+            Message message,
+            CancellationToken cancellationToken)
+            => SendMessageWithReplyAsync(
+                peer,
+                message,
+                TimeSpan.FromSeconds(3),
+                cancellationToken);
 
         public Task AddPeersAsync(
             IEnumerable<Peer> peers,

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -121,21 +121,6 @@ namespace Libplanet.Tests.Net.Protocols
             await Task.Delay(waitFor, cancellationToken);
         }
 
-        public void AddEventHandler(EventHandler<Message> eventHandler)
-        {
-            ProcessMessageHandler += eventHandler;
-        }
-
-        public void RemoveEventHandler(EventHandler<Message> eventHandler)
-        {
-            ProcessMessageHandler -= eventHandler;
-        }
-
-        public void RemoveAllEventHandlers()
-        {
-            ProcessMessageHandler = null;
-        }
-
         public async Task BootstrapAsync(
             IEnumerable<Peer> bootstrapPeers,
             TimeSpan? pingSeedTimeout = null,

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -61,9 +61,6 @@ namespace Libplanet.Tests.Net.Protocols
             Protocol = new KademliaProtocol(
                 this,
                 Address,
-                AppProtocolVersion,
-                null,
-                null,
                 _logger,
                 tableSize,
                 bucketSize

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -1,33 +1,107 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net
 {
+    /// <summary>
+    /// An interface to handle p2p, includes trading <see cref="Message"/>
+    /// and managing <see cref="Peer"/>s. Implements <see cref="IDisposable"/>.
+    /// </summary>
     public interface ITransport : IDisposable
     {
+        /// <summary>
+        /// <see cref="Peer"/> representation of <see cref="ITransport"/>.
+        /// </summary>
+        [Pure]
         Peer AsPeer { get; }
 
+        /// <summary>
+        /// List of all <see cref="Peer"/>s have in routing table.
+        /// </summary>
+        [Pure]
         IEnumerable<BoundPeer> Peers { get; }
 
+        /// <summary>
+        /// The <see cref="DateTimeOffset"/> of the last message was received.
+        /// </summary>
+        [Pure]
         DateTimeOffset? LastMessageTimestamp { get; }
 
+        /// <summary>
+        /// Setup transport layer.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
         Task StartAsync(CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Start running transport layer. To <see cref="RunAsync"/>, you should call
+        /// <see cref="StartAsync"/> first.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
         Task RunAsync(CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Stop running transport layer.
+        /// </summary>
+        /// <param name="waitFor">The <see cref="TimeSpan"/> of delay
+        /// before actual stopping.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Adds a <see cref="EventHandler"/> invoked when a message that is not
+        /// a reply is received. To handle reply, please use <see cref=
+        /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
+        /// </summary>
+        /// <param name="eventHandler">A handler of event when a message
+        /// that is not a reply is received.</param>
         void AddEventHandler(EventHandler<Message> eventHandler);
 
+        /// <summary>
+        /// Removes a <see cref="EventHandler"/> registered via <see cref="AddEventHandler"/>.
+        /// </summary>
+        /// <param name="eventHandler">A handler of event when a message
+        /// that is not a reply is received.</param>
         void RemoveEventHandler(EventHandler<Message> eventHandler);
 
+        /// <summary>
+        /// Removes all <see cref="EventHandler"/> registered via <see cref="AddEventHandler"/>.
+        /// </summary>
         void RemoveAllEventHandlers();
 
+        /// <summary>
+        /// Conduct peer discovery for given <paramref name="bootstrapPeers"/>.
+        /// </summary>
+        /// <param name="bootstrapPeers">A <see cref="IEnumerable{T}"/> of <see cref="Peer"/>s
+        /// to bootstrap.</param>
+        /// <param name="pingSeedTimeout">A timeout of waiting for the reply of <see cref="Ping"/>
+        /// message sent to seed <see cref="Peer"/>.
+        /// If <c>null</c> is given, task never halts by itself
+        /// even the target seed gives no any response.</param>
+        /// <param name="findNeighborsTimeout">A timeout of waiting for the reply of
+        /// <see cref="FindNeighbors"/> message sent to seed <see cref="Peer"/>.
+        /// If <c>null</c> is given, task never halts by itself
+        /// even the target seed gives no any response.</param>
+        /// <param name="depth">Recursive operation depth to search peers from network.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
         Task BootstrapAsync(
             IEnumerable<BoundPeer> bootstrapPeers,
             TimeSpan? pingSeedTimeout,
@@ -35,12 +109,48 @@ namespace Libplanet.Net
             int depth,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a message <paramref name="message"/> to given <paramref name="peer"/>.
+        /// </summary>
+        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
+        /// <param name="message">A <see cref="Message"/> to send.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
+        Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends a message <paramref name="message"/>
+        /// to given <paramref name="peer"/> and wait for its single reply.
+        /// </summary>
+        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
+        /// <param name="message">A <see cref="Message"/> to send.</param>
+        /// <param name="timeout">A timeout of waiting for the reply of the message.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>Reply of the message <paramref name="message"/>
+        /// sent from <paramref name="peer"/>.</returns>
         Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
             TimeSpan? timeout,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a message <paramref name="message"/>
+        /// to given <paramref name="peer"/> and wait for its multiple replies.
+        /// </summary>
+        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
+        /// <param name="message">A <see cref="Message"/> to send.</param>
+        /// <param name="timeout">A timeout of waiting for the reply of the message.</param>
+        /// <param name="expectedResponses">The number of expected replies for the message.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>Reply of the message <paramref name="message"/>
+        /// sent from <paramref name="peer"/>.</returns>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -48,8 +158,19 @@ namespace Libplanet.Net
             int expectedResponses,
             CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Broadcast messages to peers selected from the routing table.
+        /// </summary>
+        /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
+        /// If <c>null</c> is given, no peers will be excluded.</param>
+        /// <param name="message">A <see cref="Message"/> to broadcast.</param>
         void BroadcastMessage(Address? except, Message message);
 
+        /// <summary>
+        /// Method to reply message. Must set <see cref="Message.Identity"/> value made by
+        /// its corresponding message.
+        /// </summary>
+        /// <param name="message">A <see cref="Message"/> to reply.</param>
         void ReplyMessage(Message message);
     }
 }

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -8,8 +8,8 @@ using Libplanet.Net.Messages;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// An interface to handle p2p, includes trading <see cref="Message"/>
-    /// and managing <see cref="Peer"/>s. Implements <see cref="IDisposable"/>.
+    /// An interface to handle peer-to-peer networking, including <see cref="Message"/> exchanging
+    /// and <see cref="Peer"/> managing.
     /// </summary>
     public interface ITransport : IDisposable
     {
@@ -27,7 +27,7 @@ namespace Libplanet.Net
         Peer AsPeer { get; }
 
         /// <summary>
-        /// List of all <see cref="Peer"/>s have in routing table.
+        /// List of all <see cref="Peer"/>s in the routing table.
         /// </summary>
         [Pure]
         IEnumerable<BoundPeer> Peers { get; }
@@ -48,7 +48,7 @@ namespace Libplanet.Net
         Task StartAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Start running transport layer. To <see cref="RunAsync"/>, you should call
+        /// Starts running transport layer. To <see cref="RunAsync"/>, you should call
         /// <see cref="StartAsync"/> first.
         /// </summary>
         /// <param name="cancellationToken">
@@ -58,7 +58,7 @@ namespace Libplanet.Net
         Task RunAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Stop running transport layer.
+        /// Stops running transport layer.
         /// </summary>
         /// <param name="waitFor">The <see cref="TimeSpan"/> of delay
         /// before actual stopping.</param>
@@ -71,14 +71,14 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Conduct peer discovery for given <paramref name="bootstrapPeers"/>.
+        /// Conducts peer discovery for given <paramref name="bootstrapPeers"/>.
         /// </summary>
         /// <param name="bootstrapPeers">A <see cref="IEnumerable{T}"/> of <see cref="Peer"/>s
         /// to bootstrap.</param>
         /// <param name="pingSeedTimeout">A timeout of waiting for the reply of <see cref="Ping"/>
         /// message sent to seed <see cref="Peer"/>.
-        /// If <c>null</c> is given, task never halts by itself
-        /// even the target seed gives no any response.</param>
+        /// If <c>null</c> is given, the task never halts by itself
+        /// even no any response was given from the the target seed.</param>
         /// <param name="findNeighborsTimeout">A timeout of waiting for the reply of
         /// <see cref="FindNeighbors"/> message sent to seed <see cref="Peer"/>.
         /// If <c>null</c> is given, task never halts by itself
@@ -108,7 +108,7 @@ namespace Libplanet.Net
 
         /// <summary>
         /// Sends the <paramref name="message"/>
-        /// to given <paramref name="peer"/> and wait for its single reply.
+        /// to given <paramref name="peer"/> and waits for its single reply.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
         /// <param name="message">A <see cref="Message"/> to send.</param>
@@ -116,8 +116,8 @@ namespace Libplanet.Net
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
-        /// <returns>Reply of the <paramref name="message"/>
-        /// sent from <paramref name="peer"/>.</returns>
+        /// <returns>The replies of the <paramref name="message"/>
+        /// sent by <paramref name="peer"/>.</returns>
         Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -126,7 +126,7 @@ namespace Libplanet.Net
 
         /// <summary>
         /// Sends the <paramref name="message"/>
-        /// to given <paramref name="peer"/> and wait for its multiple replies.
+        /// to given <paramref name="peer"/> and waits for its multiple replies.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
         /// <param name="message">A <see cref="Message"/> to send.</param>
@@ -135,8 +135,8 @@ namespace Libplanet.Net
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
-        /// <returns>Reply of the <paramref name="message"/>
-        /// sent from <paramref name="peer"/>.</returns>
+        /// <returns>The replies of the <paramref name="message"/>
+        /// sent by <paramref name="peer"/>.</returns>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -145,7 +145,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Broadcast the <paramref name="message"/> to peers selected from the routing table.
+        /// Broadcasts the <paramref name="message"/> to peers selected from the routing table.
         /// </summary>
         /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
         /// If <c>null</c> is given, no peers will be excluded.</param>
@@ -153,9 +153,13 @@ namespace Libplanet.Net
         void BroadcastMessage(Address? except, Message message);
 
         /// <summary>
-        /// Method to reply message. Must set <see cref="Message.Identity"/> value made from
-        /// its corresponding message.
+        /// Replies message.
         /// </summary>
+        /// <remarks>
+        /// The <see cref="Message.Identity"/> of the given <paramref name="message"/> must be
+        /// matched to <see cref="Message.Identity"/> of a message corresponding to the given
+        /// <paramref name="message"/>.
+        /// </remarks>
         /// <param name="message">A <see cref="Message"/> to reply.</param>
         void ReplyMessage(Message message);
     }

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Net
         DateTimeOffset? LastMessageTimestamp { get; }
 
         /// <summary>
-        /// Setup transport layer.
+        /// Initiates transport layer.
         /// </summary>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
@@ -96,7 +96,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sends a message <paramref name="message"/> to given <paramref name="peer"/>.
+        /// Sends the <paramref name="message"/> to given <paramref name="peer"/>.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
         /// <param name="message">A <see cref="Message"/> to send.</param>
@@ -107,7 +107,7 @@ namespace Libplanet.Net
         Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sends a message <paramref name="message"/>
+        /// Sends the <paramref name="message"/>
         /// to given <paramref name="peer"/> and wait for its single reply.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
@@ -116,7 +116,7 @@ namespace Libplanet.Net
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
-        /// <returns>Reply of the message <paramref name="message"/>
+        /// <returns>Reply of the <paramref name="message"/>
         /// sent from <paramref name="peer"/>.</returns>
         Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
@@ -125,7 +125,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sends a message <paramref name="message"/>
+        /// Sends the <paramref name="message"/>
         /// to given <paramref name="peer"/> and wait for its multiple replies.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
@@ -135,7 +135,7 @@ namespace Libplanet.Net
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
-        /// <returns>Reply of the message <paramref name="message"/>
+        /// <returns>Reply of the <paramref name="message"/>
         /// sent from <paramref name="peer"/>.</returns>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
@@ -145,7 +145,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Broadcast messages to peers selected from the routing table.
+        /// Broadcast the <paramref name="message"/> to peers selected from the routing table.
         /// </summary>
         /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
         /// If <c>null</c> is given, no peers will be excluded.</param>
@@ -153,7 +153,7 @@ namespace Libplanet.Net
         void BroadcastMessage(Address? except, Message message);
 
         /// <summary>
-        /// Method to reply message. Must set <see cref="Message.Identity"/> value made by
+        /// Method to reply message. Must set <see cref="Message.Identity"/> value made from
         /// its corresponding message.
         /// </summary>
         /// <param name="message">A <see cref="Message"/> to reply.</param>

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -22,6 +22,12 @@ namespace Libplanet.Net
             TimeSpan waitFor,
             CancellationToken cancellationToken = default(CancellationToken));
 
+        void AddEventHandler(EventHandler<Message> eventHandler);
+
+        void RemoveEventHandler(EventHandler<Message> eventHandler);
+
+        void RemoveAllEventHandlers();
+
         Task BootstrapAsync(
             IEnumerable<BoundPeer> bootstrapPeers,
             TimeSpan? pingSeedTimeout,

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -14,6 +14,13 @@ namespace Libplanet.Net
     public interface ITransport : IDisposable
     {
         /// <summary>
+        /// The <see cref="EventHandler"/> invoked when a message that is not
+        /// a reply is received. To handle reply, please use <see cref=
+        /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
+        /// </summary>
+        event EventHandler<Message> ProcessMessageHandler;
+
+        /// <summary>
         /// <see cref="Peer"/> representation of <see cref="ITransport"/>.
         /// </summary>
         [Pure]
@@ -62,27 +69,6 @@ namespace Libplanet.Net
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Adds a <see cref="EventHandler"/> invoked when a message that is not
-        /// a reply is received. To handle reply, please use <see cref=
-        /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
-        /// </summary>
-        /// <param name="eventHandler">A handler of event when a message
-        /// that is not a reply is received.</param>
-        void AddEventHandler(EventHandler<Message> eventHandler);
-
-        /// <summary>
-        /// Removes a <see cref="EventHandler"/> registered via <see cref="AddEventHandler"/>.
-        /// </summary>
-        /// <param name="eventHandler">A handler of event when a message
-        /// that is not a reply is received.</param>
-        void RemoveEventHandler(EventHandler<Message> eventHandler);
-
-        /// <summary>
-        /// Removes all <see cref="EventHandler"/> registered via <see cref="AddEventHandler"/>.
-        /// </summary>
-        void RemoveAllEventHandlers();
 
         /// <summary>
         /// Conduct peer discovery for given <paramref name="bootstrapPeers"/>.

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -6,7 +6,7 @@ using Libplanet.Net.Messages;
 
 namespace Libplanet.Net
 {
-    internal interface ITransport : IDisposable
+    public interface ITransport : IDisposable
     {
         Peer AsPeer { get; }
 

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -11,12 +11,12 @@ using NetMQ;
 namespace Libplanet.Net.Messages
 {
     /// <summary>
-    /// Abstract message class used in <see cref="ITransport"/>.
+    /// Serves as the base class for messages used in <see cref="ITransport"/>.
     /// </summary>
     public abstract class Message
     {
         /// <summary>
-        /// Number of frames that all messages commonly contains. Its value is 4.
+        /// The number of frames that all messages commonly contain.
         /// </summary>
         public const int CommonFrames = 4;
 
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Messages
         }
 
         /// <summary>
-        /// Identity bytearray of the message.
+        /// <c>byte[]</c>-typed identity of the message.
         /// If a message B is the reply of the message A,
         /// B's identity must be set to A's identity.
         /// </summary>
@@ -163,7 +163,7 @@ namespace Libplanet.Net.Messages
         public AppProtocolVersion Version { get; set; }
 
         /// <summary>
-        /// Sender <see cref="Peer"/> of the message.
+        /// The sender <see cref="Peer"/> of the message.
         /// </summary>
         public Peer Remote { get; set; }
 
@@ -172,8 +172,8 @@ namespace Libplanet.Net.Messages
         protected abstract IEnumerable<NetMQFrame> DataFrames { get; }
 
         /// <summary>
-        /// Cast given <see cref="ToNetMQMessage"/> <paramref name="raw"/> to
-        /// <see cref="Message"/> and check its validity.
+        /// Casts given <see cref="NetMQMessage"/>-typed <paramref name="raw"/> into
+        /// <see cref="Message"/> and checks its validity.
         /// <seealso cref="ToNetMQMessage"/>
         /// </summary>
         /// <param name="raw">A <see cref="NetMQMessage"/> to parse.</param>
@@ -187,10 +187,10 @@ namespace Libplanet.Net.Messages
         /// <param name="differentAppProtocolVersionEncountered">A delegate called back when a peer
         /// with one different from <paramref name="localVersion"/>, and their version is
         /// signed by a trusted party (i.e., <paramref name="trustedAppProtocolVersionSigners"/>).
-        /// If this callback returns <c>false</c> an encountered peer is ignored.  If this callback
-        /// is omitted all peers with different <see cref="AppProtocolVersion"/>s are ignored.
+        /// If this callback returns <c>false</c>, an encountered peer is ignored.  If this callback
+        /// is omitted, all peers with different <see cref="AppProtocolVersion"/>s are ignored.
         /// </param>
-        /// <returns>A <see cref="Message"/> made from <paramref name="raw"/>.</returns>
+        /// <returns>A <see cref="Message"/> parsed from <paramref name="raw"/>.</returns>
         /// <exception cref="ArgumentException">Thrown when empty <paramref name="raw"/> is given.
         /// </exception>
         /// <exception cref="DifferentAppProtocolVersionException">Thrown when
@@ -306,18 +306,19 @@ namespace Libplanet.Net.Messages
         }
 
         /// <summary>
-        /// Cast the message to <see cref="NetMQMessage"/> with given <paramref name="key"/>,
+        /// Casts the message to <see cref="NetMQMessage"/> with given <paramref name="key"/>,
         /// <paramref name="peer"/> and <paramref name="version"/>.
         /// </summary>
-        /// <param name="key"><see cref="PrivateKey"/> to sign message.</param>
+        /// <param name="key">A <see cref="PrivateKey"/> to sign message.</param>
         /// <param name="peer"><see cref="Peer"/>-typed representation of the
         /// sender's transport layer.
         /// <seealso cref="ITransport.AsPeer"/></param>
         /// <param name="version"><see cref="AppProtocolVersion"/>-typed version of the
         /// transport layer.</param>
-        /// <returns>The result of casting.</returns>
+        /// <returns>A <see cref="NetMQMessage"/> containing the signed <see cref="Message"/>.
+        /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="peer"/> is
-        /// null.</exception>
+        /// <c>null</c>.</exception>
         public NetMQMessage ToNetMQMessage(PrivateKey key, Peer peer, AppProtocolVersion version)
         {
             if (peer is null)

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -10,11 +10,11 @@ using NetMQ;
 
 namespace Libplanet.Net.Messages
 {
-    internal abstract class Message
+    public abstract class Message
     {
         public const int CommonFrames = 4;
 
-        internal enum MessageType : byte
+        public enum MessageType : byte
         {
             /// <summary>
             /// Check message to determine peer is alive.

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -172,7 +172,7 @@ namespace Libplanet.Net.Messages
         protected abstract IEnumerable<NetMQFrame> DataFrames { get; }
 
         /// <summary>
-        /// Cast given <see cref="ToNetMQMessage"/>-typed <paramref name="raw"/> to
+        /// Cast given <see cref="ToNetMQMessage"/> <paramref name="raw"/> to
         /// <see cref="Message"/> and check its validity.
         /// <seealso cref="ToNetMQMessage"/>
         /// </summary>

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -10,10 +10,19 @@ using NetMQ;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// Abstract message class used in <see cref="ITransport"/>.
+    /// </summary>
     public abstract class Message
     {
+        /// <summary>
+        /// Number of frames that all messages commonly contains. Its value is 4.
+        /// </summary>
         public const int CommonFrames = 4;
 
+        /// <summary>
+        /// <c>Enum</c> represents the type of the <see cref="Message"/>.
+        /// </summary>
         public enum MessageType : byte
         {
             /// <summary>
@@ -140,16 +149,58 @@ namespace Libplanet.Net.Messages
             Sign = 3,
         }
 
+        /// <summary>
+        /// Identity bytearray of the message.
+        /// If a message B is the reply of the message A,
+        /// B's identity must be set to A's identity.
+        /// </summary>
         public byte[] Identity { get; set; }
 
+        /// <summary>
+        /// <see cref="AppProtocolVersion"/>-typed version of the
+        /// <see cref="Remote"/>'s transport layer.
+        /// </summary>
         public AppProtocolVersion Version { get; set; }
 
+        /// <summary>
+        /// Sender <see cref="Peer"/> of the message.
+        /// </summary>
         public Peer Remote { get; set; }
 
         protected abstract MessageType Type { get; }
 
         protected abstract IEnumerable<NetMQFrame> DataFrames { get; }
 
+        /// <summary>
+        /// Cast given <see cref="ToNetMQMessage"/>-typed <paramref name="raw"/> to
+        /// <see cref="Message"/> and check its validity.
+        /// <seealso cref="ToNetMQMessage"/>
+        /// </summary>
+        /// <param name="raw">A <see cref="NetMQMessage"/> to parse.</param>
+        /// <param name="reply">A flag to express whether the target is a reply of other message.
+        /// </param>
+        /// <param name="localVersion">The <see cref="AppProtocolVersion"/>-typed version of the
+        /// local transport layer. <seealso cref="ITransport"/></param>
+        /// <param name="trustedAppProtocolVersionSigners"><see cref="PublicKey"/>s of parties
+        /// to trust <see cref="AppProtocolVersion"/>s they signed.  To trust any party, pass
+        /// <c>null</c>.</param>
+        /// <param name="differentAppProtocolVersionEncountered">A delegate called back when a peer
+        /// with one different from <paramref name="localVersion"/>, and their version is
+        /// signed by a trusted party (i.e., <paramref name="trustedAppProtocolVersionSigners"/>).
+        /// If this callback returns <c>false</c> an encountered peer is ignored.  If this callback
+        /// is omitted all peers with different <see cref="AppProtocolVersion"/>s are ignored.
+        /// </param>
+        /// <returns>A <see cref="Message"/> made from <paramref name="raw"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when empty <paramref name="raw"/> is given.
+        /// </exception>
+        /// <exception cref="DifferentAppProtocolVersionException">Thrown when
+        /// <paramref name="localVersion"/> does not match with given <paramref name="raw"/>'s
+        /// <see cref="Version"/>, and their version is signed by a trusted party
+        /// (i.e., <paramref name="trustedAppProtocolVersionSigners"/>), and
+        /// <paramref name="differentAppProtocolVersionEncountered"/> is <c>null</c> or its
+        /// return value is <c>false</c>.</exception>
+        /// <exception cref="InvalidMessageException">Thrown when given <paramref name="raw"/>'s
+        /// signer is invalid.</exception>
         public static Message Parse(
             NetMQMessage raw,
             bool reply,
@@ -254,6 +305,19 @@ namespace Libplanet.Net.Messages
             return message;
         }
 
+        /// <summary>
+        /// Cast the message to <see cref="NetMQMessage"/> with given <paramref name="key"/>,
+        /// <paramref name="peer"/> and <paramref name="version"/>.
+        /// </summary>
+        /// <param name="key"><see cref="PrivateKey"/> to sign message.</param>
+        /// <param name="peer"><see cref="Peer"/>-typed representation of the
+        /// sender's transport layer.
+        /// <seealso cref="ITransport.AsPeer"/></param>
+        /// <param name="version"><see cref="AppProtocolVersion"/>-typed version of the
+        /// transport layer.</param>
+        /// <returns>The result of casting.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="peer"/> is
+        /// null.</exception>
         public NetMQMessage ToNetMQMessage(PrivateKey key, Peer peer, AppProtocolVersion version)
         {
             if (peer is null)

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -189,11 +189,8 @@ namespace Libplanet.Net
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
         }
 
-        /// <summary>
-        /// The <see cref="EventHandler" /> triggered when a <see cref="Message"/> is
-        /// received and needs processing.
-        /// </summary>
-        private event EventHandler<Message> ProcessMessageHandler;
+        /// <inheritdoc />
+        public event EventHandler<Message> ProcessMessageHandler;
 
         /// <inheritdoc cref="ITransport.AsPeer"/>
         public Peer AsPeer => EndPoint is null
@@ -347,24 +344,6 @@ namespace Libplanet.Net
 
                 Running = false;
             }
-        }
-
-        /// <inheritdoc />
-        public void AddEventHandler(EventHandler<Message> eventHandler)
-        {
-            ProcessMessageHandler += eventHandler;
-        }
-
-        /// <inheritdoc />
-        public void RemoveEventHandler(EventHandler<Message> eventHandler)
-        {
-            ProcessMessageHandler -= eventHandler;
-        }
-
-        /// <inheritdoc />
-        public void RemoveAllEventHandlers()
-        {
-            ProcessMessageHandler = null;
         }
 
         /// <inheritdoc />

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -154,9 +154,6 @@ namespace Libplanet.Net
             Protocol = new KademliaProtocol(
                 this,
                 _privateKey.ToAddress(),
-                _appProtocolVersion,
-                _trustedAppProtocolVersionSigners,
-                _differentAppProtocolVersionEncountered,
                 _logger,
                 tableSize,
                 bucketSize);

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Net
         private DifferentAppProtocolVersionEncountered _differentAppProtocolVersionEncountered;
 
         /// <summary>
-        /// Method creates <see cref="NetMQTransport"/> instance.
+        /// Creates <see cref="NetMQTransport"/> instance.
         /// </summary>
         /// <param name="privateKey"><see cref="PrivateKey"/> of the transport layer.</param>
         /// <param name="appProtocolVersion"><see cref="AppProtocolVersion"/>-typed
@@ -78,8 +78,8 @@ namespace Libplanet.Net
         /// <param name="trustedAppProtocolVersionSigners"><see cref="PublicKey"/>s of parties
         /// to trust <see cref="AppProtocolVersion"/>s they signed.  To trust any party, pass
         /// <c>null</c>.</param>
-        /// <param name="tableSize">Number of buckets in Kademlia-based routing table.</param>
-        /// <param name="bucketSize">Size of bucket in Kademlia-based routing table.</param>
+        /// <param name="tableSize">The number of buckets in Kademlia-based routing table.</param>
+        /// <param name="bucketSize">The size of bucket in Kademlia-based routing table.</param>
         /// <param name="workers">The number of background workers (i.e., threads).</param>
         /// <param name="host">A hostname to be a part of a public endpoint, that peers use when
         /// they connect to this node.  Note that this is not a hostname to listen to;
@@ -91,12 +91,12 @@ namespace Libplanet.Net
         /// <param name="differentAppProtocolVersionEncountered">A delegate called back when a peer
         /// with one different from <paramref name="appProtocolVersion"/>, and their version is
         /// signed by a trusted party (i.e., <paramref name="trustedAppProtocolVersionSigners"/>).
-        /// If this callback returns <c>false</c> an encountered peer is ignored.  If this callback
-        /// is omitted all peers with different <see cref="AppProtocolVersion"/>s are ignored.
+        /// If this callback returns <c>false</c>, an encountered peer is ignored.  If this callback
+        /// is omitted, all peers with different <see cref="AppProtocolVersion"/>s are ignored.
         /// </param>
         /// <param name="logger"><see cref="Log.Logger"/> for logging.</param>
         /// <exception cref="ArgumentException">Thrown when both <paramref name="host"/> and
-        /// <paramref name="iceServers"/> are null.</exception>
+        /// <paramref name="iceServers"/> are <c>null</c>.</exception>
         public NetMQTransport(
             PrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
@@ -364,7 +364,7 @@ namespace Libplanet.Net
         /// <summary>
         /// Adds given <paramref name="peers"/> to routing table by sending <see cref="Ping"/>.
         /// </summary>
-        /// <param name="peers"><see cref="IEnumerable{Peer}"/> of peers to add.</param>
+        /// <param name="peers">The peers to add.</param>
         /// <param name="timeout">A timeout of waiting for the reply of <see cref="Ping"/>
         /// message sent to <paramref name="peers"/>.
         /// If <c>null</c> is given, task never halts by itself
@@ -373,7 +373,8 @@ namespace Libplanet.Net
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <see cref="Protocol"/> is null.
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <see cref="Protocol"/> is <c>null</c>.
         /// </exception>
         public async Task AddPeersAsync(
             IEnumerable<Peer> peers,
@@ -444,7 +445,7 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Find and returns the <see cref="Peer"/> match with given <paramref name="target"/>.
+        /// Finds a <see cref="Peer"/> whose address value matches <paramref name="target"/>.
         /// </summary>
         /// <param name="target"><see cref="Address"/> to find.</param>
         /// <param name="depth">Recursive operation depth to search the peer from network.</param>
@@ -471,9 +472,9 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Method to visualize Kademlia-based routing table status.
-        /// Note: Will be outdated.
+        /// Visualizes Kademlia-based routing table status.
         /// </summary>
+        /// <remarks>Will be outdated.</remarks>
         /// <returns><see cref="string"/> representation of the routing table.</returns>
         public string Trace() => Protocol is null ? string.Empty : Protocol.Trace();
 
@@ -486,9 +487,11 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// Task complete when the transport is running.
+        /// Waits until this <see cref="NetMQTransport"/> instance gets started to run.
         /// </summary>
-        /// <returns>An awaitable task without value.</returns>
+        /// <seealso cref="Swarm{T}.WaitForRunningAsync()"/>
+        /// <returns>A <see cref="Task"/> completed when <see cref="Running"/>
+        /// property becomes <c>true</c>.</returns>
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
         /// <inheritdoc />
@@ -638,8 +641,8 @@ namespace Libplanet.Net
         /// Refreshes all peers in routing table.
         /// </summary>
         /// <param name="timeout">A timeout of waiting for the reply of messages.
-        /// If <c>null</c> is given, task never halts by itself even the message gives
-        /// no any response.</param>
+        /// If <c>null</c> is given, the task never halts by itself
+        /// even no any response was given from the the target peer.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -18,7 +18,7 @@ using Serilog;
 
 namespace Libplanet.Net
 {
-    internal class NetMQTransport : ITransport
+    public class NetMQTransport : ITransport
     {
         private const int MessageHistoryCapacity = 30;
 

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Protocols
 {
@@ -25,8 +24,6 @@ namespace Libplanet.Net.Protocols
         Task RebuildConnectionAsync(CancellationToken cancellationToken);
 
         Task CheckReplacementCacheAsync(CancellationToken cancellationToken);
-
-        void ReceiveMessage(Message message);
 
         string Trace();
     }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Net.Protocols
             _requestTimeout =
                 requestTimeout ??
                 TimeSpan.FromMilliseconds(Kademlia.IdleRequestTimeout);
-            _transport.AddEventHandler(ProcessMessageHandler);
+            _transport.ProcessMessageHandler += ProcessMessageHandler;
         }
 
         public IEnumerable<BoundPeer> Peers => _routing.Peers;

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -251,6 +251,7 @@ namespace Libplanet.Net.Protocols
             _logger.Verbose("Replacement cache checked.");
         }
 
+        // FIXME: Remove this method and make RoutingTable public
         public string Trace()
         {
             var trace = $"Routing table of [{_address.ToHex()}]\n";
@@ -311,6 +312,7 @@ namespace Libplanet.Net.Protocols
                     var msg =
                         "{BoundPeer}, a target peer, is in the routing table does not respond.";
                     _logger.Verbose(msg, boundPeer);
+                    RemovePeer(boundPeer);
                     return null;
                 }
 
@@ -377,6 +379,10 @@ namespace Libplanet.Net.Protocols
                     }
                     catch (PingTimeoutException)
                     {
+                        // Ignore peer not responding
+                    }
+                    finally
+                    {
                         history.Add(found);
                     }
                 }
@@ -430,7 +436,8 @@ namespace Libplanet.Net.Protocols
             }
             catch (DifferentAppProtocolVersionException)
             {
-                _logger.Error("Different AppProtocolVersion encountered at PingAsync.");
+                _logger.Error(
+                    $"Different AppProtocolVersion encountered at {nameof(PingAsync)}().");
                 throw;
             }
         }
@@ -618,7 +625,7 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        // send pong back to remote
+        // Send pong back to remote
         private void ReceivePing(Ping ping)
         {
             if (ping.Remote.Address.Equals(_address))

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Serilog;
 using Random = System.Random;
@@ -17,10 +16,6 @@ namespace Libplanet.Net.Protocols
         private readonly TimeSpan _requestTimeout;
         private readonly ITransport _transport;
         private readonly Address _address;
-        private readonly AppProtocolVersion _appProtocolVersion;
-        private readonly IImmutableSet<PublicKey> _trustedAppProtocolVersionSigners;
-        private readonly DifferentAppProtocolVersionEncountered
-            _differentAppProtocolVersionEncountered;
 
         private readonly Random _random;
         private readonly RoutingTable _routing;
@@ -33,9 +28,6 @@ namespace Libplanet.Net.Protocols
         public KademliaProtocol(
             ITransport transport,
             Address address,
-            AppProtocolVersion appProtocolVersion,
-            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
             ILogger logger,
             int? tableSize,
             int? bucketSize,
@@ -43,9 +35,6 @@ namespace Libplanet.Net.Protocols
             TimeSpan? requestTimeout = null)
         {
             _transport = transport;
-            _appProtocolVersion = appProtocolVersion;
-            _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
-            _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
             _logger = logger;
 
             _address = address;

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -21,19 +21,9 @@ namespace Libplanet.Net
         {
             switch (message)
             {
-                case Ping ping:
-                {
-                    _logger.Debug($"Received a {nameof(Ping)} message.");
-
-                    // This case can be dealt in Transport.
-                    var pong = new Pong()
-                    {
-                        Identity = ping.Identity,
-                    };
-
-                    Transport.ReplyMessage(pong);
+                case Ping _:
+                case FindNeighbors _:
                     break;
-                }
 
                 case GetChainStatus getChainStatus:
                 {
@@ -51,10 +41,6 @@ namespace Libplanet.Net
                     Transport.ReplyMessage(chainStatus);
                     break;
                 }
-
-                case FindNeighbors _:
-                    _logger.Debug($"Received a {nameof(FindNeighbors)} message.");
-                    break;
 
                 case GetBlockHashes getBlockHashes:
                 {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -242,6 +242,7 @@ namespace Libplanet.Net
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.
         /// </summary>
+        /// <seealso cref="NetMQTransport.WaitForRunningAsync()"/>
         /// <returns>A <see cref="Task"/> completed when <see cref="NetMQTransport.Running"/>
         /// property becomes <c>true</c>.</returns>
         public Task WaitForRunningAsync() => (Transport as NetMQTransport)?.WaitForRunningAsync();

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -155,7 +155,7 @@ namespace Libplanet.Net
                 iceServers,
                 differentAppProtocolVersionEncountered,
                 _logger);
-            Transport.AddEventHandler(ProcessMessageHandler);
+            Transport.ProcessMessageHandler += ProcessMessageHandler;
 
             Options = options ?? new SwarmOptions();
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -154,8 +154,8 @@ namespace Libplanet.Net
                 listenPort,
                 iceServers,
                 differentAppProtocolVersionEncountered,
-                ProcessMessageHandler,
                 _logger);
+            Transport.AddEventHandler(ProcessMessageHandler);
 
             Options = options ?? new SwarmOptions();
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -977,7 +977,7 @@ namespace Libplanet.Net
                 .CreateLinkedTokenSource(cancellationToken, _cancellationToken).Token;
 
             var netMQTransport = (NetMQTransport)Transport;
-            await netMQTransport.CheckAllPeersAsync(cancellationToken, timeout);
+            await netMQTransport.CheckAllPeersAsync(timeout, cancellationToken);
         }
 
         internal async Task AddPeersAsync(


### PR DESCRIPTION
In order to make client, `Message` class also became public.

For easier use, message handling method is changed to subscription model.