### PR TITLE
Add property `IActionContext.IsBlockAction`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ To be released.
  -  Removed `Swarm<T>.GetTrustedStateCompleterAsync()` method.  [[#1117]]
  -  Removed `trustedStateValidators` parameter from `Swarm<T>.PreloadAsync()`
     method.  [[#1117]]
+ -  Added `IActionContext.BlockAction` property. [[#1143]]
 
 ### Backward-incompatible network protocol changes
  -   `Swarm<T>` became no longer retry when `Swarm<T>` receives
@@ -146,6 +147,7 @@ To be released.
 [#1136]: https://github.com/planetarium/libplanet/pull/1136
 [#1137]: https://github.com/planetarium/libplanet/pull/1137
 [#1141]: https://github.com/planetarium/libplanet/pull/1141
+[#1143]: https://github.com/planetarium/libplanet/pull/1143
 
 
 Version 0.10.2

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1854,7 +1854,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 (Integer)2,
                 (Integer)blockActionEvaluation.OutputStates.GetState(miner));
-            Assert.True(blockActionEvaluation.InputContext.IsBlockAction);
+            Assert.True(blockActionEvaluation.InputContext.BlockAction);
 
             _blockChain.ExecuteActions(genesis);
             _blockChain.Append(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1567,6 +1567,11 @@ namespace Libplanet.Tests.Blockchain
             chain.StageTransaction(tx1);
             await chain.MineBlock(_fx.Address1);
 
+            var actionEvaluation = chain.BlockEvaluator.EvaluateActions(
+                chain.Tip,
+                StateCompleterSet<TestEvaluateAction>.Recalculate);
+            Assert.False(actionEvaluation[0].InputContext.BlockAction);
+
             Assert.Equal(
                 chain.GetState(TestEvaluateAction.SignerKey),
                 (Text)fromAddress.ToHex()

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1854,6 +1854,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 (Integer)2,
                 (Integer)blockActionEvaluation.OutputStates.GetState(miner));
+            Assert.True(blockActionEvaluation.InputContext.IsBlockAction);
 
             _blockChain.ExecuteActions(genesis);
             _blockChain.Append(

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -19,7 +19,8 @@ namespace Libplanet.Action
             IAccountStateDelta previousStates,
             int randomSeed,
             bool rehearsal = false,
-            ITrie? previousBlockStatesTrie = null
+            ITrie? previousBlockStatesTrie = null,
+            bool isBlockAction = false
         )
         {
             Signer = signer;
@@ -30,6 +31,7 @@ namespace Libplanet.Action
             Random = new Random(randomSeed);
             _randomSeed = randomSeed;
             _previousBlockStatesTrie = previousBlockStatesTrie;
+            IsBlockAction = isBlockAction;
         }
 
         public Address Signer { get; }
@@ -55,6 +57,8 @@ namespace Libplanet.Action
             }
         }
 
+        public bool IsBlockAction { get; }
+
         [Pure]
         public IActionContext GetUnconsumedContext() =>
             new ActionContext(
@@ -64,6 +68,7 @@ namespace Libplanet.Action
                 PreviousStates,
                 _randomSeed,
                 Rehearsal,
-                _previousBlockStatesTrie);
+                _previousBlockStatesTrie,
+                IsBlockAction);
     }
 }

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Action
             int randomSeed,
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null,
-            bool isBlockAction = false
+            bool blockAction = false
         )
         {
             Signer = signer;
@@ -31,7 +31,7 @@ namespace Libplanet.Action
             Random = new Random(randomSeed);
             _randomSeed = randomSeed;
             _previousBlockStatesTrie = previousBlockStatesTrie;
-            IsBlockAction = isBlockAction;
+            BlockAction = blockAction;
         }
 
         public Address Signer { get; }
@@ -57,7 +57,7 @@ namespace Libplanet.Action
             }
         }
 
-        public bool IsBlockAction { get; }
+        public bool BlockAction { get; }
 
         [Pure]
         public IActionContext GetUnconsumedContext() =>
@@ -69,6 +69,6 @@ namespace Libplanet.Action
                 _randomSeed,
                 Rehearsal,
                 _previousBlockStatesTrie,
-                IsBlockAction);
+                BlockAction);
     }
 }

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -88,6 +88,8 @@ namespace Libplanet.Action
         /// The default value is <c>false</c>.</param>
         /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
         /// </param>
+        /// <param name="isBlockAction">Pass <c>true</c> if it is
+        /// <see cref="IBlockPolicy{T}.BlockAction"/>.</param>
         /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
         /// <paramref name="actions"/>.  The order is the same to the <paramref name="actions"/>.
         /// Note that each <see cref="IActionContext.Random"/> object
@@ -103,7 +105,8 @@ namespace Libplanet.Action
             byte[] signature,
             IImmutableList<IAction> actions,
             bool rehearsal = false,
-            ITrie previousBlockStatesTrie = null)
+            ITrie previousBlockStatesTrie = null,
+            bool isBlockAction = false)
         {
             ActionContext CreateActionContext(
                 IAccountStateDelta prevStates,
@@ -116,7 +119,8 @@ namespace Libplanet.Action
                     previousStates: prevStates,
                     randomSeed: randomSeed,
                     rehearsal: rehearsal,
-                    previousBlockStatesTrie: previousBlockStatesTrie
+                    previousBlockStatesTrie: previousBlockStatesTrie,
+                    isBlockAction: isBlockAction
                 );
 
             byte[] hashedSignature;

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -88,7 +88,7 @@ namespace Libplanet.Action
         /// The default value is <c>false</c>.</param>
         /// <param name="previousBlockStatesTrie">The trie to contain states at previous block.
         /// </param>
-        /// <param name="isBlockAction">Pass <c>true</c> if it is
+        /// <param name="blockAction">Pass <c>true</c> if it is
         /// <see cref="IBlockPolicy{T}.BlockAction"/>.</param>
         /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
         /// <paramref name="actions"/>.  The order is the same to the <paramref name="actions"/>.
@@ -106,7 +106,7 @@ namespace Libplanet.Action
             IImmutableList<IAction> actions,
             bool rehearsal = false,
             ITrie previousBlockStatesTrie = null,
-            bool isBlockAction = false)
+            bool blockAction = false)
         {
             ActionContext CreateActionContext(
                 IAccountStateDelta prevStates,
@@ -120,7 +120,7 @@ namespace Libplanet.Action
                     randomSeed: randomSeed,
                     rehearsal: rehearsal,
                     previousBlockStatesTrie: previousBlockStatesTrie,
-                    isBlockAction: isBlockAction
+                    blockAction: blockAction
                 );
 
             byte[] hashedSignature;

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -71,7 +71,8 @@ namespace Libplanet.Action
         HashDigest<SHA256>? PreviousStateRootHash { get; }
 
         /// <summary>
-        /// Boolean flag indicating if this action was executed as a BlockAction.
+        /// Whether this action is executed as a block action.
+        /// <c>false</c> if it belongs to a transaction.
         /// </summary>
         [Pure]
         bool BlockAction { get; }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -71,6 +71,12 @@ namespace Libplanet.Action
         HashDigest<SHA256>? PreviousStateRootHash { get; }
 
         /// <summary>
+        /// Boolean flag indicating if this action was executed as a BlockAction.
+        /// </summary>
+        [Pure]
+        bool IsBlockAction { get; }
+
+        /// <summary>
         /// Returns a clone of this context, except that its <see cref="Random"/> has the unconsumed
         /// state (with the same seed).  The clone and its original are a distinct instance
         /// each other, in other words, one's state transfer must not affect the other one

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -74,7 +74,7 @@ namespace Libplanet.Action
         /// Boolean flag indicating if this action was executed as a BlockAction.
         /// </summary>
         [Pure]
-        bool IsBlockAction { get; }
+        bool BlockAction { get; }
 
         /// <summary>
         /// Returns a clone of this context, except that its <see cref="Random"/> has the unconsumed

--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -138,7 +138,7 @@ namespace Libplanet.Blockchain
                 Array.Empty<byte>(),
                 new[] { _blockAction }.ToImmutableList(),
                 previousBlockStatesTrie: previousBlockStatesTrie,
-                isBlockAction: true).First();
+                blockAction: true).First();
         }
     }
 }

--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -137,7 +137,8 @@ namespace Libplanet.Blockchain
                 miner,
                 Array.Empty<byte>(),
                 new[] { _blockAction }.ToImmutableList(),
-                previousBlockStatesTrie: previousBlockStatesTrie).First();
+                previousBlockStatesTrie: previousBlockStatesTrie,
+                isBlockAction: true).First();
         }
     }
 }


### PR DESCRIPTION
Previously, there was no way in the action itself to check whether it was a block action or not. You can use the IActionContext.IsBlockAction property to know if the action itself is a block action or not.