### PR TITLE
Add `clearBufferInterval` parameter into `DelayedActionRenderer<T>()` constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,7 +90,7 @@ To be released.
  -  Added `IProtocol` interface.  [[#1120]]
  -  Added `KademliaProtocol` class which implements `IProtocol`.
     [[#1120], [#1135]]
- -  Added `clearBufferInterval` parameters into `DelayedActionRenderer<T>()`
+ -  Added `reorgResistantHeight` parameters into `DelayedActionRenderer<T>()`
     constructor. [[#1163]]
 
 ### Behavioral changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,8 @@ To be released.
  -  Added `IProtocol` interface.  [[#1120]]
  -  Added `KademliaProtocol` class which implements `IProtocol`.
     [[#1120], [#1135]]
+ -  Added `clearBufferInterval` parameters into `DelayedActionRenderer<T>()`
+    constructor. [[#1163]]
 
 ### Behavioral changes
 
@@ -178,6 +180,7 @@ To be released.
 [#1147]: https://github.com/planetarium/libplanet/pull/1147
 [#1152]: https://github.com/planetarium/libplanet/pull/1152
 [#1162]: https://github.com/planetarium/libplanet/pull/1162
+[#1163]: https://github.com/planetarium/libplanet/pull/1163
 
 
 Version 0.10.2

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -425,6 +425,71 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
+        public async Task ClearRenderBufferWhenItsInterval()
+        {
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            var fx = new DefaultStoreFixture(blockAction: policy.BlockAction);
+            var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();
+            var reorgLogs = new List<(
+                Block<DumbAction> OldTip,
+                Block<DumbAction> NewTip,
+                Block<DumbAction> Branchpoint
+                )>();
+            var renderLogs = new List<(bool Unrender, ActionEvaluation Evaluation)>();
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>
+            {
+                BlockRenderer = (oldTip, newTip) => blockLogs.Add((oldTip, newTip)),
+                ReorgRenderer = (oldTip, newTip, bp) => reorgLogs.Add((oldTip, newTip, bp)),
+                ActionRenderer = (action, context, nextStates) =>
+                    renderLogs.Add((false, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorRenderer = (act, ctx, e) =>
+                    renderLogs.Add((false, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+                ActionUnrenderer = (action, context, nextStates) =>
+                    renderLogs.Add((true, new ActionEvaluation(action, context, nextStates))),
+                ActionErrorUnrenderer = (act, ctx, e) =>
+                    renderLogs.Add((true, new ActionEvaluation(act, ctx, ctx.PreviousStates, e))),
+            };
+            var delayedRenderer = new DelayedActionRenderer<DumbAction>(
+                innerRenderer, fx.Store, 2, 4);
+
+            var chain = new BlockChain<DumbAction>(
+                policy,
+                new VolatileStagePolicy<DumbAction>(),
+                fx.Store,
+                fx.StateStore,
+                fx.GenesisBlock,
+                new IActionRenderer<DumbAction>[] { delayedRenderer }
+            );
+            var key = new PrivateKey();
+            var fork1 = chain.Fork(chain.Tip.Hash);
+            var fork2 = chain.Fork(chain.Tip.Hash);
+            var fork3 = chain.Fork(chain.Tip.Hash);
+
+            var repeatCount = 10;
+            for (int i = 0; i < repeatCount; i++)
+            {
+                await chain.MineBlock(fx.Address2);
+                await fork1.MineBlock(fx.Address2);
+                await fork2.MineBlock(fx.Address2);
+                await fork3.MineBlock(fx.Address2);
+            }
+
+            Assert.Equal(23, delayedRenderer.GetBufferedActionRendererCount());
+
+            chain.Swap(fork1, true);
+            chain.Swap(fork2, true);
+            chain.Swap(fork3, true);
+            Assert.Equal(21, delayedRenderer.GetBufferedActionUnRendererCount());
+
+            for (int i = 0; i < 5; i++)
+            {
+                await chain.MineBlock(fx.Address2);
+            }
+
+            Assert.Equal(8, delayedRenderer.GetBufferedActionUnRendererCount());
+        }
+
+        [Fact]
         public async Task DelayedRendererInReorg()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -474,19 +474,22 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 await fork3.MineBlock(fx.Address2);
             }
 
-            Assert.Equal(23, delayedRenderer.GetBufferedActionRendererCount());
+            Assert.Equal(17, delayedRenderer.GetBufferedActionRendererCount());
+            Assert.Equal(0, delayedRenderer.GetBufferedActionUnRendererCount());
 
             chain.Swap(fork1, true);
             chain.Swap(fork2, true);
             chain.Swap(fork3, true);
-            Assert.Equal(21, delayedRenderer.GetBufferedActionUnRendererCount());
+            Assert.Equal(17, delayedRenderer.GetBufferedActionRendererCount());
+            Assert.Equal(15, delayedRenderer.GetBufferedActionUnRendererCount());
 
             for (int i = 0; i < 5; i++)
             {
                 await chain.MineBlock(fx.Address2);
             }
 
-            Assert.Equal(8, delayedRenderer.GetBufferedActionUnRendererCount());
+            Assert.Equal(2, delayedRenderer.GetBufferedActionRendererCount());
+            Assert.Equal(0, delayedRenderer.GetBufferedActionUnRendererCount());
         }
 
         [Fact]

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -319,6 +319,16 @@ namespace Libplanet.Blockchain.Renderers
             return Iterate().Reverse().ToImmutableArray();
         }
 
+        internal int GetBufferedActionRendererCount()
+        {
+            return _bufferedActionRenders.Count;
+        }
+
+        internal int GetBufferedActionUnRendererCount()
+        {
+            return _bufferedActionUnrenders.Count;
+        }
+
         /// <inheritdoc cref="DelayedRenderer{T}.OnTipChanged(Block{T}, Block{T}, Block{T}?)"/>
         protected override void OnTipChanged(
             Block<T> oldTip,

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -71,7 +71,8 @@ namespace Libplanet.Blockchain.Renderers
         /// See also the <see cref="DelayedRenderer{T}.Confirmations"/> property.</param>
         /// <param name="reorgResistantHeight">Configures the height of blocks to maintain the
         /// <see cref="ActionEvaluation"/> buffer. Buffered <see cref="ActionEvaluation"/>s
-        /// that belong to blocks older than this height from the tip are gone.</param>
+        /// that belong to blocks older than this height from the tip are gone.
+        /// If zero, which is a default value, is passed the buffer is not cleared.</param>
         public DelayedActionRenderer(
             IActionRenderer<T> renderer,
             IStore store,

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -260,8 +260,7 @@ namespace Libplanet.Blockchain.Renderers
                 return;
             }
 
-            var quotient = Math.DivRem(newTip.Index, _reorgResistantHeight, out _);
-            if (quotient <= 0)
+            if (newTip.Index < _reorgResistantHeight)
             {
                 return;
             }

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -510,18 +510,12 @@ namespace Libplanet.Blockchain.Renderers
             long targetBlockIndex,
             ConcurrentDictionary<HashDigest<SHA256>, List<ActionEvaluation>> buffer)
         {
-            var invalidityBlock = new List<HashDigest<SHA256>>();
-            foreach (var (hash, evaluations) in buffer.Select(x => (x.Key, x.Value)))
+            IEnumerable<HashDigest<SHA256>> invalidityBlockHashes = buffer
+                .Where(x => x.Value.First().InputContext.BlockIndex < targetBlockIndex)
+                .Select(t => t.Key);
+            foreach (HashDigest<SHA256> invalidityBlockHash in invalidityBlockHashes)
             {
-                if (evaluations.First().InputContext.BlockIndex < targetBlockIndex)
-                {
-                    invalidityBlock.Add(hash);
-                }
-            }
-
-            foreach (var hash in invalidityBlock)
-            {
-                buffer.TryRemove(hash, out _);
+                buffer.TryRemove(invalidityBlockHash, out _);
             }
         }
 


### PR DESCRIPTION
Add `clearBufferInterval` parameter into `DelayedActionRenderer<T>()` constructor for clear `DelayedActionRenderer<T>._bufferedActionRender` and `DelayedActionRenderer<T>._bufferedActionUnrender` each block interval.