### PR TITLE
feat(cli): support multiple kv-store in diff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,13 @@ To be released.
 
 ### CLI tools
 
+ -  `planet mpt diff` command became to take 4 arguments (which was 3)
+    so that it can compare state root hashes from two different
+    <abbr title="key–value">KV</abbr> stores.  The existing commands
+    like `planet mpt diff STORE A B` do not work anymore,
+    and these should be instead like `planet mpt diff STORE A STORE B`.
+    [[#1129]]
+
 [#795]: https://github.com/planetarium/libplanet/issues/795
 [#1052]: https://github.com/planetarium/libplanet/pull/1052
 [#1061]: https://github.com/planetarium/libplanet/pull/1061
@@ -114,6 +121,7 @@ To be released.
 [#1120]: https://github.com/planetarium/libplanet/pull/1120
 [#1124]: https://github.com/planetarium/libplanet/pull/1124
 [#1125]: https://github.com/planetarium/libplanet/pull/1125
+[#1129]: https://github.com/planetarium/libplanet/pull/1129
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,8 @@ To be released.
     like `planet mpt diff STORE A B` do not work anymore,
     and these should be instead like `planet mpt diff STORE A STORE B`.
     [[#1129]]
+ -  Store aliases used by `planet mpt` became to disallow names looking like
+    URIs to disambiguate aliases from the literal store URIs.  [[#1129]]
 
 [#795]: https://github.com/planetarium/libplanet/issues/795
 [#1052]: https://github.com/planetarium/libplanet/pull/1052

--- a/Libplanet.Tools/Mpt.cs
+++ b/Libplanet.Tools/Mpt.cs
@@ -129,6 +129,14 @@ namespace Libplanet.Tools
             string uri,
             [FromService] IConfigurationService<ToolConfiguration> configurationService)
         {
+            if (Uri.IsWellFormedUriString(alias, UriKind.Absolute))
+            {
+                throw new CommandExitedException(
+                    "The alias look like a URI to prevent it being ambiguous." +
+                    "Please try to use other alias name.",
+                    -1);
+            }
+
             try
             {
                 // Checks the `uri` is valid.

--- a/Libplanet.Tools/Mpt.cs
+++ b/Libplanet.Tools/Mpt.cs
@@ -132,8 +132,8 @@ namespace Libplanet.Tools
             if (Uri.IsWellFormedUriString(alias, UriKind.Absolute))
             {
                 throw new CommandExitedException(
-                    "The alias look like a URI to prevent it being ambiguous." +
-                    "Please try to use other alias name.",
+                    "The alias should not look like a URI to prevent it" +
+                    "from being ambiguous. Please try to use other alias name.",
                     -1);
             }
 


### PR DESCRIPTION
It resolves the problem which it was unavailable to compare two root hashes from each different key-value store.

It makes `planet mpt diff` more usable. 🧰 