### PR TITLE
Improve tx selecting performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,7 +77,7 @@ To be released.
  -  `Swarm<T>` became not to retry when block downloading.  [[#1062], [#1102]]
  -  `Block<T>.Evaluate()` became to validate only `Block<T>.TxHash` instead of
     its all transactions.  [[#1116]]
- -  Improved performance of `BlockChain<T>.MineBlock()`.  [[#1116]]
+ -  Improved performance of `BlockChain<T>.MineBlock()`.  [[#1116], [#1124]]
  -  Improved performance of `Block<T>.Deserialize()`.  [[#1116]]
  -  `Swarm<T>` became not to fill states from trusted peers, because now states
     can be validated rather than trusted due to MPT.  [[#1117]]
@@ -106,6 +106,7 @@ To be released.
 [#1116]: https://github.com/planetarium/libplanet/pull/1116
 [#1117]: https://github.com/planetarium/libplanet/pull/1117
 [#1119]: https://github.com/planetarium/libplanet/pull/1119
+[#1124]: https://github.com/planetarium/libplanet/pull/1124
 [#1125]: https://github.com/planetarium/libplanet/pull/1125
 
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -780,6 +780,8 @@ namespace Libplanet.Blockchain
 
             foreach (Transaction<T> tx in stagedTransactions)
             {
+                // We don't care about nonce ordering here because `.ListStagedTransactions()`
+                // returns already ordered transactions by its nonce.
                 if (!storedNonces.ContainsKey(tx.Signer))
                 {
                     storedNonces[tx.Signer] = Store.GetTxNonce(Id, tx.Signer);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -775,9 +775,25 @@ namespace Libplanet.Blockchain
             ).BytesLength;
             int maxBlockBytes = Math.Max(Policy.GetMaxBlockBytes(index), 1);
             var skippedSigners = new HashSet<Address>();
+            var storedNonces = new Dictionary<Address, long>();
+            var nextNonces = new Dictionary<Address, long>();
 
             foreach (Transaction<T> tx in stagedTransactions)
             {
+                if (!storedNonces.ContainsKey(tx.Signer))
+                {
+                    storedNonces[tx.Signer] = Store.GetTxNonce(Id, tx.Signer);
+                }
+
+                if (nextNonces.TryGetValue(tx.Signer, out long prevNonce))
+                {
+                    nextNonces[tx.Signer] = prevNonce + 1;
+                }
+                else
+                {
+                    nextNonces[tx.Signer] = storedNonces[tx.Signer] + 1;
+                }
+
                 _logger.Verbose(
                     "Preparing mining a block #{Index}; validating a tx {Index}/{Total} " +
                     "{Transaction}...",
@@ -812,9 +828,7 @@ namespace Libplanet.Blockchain
                     continue;
                 }
 
-                long storeNonce = Store.GetTxNonce(Id, tx.Signer);
-                long nextNonce = GetNextTxNonce(tx.Signer);
-                if (storeNonce <= tx.Nonce && tx.Nonce < nextNonce)
+                if (storedNonces[tx.Signer] <= tx.Nonce && tx.Nonce < nextNonces[tx.Signer])
                 {
                     if (estimatedBytes + tx.BytesLength > maxBlockBytes)
                     {


### PR DESCRIPTION
This PR improves tx selecting performance in `BlockChain<T>.MineBlock()` by storing and reusing tx's nonce instead of calculating them per each txs.