### PR TITLE
Introduce Block<T>.Header

### DIFF
--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -813,7 +813,7 @@ namespace Libplanet.Tests.Blocks
             // Size of BlockDigest
             Assert.Equal(208, emptyBlock.ToBlockDigest().Serialize().Length);
             // Size of BlockHeader
-            Assert.Equal(203, codec.Encode(emptyBlock.GetBlockHeader().ToBencodex()).Length);
+            Assert.Equal(203, codec.Encode(emptyBlock.Header.ToBencodex()).Length);
 
             // Case of a block with txs, not contained state root.
             // Size of RawBlock
@@ -821,7 +821,7 @@ namespace Libplanet.Tests.Blocks
             // Size of BlockDigest
             Assert.Equal(293, txBlock.ToBlockDigest().Serialize().Length);
             // Size of BlockHeader
-            Assert.Equal(248, codec.Encode(txBlock.GetBlockHeader().ToBencodex()).Length);
+            Assert.Equal(248, codec.Encode(txBlock.Header.ToBencodex()).Length);
         }
 
         [Fact]

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -220,6 +220,40 @@ namespace Libplanet.Blocks
         [IgnoreDuringEquals]
         public IEnumerable<Transaction<T>> Transactions { get; }
 
+        /// <summary>
+        /// The <see cref="BlockHeader"/> of the block.
+        /// </summary>
+        [IgnoreDuringEquals]
+        public BlockHeader Header
+        {
+            get
+            {
+                string timestampAsString = Timestamp.ToString(
+                    BlockHeader.TimestampFormat,
+                    CultureInfo.InvariantCulture
+                );
+                ImmutableArray<byte> previousHashAsArray =
+                    PreviousHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
+                ImmutableArray<byte> stateRootHashAsArray =
+                    StateRootHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
+
+                // FIXME: When hash is not assigned, should throw an exception.
+                return new BlockHeader(
+                    index: Index,
+                    timestamp: timestampAsString,
+                    nonce: Nonce.ToByteArray().ToImmutableArray(),
+                    miner: Miner?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
+                    difficulty: Difficulty,
+                    totalDifficulty: TotalDifficulty,
+                    previousHash: previousHashAsArray,
+                    txHash: TxHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
+                    hash: Hash.ToByteArray().ToImmutableArray(),
+                    preEvaluationHash: PreEvaluationHash.ToByteArray().ToImmutableArray(),
+                    stateRootHash: stateRootHashAsArray
+                );
+            }
+        }
+
         public static bool operator ==(Block<T> left, Block<T> right) =>
             Operator.Weave(left, right);
 
@@ -497,7 +531,7 @@ namespace Libplanet.Blocks
         public BlockDigest ToBlockDigest()
         {
             return new BlockDigest(
-                header: GetBlockHeader(),
+                header: Header,
                 txIds: Transactions
                     .Select(tx => tx.Id.ToByteArray().ToImmutableArray())
                     .ToImmutableArray());
@@ -508,36 +542,9 @@ namespace Libplanet.Blocks
             return Hash.ToString();
         }
 
-        internal BlockHeader GetBlockHeader()
-        {
-            string timestampAsString = Timestamp.ToString(
-                BlockHeader.TimestampFormat,
-                CultureInfo.InvariantCulture
-            );
-            ImmutableArray<byte> previousHashAsArray =
-                PreviousHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
-            ImmutableArray<byte> stateRootHashAsArray =
-                StateRootHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty;
-
-            // FIXME: When hash is not assigned, should throw an exception.
-            return new BlockHeader(
-                index: Index,
-                timestamp: timestampAsString,
-                nonce: Nonce.ToByteArray().ToImmutableArray(),
-                miner: Miner?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
-                difficulty: Difficulty,
-                totalDifficulty: TotalDifficulty,
-                previousHash: previousHashAsArray,
-                txHash: TxHash?.ToByteArray().ToImmutableArray() ?? ImmutableArray<byte>.Empty,
-                hash: Hash.ToByteArray().ToImmutableArray(),
-                preEvaluationHash: PreEvaluationHash.ToByteArray().ToImmutableArray(),
-                stateRootHash: stateRootHashAsArray
-            );
-        }
-
         internal void Validate(DateTimeOffset currentTime)
         {
-            GetBlockHeader().Validate(currentTime);
+            Header.Validate(currentTime);
 
             foreach (Transaction<T> tx in Transactions)
             {
@@ -549,7 +556,7 @@ namespace Libplanet.Blocks
         {
             // For consistency, order transactions by its id.
             return new RawBlock(
-                header: GetBlockHeader(),
+                header: Header,
                 transactions: Transactions.OrderBy(tx => tx.Id)
                     .Select(tx => tx.Serialize(true).ToImmutableArray()).ToImmutableArray());
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1322,7 +1322,7 @@ namespace Libplanet.Net
         private void BroadcastBlock(Address? except, Block<T> block)
         {
             _logger.Debug("Trying to broadcast blocks...");
-            var message = new BlockHeaderMessage(BlockChain.Genesis.Hash, block.GetBlockHeader());
+            var message = new BlockHeaderMessage(BlockChain.Genesis.Hash, block.Header);
             BroadcastMessage(except, message);
             _logger.Debug("Block broadcasting complete.");
         }


### PR DESCRIPTION
Renamed internal method `Block<T>.GetBlockHeader()` to public property `Block<T>.Header`.