### PR TITLE
Log block's hash in block exceptions

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1839,22 +1839,21 @@ namespace Libplanet.Blockchain
             if (nextBlock.Index != index)
             {
                 return new InvalidBlockIndexException(
-                    $"The expected block index is #{index}, but its index " +
-                    $"is #{nextBlock.Index}.");
+                    $"The expected index of block [{nextBlock.Hash}] is #{index}, " +
+                    $"but its index is #{nextBlock.Index}.");
             }
 
             if (nextBlock.Difficulty < difficulty)
             {
                 return new InvalidBlockDifficultyException(
-                    $"The expected difficulty of the block #{index} " +
-                    $"is {difficulty}, but its difficulty is " +
-                    $"{nextBlock.Difficulty}.");
+                    $"The expected difficulty of the block #{index} [{nextBlock.Hash}] " +
+                    $"is {difficulty}, but its difficulty is {nextBlock.Difficulty}.");
             }
 
             if (nextBlock.TotalDifficulty != totalDifficulty)
             {
                 var msg = $"The expected total difficulty of the block #{index} " +
-                          $"is {totalDifficulty}, but its difficulty is " +
+                          $"[{nextBlock.Hash}] is {totalDifficulty}, but its difficulty is " +
                           $"{nextBlock.TotalDifficulty}.";
                 return new InvalidBlockTotalDifficultyException(
                     nextBlock.Difficulty,
@@ -1867,13 +1866,14 @@ namespace Libplanet.Blockchain
                 if (prevHash is null)
                 {
                     return new InvalidBlockPreviousHashException(
-                        "the genesis block must have not previous block");
+                        $"The genesis block [{nextBlock.Hash}] should not have previous hash, " +
+                        $"but its value is [{nextBlock.PreviousHash}].");
                 }
 
                 return new InvalidBlockPreviousHashException(
-                    $"The block #{index} is not continuous from the " +
+                    $"The block #{index} [{nextBlock.Hash}] is not continuous from the " +
                     $"block #{index - 1}; while previous block's hash is " +
-                    $"{prevHash}, the block #{index}'s pointer to " +
+                    $"[{prevHash}], the block #{index} [{nextBlock.Hash}]'s pointer to " +
                     "the previous hash refers to " +
                     (nextBlock.PreviousHash?.ToString() ?? "nothing") + ".");
             }
@@ -1881,7 +1881,7 @@ namespace Libplanet.Blockchain
             if (nextBlock.Timestamp < prevTimestamp)
             {
                 return new InvalidBlockTimestampException(
-                    $"The block #{index}'s timestamp " +
+                    $"The block #{index} [{nextBlock.Hash}]'s timestamp " +
                     $"({nextBlock.Timestamp}) is earlier than" +
                     $" the block #{index - 1}'s ({prevTimestamp}).");
             }
@@ -1898,9 +1898,9 @@ namespace Libplanet.Blockchain
 
                 if (!rootHash.Equals(block.StateRootHash))
                 {
-                    var message = $"The block #{block.Index}'s state root hash is " +
-                                    $"{block.StateRootHash?.ToString()}, but the execution " +
-                                    $"result is {rootHash.ToString()}.";
+                    var message = $"The block #{block.Index} [{block.Hash}]'s state root hash " +
+                                  $"is {block.StateRootHash?.ToString()}, but the execution " +
+                                  $"result is {rootHash.ToString()}.";
                     throw new InvalidBlockStateRootHashException(
                         block.StateRootHash,
                         rootHash,

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -148,7 +148,7 @@ namespace Libplanet.Blockchain.Policies
             if (index < 0)
             {
                 throw new InvalidBlockIndexException(
-                    $"index must be 0 or more, but its index is {index}.");
+                    $"Count of blocks must be 0 or more, but its value is {index}.");
             }
 
             if (index <= 1)

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -235,23 +235,22 @@ namespace Libplanet.Blocks
             if (currentTime + TimestampThreshold < ts)
             {
                 throw new InvalidBlockTimestampException(
-                    $"The block #{Index}'s timestamp ({Timestamp}) is " +
-                    $"later than now ({currentTime}, " +
-                    $"threshold: {TimestampThreshold})."
+                    $"The block #{Index} [{ByteUtil.Hex(Hash)}]'s timestamp ({Timestamp}) is " +
+                    $"later than now ({currentTime}, threshold: {TimestampThreshold})."
                 );
             }
 
             if (Index < 0)
             {
                 throw new InvalidBlockIndexException(
-                    $"index must be 0 or more, but its index is {Index}."
+                    $"Block #{Index} [{ByteUtil.Hex(Hash)}]'s index must be 0 or more."
                 );
             }
 
             if (Difficulty > TotalDifficulty)
             {
-                var msg = $"A Block.Difficulty ({Difficulty}) must be less than" +
-                          $"its TotalDifficulty ({TotalDifficulty}).";
+                var msg = $"Block #{Index} [{ByteUtil.Hex(Hash)}]'s difficulty ({Difficulty}) " +
+                          $"must be less than its TotalDifficulty ({TotalDifficulty}).";
                 throw new InvalidBlockTotalDifficultyException(
                     Difficulty,
                     TotalDifficulty,
@@ -264,15 +263,16 @@ namespace Libplanet.Blocks
                 if (Difficulty != 0)
                 {
                     throw new InvalidBlockDifficultyException(
-                        "difficulty must be 0 for the genesis block, " +
+                        $"Difficulty must be 0 for the genesis block [{ByteUtil.Hex(Hash)}], " +
                         $"but its difficulty is {Difficulty}."
                     );
                 }
 
                 if (TotalDifficulty != 0)
                 {
-                    var msg = "Total difficulty must be 0 for the genesis block, " +
-                              $"but its total difficulty is {TotalDifficulty}.";
+                    var msg = "Total difficulty must be 0 for the genesis block " +
+                              $"[{ByteUtil.Hex(Hash)}], but its total difficulty is " +
+                              $"{TotalDifficulty}.";
                     throw new InvalidBlockTotalDifficultyException(
                         Difficulty,
                         TotalDifficulty,
@@ -283,7 +283,8 @@ namespace Libplanet.Blocks
                 if (!PreviousHash.IsEmpty)
                 {
                     throw new InvalidBlockPreviousHashException(
-                        "previous hash must be empty for the genesis block."
+                        $"Previous hash must be empty for the genesis block " +
+                        $"[{ByteUtil.Hex(Hash)}], but its value is [{ByteUtil.Hex(PreviousHash)}]."
                     );
                 }
             }
@@ -292,17 +293,16 @@ namespace Libplanet.Blocks
                 if (Difficulty < 1)
                 {
                     throw new InvalidBlockDifficultyException(
-                        "difficulty must be more than 0 (except of " +
-                        "the genesis block), but its difficulty is " +
-                        $"{Difficulty}."
+                        $"Block #{Index} [{ByteUtil.Hex(Hash)}]'s difficulty must be more than 0 " +
+                        $"(except of the genesis block), but its difficulty is {Difficulty}."
                     );
                 }
 
                 if (PreviousHash.IsEmpty)
                 {
                     throw new InvalidBlockPreviousHashException(
-                        "previous hash must be present except of " +
-                        "the genesis block."
+                        $"Block #{Index} [{ByteUtil.Hex(Hash)}]'s previous hash " +
+                        "must be present since it's not the genesis block."
                     );
                 }
             }
@@ -310,8 +310,9 @@ namespace Libplanet.Blocks
             if (!new HashDigest<SHA256>(PreEvaluationHash.ToArray()).Satisfies(Difficulty))
             {
                 throw new InvalidBlockNonceException(
-                    $"hash ({PreEvaluationHash}) with the nonce ({Nonce}) does not " +
-                    $"satisfy its difficulty level {Difficulty}."
+                    $"Block #{Index} [{ByteUtil.Hex(Hash)}]'s pre-evaluation hash " +
+                    $"({ByteUtil.Hex(PreEvaluationHash)}) with the nonce " +
+                    $"({ByteUtil.Hex(Nonce)}) does not satisfy its difficulty level {Difficulty}."
                 );
             }
         }


### PR DESCRIPTION
Enriched messages of exceptions which inherits `InvalidBlockException`. Now it typically has `#index [hash]` form.