### PR TITLE
feat(benchmark): add log for action execution benchmark

### DIFF
--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -87,6 +87,21 @@ namespace Libplanet.Tests.Action
             );
         }
 
+        [Fact]
+        public void PolymorphicActionToString()
+        {
+            Assert.Equal(
+                "Libplanet.Action.PolymorphicAction`1[Libplanet.Tests.Common.Action.Sleep]",
+                new PolymorphicAction<BaseAction>(new Sleep()).ToString());
+            Assert.Equal(
+                "Libplanet.Action.PolymorphicAction`1[Libplanet.Tests.Common.Action.Attack]",
+                new PolymorphicAction<BaseAction>(new Attack()).ToString());
+            Assert.Equal(
+                "Libplanet.Action.PolymorphicAction`1" +
+                "[Libplanet.Tests.Common.Action.DetectRehearsal]",
+                new PolymorphicAction<BaseAction>(new DetectRehearsal()).ToString());
+        }
+
         private class ActionNotAttributeAnnotated : IAction
         {
             public ActionNotAttributeAnnotated()

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -91,14 +91,14 @@ namespace Libplanet.Tests.Action
         public void PolymorphicActionToString()
         {
             Assert.Equal(
-                "Libplanet.Action.PolymorphicAction`1[Libplanet.Tests.Common.Action.Sleep]",
+                "Libplanet.Action.PolymorphicAction<Libplanet.Tests.Common.Action.Sleep>",
                 new PolymorphicAction<BaseAction>(new Sleep()).ToString());
             Assert.Equal(
-                "Libplanet.Action.PolymorphicAction`1[Libplanet.Tests.Common.Action.Attack]",
+                "Libplanet.Action.PolymorphicAction<Libplanet.Tests.Common.Action.Attack>",
                 new PolymorphicAction<BaseAction>(new Attack()).ToString());
             Assert.Equal(
-                "Libplanet.Action.PolymorphicAction`1" +
-                "[Libplanet.Tests.Common.Action.DetectRehearsal]",
+                "Libplanet.Action.PolymorphicAction" +
+                "<Libplanet.Tests.Common.Action.DetectRehearsal>",
                 new PolymorphicAction<BaseAction>(new DetectRehearsal()).ToString());
         }
 

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -7,6 +7,7 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
+using Serilog;
 
 namespace Libplanet.Action
 {
@@ -136,7 +137,11 @@ namespace Libplanet.Action
                 IAccountStateDelta nextStates = context.PreviousStates;
                 try
                 {
+                    DateTimeOffset actionExecutionStarted = DateTimeOffset.Now;
                     nextStates = action.Execute(context);
+                    TimeSpan spent = DateTimeOffset.Now - actionExecutionStarted;
+
+                    Log.Verbose($"{action} execution spent {spent.TotalMilliseconds} ms.");
                 }
                 catch (Exception e)
                 {

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -252,7 +252,9 @@ namespace Libplanet.Action
 
         public override string ToString()
         {
-            return $"{GetType().Namespace}.{GetType().Name}[{_innerAction}]";
+            const string polymorphicActionFullName = nameof(Libplanet) + "." + nameof(Action) +
+                                                     "." + nameof(PolymorphicAction<T>);
+            return $"{polymorphicActionFullName}<{_innerAction}>";
         }
     }
 }

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -249,5 +249,10 @@ namespace Libplanet.Action
         /// <inheritdoc/>
         public IAccountStateDelta Execute(IActionContext context) =>
             InnerAction.Execute(context);
+
+        public override string ToString()
+        {
+            return $"{GetType().Namespace}.{GetType().Name}[{_innerAction}]";
+        }
     }
 }


### PR DESCRIPTION
Also, it helps the problem that it was hard to know what `IAction` implementation the exception threw, with only exception message without debug tool. But it should be rejected or optimized if it became the part to make your application slow.