### PR TITLE
Reset all relays after reconnecting TURN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,8 @@ To be released.
     are guaranteed to still behave as it had done.  [[#1152]]
  -  Fixed a bug where `Block<T>.Evaluate()` hadn't validate its hash.  [[#1168]]
  -  Fixed memory leak due to undisposed `CancellationTokenSource`s.  [[#1182]]
+ -  Fixed a bug where `TurnClient` hadn't released its relay connections after
+    reconnecting.  [[#1185]]
 
 ### CLI tools
 
@@ -237,6 +239,7 @@ To be released.
 [#1180]: https://github.com/planetarium/libplanet/pull/1180
 [#1181]: https://github.com/planetarium/libplanet/pull/1181
 [#1182]: https://github.com/planetarium/libplanet/pull/1182
+[#1185]: https://github.com/planetarium/libplanet/pull/1185
 
 
 Version 0.10.3

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -625,7 +625,7 @@ namespace Libplanet.Tests.Net
             };
 
             var cts = new CancellationTokenSource();
-            var tasks = new List<Task> { TurnProxy(port, turnUrl, cts.Token) };
+            var proxyTask = TurnProxy(port, turnUrl, cts.Token);
 
             var seed = CreateSwarm(host: "localhost");
             var swarmA = CreateSwarm(iceServers: iceServers);
@@ -667,11 +667,12 @@ namespace Libplanet.Tests.Net
                 await swarmA.AddPeersAsync(new[] { seed.AsPeer }, null);
 
                 cts.Cancel();
+                await proxyTask;
                 cts = new CancellationTokenSource();
 
-                tasks.Add(TurnProxy(port, turnUrl, cts.Token));
-                tasks.Add(RefreshTableAsync(cts.Token));
-                tasks.Add(MineAndBroadcast(cts.Token));
+                proxyTask = TurnProxy(port, turnUrl, cts.Token);
+                _ = RefreshTableAsync(cts.Token);
+                _ = MineAndBroadcast(cts.Token);
 
                 await swarmA.BlockReceived.WaitAsync();
                 cts.Cancel();


### PR DESCRIPTION
This PR fixes a bug where `TurnClient` hadn't reset its relays after resetting.