### PR TITLE
feat(cli): add `--no-passphrase` option into `key` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,14 +153,18 @@ To be released.
     as JSON format.  [[#1240]]
  -  Added `planet apv query` subcommand to query app protocol version of
     specific peer. [[#1240]]
+ -  Added the option `--no-passphrase` to `planet key remove` command to remove
+    key without asking passphrase.  [[#1213], [#1265]]
 
 [#1192]: https://github.com/planetarium/libplanet/issues/1192
 [#1197]: https://github.com/planetarium/libplanet/pull/1197
+[#1213]: https://github.com/planetarium/libplanet/issues/1213
 [#1219]: https://github.com/planetarium/libplanet/pull/1219
 [#1228]: https://github.com/planetarium/libplanet/pull/1218
 [#1234]: https://github.com/planetarium/libplanet/pull/1234
 [#1235]: https://github.com/planetarium/libplanet/pull/1235
 [#1240]: https://github.com/planetarium/libplanet/pull/1240
+[#1265]: https://github.com/planetarium/libplanet/pull/1265
 
 
 Version 0.11.1

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -47,12 +47,18 @@ namespace Libplanet.Extensions.Cocona.Commands
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string? passphrase = null
+            string? passphrase = null,
+            [Option(Description = "Remove without asking passphrase.")]
+            bool noPassphrase = false
         )
         {
             try
             {
-                UnprotectKey(keyId, passphrase);
+                if (!noPassphrase)
+                {
+                    UnprotectKey(keyId, passphrase);
+                }
+
                 KeyStore.Remove(keyId);
             }
             catch (NoKeyException)


### PR DESCRIPTION
It resolves #1213. See also https://github.com/planetarium/NineChronicles.Headless/pull/365

Also, it needs to write a unittest. The #1233 PR contains addition of the unittest project and I will open new pull request to complement unittests of commands. If the reviewers agree it, I will do it after the pull request merged.