### PR TITLE
Break when getting blocks count is less then hash chunk size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ To be released.
 ### Backward-incompatible API changes
 
 ### Backward-incompatible network protocol changes
+ -   `Swarm<T>` became no longer retry when `Swarm<T>` receives
+      less than 500 blocks.  [[#1112]]
 
 ### Backward-incompatible storage format changes
 
@@ -61,6 +63,7 @@ To be released.
 [#1101]: https://github.com/planetarium/libplanet/pull/1101
 [#1102]: https://github.com/planetarium/libplanet/pull/1102
 [#1110]: https://github.com/planetarium/libplanet/pull/1110
+[#1112]: https://github.com/planetarium/libplanet/pull/1112
 
 
 Version 0.10.2

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1862,6 +1862,7 @@ namespace Libplanet.Net
                         cancellationToken
                     );
 
+                    var receivedBlockCountCurrentLoop = 0;
                     await foreach (Block<T> block in blocks)
                     {
                         _logger.Debug(
@@ -1879,11 +1880,11 @@ namespace Libplanet.Net
                             renderBlocks: renderBlocks,
                             renderActions: renderActions
                         );
-                        receivedBlockCount++;
+                        receivedBlockCountCurrentLoop++;
                         progress?.Report(new BlockDownloadState
                         {
                             TotalBlockCount = totalBlockCount,
-                            ReceivedBlockCount = receivedBlockCount,
+                            ReceivedBlockCount = receivedBlockCount + receivedBlockCountCurrentLoop,
                             ReceivedBlockHash = block.Hash,
                             SourcePeer = peer,
                         });
@@ -1892,6 +1893,18 @@ namespace Libplanet.Net
                             block.Index,
                             block.Hash
                         );
+                    }
+
+                    receivedBlockCount += receivedBlockCountCurrentLoop;
+
+                    // FIXME: Need test
+                    if (receivedBlockCountCurrentLoop < FindNextHashesChunkSize)
+                    {
+                        _logger.Debug(
+                            $"Got all blocks from Peer [{peer}]",
+                            peer.Address.ToHex()
+                            );
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
If getting blocks size in `Swarm<T>.FillBlocksAsync()` is less then `Swarm<T>.FindNextHashesChunkSize`, it means getting all of blocks in this try. So, do not processing next step for check.