### PR TITLE
Do not append genesis block during fork

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -174,7 +174,7 @@ namespace Libplanet.Blockchain
 
             if (Count == 0)
             {
-                if (StateStore is TrieStateStore tss && tss.ContainsBlockStates(genesisBlock.Hash))
+                if (inFork && StateStore is TrieStateStore)
                 {
                     // If the store is BlockStateStore, have to fork state reference too so
                     // should use Append().


### PR DESCRIPTION
Skip changelog because `BlockChain<T>.Fork()` is internal.