### PR TITLE
feat(cli): move reusable commands into Libplanet.Extensions.Cocona

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,9 @@ on GitHub consists of several projects:
     use Libplanet.  This project is distributed as a distinct NuGet package:
     *[Libplanet.Analyzers]*.
 
+ -  *Libplanet.Extensions.Cocona*: The project to provide the [Cocona] commands
+    to handle *Libplanet* structures in command line.
+
  -  *Libplanet.Tools*: The CLI tools for Libplanet.  This project is distributed
     as a distinct NuGet package: *[Libplanet.Tools]*. See its own
     [README.md](Libplanet.Tools/README.md).
@@ -119,6 +122,7 @@ on GitHub consists of several projects:
 [Libplanet.RocksDBStore]: https://www.nuget.org/packages/Libplanet.RocksDBStore/
 [Libplanet.Analyzers]: https://www.nuget.org/packages/Libplanet.Analyzers/
 [Libplanet.Tools]: https://www.nuget.org/packages/Libplanet.Tools/
+[Cocona]: https://www.nuget.org/packages/Cocona
 
 
 Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][2]

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -1,7 +1,3 @@
-#pragma warning disable SA1200
-using Cocona;
-#pragma warning restore SA1200
-
 namespace Libplanet.Extensions.Cocona.Commands
 {
     using System;
@@ -11,6 +7,7 @@ namespace Libplanet.Extensions.Cocona.Commands
     using System.Linq;
     using Bencodex;
     using Bencodex.Types;
+    using global::Cocona;
     using Libplanet.Crypto;
     using Libplanet.KeyStore;
     using Libplanet.Net;

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -1,18 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using Bencodex;
-using Bencodex.Types;
+#pragma warning disable SA1200
 using Cocona;
-using Libplanet.Crypto;
-using Libplanet.KeyStore;
-using Libplanet.Net;
+#pragma warning restore SA1200
 
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Commands
 {
-    public class Apv
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using Bencodex;
+    using Bencodex.Types;
+    using Libplanet.Crypto;
+    using Libplanet.KeyStore;
+    using Libplanet.Net;
+
+    public class ApvCommand
     {
         [Command(Description = "Sign a new app protocol version.")]
         public void Sign(
@@ -45,7 +48,7 @@ namespace Libplanet.Tools
             string[]? extra = null
         )
         {
-            PrivateKey key = new Key().UnprotectKey(keyId, passphrase);
+            PrivateKey key = new KeyCommand().UnprotectKey(keyId, passphrase);
             IValue? extraValue = null;
             if (extraFile is string path)
             {
@@ -159,7 +162,7 @@ namespace Libplanet.Tools
 
             if (!noKeyStore)
             {
-                Key keyInstance = new Key();
+                KeyCommand keyInstance = new KeyCommand();
                 IEnumerable<Tuple<Guid, ProtectedPrivateKey>> ppks = keyInstance.KeyStore.List()
                     .Where(pair => pair.Item2.Address.Equals(v.Signer));
                 foreach (Tuple<Guid, ProtectedPrivateKey> pair in ppks)

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -1,13 +1,10 @@
-#pragma warning disable SA1200
-using Cocona;
-#pragma warning restore SA1200
-
 namespace Libplanet.Extensions.Cocona.Commands
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using global::Cocona;
     using Libplanet.Crypto;
     using Libplanet.KeyStore;
 

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -1,16 +1,19 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+#pragma warning disable SA1200
 using Cocona;
-using Libplanet.Crypto;
-using Libplanet.KeyStore;
+#pragma warning restore SA1200
 
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Commands
 {
-    public class Key
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using Libplanet.Crypto;
+    using Libplanet.KeyStore;
+
+    public class KeyCommand
     {
-        public Key()
+        public KeyCommand()
         {
             KeyStore = Web3KeyStore.DefaultKeyStore;
         }

--- a/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
@@ -1,28 +1,32 @@
-#nullable enable
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
-using Bencodex;
-using Bencodex.Types;
+#pragma warning disable SA1200
 using Cocona;
 using Cocona.Help;
-using Libplanet.RocksDBStore;
-using Libplanet.Store.Trie;
-using Libplanet.Tools.Configuration;
+#pragma warning restore SA1200
 
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Commands
 {
+#nullable enable
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Text.Json;
+    using Bencodex;
+    using Bencodex.Types;
+    using Libplanet.Extensions.Cocona.Configuration;
+    using Libplanet.Extensions.Cocona.Services;
+    using Libplanet.RocksDBStore;
+    using Libplanet.Store.Trie;
+
     internal enum SchemeType
     {
         // This is set to 0 for `default` value.
         File = 0,
     }
 
-    public class Mpt
+    public class MptCommand
     {
         private const string KVStoreURIExample =
             "<kv-store-type>://<kv-store-path> (e.g., rocksdb:///path/to/kv-store)";

--- a/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
@@ -1,8 +1,3 @@
-#pragma warning disable SA1200
-using Cocona;
-using Cocona.Help;
-#pragma warning restore SA1200
-
 namespace Libplanet.Extensions.Cocona.Commands
 {
 #nullable enable
@@ -15,6 +10,8 @@ namespace Libplanet.Extensions.Cocona.Commands
     using System.Text.Json;
     using Bencodex;
     using Bencodex.Types;
+    using global::Cocona;
+    using global::Cocona.Help;
     using Libplanet.Extensions.Cocona.Configuration;
     using Libplanet.Extensions.Cocona.Services;
     using Libplanet.RocksDBStore;

--- a/Libplanet.Extensions.Cocona/Configuration/MptConfiguration.cs
+++ b/Libplanet.Extensions.Cocona/Configuration/MptConfiguration.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
-namespace Libplanet.Tools.Configuration
+namespace Libplanet.Extensions.Cocona.Configuration
 {
+    using System.Collections.Generic;
+
     public struct MptConfiguration
     {
         public MptConfiguration(Dictionary<string, string> aliases)

--- a/Libplanet.Extensions.Cocona/Configuration/ToolConfiguration.cs
+++ b/Libplanet.Extensions.Cocona/Configuration/ToolConfiguration.cs
@@ -1,4 +1,4 @@
-namespace Libplanet.Tools.Configuration
+namespace Libplanet.Extensions.Cocona.Configuration
 {
     public struct ToolConfiguration
     {

--- a/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
+++ b/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Text;
-
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona
 {
+    using System;
+    using System.Text;
+
     public class ConsolePasswordReader
     {
         public static string Read(string prompt)

--- a/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
+++ b/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
@@ -1,10 +1,14 @@
-using System.IO;
+#pragma warning disable SA1200
 using Cocona.Lite;
-using Libplanet.Tools.Configuration;
-using Zio.FileSystems;
+#pragma warning restore SA1200
 
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Extensions
 {
+    using System.IO;
+    using Libplanet.Extensions.Cocona.Configuration;
+    using Libplanet.Extensions.Cocona.Services;
+    using Zio.FileSystems;
+
     public static class ICoconaLiteServiceCollectionExtensions
     {
         public static void AddJsonConfigurationService(

--- a/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
+++ b/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
@@ -1,10 +1,7 @@
-#pragma warning disable SA1200
-using Cocona.Lite;
-#pragma warning restore SA1200
-
 namespace Libplanet.Extensions.Cocona.Extensions
 {
     using System.IO;
+    using global::Cocona.Lite;
     using Libplanet.Extensions.Cocona.Configuration;
     using Libplanet.Extensions.Cocona.Services;
     using Zio.FileSystems;

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -1,28 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <PackageId>Libplanet.Tools</PackageId>
-    <Title>planet: Libplanet CLI Tools</Title>
-    <Summary>planet: Libplanet CLI Tools</Summary>
-    <Description>This CLI app is a collection of utilities for application <!--
-    --> programmers who create decentralized games powered by Libplanet <!--
-    --> (https://libplanet.io/).</Description>
-    <OutputType>Exe</OutputType>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
+    <PackageId>Libplanet.Extensions.Cocona</PackageId>
     <Authors>Planetarium</Authors>
     <Company>Planetarium</Company>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryUrl>git://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Libplanet.Tools</RootNamespace>
-    <ToolCommandName>planet</ToolCommandName>
+    <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -31,29 +21,6 @@
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
-    <PackAsTool>true</PackAsTool>
-    <AssemblyName>Libplanet.Tools</AssemblyName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' ">
-    <AssemblyName>planet</AssemblyName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' And&#xD;&#xA;                             '$(RuntimeIdentifier.Substring(0, 6))' == 'linux-' ">
-    <InvariantGlobalization>true</InvariantGlobalization>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\icon.png" Pack="true" PackagePath="icon.png" />
-    <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
-    <AdditionalFiles Include="..\stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.5.*" />
@@ -82,10 +49,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
-    <!-- FIXME: We should specify the version range when the following NuGet
-    issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
   </ItemGroup>
+
 </Project>

--- a/Libplanet.Extensions.Cocona/Services/IConfigurationService.cs
+++ b/Libplanet.Extensions.Cocona/Services/IConfigurationService.cs
@@ -1,4 +1,4 @@
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Services
 {
     public interface IConfigurationService<TConfiguration>
     {

--- a/Libplanet.Extensions.Cocona/Services/JsonConfigurationService.cs
+++ b/Libplanet.Extensions.Cocona/Services/JsonConfigurationService.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using Libplanet.Tools.Configuration;
-using Zio;
-
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona.Services
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+    using Libplanet.Extensions.Cocona.Configuration;
+    using Zio;
+
     public class JsonConfigurationService : IConfigurationService<ToolConfiguration>
     {
         private readonly IFileSystem _fileSystem;

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -1,13 +1,10 @@
-#pragma warning disable SA1200
-using Cocona;
-#pragma warning restore SA1200
-
 namespace Libplanet.Extensions.Cocona
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
+    using global::Cocona;
 
     public static class Utils
     {

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -1,11 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
+#pragma warning disable SA1200
 using Cocona;
+#pragma warning restore SA1200
 
-namespace Libplanet.Tools
+namespace Libplanet.Extensions.Cocona
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+
     public static class Utils
     {
         public static CommandExitedException Error(string message, int exitCode = 128)

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -2,12 +2,14 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Cocona;
+using Libplanet.Extensions.Cocona.Commands;
+using Libplanet.Extensions.Cocona.Extensions;
 
 namespace Libplanet.Tools
 {
-    [HasSubCommands(typeof(Apv), Description = "App protocol version utilities.")]
-    [HasSubCommands(typeof(Key), Description = "Manage private keys.")]
-    [HasSubCommands(typeof(Mpt), Description = "Merkle Patricia Trie utilities.")]
+    [HasSubCommands(typeof(ApvCommand), "apv", Description = "App protocol version utilities.")]
+    [HasSubCommands(typeof(KeyCommand), "key", Description = "Manage private keys.")]
+    [HasSubCommands(typeof(MptCommand), "mpt", Description = "Merkle Patricia Trie utilities.")]
     public class Program
     {
         private static readonly string FileConfigurationServiceRoot = Path.Combine(

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Analyzers", "Libp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Analyzers.Tests", "Libplanet.Analyzers.Tests\Libplanet.Analyzers.Tests.csproj", "{B48782B9-6FA9-4D18-8564-1849FF4CF40E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Cocona", "Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj", "{B3170309-55AB-462C-9100-D77107799E82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x64.Build.0 = Release|Any CPU
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x86.ActiveCfg = Release|Any CPU
 		{B48782B9-6FA9-4D18-8564-1849FF4CF40E}.Release|x86.Build.0 = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|x64.Build.0 = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Debug|x86.Build.0 = Debug|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|x64.ActiveCfg = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|x64.Build.0 = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|x86.ActiveCfg = Release|Any CPU
+		{B3170309-55AB-462C-9100-D77107799E82}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request resolves #1206.

It separates `Libplanet.Tools` into `Libplanet.Tools` and `Libplanet.Extensions.Cocona`.
 - The `Libplanet.Extensions.Cocona` package provides commands to handle `Libplanet` structures in command line (e.g. `IKeyStore`, `AppProtocolVersion`, `TrieStateStore`). 
  - The `Libplanet.Tools` package is a tool, command set made up with commands `Libplanet.Extensions.Cocona`, which acts like before it does (i.e. `planet`).

## About [SA1200](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md)
Also, in code lines, there are the lines like below:

```csharp
#pragma warning disable SA1200
using Cocona;
#pragma warning restore SA1200
```

I used this preprocessor to ignore `SA1200` in temporally because there is conflict between `Libplanet.Extensions.Cocona` and `Cocona`. So I had thought what the best namespace is, like `Libplanet.Extensions.Commands`, `Libplanet.Extensions.CoconaCommands`, etc... You can leave your opinions in free.