### PR TITLE
Check StateRootHash first when BlockChain<T>.ExecuteAction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,8 @@ To be released.
     can be validated rather than trusted due to MPT.  [[#1117]]
  -  `HashDigest<SHA256>` became serializable.  [[#795], [#1125]]
  -  `Transaction<T>()` constructors became not to validate itself.  [[#1149]]
+ -  `BlockChain<T>.Append()` became to validate the given `Block<T>`
+    before storing its `StateRootHash`.  [[#1172]]
 
 ### Bug fixes
 
@@ -214,6 +216,7 @@ To be released.
 [#1165]: https://github.com/planetarium/libplanet/pull/1165
 [#1168]: https://github.com/planetarium/libplanet/pull/1168
 [#1170]: https://github.com/planetarium/libplanet/pull/1170
+[#1172]: https://github.com/planetarium/libplanet/pull/1172
 
 
 Version 0.10.3

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -292,7 +292,7 @@ namespace Libplanet.Tests.Blockchain
                     miner: miner,
                     difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(fx.StateStore, _policy.BlockAction);
+                ).AttachStateRootHash(blockChain.StateStore, policy.BlockAction);
 
                 blockChain.Append(block1);
 
@@ -302,7 +302,7 @@ namespace Libplanet.Tests.Blockchain
                     miner: miner,
                     difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(fx.StateStore, _policy.BlockAction);
+                ).AttachStateRootHash(blockChain.StateStore, policy.BlockAction);
 
                 Assert.Throws<TxViolatingBlockPolicyException>(() => blockChain.Append(block2));
             }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -201,7 +201,8 @@ namespace Libplanet.Tests.Blockchain
                 genesisBlock.Miner.Value,
                 genesisBlock.Hash,
                 genesisBlock.Timestamp.AddSeconds(1),
-                _emptyTransaction).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+                _emptyTransaction).AttachStateRootHash(_fx.StateStore, _policy.BlockAction)
+                .AttachStateRootHash(chain.StateStore, policy.BlockAction);
             chain.Append(validNext);
 
             var invalidStateRootHash = Block<DumbAction>.Mine(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1881,7 +1881,7 @@ namespace Libplanet.Tests.Blockchain
                 genesis,
                 txs,
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
-            );
+            ).AttachStateRootHash(_blockChain.StateStore, _policy.BlockAction);
 
             var miner = genesis.Miner.GetValueOrDefault();
             var blockActionEvaluation = _blockChain.BlockEvaluator.EvaluateBlockAction(
@@ -1895,8 +1895,7 @@ namespace Libplanet.Tests.Blockchain
                 (Integer)2,
                 (Integer)blockActionEvaluation.OutputStates.GetState(miner));
             Assert.True(blockActionEvaluation.InputContext.BlockAction);
-
-            _blockChain.ExecuteActions(genesis);
+            _blockChain.ExecuteActions(block1);
             _blockChain.Append(
                 block1,
                 DateTimeOffset.UtcNow,

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -207,5 +207,14 @@ namespace Libplanet.Store
                     new HashNode(
                         new HashDigest<SHA256>(
                             _stateHashKeyValueStore.Get(blockHash.ToByteArray()))));
+
+        internal void SetStates<T>(
+            Block<T> block,
+            HashDigest<SHA256> stateRootHash)
+            where T : IAction, new()
+        {
+            _stateHashKeyValueStore.Set(
+                block.Hash.ToByteArray(), stateRootHash.ToByteArray());
+        }
     }
 }

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -48,23 +48,8 @@ namespace Libplanet.Store
             IImmutableDictionary<string, IValue> states)
             where T : IAction, new()
         {
-            ITrie prevStatesTrie;
-            var previousBlockStateHashBytes = block.PreviousHash is null
-                ? null
-                : _stateHashKeyValueStore.Get(block.PreviousHash.Value.ToByteArray());
-            var trieRoot = previousBlockStateHashBytes is null
-                ? null
-                : new HashNode(new HashDigest<SHA256>(previousBlockStateHashBytes));
-            prevStatesTrie = new MerkleTrie(_stateKeyValueStore, trieRoot, _secure);
-
-            foreach (var pair in states)
-            {
-                prevStatesTrie = prevStatesTrie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
-            }
-
-            var newStateTrie = prevStatesTrie.Commit();
             _stateHashKeyValueStore.Set(
-                block.Hash.ToByteArray(), newStateTrie.Hash.ToByteArray());
+                block.Hash.ToByteArray(), EvalState(block, states).ToByteArray());
         }
 
         /// <inheritdoc/>
@@ -190,6 +175,30 @@ namespace Libplanet.Store
         /// <paramref name="blockHash"/>.</exception>
         public HashDigest<SHA256> GetRootHash(HashDigest<SHA256> blockHash)
             => new HashDigest<SHA256>(_stateHashKeyValueStore.Get(blockHash.ToByteArray()));
+
+        internal HashDigest<SHA256> EvalState<T>(
+            Block<T> block,
+            IImmutableDictionary<string, IValue> states,
+            bool rehearsal = false)
+            where T : IAction, new()
+        {
+            ITrie prevStatesTrie;
+            var previousBlockStateHashBytes = block.PreviousHash is null
+                ? null
+                : _stateHashKeyValueStore.Get(block.PreviousHash.Value.ToByteArray());
+            var trieRoot = previousBlockStateHashBytes is null
+                ? null
+                : new HashNode(new HashDigest<SHA256>(previousBlockStateHashBytes));
+            prevStatesTrie = new MerkleTrie(_stateKeyValueStore, trieRoot, _secure);
+
+            foreach (var pair in states)
+            {
+                prevStatesTrie = prevStatesTrie.Set(Encoding.UTF8.GetBytes(pair.Key), pair.Value);
+            }
+
+            var newStateTrie = prevStatesTrie.Commit(rehearsal);
+            return newStateTrie.Hash;
+        }
 
         internal ITrie GetTrie(HashDigest<SHA256> blockHash)
             =>


### PR DESCRIPTION
Previously, before verifying the state, the evaluated state was first saved and then verified, but now the state root hash verified first and saved. 