### PR TITLE
refactor(blockchain): use readonly tx-nonce cache

### DIFF
--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Blockchain;
@@ -14,6 +16,8 @@ namespace Libplanet.Benchmarks
     {
         private StoreFixture _fx;
         private BlockChain<DumbAction> _blockChain;
+
+        private ImmutableArray<PrivateKey> _privateKeys;
 
         public BlockChain()
         {
@@ -44,6 +48,37 @@ namespace Libplanet.Benchmarks
         public void ContainsBlock()
         {
             _blockChain.ContainsBlock(_blockChain.Tip.Hash);
+        }
+
+        [IterationSetup(Target = nameof(GetNextTxNonce))]
+        public void SetupChain_GetNextTxNonce()
+        {
+            _fx = new DefaultStoreFixture();
+            _blockChain = new BlockChain<DumbAction>(
+                new NullPolicy<DumbAction>(),
+                _fx.Store,
+                _fx.StateStore,
+                _fx.GenesisBlock);
+
+            const int privateKeyCount = 3;
+            _privateKeys = Enumerable.Range(0, privateKeyCount)
+                .Select(_ => new PrivateKey())
+                .ToImmutableArray();
+            foreach (PrivateKey privateKey in _privateKeys)
+            {
+                for (var i = 0; i < 2000; i++)
+                {
+                    _blockChain.MakeTransaction(privateKey, new DumbAction[0]);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void GetNextTxNonce()
+        {
+            _blockChain.GetNextTxNonce(_privateKeys[0].ToAddress());
+            _blockChain.GetNextTxNonce(_privateKeys[1].ToAddress());
+            _blockChain.GetNextTxNonce(_privateKeys[2].ToAddress());
         }
     }
 }


### PR DESCRIPTION
It will not resolve the `tx-nonce` performance issue clearly. But I hope it improves a lot in some cases.