### PR TITLE
Utilize multiple TURN/ICE servers to balance loads

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -58,7 +58,7 @@ steps:
           ${{ parameters.testArguments }} \
           -xml "$(Agent.TempDirectory)/xunit.xml"
     env:
-      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      TURN_SERVER_URLS: ${{ parameters.turnServerUrls }}
       LANG: ${{ parameters.locale }}
       LANGUAGE: ${{ parameters.locale }}
       LC_ALL: ${{ parameters.locale }}
@@ -79,7 +79,7 @@ steps:
         -p:SkipSonar=true
         ${{ parameters.testArguments }}
     env:
-      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      TURN_SERVER_URLS: ${{ parameters.turnServerUrls }}
       LANG: ${{ parameters.locale }}
       LANGUAGE: ${{ parameters.locale }}
       LC_ALL: ${{ parameters.locale }}

--- a/.azure-pipelines/mono.yml
+++ b/.azure-pipelines/mono.yml
@@ -63,7 +63,7 @@ steps:
           "${assemblies[@]}" \
           ${{ parameters.testArguments }}
     env:
-      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      TURN_SERVER_URLS: ${{ parameters.turnServerUrls }}
       MONO_THREADS_SUSPEND: preemptive
     timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
 
@@ -88,7 +88,7 @@ steps:
           ${{ parameters.testArguments }} \
           -xml "$(Agent.TempDirectory)/xunit.xml"
     env:
-      TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+      TURN_SERVER_URLS: ${{ parameters.turnServerUrls }}
       MONO_THREADS_SUSPEND: preemptive
     timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
   - task: PublishTestResults@2

--- a/.azure-pipelines/windows-net471.yml
+++ b/.azure-pipelines/windows-net471.yml
@@ -77,7 +77,7 @@ steps:
           ${{ parameters.testArguments }} \
           -xml "$(Agent.TempDirectory)/xunit.xml"
   env:
-    TURN_SERVER_URL: ${{ parameters.turnServerUrl }}
+    TURN_SERVER_URLS: ${{ parameters.turnServerUrls }}
     MONO_THREADS_SUSPEND: preemptive
   timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
 

--- a/.idea/.idea.Libplanet/.idea/indexLayout.xml
+++ b/.idea/.idea.Libplanet/.idea/indexLayout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ContentModelUserStore">
+  <component name="UserContentModel">
     <attachedFolders />
     <explicitIncludes />
     <explicitExcludes />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,11 +169,15 @@ mono xunit.runner.console.*/tools/net47/xunit.console.exe \
 [Xunit]: https://xunit.github.io/
 
 
-### `TURN_SERVER_URL`
+### `TURN_SERVER_URLS`
 
-Some tests depend on a TURN server.  If `TURN_SERVER_URL` environment variable
-is set (the value looks like `turn://user:password@host:3478/`)
-these tests also run.  Otherwise, these tests are skipped.
+Some tests depend on a TURN server.  If `TURN_SERVER_URLS` environment variable
+is present, these tests also run.  Otherwise, these tests are skipped.
+
+As the name implies, `TURN_SERVER_URLS` can have more than one TURN server URL.
+URLs are separated by whitespaces like `turn://user:password@host:3478/
+turn://user:password@host2:3478/`.  If multiple TURN servers are provided,
+each test case pick a random one to use so that loads are balanced.
 
 FYI there are several TURN implementations like [Coturn] and [gortc/turn],
 or cloud offers like [Xirsys].

--- a/Libplanet.Tests/Net/IceServerTest.cs
+++ b/Libplanet.Tests/Net/IceServerTest.cs
@@ -13,9 +13,7 @@ namespace Libplanet.Tests.Net
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task CreateTurnClient()
         {
-            var turnUri = new Uri(
-                Environment.GetEnvironmentVariable(
-                    FactOnlyTurnAvailableAttribute.TurnUrlVarName));
+            var turnUri = FactOnlyTurnAvailableAttribute.GetTurnUri();
             var userInfo = turnUri.UserInfo.Split(':');
             await Assert.ThrowsAsync<ArgumentException>(
                 async () =>

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -559,7 +559,7 @@ namespace Libplanet.Tests.Net
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task ExchangeWithIceServer()
         {
-            var iceServers = FactOnlyTurnAvailableAttribute.IceServers;
+            var iceServers = FactOnlyTurnAvailableAttribute.GetIceServers();
             var seed = CreateSwarm(host: "localhost");
             var swarmA = CreateSwarm(iceServers: iceServers);
             var swarmB = CreateSwarm(iceServers: iceServers);
@@ -610,9 +610,10 @@ namespace Libplanet.Tests.Net
                 port = ((IPEndPoint)socket.LocalEndPoint).Port;
             }
 
-            Uri turnUrl = FactOnlyTurnAvailableAttribute.TurnUri;
-            string username = FactOnlyTurnAvailableAttribute.Username;
-            string password = FactOnlyTurnAvailableAttribute.Password;
+            Uri turnUrl = FactOnlyTurnAvailableAttribute.GetTurnUri();
+            string[] userInfo = turnUrl.UserInfo.Split(':');
+            string username = userInfo[0];
+            string password = userInfo[1];
             var proxyUri = new Uri($"turn://{username}:{password}@localhost:{port}/");
 
             IEnumerable<IceServer> iceServers = new[]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
     parameters:
       useDotnetTest: true
       configuration: Debug
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: >-
         --logger trx
         --collect "Code coverage"
@@ -77,7 +77,7 @@ jobs:
   - template: .azure-pipelines/mono.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
@@ -88,7 +88,7 @@ jobs:
   - template: .azure-pipelines/mono.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
@@ -103,7 +103,7 @@ jobs:
   - template: .azure-pipelines/windows-net471.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testPrefix: '"$PROGRAMFILES/Mono/bin/mono.exe"'
       testArguments: -appdomains denied -parallel none -stoponfail -verbose
       copySQLitePCLRaw: true
@@ -125,7 +125,7 @@ jobs:
   - template: .azure-pipelines/mono.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testDisplayName: StandaloneOSX *.Tests.dll
       testCommand: |-
         /tmp/StandaloneOSX.app/Contents/MacOS/StandaloneOSX
@@ -141,7 +141,7 @@ jobs:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
@@ -152,7 +152,7 @@ jobs:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
   timeoutInMinutes: 30
 
@@ -164,7 +164,7 @@ jobs:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
       locale: ar_SA.UTF8
   timeoutInMinutes: 30
@@ -176,7 +176,7 @@ jobs:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
       locale: he_IL.UTF8
   timeoutInMinutes: 30
@@ -188,7 +188,7 @@ jobs:
   - template: .azure-pipelines/dotnet-core.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose
       locale: fr_FR.UTF8
   timeoutInMinutes: 30
@@ -200,5 +200,5 @@ jobs:
   - template: .azure-pipelines/windows-net471.yml
     parameters:
       configuration: $(configuration)
-      turnServerUrl: $(turnServerUrl)
+      turnServerUrls: $(turnServerUrls)
       testArguments: -parallel none -stoponfail -verbose


### PR DESCRIPTION
This patch makes the test suite to take multiple `TURN_SERVER_URLS` instead of a single `TURN_SERVER_URL` so that these loads that TURN/ICE servers receive become balanced.  I already configured `turnServerUrls` on Azure Pipelines too.

Read the changes in _CONTRIBUTING.md_ for details.