### PR TITLE
Give staged transactions lifetime on VolatileStagePolicy<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,8 @@ To be released.
 
 ### Added APIs
 
- -  Added `IStagePolicy` interface.  [[#1130], [#1131]]
- -  Added `VolatileStagePolicy` class.  [[#1130], [#1131]]
+ -  Added `IStagePolicy<T>` interface.  [[#1130], [#1131]]
+ -  Added `VolatileStagePolicy<T>` class.  [[#1130], [#1131], [#1136]]
  -  Added `ITransport` interface.  [[#1052]]
  -  Added `NetMQTransport` class which implements `ITransport`.  [[#1052]]
  -  Added `Message` abstract class.  [[#1052]]
@@ -74,7 +74,8 @@ To be released.
  -  Removed `Swarm<T>.TraceTable()` method.  [[#1120]]
  -  Added `Swarm<T>.PeerStates` property.  [[#1120]]
  -  Added `IProtocol` interface.  [[#1120]]
- -  Added `KademliaProtocol` class which implements `IProtocol`.  [[#1120]]
+ -  Added `KademliaProtocol` class which implements `IProtocol`.
+    [[#1120], [#1135]]
 
 ### Behavioral changes
 
@@ -84,7 +85,9 @@ To be released.
  -  When a `BlockChain<T>` follows `VolatileStagePolicy<T>`, which is
     Libplanet's the only built-in `IStagePolicy<T>` implementation at
     the moment, as its `StagePolicy`, its staged transactions are no longer
-    persistent but volatile instead.  [[#1130], [#1131]]
+    persistent but volatile instead.  It also automatically purges staged
+    transactions after the given `Lifetime`, which is 3 hours by default.
+    [[#1130], [#1131], [#1136]]
  -  `Swarm<T>` became not to receive states from trusted peers.
     [[#1061], [#1102]]
  -  `Swarm<T>` became not to retry when block downloading.  [[#1062], [#1102]]
@@ -135,6 +138,8 @@ To be released.
 [#1130]: https://github.com/planetarium/libplanet/issues/1130
 [#1131]: https://github.com/planetarium/libplanet/pull/1131
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
+[#1135]: https://github.com/planetarium/libplanet/pull/1135
+[#1136]: https://github.com/planetarium/libplanet/pull/1136
 
 
 Version 0.10.2

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -313,7 +313,7 @@ namespace Libplanet.Tests.Blockchain
         {
             PrivateKey privateKey = new PrivateKey();
             (Address[] addresses, Transaction<DumbAction>[] txs) =
-                MakeFixturesForAppendTests(privateKey);
+                MakeFixturesForAppendTests(privateKey, epoch: DateTimeOffset.UtcNow);
             var genesis = _blockChain.Genesis;
 
             Block<DumbAction> block1 = TestUtils.MineNext(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1639,6 +1639,16 @@ namespace Libplanet.Tests.Blockchain
             };
             StageTransactions(txsE);
 
+            foreach (var tx in _blockChain.StagePolicy.Iterate(_blockChain))
+            {
+                _logger.Fatal(
+                    "{Id}; {Signer}; {Nonce}; {Timestamp}",
+                    tx.Id,
+                    tx.Signer,
+                    tx.Nonce,
+                    tx.Timestamp);
+            }
+
             Assert.Equal(6, _blockChain.GetNextTxNonce(address));
         }
 
@@ -2011,8 +2021,10 @@ namespace Libplanet.Tests.Blockchain
             MakeIncompleteBlockStates() =>
             MakeIncompleteBlockStates(_fx.Store, _fx.StateStore);
 
-        private (Address[], Transaction<DumbAction>[])
-            MakeFixturesForAppendTests(PrivateKey privateKey = null)
+        private (Address[], Transaction<DumbAction>[]) MakeFixturesForAppendTests(
+            PrivateKey privateKey = null,
+            DateTimeOffset epoch = default
+        )
         {
             Address[] addresses =
             {
@@ -2039,7 +2051,7 @@ namespace Libplanet.Tests.Blockchain
                         new DumbAction(addresses[0], "foo"),
                         new DumbAction(addresses[1], "bar"),
                     },
-                    timestamp: DateTimeOffset.MinValue,
+                    timestamp: epoch,
                     nonce: 0,
                     privateKey: privateKey),
                 _fx.MakeTransaction(
@@ -2048,7 +2060,7 @@ namespace Libplanet.Tests.Blockchain
                         new DumbAction(addresses[2], "baz"),
                         new DumbAction(addresses[3], "qux"),
                     },
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(5),
+                    timestamp: epoch.AddSeconds(5),
                     nonce: 1,
                     privateKey: privateKey),
             };

--- a/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -11,10 +11,11 @@ namespace Libplanet.Tests.Blockchain.Policies
 {
     public abstract class StagePolicyTest
     {
-        private readonly BlockPolicy<DumbAction> _policy;
-        private readonly DefaultStoreFixture _fx;
-        private readonly BlockChain<DumbAction> _chain;
-        private readonly Transaction<DumbAction>[] _txs;
+        protected readonly BlockPolicy<DumbAction> _policy;
+        protected readonly DefaultStoreFixture _fx;
+        protected readonly BlockChain<DumbAction> _chain;
+        protected readonly PrivateKey _key;
+        protected readonly Transaction<DumbAction>[] _txs;
 
         protected StagePolicyTest()
         {
@@ -27,11 +28,11 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.StateStore,
                 _fx.GenesisBlock
             );
-            var key = new PrivateKey();
+            _key = new PrivateKey();
             _txs = Enumerable.Range(0, 5).Select(i =>
                 Transaction<DumbAction>.Create(
                     i,
-                    key,
+                    _key,
                     _fx.GenesisBlock.Hash,
                     Enumerable.Empty<DumbAction>()
                 )

--- a/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
@@ -33,7 +33,9 @@ namespace Libplanet.Tests.Blockchain.Policies
             Assert.Equal(tx, _stagePolicy.Get(_chain, tx.Id, false));
             Assert.Contains(tx, _stagePolicy.Iterate(_chain));
 
-            Thread.Sleep(timeBuffer * 2);
+            // On some targets TimeSpan * int does not exist:
+            Thread.Sleep(timeBuffer);
+            Thread.Sleep(timeBuffer);
 
             Assert.False(_stagePolicy.HasStaged(_chain, tx.Id, true));
             Assert.Null(_stagePolicy.Get(_chain, tx.Id, true));

--- a/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Linq;
+using System.Threading;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
 
 namespace Libplanet.Tests.Blockchain.Policies
 {
@@ -10,5 +15,29 @@ namespace Libplanet.Tests.Blockchain.Policies
 
         protected override IStagePolicy<DumbAction> StagePolicy =>
             _stagePolicy;
+
+        [Fact]
+        public void Lifetime()
+        {
+            TimeSpan timeBuffer = TimeSpan.FromSeconds(2.5);
+
+            Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
+                0,
+                _key,
+                _fx.GenesisBlock.Hash,
+                Enumerable.Empty<DumbAction>(),
+                timestamp: DateTimeOffset.UtcNow - _stagePolicy.Lifetime + timeBuffer
+            );
+            _stagePolicy.Stage(_chain, tx);
+            Assert.True(_stagePolicy.HasStaged(_chain, tx.Id, false));
+            Assert.Equal(tx, _stagePolicy.Get(_chain, tx.Id, false));
+            Assert.Contains(tx, _stagePolicy.Iterate(_chain));
+
+            Thread.Sleep(timeBuffer * 2);
+
+            Assert.False(_stagePolicy.HasStaged(_chain, tx.Id, true));
+            Assert.Null(_stagePolicy.Get(_chain, tx.Id, true));
+            Assert.DoesNotContain(tx, _stagePolicy.Iterate(_chain));
+        }
     }
 }

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -157,8 +157,8 @@ namespace Libplanet.Tests.Store
         )
         {
             privateKey = privateKey ?? new PrivateKey();
-            timestamp = timestamp ??
-                new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
+            timestamp = timestamp ?? DateTimeOffset.UtcNow;
+
             return Transaction<DumbAction>.Create(
                 nonce,
                 privateKey,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -668,6 +668,11 @@ namespace Libplanet.Blockchain
 
             foreach (long n in stagedTxNonces)
             {
+                if (n < nonce)
+                {
+                    continue;
+                }
+
                 if (n != nonce)
                 {
                     break;


### PR DESCRIPTION
This patch introduces the `lifetime` parameter (which is 3 hours<sup>1</sup> by default) to the `VolatileStagePolicy<T>()` constructor, and the corresponding `VolatileStagePolicy<T>.Lifetime` property.  Staged transactions that have reached their lifetime are evicted from the stage, and never can be staged again.

Closes #1130.

----

1. Note that this default value is burrowed from [Go Ethereum's `--txpool.lifetime` option's][1].

[1]: https://github.com/ethereum/go-ethereum/blob/v1.9.25/core/tx_pool.go#L167