### PR TITLE
fix(blockchain): rwlock when call `SetStates()` on `MineBlock()`

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -849,7 +849,16 @@ namespace Libplanet.Blockchain
 
             if (StateStore is TrieStateStore trieStateStore)
             {
-                SetStates(block, actionEvaluations, false);
+                _rwlock.EnterWriteLock();
+                try
+                {
+                    SetStates(block, actionEvaluations, false);
+                }
+                finally
+                {
+                    _rwlock.ExitWriteLock();
+                }
+
                 block = new Block<T>(block, trieStateStore.GetRootHash(block.Hash));
             }
 


### PR DESCRIPTION
The title say it all