### PR TITLE
Enrich `planet apv` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ To be released.
     [[#1228]]
  -  Added `Swarm<T>.AddPeersAsync()` method.  [[#1234]]
  -  Added `NetMQTransport.QueryAppProtocolVersion()` static method.  [[#1235]]
+ -  Added `BoundPeer.Parse()` static method.  [[#1240]]
 
 ### Behavioral changes
 
@@ -36,8 +37,10 @@ To be released.
 
 ### CLI tools
 
- -  Added the flag `--json` to `planet apv analyze` comamnd to print result as
-    JSON format.  [[#1240]]
+ -  Added the option `--json` to `planet apv analyze` command to print result
+    as JSON format.  [[#1240]]
+ -  Added `planet apv query` subcommand to query app protocol version of
+    specific peer. [[#1240]]
 
 [#1219]: https://github.com/planetarium/libplanet/pull/1219
 [#1228]: https://github.com/planetarium/libplanet/pull/1218

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,10 +36,14 @@ To be released.
 
 ### CLI tools
 
+ -  Added the flag `--json` to `planet apv analyze` comamnd to print result as
+    JSON format.  [[#1240]]
+
 [#1219]: https://github.com/planetarium/libplanet/pull/1219
 [#1228]: https://github.com/planetarium/libplanet/pull/1218
 [#1234]: https://github.com/planetarium/libplanet/pull/1234
 [#1235]: https://github.com/planetarium/libplanet/pull/1235
+[#1240]: https://github.com/planetarium/libplanet/pull/1240
 
 
 Version 0.11.0

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -5,6 +5,7 @@ namespace Libplanet.Extensions.Cocona.Commands
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Text.Json;
     using Bencodex;
     using Bencodex.Types;
     using global::Cocona;
@@ -192,7 +193,9 @@ namespace Libplanet.Extensions.Cocona.Commands
                 Description = "An app protocol version token to analyze.  " +
                     "Read from the standard input if omitted."
             )]
-            string? token = null
+            string? token = null,
+            [Option(Description = "Print information of given token as JSON.")]
+            bool json = false
         )
         {
             AppProtocolVersion v = ParseAppProtocolVersionToken(token);
@@ -263,7 +266,14 @@ namespace Libplanet.Extensions.Cocona.Commands
                 TreeIntoTable(v.Extra, data, "extra");
             }
 
-            Utils.PrintTable(("Field", "Value"), data);
+            if (json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(data.ToDictionary(e => e.Item1, e => e.Item2)));
+            }
+            else
+            {
+                Utils.PrintTable(("Field", "Value"), data);
+            }
         }
 
         private AppProtocolVersion ParseAppProtocolVersionToken(string? token)

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -12,6 +12,7 @@ namespace Libplanet.Extensions.Cocona.Commands
     using Libplanet.Crypto;
     using Libplanet.KeyStore;
     using Libplanet.Net;
+    using Libplanet.Net.Transports;
 
     public class ApvCommand
     {
@@ -274,6 +275,39 @@ namespace Libplanet.Extensions.Cocona.Commands
             {
                 Utils.PrintTable(("Field", "Value"), data);
             }
+        }
+
+        [Command(Description = "Query app protocol version (a.k.a. APV) of target node.")]
+        public void Query(
+            [Argument(
+                Name = "TARGET",
+#pragma warning disable MEN002 // Line is too long
+                Description = "Comma seperated peer information({pubkey},{host},{port}) of target node. (e.g. 027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c.planetarium.dev,31236)")]
+#pragma warning restore MEN002 // Line is too long
+            string peerInfo)
+        {
+            BoundPeer peer;
+            AppProtocolVersion apv;
+
+            try
+            {
+                peer = BoundPeer.ParsePeer(peerInfo);
+            }
+            catch
+            {
+                throw Utils.Error($"Failed to parse peer. Please check the input. [{peerInfo}]");
+            }
+
+            try
+            {
+                apv = peer.QueryAppProtocolVersion();
+            }
+            catch
+            {
+                throw Utils.Error($"Failed to query app protocol version.");
+            }
+
+            Console.WriteLine(apv.Token);
         }
 
         private AppProtocolVersion ParseAppProtocolVersionToken(string? token)

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -39,6 +39,7 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/Libplanet.Tests/Net/BoundPeerTest.cs
+++ b/Libplanet.Tests/Net/BoundPeerTest.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Xunit;
+
+namespace Libplanet.Tests.Net
+{
+    public class BoundPeerTest
+    {
+        [Fact]
+        public void ParsePeer()
+        {
+#pragma warning disable MEN002 // Line is too long
+            var peerInfo = "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,3333";
+            var expected = new BoundPeer(
+                new PublicKey(ByteUtil.ParseHex("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233")),
+                new DnsEndPoint("192.168.0.1", 3333)
+            );
+#pragma warning restore MEN002 // Line is too long
+            Assert.Equal(expected, BoundPeer.ParsePeer(peerInfo));
+        }
+
+        [Fact]
+        public void ParsePeerException()
+        {
+            Assert.Throws<ArgumentNullException>(() => { BoundPeer.ParsePeer(null); });
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer(string.Empty));
+#pragma warning disable MEN002 // Line is too long
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,999999"));
+#pragma warning restore MEN002 // Line is too long
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two features as below. it addresses #1237 and #1238 

- Added `--json` flag to `planet apv analyze` to format the result as JSON.
- Added `planet apv query` subcommand.

And, it also adds `BoundPeer.Parse(string)` for convenience.