### PR TITLE
feat(cli): improve `planet mpt diff` output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -193,6 +193,8 @@ To be released.
  -  Store aliases used by `planet mpt` became to disallow names looking like
     URIs to disambiguate aliases from the literal store URIs.  [[#1129]]
  -  Added new subcommands `planet mpt list` and `planet mpt query`.  [[#1137]]
+ -  `planet mpt diff` command became to print the differences between
+    other state root hashes into stdout as JSON format.  [[#1138], [#1191]]
 
 [#795]: https://github.com/planetarium/libplanet/issues/795
 [#1052]: https://github.com/planetarium/libplanet/pull/1052
@@ -223,6 +225,7 @@ To be released.
 [#1135]: https://github.com/planetarium/libplanet/pull/1135
 [#1136]: https://github.com/planetarium/libplanet/pull/1136
 [#1137]: https://github.com/planetarium/libplanet/pull/1137
+[#1138]: https://github.com/planetarium/libplanet/issues/1138
 [#1141]: https://github.com/planetarium/libplanet/pull/1141
 [#1142]: https://github.com/planetarium/libplanet/issues/1142
 [#1143]: https://github.com/planetarium/libplanet/pull/1143
@@ -247,6 +250,7 @@ To be released.
 [#1184]: https://github.com/planetarium/libplanet/pull/1184
 [#1185]: https://github.com/planetarium/libplanet/pull/1185
 [#1186]: https://github.com/planetarium/libplanet/pull/1186
+[#1191]: https://github.com/planetarium/libplanet/pull/1191
 
 
 Version 0.10.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,9 @@ on GitHub consists of several projects:
  -  *Libplanet.Analyzers.Tests*: Unit tests of the *Libplanet.Analyzers*
     project.
 
+ -  *Libplanet.Tools.Tests*: Unit tests of the *Libplanet.Tools*
+    project.
+
 
 [NuGet package]: https://www.nuget.org/packages/Libplanet/
 [TURN & STUN]: https://snack.planetarium.dev/eng/2019/06/nat_traversal_2/

--- a/Libplanet.Tools.Tests/Libplanet.Tools.Tests.csproj
+++ b/Libplanet.Tools.Tests/Libplanet.Tools.Tests.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
+        <Link>Menees.Analyzers.Settings.xml</Link>
+      </AdditionalFiles>
+      <AdditionalFiles Include="..\stylecop.json" />
+    </ItemGroup>
+  
+    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+      <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+    </PropertyGroup>
+  
+    <PropertyGroup>
+      <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
+  
+    <ItemGroup>
+      <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>
+          runtime; build; native; contentfiles; analyzers
+        </IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
+      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    </ItemGroup>
+  
+    <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+  
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+      <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Libplanet.Tools\Libplanet.Tools.csproj" />
+        <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Libplanet.Tools.Tests/MptTest.cs
+++ b/Libplanet.Tools.Tests/MptTest.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Bencodex.Types;
+using Libplanet.RocksDBStore;
+using Libplanet.Store.Trie;
+using Libplanet.Tools.Configuration;
+using Xunit;
+
+namespace Libplanet.Tools.Tests
+{
+    public class MptTest : IDisposable
+    {
+        private readonly Mpt _command;
+        private readonly string _pathA;
+        private readonly string _pathB;
+        private readonly ITrie _trieA;
+        private readonly ITrie _trieB;
+
+        public MptTest()
+        {
+            _command = new Mpt();
+
+            _pathA = NewTempPath();
+            _pathB = NewTempPath();
+            using var stateKeyValueStoreA = new RocksDBKeyValueStore(_pathA);
+            using var stateKeyValueStoreB = new RocksDBKeyValueStore(_pathB);
+            _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
+                ImmutableDictionary<string, IValue>.Empty
+                    .Add("deleted", default(Null))
+                    .Add("common", (Text)"before")).Commit();
+            _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
+                ImmutableDictionary<string, IValue>.Empty
+                    .Add("created", default(Null))
+                    .Add("common", (Text)"after")).Commit();
+        }
+
+        [SkippableFact]
+        public void Diff_PrintsAsJson()
+        {
+            using StringWriter stringWriter = new StringWriter {NewLine = "\n"};
+            var originalOutWriter = Console.Out;
+            try
+            {
+                Console.SetOut(stringWriter);
+                var kvStoreUri = $"rocksdb://{_pathA}";
+                var otherKvStoreUri = $"rocksdb://{_pathB}";
+                var configuration = new ToolConfiguration();
+                string stateRootHashHex = ByteUtil.Hex(_trieA.Hash.ByteArray);
+                string otherStateRootHashHex = ByteUtil.Hex(_trieB.Hash.ByteArray);
+
+                _command.Diff(
+                    kvStoreUri,
+                    stateRootHashHex,
+                    otherKvStoreUri,
+                    otherStateRootHashHex,
+                    new TestToolConfigurationService(configuration));
+
+                Assert.Equal(
+                    $@"{{""636f6d6d6f6e"":{{""{stateRootHashHex}"":""75363a6265666f7265"",""{otherStateRootHashHex}"":""75353a6166746572""}},""64656c65746564"":{{""{stateRootHashHex}"":""6e""}},""63726561746564"":{{""{otherStateRootHashHex}"":""6e""}}}}",
+                    stringWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOutWriter);
+            }
+        }
+
+        private static string NewTempPath() => Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_pathA))
+            {
+                Directory.Delete(_pathA, true);
+            }
+
+            if (Directory.Exists(_pathB))
+            {
+                Directory.Delete(_pathB, true);
+            }
+        }
+    }
+}

--- a/Libplanet.Tools.Tests/TestToolConfigurationService.cs
+++ b/Libplanet.Tools.Tests/TestToolConfigurationService.cs
@@ -1,0 +1,24 @@
+using Libplanet.Tools.Configuration;
+
+namespace Libplanet.Tools.Tests
+{
+    public class TestToolConfigurationService : IConfigurationService<ToolConfiguration>
+    {
+        private ToolConfiguration Configuration { get; set; }
+
+        public TestToolConfigurationService(ToolConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public ToolConfiguration Load()
+        {
+            return Configuration;
+        }
+
+        public void Store(ToolConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+    }
+}

--- a/Libplanet.Tools/Mpt.cs
+++ b/Libplanet.Tools/Mpt.cs
@@ -73,20 +73,13 @@ namespace Libplanet.Tools
                 otherKeyValueStore,
                 HashDigest<SHA256>.FromString(otherStateRootHashHex));
 
-            foreach (var group in trie.DifferentNodes(otherTrie))
-            {
-                Console.Error.Write("Path: ");
-                Console.WriteLine(Encoding.UTF8.GetString(ByteUtil.ParseHex(group.Key)));
-                var values = group.ToArray();
-                foreach (var pair in values)
-                {
-                    Console.Error.Write("At ");
-                    Console.WriteLine(ByteUtil.Hex(pair.Root.ToByteArray()));
-                    Console.WriteLine(pair.Value.Inspection);
-                }
-
-                Console.WriteLine();
-            }
+            var codec = new Codec();
+            var dictionary = trie.DifferentNodes(otherTrie).ToDictionary(
+                group => group.Key,
+                group => group.ToDictionary(
+                    pair => ByteUtil.Hex(pair.Root.ByteArray),
+                    pair => ByteUtil.Hex(codec.Encode(pair.Value))));
+            Console.Write(JsonSerializer.Serialize(dictionary));
         }
 
         [Command(Description = "Export all states of the state root hash as JSON.")]

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Analyzers", "Libp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Analyzers.Tests", "Libplanet.Analyzers.Tests\Libplanet.Analyzers.Tests.csproj", "{B48782B9-6FA9-4D18-8564-1849FF4CF40E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Tools.Tests", "Libplanet.Tools.Tests\Libplanet.Tools.Tests.csproj", "{A43E44E5-F9C1-44BD-A593-419EC113117B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x64.Build.0 = Release|Any CPU
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x86.ActiveCfg = Release|Any CPU
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x86.Build.0 = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|x64.Build.0 = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Debug|x86.Build.0 = Debug|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|x64.ActiveCfg = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|x64.Build.0 = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|x86.ActiveCfg = Release|Any CPU
+		{A43E44E5-F9C1-44BD-A593-419EC113117B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Libplanet/AssemblyInfo.cs
+++ b/Libplanet/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
+[assembly: InternalsVisibleTo("Libplanet.Tools.Tests")]
 [assembly: InternalsVisibleTo("Libplanet.Benchmarks")]


### PR DESCRIPTION
It resolves #1138. `planet mpt diff` became to print the differences as JSON format. You can see the schema of it at #1138's description.