### PR TITLE
Class and filename typo fixed

### DIFF
--- a/Libplanet.Tests/Blocks/InvalidBlockTxHashExceptionTest.cs
+++ b/Libplanet.Tests/Blocks/InvalidBlockTxHashExceptionTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Libplanet.Tests.Blocks
 {
-    public class InvalidBlocckTxHashExceptionTest
+    public class InvalidBlockTxHashExceptionTest
     {
         [Fact]
         public void Serialize()


### PR DESCRIPTION
Typos in class name `InvalidBlocckTxHashExceptionTest` and file name `InvalidBlocckTxHashExceptionTest.cs` in `Libplanet.Tests` respectively changed to `InvalidBlockTxHashExceptionTest` and `InvalidBlockTxHashExceptionTest.cs`.