### PR TITLE
fix: TransferAsset vulnerability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,9 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a vulnerability that `AccountStateDeltaImpl.TransferAsset()` if
+    sender and recipient are same. [#1133]
+
 ### CLI tools
 
 [#795]: https://github.com/planetarium/libplanet/issues/795
@@ -115,6 +118,7 @@ To be released.
 [#1124]: https://github.com/planetarium/libplanet/pull/1124
 [#1125]: https://github.com/planetarium/libplanet/pull/1125
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
+[#1133]: https://github.com/planetarium/libplanet/pull/1133
 
 
 Version 0.10.2

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -176,6 +176,9 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(Value(0, -1), a.GetBalance(_addr[0], _currencies[0]));
             Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
+
+            a = a.TransferAsset(_addr[1], _addr[1], Value(0, 6));
+            Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
         }
 
         [Fact]

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -128,7 +128,6 @@ namespace Libplanet.Action
 
             Currency currency = value.Currency;
             FungibleAssetValue senderBalance = GetBalance(sender, currency);
-            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
 
             if (!allowNegativeBalance && senderBalance < value)
             {
@@ -137,9 +136,13 @@ namespace Libplanet.Action
                 throw new InsufficientBalanceException(sender, senderBalance, msg);
             }
 
+            _updatedFungibleAssets = _updatedFungibleAssets
+                .SetItem((sender, currency), (senderBalance - value).RawValue);
+
+            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
+
             return UpdateFungibleAssets(
                 _updatedFungibleAssets
-                    .SetItem((sender, currency), (senderBalance - value).RawValue)
                     .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
         }

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -77,9 +77,7 @@ namespace Libplanet.Action
         /// <inheritdoc/>
         [Pure]
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
-            _updatedFungibleAssets.TryGetValue((address, currency), out BigInteger balance)
-                ? FungibleAssetValue.FromRawValue(currency, balance)
-                : _accountBalanceGetter(address, currency);
+            GetBalance(address, currency, _updatedFungibleAssets);
 
         /// <inheritdoc/>
         [Pure]
@@ -136,13 +134,17 @@ namespace Libplanet.Action
                 throw new InsufficientBalanceException(sender, senderBalance, msg);
             }
 
-            _updatedFungibleAssets = _updatedFungibleAssets
+            IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets =
+                _updatedFungibleAssets
                 .SetItem((sender, currency), (senderBalance - value).RawValue);
 
-            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
+            FungibleAssetValue recipientBalance = GetBalance(
+                recipient,
+                currency,
+                updatedFungibleAssets);
 
             return UpdateFungibleAssets(
-                _updatedFungibleAssets
+                updatedFungibleAssets
                     .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
         }
@@ -182,6 +184,15 @@ namespace Libplanet.Action
                 _updatedFungibleAssets.SetItem((owner, currency), (balance - value).RawValue)
             );
         }
+
+        [Pure]
+        private FungibleAssetValue GetBalance(
+            Address address,
+            Currency currency,
+            IImmutableDictionary<(Address, Currency), BigInteger> state) =>
+            state.TryGetValue((address, currency), out BigInteger balance)
+                ? FungibleAssetValue.FromRawValue(currency, balance)
+                : _accountBalanceGetter(address, currency);
 
         [Pure]
         private AccountStateDeltaImpl UpdateStates(


### PR DESCRIPTION
Previously, TransferAsset used the previously imported GetBalance of the recipient, so if the recipient and the sender were the same, there was a phenomenon that gold was duplicated continuously. Fix that phenomenon.