### PR TITLE
feat(rocksdb): configure rocksdb options

### DIFF
--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -69,11 +69,17 @@ namespace Libplanet.RocksDBStore
         /// <param name="blockCacheSize">The capacity of the block cache.</param>
         /// <param name="txCacheSize">The capacity of the transaction cache.</param>
         /// <param name="statesCacheSize">The capacity of the states cache.</param>
+        /// <param name="maxTotalWalSize">The number to configure max_total_wal_size RocksDB option.
+        /// </param>
+        /// <param name="keepLogFileNum">The number to configure keep_log_file_num RocksDB option.
+        /// </param>
         public RocksDBStore(
             string path,
             int blockCacheSize = 512,
             int txCacheSize = 1024,
-            int statesCacheSize = 10000
+            int statesCacheSize = 10000,
+            ulong? maxTotalWalSize = null,
+            ulong? keepLogFileNum = null
         )
         {
             _logger = Log.ForContext<RocksDBStore>();
@@ -101,6 +107,16 @@ namespace Libplanet.RocksDBStore
             _path = path;
             _options = new DbOptions()
                 .SetCreateIfMissing();
+
+            if (maxTotalWalSize is ulong maxTotalWalSizeValue)
+            {
+                _options = _options.SetMaxTotalWalSize(maxTotalWalSizeValue);
+            }
+
+            if (keepLogFileNum is ulong keepLogFileNumValue)
+            {
+                _options = _options.SetKeepLogFileNum(keepLogFileNumValue);
+            }
 
             _blockDb = RocksDBUtils.OpenRocksDb(_options, RocksDbPath(BlockDbName));
             _txDb = RocksDBUtils.OpenRocksDb(_options, RocksDbPath(TxDbName));


### PR DESCRIPTION
It provides a new feature to configure some options of RocksDB options.

With `maxTotalWalSize`, you can limit the size of [WAL].
With `keepLogFileNum`, you can limit the number of log files.


[WAL]: https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log