### PR TITLE
Multiplex the order of staged transactions (port)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
     all transactions virtually forever after a signer's transactions once have
     been staged without the ascending order of nonce (usually due to their
     inconsistent propagation latency on the network).  [[#1057], [#1059]]
+ -  `BlockChain<T>.MineBlock()` method became to cut off staged transactions
+    to mine if it takes longer than 4 seconds to collect and validate them.
+    Those rest staged transactions are postponed until next block mining.
+    [[#1057], [#1059]]
 
 [#1057]: https://github.com/planetarium/libplanet/pull/1057
 [#1059]: https://github.com/planetarium/libplanet/pull/1059

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.10.1
 
 To be released.
 
+ -  Fixed `BlockChain<T>.MineBlock()` method's bug which excludes one's
+    all transactions virtually forever after a signer's transactions once have
+    been staged without the ascending order of nonce (usually due to their
+    inconsistent propagation latency on the network).  [[#1057], [#1059]]
+
+[#1057]: https://github.com/planetarium/libplanet/pull/1057
+[#1059]: https://github.com/planetarium/libplanet/pull/1059
 
 
 Version 0.10.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Crypto;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
+using Serilog;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public partial class BlockChainTest
+    {
+        [Fact]
+        public void ListStagedTransactions()
+        {
+            Transaction<DumbAction> MkTx(PrivateKey key, long nonce, DateTimeOffset? ts = null) =>
+                Transaction<DumbAction>.Create(
+                    nonce,
+                    key,
+                    _blockChain.Genesis.Hash,
+                    new DumbAction[0],
+                    null,
+                    ts ?? DateTimeOffset.UtcNow
+                );
+
+            PrivateKey a = new PrivateKey();
+            PrivateKey b = new PrivateKey();
+            PrivateKey c = new PrivateKey();
+            PrivateKey d = new PrivateKey();
+            PrivateKey e = new PrivateKey();
+
+            // A normal case and corner cases:
+            // A. Normal case (3 txs: 0, 1, 2)
+            // B. Nonces are out of order (2 tsx: 1, 0)
+            // C. Smaller nonces have later timestamps (2 txs: 0 (later), 1)
+            // D. Some nonce numbers are missed out (3 txs: 0, 1, 3)
+            // E. Reused nonces (4 txs: 0, 1, 1, 2)
+            _blockChain.MakeTransaction(a, new DumbAction[0]);
+
+            DateTimeOffset currentTime = DateTimeOffset.UtcNow;
+            _blockChain.StageTransaction(MkTx(b, 1, currentTime + TimeSpan.FromHours(1)));
+
+            _blockChain.StageTransaction(MkTx(c, 0, DateTimeOffset.UtcNow + TimeSpan.FromHours(1)));
+
+            _blockChain.StageTransaction(MkTx(d, 0, DateTimeOffset.UtcNow));
+
+            _blockChain.StageTransaction(MkTx(e, 0, DateTimeOffset.UtcNow));
+
+            _blockChain.MakeTransaction(a, new DumbAction[0]);
+
+            _blockChain.StageTransaction(MkTx(b, 0, currentTime));
+
+            _blockChain.StageTransaction(MkTx(c, 1, DateTimeOffset.UtcNow));
+
+            _blockChain.StageTransaction(MkTx(d, 1, DateTimeOffset.UtcNow));
+
+            _blockChain.StageTransaction(MkTx(e, 1, DateTimeOffset.UtcNow));
+
+            _blockChain.StageTransaction(MkTx(d, 3, DateTimeOffset.UtcNow));
+
+            _blockChain.StageTransaction(MkTx(e, 1, DateTimeOffset.UtcNow));
+            _blockChain.StageTransaction(MkTx(e, 2, DateTimeOffset.UtcNow));
+
+            _blockChain.MakeTransaction(a, new DumbAction[0]);
+
+            ImmutableArray<Transaction<DumbAction>> stagedTransactions =
+                _blockChain.ListStagedTransactions();
+            (Address Signer, long Nonce)[] actual =
+                stagedTransactions.Select(tx => (tx.Signer, tx.Nonce)).ToArray();
+            (Address Signer, long Nonce)[] expected =
+            {
+                (a.ToAddress(), 0),
+                (b.ToAddress(), 0),
+                (c.ToAddress(), 0),
+                (d.ToAddress(), 0),
+                (e.ToAddress(), 0),
+                (a.ToAddress(), 1),
+                (b.ToAddress(), 1),
+                (c.ToAddress(), 1),
+                (d.ToAddress(), 1),
+                (e.ToAddress(), 1),
+                (d.ToAddress(), 3),
+                (e.ToAddress(), 1),
+                (e.ToAddress(), 2),
+                (a.ToAddress(), 2),
+            };
+
+            var signerMap = new Dictionary<Address, char>()
+            {
+                [a.ToAddress()] = 'A',
+                [b.ToAddress()] = 'B',
+                [c.ToAddress()] = 'C',
+                [d.ToAddress()] = 'D',
+                [e.ToAddress()] = 'E',
+            };
+
+            Log.Logger.Debug("Expected vs Actual");
+            foreach ((var ex, var ac) in expected.Zip(actual, (e_, a_) => (e_, a_)))
+            {
+                Log.Logger.Debug(
+                    "{0} {1} != {2} {3}",
+                    signerMap[ex.Signer],
+                    ex.Nonce,
+                    signerMap[ac.Signer],
+                    ac.Nonce
+                );
+            }
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -264,6 +264,42 @@ namespace Libplanet.Tests.Blockchain
             }
         }
 
+        [Theory]
+        [InlineData(3)]
+        [InlineData(2)]
+        [InlineData(1)]
+        public async void MineBlockWithReverseNonces(int maxTxs)
+        {
+            var key = new PrivateKey();
+            var txs = new[]
+            {
+                Transaction<DumbAction>.Create(
+                    2,
+                    key,
+                    _blockChain.Genesis.Hash,
+                    new DumbAction[0]
+                ),
+                Transaction<DumbAction>.Create(
+                    1,
+                    key,
+                    _blockChain.Genesis.Hash,
+                    new DumbAction[0]
+                ),
+                Transaction<DumbAction>.Create(
+                    0,
+                    key,
+                    _blockChain.Genesis.Hash,
+                    new DumbAction[0]
+                ),
+            };
+            StageTransactions(txs);
+            Block<DumbAction> block = await _blockChain.MineBlock(
+                _fx.Address1,
+                maxTransactions: maxTxs
+            );
+            Assert.Equal(maxTxs, block.Transactions.Count());
+        }
+
         [Fact]
         public async void CanFindBlockByIndex()
         {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
@@ -676,6 +677,7 @@ namespace Libplanet.Blockchain
             }
         }
 
+#pragma warning disable MEN003
         /// <summary>
         /// Mines a next <see cref="Block{T}"/> using staged <see cref="Transaction{T}"/>s,
         /// and then <see cref="Append(Block{T}, StateCompleterSet{T}?)"/> it to the chain
@@ -719,8 +721,29 @@ namespace Libplanet.Blockchain
             long difficulty = Policy.GetNextBlockDifficulty(this);
             HashDigest<SHA256>? prevHash = Store.IndexBlockHash(Id, index - 1);
 
+            int sessionId = new System.Random().Next();
+            int procId = Process.GetCurrentProcess().Id;
+            _logger.Debug(
+                "Start to mine a block #{Index} [difficulty: {Difficulty}; prev: {prevHash}; " +
+                "session: {SessionId}; proc: {ProcessId}]... ",
+                index,
+                difficulty,
+                prevHash,
+                sessionId,
+                procId
+            );
+
             ImmutableArray<Transaction<T>> stagedTransactions = ListStagedTransactions();
+            _logger.Debug(
+                "There are {Transactions} staged transactions.",
+                stagedTransactions.Length
+            );
+
             var transactionsToMine = new List<Transaction<T>>();
+            int i = 0;
+
+            // FIXME: The tx collection timeout should be configurable.
+            DateTimeOffset timeout = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(4);
 
             // Makes an empty block to estimate the length of bytes without transactions.
             var estimatedBytes = new Block<T>(
@@ -738,27 +761,44 @@ namespace Libplanet.Blockchain
 
             foreach (Transaction<T> tx in stagedTransactions)
             {
+                _logger.Verbose(
+                    "Preparing mining a block #{Index}; validating a tx {Index}/{Total} " +
+                    "{Transaction}...",
+                    index,
+                    ++i,
+                    stagedTransactions.Length,
+                    tx.Id
+                );
+
+                if (transactionsToMine.Count >= maxTransactions)
+                {
+                    _logger.Information(
+                        "Not all staged transactions will be included in a block #{Index} to " +
+                        "be mined by {Miner}, because it reaches the maximum number of " +
+                        "acceptable transactions: {MaxTransactions}",
+                        index,
+                        miner,
+                        maxTransactions
+                    );
+                    break;
+                }
+
                 if (!Policy.DoesTransactionFollowsPolicy(tx, this))
                 {
+                    _logger.Debug(
+                        "Unstage the tx {Index}/{Total} {Transaction} as it doesn't follow policy.",
+                        i,
+                        stagedTransactions.Length,
+                        tx.Id
+                    );
                     UnstageTransaction(tx);
+                    continue;
                 }
-                else if (!skippedSigners.Contains(tx.Signer) &&
-                         Store.GetTxNonce(Id, tx.Signer) <= tx.Nonce &&
-                         tx.Nonce < GetNextTxNonce(tx.Signer))
-                {
-                    if (transactionsToMine.Count >= maxTransactions)
-                    {
-                        _logger.Information(
-                            "Not all staged transactions will be included in a block #{Index} to " +
-                            "be mined by {Miner}, because it reaches the maximum number of " +
-                            "acceptable transactions: {MaxTransactions}",
-                            index,
-                            miner,
-                            maxTransactions
-                        );
-                        break;
-                    }
 
+                long storeNonce = Store.GetTxNonce(Id, tx.Signer);
+                long nextNonce = GetNextTxNonce(tx.Signer);
+                if (storeNonce <= tx.Nonce && tx.Nonce < nextNonce)
+                {
                     if (estimatedBytes + tx.BytesLength > maxBlockBytes)
                     {
                         // Once someone's tx is excluded from a block, their later txs are also all
@@ -778,6 +818,27 @@ namespace Libplanet.Blockchain
 
                     transactionsToMine.Add(tx);
                     estimatedBytes += tx.BytesLength;
+                }
+                else
+                {
+                    _logger.Debug(
+                        "Tx {Index}/{Total} {Transaction} has an invalid nonce: {Nonce} " +
+                        "({Signer}).",
+                        i,
+                        stagedTransactions.Length,
+                        tx.Id,
+                        tx.Nonce,
+                        tx.Signer
+                    );
+                }
+
+                if (timeout < DateTimeOffset.UtcNow)
+                {
+                    _logger.Debug(
+                        "Reached the time limit to collect staged transactions; other staged " +
+                        "transactions will be mined later."
+                    );
+                    break;
                 }
             }
 
@@ -839,13 +900,34 @@ namespace Libplanet.Blockchain
                 block = new Block<T>(block, trieStateStore.GetRootHash(block.Hash));
             }
 
+            _logger.Debug(
+                "Mined a block #{Index} [difficulty: {Difficulty}; prev: {prevHash}; " +
+                "session: {SessionId}; proc: {ProcessId}].",
+                index,
+                difficulty,
+                prevHash,
+                sessionId,
+                procId
+            );
+
             if (append)
             {
                 Append(block, currentTime);
+
+                _logger.Debug(
+                    "Appended a block #{Index} [difficulty: {Difficulty}; prev: {prevHash}; " +
+                    "session: {SessionId}; proc: {ProcessId}].",
+                    index,
+                    difficulty,
+                    prevHash,
+                    sessionId,
+                    procId
+                );
             }
 
             return block;
         }
+#pragma warning restore MEN003
 
         /// <summary>
         /// Mines a next <see cref="Block{T}"/> using staged <see cref="Transaction{T}"/>s,


### PR DESCRIPTION
This ports the hotfix #1057 to the 0.10-maintenance branch.  Also applied reviews from #1057.  Read the changelog too.