### PR TITLE
Make `Swarm<T>.RefreshTableAsync` config constants configurable and change structure of `PeerState`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,11 +36,15 @@ To be released.
  -  Removed `Swarm<T>.GetTrustedStateCompleterAsync()` method.  [[#1117]]
  -  Removed `trustedStateValidators` parameter from `Swarm<T>.PreloadAsync()`
     method.  [[#1117]]
+ -  Removed `Swarm<T>.TraceTable()` method.  [[#1120]]
  -  Added `IActionContext.BlockAction` property. [[#1143]]
  -  Added nullable `TimeSpan`-typed `messageLifespan` parameter into
     `NetMQTransport()` constructor.  [[#1171]]
  -  Added `IStore.ForkTxNonces()` method.  [[#1198]]
-
+ -  Removed `PeerState.Address` Property.  [[#1215]]
+ -  `IProtocol.RebuildConnectionAsync(CancellationToken)` method was
+    replaced by, `IProtocol.RebuildConnectionAsync(int, CancellationToken)`
+    method.  [[#1215]]
 
 ### Backward-incompatible network protocol changes
 
@@ -135,7 +139,6 @@ To be released.
     class.  [[#1119]]
  -  Added `InvalidBlockProtocolVersionException` class.  [[#1142], [#1147]]
  -  Added `InvalidBlockTxHashException` class.  [[#1116]]
- -  Removed `Swarm<T>.TraceTable()` method.  [[#1120]]
  -  Added `Swarm<T>.PeerStates` property.  [[#1120]]
  -  Added `IProtocol` interface.  [[#1120]]
  -  Added `KademliaProtocol` class which implements `IProtocol`.
@@ -147,6 +150,11 @@ To be released.
     to `Transaction<T>.Deserialize()`.  [[#1149]]
  -  Added `SwarmOptions.MessageLifespan` property.  [[#1171]]
  -  Added `InvalidTimestampException` class.  [[#1171]]
+ -  Added `PeerState.Peer` Property.  [[#1215]]
+ -  Added `SwarmOptions.RefreshPeriod` property,
+    which is 10 seconds by default.  [[#1215]]
+ -  Added `SwarmOptions.RefreshLifespan` property,
+    which is 60 seconds by default.  [[#1215]]
 
 ### Behavioral changes
 
@@ -188,6 +196,9 @@ To be released.
     `Swarm<T>.BootstrapAsync()` before `Swarm<T>.StartAsync()`,
     peers in your table may not have you in their table right after
     `Swarm<T>.StartAsync()` (which was almost guaranteed before).  [[#1208]]
+ -  Peers added during `Swarm<T>.BootstrapAsync()` before
+    `Swarm<T>.StartAsync()` are now marked as stale so that
+    `Swarm<T>.RefreshTableAsync()` will update.  [[#1215]]
  -  Following classes became to leave log messages with its class as logging
     context.  [[#1218]]
      -  `TrieStateStore` class
@@ -284,6 +295,7 @@ To be released.
 [#1204]: https://github.com/planetarium/libplanet/pull/1204
 [#1208]: https://github.com/planetarium/libplanet/pull/1208
 [#1212]: https://github.com/planetarium/libplanet/pull/1212
+[#1215]: https://github.com/planetarium/libplanet/pull/1215
 [#1218]: https://github.com/planetarium/libplanet/pull/1218
 
 
@@ -294,7 +306,7 @@ Version 0.10.3
 Released on January 28, 2021.
 
 -  `BlockChain<T>.MineBlock()` became to unstage transactions that have lower
-   nonce than exepcted.  [[#1174]]
+   nonce than expected.  [[#1174]]
 
 [#1174]: https://github.com/planetarium/libplanet/pull/1174
 

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -76,13 +76,13 @@ namespace Libplanet.Tests.Net.Protocols
 
         public DateTimeOffset? LastMessageTimestamp { get; private set; }
 
+        public bool Running => !(_swarmCancellationTokenSource is null);
+
         internal ConcurrentBag<Message> ReceivedMessages { get; }
 
         internal RoutingTable Table { get; }
 
         internal IProtocol Protocol { get; }
-
-        internal bool Running => !(_swarmCancellationTokenSource is null);
 
         public void Dispose()
         {

--- a/Libplanet/Net/ITransport.cs
+++ b/Libplanet/Net/ITransport.cs
@@ -33,6 +33,13 @@ namespace Libplanet.Net
         DateTimeOffset? LastMessageTimestamp { get; }
 
         /// <summary>
+        /// Whether this <see cref="ITransport"/> instance is running.
+        /// </summary>
+        /// <value>Gets the value indicates whether the instance is running.</value>
+        [Pure]
+        bool Running { get; }
+
+        /// <summary>
         /// Initiates transport layer.
         /// </summary>
         /// <param name="cancellationToken">

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -199,10 +199,7 @@ namespace Libplanet.Net
         /// <inheritdoc cref="ITransport.LastMessageTimestamp"/>
         public DateTimeOffset? LastMessageTimestamp { get; private set; }
 
-        /// <summary>
-        /// Whether this <see cref="NetMQTransport"/> instance is running.
-        /// </summary>
-        /// <returns>Boolean value indicates whether the instance is running.</returns>
+        /// <inheritdoc cref="ITransport.Running"/>
         public bool Running
         {
             get => _runningEvent.Task.Status == TaskStatus.RanToCompletion;

--- a/Libplanet/Net/PeerState.cs
+++ b/Libplanet/Net/PeerState.cs
@@ -16,9 +16,9 @@ namespace Libplanet.Net
         }
 
         /// <summary>
-        /// <see cref="Address"/> of peer.
+        /// <see cref="BoundPeer"/> of the state.
         /// </summary>
-        public Address Address => Peer.Address;
+        public BoundPeer Peer { get; set; }
 
         /// <summary>
         /// Last time messages were exchanged.
@@ -34,7 +34,5 @@ namespace Libplanet.Net
         /// Delay of verification in milliseconds.
         /// </summary>
         public TimeSpan? Latency { get; internal set; }
-
-        internal BoundPeer Peer { get; set; }
     }
 }

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -67,10 +67,11 @@ namespace Libplanet.Net.Protocols
         /// <summary>
         /// Reconstructs network connection between peers on network.
         /// </summary>
+        /// <param name="depth">Recursive operation depth to search peers from network.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
-        Task RebuildConnectionAsync(CancellationToken cancellationToken);
+        Task RebuildConnectionAsync(int depth, CancellationToken cancellationToken);
 
         /// <summary>
         /// Checks the <see cref="KBucket"/> in the <see cref="RoutingTable"/> and if

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -247,7 +247,7 @@ namespace Libplanet.Net.Protocols
         }
 
         /// <inheritdoc />
-        public async Task RebuildConnectionAsync(CancellationToken cancellationToken)
+        public async Task RebuildConnectionAsync(int depth, CancellationToken cancellationToken)
         {
             _logger.Verbose("Rebuilding connection...");
             var buffer = new byte[20];
@@ -259,7 +259,7 @@ namespace Libplanet.Net.Protocols
                     new ConcurrentBag<BoundPeer>(),
                     new Address(buffer),
                     null,
-                    -1,
+                    depth,
                     _requestTimeout,
                     cancellationToken));
             }
@@ -269,7 +269,7 @@ namespace Libplanet.Net.Protocols
                     new ConcurrentBag<BoundPeer>(),
                     _address,
                     null,
-                    Kademlia.MaxDepth,
+                    depth,
                     _requestTimeout,
                     cancellationToken));
             try

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -444,7 +444,7 @@ namespace Libplanet.Net
                 depth,
                 cancellationToken);
 
-            if (!((NetMQTransport)Transport).Running)
+            if (!Transport.Running)
             {
                 // Mark added peers as stale if bootstrap is called before transport is running
                 // FIXME: Peers added before bootstrap might be updated.

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -367,8 +367,8 @@ namespace Libplanet.Net
             {
                 tasks.Add(
                     RefreshTableAsync(
-                        TimeSpan.FromSeconds(10),
-                        TimeSpan.FromSeconds(10),
+                        Options.RefreshPeriod,
+                        Options.RefreshLifespan,
                         _cancellationToken));
                 tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
                 tasks.Add(Transport.RunAsync(_cancellationToken));

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1979,7 +1979,9 @@ namespace Libplanet.Net
                 try
                 {
                     await Task.Delay(period, cancellationToken);
-                    await PeerDiscovery.RebuildConnectionAsync(cancellationToken);
+                    await PeerDiscovery.RebuildConnectionAsync(
+                        Kademlia.MaxDepth,
+                        cancellationToken);
                 }
                 catch (OperationCanceledException e)
                 {

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Libplanet.Blocks;
 using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
 using Libplanet.Tx;
 
 namespace Libplanet.Net
@@ -47,5 +48,16 @@ namespace Libplanet.Net
         /// The lifespan of <see cref="Message"/>.
         /// </summary>
         public TimeSpan? MessageLifespan { get; set; } = null;
+
+        /// <summary>
+        /// The frequency of <see cref="IProtocol.RefreshTableAsync" />.
+        /// </summary>
+        public TimeSpan RefreshPeriod { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// The lifespan of <see cref="Peer"/> in routing table.
+        /// <seealso cref="IProtocol.RefreshTableAsync" />
+        /// </summary>
+        public TimeSpan RefreshLifespan { get; set; } = TimeSpan.FromSeconds(60);
     }
 }


### PR DESCRIPTION
This PR contains two changes:
 - Added `SwarmOptions.RefreshPeriod` and `SwarmOptions.RefreshLifespan` which configures refresh of routing table. It have 10 seconds and 60 seconds as its default value.
 - Removed `PeerState.Address`, added `PeerState.Peer` instead which has more information.

This contains one backward incompatible change and one behavioral change, please feel free two tell me if it will be better to separate two patches into two pull requests.