### PR TITLE
Reuse action evaluations from mining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,8 @@ To be released.
  -  `Swarm<T>` became not to receive states from trusted peers.
     [[#1061], [#1102]]
  -  `Swarm<T>` became not to retry when block downloading.  [[#1062], [#1102]]
- -  `Block<T>.Validate()` became to validate only `Block<T>.TxHash` instead of its all transactions.  [[#1116]]
+ -  `Block<T>.Evaluate()` became to validate only `Block<T>.TxHash` instead of
+    its all transactions.  [[#1116]]
  -  Improved performance of `BlockChain<T>.MineBlock()`.  [[#1116]]
  -  Improved performance of `Block<T>.Deserialize()`.  [[#1116]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ To be released.
     class.  [[#1119]]
  -  Added `Libplanet.Blockchain.Renderers.Debug.InvalidRenderException<T>`
     class.  [[#1119]]
+ -  Added `InvalidBlockTxHashException` class.  [[#1116]]
 
 ### Behavioral changes
 
@@ -62,6 +63,9 @@ To be released.
  -  `Swarm<T>` became not to receive states from trusted peers.
     [[#1061], [#1102]]
  -  `Swarm<T>` became not to retry when block downloading.  [[#1062], [#1102]]
+ -  `Block<T>.Validate()` became to validate only `Block<T>.TxHash` instead of its all transactions.  [[#1116]]
+ -  Improved performance of `BlockChain<T>.MineBlock()`.  [[#1116]]
+ -  Improved performance of `Block<T>.Deserialize()`.  [[#1116]]
 
 ### Bug fixes
 
@@ -82,6 +86,7 @@ To be released.
 [#1102]: https://github.com/planetarium/libplanet/pull/1102
 [#1110]: https://github.com/planetarium/libplanet/pull/1110
 [#1112]: https://github.com/planetarium/libplanet/pull/1112
+[#1116]: https://github.com/planetarium/libplanet/pull/1116
 [#1119]: https://github.com/planetarium/libplanet/pull/1119
 
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -687,6 +687,7 @@ namespace Libplanet.Tests.Blockchain
                     nonce: nonce,
                     privateKey: signer);
                 heavyTxs.Add(heavyTx);
+                nonce += 1;
             }
 
             var block1 = TestUtils.MineNext(

--- a/Libplanet.Tests/Blocks/InvalidBlocckTxHashExceptionTest.cs
+++ b/Libplanet.Tests/Blocks/InvalidBlocckTxHashExceptionTest.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+using Xunit;
+
+namespace Libplanet.Tests.Blocks
+{
+    public class InvalidBlocckTxHashExceptionTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var blockHash = new HashDigest<SHA256>(
+                TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)
+            );
+            var calculatedBlockHash = new HashDigest<SHA256>(
+                TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)
+            );
+            var exc = new InvalidBlockTxHashException("TESTING", blockHash, calculatedBlockHash);
+
+            var formatter = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                formatter.Serialize(ms, exc);
+                ms.Seek(0, SeekOrigin.Begin);
+                var deserialized = (InvalidBlockTxHashException)formatter.Deserialize(ms);
+
+                Assert.Equal(deserialized, exc);
+            }
+        }
+    }
+}

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -526,13 +526,9 @@ namespace Libplanet.Blocks
         /// <exception cref="InvalidBlockNonceException">Thrown when
         /// the <see cref="Nonce"/> does not satisfy its
         /// <see cref="Difficulty"/> level.</exception>
-        /// <exception cref="InvalidTxSignatureException">Thrown when its
-        /// <see cref="Transaction{T}.Signature"/> is invalid or not signed by
-        /// the account who corresponds to its
-        /// <see cref="Transaction{T}.PublicKey"/>.</exception>
-        /// <exception cref="InvalidTxPublicKeyException">Thrown when its
-        /// <see cref="Transaction{T}.Signer"/> is not derived from its
-        /// <see cref="Transaction{T}.PublicKey"/>.</exception>
+        /// <exception cref="InvalidBlockTxHashException">Thrown when
+        /// the <see cref="TxHash" /> does not match with its
+        /// <see cref="Transactions"/>.</exception>
         /// <exception cref="InvalidTxUpdatedAddressesException">Thrown when
         /// any <see cref="IAction"/> of <see cref="Transactions"/> tries
         /// to update the states of <see cref="Address"/>es not included

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -72,28 +72,7 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions.OrderBy(tx => tx.Id).ToArray();
-            if (Transactions.Any())
-            {
-                byte[][] serializedTxs = Transactions.Select(tx => tx.Serialize(true)).ToArray();
-                int txHashSourceLength = serializedTxs.Select(b => b.Length).Sum() + 2;
-                var txHashSource = new byte[txHashSourceLength];
-
-                // Bencodex lists look like: l...e
-                txHashSource[0] = 0x6c;
-                txHashSource[txHashSourceLength - 1] = 0x65;
-                int offset = 1;
-                foreach (byte[] serializedTx in serializedTxs)
-                {
-                    serializedTx.CopyTo(txHashSource, offset);
-                    offset += serializedTx.Length;
-                }
-
-                TxHash = Hashcash.Hash(txHashSource);
-            }
-            else
-            {
-                TxHash = null;
-            }
+            TxHash = CalcualteTxHashes(Transactions);
 
             PreEvaluationHash = preEvaluationHash ?? Hashcash.Hash(SerializeForHash());
             StateRootHash = stateRootHash;
@@ -166,6 +145,7 @@ namespace Libplanet.Blocks
 
         private Block(RawBlock rb)
             : this(
+                new HashDigest<SHA256>(rb.Header.Hash),
                 rb.Header.Index,
                 rb.Header.Difficulty,
                 rb.Header.TotalDifficulty,
@@ -178,6 +158,9 @@ namespace Libplanet.Blocks
                     rb.Header.Timestamp,
                     BlockHeader.TimestampFormat,
                     CultureInfo.InvariantCulture).ToUniversalTime(),
+#pragma warning disable MEN002 // Line is too long
+                rb.Header.TxHash.Any() ? new HashDigest<SHA256>(rb.Header.TxHash) : (HashDigest<SHA256>?)null,
+#pragma warning restore MEN002 // Line is too long
                 rb.Transactions
                     .Select(tx => Transaction<T>.Deserialize(tx.ToArray()))
                     .ToList(),
@@ -186,6 +169,36 @@ namespace Libplanet.Blocks
                 rb.Header.StateRootHash.Any() ? new HashDigest<SHA256>(rb.Header.StateRootHash) : (HashDigest<SHA256>?)null)
 #pragma warning restore MEN002 // Line is too long
         {
+        }
+
+        private Block(
+            HashDigest<SHA256> hash,
+            long index,
+            long difficulty,
+            BigInteger totalDifficulty,
+            Nonce nonce,
+            Address? miner,
+            HashDigest<SHA256>? previousHash,
+            DateTimeOffset timestamp,
+            HashDigest<SHA256>? txHash,
+            IEnumerable<Transaction<T>> transactions,
+            HashDigest<SHA256>? preEvaluationHash,
+            HashDigest<SHA256>? stateRootHash
+        )
+        {
+            Index = index;
+            Difficulty = difficulty;
+            TotalDifficulty = totalDifficulty;
+            Nonce = nonce;
+            Miner = miner;
+            PreviousHash = previousHash;
+            Timestamp = timestamp;
+            Hash = hash;
+            PreEvaluationHash = preEvaluationHash ??
+                throw new ArgumentNullException(nameof(preEvaluationHash));
+            StateRootHash = stateRootHash;
+            TxHash = txHash;
+            Transactions = transactions.ToImmutableArray();
         }
 
         /// <summary>
@@ -591,19 +604,48 @@ namespace Libplanet.Blocks
         {
             Header.Validate(currentTime);
 
-            foreach (Transaction<T> tx in Transactions)
+            HashDigest<SHA256>? calculatedTxHash =
+                CalcualteTxHashes(Transactions.OrderBy(tx => tx.Id));
+            if (!calculatedTxHash.Equals(TxHash))
             {
-                tx.Validate();
+                throw new InvalidBlockTxHashException(
+                    $"Block #{Index} {Hash}'s TxHash doesn't match its content.",
+                    TxHash,
+                    calculatedTxHash
+                );
             }
         }
 
         internal RawBlock ToRawBlock()
         {
-            // For consistency, order transactions by its id.
             return new RawBlock(
                 header: Header,
-                transactions: Transactions.OrderBy(tx => tx.Id)
-                    .Select(tx => tx.Serialize(true).ToImmutableArray()).ToImmutableArray());
+                transactions: Transactions
+                .Select(tx => tx.Serialize(true).ToImmutableArray()).ToImmutableArray());
+        }
+
+        private static HashDigest<SHA256>? CalcualteTxHashes(IEnumerable<Transaction<T>> txs)
+        {
+            if (!txs.Any())
+            {
+                return null;
+            }
+
+            byte[][] serializedTxs = txs.Select(tx => tx.Serialize(true)).ToArray();
+            int txHashSourceLength = serializedTxs.Select(b => b.Length).Sum() + 2;
+            var txHashSource = new byte[txHashSourceLength];
+
+            // Bencodex lists look like: l...e
+            txHashSource[0] = 0x6c;
+            txHashSource[txHashSourceLength - 1] = 0x65;
+            int offset = 1;
+            foreach (byte[] serializedTx in serializedTxs)
+            {
+                serializedTx.CopyTo(txHashSource, offset);
+                offset += serializedTx.Length;
+            }
+
+            return Hashcash.Hash(txHashSource);
         }
 
         private byte[] SerializeForHash(HashDigest<SHA256>? stateRootHash = null)

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -196,6 +196,10 @@ namespace Libplanet.Blocks
             Hash = hash;
             PreEvaluationHash = preEvaluationHash ??
                 throw new ArgumentNullException(nameof(preEvaluationHash));
+
+            // See also: https://github.com/planetarium/libplanet/pull/1116#discussion_r535836480
+            // FIXME: we should convert `StateRootHash`'s type to `HashDisgest<SHA256>` after
+            // removing `IBlockStateStore`.
             StateRootHash = stateRootHash;
             TxHash = txHash;
             Transactions = transactions.ToImmutableArray();

--- a/Libplanet/Blocks/InvalidBlockTxHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockTxHashException.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Runtime.Serialization;
+using System.Security.Cryptography;
+
+namespace Libplanet.Blocks
+{
+    [Serializable]
+    [Equals]
+    public class InvalidBlockTxHashException : InvalidBlockException
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="InvalidBlockTxHashException"/> class.
+        /// </summary>
+        /// <param name="blockTxHash">The hashdigest of <see cref="Block{T}.TxHash"/>.</param>
+        /// <param name="calculatedTxHash">The calculated hashdigest from
+        /// <see cref="Block{T}.Transactions"/>.</param>
+        /// <param name="message">The message that describes the error.</param>
+        public InvalidBlockTxHashException(
+            string message,
+            HashDigest<SHA256>? blockTxHash,
+            HashDigest<SHA256>? calculatedTxHash)
+            : base($"{message}\n" +
+                $"In block header: {blockTxHash}\n" +
+                $"Calculated: {calculatedTxHash}")
+        {
+            BlockTxHash = blockTxHash;
+            CalculatedTxHash = calculatedTxHash;
+        }
+
+        protected InvalidBlockTxHashException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if ((byte[])info.GetValue(nameof(BlockTxHash), typeof(byte[])) is { } bTxHashBytes)
+            {
+                BlockTxHash = new HashDigest<SHA256>(bTxHashBytes);
+            }
+
+            if ((byte[])info.GetValue(nameof(CalculatedTxHash), typeof(byte[])) is { } cTxHashBytes)
+            {
+                CalculatedTxHash = new HashDigest<SHA256>(cTxHashBytes);
+            }
+        }
+
+        /// <summary>
+        /// The hashdigest from actual block.
+        /// </summary>
+        public HashDigest<SHA256>? BlockTxHash { get; }
+
+        /// <summary>
+        /// The calculated hashdigest from transactions in the block.
+        /// </summary>
+        public HashDigest<SHA256>? CalculatedTxHash { get; }
+
+        public static bool operator ==(
+            InvalidBlockTxHashException left,
+            InvalidBlockTxHashException right
+        ) => Operator.Weave(left, right);
+
+        public static bool operator !=(
+            InvalidBlockTxHashException left,
+            InvalidBlockTxHashException right
+        ) => Operator.Weave(left, right);
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(BlockTxHash), BlockTxHash?.ToByteArray());
+            info.AddValue(nameof(CalculatedTxHash), CalculatedTxHash?.ToByteArray());
+        }
+    }
+}

--- a/Libplanet/Blocks/InvalidBlockTxHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockTxHashException.cs
@@ -11,8 +11,8 @@ namespace Libplanet.Blocks
         /// <summary>
         /// Initializes a new instance of <see cref="InvalidBlockTxHashException"/> class.
         /// </summary>
-        /// <param name="blockTxHash">The hashdigest of <see cref="Block{T}.TxHash"/>.</param>
-        /// <param name="calculatedTxHash">The calculated hashdigest from
+        /// <param name="blockTxHash">The hash digest of <see cref="Block{T}.TxHash"/>.</param>
+        /// <param name="calculatedTxHash">The calculated hash digest from
         /// <see cref="Block{T}.Transactions"/>.</param>
         /// <param name="message">The message that describes the error.</param>
         public InvalidBlockTxHashException(
@@ -42,12 +42,12 @@ namespace Libplanet.Blocks
         }
 
         /// <summary>
-        /// The hashdigest from actual block.
+        /// The hash digest from actual block.
         /// </summary>
         public HashDigest<SHA256>? BlockTxHash { get; }
 
         /// <summary>
-        /// The calculated hashdigest from transactions in the block.
+        /// The calculated hash digest from transactions in the block.
         /// </summary>
         public HashDigest<SHA256>? CalculatedTxHash { get; }
 


### PR DESCRIPTION
This PR increases the performance of `BlockChain<T>.MineBlock()` and `Block<T>.Deserialize()`.

- `BlockChain<T>.MineBlock()` became to reuse action evaluations while `.Append()`.
- `Block<T>.Deserielize()` became to accept all serialized values(e.g. `.Hash`, `.TxHash`) instead of re-calculating them.

and it also changes the behavior of `Block<T>.Validate()` to only checks its `.TxHash`, not all `.Transactions`. for it, I created `InvalidBlockTxHashException` as a new exception.