### PR TITLE
Port updates from 0.10.2 & make BlockExceedingTransactionsException public

### DIFF
--- a/.github/bin/dist-npm.sh
+++ b/.github/bin/dist-npm.sh
@@ -15,7 +15,7 @@ fi
 if [ "$publish_package" = "" ]; then
   dry_run=--dry-run
 else
-  dry_run=--dry-run
+  dry_run=
 fi
 
 set -x

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,19 @@ To be released.
 [#1102]: https://github.com/planetarium/libplanet/pull/1102
 
 
+Version 0.10.2
+--------------
+
+Released on November 25, 2020.
+
+ -  Fixed `BlockChain<T>.Append()` method's bug that it had accepted
+    a `Block<T>` having more `Transactions` than the number specified by
+    the `IBlockPolicy<T>.MaxTransactionsPerBlock` property.  Now it throws
+    `InvalidBlockException` instead for such case.  [[#1104]]
+
+[#1104]: https://github.com/planetarium/libplanet/pull/1104
+
+
 Version 0.10.1
 --------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ To be released.
 
 ### Added APIs
 
+ -  Added `BlockExceedingTransactionsException` class.  [[#1104], [#1110]]
  -  Added `BlockChain<T>.GetStagedTransactionIds()` method.  [[#1089]]
  -  (Libplanet.RocksDBStore) Added `maxTotalWalSize` and `keepLogFileNum`
     parameters into `RocksDBStore` constructor.  [[#1065], [#1102]]
@@ -59,6 +60,7 @@ To be released.
 [#1089]: https://github.com/planetarium/libplanet/pull/1089
 [#1101]: https://github.com/planetarium/libplanet/pull/1101
 [#1102]: https://github.com/planetarium/libplanet/pull/1102
+[#1110]: https://github.com/planetarium/libplanet/pull/1110
 
 
 Version 0.10.2

--- a/Libplanet.Tests/Blocks/BlockExceedingTransactionsExceptionTest.cs
+++ b/Libplanet.Tests/Blocks/BlockExceedingTransactionsExceptionTest.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Blocks;
+using Xunit;
+
+namespace Libplanet.Tests.Blocks
+{
+    public class BlockExceedingTransactionsExceptionTest
+    {
+        public void Serialization()
+        {
+            var e = new BlockExceedingTransactionsException(100, 50, "A message.");
+            var f = new BinaryFormatter();
+            InvalidBlockBytesLengthException e2;
+
+            using (var s = new MemoryStream())
+            {
+                f.Serialize(s, e);
+                s.Seek(0, SeekOrigin.Begin);
+                e2 = (InvalidBlockBytesLengthException)f.Deserialize(s);
+            }
+
+            Assert.Equal(e.Message, e2.Message);
+            Assert.Equal(e.ActualTransactions, e2.BlockBytesLength);
+            Assert.Equal(e.MaxTransactionsPerBlock, e2.MaxBlockBytesLength);
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -539,9 +539,14 @@ namespace Libplanet.Blockchain
         /// are required for action execution and rendering.
         /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.
         /// </param>
-        /// <exception cref="InvalidBlockException">Thrown when the given
-        /// <paramref name="block"/> is invalid, in itself or according to
-        /// the <see cref="Policy"/>.</exception>
+        /// <exception cref="InvalidBlockBytesLengthException">Thrown when the given <paramref
+        /// name="block"/> is too long in bytes (according to <see
+        /// cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>).</exception>
+        /// <exception cref="BlockExceedingTransactionsException">Thrown when the given <paramref
+        /// name="block"/> has too many transactions (according to <see
+        /// cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).</exception>
+        /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
+        /// is invalid, in itself or according to the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
         /// <see cref="Transaction{T}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
@@ -562,12 +567,14 @@ namespace Libplanet.Blockchain
         /// are required for action execution and rendering.
         /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.
         /// </param>
-        /// <exception cref="InvalidBlockBytesLengthException">Thrown when the block to mine is
-        /// too long (according to <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>) in bytes.
-        /// </exception>
+        /// <exception cref="InvalidBlockBytesLengthException">Thrown when the given <paramref
+        /// name="block"/> is too long in bytes (according to <see
+        /// cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>).</exception>
+        /// <exception cref="BlockExceedingTransactionsException">Thrown when the given <paramref
+        /// name="block"/> has too many transactions (according to <see
+        /// cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).</exception>
         /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
-        /// is invalid (e.g., too many transactions), in itself or according to
-        /// the <see cref="Policy"/>.</exception>
+        /// is invalid, in itself or according to the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
         /// <see cref="Transaction{T}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -565,8 +565,8 @@ namespace Libplanet.Blockchain
         /// <exception cref="InvalidBlockBytesLengthException">Thrown when the block to mine is
         /// too long (according to <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>) in bytes.
         /// </exception>
-        /// <exception cref="InvalidBlockException">Thrown when the given
-        /// <paramref name="block"/> is invalid, in itself or according to
+        /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
+        /// is invalid (e.g., too many transactions), in itself or according to
         /// the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
         /// <see cref="Transaction{T}.Nonce"/> is different from
@@ -1059,6 +1059,16 @@ namespace Libplanet.Blockchain
             stateCompleters ??= StateCompleterSet<T>.Recalculate;
 
             _logger.Debug("Trying to append block {blockIndex}: {block}", block?.Index, block);
+
+            if (block.Transactions.Count() is { } txCount &&
+                txCount > Policy.MaxTransactionsPerBlock)
+            {
+                throw new BlockExceedingTransactionsException(
+                    txCount,
+                    Policy.MaxTransactionsPerBlock,
+                    "The block to append has too many transactions."
+                );
+            }
 
             if (block.BytesLength > Policy.GetMaxBlockBytes(block.Index))
             {

--- a/Libplanet/Blocks/BlockExceedingTransactionsException.cs
+++ b/Libplanet/Blocks/BlockExceedingTransactionsException.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Blocks
     /// <see cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).
     /// </summary>
     [Serializable]
-    internal class BlockExceedingTransactionsException : InvalidBlockException, ISerializable
+    public class BlockExceedingTransactionsException : InvalidBlockException, ISerializable
     {
         public BlockExceedingTransactionsException(
             int actualTransactions,

--- a/Libplanet/Blocks/BlockExceedingTransactionsException.cs
+++ b/Libplanet/Blocks/BlockExceedingTransactionsException.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Runtime.Serialization;
+using Libplanet.Blockchain.Policies;
+
+namespace Libplanet.Blocks
+{
+    /// <summary>
+    /// The exception that is thrown when a <see cref="Block{T}"/> has too many
+    /// <see cref="Block{T}.Transactions"/> (i.e., more than the number specified by
+    /// <see cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).
+    /// </summary>
+    [Serializable]
+    internal class BlockExceedingTransactionsException : InvalidBlockException, ISerializable
+    {
+        public BlockExceedingTransactionsException(
+            int actualTransactions,
+            int maxTransactionsPerBlock,
+            string message
+        )
+            : base(
+                $"{message}\n" +
+                $"Actual: {actualTransactions} txs\n" +
+                $"Allowed (max): {maxTransactionsPerBlock} txs")
+        {
+            ActualTransactions = actualTransactions;
+            MaxTransactionsPerBlock = maxTransactionsPerBlock;
+        }
+
+        public BlockExceedingTransactionsException(SerializationInfo info, StreamingContext context)
+            : base(info.GetString(nameof(Message)) ?? string.Empty)
+        {
+            ActualTransactions = info.GetInt32(nameof(ActualTransactions));
+            MaxTransactionsPerBlock = info.GetInt32(nameof(MaxTransactionsPerBlock));
+        }
+
+        /// <summary>
+        /// The actual number of transactions in the block.
+        /// </summary>
+        public int ActualTransactions { get; set; }
+
+        /// <summary>
+        /// The maximum allowed number of transactions per block.
+        /// </summary>
+        /// <seealso cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>
+        public int MaxTransactionsPerBlock { get; set; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Message), Message);
+            info.AddValue(nameof(ActualTransactions), ActualTransactions);
+            info.AddValue(nameof(MaxTransactionsPerBlock), MaxTransactionsPerBlock);
+        }
+    }
+}

--- a/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
+++ b/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
@@ -29,8 +29,8 @@ namespace Libplanet.Blocks
         )
             : base(
                 $"{message}\n" +
-                $"Actual: #{blockBytesLength} bytes\n" +
-                $"Allowed (max): #{maxBlockBytesLength}")
+                $"Actual: {blockBytesLength} bytes\n" +
+                $"Allowed (max): {maxBlockBytesLength} bytes")
         {
             BlockBytesLength = blockBytesLength;
             MaxBlockBytesLength = maxBlockBytesLength;


### PR DESCRIPTION
- Port updates from 0.10.2.
- Make `BlockExceedingTransactionsException` class public (as mentioned in #1104).