### PR TITLE
Fix memory leakage in relayed clients

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -218,6 +218,7 @@ To be released.
     updated cached peers multiple times.  [[#1219]]
  -  Fixed memory leak due to undisposed `CancellationTokenRegistration`s.
     [[#1228]]
+ -  Fixed memory leak due to undisposed TCP relay clients.  [[#1236]]
  -  Fixed a bug where `DefaultStore.Dispose()` and `TrieStateStore.Dispose()`
     had not been idempotent.  [[#1272]]
  -  (Libplanet.RocksDBStore) Fixed a bug where `RocksDBStore.Dispose()`,
@@ -246,6 +247,7 @@ To be released.
 [#1230]: https://github.com/planetarium/libplanet/issues/1230
 [#1234]: https://github.com/planetarium/libplanet/pull/1234
 [#1235]: https://github.com/planetarium/libplanet/pull/1235
+[#1236]: https://github.com/planetarium/libplanet/pull/1236
 [#1240]: https://github.com/planetarium/libplanet/pull/1240
 [#1242]: https://github.com/planetarium/libplanet/pull/1242
 [#1265]: https://github.com/planetarium/libplanet/pull/1265

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -74,9 +74,7 @@ namespace Libplanet.Stun
         public async Task InitializeTurnAsync(CancellationToken cancellationToken)
         {
             _control = new TcpClient();
-#pragma warning disable PC001 // API not supported on all platforms
-            _control.Connect(_host, _port);
-#pragma warning restore PC001 // API not supported on all platforms
+            await _control.ConnectAsync(_host, _port);
             _processMessage = ProcessMessage(_turnTaskCts.Token);
 
             BehindNAT = await IsBehindNAT(cancellationToken);
@@ -274,9 +272,7 @@ namespace Libplanet.Stun
             try
             {
                 using var client = new TcpClient();
-#pragma warning disable PC001 // API not supported on all platforms
-                client.Connect(_host, _port);
-#pragma warning restore PC001 // API not supported on all platforms
+                await client.ConnectAsync(_host, _port);
                 NetworkStream stream = client.GetStream();
 
                 var request = new BindingRequest();
@@ -306,9 +302,7 @@ namespace Libplanet.Stun
             while (!cancellationToken.IsCancellationRequested)
             {
                 var tcpClient = new TcpClient();
-#pragma warning disable PC001  // API not supported on all platforms
-                tcpClient.Connect(new IPEndPoint(IPAddress.Loopback, listenPort));
-#pragma warning restore PC001
+                await tcpClient.ConnectAsync(IPAddress.Loopback, listenPort);
                 NetworkStream localStream = tcpClient.GetStream();
                 NetworkStream turnStream = await AcceptRelayedStreamAsync(cancellationToken);
 #pragma warning disable CS4014

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -124,7 +124,7 @@ namespace Libplanet.Stun
 
         public async Task<IPEndPoint> AllocateRequestAsync(
             TimeSpan lifetime,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             StunMessage response;
@@ -157,7 +157,7 @@ namespace Libplanet.Stun
 
         public async Task CreatePermissionAsync(
             IPEndPoint peerAddress,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new CreatePermissionRequest(peerAddress);
@@ -174,8 +174,8 @@ namespace Libplanet.Stun
             }
         }
 
-        public async Task<NetworkStream> AcceptRelayedStreamAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<(TcpClient, NetworkStream)> AcceptRelayedStreamAsync(
+            CancellationToken cancellationToken = default)
         {
             while (true)
             {
@@ -212,7 +212,7 @@ namespace Libplanet.Stun
         }
 
         public async Task<IPEndPoint> GetMappedAddressAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new BindingRequest();
@@ -234,7 +234,7 @@ namespace Libplanet.Stun
 
         public async Task<TimeSpan> RefreshAllocationAsync(
             TimeSpan lifetime,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new RefreshRequest((int)lifetime.TotalSeconds);
@@ -259,15 +259,13 @@ namespace Libplanet.Stun
             throw new TurnClientException("RefreshRequest failed.", response);
         }
 
-        public async Task<bool> IsBehindNAT(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<bool> IsBehindNAT(CancellationToken cancellationToken = default)
         {
             IPEndPoint mapped = await GetMappedAddressAsync(cancellationToken);
             return !_control.Client.LocalEndPoint.Equals(mapped);
         }
 
-        public async Task<bool> IsConnectable(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<bool> IsConnectable(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -295,9 +293,7 @@ namespace Libplanet.Stun
             _logger.Debug($"{nameof(TurnClient)} is disposed.");
         }
 
-        public async Task BindProxies(
-            int listenPort,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task BindProxies(int listenPort, CancellationToken cancellationToken = default)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -327,7 +323,7 @@ namespace Libplanet.Stun
         private List<Task> BindMultipleProxies(
             int listenPort,
             int count,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return Enumerable.Range(1, count)
                 .Select(x => BindProxies(listenPort, cancellationToken))


### PR DESCRIPTION
This patch fixes memory leakage caused by not freeing disposed TCP clients in `TurnClient`.