### PR TITLE
Ignore stale block demand

### DIFF
--- a/Libplanet/Net/BlockDemand.cs
+++ b/Libplanet/Net/BlockDemand.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using Libplanet.Blocks;
 
 namespace Libplanet.Net
@@ -18,10 +19,17 @@ namespace Libplanet.Net
         /// </summary>
         public readonly BoundPeer Peer;
 
-        public BlockDemand(BlockHeader header, BoundPeer peer)
+        /// <summary>
+        /// The <see cref="DateTimeOffset"/> when
+        /// the corresponding block information was received.
+        /// </summary>
+        public readonly DateTimeOffset Timestamp;
+
+        public BlockDemand(BlockHeader header, BoundPeer peer, DateTimeOffset timestamp)
         {
             Header = header;
             Peer = peer;
+            Timestamp = timestamp;
         }
     }
 }

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -189,7 +189,7 @@ namespace Libplanet.Net
                         header.Index,
                         ByteUtil.Hex(header.Hash),
                         peer);
-                    BlockDemand = new BlockDemand(header, peer);
+                    BlockDemand = new BlockDemand(header, peer, DateTimeOffset.UtcNow);
                 }
                 else
                 {

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -182,7 +182,7 @@ namespace Libplanet.Net
 
             using (await _blockSyncMutex.LockAsync(cancellationToken))
             {
-                if (IsDemandNeeded(header))
+                if (IsDemandNeeded(header, peer))
                 {
                     _logger.Debug(
                         "BlockDemand #{index} {blockHash} from {peer}.",

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -34,7 +34,6 @@ namespace Libplanet.Net
 
         private readonly AsyncLock _blockSyncMutex;
         private readonly AsyncLock _runningMutex;
-        private readonly TimeSpan _blockDemandLifespan = TimeSpan.FromMinutes(1);
 
         private readonly ILogger _logger;
         private readonly IStore _store;
@@ -1695,7 +1694,7 @@ namespace Libplanet.Net
         {
             return target.TotalDifficulty > BlockChain.Tip.TotalDifficulty
                    && (BlockDemand is null
-                       || (BlockDemand.Value.Timestamp + _blockDemandLifespan <
+                       || (BlockDemand.Value.Timestamp + Options.BlockDemandLifespan <
                            DateTimeOffset.UtcNow && !BlockDemand.Value.Peer.Equals(peer))
                        || BlockDemand.Value.Header.TotalDifficulty < target.TotalDifficulty);
         }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -34,6 +34,7 @@ namespace Libplanet.Net
 
         private readonly AsyncLock _blockSyncMutex;
         private readonly AsyncLock _runningMutex;
+        private readonly TimeSpan _blockDemandLifespan = TimeSpan.FromMinutes(1);
 
         private readonly ILogger _logger;
         private readonly IStore _store;
@@ -1690,11 +1691,13 @@ namespace Libplanet.Net
             BroadcastMessage(except, message);
         }
 
-        private bool IsDemandNeeded(BlockHeader target)
+        private bool IsDemandNeeded(BlockHeader target, BoundPeer peer)
         {
-            return target.TotalDifficulty > BlockChain.Tip.TotalDifficulty &&
-                   (BlockDemand is null ||
-                    BlockDemand.Value.Header.TotalDifficulty < target.TotalDifficulty);
+            return target.TotalDifficulty > BlockChain.Tip.TotalDifficulty
+                   && (BlockDemand is null
+                       || (BlockDemand.Value.Timestamp + _blockDemandLifespan <
+                           DateTimeOffset.UtcNow && !BlockDemand.Value.Peer.Equals(peer))
+                       || BlockDemand.Value.Header.TotalDifficulty < target.TotalDifficulty);
         }
 
         private async Task SyncPreviousBlocksAsync(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1981,6 +1981,8 @@ namespace Libplanet.Net
                 {
                     using (await _blockSyncMutex.LockAsync(cancellationToken))
                     {
+                        _logger.Debug(
+                            $"{nameof(ProcessFillBlocks)} finished. Reset {nameof(BlockDemand)}");
                         BlockDemand = null;
                     }
                 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1981,6 +1981,8 @@ namespace Libplanet.Net
                 {
                     using (await _blockSyncMutex.LockAsync(cancellationToken))
                     {
+                        // FIXME: Should only reset when BlockDemand has not changed
+                        // from the beginning of this operation.
                         _logger.Debug(
                             $"{nameof(ProcessFillBlocks)} finished. Reset {nameof(BlockDemand)}");
                         BlockDemand = null;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1983,8 +1983,8 @@ namespace Libplanet.Net
                     {
                         // FIXME: Should only reset when BlockDemand has not changed
                         // from the beginning of this operation.
-                        _logger.Debug(
-                            $"{nameof(ProcessFillBlocks)} finished. Reset {nameof(BlockDemand)}");
+                        _logger.Debug($"{nameof(ProcessFillBlocks)}() finished. " +
+                                      $"Reset {nameof(BlockDemand)}...");
                         BlockDemand = null;
                     }
                 }

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -36,5 +36,10 @@ namespace Libplanet.Net
         /// The timeout used to block download in preloading.
         /// </summary>
         public TimeSpan BlockDownloadTimeout { get; set; } = Timeout.InfiniteTimeSpan;
+
+        /// <summary>
+        /// The lifespan of block demand.
+        /// </summary>
+        public TimeSpan BlockDemandLifespan { get; set; } = TimeSpan.FromMinutes(1);
     }
 }


### PR DESCRIPTION
I skipped changelog for `BlockDemand.Timestamp` because BlockDemand struct is first introduced in 0.11.