### PR TITLE
Optimize action evaluation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -183,6 +183,7 @@ To be released.
  -  Added `BlockHeader.EvaluationDigest` property.  [[#931], [#935]]
  -  Added `Block<T>.PreEvaluationHash` property.  [[#931], [#935]]
  -  Added `BlockHeader.PreEvaluationHash` property.  [[#931], [#935]]
+ -  Added `Transaction<T>.BytesLength` property.  [[#201], [#1050]]
  -  Added `HashDigest(ImmutableArray<byte>)` constructor.  [[#931], [#935]]
  -  Incomplete block states became able to be handled in more flexible way.
     [[#929], [#934], [#946], [#954]]

--- a/Libplanet.Tests/ByteArrayExtensionsTest.cs
+++ b/Libplanet.Tests/ByteArrayExtensionsTest.cs
@@ -25,5 +25,17 @@ namespace Libplanet.Tests
             Assert.True(bytes.StartsWith(new byte[] { 0 }));
             Assert.True(bytes.StartsWith(new byte[] { 0, 1 }));
         }
+
+        [Fact]
+        public void IndexOf()
+        {
+            Func<string, byte[]> b = ByteUtil.ParseHex;
+            Assert.Equal(-1, new byte[0].IndexOf(b("0a0b0c")));
+            Assert.Equal(-1, b("0a0b").IndexOf(b("0a0b0c")));
+            Assert.Equal(0, b("0a0b0c0d").IndexOf(b("0a0b0c")));
+            Assert.Equal(1, b("0a0b0c0d").IndexOf(b("0b0c0d")));
+            Assert.Equal(2, b("08090a0b0c0d").IndexOf(b("0a0b0c")));
+            Assert.Equal(-1, b("07080a0b0c0d").IndexOf(b("070809")));
+        }
     }
 }

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -94,6 +94,7 @@ namespace Libplanet.Tests.Tx
                 (stateStore, "RecordRehearsal"),
                 DumbAction.RehearsalRecords.Value
             );
+            Assert.Equal(338, tx.BytesLength);
         }
 
         [Fact]
@@ -324,6 +325,7 @@ namespace Libplanet.Tests.Tx
             };
 
             AssertBytesEqual(expected, _fx.Tx.Serialize(true));
+            Assert.Equal(expected.Length, _fx.Tx.BytesLength);
         }
 
         [Fact]
@@ -363,6 +365,7 @@ namespace Libplanet.Tests.Tx
             };
 
             AssertBytesEqual(expected, _fx.TxWithActions.Serialize(true));
+            Assert.Equal(expected.Length, _fx.TxWithActions.BytesLength);
         }
 
         [Fact]
@@ -426,6 +429,7 @@ namespace Libplanet.Tests.Tx
                 ),
                 tx.Id
             );
+            Assert.Equal(tx.BytesLength, bytes.Length);
         }
 
         [Fact]
@@ -533,6 +537,7 @@ namespace Libplanet.Tests.Tx
                 }),
                 tx.Actions[1].InnerAction.PlainValue
             );
+            Assert.Equal(bytes.Length, tx.BytesLength);
         }
 
         [SuppressMessage(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -416,10 +416,11 @@ namespace Libplanet.Blockchain
             _rwlock.EnterReadLock();
             try
             {
-                return _blocks.ContainsKey(blockHash) &&
-                       _blocks[blockHash].Index is long branchPointIndex &&
-                       branchPointIndex <= Tip?.Index &&
-                       this[branchPointIndex].Hash.Equals(blockHash);
+                return
+                    _blocks.ContainsKey(blockHash) &&
+                    Store.GetBlockIndex(blockHash) is { } branchPointIndex &&
+                    branchPointIndex <= Tip.Index &&
+                    Store.IndexBlockHash(Id, branchPointIndex).Equals(blockHash);
             }
             finally
             {

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -70,13 +70,29 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions.OrderBy(tx => tx.Id).ToArray();
-            var codec = new Codec();
-            TxHash = Transactions.Any()
-                ? Hashcash.Hash(
-                    codec.Encode(
-                        new Bencodex.Types.List(Transactions.Select(tx =>
-                            (IValue)tx.ToBencodex(true)))))
-                : (HashDigest<SHA256>?)null;
+            if (Transactions.Any())
+            {
+                byte[][] serializedTxs = Transactions.Select(tx => tx.Serialize(true)).ToArray();
+                int txHashSourceLength = serializedTxs.Select(b => b.Length).Sum() + 2;
+                var txHashSource = new byte[txHashSourceLength];
+
+                // Bencodex lists look like: l...e
+                txHashSource[0] = 0x6c;
+                txHashSource[txHashSourceLength - 1] = 0x65;
+                int offset = 1;
+                foreach (byte[] serializedTx in serializedTxs)
+                {
+                    serializedTx.CopyTo(txHashSource, offset);
+                    offset += serializedTx.Length;
+                }
+
+                TxHash = Hashcash.Hash(txHashSource);
+            }
+            else
+            {
+                TxHash = null;
+            }
+
             PreEvaluationHash = preEvaluationHash ?? Hashcash.Hash(SerializeForHash());
             StateRootHash = stateRootHash;
 

--- a/Libplanet/ByteArrayExtensions.cs
+++ b/Libplanet/ByteArrayExtensions.cs
@@ -50,5 +50,40 @@ namespace Libplanet
 
             return true;
         }
+
+        [Pure]
+        internal static int IndexOf(this byte[] bytes, byte[] sub)
+        {
+            // TODO: Make this method public and write the docs.
+            if (bytes.Length < 1)
+            {
+                return sub.Length > 0 ? -1 : 0;
+            }
+            else if (bytes.Length < sub.Length)
+            {
+                return -1;
+            }
+
+            // TODO: We need to optimize this...
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bool found = true;
+                for (int j = 0; j < sub.Length; j++)
+                {
+                    if (bytes[i + j] != sub[j])
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+
+                if (found)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
     }
 }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -34,6 +34,7 @@ namespace Libplanet.Tx
         // If a tx is longer than 50 KiB don't cache its bytes representation to _bytes.
         private const int BytesCacheThreshold = 50 * 1024;
 
+        private TxId? _id;
         private byte[] _signature;
         private byte[] _bytes;
         private int _bytesLength;
@@ -173,10 +174,6 @@ namespace Libplanet.Tx
             PublicKey = publicKey ??
                         throw new ArgumentNullException(nameof(publicKey));
 
-            using var hasher = SHA256.Create();
-            byte[] payload = Serialize(true);
-            Id = new TxId(hasher.ComputeHash(payload));
-
             if (validate)
             {
                 Validate();
@@ -210,7 +207,20 @@ namespace Libplanet.Tx
         /// <para>For more characteristics, see <see cref="TxId"/> type.</para>
         /// </summary>
         /// <seealso cref="TxId"/>
-        public TxId Id { get; }
+        public TxId Id
+        {
+            get
+            {
+                if (!(_id is { } nonNull))
+                {
+                    using var hasher = SHA256.Create();
+                    byte[] payload = Serialize(true);
+                    _id = nonNull = new TxId(hasher.ComputeHash(payload));
+                }
+
+                return nonNull;
+            }
+        }
 
         /// <summary>
         /// The number of previous <see cref="Transaction{T}"/>s committed by


### PR DESCRIPTION
Applied several optimizations on action evaluation.  With this patch, evaluating actions in 50,000 blocks on Nine Chronicles' mainnet takes less than about 50 seconds now (and it was about 1 minute before; MacBook Pro 2018; 2.2GHz Intel Core i7; 16 GB 2400 MHz DDR4).

This should be ported to 0.10-maintenance as well.