### PR TITLE
Fix `new Null()` to `default(Null)`

### DIFF
--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -210,7 +210,7 @@ namespace Libplanet.Assets
 #pragma warning disable SA1129  // See also: https://github.com/planetarium/bencodex.net/issues/20
             IValue minters = Minters is ImmutableHashSet<Address> a
                 ? new List(a.OrderBy(m => m).Select(m => (IValue)new Binary(m.ToByteArray())))
-                : (IValue)new Null();
+                : (IValue)default(Null);
 #pragma warning restore SA1129
             IValue serialized = Dictionary.Empty
                 .Add("ticker", Ticker)


### PR DESCRIPTION
There is only line to construct the `Null` struct with `new Null()` and we need change it to `default(Null)` if possible.