### PR TITLE
fix(mpt): treat as null if EmptyRootHash came as root

### DIFF
--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -16,6 +16,10 @@ namespace Libplanet.Tests.Store.Trie
                 = new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size));
             var merkleTrie = new MerkleTrie(new MemoryKeyValueStore(), hashDigest);
             Assert.Equal(hashDigest, merkleTrie.Hash);
+
+            // See https://github.com/planetarium/libplanet/pull/1091
+            merkleTrie = new MerkleTrie(new MemoryKeyValueStore(), MerkleTrie.EmptyRootHash);
+            Assert.Null(merkleTrie.Root);
         }
 
         [Fact]

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -63,7 +63,9 @@ namespace Libplanet.Store.Trie
         internal MerkleTrie(IKeyValueStore keyValueStore, INode? root = null, bool secure = false)
         {
             KeyValueStore = keyValueStore;
-            Root = root;
+            Root = root is HashNode hashNode && hashNode.HashDigest.Equals(EmptyRootHash)
+                ? null
+                : root;
             _secure = secure;
         }
 

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Store.Trie
 
         public HashDigest<SHA256> Hash => Root?.Hash() ?? EmptyRootHash;
 
-        private INode? Root { get; }
+        internal INode? Root { get; }
 
         private IKeyValueStore KeyValueStore { get; }
 


### PR DESCRIPTION
It fixes a bug where it couldn't store any states after genesis block if genesis block doesn't initialize any states.