### PR TITLE
Fix broken tests

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1270,6 +1270,9 @@ namespace Libplanet.Tests.Net
                         await swarmA.Protocol.RefreshTableAsync(
                             TimeSpan.FromSeconds(1), cancellationToken);
                     }
+                    catch (InvalidOperationException)
+                    {
+                    }
                     catch (TurnClientException)
                     {
                     }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1268,7 +1268,7 @@ namespace Libplanet.Tests.Net
                     try
                     {
                         await swarmA.Protocol.RefreshTableAsync(
-                            TimeSpan.FromSeconds(10), cancellationToken);
+                            TimeSpan.FromSeconds(1), cancellationToken);
                     }
                     catch (TurnClientException)
                     {
@@ -1282,7 +1282,7 @@ namespace Libplanet.Tests.Net
                 {
                     var block = await seed.BlockChain.MineBlock(seed.Address);
                     seed.BroadcastBlock(block);
-                    await Task.Delay(5000, cancellationToken);
+                    await Task.Delay(1000, cancellationToken);
                 }
             }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,17 +156,6 @@ jobs:
       testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
-- job: Windows_NETCore
-  pool:
-    vmImage: windows-2019
-  steps:
-  - template: .azure-pipelines/dotnet-core.yml
-    parameters:
-      configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
-      testArguments: -parallel none -stoponfail -verbose
-  timeoutInMinutes: 30
-
 # Run tests with an alternative locale configuration
 - job: Linux_NETCore_ar_SA
   pool:


### PR DESCRIPTION
- Fixes the `ReconnectToTurn` test that fails intermittently.
- Removes the Windows_NETCore test from the CI, which can be replaced by Windows_NETCore_coverage. I think removing the test can alleviate the test timeout problem.