### PR TITLE
Drop .NET Core 2.2 support for unit tests and require 3.1 instead

### DIFF
--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -1,7 +1,7 @@
 parameters:
   configuration: Debug
   testDisplayName: xunit.console.exe *.Tests.dll
-  testCommand: "mono --server xunit.runner.console.*/tools/net471/xunit.console.exe"
+  testCommand: "mono --server xunit.runner.console.*/tools/net47/xunit.console.exe"
   testArguments: -verbose -parallel none
   testTimeoutInMinutes: 16
   excludeTests: ""
@@ -21,6 +21,7 @@ steps:
     script: |
       msbuild \
         /restore \
+        /p:TestsTargetFramework=net47 \
         /p:Configuration=${{ parameters.configuration }} \
         /p:SkipSonar=true
 

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -33,7 +33,7 @@ steps:
     solution: Libplanet.sln
     msbuildVersion: "16.0"
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: /restore /p:SkipSonar=true
+    msbuildArguments: /restore /p:TestsTargetFramework=net471 /p:SkipSonar=true
 
 - ${{ if eq(parameters.copySQLitePCLRaw, true) }}:
   # https://github.com/sschmid/Entitas-CSharp/issues/811#issuecomment-449182023

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ To build and run unit tests at a time with .NET Core execute the below command:
 
     dotnet test
 
-To run unit tests with .NET Framework:
+To run unit tests with .NET Framework on Windows:
 
 ~~~~ pwsh
 nuget install xunit.runner.console -Version 2.4.1
@@ -155,9 +155,9 @@ Or with Mono:
 
 ~~~~ bash
 nuget install xunit.runner.console
-msbuild /restore /p:TestsTargetFramework=net472
-mono xunit.runner.console.*/tools/net472/xunit.console.exe \
-    *.Tests/bin/Debug/net472/*.Tests.dll
+msbuild /restore /p:TestsTargetFramework=net47
+mono xunit.runner.console.*/tools/net47/xunit.console.exe \
+    *.Tests/bin/Debug/net47/*.Tests.dll
 ~~~~
 
 [Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622

--- a/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -16,16 +16,6 @@
     </AdditionalFiles>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
-                             '$(MSBuildVersion)'&gt;='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
-                             '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net47</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Benchmarks</RootNamespace>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(MSBuildVersion)' >='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -15,16 +15,6 @@
     </AdditionalFiles>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And
-                             '$(MSBuildVersion)'&gt;='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
-                             '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net47</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,22 +9,12 @@
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MSBuildRuntimeType)'!='Mono' And
-                            '$(MSBuildVersion)'>='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
-                             '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net47</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -16,14 +16,6 @@
     </AdditionalFiles>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'!='Mono' And '$(MSBuildVersion)'&gt;='16.3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net47</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
As .NET Core 2.2 is quite outdated, let's drop .NET Core 2.2 support for unit tests and require 3.1 instead.

This also removes the old workaround for Rider (note that older versions of Rider cannot run MSBuild on .NET Core) which is unnecessary nowadays.  It fixes test discovery on JetBrains Rider.  /cc @riemannulus