### PR TITLE
Do not append genesis during fork

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -172,7 +172,13 @@ namespace Libplanet.Blockchain
                 GetBalance,
                 trieGetter);
 
-            if (Count == 0)
+            if (inFork && !(StateStore is IBlockStatesStore))
+            {
+                // If the store is BlockStateStore, have to fork state reference too so
+                // should use Append().
+                Store.AppendIndex(Id, genesisBlock.Hash);
+            }
+            else if (Count == 0)
             {
                 Append(
                     genesisBlock,


### PR DESCRIPTION
~Instead `IStore.ForkBlockIndexes()` became to iterate from 0 (was 1).~

Instead just append its index only.