### PR TITLE
Fix/transactions immutable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,12 @@ To be released.
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
  -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
     `Libplanet.Net.Transports`.  [[#1235]]
+ -  `Block` now enforces a collection of `Transaction`s to be less mutable.
+    [[#1274]]
+     -  The type of `Block` constructor's `transactions` parameter became
+        `IReadOnlyList<T>` (was `IEnumerable<T>`).
+     -  The type of `Transactions` proberty of `Block` became `IReadOnlyList<T>`
+        (was `IEnumerable<T>`).
 
 ### Backward-incompatible network protocol changes
 
@@ -168,7 +174,7 @@ To be released.
 [#1240]: https://github.com/planetarium/libplanet/pull/1240
 [#1265]: https://github.com/planetarium/libplanet/pull/1265
 [#1268]: https://github.com/planetarium/libplanet/pull/1268
-
+[#1274]: https://github.com/planetarium/libplanet/pull/1274
 
 Version 0.11.1
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,12 +121,12 @@ To be released.
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
  -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
     `Libplanet.Net.Transports`.  [[#1235]]
- -  `Block<T>` now enforces a collection of `Transaction<T>`s to be less mutable.
-    [[#1274]]
+ -  `Block<T>` now enforces a collection of `Transaction<T>`s to be less
+    mutable.  [[#1274]]
      -  The type of `Block<T>()` constructor's `transactions` parameter became
         `IReadOnlyList<T>` (was `IEnumerable<T>`).
-     -  The type of `Transactions` property of `Block<T>` became `IReadOnlyList<T>`
-        (was `IEnumerable<T>`).
+     -  The type of `Transactions` property of `Block<T>` became
+        `IReadOnlyList<T>` (was `IEnumerable<T>`).
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,11 +121,11 @@ To be released.
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
  -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
     `Libplanet.Net.Transports`.  [[#1235]]
- -  `Block` now enforces a collection of `Transaction`s to be less mutable.
+ -  `Block<T>` now enforces a collection of `Transaction<T>`s to be less mutable.
     [[#1274]]
-     -  The type of `Block` constructor's `transactions` parameter became
+     -  The type of `Block<T>()` constructor's `transactions` parameter became
         `IReadOnlyList<T>` (was `IEnumerable<T>`).
-     -  The type of `Transactions` proberty of `Block` became `IReadOnlyList<T>`
+     -  The type of `Transactions` property of `Block<T>` became `IReadOnlyList<T>`
         (was `IEnumerable<T>`).
 
 ### Backward-incompatible network protocol changes

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 new Address(TestUtils.GetRandomBytes(Address.Size)),
                 new BlockHash(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
                 DateTimeOffset.UtcNow,
-                ImmutableHashSet<Transaction<NoOpAction>>.Empty,
+                ImmutableArray<Transaction<NoOpAction>>.Empty,
                 stateRootHash: new HashDigest<SHA256>(
                     TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
             var query =

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -330,7 +330,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block2 = TestUtils.MineNext(
                 block1,
-                ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(txs[0]),
+                ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
@@ -349,7 +349,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block3 = TestUtils.MineNext(
                 block2,
-                ImmutableHashSet<Transaction<DumbAction>>.Empty.Add(txs[1]),
+                ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1714,7 +1714,7 @@ namespace Libplanet.Tests.Blockchain
 
             var genesis = _blockChain.Genesis;
 
-            Block<T> MineNext<T>(Block<T> block, IEnumerable<Transaction<T>> txs)
+            Block<T> MineNext<T>(Block<T> block, IReadOnlyList<Transaction<T>> txs)
                 where T : IAction, new() => TestUtils.MineNext(
                     block,
                     txs,

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -96,7 +97,7 @@ namespace Libplanet.Tests.Net
                 receiverSwarm.Address,
                 null,
                 DateTimeOffset.MinValue,
-                Enumerable.Empty<Transaction<DumbAction>>());
+                ImmutableArray<Transaction<DumbAction>>.Empty);
             BlockChain<DumbAction> seedChain = TestUtils.MakeBlockChain(
                 receiverChain.Policy,
                 new DefaultStore(path: null),

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -831,7 +831,7 @@ namespace Libplanet.Tests.Net
                 minerAddress,
                 null,
                 DateTimeOffset.MinValue,
-                Enumerable.Empty<Transaction<DumbAction>>());
+                ImmutableArray<Transaction<DumbAction>>.Empty);
             var genesisBlock2 = new Block<DumbAction>(
                 0,
                 0,
@@ -840,7 +840,7 @@ namespace Libplanet.Tests.Net
                 minerAddress,
                 null,
                 DateTimeOffset.MinValue,
-                Enumerable.Empty<Transaction<DumbAction>>());
+                ImmutableArray<Transaction<DumbAction>>.Empty);
 
             BlockChain<DumbAction> MakeBlockChain(Block<DumbAction> genesisBlock) =>
                 TestUtils.MakeBlockChain(

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -182,7 +182,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
         public static Block<T> MineGenesis<T>(
             Address? miner = null,
-            IEnumerable<Transaction<T>> transactions = null,
+            IReadOnlyList<Transaction<T>> transactions = null,
             DateTimeOffset? timestamp = null,
             int protocolVersion = Block<T>.CurrentProtocolVersion
         )
@@ -210,7 +210,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
         public static Block<T> MineNext<T>(
             Block<T> previousBlock,
-            IEnumerable<Transaction<T>> txs = null,
+            IReadOnlyList<Transaction<T>> txs = null,
             byte[] nonce = null,
             long difficulty = 1,
             Address? miner = null,

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -285,7 +285,7 @@ namespace Libplanet.Blocks
         public HashDigest<SHA256>? TxHash { get; }
 
         [IgnoreDuringEquals]
-        public IEnumerable<Transaction<T>> Transactions { get; }
+        public IReadOnlyList<Transaction<T>> Transactions { get; }
 
         /// <summary>
         /// The bytes length in its serialized format.

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Blocks
             Address? miner,
             BlockHash? previousHash,
             DateTimeOffset timestamp,
-            IEnumerable<Transaction<T>> transactions,
+            IReadOnlyList<Transaction<T>> transactions,
             BlockHash? preEvaluationHash = null,
             HashDigest<SHA256>? stateRootHash = null,
             int protocolVersion = CurrentProtocolVersion)
@@ -202,7 +202,7 @@ namespace Libplanet.Blocks
             BlockHash? previousHash,
             DateTimeOffset timestamp,
             HashDigest<SHA256>? txHash,
-            IEnumerable<Transaction<T>> transactions,
+            IReadOnlyList<Transaction<T>> transactions,
             BlockHash? preEvaluationHash,
             HashDigest<SHA256>? stateRootHash
         )

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -91,7 +91,8 @@ namespace Libplanet.Store
                         CultureInfo.InvariantCulture
                     ).ToUniversalTime(),
                     transactions: blockDigest.TxIds
-                        .Select(bytes => GetTransaction<T>(new TxId(bytes.ToArray()))),
+                        .Select(bytes => GetTransaction<T>(new TxId(bytes.ToArray())))
+                        .ToImmutableArray(),
                     preEvaluationHash: preEvaluationHash,
                     stateRootHash: stateRootHash,
                     protocolVersion: blockDigest.Header.ProtocolVersion


### PR DESCRIPTION
Changed property of `Transactions` of `Block` to `IReadOnlyList<T>` from `IEnumerable<T>` to partially mitigate [the multiple enumeration problem](https://www.jetbrains.com/help/resharper/PossibleMultipleEnumeration.html).

Constructor now also receives `IReadOnlyList<T>` to further enforce this point.