### PR TITLE
Stale outdated chains

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "ciphertext",
     "indeterministic",
     "nonces",
+    "outdate",
     "parameterless",
     "preload",
     "roadmap",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,13 +19,13 @@ To be released.
  -  Added `stagePolicy` as the second parameter to `BlockChain<T>()`
     constructor.  [[#1130], [#1131]]
  -  Added `IBlockPolicy<T>.CanonicalChainComparer` property to make
-    the canonical chain .  [[#1155], [#1165]]
+    the canonical chain.  [[#1155], [#1165], [#1184]]
  -  Added `canonicalChainComparer` as the last parameter to `BlockPolicy()`
-    constructors.  [[#1155], [#1165]]
+    constructors.  [[#1155], [#1165], [#1184]]
  -  Added `canonicalChainComparer` as the second parameter to
-    `DelayedRenderer()` constructor.  [[#1155], [#1165]]
+    `DelayedRenderer()` constructor.  [[#1155], [#1165], [#1184]]
  -  Added `canonicalChainComparer` as the second parameter to
-    `DelayedActionRenderer()` constructor.  [[#1155], [#1165]]
+    `DelayedActionRenderer()` constructor.  [[#1155], [#1165], [#1184]]
  -  Added `reorgResistantHeight` parameter into `DelayedActionRenderer<T>()`
     constructor. [[#1163]]
  -  Added `IStore.SetBlockPerceivedTime()` method.  [[#1184]]
@@ -76,8 +76,8 @@ To be released.
  -  Added `BlockChain<T>.PerceiveBlock()` method.  [[#1155], [#1184]]
  -  Added `DelayedRenderer<T>.CanonicalChainComparer` and
     `DelayedActionRenderer<T>.CanonicalChainComparer` properties.
-    [[#1155], [#1165]]
- -  Added `TotalDifficultyComparer` class.  [[#1155], [#1165], [#1170]]
+    [[#1155], [#1165], [#1184]]
+ -  Added `TotalDifficultyComparer` class.  [[#1155], [#1165], [#1170], [#1184]]
  -  Added `IStagePolicy<T>` interface.  [[#1130], [#1131], [#1186]]
  -  Added `VolatileStagePolicy<T>` class.  [[#1130], [#1131], [#1136], [#1186]]
  -  Added `ITransport` interface.  [[#1052]]
@@ -140,7 +140,8 @@ To be released.
  -  Introduced the [protocol versioning scheme][#1142].  This purposes to change
     the protocol without breaking backward compatibility.  Even the protocol
     is changed, the existing blocks made before the new protocol are guaranteed
-    to behave as it had done.  [[#1142], [#1147], [#1162], [#1170]]
+    to behave as it had done.
+    [[#1142], [#1147], [#1155] [#1162], [#1170], [#1184]]
  -  Since `BlockHeader.ProtocolVersion` was added, the existing blocks are
     considered protocol compliant with the protocol version zero.
     [[#1142], [#1147], [#1162]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
     `DelayedActionRenderer()` constructor.  [[#1155], [#1165]]
  -  Added `reorgResistantHeight` parameter into `DelayedActionRenderer<T>()`
     constructor. [[#1163]]
+ -  Added `IStore.SetBlockPerceivedTime()` method.  [[#1184]]
+ -  Added `IStore.GetBlockPerceivedTime()` method.  [[#1184]]
  -  Removed `TransactionSet<T>` class.  [[#1165]]
  -  Removed `IBlockStatesStore` interface.  [[#1117]]
  -  Removed `BaseBlockStatesStore` abstract class.  [[#1117]]
@@ -239,6 +241,7 @@ To be released.
 [#1180]: https://github.com/planetarium/libplanet/pull/1180
 [#1181]: https://github.com/planetarium/libplanet/pull/1181
 [#1182]: https://github.com/planetarium/libplanet/pull/1182
+[#1184]: https://github.com/planetarium/libplanet/pull/1184
 [#1185]: https://github.com/planetarium/libplanet/pull/1185
 [#1186]: https://github.com/planetarium/libplanet/pull/1186
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,11 +67,13 @@ To be released.
  -  Added `Block<T>.Header` property.  [[#1070], [#1102]]
  -  Added `BlockHeader.ProtocolVersion` property.  [[#1142], [#1147]]
  -  Added `IBlockExcerpt` interface.  [[#1155], [#1165], [#1170]]
- -  Added `BlockExcerpt` class.  [[#1155], [#1165], [#1170]]
+ -  Added `BlockExcerpt` static class.  [[#1155], [#1165], [#1170], [#1184]]
  -  `Block<T>` became to implement `IBlockExceprt` interface.
     [[#1155], [#1165], [#1170]]
  -  `BlockHeader` became to implement `IBlockExceprt` interface.
     [[#1155], [#1165], [#1170]]
+ -  Added `BlockPerception` struct.  [[#1155], [#1184]]
+ -  Added `BlockChain<T>.PerceiveBlock()` method.  [[#1155], [#1184]]
  -  Added `DelayedRenderer<T>.CanonicalChainComparer` and
     `DelayedActionRenderer<T>.CanonicalChainComparer` properties.
     [[#1155], [#1165]]

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Tests.Blockchain
             _difficulty = difficulty;
         }
 
-        public IComparer<IBlockExcerpt> CanonicalChainComparer => new TotalDifficultyComparer();
+        public IComparer<BlockPerception> CanonicalChainComparer => new TotalDifficultyComparer();
 
         public IAction BlockAction => null;
 

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -19,7 +20,8 @@ namespace Libplanet.Tests.Blockchain
             _difficulty = difficulty;
         }
 
-        public IComparer<BlockPerception> CanonicalChainComparer => new TotalDifficultyComparer();
+        public IComparer<BlockPerception> CanonicalChainComparer =>
+            new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
 
         public IAction BlockAction => null;
 

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _chainB
             );
 
-            _canonicalChainComparer = new TotalDifficultyComparer();
+            _canonicalChainComparer = new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
 
             _store = new DefaultStore(null);
             foreach (Block<DumbAction> b in _chainA.Concat(_chainB))

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         protected static readonly IReadOnlyList<Block<DumbAction>> _chainA;
         protected static readonly IReadOnlyList<Block<DumbAction>> _chainB;
         protected static readonly Block<DumbAction> _branchpoint;
-        protected IComparer<IBlockExcerpt> _canonicalChainComparer;
+        protected IComparer<BlockPerception> _canonicalChainComparer;
         protected IStore _store;
         protected ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
+++ b/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Tests.Blocks;
 using Xunit;
 
 namespace Libplanet.Tests.Blockchain
@@ -11,35 +11,35 @@ namespace Libplanet.Tests.Blockchain
     {
         private static readonly BlockExcerpt[] Fixture =
         {
-            new BlockExcerpt
+            new SimpleBlockExcerpt
             { // 0
                 ProtocolVersion = BlockHeader.CurrentProtocolVersion - 1,
                 Index = 604665,
                 Hash = H("4f612467ed79cb854d1901f131ccfc8a40bba89651e1a9e1dcea1287dd70d8ee"),
                 TotalDifficulty = 21584091240753,
             },
-            new BlockExcerpt
+            new SimpleBlockExcerpt
             { // 1
                 ProtocolVersion = BlockHeader.CurrentProtocolVersion - 1,
                 Index = 604664,
                 Hash = H("9a87556f3198d8bd48300d2a6a5957d661c760a7fb72ef4a4b8c01c155b77e99"),
                 TotalDifficulty = 21584061959429,
             },
-            new BlockExcerpt
+            new SimpleBlockExcerpt
             { // 2
                 ProtocolVersion = BlockHeader.CurrentProtocolVersion - 1,
                 Index = 604663,
                 Hash = H("11358698ce49a8356c12578bdbdc986927ef02e82e3cfef2b6385023a56bad41"),
                 TotalDifficulty = 21584032692395,
             },
-            new BlockExcerpt
+            new SimpleBlockExcerpt
             { // 3
                 ProtocolVersion = BlockHeader.CurrentProtocolVersion,
                 Index = 604662,
                 Hash = H("3603b146dd66090df531d99061b9fb15e3314cd753b333cfc2432867620fd4f1"),
                 TotalDifficulty = 21584003439644,
             },
-            new BlockExcerpt
+            new SimpleBlockExcerpt
             { // 4
                 ProtocolVersion = BlockHeader.CurrentProtocolVersion - 1,
                 Index = 604661,
@@ -61,31 +61,5 @@ namespace Libplanet.Tests.Blockchain
         }
 
         private static HashDigest<SHA256> H(string h) => HashDigest<SHA256>.FromString(h);
-
-        private struct BlockExcerpt : IBlockExcerpt
-        {
-            public BlockExcerpt(
-                int protocolVersion,
-                long index,
-                HashDigest<SHA256> hash,
-                BigInteger totalDifficulty
-            )
-            {
-                ProtocolVersion = protocolVersion;
-                Index = index;
-                Hash = hash;
-                TotalDifficulty = totalDifficulty;
-            }
-
-            public int ProtocolVersion { get; set; }
-
-            public long Index { get; set; }
-
-            public HashDigest<SHA256> Hash { get; set; }
-
-            public BigInteger TotalDifficulty { get; set; }
-
-            public override string ToString() => this.ToExcerptString();
-        }
     }
 }

--- a/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
+++ b/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Tests.Blocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Blockchain
 {
@@ -52,22 +54,67 @@ namespace Libplanet.Tests.Blockchain
         private static readonly BlockPerception[] BlockPerceptions =
         {
             new BlockPerception(BlockExcerpts[0], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
-            new BlockPerception(BlockExcerpts[1], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
-            new BlockPerception(BlockExcerpts[2], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+            new BlockPerception(BlockExcerpts[1], DateTimeOffset.FromUnixTimeSeconds(1609426815)),
+            new BlockPerception(BlockExcerpts[2], DateTimeOffset.FromUnixTimeSeconds(1609426815)),
             new BlockPerception(BlockExcerpts[3], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
             new BlockPerception(BlockExcerpts[4], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
         };
 
+        private readonly ITestOutputHelper _output;
+
+        public TotalDifficultyComparerTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void Sort()
         {
-            BlockPerception[] sorted =
-                BlockPerceptions.OrderBy(e => e, new TotalDifficultyComparer()).ToArray();
-            Assert.Equal(BlockPerceptions[2], sorted[0]);
-            Assert.Equal(BlockPerceptions[1], sorted[1]);
-            Assert.Equal(BlockPerceptions[0], sorted[2]);
-            Assert.Equal(BlockPerceptions[4], sorted[3]);
-            Assert.Equal(BlockPerceptions[3], sorted[4]);
+            void PrintBlocks(IEnumerable<BlockPerception> blocks)
+            {
+                foreach (BlockPerception b in blocks)
+                {
+                    _output.WriteLine(
+                        nameof(BlockPerceptions) + "[{0}]",
+                        Array.IndexOf(BlockPerceptions, b)
+                    );
+                }
+
+                _output.WriteLine(string.Empty);
+            }
+
+            DateTimeOffset currentTime = DateTimeOffset.FromUnixTimeSeconds(1609426815);
+            TimeSpan outdateAfter = TimeSpan.FromSeconds(15);
+            var comparer = new TotalDifficultyComparer(outdateAfter, () => currentTime);
+            BlockPerception[] sorted = BlockPerceptions.OrderBy(e => e, comparer).ToArray();
+            PrintBlocks(sorted);
+            Assert.Equal(BlockPerceptions[0], sorted[0]);
+            Assert.Equal(BlockPerceptions[4], sorted[1]);
+            Assert.Equal(BlockPerceptions[3], sorted[2]);
+            Assert.Equal(BlockPerceptions[2], sorted[3]);
+            Assert.Equal(BlockPerceptions[1], sorted[4]);
+
+            sorted = BlockPerceptions
+                .Select(p => new BlockPerception(p.BlockExcerpt, currentTime))
+                .OrderBy(e => e, comparer)
+                .ToArray();
+            PrintBlocks(sorted);
+            Assert.Equal(BlockPerceptions[2].BlockExcerpt, sorted[0].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[1].BlockExcerpt, sorted[1].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[0].BlockExcerpt, sorted[2].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[4].BlockExcerpt, sorted[3].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[3].BlockExcerpt, sorted[4].BlockExcerpt);
+
+            sorted = BlockPerceptions
+                .Select(p => new BlockPerception(p.BlockExcerpt, currentTime - outdateAfter))
+                .OrderBy(e => e, comparer)
+                .ToArray();
+            PrintBlocks(sorted);
+            Assert.Equal(BlockPerceptions[2].BlockExcerpt, sorted[0].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[1].BlockExcerpt, sorted[1].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[0].BlockExcerpt, sorted[2].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[4].BlockExcerpt, sorted[3].BlockExcerpt);
+            Assert.Equal(BlockPerceptions[3].BlockExcerpt, sorted[4].BlockExcerpt);
         }
 
         private static HashDigest<SHA256> H(string h) => HashDigest<SHA256>.FromString(h);

--- a/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
+++ b/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Blockchain;
@@ -9,7 +10,7 @@ namespace Libplanet.Tests.Blockchain
 {
     public class TotalDifficultyComparerTest
     {
-        private static readonly BlockExcerpt[] Fixture =
+        private static readonly SimpleBlockExcerpt[] BlockExcerpts =
         {
             new SimpleBlockExcerpt
             { // 0
@@ -48,16 +49,25 @@ namespace Libplanet.Tests.Blockchain
             },
         };
 
+        private static readonly BlockPerception[] BlockPerceptions =
+        {
+            new BlockPerception(BlockExcerpts[0], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+            new BlockPerception(BlockExcerpts[1], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+            new BlockPerception(BlockExcerpts[2], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+            new BlockPerception(BlockExcerpts[3], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+            new BlockPerception(BlockExcerpts[4], DateTimeOffset.FromUnixTimeSeconds(1609426800)),
+        };
+
         [Fact]
         public void Sort()
         {
-            BlockExcerpt[] sorted =
-                Fixture.OrderBy(e => e, new TotalDifficultyComparer()).ToArray();
-            Assert.Equal(Fixture[2], sorted[0]);
-            Assert.Equal(Fixture[1], sorted[1]);
-            Assert.Equal(Fixture[0], sorted[2]);
-            Assert.Equal(Fixture[4], sorted[3]);
-            Assert.Equal(Fixture[3], sorted[4]);
+            BlockPerception[] sorted =
+                BlockPerceptions.OrderBy(e => e, new TotalDifficultyComparer()).ToArray();
+            Assert.Equal(BlockPerceptions[2], sorted[0]);
+            Assert.Equal(BlockPerceptions[1], sorted[1]);
+            Assert.Equal(BlockPerceptions[0], sorted[2]);
+            Assert.Equal(BlockPerceptions[4], sorted[3]);
+            Assert.Equal(BlockPerceptions[3], sorted[4]);
         }
 
         private static HashDigest<SHA256> H(string h) => HashDigest<SHA256>.FromString(h);

--- a/Libplanet.Tests/Blocks/SimpleBlockExcerpt.cs
+++ b/Libplanet.Tests/Blocks/SimpleBlockExcerpt.cs
@@ -1,0 +1,32 @@
+using System.Numerics;
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+
+namespace Libplanet.Tests.Blocks
+{
+    public struct SimpleBlockExcerpt : IBlockExcerpt
+    {
+        public SimpleBlockExcerpt(
+            int protocolVersion,
+            long index,
+            HashDigest<SHA256> hash,
+            BigInteger totalDifficulty
+        )
+        {
+            ProtocolVersion = protocolVersion;
+            Index = index;
+            Hash = hash;
+            TotalDifficulty = totalDifficulty;
+        }
+
+        public int ProtocolVersion { get; set; }
+
+        public long Index { get; set; }
+
+        public HashDigest<SHA256> Hash { get; set; }
+
+        public BigInteger TotalDifficulty { get; set; }
+
+        public override string ToString() => this.ToExcerptString();
+    }
+}

--- a/Libplanet.Tests/Menees.Analyzers.Settings.xml
+++ b/Libplanet.Tests/Menees.Analyzers.Settings.xml
@@ -2,5 +2,5 @@
 <Menees.Analyzers.Settings>
   <MaxLineColumns>100</MaxLineColumns>
   <MaxMethodLines>300</MaxMethodLines>
-  <MaxFileLines>2400</MaxFileLines>
+  <MaxFileLines>2450</MaxFileLines>
 </Menees.Analyzers.Settings>

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Tests.Net
         [InlineData(1)]
         public async Task DetermineCanonicalChain(short canonComparerType)
         {
-            IComparer<IBlockExcerpt> canonComparer;
+            IComparer<BlockPerception> canonComparer;
             switch (canonComparerType)
             {
                 default:
@@ -27,10 +27,10 @@ namespace Libplanet.Tests.Net
                     break;
 
                 case 1:
-                    canonComparer = new AnonymousComparer<IBlockExcerpt>((a, b) =>
+                    canonComparer = new AnonymousComparer<BlockPerception>((a, b) =>
                         string.Compare(
-                            a.Hash.ToString(),
-                            b.Hash.ToString(),
+                            a.BlockExcerpt.Hash.ToString(),
+                            b.BlockExcerpt.Hash.ToString(),
                             StringComparison.Ordinal
                         )
                     );
@@ -92,7 +92,12 @@ namespace Libplanet.Tests.Net
                     break;
             }
 
-            Assert.True(canonComparer.Compare(bestBlock, chain1.Tip) > 0);
+            Assert.True(
+                canonComparer.Compare(
+                    new BlockPerception(bestBlock),
+                    chain1.PerceiveBlock(chain1.Tip)
+                ) > 0
+            );
             chain2.Append(bestBlock);
 
             try

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Net
             switch (canonComparerType)
             {
                 default:
-                    canonComparer = new TotalDifficultyComparer();
+                    canonComparer = new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
                     break;
 
                 case 1:

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -167,6 +167,29 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
+        public void BlockPerceivedTime()
+        {
+            Assert.Null(Fx.Store.GetBlockPerceivedTime(Fx.Hash1));
+            Assert.Null(Fx.Store.GetBlockPerceivedTime(Fx.Hash2));
+
+            DateTimeOffset time1 = DateTimeOffset.FromUnixTimeSeconds(1609426800);
+            DateTimeOffset time2 = DateTimeOffset.FromUnixTimeSeconds(1612254976);
+            DateTimeOffset time3 = DateTimeOffset.FromUnixTimeSeconds(1612432420);
+
+            Fx.Store.SetBlockPerceivedTime(Fx.Hash1, time1);
+            Assert.Equal(time1, Fx.Store.GetBlockPerceivedTime(Fx.Hash1));
+            Assert.Null(Fx.Store.GetBlockPerceivedTime(Fx.Hash2));
+
+            Fx.Store.SetBlockPerceivedTime(Fx.Hash1, time2);
+            Assert.Equal(time2, Fx.Store.GetBlockPerceivedTime(Fx.Hash1));
+            Assert.Null(Fx.Store.GetBlockPerceivedTime(Fx.Hash2));
+
+            Fx.Store.SetBlockPerceivedTime(Fx.Hash2, time3);
+            Assert.Equal(time2, Fx.Store.GetBlockPerceivedTime(Fx.Hash1));
+            Assert.Equal(time3, Fx.Store.GetBlockPerceivedTime(Fx.Hash2));
+        }
+
+        [SkippableFact]
         public void StoreTx()
         {
             Assert.Equal(0, Fx.Store.CountTransactions());

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -54,6 +54,21 @@ namespace Libplanet.Tests.Store
             return _store.ContainsBlock(blockHash);
         }
 
+        public void SetBlockPerceivedTime(
+            HashDigest<SHA256> blockHash,
+            DateTimeOffset perceivedTime
+        )
+        {
+            Log(nameof(SetBlockPerceivedTime), blockHash, perceivedTime);
+            _store.SetBlockPerceivedTime(blockHash, perceivedTime);
+        }
+
+        public DateTimeOffset? GetBlockPerceivedTime(HashDigest<SHA256> blockHash)
+        {
+            Log(nameof(GetBlockPerceivedTime), blockHash);
+            return _store.GetBlockPerceivedTime(blockHash);
+        }
+
         public void DeleteChainId(Guid chainId)
         {
             Log(nameof(DeleteChainId), chainId);

--- a/Libplanet.sln.DotSettings
+++ b/Libplanet.sln.DotSettings
@@ -20,6 +20,7 @@
   <s:Boolean x:Key="/Default/UserDictionary/Words/=ciphertext/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=indeterministic/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=nonces/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=outdate/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=parameterless/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=preload/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=roadmap/@EntryIndexedValue">True</s:Boolean>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -690,6 +690,36 @@ namespace Libplanet.Blockchain
             return nonce;
         }
 
+        /// <summary>
+        /// Records and queries the <paramref name="perceivedTime"/> of the given
+        /// <paramref name="blockExcerpt"/>.
+        /// <para>Although blocks have their own <see cref="Block{T}.Timestamp"/>, but these values
+        /// are untrustworthy as they are arbitrarily determined by their miners.</para>
+        /// <para>On the other hand, this method returns the subjective time according to the local
+        /// node's perception.</para>
+        /// <para>If the local node has never perceived the <paramref name="blockExcerpt"/> yet,
+        /// it is perceived at that moment and the current time is returned instead. (However, you
+        /// can replace the current time with the <paramref name="perceivedTime"/> option.)
+        /// In other words, this method is idempotent.</para>
+        /// </summary>
+        /// <param name="blockExcerpt">The perceived block.</param>
+        /// <param name="perceivedTime">The time the local node perceived the given <paramref
+        /// name="blockExcerpt"/>.  The current time by default.</param>
+        /// <returns>A pair of a block and the time it was perceived.</returns>
+        public BlockPerception PerceiveBlock(
+            IBlockExcerpt blockExcerpt,
+            DateTimeOffset? perceivedTime = null
+        )
+        {
+            if (!(Store.GetBlockPerceivedTime(blockExcerpt.Hash) is { } time))
+            {
+                time = perceivedTime ?? DateTimeOffset.UtcNow;
+                Store.SetBlockPerceivedTime(blockExcerpt.Hash, time);
+            }
+
+            return new BlockPerception(blockExcerpt, time);
+        }
+
 #pragma warning disable MEN003
         /// <summary>
         /// Mines a next <see cref="Block{T}"/> using staged <see cref="Transaction{T}"/>s,

--- a/Libplanet/Blockchain/BlockPerception.cs
+++ b/Libplanet/Blockchain/BlockPerception.cs
@@ -1,0 +1,57 @@
+using System;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// Pair of a block and the time the local node perceived it.
+    /// <para>Purposes to be compared when the canonical chain is determined.</para>
+    /// </summary>
+    public readonly struct BlockPerception
+    {
+        /// <summary>
+        /// Creates a pair.
+        /// </summary>
+        /// <param name="blockExcerpt">The block perceived by the local node.</param>
+        /// <param name="perceivedTime">The time the local node perceived the
+        /// <paramref name="blockExcerpt"/>.</param>
+        public BlockPerception(IBlockExcerpt blockExcerpt, DateTimeOffset perceivedTime)
+        {
+            BlockExcerpt = blockExcerpt;
+            PerceivedTime = perceivedTime;
+        }
+
+        /// <summary>
+        /// Creates a pair with setting <see cref="PerceivedTime"/> to the current time.
+        /// </summary>
+        /// <param name="blockExcerpt">The block perceived by the local node.</param>
+        public BlockPerception(IBlockExcerpt blockExcerpt)
+            : this(blockExcerpt, DateTimeOffset.UtcNow)
+        {
+        }
+
+        /// <summary>
+        /// The block perceived by the local node.
+        /// </summary>
+        public IBlockExcerpt BlockExcerpt { get; }
+
+        /// <summary>
+        /// The time the local node perceived the <see cref="BlockExcerpt"/>.
+        /// </summary>
+        public DateTimeOffset PerceivedTime { get; }
+
+        public override string ToString()
+        {
+            const string F = nameof(BlockExcerpt);
+            IBlockExcerpt excerpt = BlockExcerpt;
+            return
+                $"{nameof(BlockPerception)} {{" +
+                $" {F}.{nameof(excerpt.ProtocolVersion)} = {excerpt.ProtocolVersion}," +
+                $" {F}.{nameof(excerpt.Index)} = {excerpt.Index}," +
+                $" {F}.{nameof(excerpt.Hash)} = {excerpt.Hash}," +
+                $" {F}.{nameof(excerpt.TotalDifficulty)} = {excerpt.TotalDifficulty}," +
+                $" {nameof(PerceivedTime)} = {PerceivedTime}" +
+                " }";
+        }
+    }
+}

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -92,7 +92,9 @@ namespace Libplanet.Blockchain.Policies
         /// A predicate that determines if the transaction follows the block policy.
         /// </param>
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
-        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
+        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> (having
+        /// <see cref="TotalDifficultyComparer.OutdateAfter"/> configured to triple of
+        /// <paramref name="blockInterval"/>) is used by default.</param>
         public BlockPolicy(
             IAction blockAction,
             TimeSpan blockInterval,
@@ -138,7 +140,8 @@ namespace Libplanet.Blockchain.Policies
             _maxBlockBytes = maxBlockBytes;
             _maxGenesisBytes = maxGenesisBytes;
             _doesTransactionFollowPolicy = doesTransactionFollowPolicy ?? ((_, __) => true);
-            CanonicalChainComparer = canonicalChainComparer ?? new TotalDifficultyComparer();
+            CanonicalChainComparer = canonicalChainComparer
+                ?? new TotalDifficultyComparer(blockInterval + blockInterval + blockInterval);
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Blockchain.Policies
         /// A predicate that determines if the transaction follows the block policy.
         /// </param>
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
-        /// chain.  If omitted, <see cref="CanonicalChainComparer"/> is used by default.</param>
+        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
         public BlockPolicy(
             IAction blockAction = null,
             int blockIntervalMilliseconds = 5000,
@@ -54,7 +54,7 @@ namespace Libplanet.Blockchain.Policies
             int maxBlockBytes = 100 * 1024,
             int maxGenesisBytes = 1024 * 1024,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
-            IComparer<IBlockExcerpt> canonicalChainComparer = null
+            IComparer<BlockPerception> canonicalChainComparer = null
         )
             : this(
                 blockAction,
@@ -92,7 +92,7 @@ namespace Libplanet.Blockchain.Policies
         /// A predicate that determines if the transaction follows the block policy.
         /// </param>
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
-        /// chain.  If omitted, <see cref="CanonicalChainComparer"/> is used by default.</param>
+        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
         public BlockPolicy(
             IAction blockAction,
             TimeSpan blockInterval,
@@ -102,7 +102,7 @@ namespace Libplanet.Blockchain.Policies
             int maxBlockBytes,
             int maxGenesisBytes,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
-            IComparer<IBlockExcerpt> canonicalChainComparer = null
+            IComparer<BlockPerception> canonicalChainComparer = null
         )
         {
             if (blockInterval < TimeSpan.Zero)
@@ -158,7 +158,7 @@ namespace Libplanet.Blockchain.Policies
         public TimeSpan BlockInterval { get; }
 
         /// <inheritdoc />
-        public IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
+        public IComparer<BlockPerception> CanonicalChainComparer { get; }
 
         private long MinimumDifficulty { get; }
 

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Blockchain.Policies
         /// </summary>
         /// <seealso cref="IBlockExcerpt"/>
         /// <seealso cref="TotalDifficultyComparer"/>
-        IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
+        IComparer<BlockPerception> CanonicalChainComparer { get; }
 
         /// <summary>
         /// A block action to execute and be rendered for every block.

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Blockchain.Renderers
         /// If zero, which is a default value, is passed the buffer is not cleared.</param>
         public DelayedActionRenderer(
             IActionRenderer<T> renderer,
-            IComparer<IBlockExcerpt> canonicalChainComparer,
+            IComparer<BlockPerception> canonicalChainComparer,
             IStore store,
             int confirmations,
             long reorgResistantHeight = 0)

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Blockchain.Renderers
     /// ]]></code>
     /// </example>
     /// <remarks>Since <see cref="IActionRenderer{T}"/> is a subtype of <see cref="IRenderer{T}"/>,
-    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IComparer{IBlockExcerpt}, IStore, int)"/>
+    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IComparer{BlockPerception}, IStore, int)"/>
     /// constructor can take an <see cref="IActionRenderer{T}"/> instance as well.
     /// However, even it takes an action renderer, action-level fine-grained events won't hear.
     /// For action renderers, please use <see cref="DelayedActionRenderer{T}"/> instead.</remarks>
@@ -62,7 +62,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <paramref name="confirmations"/> is not greater than zero.</exception>
         public DelayedRenderer(
             IRenderer<T> renderer,
-            IComparer<IBlockExcerpt> canonicalChainComparer,
+            IComparer<BlockPerception> canonicalChainComparer,
             IStore store,
             int confirmations
         )
@@ -100,7 +100,7 @@ namespace Libplanet.Blockchain.Renderers
         /// The same canonical chain comparer to <see cref="BlockChain{T}.Policy"/>.
         /// </summary>
         /// <seealso cref="IBlockPolicy{T}.CanonicalChainComparer"/>
-        public IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
+        public IComparer<BlockPerception> CanonicalChainComparer { get; }
 
         /// <summary>
         /// The same store to what <see cref="BlockChain{T}"/> uses.

--- a/Libplanet/Blockchain/TotalDifficultyComparer.cs
+++ b/Libplanet/Blockchain/TotalDifficultyComparer.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -15,22 +16,14 @@ namespace Libplanet.Blockchain
     /// protocol version, it always consider the higher version greater.</remarks>
     /// <seealso cref="IBlockPolicy{T}.CanonicalChainComparer"/>
     /// <seealso cref="IBlockExcerpt"/>
-    public class TotalDifficultyComparer : IComparer<IBlockExcerpt>
+    public class TotalDifficultyComparer : IComparer<BlockPerception>
     {
         /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
-        public int Compare(IBlockExcerpt? x, IBlockExcerpt? y)
+        public int Compare(BlockPerception x, BlockPerception y)
         {
-            if (x is null)
-            {
-                return -1;
-            }
-            else if (y is null)
-            {
-                return 1;
-            }
-
-            int vcmp = x.ProtocolVersion.CompareTo(y.ProtocolVersion);
-            return vcmp == 0 ? x.TotalDifficulty.CompareTo(y.TotalDifficulty) : vcmp;
+            IBlockExcerpt xBlock = x.BlockExcerpt, yBlock = y.BlockExcerpt;
+            int vcmp = xBlock.ProtocolVersion.CompareTo(yBlock.ProtocolVersion);
+            return vcmp == 0 ? xBlock.TotalDifficulty.CompareTo(yBlock.TotalDifficulty) : vcmp;
         }
     }
 }

--- a/Libplanet/Blockchain/TotalDifficultyComparer.cs
+++ b/Libplanet/Blockchain/TotalDifficultyComparer.cs
@@ -18,9 +18,53 @@ namespace Libplanet.Blockchain
     /// <seealso cref="IBlockExcerpt"/>
     public class TotalDifficultyComparer : IComparer<BlockPerception>
     {
+        private readonly Func<DateTimeOffset> _currentTimeGetter;
+
+        /// <summary>
+        /// Creates a <see cref="TotalDifficultyComparer"/> instance.
+        /// </summary>
+        /// <param name="outdateAfter">Blocks taken this time since they are perceived are
+        /// considered outdated, so that chains having these blocks as their tips become stale.
+        /// </param>
+        public TotalDifficultyComparer(TimeSpan outdateAfter)
+            : this(outdateAfter, () => DateTimeOffset.UtcNow)
+        {
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TotalDifficultyComparer"/> instance.
+        /// </summary>
+        /// <param name="outdateAfter">Blocks taken this time since they are perceived are
+        /// considered outdated, so that chains having these blocks as their tips become stale.
+        /// </param>
+        /// <param name="currentTimeGetter">Configures the way to get the current time instead of
+        /// <see cref="DateTimeOffset.UtcNow"/> property.</param>
+        public TotalDifficultyComparer(
+            TimeSpan outdateAfter,
+            Func<DateTimeOffset> currentTimeGetter
+        )
+        {
+            _currentTimeGetter = currentTimeGetter;
+            OutdateAfter = outdateAfter;
+        }
+
+        /// <summary>
+        /// Blocks taken this time since they are perceived are considered outdated, so that
+        /// chains having these blocks as their tips become stale.
+        /// </summary>
+        public TimeSpan OutdateAfter { get; }
+
         /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
         public int Compare(BlockPerception x, BlockPerception y)
         {
+            DateTimeOffset outdateBefore = _currentTimeGetter() - OutdateAfter;
+            bool xOutdated = x.PerceivedTime <= outdateBefore,
+                 yOutdated = y.PerceivedTime <= outdateBefore;
+            if (xOutdated != yOutdated)
+            {
+                return xOutdated ? -1 : 1;
+            }
+
             IBlockExcerpt xBlock = x.BlockExcerpt, yBlock = y.BlockExcerpt;
             int vcmp = xBlock.ProtocolVersion.CompareTo(yBlock.ProtocolVersion);
             return vcmp == 0 ? xBlock.TotalDifficulty.CompareTo(yBlock.TotalDifficulty) : vcmp;

--- a/Libplanet/Blocks/BlockExcerpt.cs
+++ b/Libplanet/Blocks/BlockExcerpt.cs
@@ -12,12 +12,15 @@ namespace Libplanet.Blocks
         /// </summary>
         /// <param name="excerpt">An excerpt object to show.</param>
         /// <returns>Extracted members as a string.</returns>
-        public static string ToExcerptString(this IBlockExcerpt excerpt) =>
-            $"{excerpt.GetType().Name} {{" +
-            $" {nameof(IBlockExcerpt.ProtocolVersion)} = {excerpt.ProtocolVersion}," +
-            $" {nameof(IBlockExcerpt.Index)} = {excerpt.Index}," +
-            $" {nameof(IBlockExcerpt.Hash)} = {excerpt.Hash}," +
-            $" {nameof(IBlockExcerpt.TotalDifficulty)} = {excerpt.TotalDifficulty}" +
-            " }";
+        public static string ToExcerptString(this IBlockExcerpt excerpt)
+        {
+            return
+                $"{excerpt.GetType().Name} {{" +
+                $" {nameof(excerpt.ProtocolVersion)} = {excerpt.ProtocolVersion}," +
+                $" {nameof(excerpt.Index)} = {excerpt.Index}," +
+                $" {nameof(excerpt.Hash)} = {excerpt.Hash}," +
+                $" {nameof(excerpt.TotalDifficulty)} = {excerpt.TotalDifficulty}" +
+                " }";
+        }
     }
 }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -121,6 +121,15 @@ namespace Libplanet.Store
         public abstract bool ContainsBlock(HashDigest<SHA256> blockHash);
 
         /// <inheritdoc/>
+        public abstract void SetBlockPerceivedTime(
+            HashDigest<SHA256> blockHash,
+            DateTimeOffset perceivedTime
+        );
+
+        /// <inheritdoc/>
+        public abstract DateTimeOffset? GetBlockPerceivedTime(HashDigest<SHA256> blockHash);
+
+        /// <inheritdoc/>
         public abstract IEnumerable<KeyValuePair<Address, long>> ListTxNonces(Guid chainId);
 
         /// <inheritdoc/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -177,6 +177,21 @@ namespace Libplanet.Store
         bool ContainsBlock(HashDigest<SHA256> blockHash);
 
         /// <summary>
+        /// Records the perceived time of a block.  If there is already a record, it is overwritten.
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to record its perceived time.
+        /// </param>
+        /// <param name="perceivedTime">The perceived time to record.</param>
+        void SetBlockPerceivedTime(HashDigest<SHA256> blockHash, DateTimeOffset perceivedTime);
+
+        /// <summary>
+        /// Queries the perceived time of a block, if it has been recorded.
+        /// </summary>
+        /// <param name="blockHash"><see cref="Block{T}.Hash"/> to query.</param>
+        /// <returns>The perceived time of a block, if it exists.  Otherwise, <c>null</c>.</returns>
+        DateTimeOffset? GetBlockPerceivedTime(HashDigest<SHA256> blockHash);
+
+        /// <summary>
         /// Lists all <see cref="Address"/>es that have ever signed <see cref="Transaction{T}"/>,
         /// and their corresponding <see cref="Transaction{T}"/> nonces.
         /// </summary>


### PR DESCRIPTION
This completely fixes #1155, in particular:

> Also: we may need to consider time a node received blocks.

I also added a new struct to represent the concept of local node's perception of blocks: `BlockPerception`.

See also the changelog.