### PR TITLE
Introduce BoundPeerExtensions and .QueryAppProtocolVersion()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
+ -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
+    `Libplanet.Net.Transports`.  [[#1235]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ To be released.
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]
  -  Added `Swarm<T>.AddPeersAsync()` method.  [[#1234]]
+ -  Added `NetMQTransport.QueryAppProtocolVersion()` static method.  [[#1235]]
 
 ### Behavioral changes
 
@@ -38,6 +39,7 @@ To be released.
 [#1219]: https://github.com/planetarium/libplanet/pull/1219
 [#1228]: https://github.com/planetarium/libplanet/pull/1218
 [#1234]: https://github.com/planetarium/libplanet/pull/1234
+[#1235]: https://github.com/planetarium/libplanet/pull/1235
 
 
 Version 0.11.0

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -10,6 +10,7 @@ using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Nito.AsyncEx;
 using Serilog;
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -11,6 +11,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Messages;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -16,6 +16,7 @@ using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 using Libplanet.Stun;
 using Libplanet.Tests.Blockchain;

--- a/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Transports;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Transports
+{
+    public class BoundPeerExtensionsTest
+    {
+        [Fact]
+        public async Task QueryAppProtocolVersion()
+        {
+            var fx = new DefaultStoreFixture();
+            var policy = new BlockPolicy<DumbAction>();
+            var blockchain = TestUtils.MakeBlockChain(policy, fx.Store, fx.StateStore);
+            var apvKey = new PrivateKey();
+            var swarmKey = new PrivateKey();
+            AppProtocolVersion apv = AppProtocolVersion.Sign(apvKey, 1);
+
+            string host = IPAddress.Loopback.ToString();
+            int port = FreeTcpPort();
+
+            using (var swarm = new Swarm<DumbAction>(
+                blockchain,
+                swarmKey,
+                apv,
+                host: host,
+                listenPort: port))
+            {
+                var peer = new BoundPeer(swarmKey.PublicKey, new DnsEndPoint(host, port));
+                // Before swarm starting...
+                Assert.Throws<TimeoutException>(() =>
+                {
+                    peer.QueryAppProtocolVersion(timeout: TimeSpan.FromSeconds(1));
+                });
+                _ = swarm.StartAsync();
+                try
+                {
+                    AppProtocolVersion receivedAPV = peer.QueryAppProtocolVersion();
+                    Assert.Equal(apv, receivedAPV);
+                }
+                finally
+                {
+                    await swarm.StopAsync();
+                }
+            }
+        }
+
+        private static int FreeTcpPort()
+        {
+            var l = new TcpListener(IPAddress.Loopback, 0);
+            l.Start();
+            int port = ((IPEndPoint)l.LocalEndpoint).Port;
+            l.Stop();
+            return port;
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Net.Transports;
 using NetMQ;
 
 namespace Libplanet.Net.Messages

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Net.Messages;
+using Libplanet.Net.Transports;
 using Serilog;
 using Random = System.Random;
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -17,6 +17,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 using Libplanet.Tx;
 using Nito.AsyncEx;

--- a/Libplanet/Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet/Net/Transports/BoundPeerExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using NetMQ;
+using NetMQ.Sockets;
+
+namespace Libplanet.Net.Transports
+{
+    /// <summary>
+    /// This extension class activates transport-oriented methods on <see cref="BoundPeer"/>.
+    /// </summary>
+    /// <seealso cref="BoundPeer"/>
+    public static class BoundPeerExtensions
+    {
+        /// <summary>
+        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to query
+        /// <see cref="AppProtocolVersion"/>.</param>
+        /// <param name="timeout">Timeout value for request.</param>
+        /// <returns><see cref="AppProtocolVersion"/> of given peer. </returns>
+        public static AppProtocolVersion QueryAppProtocolVersion(
+            this BoundPeer peer,
+            TimeSpan? timeout = null
+        )
+        {
+            using var dealerSocket = new DealerSocket(ToNetMQAddress(peer));
+            var key = new PrivateKey();
+            var ping = new Ping();
+            NetMQMessage request = ping.ToNetMQMessage(
+                key,
+                new Peer(key.PublicKey),
+                DateTimeOffset.UtcNow,
+                default
+            );
+
+            TimeSpan timeoutNotNull = timeout ?? TimeSpan.FromSeconds(5);
+            if (dealerSocket.TrySendMultipartMessage(timeoutNotNull, request))
+            {
+                var response = new NetMQMessage();
+                if (dealerSocket.TryReceiveMultipartMessage(timeoutNotNull, ref response))
+                {
+                    return AppProtocolVersion.FromToken(response.First.ConvertToString());
+                }
+            }
+
+            throw new TimeoutException(
+                $"Peer[{peer}] didn't respond within the specified time[{timeout}]."
+            );
+        }
+
+        internal static string ToNetMQAddress(this BoundPeer peer)
+        {
+            return $"tcp://{peer.EndPoint.Host}:{peer.EndPoint.Port}";
+        }
+    }
+}

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Net.Messages;
 
-namespace Libplanet.Net
+namespace Libplanet.Net.Transports
 {
     /// <summary>
     /// An interface to handle peer-to-peer networking, including <see cref="Message"/> exchanging
@@ -46,7 +46,7 @@ namespace Libplanet.Net
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
-        Task StartAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task StartAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Starts running transport layer. To <see cref="RunAsync"/>, you should call
@@ -56,7 +56,7 @@ namespace Libplanet.Net
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
-        Task RunAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task RunAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stops running transport layer.
@@ -69,7 +69,7 @@ namespace Libplanet.Net
         /// <returns>An awaitable task without value.</returns>
         Task StopAsync(
             TimeSpan waitFor,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sends the <paramref name="message"/> to given <paramref name="peer"/>.
@@ -118,7 +118,7 @@ namespace Libplanet.Net
             Message message,
             TimeSpan? timeout,
             int expectedResponses,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Broadcasts the <paramref name="message"/> to peers selected from the routing table.

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -16,7 +16,7 @@ using NetMQ.Sockets;
 using Nito.AsyncEx;
 using Serilog;
 
-namespace Libplanet.Net
+namespace Libplanet.Net.Transports
 {
     /// <summary>
     /// Implementation of <see cref="ITransport"/> interface using NetMQ.
@@ -296,7 +296,7 @@ namespace Libplanet.Net
         /// <inheritdoc />
         public async Task StopAsync(
             TimeSpan waitFor,
-            CancellationToken cancellationToken = default(CancellationToken)
+            CancellationToken cancellationToken = default
         )
         {
             if (Running)
@@ -389,7 +389,7 @@ namespace Libplanet.Net
             Message message,
             TimeSpan? timeout,
             int expectedResponses,
-            CancellationToken cancellationToken = default(CancellationToken)
+            CancellationToken cancellationToken = default
         )
         {
             if (!(_turnClient is null) && _turnClient.BehindNAT)
@@ -692,7 +692,7 @@ namespace Libplanet.Net
         }
 
         private async Task ProcessRuntime(
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             while (!cancellationToken.IsCancellationRequested)
             {

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -610,7 +610,7 @@ namespace Libplanet.Net.Transports
 
                 foreach (BoundPeer peer in peers)
                 {
-                    string endpoint = ToNetMQAddress(peer);
+                    string endpoint = peer.ToNetMQAddress();
                     if (!_dealers.TryGetValue(peer.Address, out DealerSocket dealer) ||
                         dealer.IsDisposed)
                     {
@@ -747,7 +747,7 @@ namespace Libplanet.Net.Transports
                 DateTimeOffset.UtcNow - req.RequestedTime);
             DateTimeOffset startedTime = DateTimeOffset.UtcNow;
 
-            using var dealer = new DealerSocket(ToNetMQAddress(req.Peer));
+            using var dealer = new DealerSocket(req.Peer.ToNetMQAddress());
 
             _logger.Debug(
                 "Trying to send {Message} to {Peer}...",
@@ -817,19 +817,6 @@ namespace Libplanet.Net.Transports
                 req.Message,
                 req.Id,
                 DateTimeOffset.UtcNow - startedTime);
-        }
-
-        private void CheckStarted()
-        {
-            if (!Running)
-            {
-                throw new NoSwarmContextException("Swarm hasn't started yet.");
-            }
-        }
-
-        private string ToNetMQAddress(BoundPeer peer)
-        {
-            return $"tcp://{peer.EndPoint.Host}:{peer.EndPoint.Port}";
         }
 
         private async Task CreatePermission(BoundPeer peer)


### PR DESCRIPTION
~This PR introduces `NetMQTransport.QueryAppProtocolVersion()` to get current APV of specific node via `Ping` message.~

This PR contains two changes

1. it moves `ITransport` and `NetMQTransport` to a new `Libplanet.Net.Transports` namespace.
2. it introduces `Libplanet.Net.Transports.BoundPeerExtensions` and `.QueryAppProtocolVersion()`  to get current APV of specific node via `Ping` message.