### PR TITLE
fix(benchmarks): bump BenchmarkDotNet

### DIFF
--- a/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It resolves #1059 by bumping `BenchmarkDotNet`'s version into [0.12.1](https://benchmarkdotnet.org/changelog/v0.12.1.html).
Compare [failed benchmark action](https://github.com/moreal/libplanet/runs/1422688330?check_suite_focus=true) and [succeeded benchmark action](https://github.com/moreal/libplanet/runs/1424958760?check_suite_focus=true).