### PR TITLE
Introduce `Swarm<T>.AddPeersAsync()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ To be released.
 
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]
+ -  Added `Swarm<T>.AddPeersAsync()` method.  [[#1234]]
 
 ### Behavioral changes
 
@@ -34,6 +35,7 @@ To be released.
 
 [#1219]: https://github.com/planetarium/libplanet/pull/1219
 [#1228]: https://github.com/planetarium/libplanet/pull/1218
+[#1234]: https://github.com/planetarium/libplanet/pull/1234
 
 
 Version 0.11.0

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -929,7 +929,16 @@ namespace Libplanet.Net
             await kademliaProtocol.CheckAllPeersAsync(timeout, cancellationToken);
         }
 
-        internal async Task AddPeersAsync(
+        /// <summary>
+        /// Adds <paramref name="peers"/> to routing table by sending a simple message.
+        /// </summary>
+        /// <param name="peers">A list of peers to add.</param>
+        /// <param name="timeout">Timeout for this operation. If it is set to <c>null</c>,
+        /// wait infinitely until the requested operation is finished.</param>
+        /// <param name="cancellationToken">A cancellation token used to propagate notification
+        /// that this operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
+        public async Task AddPeersAsync(
             IEnumerable<Peer> peers,
             TimeSpan? timeout,
             CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
This patch refactors `Swarm<T>.AddPeersAsync()` to public which was internal before.