### PR TITLE
docs: correct invalid links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -244,8 +244,8 @@ To be released.
 [#1142]: https://github.com/planetarium/libplanet/issues/1142
 [#1143]: https://github.com/planetarium/libplanet/pull/1143
 [#1147]: https://github.com/planetarium/libplanet/pull/1147
-[#1148]: https://github.com/planetarium/libplanet/pull/1148
-[#1149]: https://github.com/planetarium/libplanet/pull/1149
+[#1148]: https://github.com/planetarium/libplanet/issues/1148
+[#1149]: https://github.com/planetarium/libplanet/issues/1149
 [#1152]: https://github.com/planetarium/libplanet/pull/1152
 [#1155]: https://github.com/planetarium/libplanet/issues/1155
 [#1160]: https://github.com/planetarium/libplanet/issues/1160


### PR DESCRIPTION
This pull request fixes an invalid links in *CHANGES.md*. Originally, @dahlia was noticed it in #1169 as review comment and I updated it. But it was back to before applying while rebasing as mistake.