### PR TITLE
Optimize action evaluation (port)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ To be released.
     to mine if it takes longer than 4 seconds to collect and validate them.
     Those rest staged transactions are postponed until next block mining.
     [[#1057], [#1059]]
+ -  `BlockChain<T>.ContainsBlock()` method was optimized so that it does not
+    needlessly load an entire block, but looks up only an index instead.
+    [[#1057], [#1059]]
  -  `BlockChain<T>` became not to validate genesis block during fork,
     where the state store is not an implementation of `IBlockStatesStore`.
     [[#1063]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Version 0.10.1
 
 To be released.
 
+ -  The result bytes of `Transaction<T>.Serialize()` became cached
+    under the hood.  [[#1079, #1080]]
  -  Fixed `BlockChain<T>.MineBlock()` method's bug which excludes one's
     all transactions virtually forever after a signer's transactions once have
     been staged without the ascending order of nonce (usually due to their
@@ -25,6 +27,8 @@ To be released.
 [#1059]: https://github.com/planetarium/libplanet/pull/1059
 [#1063]: https://github.com/planetarium/libplanet/pull/1063
 [#1066]: https://github.com/planetarium/libplanet/pull/1066
+[#1079]: https://github.com/planetarium/libplanet/pull/1079
+[#1080]: https://github.com/planetarium/libplanet/pull/1080
 
 
 Version 0.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Version 0.10.1
 
 To be released.
 
+ -  `Transaction<T>.Id` property became lazy-loaded and cached if it's once
+    loaded.  (It had been loaded when the object is instantiated.)
+    [[#1079, #1080]]
  -  The result bytes of `Transaction<T>.Serialize()` became cached
     under the hood.  [[#1079, #1080]]
  -  Fixed `BlockChain<T>.MineBlock()` method's bug which excludes one's

--- a/Libplanet.Tests/ByteArrayExtensionsTest.cs
+++ b/Libplanet.Tests/ByteArrayExtensionsTest.cs
@@ -25,5 +25,17 @@ namespace Libplanet.Tests
             Assert.True(bytes.StartsWith(new byte[] { 0 }));
             Assert.True(bytes.StartsWith(new byte[] { 0, 1 }));
         }
+
+        [Fact]
+        public void IndexOf()
+        {
+            Func<string, byte[]> b = ByteUtil.ParseHex;
+            Assert.Equal(-1, new byte[0].IndexOf(b("0a0b0c")));
+            Assert.Equal(-1, b("0a0b").IndexOf(b("0a0b0c")));
+            Assert.Equal(0, b("0a0b0c0d").IndexOf(b("0a0b0c")));
+            Assert.Equal(1, b("0a0b0c0d").IndexOf(b("0b0c0d")));
+            Assert.Equal(2, b("08090a0b0c0d").IndexOf(b("0a0b0c")));
+            Assert.Equal(-1, b("07080a0b0c0d").IndexOf(b("070809")));
+        }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -416,10 +416,11 @@ namespace Libplanet.Blockchain
             _rwlock.EnterReadLock();
             try
             {
-                return _blocks.ContainsKey(blockHash) &&
-                       _blocks[blockHash].Index is long branchPointIndex &&
-                       branchPointIndex <= Tip?.Index &&
-                       this[branchPointIndex].Hash.Equals(blockHash);
+                return
+                    _blocks.ContainsKey(blockHash) &&
+                    Store.GetBlockIndex(blockHash) is { } branchPointIndex &&
+                    branchPointIndex <= Tip.Index &&
+                    Store.IndexBlockHash(Id, branchPointIndex).Equals(blockHash);
             }
             finally
             {

--- a/Libplanet/ByteArrayExtensions.cs
+++ b/Libplanet/ByteArrayExtensions.cs
@@ -50,5 +50,40 @@ namespace Libplanet
 
             return true;
         }
+
+        [Pure]
+        internal static int IndexOf(this byte[] bytes, byte[] sub)
+        {
+            // TODO: Make this method public and write the docs.
+            if (bytes.Length < 1)
+            {
+                return sub.Length > 0 ? -1 : 0;
+            }
+            else if (bytes.Length < sub.Length)
+            {
+                return -1;
+            }
+
+            // TODO: We need to optimize this...
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bool found = true;
+                for (int j = 0; j < sub.Length; j++)
+                {
+                    if (bytes[i + j] != sub[j])
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+
+                if (found)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
     }
 }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -35,6 +35,7 @@ namespace Libplanet.Tx
         // If a tx is longer than 50 KiB don't cache its bytes representation to _bytes.
         private const int BytesCacheThreshold = 50 * 1024;
 
+        private TxId? _id;
         private byte[] _signature;
         private byte[] _bytes;
         private int _bytesLength;
@@ -174,10 +175,6 @@ namespace Libplanet.Tx
             PublicKey = publicKey ??
                         throw new ArgumentNullException(nameof(publicKey));
 
-            using var hasher = SHA256.Create();
-            byte[] payload = Serialize(true);
-            Id = new TxId(hasher.ComputeHash(payload));
-
             if (validate)
             {
                 Validate();
@@ -211,7 +208,20 @@ namespace Libplanet.Tx
         /// <para>For more characteristics, see <see cref="TxId"/> type.</para>
         /// </summary>
         /// <seealso cref="TxId"/>
-        public TxId Id { get; }
+        public TxId Id
+        {
+            get
+            {
+                if (!(_id is { } nonNull))
+                {
+                    using var hasher = SHA256.Create();
+                    byte[] payload = Serialize(true);
+                    _id = nonNull = new TxId(hasher.ComputeHash(payload));
+                }
+
+                return nonNull;
+            }
+        }
 
         /// <summary>
         /// The number of previous <see cref="Transaction{T}"/>s committed by

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -32,7 +32,11 @@ namespace Libplanet.Tx
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
+        // If a tx is longer than 50 KiB don't cache its bytes representation to _bytes.
+        private const int BytesCacheThreshold = 50 * 1024;
+
         private byte[] _signature;
+        private byte[] _bytes;
         private int _bytesLength;
 
         /// <summary>
@@ -311,6 +315,11 @@ namespace Libplanet.Tx
             }
 
             var tx = new Transaction<T>(dict);
+            if (bytes.Length < BytesCacheThreshold)
+            {
+                tx._bytes = bytes;
+            }
+
             tx._bytesLength = bytes.Length;
             return tx;
         }
@@ -499,10 +508,45 @@ namespace Libplanet.Tx
         /// representation of this <see cref="Transaction{T}"/>.</returns>
         public byte[] Serialize(bool sign)
         {
-            var codec = new Codec();
+            Codec codec = null;
+            if (_bytes is { })
+            {
+                if (sign)
+                {
+                    return _bytes;
+                }
+
+                // Poor man's way to optimize serialization without signature...
+                // FIXME: We need to rather reorganize the serialization layout
+                //        & optimize Bencodex.Codec in general.
+                if (_signature is { } && _signature.Length > 0)
+                {
+                    codec = new Codec();
+                    byte[] sigDict =
+                        codec.Encode(Dictionary.Empty.Add(RawTransaction.SignatureKey, _signature));
+                    var sigField = new byte[sigDict.Length - 1];
+                    Array.Copy(sigDict, 1, sigField, 0, sigField.Length);
+                    int sigOffset = _bytes.IndexOf(sigField);
+                    if (sigOffset > 0)
+                    {
+                        int sigEnd = sigOffset + _signature.Length;
+                        var buffer = new byte[_bytes.Length - sigField.Length];
+                        Array.Copy(_bytes, buffer, sigOffset);
+                        Array.Copy(_bytes, sigEnd, buffer, sigOffset, _bytesLength - sigEnd);
+                        return buffer;
+                    }
+                }
+            }
+
+            codec ??= new Codec();
             byte[] serialized = codec.Encode(ToBencodex(sign));
             if (sign)
             {
+                if (serialized.Length < BytesCacheThreshold)
+                {
+                    _bytes = serialized;
+                }
+
                 _bytesLength = serialized.Length;
             }
 


### PR DESCRIPTION
*This must be merged after #1067 is merged first.*

This ports #1079 into the 0.10-maintenance branch.  Changelogs were added too.

> Applied several optimizations on action evaluation. With this patch, evaluating actions in 50,000 blocks on Nine Chronicles' mainnet takes less than about 50 seconds now (and it was about 1 minute before; MacBook Pro 2018; 2.2GHz Intel Core i7; 16 GB 2400 MHz DDR4).
> 
> This should be ported to 0.10-maintenance as well.

