### PR TITLE
fix(net): reset block demand when not changed

### DIFF
--- a/Libplanet.Tests/Menees.Analyzers.Settings.xml
+++ b/Libplanet.Tests/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>300</MaxMethodLines>
-  <MaxFileLines>2550</MaxFileLines>
+  <MaxFileLines>2600</MaxFileLines>
 </Menees.Analyzers.Settings>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1732,8 +1732,9 @@ namespace Libplanet.Net
                     continue;
                 }
 
-                BoundPeer peer = BlockDemand.Value.Peer;
-                var hash = new HashDigest<SHA256>(BlockDemand.Value.Header.Hash.ToArray());
+                BlockDemand blockDemand = BlockDemand.Value;
+                BoundPeer peer = blockDemand.Peer;
+                var hash = new HashDigest<SHA256>(blockDemand.Header.Hash.ToArray());
 
                 try
                 {
@@ -1773,11 +1774,12 @@ namespace Libplanet.Net
                 {
                     using (await _blockSyncMutex.LockAsync(cancellationToken))
                     {
-                        // FIXME: Should only reset when BlockDemand has not changed
-                        // from the beginning of this operation.
-                        _logger.Debug($"{nameof(ProcessFillBlocks)}() finished. " +
-                                      $"Reset {nameof(BlockDemand)}...");
-                        BlockDemand = null;
+                        _logger.Debug($"{nameof(ProcessFillBlocks)}() finished.");
+                        if (BlockDemand.Equals(blockDemand))
+                        {
+                            _logger.Debug($"Reset {nameof(BlockDemand)}...");
+                            BlockDemand = null;
+                        }
                     }
                 }
             }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -233,6 +233,8 @@ namespace Libplanet.Net
 
         internal AsyncAutoResetEvent FillBlocksAsyncFailed { get; } = new AsyncAutoResetEvent();
 
+        internal AsyncAutoResetEvent ProcessFillBlocksFinished { get; } = new AsyncAutoResetEvent();
+
         internal SwarmOptions Options { get; }
 
         /// <summary>
@@ -1780,6 +1782,8 @@ namespace Libplanet.Net
                             _logger.Debug($"Reset {nameof(BlockDemand)}...");
                             BlockDemand = null;
                         }
+
+                        ProcessFillBlocksFinished.Set();
                     }
                 }
             }


### PR DESCRIPTION
This fixes an issue where it can reset block demand at an incorrect time. For instance:

- Received `BlockHeader` 100 and `BlockDemand` 100 block.
- `ProcessFillBlocks()` starts to download the 100 blocks.
- Received `BlockHeader` 101 and `BlockDemand` 101 block.
- `ProcessFillBlocks()` finished to download the 100 blocks and reset `Swarm<T>.BlockDemand` as `null`.
- Though `BlockHeader` 101 was received, it was ignored.

I tried to fix the problem by resetting the block demand as `null` when starting `SyncPreviousBlocksAsync()` after moving the block demand as the local variable, but it makes many code changes and I felt hard to build the situation. So I fixed the problem with the current changes simply. Also, I skipped the changelog because `Swarm<T>.BlockDemand` was not released yet. If you think it needs to be recorded in the changelog or have other suggestions, please leave your opinions free.