### PR TITLE
Fix TransferAsset vulnerability (take 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -125,13 +125,11 @@ To be released.
  -  Fixed a bug where `BlockChain<T>.MineBlock()` was not automatically
     cancelled when the tip of the chain was changed occasionally.  [[#1141]]
  -  Fixed a vulnerability of the `IAccountStateDelta.TransferAsset()`'s
-    internal implementation that it had doubled the balance for transferring
-    to themselves. *Since this behavioral change breaks the protocol-level
-    compatibility if any actions in your app had used
-    `IAccountStateDelta.TransferAsset()`, you must make the action to
-    conditionally work as it had done for the hard-coded block index before
-    this patch is applied, or you may be possible to
-    hard-fork the network.*  [[#1134]]
+    internal implementation that it had doubled recipient's balance when
+    a sender and a recipient is the same.
+    *Since this changes the protocol, for backward compatibility, the actions
+    belonging to the existing block, which was mined before the protocol v1,
+    are guaranteed to still behave as it had done.  [[#1152]]
 
 ### CLI tools
 
@@ -171,7 +169,6 @@ To be released.
 [#1130]: https://github.com/planetarium/libplanet/issues/1130
 [#1131]: https://github.com/planetarium/libplanet/pull/1131
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
-[#1134]: https://github.com/planetarium/libplanet/pull/1134
 [#1135]: https://github.com/planetarium/libplanet/pull/1135
 [#1136]: https://github.com/planetarium/libplanet/pull/1136
 [#1137]: https://github.com/planetarium/libplanet/pull/1137
@@ -179,6 +176,7 @@ To be released.
 [#1142]: https://github.com/planetarium/libplanet/issues/1142
 [#1143]: https://github.com/planetarium/libplanet/pull/1143
 [#1147]: https://github.com/planetarium/libplanet/pull/1147
+[#1152]: https://github.com/planetarium/libplanet/pull/1152
 
 
 Version 0.10.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,14 @@ To be released.
 
  -  Fixed a bug where `BlockChain<T>.MineBlock()` was not automatically
     cancelled when the tip of the chain was changed occasionally.  [[#1141]]
+ -  Fixed a vulnerability of the `IAccountStateDelta.TransferAsset()`'s
+    internal implementation that it had doubled the balance for transferring
+    to themselves. *Since this behavioral change breaks the protocol-level
+    compatibility if any actions in your app had used
+    `IAccountStateDelta.TransferAsset()`, you must make the action to
+    conditionally work as it had done for the hard-coded block index before
+    this patch is applied, or you may be possible to
+    hard-fork the network.*  [[#1134]]
 
 ### CLI tools
 
@@ -163,6 +171,7 @@ To be released.
 [#1130]: https://github.com/planetarium/libplanet/issues/1130
 [#1131]: https://github.com/planetarium/libplanet/pull/1131
 [#1132]: https://github.com/planetarium/libplanet/pull/1132
+[#1134]: https://github.com/planetarium/libplanet/pull/1134
 [#1135]: https://github.com/planetarium/libplanet/pull/1135
 [#1136]: https://github.com/planetarium/libplanet/pull/1136
 [#1137]: https://github.com/planetarium/libplanet/pull/1137

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -176,6 +176,9 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(Value(0, -1), a.GetBalance(_addr[0], _currencies[0]));
             Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
+
+            a = a.TransferAsset(_addr[1], _addr[1], Value(0, 6));
+            Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
         }
 
         [Fact]

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -1,6 +1,5 @@
 using Libplanet.Action;
 using Libplanet.Blockchain;
-using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -8,27 +7,27 @@ using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Action
 {
-    public class AccountStateDeltaImplTest : AccountStateDeltaTest
+    public class AccountStateDeltaImplV0Test : AccountStateDeltaTest
     {
-        public AccountStateDeltaImplTest(ITestOutputHelper output)
+        public AccountStateDeltaImplV0Test(ITestOutputHelper output)
             : base(output)
         {
         }
 
-        public override int ProtocolVersion { get; } = Block<DumbAction>.CurrentProtocolVersion;
+        public override int ProtocolVersion { get; } = 0;
 
         public override IAccountStateDelta CreateInstance(
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
             Address signer
         ) =>
-            new AccountStateDeltaImpl(accountStateGetter, accountBalanceGetter, signer);
+            new AccountStateDeltaImplV0(accountStateGetter, accountBalanceGetter, signer);
 
         [Fact]
         public override void TransferAsset()
         {
             base.TransferAsset();
-            Assert.IsType<AccountStateDeltaImpl>(_init);
+            Assert.IsType<AccountStateDeltaImplV0>(_init);
 
             IAccountStateDelta a = _init.TransferAsset(
                 _addr[0],
@@ -36,11 +35,11 @@ namespace Libplanet.Tests.Action
                 Value(0, 6),
                 allowNegativeBalance: true
             );
-            Assert.IsType<AccountStateDeltaImpl>(a);
+            Assert.IsType<AccountStateDeltaImplV0>(a);
             Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
             a = a.TransferAsset(_addr[1], _addr[1], Value(0, 5));
-            Assert.IsType<AccountStateDeltaImpl>(a);
-            Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
+            Assert.IsType<AccountStateDeltaImplV0>(a);
+            Assert.Equal(Value(0, 11), a.GetBalance(_addr[1], _currencies[0]));
         }
 
         [Fact]
@@ -63,7 +62,7 @@ namespace Libplanet.Tests.Action
                 ).AttachStateRootHash(chain.StateStore, chain.Policy.BlockAction)
             );
             Assert.Equal(
-                DumbAction.DumbCurrency * 5,
+                DumbAction.DumbCurrency * 6,
                 chain.GetBalance(_addr[0], DumbAction.DumbCurrency)
             );
 

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Crypto;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tests.Blockchain;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Action
+{
+    public abstract class AccountStateDeltaTest
+    {
+        protected readonly PrivateKey[] _keys;
+        protected readonly Address[] _addr;
+        protected readonly Currency[] _currencies;
+        protected readonly IImmutableDictionary<Address, IValue> _states;
+        protected readonly IImmutableDictionary<(Address, Currency), BigInteger> _assets;
+        protected readonly IAccountStateDelta _init;
+
+        protected AccountStateDeltaTest(ITestOutputHelper output)
+        {
+            _keys = new[]
+            {
+                new PrivateKey(),
+                new PrivateKey(),
+                new PrivateKey(),
+            };
+
+            _addr = _keys.Select(AddressExtensions.ToAddress).ToArray();
+
+            _currencies = new[]
+            {
+                new Currency("FOO", 0, minter: _addr[0]),
+                new Currency("BAR", 0, minters: _addr.Take(2).ToImmutableHashSet()),
+                new Currency("BAZ", 0, minter: null),
+            };
+
+            _states = new Dictionary<Address, IValue>
+            {
+                [_addr[0]] = (Text)"a",
+                [_addr[1]] = (Text)"b",
+            }.ToImmutableDictionary();
+
+            _assets = new Dictionary<(Address, Currency), BigInteger>
+            {
+                [(_addr[0], _currencies[0])] = 5,
+                [(_addr[0], _currencies[1])] = -10,
+                [(_addr[1], _currencies[1])] = 15,
+                [(_addr[1], _currencies[2])] = 20,
+            }.ToImmutableDictionary();
+
+            output.WriteLine("Fixtures  {0,-42}  FOO  BAR  BAZ  State", "Address");
+            int i = 0;
+            foreach (Address a in _addr)
+            {
+                output.WriteLine(
+                    "_addr[{0}]  {1}  {2,3}  {3,3}  {4,3}  {5}",
+                    i++,
+                    a,
+                    GetBalance(a, _currencies[0]),
+                    GetBalance(a, _currencies[1]),
+                    GetBalance(a, _currencies[2]),
+                    GetState(a)
+                );
+            }
+
+            _init = CreateInstance(GetState, GetBalance, _addr[0]);
+        }
+
+        public abstract int ProtocolVersion { get; }
+
+        public abstract IAccountStateDelta CreateInstance(
+            AccountStateGetter accountStateGetter,
+            AccountBalanceGetter accountBalanceGetter,
+            Address signer
+        );
+
+        [Fact]
+        public virtual void NullDelta()
+        {
+            Assert.Empty(_init.UpdatedAddresses);
+            Assert.Empty(_init.StateUpdatedAddresses);
+            Assert.Empty(_init.UpdatedFungibleAssets);
+            Assert.Equal("a", (Text)_init.GetState(_addr[0]));
+            Assert.Equal("b", (Text)_init.GetState(_addr[1]));
+            Assert.Null(_init.GetState(_addr[2]));
+            Assert.Equal(Value(0, 5), _init.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(1, -10), _init.GetBalance(_addr[0], _currencies[1]));
+            Assert.Equal(Zero(2), _init.GetBalance(_addr[0], _currencies[2]));
+            Assert.Equal(Zero(0), _init.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(1, 15), _init.GetBalance(_addr[1], _currencies[1]));
+            Assert.Equal(Value(2, 20), _init.GetBalance(_addr[1], _currencies[2]));
+            Assert.Equal(Zero(0), _init.GetBalance(_addr[2], _currencies[0]));
+            Assert.Equal(Zero(1), _init.GetBalance(_addr[2], _currencies[1]));
+            Assert.Equal(Zero(2), _init.GetBalance(_addr[2], _currencies[2]));
+        }
+
+        [Fact]
+        public virtual void States()
+        {
+            IAccountStateDelta a = _init.SetState(_addr[0], (Text)"A");
+            Assert.Equal("A", (Text)a.GetState(_addr[0]));
+            Assert.Equal("a", (Text)_init.GetState(_addr[0]));
+            Assert.Equal("b", (Text)a.GetState(_addr[1]));
+            Assert.Equal("b", (Text)_init.GetState(_addr[1]));
+            Assert.Null(a.GetState(_addr[2]));
+            Assert.Null(_init.GetState(_addr[2]));
+            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.StateUpdatedAddresses);
+            Assert.Equal(a.StateUpdatedAddresses, a.UpdatedAddresses);
+            Assert.Empty(a.UpdatedFungibleAssets);
+            Assert.Empty(_init.UpdatedAddresses);
+            Assert.Empty(_init.StateUpdatedAddresses);
+            Assert.Empty(_init.UpdatedFungibleAssets);
+
+            IAccountStateDelta b = a.SetState(_addr[0], (Text)"z");
+            Assert.Equal("z", (Text)b.GetState(_addr[0]));
+            Assert.Equal("A", (Text)a.GetState(_addr[0]));
+            Assert.Equal("a", (Text)_init.GetState(_addr[0]));
+            Assert.Equal("b", (Text)b.GetState(_addr[1]));
+            Assert.Equal("b", (Text)a.GetState(_addr[1]));
+            Assert.Null(b.GetState(_addr[2]));
+            Assert.Null(a.GetState(_addr[2]));
+            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.StateUpdatedAddresses);
+            Assert.Equal(a.StateUpdatedAddresses, a.UpdatedAddresses);
+            Assert.Empty(_init.UpdatedAddresses);
+            Assert.Empty(_init.StateUpdatedAddresses);
+
+            IAccountStateDelta c = b.SetState(_addr[0], (Text)"a");
+            Assert.Equal("a", (Text)c.GetState(_addr[0]));
+            Assert.Equal("z", (Text)b.GetState(_addr[0]));
+            Assert.Empty(_init.UpdatedAddresses);
+            Assert.Empty(_init.StateUpdatedAddresses);
+        }
+
+        [Fact]
+        public virtual void FungibleAssets()
+        {
+            IAccountStateDelta a = _init.TransferAsset(_addr[1], _addr[2], Value(2, 5));
+            Assert.Equal(Value(2, 15), a.GetBalance(_addr[1], _currencies[2]));
+            Assert.Equal(Value(2, 5), a.GetBalance(_addr[2], _currencies[2]));
+            Assert.Equal(Value(0, 5), a.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(1, -10), a.GetBalance(_addr[0], _currencies[1]));
+            Assert.Equal(Zero(2), a.GetBalance(_addr[0], _currencies[2]));
+            Assert.Equal(Zero(0), a.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(1, 15), a.GetBalance(_addr[1], _currencies[1]));
+            Assert.Equal(Zero(0), a.GetBalance(_addr[2], _currencies[0]));
+            Assert.Equal(Zero(1), a.GetBalance(_addr[2], _currencies[1]));
+            Assert.Equal(
+                new Dictionary<Address, IImmutableSet<Currency>>
+                {
+                    [_addr[1]] = ImmutableHashSet.Create(_currencies[2]),
+                    [_addr[2]] = ImmutableHashSet.Create(_currencies[2]),
+                }.ToImmutableDictionary(),
+                a.UpdatedFungibleAssets
+            );
+            Assert.Equal(a.UpdatedFungibleAssets.Keys.ToImmutableHashSet(), a.UpdatedAddresses);
+            Assert.Empty(a.StateUpdatedAddresses);
+            Assert.Empty(_init.UpdatedAddresses);
+            Assert.Empty(_init.StateUpdatedAddresses);
+            Assert.Empty(_init.UpdatedFungibleAssets);
+        }
+
+        [Fact]
+        public virtual void TransferAsset()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.TransferAsset(_addr[0], _addr[1], Zero(0))
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.TransferAsset(_addr[0], _addr[1], Value(0, -1))
+            );
+            Assert.Throws<InsufficientBalanceException>(() =>
+                _init.TransferAsset(_addr[0], _addr[1], Value(0, 6))
+            );
+
+            IAccountStateDelta a = _init.TransferAsset(
+                _addr[0],
+                _addr[1],
+                Value(0, 6),
+                allowNegativeBalance: true
+            );
+            Assert.Equal(Value(0, -1), a.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(0, 6), a.GetBalance(_addr[1], _currencies[0]));
+        }
+
+        [Fact]
+        public virtual BlockChain<DumbAction> TransferAssetInBlock()
+        {
+            var store = new DefaultStore(null);
+            var stateStore = new TrieStateStore(
+                new DefaultKeyValueStore(null),
+                new DefaultKeyValueStore(null)
+            );
+            BlockChain<DumbAction> chain = TestUtils.MakeBlockChain(
+                new NullPolicy<DumbAction>(),
+                store,
+                stateStore,
+                protocolVersion: ProtocolVersion
+            );
+
+            DumbAction action = new DumbAction(_addr[0], "a", _addr[1], _addr[0], 5);
+            Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
+                0,
+                _keys[0],
+                chain.Genesis.Hash,
+                new[] { action }
+            );
+            chain.Append(
+                TestUtils.MineNext(
+                    chain.Tip,
+                    new[] { tx },
+                    protocolVersion: ProtocolVersion
+                ).AttachStateRootHash(stateStore, chain.Policy.BlockAction)
+            );
+            Assert.Equal(
+                DumbAction.DumbCurrency * 5,
+                chain.GetBalance(_addr[0], DumbAction.DumbCurrency)
+            );
+            Assert.Equal(
+                DumbAction.DumbCurrency * -5,
+                chain.GetBalance(_addr[1], DumbAction.DumbCurrency)
+            );
+
+            return chain;
+        }
+
+        [Fact]
+        public virtual void MintAsset()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.MintAsset(_addr[0], Zero(0))
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.MintAsset(_addr[0], Value(0, -1))
+            );
+
+            IAccountStateDelta delta0 = _init;
+            // currencies[0] (FOO) allows only _addr[0] to mint
+            delta0 = delta0.MintAsset(_addr[0], Value(0, 10));
+            Assert.Equal(Value(0, 15), delta0.GetBalance(_addr[0], _currencies[0]));
+
+            // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
+            delta0 = delta0.MintAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 25), delta0.GetBalance(_addr[1], _currencies[1]));
+
+            // currencies[2] (BAZ) allows everyone to mint
+            delta0 = delta0.MintAsset(_addr[2], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[2], _currencies[2]));
+
+            IAccountStateDelta delta1 = CreateInstance(GetState, GetBalance, _addr[1]);
+            // currencies[0] (FOO) disallows _addr[1] to mint
+            Assert.Throws<CurrencyPermissionException>(() =>
+                delta1.MintAsset(_addr[1], Value(0, 10))
+            );
+
+            // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
+            delta1 = delta1.MintAsset(_addr[0], Value(1, 20));
+            Assert.Equal(Value(1, 10), delta1.GetBalance(_addr[0], _currencies[1]));
+
+            // currencies[2] (BAZ) allows everyone to mint
+            delta1 = delta1.MintAsset(_addr[2], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[2], _currencies[2]));
+        }
+
+        [Fact]
+        public virtual void BurnAsset()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.BurnAsset(_addr[0], Zero(0))
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _init.BurnAsset(_addr[0], Value(0, -1))
+            );
+            Assert.Throws<InsufficientBalanceException>(() =>
+                _init.BurnAsset(_addr[0], Value(0, 6))
+            );
+
+            IAccountStateDelta delta0 = _init;
+            // currencies[0] (FOO) allows only _addr[0] to burn
+            delta0 = delta0.BurnAsset(_addr[0], Value(0, 4));
+            Assert.Equal(Value(0, 1), delta0.GetBalance(_addr[0], _currencies[0]));
+
+            // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
+            delta0 = delta0.BurnAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 5), delta0.GetBalance(_addr[1], _currencies[1]));
+
+            // currencies[2] (BAZ) allows everyone to burn
+            delta0 = delta0.BurnAsset(_addr[1], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[1], _currencies[2]));
+
+            IAccountStateDelta delta1 = CreateInstance(GetState, GetBalance, _addr[1]);
+            // currencies[0] (FOO) disallows _addr[1] to burn
+            Assert.Throws<CurrencyPermissionException>(() =>
+                delta1.BurnAsset(_addr[0], Value(0, 5))
+            );
+
+            // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
+            delta1 = delta1.BurnAsset(_addr[1], Value(1, 10));
+            Assert.Equal(Value(1, 5), delta1.GetBalance(_addr[1], _currencies[1]));
+
+            // currencies[2] (BAZ) allows everyone to burn
+            delta1 = delta1.BurnAsset(_addr[1], Value(2, 10));
+            Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[1], _currencies[2]));
+        }
+
+        protected FungibleAssetValue Value(int currencyIndex, BigInteger quantity) =>
+            new FungibleAssetValue(_currencies[currencyIndex], quantity, 0);
+
+        protected FungibleAssetValue Zero(int currencyIndex) => Value(currencyIndex, 0);
+
+        protected IValue GetState(Address address) =>
+            _states.TryGetValue(address, out IValue v) ? v : null;
+
+        protected FungibleAssetValue GetBalance(Address address, Currency currency) =>
+            new FungibleAssetValue(
+                currency,
+                _assets.TryGetValue((address, currency), out BigInteger balance) ? balance : 0,
+                0
+            );
+    }
+}

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -128,7 +128,6 @@ namespace Libplanet.Action
 
             Currency currency = value.Currency;
             FungibleAssetValue senderBalance = GetBalance(sender, currency);
-            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
 
             if (!allowNegativeBalance && senderBalance < value)
             {
@@ -137,9 +136,13 @@ namespace Libplanet.Action
                 throw new InsufficientBalanceException(sender, senderBalance, msg);
             }
 
+            _updatedFungibleAssets = _updatedFungibleAssets
+                .SetItem((sender, currency), (senderBalance - value).RawValue);
+
+            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
+
             return UpdateFungibleAssets(
                 _updatedFungibleAssets
-                    .SetItem((sender, currency), (senderBalance - value).RawValue)
                     .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
         }

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -16,11 +16,13 @@ namespace Libplanet.Action
     [Pure]
     internal class AccountStateDeltaImpl : IAccountStateDelta
     {
-        private readonly AccountStateGetter _accountStateGetter;
-        private readonly AccountBalanceGetter _accountBalanceGetter;
-        private readonly Address _signer;
-        private IImmutableDictionary<Address, IValue> _updatedStates;
-        private IImmutableDictionary<(Address, Currency), BigInteger> _updatedFungibleAssets;
+#pragma warning disable SA1401
+        protected readonly AccountStateGetter _accountStateGetter;
+        protected readonly AccountBalanceGetter _accountBalanceGetter;
+        protected readonly Address _signer;
+        protected IImmutableDictionary<Address, IValue> _updatedStates;
+        protected IImmutableDictionary<(Address, Currency), BigInteger> _updatedFungibleAssets;
+#pragma warning restore SA1401
 
         /// <summary>
         /// Creates a null delta from the given <paramref name="accountStateGetter"/>.
@@ -76,12 +78,12 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
-        public FungibleAssetValue GetBalance(Address address, Currency currency) =>
+        public virtual FungibleAssetValue GetBalance(Address address, Currency currency) =>
             GetBalance(address, currency, _updatedFungibleAssets);
 
         /// <inheritdoc/>
         [Pure]
-        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+        public virtual IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
         {
             if (value.Sign <= 0)
             {
@@ -109,7 +111,7 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
-        public IAccountStateDelta TransferAsset(
+        public virtual IAccountStateDelta TransferAsset(
             Address sender,
             Address recipient,
             FungibleAssetValue value,
@@ -151,7 +153,7 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
-        public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+        public virtual IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
         {
             string msg;
 
@@ -186,7 +188,7 @@ namespace Libplanet.Action
         }
 
         [Pure]
-        private FungibleAssetValue GetBalance(
+        protected virtual FungibleAssetValue GetBalance(
             Address address,
             Currency currency,
             IImmutableDictionary<(Address, Currency), BigInteger> balances) =>
@@ -195,7 +197,7 @@ namespace Libplanet.Action
                 : _accountBalanceGetter(address, currency);
 
         [Pure]
-        private AccountStateDeltaImpl UpdateStates(
+        protected virtual AccountStateDeltaImpl UpdateStates(
             IImmutableDictionary<Address, IValue> updatedStates
         ) =>
             new AccountStateDeltaImpl(_accountStateGetter, _accountBalanceGetter, _signer)
@@ -205,7 +207,7 @@ namespace Libplanet.Action
             };
 
         [Pure]
-        private AccountStateDeltaImpl UpdateFungibleAssets(
+        protected virtual AccountStateDeltaImpl UpdateFungibleAssets(
             IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets
         ) =>
             new AccountStateDeltaImpl(_accountStateGetter, _accountBalanceGetter, _signer)

--- a/Libplanet/Action/AccountStateDeltaImplV0.cs
+++ b/Libplanet/Action/AccountStateDeltaImplV0.cs
@@ -27,9 +27,9 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         public override FungibleAssetValue GetBalance(Address address, Currency currency) =>
-            _updatedFungibleAssets.TryGetValue((address, currency), out BigInteger balance)
+            UpdatedFungibles.TryGetValue((address, currency), out BigInteger balance)
                 ? FungibleAssetValue.FromRawValue(currency, balance)
-                : _accountBalanceGetter(address, currency);
+                : BalanceGetter(address, currency);
 
         /// <inheritdoc/>
         [Pure]
@@ -60,7 +60,7 @@ namespace Libplanet.Action
             }
 
             return UpdateFungibleAssets(
-                _updatedFungibleAssets
+                UpdatedFungibles
                     .SetItem((sender, currency), (senderBalance - value).RawValue)
                     .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
@@ -70,20 +70,20 @@ namespace Libplanet.Action
         protected override AccountStateDeltaImpl UpdateStates(
             IImmutableDictionary<Address, IValue> updatedStates
         ) =>
-            new AccountStateDeltaImplV0(_accountStateGetter, _accountBalanceGetter, _signer)
+            new AccountStateDeltaImplV0(StateGetter, BalanceGetter, Signer)
             {
-                _updatedStates = updatedStates,
-                _updatedFungibleAssets = _updatedFungibleAssets,
+                UpdatedStates = updatedStates,
+                UpdatedFungibles = UpdatedFungibles,
             };
 
         [Pure]
         protected override AccountStateDeltaImpl UpdateFungibleAssets(
             IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets
         ) =>
-            new AccountStateDeltaImplV0(_accountStateGetter, _accountBalanceGetter, _signer)
+            new AccountStateDeltaImplV0(StateGetter, BalanceGetter, Signer)
             {
-                _updatedStates = _updatedStates,
-                _updatedFungibleAssets = updatedFungibleAssets,
+                UpdatedStates = UpdatedStates,
+                UpdatedFungibles = updatedFungibleAssets,
             };
     }
 }

--- a/Libplanet/Action/AccountStateDeltaImplV0.cs
+++ b/Libplanet/Action/AccountStateDeltaImplV0.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Assets;
+
+#nullable enable
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// Equivalent to <see cref="AccountStateDeltaImpl"/> except that it maintains its old (v0)
+    /// incorrect behavior of <see cref="TransferAsset"/>.
+    /// </summary>
+    [Pure]
+    internal class AccountStateDeltaImplV0 : AccountStateDeltaImpl
+    {
+        internal AccountStateDeltaImplV0(
+            AccountStateGetter accountStateGetter,
+            AccountBalanceGetter accountBalanceGetter,
+            Address signer
+        )
+            : base(accountStateGetter, accountBalanceGetter, signer)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override FungibleAssetValue GetBalance(Address address, Currency currency) =>
+            _updatedFungibleAssets.TryGetValue((address, currency), out BigInteger balance)
+                ? FungibleAssetValue.FromRawValue(currency, balance)
+                : _accountBalanceGetter(address, currency);
+
+        /// <inheritdoc/>
+        [Pure]
+        public override IAccountStateDelta TransferAsset(
+            Address sender,
+            Address recipient,
+            FungibleAssetValue value,
+            bool allowNegativeBalance = false
+        )
+        {
+            if (value.Sign <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    "The value to transfer has to be greater than zero."
+                );
+            }
+
+            Currency currency = value.Currency;
+            FungibleAssetValue senderBalance = GetBalance(sender, currency);
+            FungibleAssetValue recipientBalance = GetBalance(recipient, currency);
+
+            if (!allowNegativeBalance && senderBalance < value)
+            {
+                var msg = $"The account {sender}'s balance of {currency} is insufficient to " +
+                          $"transfer: {senderBalance} < {value}.";
+                throw new InsufficientBalanceException(sender, senderBalance, msg);
+            }
+
+            return UpdateFungibleAssets(
+                _updatedFungibleAssets
+                    .SetItem((sender, currency), (senderBalance - value).RawValue)
+                    .SetItem((recipient, currency), (recipientBalance + value).RawValue)
+            );
+        }
+
+        [Pure]
+        protected override AccountStateDeltaImpl UpdateStates(
+            IImmutableDictionary<Address, IValue> updatedStates
+        ) =>
+            new AccountStateDeltaImplV0(_accountStateGetter, _accountBalanceGetter, _signer)
+            {
+                _updatedStates = updatedStates,
+                _updatedFungibleAssets = _updatedFungibleAssets,
+            };
+
+        [Pure]
+        protected override AccountStateDeltaImpl UpdateFungibleAssets(
+            IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets
+        ) =>
+            new AccountStateDeltaImplV0(_accountStateGetter, _accountBalanceGetter, _signer)
+            {
+                _updatedStates = _updatedStates,
+                _updatedFungibleAssets = updatedFungibleAssets,
+            };
+    }
+}

--- a/Libplanet/Blockchain/BlockEvaluator.cs
+++ b/Libplanet/Blockchain/BlockEvaluator.cs
@@ -116,16 +116,19 @@ namespace Libplanet.Blockchain
 
             if (lastStates is null)
             {
-                lastStates = new AccountStateDeltaImpl(
-                    a => _stateGetter(a, block.PreviousHash, stateCompleters.StateCompleter),
-                    (address, currency) => _balanceGetter(
+                IValue? GetState(Address a) =>
+                    _stateGetter(a, block.PreviousHash, stateCompleters.StateCompleter);
+
+                FungibleAssetValue GetBalance(Address address, Currency currency) =>
+                    _balanceGetter(
                         address,
                         currency,
                         block.PreviousHash,
                         stateCompleters.FungibleAssetStateCompleter
-                    ),
-                    miner
-                );
+                    );
+                lastStates = block.ProtocolVersion > 0
+                    ? new AccountStateDeltaImpl(GetState, GetBalance, miner)
+                    : new AccountStateDeltaImplV0(GetState, GetBalance, miner);
             }
 
             return ActionEvaluation.EvaluateActionsGradually(

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -497,11 +497,10 @@ namespace Libplanet.Blocks
             IAccountStateDelta delta;
             foreach (Transaction<T> tx in Transactions)
             {
-                delta = new AccountStateDeltaImpl(
-                    accountStateGetter,
-                    accountBalanceGetter,
-                    tx.Signer
-                );
+                delta = ProtocolVersion > 0
+                    ? new AccountStateDeltaImpl(accountStateGetter, accountBalanceGetter, tx.Signer)
+                    : new AccountStateDeltaImplV0(
+                        accountStateGetter, accountBalanceGetter, tx.Signer);
                 IEnumerable<ActionEvaluation> evaluations =
                     tx.EvaluateActionsGradually(
                         PreEvaluationHash,


### PR DESCRIPTION
I rebased #1134 on the current main, and made it to maintain backward compatibility with [protocol version] 0.

Please review this instead of #1134. The commit I added besides #1134 is: 506ae01d5b6d29d93acdbcca0a7a10c79065cb16.

Closes #1134.

[protocol version]: https://github.com/planetarium/libplanet/issues/1142