### PR TITLE
Handshake protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,9 +16,20 @@ To be released.
 
 ### Behavioral changes
 
+ -  When received a message from the peer which is not exist in the routing
+    table, `KademliaProtocol` became to validate remote peer's network address
+    by sending a ping message to the peer before adding it to the routing
+    table.  [[#1160], [#1189], [#1193]]
+ -  `KademliaProtocol` became not to send ping message to one peer if the
+    protocol is already waiting for the reply of previous ping message.
+    [[#1160], [#1189], [#1193]]
+
 ### Bug fixes
 
 ### CLI tools
+
+[#1189]: https://github.com/planetarium/libplanet/issues/1189
+[#1193]: https://github.com/planetarium/libplanet/pull/1193
 
 
 Version 0.11.0

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -75,8 +75,7 @@ namespace Libplanet.Benchmarks
 
             for (int i = 0; i < SwarmNumber - 1; i++)
             {
-                _swarms[i].AddPeersAsync(new[] { _swarms[i + 1].AsPeer }, null)
-                    .Wait(WaitTimeout);
+                _swarms[i].RoutingTable.AddPeer(_swarms[i + 1].AsPeer as BoundPeer);
             }
 
             _blockChains[0].Append(_blocks[1]);

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -212,9 +212,9 @@ namespace Libplanet.Tests.Net.Protocols
             await StartTestTransportAsync(transportB);
             await StartTestTransportAsync(transportC);
 
-            await transportA.AddPeersAsync(new[] { transport.AsPeer }, null);
-            await transportB.AddPeersAsync(new[] { transport.AsPeer }, null);
-            await transportC.AddPeersAsync(new[] { transport.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportA.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportB.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportC.AsPeer }, null);
 
             Assert.Single(transportA.Peers);
             Assert.Contains(transportA.AsPeer, transport.Peers);
@@ -240,10 +240,10 @@ namespace Libplanet.Tests.Net.Protocols
             await StartTestTransportAsync(transportB);
             await StartTestTransportAsync(transportC);
 
-            await transportA.AddPeersAsync(new[] { transport.AsPeer }, null);
-            await transportB.AddPeersAsync(new[] { transport.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportA.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportB.AsPeer }, null);
             await Task.Delay(100);
-            await transportC.AddPeersAsync(new[] { transport.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportC.AsPeer }, null);
 
             Assert.Single(transportA.Peers);
             Assert.Contains(transportA.AsPeer, transport.Peers);
@@ -276,8 +276,8 @@ namespace Libplanet.Tests.Net.Protocols
             await StartTestTransportAsync(transportB);
             await StartTestTransportAsync(transportC);
 
-            await transportA.AddPeersAsync(new[] { transport.AsPeer }, null);
-            await transportB.AddPeersAsync(new[] { transport.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportA.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportB.AsPeer }, null);
 
             Assert.Single(transport.Peers);
             Assert.Contains(transportA.AsPeer, transport.Peers);
@@ -286,7 +286,7 @@ namespace Libplanet.Tests.Net.Protocols
             await transportA.StopAsync(TimeSpan.Zero);
             await transportB.StopAsync(TimeSpan.Zero);
 
-            await transportC.AddPeersAsync(new[] { transport.AsPeer }, null);
+            await transport.AddPeersAsync(new[] { transportC.AsPeer }, null);
             await transport.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
             await transport.Protocol.CheckReplacementCacheAsync(default(CancellationToken));
 
@@ -323,6 +323,7 @@ namespace Libplanet.Tests.Net.Protocols
                 }
 
                 Log.Debug("Bootstrap completed.");
+                await Task.Delay(1000);
 
                 var tasks =
                     transports.Select(transport => transport.WaitForTestMessageWithData("foo"));

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
@@ -15,7 +16,9 @@ namespace Libplanet.Tests.Net.Protocols
     public class ProtocolTest
     {
         private const int Timeout = 60 * 1000;
-        private readonly Dictionary<Address, TestTransport> _transports;
+        private readonly Dictionary<string, TestTransport> _transports;
+
+        private int _assignedPort;
 
         public ProtocolTest(ITestOutputHelper output)
         {
@@ -28,7 +31,8 @@ namespace Libplanet.Tests.Net.Protocols
                 .CreateLogger()
                 .ForContext<ProtocolTest>();
 
-            _transports = new Dictionary<Address, TestTransport>();
+            _transports = new Dictionary<string, TestTransport>();
+            _assignedPort = 1234;
         }
 
         [Fact]
@@ -362,7 +366,7 @@ namespace Libplanet.Tests.Net.Protocols
             });
 
             var seed = CreateTestTransport(privateKey0);
-            var t1 = CreateTestTransport(privateKey1, true);
+            var t1 = CreateTestTransport(privateKey1, blockBroadcast: true);
             var t2 = CreateTestTransport(privateKey2);
             await StartTestTransportAsync(seed);
             await StartTestTransportAsync(t1);
@@ -516,6 +520,8 @@ namespace Libplanet.Tests.Net.Protocols
 
         private TestTransport CreateTestTransport(
             PrivateKey privateKey = null,
+            string host = null,
+            int? listenPort = null,
             bool blockBroadcast = false,
             int tableSize = Kademlia.TableSize,
             int bucketSize = Kademlia.BucketSize,
@@ -524,6 +530,8 @@ namespace Libplanet.Tests.Net.Protocols
             return new TestTransport(
                 _transports,
                 privateKey ?? new PrivateKey(),
+                host ?? IPAddress.Loopback.ToString(),
+                listenPort ?? _assignedPort++,
                 blockBroadcast,
                 tableSize,
                 bucketSize,

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -82,39 +82,9 @@ namespace Libplanet.Tests.Net.Protocols
                 await transportA.MessageReceived.WaitAsync();
                 await Task.Delay(100);
 
-                Assert.Single(transportA.ReceivedMessages);
-                Assert.Single(transportB.ReceivedMessages);
-                Assert.Contains(transportA.AsPeer, transportB.Peers);
-            }
-            finally
-            {
-                await transportA.StopAsync(TimeSpan.Zero);
-                await transportB.StopAsync(TimeSpan.Zero);
-            }
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async Task PingTwice()
-        {
-            var transportA = CreateTestTransport();
-            var transportB = CreateTestTransport();
-
-            try
-            {
-                await StartTestTransportAsync(transportA);
-                await StartTestTransportAsync(transportB);
-
-                transportA.SendPing(transportB.AsPeer);
-                await transportA.MessageReceived.WaitAsync();
-                await transportB.MessageReceived.WaitAsync();
-                transportB.SendPing(transportA.AsPeer);
-                await transportA.MessageReceived.WaitAsync();
-                await transportB.MessageReceived.WaitAsync();
-
                 Assert.Equal(2, transportA.ReceivedMessages.Count);
                 Assert.Equal(2, transportB.ReceivedMessages.Count);
                 Assert.Contains(transportA.AsPeer, transportB.Peers);
-                Assert.Contains(transportB.AsPeer, transportA.Peers);
             }
             finally
             {
@@ -181,7 +151,9 @@ namespace Libplanet.Tests.Net.Protocols
                 await StartTestTransportAsync(transportC);
 
                 await transportB.BootstrapAsync(new[] { transportA.AsPeer });
+                await Task.Delay(100);
                 await transportC.BootstrapAsync(new[] { transportA.AsPeer });
+                await Task.Delay(100);
 
                 Assert.Contains(transportB.AsPeer, transportC.Peers);
                 Assert.Contains(transportC.AsPeer, transportB.Peers);

--- a/Libplanet.Tests/Net/SwarmExtensions.cs
+++ b/Libplanet.Tests/Net/SwarmExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Action;
+using Libplanet.Net;
+
+namespace Libplanet.Tests.Net
+{
+    internal static class SwarmExtensions
+    {
+        public static void AddPeer<T>(this Swarm<T> swarm, Peer peer)
+            where T : IAction, new()
+        {
+            if (swarm.RoutingTable is null)
+            {
+                throw new NullReferenceException(nameof(swarm.RoutingTable));
+            }
+
+            swarm.RoutingTable.AddPeer(peer as BoundPeer);
+        }
+
+        public static void AddPeers<T>(this Swarm<T> swarm, IEnumerable<Peer> peers)
+            where T : IAction, new()
+        {
+            foreach (var peer in peers.Where(p => p is BoundPeer _).Select(p => p as BoundPeer))
+            {
+                swarm.AddPeer(peer);
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Tests/Net/SwarmTest.AppProtocolVersion.cs
@@ -32,11 +32,12 @@ namespace Libplanet.Tests.Net
 
                 var peers = new[] { c.AsPeer, d.AsPeer };
 
-                foreach (var peer in peers)
-                {
-                    await a.AddPeersAsync(new[] { peer }, null);
-                    await b.AddPeersAsync(new[] { peer }, null);
-                }
+                await a.BootstrapAsync(new[] { c.AsPeer }, null, null);
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await a.BootstrapAsync(new[] { d.AsPeer }, null, null));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await b.BootstrapAsync(new[] { c.AsPeer }, null, null));
+                await b.BootstrapAsync(new[] { d.AsPeer }, null, null);
 
                 Assert.Equal(new[] { c.AsPeer }, a.Peers.ToArray());
                 Assert.Equal(new[] { d.AsPeer }, b.Peers.ToArray());
@@ -148,13 +149,20 @@ namespace Libplanet.Tests.Net
                 await StartAsync(e);
                 await StartAsync(f);
 
-                var peers = new[] { c.AsPeer, d.AsPeer, e.AsPeer, f.AsPeer };
-
-                foreach (var peer in peers)
-                {
-                    await a.AddPeersAsync(new[] { peer }, null);
-                    await b.AddPeersAsync(new[] { peer }, null);
-                }
+                await a.BootstrapAsync(new[] { c.AsPeer }, null, null);
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await a.BootstrapAsync(new[] { d.AsPeer }, null, null));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await a.BootstrapAsync(new[] { e.AsPeer }, null, null));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await a.BootstrapAsync(new[] { f.AsPeer }, null, null));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await b.BootstrapAsync(new[] { c.AsPeer }, null, null));
+                await b.BootstrapAsync(new[] { d.AsPeer }, null, null);
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await b.BootstrapAsync(new[] { e.AsPeer }, null, null));
+                await Assert.ThrowsAsync<PeerDiscoveryException>(
+                    async () => await b.BootstrapAsync(new[] { f.AsPeer }, null, null));
 
                 Assert.Equal(new[] { c.AsPeer }, a.Peers.ToArray());
                 Assert.Equal(new[] { d.AsPeer }, b.Peers.ToArray());

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Net
 
                 Assert.Equal(swarmA.AsPeer, swarmB.AsPeer);
 
-                await swarmA.AddPeersAsync(new[] { seed.AsPeer }, null);
+                await swarmA.BootstrapAsync(new[] { seed.AsPeer }, null, null);
                 await StopAsync(swarmA);
                 await seed.PeerDiscovery.RefreshTableAsync(
                     TimeSpan.Zero,
@@ -55,7 +55,7 @@ namespace Libplanet.Tests.Net
 
                 Assert.DoesNotContain(swarmA.AsPeer, seed.Peers);
 
-                await swarmB.AddPeersAsync(new[] { seed.AsPeer }, null);
+                await swarmB.BootstrapAsync(new[] { seed.AsPeer }, null, null);
 
                 // This is added for context switching.
                 await Task.Delay(100);
@@ -107,7 +107,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(receiverSwarm);
                 await StartAsync(seedSwarm);
 
-                await seedSwarm.AddPeersAsync(new[] { receiverSwarm.AsPeer }, null);
+                seedSwarm.AddPeers(new[] { receiverSwarm.AsPeer });
                 Block<DumbAction> block = await seedChain.MineBlock(seedSwarm.Address);
                 seedSwarm.BroadcastBlock(block);
                 while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
@@ -178,7 +178,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(a);
                 await StartAsync(b);
 
-                await a.AddPeersAsync(new[] { b.AsPeer }, null);
+                a.AddPeers(new[] { b.AsPeer });
 
                 var minerCanceller = new CancellationTokenSource();
                 Task miningA = CreateMiner(a, chainA, 5000, minerCanceller.Token);
@@ -228,9 +228,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
-                await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
-                await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmB.AddPeers(new[] { swarmC.AsPeer });
+                swarmC.AddPeers(new[] { swarmA.AsPeer });
 
                 swarmA.BroadcastTxs(new[] { tx });
 
@@ -272,7 +272,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmC);
 
-                await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmC.AsPeer });
 
                 for (var i = 0; i < 100; i++)
                 {
@@ -333,7 +333,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
 
                 // Broadcast tx swarmA to swarmB
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
 
                 await swarmB.TxReceived.WaitAsync();
                 Assert.Equal(tx, chainB.GetTransaction(tx.Id));
@@ -341,7 +341,7 @@ namespace Libplanet.Tests.Net
                 await StopAsync(swarmA);
 
                 // Re-Broadcast received tx swarmB to swarmC
-                await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
+                swarmB.AddPeers(new[] { swarmC.AsPeer });
 
                 await swarmC.TxReceived.WaitAsync();
                 Assert.Equal(tx, chainC.GetTransaction(tx.Id));
@@ -457,7 +457,7 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(1, tx2.Nonce);
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
                 swarmA.BroadcastTxs(new[] { tx1, tx2 });
                 await swarmB.TxReceived.WaitAsync();
                 Assert.Equal(
@@ -482,8 +482,8 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(2, tx4.Nonce);
 
                 await StartAsync(swarmC);
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
-                await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmB.AddPeers(new[] { swarmC.AsPeer });
 
                 swarmA.BroadcastTxs(new[] { tx3, tx4 });
                 await swarmC.TxReceived.WaitAsync();
@@ -539,8 +539,12 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                await BootstrapAsync(swarmB, swarmA.AsPeer);
-                await BootstrapAsync(swarmC, swarmA.AsPeer);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeers(new[] { swarmC.AsPeer });
+                swarmB.AddPeers(new[] { swarmC.AsPeer });
+                swarmB.AddPeers(new[] { swarmA.AsPeer });
+                swarmC.AddPeers(new[] { swarmA.AsPeer });
+                swarmC.AddPeers(new[] { swarmB.AsPeer });
 
                 swarmB.BroadcastBlock(chainB[-1]);
 
@@ -717,7 +721,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
                 swarmA.BroadcastBlock(chainA[-1]);
                 await swarmB.BlockAppended.WaitAsync();
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -107,7 +107,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(receiverSwarm);
                 await StartAsync(seedSwarm);
 
-                await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
+                await seedSwarm.AddPeersAsync(new[] { receiverSwarm.AsPeer }, null);
                 Block<DumbAction> block = await seedChain.MineBlock(seedSwarm.Address);
                 seedSwarm.BroadcastBlock(block);
                 while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
@@ -717,7 +717,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await BootstrapAsync(swarmB, swarmA.AsPeer);
+                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
                 swarmA.BroadcastBlock(chainA[-1]);
                 await swarmB.BlockAppended.WaitAsync();
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -107,7 +107,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(receiverSwarm);
                 await StartAsync(seedSwarm);
 
-                seedSwarm.AddPeers(new[] { receiverSwarm.AsPeer });
+                seedSwarm.AddPeer(receiverSwarm.AsPeer);
                 Block<DumbAction> block = await seedChain.MineBlock(seedSwarm.Address);
                 seedSwarm.BroadcastBlock(block);
                 while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
@@ -178,7 +178,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(a);
                 await StartAsync(b);
 
-                a.AddPeers(new[] { b.AsPeer });
+                a.AddPeer(b.AsPeer);
 
                 var minerCanceller = new CancellationTokenSource();
                 Task miningA = CreateMiner(a, chainA, 5000, minerCanceller.Token);
@@ -228,9 +228,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
-                swarmB.AddPeers(new[] { swarmC.AsPeer });
-                swarmC.AddPeers(new[] { swarmA.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmB.AddPeer(swarmC.AsPeer);
+                swarmC.AddPeer(swarmA.AsPeer);
 
                 swarmA.BroadcastTxs(new[] { tx });
 
@@ -272,7 +272,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmC);
 
-                swarmA.AddPeers(new[] { swarmC.AsPeer });
+                swarmA.AddPeer(swarmC.AsPeer);
 
                 for (var i = 0; i < 100; i++)
                 {
@@ -333,7 +333,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
 
                 // Broadcast tx swarmA to swarmB
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 await swarmB.TxReceived.WaitAsync();
                 Assert.Equal(tx, chainB.GetTransaction(tx.Id));
@@ -341,7 +341,7 @@ namespace Libplanet.Tests.Net
                 await StopAsync(swarmA);
 
                 // Re-Broadcast received tx swarmB to swarmC
-                swarmB.AddPeers(new[] { swarmC.AsPeer });
+                swarmB.AddPeer(swarmC.AsPeer);
 
                 await swarmC.TxReceived.WaitAsync();
                 Assert.Equal(tx, chainC.GetTransaction(tx.Id));
@@ -457,7 +457,7 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(1, tx2.Nonce);
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
                 swarmA.BroadcastTxs(new[] { tx1, tx2 });
                 await swarmB.TxReceived.WaitAsync();
                 Assert.Equal(
@@ -482,8 +482,8 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(2, tx4.Nonce);
 
                 await StartAsync(swarmC);
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
-                swarmB.AddPeers(new[] { swarmC.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmB.AddPeer(swarmC.AsPeer);
 
                 swarmA.BroadcastTxs(new[] { tx3, tx4 });
                 await swarmC.TxReceived.WaitAsync();
@@ -539,12 +539,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
-                swarmA.AddPeers(new[] { swarmC.AsPeer });
-                swarmB.AddPeers(new[] { swarmC.AsPeer });
-                swarmB.AddPeers(new[] { swarmA.AsPeer });
-                swarmC.AddPeers(new[] { swarmA.AsPeer });
-                swarmC.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeers(new[] { swarmB.AsPeer, swarmC.AsPeer });
+                swarmB.AddPeers(new[] { swarmC.AsPeer, swarmA.AsPeer });
+                swarmC.AddPeers(new[] { swarmA.AsPeer, swarmB.AsPeer });
 
                 swarmB.BroadcastBlock(chainB[-1]);
 
@@ -721,7 +718,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
                 swarmA.BroadcastBlock(chainA[-1]);
                 await swarmB.BlockAppended.WaitAsync();
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -627,7 +627,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarm);
                 await StartAsync(receiverSwarm);
 
-                await BootstrapAsync(receiverSwarm, minerSwarm.AsPeer);
+                minerSwarm.AddPeer(receiverSwarm.AsPeer);
 
                 var block1 = TestUtils.MineNext(
                         blockChain.Genesis,
@@ -673,7 +673,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await BootstrapAsync(swarmB, swarmA.AsPeer);
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 await chainA.MineBlock(swarmA.Address);
                 swarmA.BroadcastBlock(chainA[-1]);

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -522,7 +522,7 @@ namespace Libplanet.Tests.Net
             Assert.Equal(swarm0.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);
         }
 
-        [Theory]
+        [Theory(Timeout = Timeout)]
         [InlineData(0)]
         [InlineData(50)]
         [InlineData(100)]

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
 
                 await receiverSwarm.PreloadAsync();
 
@@ -85,7 +85,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
 
                 await receiverSwarm.PreloadAsync();
                 var state = receiverChain.GetState(address1);
@@ -143,7 +143,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
 
                 _logger.Verbose("Both chains before synchronization:");
                 _logger.CompareBothChains(
@@ -259,7 +259,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
                 Task waitTask = receiverSwarm.BlockDownloadStarted.WaitAsync();
 
                 Task preloadTask = receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15));
@@ -308,7 +308,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
 
                 var action = new ThrowException { ThrowOnExecution = true };
@@ -393,11 +393,11 @@ namespace Libplanet.Tests.Net
                 nominerSwarm0.FindNextHashesChunkSize = 2;
                 nominerSwarm1.FindNextHashesChunkSize = 2;
 
-                await nominerSwarm0.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                nominerSwarm0.AddPeers(new[] { minerSwarm.AsPeer });
                 await nominerSwarm0.PreloadAsync();
-                await nominerSwarm1.AddPeersAsync(new[] { nominerSwarm0.AsPeer }, null);
+                nominerSwarm1.AddPeers(new[] { nominerSwarm0.AsPeer });
                 await nominerSwarm1.PreloadAsync();
-                await receiverSwarm.AddPeersAsync(new[] { nominerSwarm1.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { nominerSwarm1.AsPeer });
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15), progress);
 
                 // Await 1 second to make sure all progresses is reported.
@@ -500,7 +500,7 @@ namespace Libplanet.Tests.Net
 
             Assert.Equal(swarm0.BlockChain.BlockHashes, swarm1.BlockChain.BlockHashes);
 
-            await receiverSwarm.AddPeersAsync(new[] { swarm0.AsPeer, swarm1.AsPeer }, null);
+            receiverSwarm.AddPeers(new[] { swarm0.AsPeer, swarm1.AsPeer });
             Assert.Equal(
                 new[] { swarm0.AsPeer, swarm1.AsPeer }.ToImmutableHashSet(),
                 receiverSwarm.Peers.ToImmutableHashSet());
@@ -557,7 +557,7 @@ namespace Libplanet.Tests.Net
 
             minerSwarm.FindNextHashesChunkSize = 2;
             await StartAsync(minerSwarm);
-            await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+            receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
 
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(cancelAfter);
@@ -682,7 +682,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
                 await receiverSwarm.PreloadAsync();
             }
             finally
@@ -765,7 +765,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                await receiverSwarm.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
                 await receiverSwarm.PreloadAsync();
             }
             finally
@@ -803,9 +803,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm1);
                 await StartAsync(minerSwarm2);
-                await receiverSwarm.AddPeersAsync(
-                    new[] { minerSwarm1.AsPeer, minerSwarm2.AsPeer },
-                    null);
+                receiverSwarm.AddPeers(new[] { minerSwarm1.AsPeer, minerSwarm2.AsPeer });
                 await receiverSwarm.PreloadAsync();
             }
             finally
@@ -876,8 +874,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(validSeedSwarm);
                 await StartAsync(invalidSeedSwarm);
 
-                await receiverSwarm.AddPeersAsync(
-                    new[] { validSeedSwarm.AsPeer, invalidSeedSwarm.AsPeer }, null);
+                receiverSwarm.AddPeers(new[] { validSeedSwarm.AsPeer, invalidSeedSwarm.AsPeer });
                 await receiverSwarm.PreloadAsync();
 
                 Assert.Equal(receiverChain.Tip, validSeedChain.Tip);

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
 
                 await receiverSwarm.PreloadAsync();
 
@@ -85,7 +85,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
 
                 await receiverSwarm.PreloadAsync();
                 var state = receiverChain.GetState(address1);
@@ -143,7 +143,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
 
                 _logger.Verbose("Both chains before synchronization:");
                 _logger.CompareBothChains(
@@ -259,7 +259,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
                 Task waitTask = receiverSwarm.BlockDownloadStarted.WaitAsync();
 
                 Task preloadTask = receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15));
@@ -308,7 +308,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(minerSwarm);
 
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
 
                 var action = new ThrowException { ThrowOnExecution = true };
@@ -393,11 +393,11 @@ namespace Libplanet.Tests.Net
                 nominerSwarm0.FindNextHashesChunkSize = 2;
                 nominerSwarm1.FindNextHashesChunkSize = 2;
 
-                nominerSwarm0.AddPeers(new[] { minerSwarm.AsPeer });
+                nominerSwarm0.AddPeer(minerSwarm.AsPeer);
                 await nominerSwarm0.PreloadAsync();
-                nominerSwarm1.AddPeers(new[] { nominerSwarm0.AsPeer });
+                nominerSwarm1.AddPeer(nominerSwarm0.AsPeer);
                 await nominerSwarm1.PreloadAsync();
-                receiverSwarm.AddPeers(new[] { nominerSwarm1.AsPeer });
+                receiverSwarm.AddPeer(nominerSwarm1.AsPeer);
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(15), progress);
 
                 // Await 1 second to make sure all progresses is reported.
@@ -557,7 +557,7 @@ namespace Libplanet.Tests.Net
 
             minerSwarm.FindNextHashesChunkSize = 2;
             await StartAsync(minerSwarm);
-            receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+            receiverSwarm.AddPeer(minerSwarm.AsPeer);
 
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(cancelAfter);
@@ -682,7 +682,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
                 await receiverSwarm.PreloadAsync();
             }
             finally
@@ -765,7 +765,7 @@ namespace Libplanet.Tests.Net
             try
             {
                 await StartAsync(minerSwarm);
-                receiverSwarm.AddPeers(new[] { minerSwarm.AsPeer });
+                receiverSwarm.AddPeer(minerSwarm.AsPeer);
                 await receiverSwarm.PreloadAsync();
             }
             finally

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -105,9 +105,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(seed);
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                await seed.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                seed.AddPeers(new[] { swarmA.AsPeer });
                 await StopAsync(swarmA);
-                await seed.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                seed.AddPeers(new[] { swarmB.AsPeer });
 
                 Assert.Contains(swarmB.AsPeer, seed.Peers);
             }
@@ -164,49 +164,6 @@ namespace Libplanet.Tests.Net
 
             await StopAsync(swarm);
             Assert.False(swarm.Running);
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async Task AddPeersWithoutStart()
-        {
-            Swarm<DumbAction> a = CreateSwarm();
-            Swarm<DumbAction> b = CreateSwarm();
-
-            try
-            {
-                await StartAsync(b);
-
-                await a.AddPeersAsync(new Peer[] { b.AsPeer }, null);
-
-                Assert.Contains(b.AsPeer, a.Peers);
-                Assert.Empty(b.Peers);
-            }
-            finally
-            {
-                await StopAsync(b);
-            }
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async Task AddPeersAsync()
-        {
-            Swarm<DumbAction> a = CreateSwarm();
-            Swarm<DumbAction> b = CreateSwarm();
-
-            try
-            {
-                await StartAsync(a);
-                await StartAsync(b);
-
-                await a.AddPeersAsync(new Peer[] { b.AsPeer }, null);
-
-                Assert.Contains(b.AsPeer, a.Peers);
-            }
-            finally
-            {
-                await StopAsync(a);
-                await StopAsync(b);
-            }
         }
 
         [Fact(Timeout = Timeout)]
@@ -322,7 +279,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
 
                 (long, HashDigest<SHA256>)[] inventories1 = (
                     await swarmB.GetBlockHashes(
@@ -389,7 +346,7 @@ namespace Libplanet.Tests.Net
 
                 var peer = swarmA.AsPeer as BoundPeer;
 
-                await swarmB.AddPeersAsync(new[] { peer }, null);
+                swarmB.AddPeers(new[] { peer });
 
                 Tuple<long, HashDigest<SHA256>>[] hashes = await swarmB.GetBlockHashes(
                     peer,
@@ -466,7 +423,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
 
                 List<Transaction<DumbAction>> txs =
                     await swarmA.GetTxsAsync(
@@ -568,15 +525,15 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
 
                 // Public-Private
-                await seed.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                await seed.BootstrapAsync(new[] { swarmA.AsPeer }, null, null);
                 Assert.Contains(swarmA.AsPeer, seed.Peers);
 
                 // Private-Public
-                await swarmB.AddPeersAsync(new[] { seed.AsPeer }, null);
+                await swarmB.BootstrapAsync(new[] { seed.AsPeer }, null, null);
                 Assert.Contains(seed.AsPeer, swarmB.Peers);
 
                 // Private-Private
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                await swarmA.BootstrapAsync(new[] { swarmB.AsPeer }, null, null);
                 Assert.Contains(swarmB.AsPeer, swarmA.Peers);
             }
             finally
@@ -651,7 +608,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(seed);
                 await StartAsync(swarmA);
 
-                await swarmA.AddPeersAsync(new[] { seed.AsPeer }, null);
+                swarmA.AddPeers(new[] { seed.AsPeer });
 
                 cts.Cancel();
                 await proxyTask;
@@ -713,7 +670,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(swarm1);
                 await StartAsync(swarm2);
-                await swarm2.AddPeersAsync(new[] { swarm1.AsPeer }, null);
+                swarm2.AddPeers(new[] { swarm1.AsPeer });
 
                 swarm2.BroadcastBlock(block3);
                 await swarm1.FillBlocksAsyncFailed.WaitAsync();
@@ -1164,7 +1121,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
 
                 Task task = swarmB.FillBlocksAsyncStarted.WaitAsync();
                 swarmA.BroadcastBlock(block);
@@ -1235,8 +1192,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
-                await swarmA.AddPeersAsync(new[] { swarmC.AsPeer }, null);
+                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeers(new[] { swarmC.AsPeer });
 
                 var block = await swarmA.BlockChain.MineBlock(swarmA.Address);
 
@@ -1282,9 +1239,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
                 await StartAsync(swarmD);
 
-                await swarmA.AddPeersAsync(new Peer[] { swarmB.AsPeer }, null);
-                await swarmB.AddPeersAsync(new Peer[] { swarmC.AsPeer }, null);
-                await swarmC.AddPeersAsync(new Peer[] { swarmD.AsPeer }, null);
+                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
+                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
+                swarmC.AddPeers(new Peer[] { swarmD.AsPeer });
 
                 BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmB.AsPeer.Address,
@@ -1324,8 +1281,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                await swarmA.AddPeersAsync(new Peer[] { swarmB.AsPeer }, null);
-                await swarmB.AddPeersAsync(new Peer[] { swarmC.AsPeer }, null);
+                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
+                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
 
                 await StopAsync(swarmB);
 
@@ -1366,9 +1323,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
                 await StartAsync(swarmD);
 
-                await swarmA.AddPeersAsync(new Peer[] { swarmB.AsPeer }, null);
-                await swarmB.AddPeersAsync(new Peer[] { swarmC.AsPeer }, null);
-                await swarmC.AddPeersAsync(new Peer[] { swarmD.AsPeer }, null);
+                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
+                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
+                swarmC.AddPeers(new Peer[] { swarmD.AsPeer });
 
                 BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmC.AsPeer.Address,
@@ -1378,7 +1335,7 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(swarmC.AsPeer.Address, foundPeer.Address);
                 swarmA.RoutingTable.Clear();
                 Assert.Empty(swarmA.Peers);
-                await swarmA.AddPeersAsync(new Peer[] { swarmB.AsPeer }, null);
+                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
 
                 foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmD.AsPeer.Address,

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -105,9 +105,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(seed);
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                seed.AddPeers(new[] { swarmA.AsPeer });
+                seed.AddPeer(swarmA.AsPeer);
                 await StopAsync(swarmA);
-                seed.AddPeers(new[] { swarmB.AsPeer });
+                seed.AddPeer(swarmB.AsPeer);
 
                 Assert.Contains(swarmB.AsPeer, seed.Peers);
             }
@@ -279,7 +279,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 (long, HashDigest<SHA256>)[] inventories1 = (
                     await swarmB.GetBlockHashes(
@@ -346,7 +346,7 @@ namespace Libplanet.Tests.Net
 
                 var peer = swarmA.AsPeer as BoundPeer;
 
-                swarmB.AddPeers(new[] { peer });
+                swarmB.AddPeer(peer);
 
                 Tuple<long, HashDigest<SHA256>>[] hashes = await swarmB.GetBlockHashes(
                     peer,
@@ -423,7 +423,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 List<Transaction<DumbAction>> txs =
                     await swarmA.GetTxsAsync(
@@ -608,7 +608,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(seed);
                 await StartAsync(swarmA);
 
-                swarmA.AddPeers(new[] { seed.AsPeer });
+                swarmA.AddPeer(seed.AsPeer);
 
                 cts.Cancel();
                 await proxyTask;
@@ -670,7 +670,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(swarm1);
                 await StartAsync(swarm2);
-                swarm2.AddPeers(new[] { swarm1.AsPeer });
+                swarm2.AddPeer(swarm1.AsPeer);
 
                 swarm2.BroadcastBlock(block3);
                 await swarm1.FillBlocksAsyncFailed.WaitAsync();
@@ -729,7 +729,7 @@ namespace Libplanet.Tests.Net
             await StartAsync(miner1);
             await StartAsync(miner2);
 
-            await BootstrapAsync(miner2, miner1.AsPeer);
+            miner2.AddPeer(miner1.AsPeer);
 
             miner2.BroadcastBlock(latest);
 
@@ -776,6 +776,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(miner2);
 
                 await BootstrapAsync(miner2, miner1.AsPeer);
+                miner2.AddPeer(miner1.AsPeer);
 
                 miner2.BroadcastBlock(block);
                 await miner1.BlockReceived.WaitAsync();
@@ -1121,7 +1122,7 @@ namespace Libplanet.Tests.Net
             {
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 Task task = swarmB.FillBlocksAsyncStarted.WaitAsync();
                 swarmA.BroadcastBlock(block);
@@ -1192,8 +1193,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                swarmA.AddPeers(new[] { swarmB.AsPeer });
-                swarmA.AddPeers(new[] { swarmC.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmA.AddPeer(swarmC.AsPeer);
 
                 var block = await swarmA.BlockChain.MineBlock(swarmA.Address);
 
@@ -1239,9 +1240,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
                 await StartAsync(swarmD);
 
-                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
-                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
-                swarmC.AddPeers(new Peer[] { swarmD.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmB.AddPeer(swarmC.AsPeer);
+                swarmC.AddPeer(swarmD.AsPeer);
 
                 BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmB.AsPeer.Address,
@@ -1281,8 +1282,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmB);
                 await StartAsync(swarmC);
 
-                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
-                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmB.AddPeer(swarmC.AsPeer);
 
                 await StopAsync(swarmB);
 
@@ -1323,9 +1324,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
                 await StartAsync(swarmD);
 
-                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
-                swarmB.AddPeers(new Peer[] { swarmC.AsPeer });
-                swarmC.AddPeers(new Peer[] { swarmD.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
+                swarmB.AddPeer(swarmC.AsPeer);
+                swarmC.AddPeer(swarmD.AsPeer);
 
                 BoundPeer foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmC.AsPeer.Address,
@@ -1335,7 +1336,7 @@ namespace Libplanet.Tests.Net
                 Assert.Equal(swarmC.AsPeer.Address, foundPeer.Address);
                 swarmA.RoutingTable.Clear();
                 Assert.Empty(swarmA.Peers);
-                swarmA.AddPeers(new Peer[] { swarmB.AsPeer });
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 foundPeer = await swarmA.FindSpecificPeerAsync(
                     swarmD.AsPeer.Address,

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -775,7 +775,6 @@ namespace Libplanet.Tests.Net
                 await StartAsync(miner1);
                 await StartAsync(miner2);
 
-                await BootstrapAsync(miner2, miner1.AsPeer);
                 miner2.AddPeer(miner1.AsPeer);
 
                 miner2.BroadcastBlock(block);
@@ -826,8 +825,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(miner1);
                 await StartAsync(miner2);
 
-                await BootstrapAsync(miner2, miner1.AsPeer);
-                await BootstrapAsync(receiver, miner1.AsPeer);
+                miner1.AddPeers(new[] { receiver.AsPeer, miner2.AsPeer });
+                miner2.AddPeers(new[] { receiver.AsPeer, miner1.AsPeer });
 
                 var t = receiver.PreloadAsync();
                 await miner1.BlockChain.MineBlock(miner1.Address);
@@ -891,9 +890,9 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerA);
                 await StartAsync(minerB);
 
-                await BootstrapAsync(minerA, minerB.AsPeer);
+                minerB.AddPeer(minerA.AsPeer);
 
-                Log.Debug("Reorg occurrs.");
+                Log.Debug("Reorg occurs.");
                 minerB.BroadcastBlock(blockC);
                 await minerA.BlockAppended.WaitAsync();
 
@@ -957,7 +956,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await BootstrapAsync(swarmA, swarmB.AsPeer);
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 swarmA.BroadcastTxs(new[] { validTx, invalidTx });
                 await swarmB.TxReceived.WaitAsync();
@@ -1020,7 +1019,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                await BootstrapAsync(swarmA, swarmB.AsPeer);
+                swarmA.AddPeer(swarmB.AsPeer);
 
                 swarmA.BroadcastTxs(new[] { tx });
                 await swarmB.TxReceived.WaitAsync();
@@ -1067,8 +1066,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(minerSwarmB);
                 await StartAsync(receiverSwarm);
 
-                await BootstrapAsync(minerSwarmA, receiverSwarm.AsPeer);
-                await BootstrapAsync(minerSwarmB, receiverSwarm.AsPeer);
+                minerSwarmA.AddPeer(receiverSwarm.AsPeer);
+                minerSwarmB.AddPeer(receiverSwarm.AsPeer);
 
                 // Broadcast SwarmA's first block.
                 var b1 = await minerChainA.MineBlock(minerSwarmA.Address);
@@ -1379,7 +1378,7 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await BootstrapAsync(sender, receiver.AsPeer);
+                sender.AddPeer(receiver.AsPeer);
 
                 sender.BroadcastBlock(sender.BlockChain.Tip);
 
@@ -1420,7 +1419,7 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await BootstrapAsync(sender, receiver.AsPeer);
+                sender.AddPeer(receiver.AsPeer);
 
                 sender.BroadcastBlock(sender.BlockChain.Tip);
 
@@ -1455,8 +1454,8 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await BootstrapAsync(sender1, receiver.AsPeer);
-                await BootstrapAsync(sender2, receiver.AsPeer);
+                sender1.AddPeer(receiver.AsPeer);
+                sender2.AddPeer(receiver.AsPeer);
 
                 sender1.BlockChain.Append(b1);
                 sender2.BlockChain.Append(b1);
@@ -1520,7 +1519,7 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarm2);
                 await StartAsync(swarm3);
 
-                await BootstrapAsync(swarm1, swarm2.AsPeer);
+                swarm1.AddPeer(swarm2.AsPeer);
 
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
@@ -1537,7 +1536,7 @@ namespace Libplanet.Tests.Net
                     peerChainState.First()
                 );
 
-                await BootstrapAsync(swarm1, swarm3.AsPeer);
+                swarm1.AddPeer(swarm3.AsPeer);
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(
@@ -1570,6 +1569,7 @@ namespace Libplanet.Tests.Net
                 Assert.Null(swarm1.LastMessageTimestamp);
                 DateTimeOffset bootstrappedAt = DateTimeOffset.UtcNow;
                 await BootstrapAsync(swarm2, swarm1.AsPeer);
+                await Task.Delay(1000);
                 await StartAsync(swarm2);
 
                 Assert.NotNull(swarm1.LastMessageTimestamp);
@@ -1730,7 +1730,7 @@ namespace Libplanet.Tests.Net
 
             await StartAsync(sender);
             await StartAsync(receiver);
-            await BootstrapAsync(sender, receiver.AsPeer);
+            sender.AddPeer(receiver.AsPeer);
 
             sender.BroadcastBlock(lowerBlock);
             await receiver.FillBlocksAsyncStarted.WaitAsync();

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -554,6 +554,12 @@ namespace Libplanet.Net.Protocols
                 RemovePeer(peer);
                 throw new TimeoutException($"Timeout occurred during {nameof(ValidateAsync)}");
             }
+            catch (InvalidMessageException)
+            {
+                _logger.Verbose("Peer {Peer} is invalid, removing...", peer);
+                RemovePeer(peer);
+                throw;
+            }
         }
 
         /// <summary>

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Net.Protocols
                 TimeSpan.FromMilliseconds(5000);
             _transport.ProcessMessageHandler += ProcessMessageHandler;
             _cache = new ConcurrentDictionary<Address, BoundPeer>();
-            _cacheSize = int.MaxValue;
+            _cacheSize = _table.TableSize * _table.BucketSize;
         }
 
         /// <inheritdoc />

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -292,17 +292,14 @@ namespace Libplanet.Net.Protocols
                     try
                     {
                         _logger.Verbose("Check peer {Peer}.", replacement);
-
-                        await PingAsync(replacement, _requestTimeout, cancellationToken);
                         _table.RemoveCache(replacement);
-                        Update(replacement);
+                        await PingAsync(replacement, _requestTimeout, cancellationToken);
                     }
                     catch (PingTimeoutException)
                     {
                         _logger.Verbose(
                             "Remove stale peer {Peer} from replacement cache.",
                             replacement);
-                        _table.RemoveCache(replacement);
                     }
                 }
             }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -468,6 +468,15 @@ namespace Libplanet.Net.Protocols
                     throw new InvalidMessageException("Cannot receive pong from self", pong);
                 }
 
+                if (!pong.Remote.Address.Equals(target.Address))
+                {
+                    // Verify sender
+                    throw new InvalidMessageException(
+                        "Remote peer of Pong does not match with the target peer. " +
+                        $"(Expected: {target.Address}, Actual: {pong.Remote.Address})",
+                        pong);
+                }
+
                 _table.AddPeer(target);
             }
             catch (TimeoutException)

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -118,6 +118,22 @@ namespace Libplanet.Net.Protocols
         /// <see cref="Address"/> is equal to the <see cref="Address"/> of self.</exception>
         public void AddPeer(BoundPeer peer) => AddPeer(peer, DateTimeOffset.UtcNow);
 
+        public void UpdatePeer(BoundPeer peer)
+        {
+            if (peer is null)
+            {
+                throw new ArgumentNullException(nameof(peer));
+            }
+
+            if (peer.Address.Equals(_address))
+            {
+                throw new ArgumentException("Cannot add update self.");
+            }
+
+            _logger.Debug("Updating peer {Peer} from routing table.", peer);
+            BucketOf(peer).Update(peer);
+        }
+
         public bool RemovePeer(BoundPeer peer)
         {
             if (peer is null)

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -929,22 +929,27 @@ namespace Libplanet.Net
             await kademliaProtocol.CheckAllPeersAsync(timeout, cancellationToken);
         }
 
-        internal async Task AddPeersAsync(
-            IEnumerable<Peer> peers,
-            TimeSpan? timeout,
-            CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// This methods directly adds given peer to routing table.
+        /// It is not recommended to use this method outside of testing purpose.
+        /// Use
+        /// <seealso cref="BootstrapAsync(IEnumerable{Peer},double,double,int,CancellationToken)"/>
+        /// instead to initiate network connection.
+        /// </summary>
+        /// <param name="peers">List of <see cref="Peer"/>s to add.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <see cref="Swarm{T}.RoutingTable"/> is null.</exception>
+        internal void AddPeers(IEnumerable<Peer> peers)
         {
-            if (Transport is null)
+            if (RoutingTable is null)
             {
-                throw new ArgumentNullException(nameof(Transport));
+                throw new ArgumentNullException(nameof(RoutingTable));
             }
 
-            if (cancellationToken == default(CancellationToken))
+            foreach (var peer in peers.Where(p => p is BoundPeer _).Select(p => p as BoundPeer))
             {
-                cancellationToken = _cancellationToken;
+                RoutingTable.AddPeer(peer);
             }
-
-            await PeerDiscovery.AddPeersAsync(peers, timeout, cancellationToken);
         }
 
         // FIXME: This would be better if it's merged with GetDemandBlockHashes

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -929,29 +929,6 @@ namespace Libplanet.Net
             await kademliaProtocol.CheckAllPeersAsync(timeout, cancellationToken);
         }
 
-        /// <summary>
-        /// This methods directly adds given peer to routing table.
-        /// It is not recommended to use this method outside of testing purpose.
-        /// Use
-        /// <seealso cref="BootstrapAsync(IEnumerable{Peer},double,double,int,CancellationToken)"/>
-        /// instead to initiate network connection.
-        /// </summary>
-        /// <param name="peers">List of <see cref="Peer"/>s to add.</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when <see cref="Swarm{T}.RoutingTable"/> is null.</exception>
-        internal void AddPeers(IEnumerable<Peer> peers)
-        {
-            if (RoutingTable is null)
-            {
-                throw new ArgumentNullException(nameof(RoutingTable));
-            }
-
-            foreach (var peer in peers.Where(p => p is BoundPeer _).Select(p => p as BoundPeer))
-            {
-                RoutingTable.AddPeer(peer);
-            }
-        }
-
         // FIXME: This would be better if it's merged with GetDemandBlockHashes
         internal async IAsyncEnumerable<Tuple<long, HashDigest<SHA256>>> GetBlockHashes(
             BoundPeer peer,


### PR DESCRIPTION
This patch make a peer to authenticate the message received before add it to routing table.

For example, if peer A sends `Ping` to peer B, peer B used to add peer A to its routing table. But after this patch peer B will reply `Pong` as usual, and send `Ping` again to peer A to verify that the information it sent is valid.

Todo: Should ignore non-`Ping` messages (i.e. `GetBlocks`) if the remote peer of the message is not in the routing table to prevent DDoS attack from maleficent peers.