### PR TITLE
Register WatchTip at beggining of MineBlock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,9 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `BlockChain<T>.MineBlock()` was not automatically
+    cancelled when the tip of the chain was changed occasionally.  [[#1141]]
+
 ### CLI tools
 
  -  `planet mpt diff` command became to take 4 arguments (which was 3)
@@ -140,6 +143,7 @@ To be released.
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
 [#1135]: https://github.com/planetarium/libplanet/pull/1135
 [#1136]: https://github.com/planetarium/libplanet/pull/1136
+[#1141]: https://github.com/planetarium/libplanet/pull/1141
 
 
 Version 0.10.2

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -716,6 +716,12 @@ namespace Libplanet.Blockchain
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
+            void WatchTip(object target, (Block<T> OldTip, Block<T> NewTip) tip) => cts.Cancel();
+            TipChanged += WatchTip;
+
             maxTransactions = Math.Max(
                 Math.Min(
                     maxTransactions ?? Policy.MaxTransactionsPerBlock,
@@ -874,13 +880,6 @@ namespace Libplanet.Blockchain
                 stagedTransactions.Length
             );
 
-            CancellationTokenSource cts = new CancellationTokenSource();
-            CancellationTokenSource cancellationTokenSource =
-                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
-
-            void WatchTip(object target, (Block<T> OldTip, Block<T> NewTip) tip) => cts.Cancel();
-            TipChanged += WatchTip;
-
             Block<T> block;
             try
             {
@@ -902,7 +901,7 @@ namespace Libplanet.Blockchain
                 if (cts.IsCancellationRequested)
                 {
                     throw new OperationCanceledException(
-                        "Mining canceled due to change of tip index");
+                        "Mining canceled due to change of tip index.");
                 }
 
                 throw new OperationCanceledException(cancellationToken);


### PR DESCRIPTION
Mining hadn't been cancelled if the tip of the chain is changed in specific situation. This patch register event handler at the very beginning of `MineBlock()` to cover the case where tip is changed before event registration.