### PR TITLE
fix: correct a typo

### DIFF
--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -73,7 +73,7 @@ namespace Libplanet.Net
         /// <summary>
         /// Conducts peer discovery for given <paramref name="bootstrapPeers"/>.
         /// </summary>
-        /// <param name="bootstrapPeers">A <see cref="IEnumerable{T}"/> of <see cref="Peer"/>s
+        /// <param name="bootstrapPeers">A list of <see cref="Peer"/>s
         /// to bootstrap.</param>
         /// <param name="pingSeedTimeout">A timeout of waiting for the reply of <see cref="Ping"/>
         /// message sent to seed <see cref="Peer"/>.


### PR DESCRIPTION
It fixes a typo in `ITransport.BootstrapAsync()`'s `bootstrapPeers` parameter.

![image](https://user-images.githubusercontent.com/26626194/101321647-09cd2580-38a9-11eb-9a2f-8a108c0b55df.png)

https://docs.libplanet.io/main/api/Libplanet.Net.ITransport.html#Libplanet_Net_ITransport_BootstrapAsync_IEnumerable_Libplanet_Net_BoundPeer__System_Nullable_TimeSpan__System_Nullable_TimeSpan__System_Int32_CancellationToken_