### PR TITLE
Dispose `CancellationTokenRegistration`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,17 +8,27 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
 
+ -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
+    [[#1228]]
+
 ### Behavioral changes
 
 ### Bug fixes
 
+ -  Fixed memory leak due to undisposed `CancellationTokenRegistration`s.
+    [[#1228]]
+
 ### CLI tools
+
+[#1228]: https://github.com/planetarium/libplanet/pull/1218
 
 
 Version 0.11.0
@@ -317,7 +327,6 @@ Released on March 30, 2021.
 [#1212]: https://github.com/planetarium/libplanet/pull/1212
 [#1215]: https://github.com/planetarium/libplanet/pull/1215
 [#1218]: https://github.com/planetarium/libplanet/pull/1218
-
 
 
 Version 0.10.3

--- a/Libplanet.Stun.Tests/Stun/Messages/AllocateErrorResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/AllocateErrorResponseTest.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Stun.Tests.Messages
             using (var stream = new MemoryStream(bytes))
             {
                 var response =
-                    (AllocateErrorResponse)await StunMessage.Parse(stream);
+                    (AllocateErrorResponse)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet.Stun.Tests/Stun/Messages/AllocateSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/AllocateSuccessResponseTest.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Stun.Tests.Messages
             using (var stream = new MemoryStream(bytes))
             {
                 var response =
-                    (AllocateSuccessResponse)await StunMessage.Parse(stream);
+                    (AllocateSuccessResponse)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSucessTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSucessTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Stun.Tests.Messages
             using (var stream = new MemoryStream(bytes))
             {
                 var response =
-                    (BindingSuccessResponse)await StunMessage.Parse(stream);
+                    (BindingSuccessResponse)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new IPEndPoint(IPAddress.Parse("211.176.129.90"), 54141),
                     response.MappedAddress);

--- a/Libplanet.Stun.Tests/Stun/Messages/ConnectionAttemptTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/ConnectionAttemptTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Stun.Tests.Messages
             using (var stream = new MemoryStream(bytes))
             {
                 var response =
-                    (ConnectionAttempt)await StunMessage.Parse(stream);
+                    (ConnectionAttempt)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[] { 0x21, 0x5a, 0x86, 0x01 },
                     response.ConnectionId);

--- a/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/ConnectionBindSuccessResponseTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Stun.Tests.Messages
 
             using (var stream = new MemoryStream(bytes))
             {
-                var response = await StunMessage.Parse(stream);
+                var response = await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/CreatePermissionSuccessResponseTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Stun.Tests.Messages
 
             using (var stream = new MemoryStream(bytes))
             {
-                var response = await StunMessage.Parse(stream);
+                var response = await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshErrorResponseTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Stun.Tests.Messages
 
             using (var stream = new MemoryStream(bytes))
             {
-                var response = (RefreshErrorResponse)await StunMessage.Parse(stream);
+                var response = (RefreshErrorResponse)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet.Stun.Tests/Stun/Messages/RefreshSuccessResponseTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/RefreshSuccessResponseTest.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Stun.Tests.Messages
             using (var stream = new MemoryStream(bytes))
             {
                 var response =
-                    (RefreshSuccessResponse)await StunMessage.Parse(stream);
+                    (RefreshSuccessResponse)await StunMessage.ParseAsync(stream);
                 Assert.Equal(
                     new byte[]
                     {

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -348,7 +348,7 @@ namespace Libplanet.Net
                         timeoutToken,
                         ct
                     );
-                    timeoutToken.Register(() =>
+                    using CancellationTokenRegistration ctr = timeoutToken.Register(() =>
                         _logger.Debug("Timed out to wait a response from {Peer}.", peer)
                     );
                     CancellationToken linkedToken = linkedTokenSource.Token;
@@ -486,7 +486,7 @@ namespace Libplanet.Net
                     if (tasks.Any())
                     {
                         var tcs = new TaskCompletionSource<object>();
-                        cancellationToken.Register(
+                        using CancellationTokenRegistration ctr = cancellationToken.Register(
                             () => tcs.TrySetCanceled(),
                             useSynchronizationContext: false
                         );

--- a/Libplanet/Net/NetMQTransport.cs
+++ b/Libplanet/Net/NetMQTransport.cs
@@ -411,7 +411,8 @@ namespace Libplanet.Net
                 Interlocked.Increment(ref _requestCount);
 
                 // FIXME should we also cancel tcs sender side too?
-                cancellationToken.Register(() => tcs.TrySetCanceled());
+                using CancellationTokenRegistration ctr =
+                    cancellationToken.Register(() => tcs.TrySetCanceled());
                 await _requests.AddAsync(
                     new MessageRequest(reqId, message, peer, now, timeout, expectedResponses, tcs),
                     cancellationToken

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -525,7 +525,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
-            cancellationToken.Register(() =>
+            using CancellationTokenRegistration ctr = cancellationToken.Register(() =>
                 _logger.Information("Preloading is requested to be cancelled.")
             );
 


### PR DESCRIPTION
Undiposed `CancellationTokenRegistration` were causing memory leak. This patch fixes the bug and made `TurnClient.ReceiveMessageAsync` cancellable.

Additionally this provides `CancellationToken` support for `StunMessage.ParseAsync()` (which was `SturnMessage.Parse()`).