### PR TITLE
Add lifespan to messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,9 @@ To be released.
      -  `RecentStates` message type (with the type number `0x13`)
      -  `GetBlockStates` message type (with the type number `0x22`)
      -  `BlockStates` message type (with the type number `0x23`)
+ -  `Swarm<T>` became to ignore messages more than a certain amount of time
+    since they were created, the value is `SwarmOptions.MessageLifespan`.
+    [[#1160], [#1171]]
 
 ### Backward-incompatible storage format changes
 
@@ -211,11 +214,13 @@ To be released.
 [#1149]: https://github.com/planetarium/libplanet/pull/1149
 [#1152]: https://github.com/planetarium/libplanet/pull/1152
 [#1155]: https://github.com/planetarium/libplanet/issues/1155
+[#1160]: https://github.com/planetarium/libplanet/issues/1160
 [#1162]: https://github.com/planetarium/libplanet/pull/1162
 [#1163]: https://github.com/planetarium/libplanet/pull/1163
 [#1165]: https://github.com/planetarium/libplanet/pull/1165
 [#1168]: https://github.com/planetarium/libplanet/pull/1168
 [#1170]: https://github.com/planetarium/libplanet/pull/1170
+[#1171]: https://github.com/planetarium/libplanet/pull/1171
 [#1172]: https://github.com/planetarium/libplanet/pull/1172
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ To be released.
  -  Removed `trustedStateValidators` parameter from `Swarm<T>.PreloadAsync()`
     method.  [[#1117]]
  -  Added `IActionContext.BlockAction` property. [[#1143]]
+ -  Added nullable `TimeSpan`-typed `messageLifespan` parameter into
+    `NetMQTransport` constructor.  [[#1171]]
+
 
 ### Backward-incompatible network protocol changes
 
@@ -49,9 +52,8 @@ To be released.
      -  `RecentStates` message type (with the type number `0x13`)
      -  `GetBlockStates` message type (with the type number `0x22`)
      -  `BlockStates` message type (with the type number `0x23`)
- -  `Swarm<T>` became to ignore messages more than a certain amount of time
-    since they were created, the value is `SwarmOptions.MessageLifespan`.
-    [[#1160], [#1171]]
+ -  `Swarm<T>` became to ignore messages made earlier than a certain amount of time,
+    which is configured by `SwarmOptions.MessageLifespan`.  [[#1160], [#1171]]
 
 ### Backward-incompatible storage format changes
 
@@ -122,6 +124,8 @@ To be released.
  -  Added `InvalidBlockPreEvaluationHashException` class.  [[#1148]]
  -  Added the parameter `validate` which is `true` by default,
     to `Transaction<T>.Deserialize()`.  [[#1149]]
+ -  Added `SwarmOptions.MessageLifespan` property.  [[#1171]]
+ -  Added `InvalidTimestampException` class.  [[#1171]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ To be released.
     method.  [[#1117]]
  -  Added `IActionContext.BlockAction` property. [[#1143]]
  -  Added nullable `TimeSpan`-typed `messageLifespan` parameter into
-    `NetMQTransport` constructor.  [[#1171]]
+    `NetMQTransport()` constructor.  [[#1171]]
 
 
 ### Backward-incompatible network protocol changes
@@ -52,8 +52,9 @@ To be released.
      -  `RecentStates` message type (with the type number `0x13`)
      -  `GetBlockStates` message type (with the type number `0x22`)
      -  `BlockStates` message type (with the type number `0x23`)
- -  `Swarm<T>` became to ignore messages made earlier than a certain amount of time,
-    which is configured by `SwarmOptions.MessageLifespan`.  [[#1160], [#1171]]
+ -  `Swarm<T>` became to ignore messages made earlier than a certain amount of
+    time, which is configured by `SwarmOptions.MessageLifespan`.
+    [[#1160], [#1171]]
 
 ### Backward-incompatible storage format changes
 

--- a/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
+++ b/Libplanet.Tests/Net/Messages/BlockHashesTest.cs
@@ -34,8 +34,9 @@ namespace Libplanet.Tests.Net.Messages
             var privKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
-            NetMQFrame[] frames =
-                msg.ToNetMQMessage(privKey, peer, ver).Skip(Message.CommonFrames).ToArray();
+            NetMQFrame[] frames = msg.ToNetMQMessage(privKey, peer, DateTimeOffset.UtcNow, ver)
+                .Skip(Message.CommonFrames)
+                .ToArray();
             var restored = new BlockHashes(frames);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -38,6 +38,7 @@ namespace Libplanet.Tests.Net.Messages
                     true,
                     invalidAppProtocolVersion,
                     ImmutableHashSet<PublicKey>.Empty,
+                    null,
                     null));
         }
 
@@ -63,6 +64,7 @@ namespace Libplanet.Tests.Net.Messages
                     true,
                     invalidAppProtocolVersion,
                     ImmutableHashSet<PublicKey>.Empty,
+                    null,
                     null));
         }
 
@@ -80,7 +82,7 @@ namespace Libplanet.Tests.Net.Messages
             var message = new Ping();
             NetMQMessage raw =
                 message.ToNetMQMessage(privateKey, peer, dateTimeOffset, appProtocolVersion);
-            var parsed = Message.Parse(raw, true, appProtocolVersion, null, null);
+            var parsed = Message.Parse(raw, true, appProtocolVersion, null, null, null);
             Assert.Equal(peer, parsed.Remote);
             Assert.Equal(appProtocolVersion, parsed.Version);
             Assert.Equal(dateTimeOffset, parsed.Timestamp);

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -69,6 +69,43 @@ namespace Libplanet.Tests.Net.Messages
         }
 
         [Fact]
+        public void InvalidTimestamp()
+        {
+            var privateKey = new PrivateKey();
+            var peer = new Peer(privateKey.PublicKey);
+            var futureOffset = DateTimeOffset.MaxValue;
+            var pastOffset = DateTimeOffset.MinValue;
+            var appProtocolVersion = new AppProtocolVersion(
+                1,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var message = new Ping();
+            NetMQMessage futureRaw =
+                message.ToNetMQMessage(privateKey, peer, futureOffset, appProtocolVersion);
+            // Messages from the future throws InvalidTimestampException.
+            Assert.Throws<InvalidTimestampException>(() =>
+                Message.Parse(
+                    futureRaw,
+                    true,
+                    appProtocolVersion,
+                    ImmutableHashSet<PublicKey>.Empty,
+                    null,
+                    TimeSpan.FromSeconds(1)));
+            NetMQMessage pastRaw =
+                message.ToNetMQMessage(privateKey, peer, futureOffset, appProtocolVersion);
+            // Messages from the far past throws InvalidTimestampException.
+            Assert.Throws<InvalidTimestampException>(() =>
+                Message.Parse(
+                    pastRaw,
+                    true,
+                    appProtocolVersion,
+                    ImmutableHashSet<PublicKey>.Empty,
+                    null,
+                    TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
         public void Parse()
         {
             var privateKey = new PrivateKey();

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -93,7 +93,7 @@ namespace Libplanet.Tests.Net.Messages
                     null,
                     TimeSpan.FromSeconds(1)));
             NetMQMessage pastRaw =
-                message.ToNetMQMessage(privateKey, peer, futureOffset, appProtocolVersion);
+                message.ToNetMQMessage(privateKey, peer, pastOffset, appProtocolVersion);
             // Messages from the far past throws InvalidTimestampException.
             Assert.Throws<InvalidTimestampException>(() =>
                 Message.Parse(

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -25,7 +26,11 @@ namespace Libplanet.Tests.Net.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var message = new Ping();
-            var netMQMessage = message.ToNetMQMessage(privateKey, peer, validAppProtocolVersion);
+            var netMQMessage = message.ToNetMQMessage(
+                privateKey,
+                peer,
+                DateTimeOffset.UtcNow,
+                validAppProtocolVersion);
 
             Assert.Throws<DifferentAppProtocolVersionException>(() =>
                 Message.Parse(

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -65,5 +65,25 @@ namespace Libplanet.Tests.Net.Messages
                     ImmutableHashSet<PublicKey>.Empty,
                     null));
         }
+
+        [Fact]
+        public void Parse()
+        {
+            var privateKey = new PrivateKey();
+            var peer = new Peer(privateKey.PublicKey);
+            var dateTimeOffset = DateTimeOffset.UtcNow;
+            var appProtocolVersion = new AppProtocolVersion(
+                1,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var message = new Ping();
+            NetMQMessage raw =
+                message.ToNetMQMessage(privateKey, peer, dateTimeOffset, appProtocolVersion);
+            var parsed = Message.Parse(raw, true, appProtocolVersion, null, null);
+            Assert.Equal(peer, parsed.Remote);
+            Assert.Equal(appProtocolVersion, parsed.Version);
+            Assert.Equal(dateTimeOffset, parsed.Timestamp);
+        }
     }
 }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -588,7 +588,11 @@ namespace Libplanet.Tests.Net
                 {
                     var request = new GetBlocks(hashes.Select(pair => pair.Item2), 2);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey, swarmB.AsPeer, swarmB.AppProtocolVersion)
+                        request.ToNetMQMessage(
+                            privateKey,
+                            swarmB.AsPeer,
+                            DateTimeOffset.UtcNow,
+                            swarmB.AppProtocolVersion)
                     );
 
                     NetMQMessage response = socket.ReceiveMultipartMessage();
@@ -2374,7 +2378,11 @@ namespace Libplanet.Tests.Net
                     var request =
                         new BlockHeaderMessage(swarm.BlockChain.Genesis.Hash, higherBlock.Header);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey1, sender1, swarm.AppProtocolVersion)
+                        request.ToNetMQMessage(
+                            privateKey1,
+                            sender1,
+                            DateTimeOffset.UtcNow,
+                            swarm.AppProtocolVersion)
                     );
                     await swarm.BlockHeaderReceived.WaitAsync();
                     await Task.Delay(100);
@@ -2385,7 +2393,11 @@ namespace Libplanet.Tests.Net
                     request =
                         new BlockHeaderMessage(swarm.BlockChain.Genesis.Hash, lowerBlock.Header);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey2, sender2, swarm.AppProtocolVersion)
+                        request.ToNetMQMessage(
+                            privateKey2,
+                            sender2,
+                            DateTimeOffset.UtcNow,
+                            swarm.AppProtocolVersion)
                     );
                     await swarm.BlockHeaderReceived.WaitAsync();
                     // Await for context change
@@ -2401,7 +2413,11 @@ namespace Libplanet.Tests.Net
                     request =
                         new BlockHeaderMessage(swarm.BlockChain.Genesis.Hash, higherBlock.Header);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey1, sender1, swarm.AppProtocolVersion)
+                        request.ToNetMQMessage(
+                            privateKey1,
+                            sender1,
+                            DateTimeOffset.UtcNow,
+                            swarm.AppProtocolVersion)
                     );
                     await swarm.BlockHeaderReceived.WaitAsync();
                     await Task.Delay(100);
@@ -2413,7 +2429,11 @@ namespace Libplanet.Tests.Net
                     request =
                         new BlockHeaderMessage(swarm.BlockChain.Genesis.Hash, lowerBlock.Header);
                     socket.SendMultipartMessage(
-                        request.ToNetMQMessage(privateKey2, sender2, swarm.AppProtocolVersion)
+                        request.ToNetMQMessage(
+                            privateKey2,
+                            sender2,
+                            DateTimeOffset.UtcNow,
+                            swarm.AppProtocolVersion)
                     );
                     await swarm.BlockHeaderReceived.WaitAsync();
                     await Task.Delay(100);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -601,6 +601,7 @@ namespace Libplanet.Tests.Net
                         true,
                         swarmA.AppProtocolVersion,
                         swarmA.TrustedAppProtocolVersionSigners,
+                        null,
                         null);
                     Libplanet.Net.Messages.Blocks blockMessage =
                         (Libplanet.Net.Messages.Blocks)parsedMessage;
@@ -613,6 +614,7 @@ namespace Libplanet.Tests.Net
                         true,
                         swarmA.AppProtocolVersion,
                         swarmA.TrustedAppProtocolVersionSigners,
+                        null,
                         null);
                     blockMessage = (Libplanet.Net.Messages.Blocks)parsedMessage;
 

--- a/Libplanet/Net/InvalidTimestampException.cs
+++ b/Libplanet/Net/InvalidTimestampException.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Net
+{
+    [Serializable]
+    public class InvalidTimestampException : Exception
+    {
+        internal InvalidTimestampException(
+            string message,
+            DateTimeOffset createdOffset,
+            TimeSpan lifespan,
+            DateTimeOffset currentOffset,
+            Exception innerException
+        )
+            : base(message, innerException)
+        {
+            CreatedOffset = createdOffset;
+            Lifespan = lifespan;
+            CurrentOffset = currentOffset;
+        }
+
+        internal InvalidTimestampException(
+            string message,
+            DateTimeOffset createdOffset,
+            TimeSpan lifespan,
+            DateTimeOffset currentOffset)
+            : base(message)
+        {
+            CreatedOffset = createdOffset;
+            Lifespan = lifespan;
+            CurrentOffset = currentOffset;
+        }
+
+        protected InvalidTimestampException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
+            CreatedOffset = info.GetValue(nameof(CreatedOffset), typeof(DateTimeOffset))
+                is DateTimeOffset createdOffset
+                ? createdOffset
+                : throw new SerializationException(
+                    $"{nameof(CreatedOffset)} is expected to be a non-null " +
+                    $"{nameof(DateTimeOffset)}.");
+            Lifespan = info.GetValue(nameof(Lifespan), typeof(TimeSpan))
+                is TimeSpan lifetime
+                ? lifetime
+                : throw new SerializationException(
+                    $"{nameof(Lifespan)} is expected to be a non-null " +
+                    $"{nameof(TimeSpan)}.");
+            CurrentOffset = info.GetValue(nameof(CurrentOffset), typeof(DateTimeOffset))
+                is DateTimeOffset currentOffset
+                ? currentOffset
+                : throw new SerializationException(
+                    $"{nameof(CurrentOffset)} is expected to be a non-null " +
+                    $"{nameof(DateTimeOffset)}.");
+        }
+
+        internal DateTimeOffset CreatedOffset { get; }
+
+        internal TimeSpan Lifespan { get; }
+
+        internal DateTimeOffset CurrentOffset { get; }
+
+        public override void GetObjectData(
+            SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(CreatedOffset), CreatedOffset);
+            info.AddValue(nameof(Lifespan), Lifespan);
+            info.AddValue(nameof(CurrentOffset), CurrentOffset);
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -19,6 +20,8 @@ namespace Libplanet.Net.Messages
         /// The number of frames that all messages commonly contain.
         /// </summary>
         public const int CommonFrames = 5;
+
+        internal const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         /// <summary>
         /// <c>Enum</c> represents the type of the <see cref="Message"/>.
@@ -245,9 +248,11 @@ namespace Libplanet.Net.Messages
             if (!(lifetime is null) &&
                 (currentTime < timestamp || timestamp + lifetime < currentTime))
             {
-                var msg = $"Received message is invalid, created at {timestamp} " +
+                var msg = $"Received message is invalid, created at " +
+                          $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +
                           $"but designated lifetime is {lifetime} and the current datetime " +
-                          $"offset is {currentTime}.";
+                          $"offset is " +
+                          $"{currentTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}.";
                 throw new InvalidTimestampException(msg, timestamp, lifetime.Value, currentTime);
             }
 

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -40,6 +40,7 @@ namespace Libplanet.Net
         private readonly IList<IceServer> _iceServers;
         private readonly ILogger _logger;
         private readonly AsyncLock _turnClientMutex;
+        private readonly TimeSpan? _messageLifespan;
 
         private NetMQQueue<NetMQMessage> _replyQueue;
         private NetMQQueue<(Address?, Message)> _broadcastQueue;
@@ -98,6 +99,10 @@ namespace Libplanet.Net
         /// If this callback returns <c>false</c>, an encountered peer is ignored.  If this callback
         /// is omitted, all peers with different <see cref="AppProtocolVersion"/>s are ignored.
         /// </param>
+        /// <param name="messageLifespan">
+        /// The lifespan of a message.
+        /// Messages generated before this value from the current time are ignored.
+        /// If <c>null</c> is given, messages will not be ignored by its timestamp.</param>
         /// <exception cref="ArgumentException">Thrown when both <paramref name="host"/> and
         /// <paramref name="iceServers"/> are <c>null</c>.</exception>
         public NetMQTransport(
@@ -109,7 +114,8 @@ namespace Libplanet.Net
             string host,
             int? listenPort,
             IEnumerable<IceServer> iceServers,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered)
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
+            TimeSpan? messageLifespan = null)
         {
             Running = false;
 
@@ -121,6 +127,7 @@ namespace Libplanet.Net
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
             _turnClientMutex = new AsyncLock();
             _table = table;
+            _messageLifespan = messageLifespan;
 
             if (_host != null && _listenPort is int listenPortAsInt)
             {
@@ -447,6 +454,20 @@ namespace Libplanet.Net
                 _logger.Error(e, logMsg, peer.Address, reqId, e.ExpectedVersion, e.ActualVersion);
                 throw;
             }
+            catch (InvalidTimestampException ite)
+            {
+                const string logMsg =
+                    "{PeerAddress} sent a reply to {RequestId} with stale timestamp; " +
+                    "(timestamp: {Timestamp}, lifespan: {Lifespan}, current: {Current})";
+                _logger.Error(
+                    logMsg,
+                    peer.Address,
+                    reqId,
+                    ite.CreatedOffset,
+                    ite.Lifespan,
+                    ite.CurrentOffset);
+                throw;
+            }
             catch (TimeoutException)
             {
                 _logger.Debug(
@@ -518,8 +539,10 @@ namespace Libplanet.Net
                         false,
                         _appProtocolVersion,
                         _trustedAppProtocolVersionSigners,
-                        _differentAppProtocolVersionEncountered);
+                        _differentAppProtocolVersionEncountered,
+                        _messageLifespan);
                     _logger.Debug("A message has parsed: {0}, from {1}", message, message.Remote);
+
                     MessageHistory.Enqueue(message);
                     LastMessageTimestamp = DateTimeOffset.UtcNow;
 
@@ -544,6 +567,12 @@ namespace Libplanet.Net
                     };
                     ReplyMessage(differentVersion);
                     _logger.Debug("Message from peer with different version received.");
+                }
+                catch (InvalidTimestampException ite)
+                {
+                    const string logMsg = "The received message is stale. " +
+                              "(timestamp: {Timestamp}, lifespan: {Lifespan}, current: {Current})";
+                    _logger.Debug(logMsg, ite.CreatedOffset, ite.Lifespan, ite.CurrentOffset);
                 }
                 catch (InvalidMessageException ex)
                 {
@@ -756,7 +785,8 @@ namespace Libplanet.Net
                         true,
                         _appProtocolVersion,
                         _trustedAppProtocolVersionSigners,
-                        _differentAppProtocolVersionEncountered);
+                        _differentAppProtocolVersionEncountered,
+                        _messageLifespan);
                     _logger.Debug(
                         "A reply has parsed: {Reply} from {ReplyRemote}",
                         reply,
@@ -771,6 +801,10 @@ namespace Libplanet.Net
             catch (DifferentAppProtocolVersionException dapve)
             {
                 tcs.TrySetException(dapve);
+            }
+            catch (InvalidTimestampException ite)
+            {
+                tcs.TrySetException(ite);
             }
             catch (TimeoutException te)
             {

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -490,7 +490,11 @@ namespace Libplanet.Net
         {
             string identityHex = ByteUtil.Hex(message.Identity);
             _logger.Debug("Reply {Message} to {Identity}...", message, identityHex);
-            _replyQueue.Enqueue(message.ToNetMQMessage(_privateKey, AsPeer, _appProtocolVersion));
+            _replyQueue.Enqueue(message.ToNetMQMessage(
+                _privateKey,
+                AsPeer,
+                DateTimeOffset.UtcNow,
+                _appProtocolVersion));
         }
 
         private void ReceiveMessage(object sender, NetMQSocketEventArgs e)
@@ -568,7 +572,11 @@ namespace Libplanet.Net
                 _logger.Debug("Broadcasting message: {Message} as {AsPeer}", msg, AsPeer);
                 _logger.Debug("Peers to broadcast: {PeersCount}", peers.Count);
 
-                NetMQMessage message = msg.ToNetMQMessage(_privateKey, AsPeer, _appProtocolVersion);
+                NetMQMessage message = msg.ToNetMQMessage(
+                    _privateKey,
+                    AsPeer,
+                    DateTimeOffset.UtcNow,
+                    _appProtocolVersion);
 
                 foreach (BoundPeer peer in peers)
                 {
@@ -716,7 +724,11 @@ namespace Libplanet.Net
                 req.Message,
                 req.Peer
             );
-            var message = req.Message.ToNetMQMessage(_privateKey, AsPeer, _appProtocolVersion);
+            var message = req.Message.ToNetMQMessage(
+                _privateKey,
+                AsPeer,
+                DateTimeOffset.UtcNow,
+                _appProtocolVersion);
             var result = new List<Message>();
             TaskCompletionSource<IEnumerable<Message>> tcs = req.TaskCompletionSource;
             try

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -467,6 +467,12 @@ namespace Libplanet.Net.Protocols
                     target,
                     $"Timeout occurred during dial to {target}.");
             }
+            catch (InvalidTimestampException)
+            {
+                throw new PingTimeoutException(
+                    target,
+                    $"Received Pong from {target} has invalid timestamp.");
+            }
             catch (DifferentAppProtocolVersionException)
             {
                 _logger.Error(
@@ -651,6 +657,11 @@ namespace Libplanet.Net.Protocols
                 }
 
                 return neighbors.Found;
+            }
+            catch (InvalidTimestampException)
+            {
+                _logger.Debug($"Reply of {nameof(GetNeighbors)}'s timestamp is stale.");
+                return ImmutableArray<BoundPeer>.Empty;
             }
             catch (TimeoutException)
             {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -142,6 +142,7 @@ namespace Libplanet.Net
             _logger = Log.ForContext<Swarm<T>>()
                 .ForContext("SwarmId", loggerId);
 
+            Options = options ?? new SwarmOptions();
             RoutingTable = new RoutingTable(Address, tableSize, bucketSize);
             Transport = new NetMQTransport(
                 RoutingTable,
@@ -152,10 +153,10 @@ namespace Libplanet.Net
                 host,
                 listenPort,
                 iceServers,
-                differentAppProtocolVersionEncountered);
+                differentAppProtocolVersionEncountered,
+                Options.MessageLifespan);
             Transport.ProcessMessageHandler += ProcessMessageHandler;
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
-            Options = options ?? new SwarmOptions();
         }
 
         ~Swarm()

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using Libplanet.Blocks;
+using Libplanet.Net.Messages;
 using Libplanet.Tx;
 
 namespace Libplanet.Net
@@ -41,5 +42,10 @@ namespace Libplanet.Net
         /// The lifespan of block demand.
         /// </summary>
         public TimeSpan BlockDemandLifespan { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// The lifespan of <see cref="Message"/>.
+        /// </summary>
+        public TimeSpan? MessageLifespan { get; set; } = null;
     }
 }


### PR DESCRIPTION
Added timestamp to messages. Network transport used in swarm will now ignore messages created in certain time before current time, or after current moment. The amount of lifespan of a message is configured in `SwarmOptions.MessageLifespan`, if `null` is given then timestamp will not being used in message validation.

There are API changes in `Message`, but I omitted it in the changelog because the abstract class `Message` haven't released yet.

Please refer to #1160.