### PR TITLE
More reduce undisposed CancellationTokenSource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -200,7 +200,8 @@ To be released.
     belonging to the existing block, which was mined before the protocol v1,
     are guaranteed to still behave as it had done.  [[#1152]]
  -  Fixed a bug where `Block<T>.Evaluate()` hadn't validate its hash.  [[#1168]]
- -  Fixed memory leak due to undisposed `CancellationTokenSource`s.  [[#1182]]
+ -  Fixed memory leak due to undisposed `CancellationTokenSource`s.
+    [[#1182], [#1212]]
  -  Fixed a bug where `TurnClient` hadn't released its relay connections after
     reconnecting.  [[#1185]]
 
@@ -274,6 +275,7 @@ To be released.
 [#1198]: https://github.com/planetarium/libplanet/pull/1198
 [#1204]: https://github.com/planetarium/libplanet/pull/1204
 [#1208]: https://github.com/planetarium/libplanet/pull/1208
+[#1212]: https://github.com/planetarium/libplanet/pull/1212
 
 
 Version 0.10.3

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -752,8 +752,8 @@ namespace Libplanet.Blockchain
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
-            CancellationTokenSource cts = new CancellationTokenSource();
-            CancellationTokenSource cancellationTokenSource =
+            using var cts = new CancellationTokenSource();
+            using CancellationTokenSource cancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
             void WatchTip(object target, (Block<T> OldTip, Block<T> NewTip) tip) => cts.Cancel();
             TipChanged += WatchTip;
@@ -960,8 +960,6 @@ namespace Libplanet.Blockchain
             finally
             {
                 TipChanged -= WatchTip;
-                cancellationTokenSource.Dispose();
-                cts.Dispose();
             }
 
             IReadOnlyList<ActionEvaluation> actionEvaluations = BlockEvaluator.EvaluateActions(

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -67,6 +67,8 @@ namespace Libplanet.Net
         /// </summary>
         private DifferentAppProtocolVersionEncountered _differentAppProtocolVersionEncountered;
 
+        private bool _disposed;
+
         /// <summary>
         /// Creates <see cref="NetMQTransport"/> instance.
         /// </summary>
@@ -338,9 +340,16 @@ namespace Libplanet.Net
         /// <inheritdoc />
         public void Dispose()
         {
-            _runtimeCancellationTokenSource.Cancel();
-            _turnCancellationTokenSource.Cancel();
-            _runtimeProcessor.Wait();
+            if (!_disposed)
+            {
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+                _runtimeProcessor.Wait();
+
+                _runtimeCancellationTokenSource.Dispose();
+                _turnCancellationTokenSource.Dispose();
+                _disposed = true;
+            }
         }
 
         /// <summary>
@@ -827,7 +836,7 @@ namespace Libplanet.Net
 
         private async Task CreatePermission(BoundPeer peer)
         {
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             IPAddress[] ips;
 
             // Cancellation After 2.5 sec
@@ -879,10 +888,6 @@ namespace Libplanet.Net
                 {
                     throw;
                 }
-            }
-            finally
-            {
-                cts.Dispose();
             }
         }
 


### PR DESCRIPTION
This PR adds handling for `CancellationTokenSource.Dispose()` to prevent memory leakages.