### PR TITLE
docs: correct document

### DIFF
--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -160,8 +160,6 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc/>
-        /// <exception cref="InvalidBlockStateRootHashException">It will be thrown when the
-        /// given block has incorrect <see cref="Block{T}.StateRootHash"/>.</exception>
         public virtual InvalidBlockException ValidateNextBlock(
             BlockChain<T> blocks,
             Block<T> nextBlock)


### PR DESCRIPTION
`BlockPolicy.ValidateNextBlock` has been become not to throw `InvalidBlockStateRootHashException` since https://github.com/planetarium/libplanet/pull/1010