### PR TITLE
Execute `Transaction<T>.Actions` all or nothing at all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,7 @@ To be released.
  -  Added `NetMQTransport.QueryAppProtocolVersion()` static method.  [[#1235]]
  -  Added `BoundPeer.Parse()` static method.  [[#1240]]
  -  Added `TransportException` class.  [[#1242]]
+ -  Added `AtomicActionRenderer<T>` class.  [[#1267], [#1275]]
 
 ### Behavioral changes
 
@@ -174,6 +175,8 @@ To be released.
         action, action rendering methods in `IActionRenderer<T>`
         (`RenderAction()`, `RenderActionError()`, `UnrenderAction()`, and
         `UnrenderActionError()`) became not invoked.
+        If you want to dismiss all actions in unsuccessful transactions at all,
+        wrap your action renderer with `AtomicActionRenderer<T>`.
  -  Fixed a bug where `KademliaProtocol.BootstrapAsync()` has sent multiple
     `Ping` messages to other peers.  [[#1219]]
  -  Fixed a bug where `KademliaProtocol.CheckReplacementCacheAsync()` has

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,6 +118,7 @@ To be released.
      -  The type of `TrieStateStore.PruneStates()` method's `excludeBlockHashes`
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
+ -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
  -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
     `Libplanet.Net.Transports`.  [[#1235]]
@@ -195,6 +196,7 @@ To be released.
 [#1268]: https://github.com/planetarium/libplanet/pull/1268
 [#1272]: https://github.com/planetarium/libplanet/pull/1272
 [#1274]: https://github.com/planetarium/libplanet/pull/1274
+[#1275]: https://github.com/planetarium/libplanet/pull/1275
 [#1278]: https://github.com/planetarium/libplanet/pull/1278
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,6 +159,21 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where executing `Transaction<T>.Actions` had not been atomic.
+    `Actions` in a `Transaction<T>` now became executed all or nothing at all.
+    [[#1267], [#1275]]
+     -  `Transaction<T>.EvaluateActions()` method became atomic.
+     -  `Transaction<T>.EvaluateActionsGradually()` method had returned
+        the same number of `ActionEvaluation`s to `Transaction<T>.Actions`,
+        but now became to omit the evaluations after the first action throwing
+        an exception.  If no action throws any exception, it still returns
+        the same number of `ActionEvaluation`s to `Transaction<T>.Actions`.
+     -  State-wise, `Transaction<T>`s having any exception-throwing action
+        now do not commit any changes at all to `IStateStore`.
+     -  Rendering-wise, for actions following the first exception-throwing
+        action, action rendering methods in `IActionRenderer<T>`
+        (`RenderAction()`, `RenderActionError()`, `UnrenderAction()`, and
+        `UnrenderActionError()`) became not invoked.
  -  Fixed a bug where `KademliaProtocol.BootstrapAsync()` has sent multiple
     `Ping` messages to other peers.  [[#1219]]
  -  Fixed a bug where `KademliaProtocol.CheckReplacementCacheAsync()` has
@@ -193,6 +208,7 @@ To be released.
 [#1240]: https://github.com/planetarium/libplanet/pull/1240
 [#1242]: https://github.com/planetarium/libplanet/pull/1242
 [#1265]: https://github.com/planetarium/libplanet/pull/1265
+[#1267]: https://github.com/planetarium/libplanet/issues/1267
 [#1268]: https://github.com/planetarium/libplanet/pull/1268
 [#1272]: https://github.com/planetarium/libplanet/pull/1272
 [#1274]: https://github.com/planetarium/libplanet/pull/1274

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Store.Trie;
+using Libplanet.Tx;
 using Xunit;
 
 namespace Libplanet.Tests.Action
@@ -21,10 +22,17 @@ namespace Libplanet.Tests.Action
                 (1, 534011718),
             };
             var address = new Address("21744f4f08db23e044178dafb8273aeb5ebe6644");
+            var txid = new TxId(new byte[]
+            {
+                0xd8, 0x35, 0x6c, 0x35, 0xb8, 0x6e, 0x49, 0xf0, 0x84, 0x3c, 0x9c,
+                0xe8, 0x26, 0xe1, 0xda, 0x01, 0x4f, 0x7a, 0x1b, 0xa8, 0x28, 0x32,
+                0x8f, 0x8c, 0x12, 0x32, 0x72, 0x84, 0x00, 0xfc, 0x74, 0x89,
+            });
             foreach (var (seed, expected) in testCases)
             {
                 var context = new ActionContext(
                     signer: address,
+                    txid: txid,
                     miner: address,
                     blockIndex: 1,
                     previousStates: new DumbAccountStateDelta(),
@@ -39,8 +47,16 @@ namespace Libplanet.Tests.Action
         public void GuidShouldBeDeterministic()
         {
             var address = new Address("21744f4f08db23e044178dafb8273aeb5ebe6644");
+            var txid = new TxId(new byte[]
+            {
+                0xd8, 0x35, 0x6c, 0x35, 0xb8, 0x6e, 0x49, 0xf0, 0x84, 0x3c, 0x9c,
+                0xe8, 0x26, 0xe1, 0xda, 0x01, 0x4f, 0x7a, 0x1b, 0xa8, 0x28, 0x32,
+                0x8f, 0x8c, 0x12, 0x32, 0x72, 0x84, 0x00, 0xfc, 0x74, 0x89,
+            });
+
             var context1 = new ActionContext(
                 signer: address,
+                txid: txid,
                 miner: address,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
@@ -49,6 +65,7 @@ namespace Libplanet.Tests.Action
 
             var context2 = new ActionContext(
                 signer: address,
+                txid: txid,
                 miner: address,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
@@ -57,6 +74,7 @@ namespace Libplanet.Tests.Action
 
             var context3 = new ActionContext(
                 signer: address,
+                txid: txid,
                 miner: address,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
@@ -87,16 +105,23 @@ namespace Libplanet.Tests.Action
         public void GuidVersionAndVariant()
         {
             var address = new Address("21744f4f08db23e044178dafb8273aeb5ebe6644");
+            var txid = new TxId(new byte[]
+            {
+                0xd8, 0x35, 0x6c, 0x35, 0xb8, 0x6e, 0x49, 0xf0, 0x84, 0x3c, 0x9c,
+                0xe8, 0x26, 0xe1, 0xda, 0x01, 0x4f, 0x7a, 0x1b, 0xa8, 0x28, 0x32,
+                0x8f, 0x8c, 0x12, 0x32, 0x72, 0x84, 0x00, 0xfc, 0x74, 0x89,
+            });
 
             for (var i = 0; i < 100; i++)
             {
                 var context = new ActionContext(
-                        signer: address,
-                        miner: address,
-                        blockIndex: 1,
-                        previousStates: new DumbAccountStateDelta(),
-                        randomSeed: i
-                    );
+                    signer: address,
+                    txid: txid,
+                    miner: address,
+                    blockIndex: 1,
+                    previousStates: new DumbAccountStateDelta(),
+                    randomSeed: i
+                );
                 var guid = context.Random.GenerateRandomGuid().ToString();
 
                 Assert.Equal('4', guid[14]);
@@ -110,6 +135,7 @@ namespace Libplanet.Tests.Action
             var random = new System.Random();
             var original = new ActionContext(
                 signer: random.NextAddress(),
+                txid: random.NextTxId(),
                 miner: random.NextAddress(),
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
@@ -142,6 +168,7 @@ namespace Libplanet.Tests.Action
             var random = new System.Random();
             var actionContext = new ActionContext(
                 signer: random.NextAddress(),
+                txid: random.NextTxId(),
                 miner: random.NextAddress(),
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -1,14 +1,35 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Fixtures;
+using Libplanet.Tx;
+using Serilog;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Action
 {
     public class ActionEvaluationTest
     {
+        private readonly ILogger _logger;
+
+        public ActionEvaluationTest(ITestOutputHelper output)
+        {
+            Log.Logger = _logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(output)
+                .CreateLogger()
+                .ForContext<ActionEvaluationTest>();
+        }
+
         [Fact]
         public void Constructor()
         {
@@ -50,6 +71,127 @@ namespace Libplanet.Tests.Action
                 (Text)"item",
                 evaluation.OutputStates.GetState(address)
             );
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task EvaluateActionsGradually(bool rehearsal)
+        {
+            var fx = new IntegerSet(new[] { 5, 10 });
+
+            // a: ((5 + 1) * 2) + 3 = 15
+            (Transaction<Arithmetic> a, var deltaA) = fx.Sign(
+                0,
+                Arithmetic.Add(1),
+                Arithmetic.Mul(2),
+                Arithmetic.Add(3)
+            );
+
+            Block<Arithmetic> blockA = await fx.Mine();
+            ActionEvaluation[] evalsA = ActionEvaluation.EvaluateActionsGradually(
+                blockA.Hash,
+                blockIndex: blockA.Index,
+                txid: a.Id,
+                previousStates: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
+                minerAddress: blockA.Miner ?? default,
+                signer: a.Signer,
+                signature: a.Signature,
+                actions: a.Actions.ToImmutableArray<IAction>(),
+                rehearsal: rehearsal,
+                previousBlockStatesTrie: fx.GetTrie(blockA.PreviousHash),
+                blockAction: false
+            ).ToArray();
+
+            Assert.Equal(evalsA.Length, deltaA.Count - 1);
+            for (int i = 0; i < evalsA.Length; i++)
+            {
+                ActionEvaluation eval = evalsA[i];
+                _logger.Debug("evalsA[{0}] = {1}", i, eval);
+                _logger.Debug("a.Actions[{0}] = {1}", i, a.Actions[i]);
+                Assert.Equal(a.Actions[i], eval.Action);
+                IActionContext context = eval.InputContext;
+                Assert.Equal(blockA.Miner, context.Miner);
+                Assert.Equal(blockA.Index, context.BlockIndex);
+                Assert.Equal(
+                    deltaA[i].RootHash,
+                    context.PreviousStateRootHash
+                );
+                Assert.Equal(a.Signer, context.Signer);
+                Assert.False(context.BlockAction);
+                Assert.Equal(rehearsal, context.Rehearsal);
+                IAccountStateDelta prevStates = context.PreviousStates;
+                Assert.Equal(
+                    i > 0 ? new[] { a.Signer } : new Address[0],
+                    prevStates.UpdatedAddresses
+                );
+                Assert.Equal((Integer)deltaA[i].Value, prevStates.GetState(a.Signer));
+                IAccountStateDelta outputStates = eval.OutputStates;
+                Assert.Equal(new[] { a.Signer }, outputStates.UpdatedAddresses);
+                Assert.Equal((Integer)deltaA[i + 1].Value, outputStates.GetState(a.Signer));
+                Assert.Null(eval.Exception);
+            }
+
+            // b: error(10 - 3) + -3 =
+            //         (10 - 3)      = 7  (only input of error() is left)
+            (Transaction<Arithmetic> b, var deltaB) = fx.Sign(
+                1,
+                Arithmetic.Sub(3),
+                new Arithmetic(),
+                Arithmetic.Add(-1)
+            );
+
+            Block<Arithmetic> blockB = await fx.Mine();
+            ActionEvaluation[] evalsB = ActionEvaluation.EvaluateActionsGradually(
+                blockB.Hash,
+                blockIndex: blockB.Index,
+                txid: b.Id,
+                previousStates: fx.CreateAccountStateDelta(0, blockB.PreviousHash),
+                minerAddress: blockB.Miner ?? default,
+                signer: b.Signer,
+                signature: b.Signature,
+                actions: b.Actions.ToImmutableArray<IAction>(),
+                rehearsal: rehearsal,
+                previousBlockStatesTrie: fx.GetTrie(blockB.PreviousHash),
+                blockAction: false
+            ).ToArray();
+
+            Assert.Equal(evalsB.Length, deltaB.Count - 1);
+            for (int i = 0; i < evalsB.Length; i++)
+            {
+                ActionEvaluation eval = evalsB[i];
+                _logger.Debug("evalsB[{0}] = {@1}", i, eval);
+                _logger.Debug("b.Actions[{0}] = {@1}", i, b.Actions[i]);
+                Assert.Equal(b.Actions[i], eval.Action);
+                IActionContext context = eval.InputContext;
+                Assert.Equal(blockB.Miner, context.Miner);
+                Assert.Equal(blockB.Index, context.BlockIndex);
+                Assert.Equal(
+                    deltaB[i].RootHash,
+                    context.PreviousStateRootHash
+                );
+                Assert.Equal(b.Signer, context.Signer);
+                Assert.False(context.BlockAction);
+                Assert.Equal(rehearsal, context.Rehearsal);
+                IAccountStateDelta prevStates = context.PreviousStates;
+                Assert.Equal(
+                    i > 0 ? new[] { b.Signer } : new Address[0],
+                    prevStates.UpdatedAddresses
+                );
+                Assert.Equal((Integer)deltaB[i].Value, prevStates.GetState(b.Signer));
+                IAccountStateDelta outputStates = eval.OutputStates;
+                Assert.Equal(new[] { b.Signer }, outputStates.UpdatedAddresses);
+                Assert.Equal((Integer)deltaB[i + 1].Value, outputStates.GetState(b.Signer));
+                if (i == 1)
+                {
+                    Assert.IsType<UnexpectedlyTerminatedActionException>(eval.Exception);
+                    Assert.IsType<InvalidOperationException>(eval.Exception.InnerException);
+                }
+                else
+                {
+                    Assert.Null(eval.Exception);
+                }
+            }
         }
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -12,11 +12,13 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void Constructor()
         {
+            var txid = new System.Random().NextTxId();
             Address address = new PrivateKey().ToAddress();
             var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(
                     address,
+                    txid,
                     address,
                     1,
                     new AccountStateDeltaImpl(
@@ -38,6 +40,7 @@ namespace Libplanet.Tests.Action
             Assert.Equal(address, action.TargetAddress);
             Assert.Equal("item", action.Item);
             Assert.Equal(address, evaluation.InputContext.Signer);
+            Assert.Equal(txid, evaluation.InputContext.TxId);
             Assert.Equal(address, evaluation.InputContext.Miner);
             Assert.Equal(1, evaluation.InputContext.BlockIndex);
             Assert.Null(

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
 
         private static IActionContext _actionContext =
-            new ActionContext(default, default, default, _stateDelta, default);
+            new ActionContext(default, default, default, default, _stateDelta, default);
 
         private static Exception _exception = new Exception();
 

--- a/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blockchain.Renderers.Debug;
+using Libplanet.Tests.Fixtures;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class AtomicActionRendererTest
+    {
+        private readonly RecordingActionRenderer<Arithmetic> _record;
+        private readonly AtomicActionRenderer<Arithmetic> _renderer;
+        private readonly IntegerSet _fx;
+        private Transaction<Arithmetic> _successTx;
+
+        public AtomicActionRendererTest()
+        {
+            _record = new RecordingActionRenderer<Arithmetic>();
+            _renderer = new AtomicActionRenderer<Arithmetic>(_record);
+            _fx = new IntegerSet(new BigInteger?[] { 0 }, null, new[] { _renderer });
+            (_successTx, _) = _fx.Sign(
+                0,
+                Arithmetic.Add(1),
+                Arithmetic.Mul(2),
+                Arithmetic.Add(3)
+            );
+
+            // failing transaction; should not be rendered:
+            _fx.Sign(
+                0,
+                Arithmetic.Add(1),
+                new Arithmetic(),
+                Arithmetic.Add(3)
+            );
+            _record.ResetRecords();
+        }
+
+        [Fact]
+        public async Task Block()
+        {
+            await _fx.Mine();
+            IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
+            Assert.Equal(5, records.Count);
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[0], r => Assert.True(r.Begin));
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[0], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[1], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[2], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[4], r => Assert.True(r.End));
+        }
+
+        [Fact]
+        public async Task Reorg()
+        {
+            BlockChain<Arithmetic> @base = _fx.Chain.Fork(_fx.Genesis.Hash);
+            await _fx.Mine();
+            _record.ResetRecords();
+            _fx.Chain.Swap(@base, true);
+            IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
+            Assert.Equal(7, records.Count);
+            AssertTypeAnd<RenderRecord<Arithmetic>.Reorg>(records[0], r => Assert.True(r.Begin));
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[2], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[1], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
+            {
+                Assert.Equal(_successTx.Id, r.Context.TxId);
+                Assert.Equal(_successTx.Actions[0], r.Action);
+            });
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[4], r => Assert.True(r.Begin));
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[5], r => Assert.True(r.End));
+            AssertTypeAnd<RenderRecord<Arithmetic>.Reorg>(records[6], r => Assert.True(r.End));
+        }
+
+        private static void AssertTypeAnd<T>(object obj, Action<T> callback)
+        {
+            Assert.IsType<T>(obj);
+            callback((T)obj);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -738,6 +738,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         private IActionContext FakeContext(long blockIndex = 1) =>
-            new ActionContext(default, default, blockIndex, _emptyStates, 0);
+            new ActionContext(default, default, default, blockIndex, _emptyStates, 0);
     }
 }

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -72,7 +72,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             bool called = false;
             LogEvent firstLog = null;
             IActionContext actionContext =
-                new ActionContext(default, default, 123, _stateDelta, default, rehearsal);
+                new ActionContext(default, default, default, 123, _stateDelta, default, rehearsal);
             Exception actionError = new Exception();
             IActionRenderer<DumbAction> actionRenderer;
             if (error)

--- a/Libplanet.Tests/Fixtures/Arithmetic.cs
+++ b/Libplanet.Tests/Fixtures/Arithmetic.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Tests.Fixtures
+{
+    /// <summary>
+    /// A simple arithmetic action.  This assumes that every address has an integer state or
+    /// a <c>null</c> state (not <see cref="Bencodex.Types.Null"/>, but <c>null</c> reference).
+    /// </summary>
+    public sealed class Arithmetic : IAction, IEquatable<Arithmetic>
+    {
+        public Arithmetic()
+        {
+            Error = "An uninitialized action.";
+        }
+
+        public Arithmetic(OperatorType @operator, BigInteger operand)
+        {
+            Error = null;
+            Operator = @operator;
+            Operand = operand;
+        }
+
+        public string Error { get; private set; }
+
+        public OperatorType Operator { get; private set; }
+
+        public BigInteger Operand { get; private set; }
+
+        public IValue PlainValue => Bencodex.Types.Dictionary.Empty
+            .Add(
+                "op",
+                Operator is OperatorType op ? new Text(op.ToString()) : (IValue)default(Null)
+            )
+            .Add("operand", (IValue)new Bencodex.Types.Integer(Operand));
+
+        public static Arithmetic Add(BigInteger operand) =>
+            new Arithmetic(OperatorType.Add, operand);
+
+        public static Arithmetic Sub(BigInteger operand) =>
+            new Arithmetic(OperatorType.Sub, operand);
+
+        public static Arithmetic Mul(BigInteger operand) =>
+            new Arithmetic(OperatorType.Mul, operand);
+
+        public static Arithmetic Div(BigInteger operand) =>
+            new Arithmetic(OperatorType.Div, operand);
+
+        public static Arithmetic Mod(BigInteger operand) =>
+            new Arithmetic(OperatorType.Mod, operand);
+
+        public void LoadPlainValue(IValue plainValue)
+        {
+            if (!(plainValue is Dictionary d))
+            {
+                Error =
+                    "The action serialization is invalid; " +
+                    "the serialization should be a dictionary.";
+                return;
+            }
+
+            if (!d.TryGetValue((Text)"op", out IValue opValue))
+            {
+                Error = "The serialized dictionary lacks the key \"op\".";
+                return;
+            }
+
+            if (!(opValue is Text opText))
+            {
+                Error = "The serialized \"op\" field is not a text.";
+                return;
+            }
+
+            string opStr = opText.Value;
+            if (!OperatorType.TryParse(opStr, true, out OperatorType op))
+            {
+                Error = $"The serialized operator \"{opStr}\" is invalid.";
+                return;
+            }
+
+            if (!d.TryGetValue((Text)"operand", out IValue operandValue))
+            {
+                Error = "The serialized dictionary lacks the key \"operand\".";
+                return;
+            }
+
+            if (!(operandValue is Bencodex.Types.Integer operandInt))
+            {
+                Error = "The serialized \"operand\" field is not an integer.";
+                return;
+            }
+
+            Operator = op;
+            Operand = operandInt.Value;
+            Error = null;
+        }
+
+        public IAccountStateDelta Execute(IActionContext context)
+        {
+            if (Error != null)
+            {
+                throw new InvalidOperationException(Error);
+            }
+
+            IValue v = context.PreviousStates.GetState(context.Signer) ?? (Bencodex.Types.Integer)0;
+            if (!(v is Bencodex.Types.Integer value))
+            {
+                throw new InvalidOperationException(
+                    $"The state of the address {context.Signer} is not an integer."
+                );
+            }
+
+            Func<BigInteger, BigInteger, BigInteger> func = Operator.ToFunc();
+            BigInteger result = func(value, Operand);
+            return context.PreviousStates.SetState(context.Signer, (Bencodex.Types.Integer)result);
+        }
+
+        public bool Equals(Arithmetic other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            else if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            else
+            {
+                return Error == other.Error &&
+                   Operator == other.Operator &&
+                   Operand.Equals(other.Operand);
+            }
+        }
+
+        public override bool Equals(object obj) =>
+            ReferenceEquals(this, obj) || (obj is Arithmetic other && Equals(other));
+
+        public override int GetHashCode() =>
+            (Error, (int)Operator, Operand).GetHashCode();
+    }
+}

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tests.Blockchain;
+using Libplanet.Tests.Store.Trie;
+using Libplanet.Tx;
+
+namespace Libplanet.Tests.Fixtures
+{
+    public sealed class IntegerSet
+    {
+        public readonly IReadOnlyList<PrivateKey> PrivateKeys;
+        public readonly IReadOnlyList<Address> Addresses;
+        public readonly IReadOnlyList<Transaction<Arithmetic>> Txs;
+        public readonly Address Miner;
+        public readonly Block<Arithmetic> Genesis;
+        public readonly BlockChain<Arithmetic> Chain;
+        public readonly IStore Store;
+        public readonly IKeyValueStore KVStore;
+        public readonly TrieStateStore StateStore;
+
+        public IntegerSet(int[] initialStates)
+            : this(initialStates.Select(s => new BigInteger?(s)).ToArray(), null, null)
+        {
+        }
+
+        public IntegerSet(
+            IReadOnlyList<BigInteger?> initialStates,
+            IBlockPolicy<Arithmetic> policy = null,
+            IEnumerable<IRenderer<Arithmetic>> renderers = null
+        )
+        {
+            PrivateKeys = initialStates.Select(_ => new PrivateKey()).ToImmutableArray();
+            Addresses = PrivateKeys.Select(AddressExtensions.ToAddress).ToImmutableArray();
+            Txs = initialStates
+                .Select((state, index) => new { State = state, Key = PrivateKeys[index] })
+                .Where(pair => !(pair.State is null))
+                .Select(pair => new { State = (BigInteger)pair.State, pair.Key })
+                .Select(pair => new { Action = Arithmetic.Add(pair.State), pair.Key })
+                .Select(pair =>
+                    Transaction<Arithmetic>.Create(
+                        0,
+                        pair.Key,
+                        null,
+                        new[] { pair.Action },
+                        ImmutableHashSet<Address>.Empty.Add(pair.Key.ToAddress())
+                    )
+                )
+                .ToImmutableArray();
+            Miner = new System.Random().NextAddress();
+            policy = policy ?? new NullPolicy<Arithmetic>();
+            Store = new DefaultStore(null);
+            KVStore = new MemoryKeyValueStore();
+            StateStore = new TrieStateStore(KVStore, KVStore);
+            Genesis = Block<Arithmetic>.Mine(0, 0, 0, Miner, null, DateTimeOffset.UtcNow, Txs)
+                .AttachStateRootHash(StateStore, policy.BlockAction);
+            Chain = new BlockChain<Arithmetic>(
+                policy,
+                new VolatileStagePolicy<Arithmetic>(),
+                Store,
+                StateStore,
+                Genesis,
+                renderers
+            );
+        }
+
+        public int Count => Addresses.Count;
+
+        public IBlockPolicy<Arithmetic> Policy => Chain.Policy;
+
+        public IReadOnlyList<IRenderer<Arithmetic>> Renderers => Chain.Renderers;
+
+        public Block<Arithmetic> Tip => Chain.Tip;
+
+        public TxWithContext Sign(PrivateKey signer, params Arithmetic[] actions)
+        {
+            Address signerAddress = signer.ToAddress();
+            string rawStateKey = KeyConverters.ToStateKey(signerAddress);
+            long nonce = Chain.GetNextTxNonce(signerAddress);
+            Transaction<Arithmetic> tx =
+                Transaction<Arithmetic>.Create(nonce, signer, Genesis.Hash, actions);
+            BigInteger prevState = Chain.GetState(signerAddress) is Bencodex.Types.Integer i
+                ? i.Value
+                : 0;
+            HashDigest<SHA256> prevStateRootHash = Chain.Tip.StateRootHash.Value;
+            ITrie prevTrie = GetTrie(Chain.Tip.Hash);
+            (BigInteger, HashDigest<SHA256>) prevPair = (prevState, prevStateRootHash);
+            (BigInteger, HashDigest<SHA256>) stagedStates = Chain.ListStagedTransactions()
+                .Where(t => t.Signer.Equals(signerAddress))
+                .OrderBy(t => t.Nonce)
+                .SelectMany(t => t.Actions)
+                .TakeWhile(a => a.Error is null)
+                .Aggregate(prevPair, (prev, act) =>
+                {
+                    BigInteger nextState = act.Operator.ToFunc()(prev.Item1, act.Operand);
+                    var updatedRawStates = ImmutableDictionary<string, IValue>.Empty
+                        .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
+                    HashDigest<SHA256> nextRootHash =
+                        prevTrie.Set(updatedRawStates).Commit().Hash;
+                    return (nextState, nextRootHash);
+                });
+            Chain.StageTransaction(tx);
+            ImmutableArray<(BigInteger, HashDigest<SHA256>)> expectedDelta = tx.Actions
+                .Take(tx.Actions.TakeWhile(a => a.Error is null).Count() + 1)
+                .Aggregate(
+                    ImmutableArray.Create(stagedStates),
+                    (delta, act) =>
+                    {
+                        BigInteger nextState =
+                            act.Operator.ToFunc()(delta[delta.Length - 1].Item1, act.Operand);
+                        var updatedRawStates = ImmutableDictionary<string, IValue>.Empty
+                            .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
+                        HashDigest<SHA256> nextRootHash =
+                            prevTrie.Set(updatedRawStates).Commit().Hash;
+                        return delta.Add((nextState, nextRootHash));
+                    }
+                );
+            return new TxWithContext()
+            {
+                Tx = tx,
+                ExpectedDelta = expectedDelta,
+            };
+        }
+
+        public TxWithContext Sign(int signerIndex, params Arithmetic[] actions) =>
+            Sign(PrivateKeys[signerIndex], actions);
+
+        public async Task<Block<Arithmetic>> Mine(CancellationToken cancellationToken = default)
+        {
+            Block<Arithmetic> draft = await Chain.MineBlock(
+                Miner,
+                DateTimeOffset.UtcNow,
+                cancellationToken: cancellationToken
+            );
+            return draft.AttachStateRootHash(StateStore, Policy.BlockAction);
+        }
+
+        public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)
+        {
+            offset = offset ?? Tip.Hash;
+            return new AccountStateDeltaImpl(
+                a => Chain.GetState(a, offset),
+                (a, c) => Chain.GetBalance(a, c, offset),
+                signer
+            );
+        }
+
+        public IAccountStateDelta CreateAccountStateDelta(int signerIndex, BlockHash? offset = null)
+            => CreateAccountStateDelta(Addresses[signerIndex], offset);
+
+        public ITrie GetTrie(BlockHash? blockHash) =>
+            blockHash is BlockHash h ? StateStore.GetTrie(h) : null;
+
+        public struct TxWithContext
+        {
+            public Transaction<Arithmetic> Tx;
+            public IReadOnlyList<(BigInteger Value, HashDigest<SHA256> RootHash)> ExpectedDelta;
+
+            public void Deconstruct(
+                out Transaction<Arithmetic> tx,
+                out IReadOnlyList<(BigInteger Value, HashDigest<SHA256> RootHash)> expectedDelta
+            )
+            {
+                tx = Tx;
+                expectedDelta = ExpectedDelta;
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Fixtures/OperatorType.cs
+++ b/Libplanet.Tests/Fixtures/OperatorType.cs
@@ -1,0 +1,11 @@
+namespace Libplanet.Tests.Fixtures
+{
+    public enum OperatorType
+    {
+        Add,
+        Sub,
+        Mul,
+        Div,
+        Mod,
+    }
+}

--- a/Libplanet.Tests/Fixtures/OperatorTypeExtensions.cs
+++ b/Libplanet.Tests/Fixtures/OperatorTypeExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Numerics;
+
+namespace Libplanet.Tests.Fixtures
+{
+    public static class OperatorTypeExtensions
+    {
+        public static Func<BigInteger, BigInteger, BigInteger> ToFunc(this OperatorType @operator)
+        {
+            switch (@operator)
+            {
+                case OperatorType.Add:
+                    return BigInteger.Add;
+                case OperatorType.Sub:
+                    return BigInteger.Subtract;
+                case OperatorType.Mul:
+                    return BigInteger.Multiply;
+                case OperatorType.Div:
+                    return BigInteger.Divide;
+                case OperatorType.Mod:
+                    return BigInteger.Remainder;
+            }
+
+            throw new ArgumentException("Unsupported operator: " + @operator, nameof(@operator));
+        }
+    }
+}

--- a/Libplanet.Tests/RandomExtensions.cs
+++ b/Libplanet.Tests/RandomExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using Libplanet.Tx;
 
 namespace Libplanet.Tests
 {
@@ -11,6 +12,9 @@ namespace Libplanet.Tests
             random.NextBytes(buffer);
             return buffer;
         }
+
+        public static TxId NextTxId(this Random random) =>
+            new TxId(random.NextBytes(TxId.Size));
 
         public static Address NextAddress(this Random random) =>
             new Address(random.NextBytes(Address.Size));

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -610,6 +610,7 @@ namespace Libplanet.Tests.Tx
                     ActionEvaluation eval = evaluations[i];
                     Assert.Equal(actions[i], eval.Action);
                     Assert.Equal(_fx.Address1, eval.InputContext.Signer);
+                    Assert.Equal(tx.Id, eval.InputContext.TxId);
                     Assert.Equal(addresses[0], eval.InputContext.Miner);
                     Assert.Equal(1, eval.InputContext.BlockIndex);
                     Assert.Equal(rehearsal, eval.InputContext.Rehearsal);

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using Libplanet.Store.Trie;
+using Libplanet.Tx;
 
 namespace Libplanet.Action
 {
@@ -14,6 +15,7 @@ namespace Libplanet.Action
 
         public ActionContext(
             Address signer,
+            TxId? txid,
             Address miner,
             long blockIndex,
             IAccountStateDelta previousStates,
@@ -24,6 +26,7 @@ namespace Libplanet.Action
         )
         {
             Signer = signer;
+            TxId = txid;
             Miner = miner;
             BlockIndex = blockIndex;
             Rehearsal = rehearsal;
@@ -35,6 +38,8 @@ namespace Libplanet.Action
         }
 
         public Address Signer { get; }
+
+        public TxId? TxId { get; }
 
         public Address Miner { get; }
 
@@ -63,6 +68,7 @@ namespace Libplanet.Action
         public IActionContext GetUnconsumedContext() =>
             new ActionContext(
                 Signer,
+                TxId,
                 Miner,
                 BlockIndex,
                 PreviousStates,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -136,10 +136,10 @@ namespace Libplanet.Action
                 (signature.Any() ? BitConverter.ToInt32(hashedSignature, 0) : 0);
 
             IAccountStateDelta states = previousStates;
-            Exception exc = null;
             ILogger logger = Log.ForContext<ActionEvaluation>();
             foreach (IAction action in actions)
             {
+                Exception exc = null;
                 ActionContext context = CreateActionContext(states, seed);
                 IAccountStateDelta nextStates = context.PreviousStates;
                 try
@@ -190,6 +190,11 @@ namespace Libplanet.Action
                     nextStates,
                     exc
                 );
+
+                if (exc is { })
+                {
+                    yield break;
+                }
 
                 states = nextStates;
                 unchecked

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -114,6 +114,7 @@ namespace Libplanet.Action
             ) =>
                 new ActionContext(
                     signer: signer,
+                    txid: txid,
                     miner: minerAddress,
                     blockIndex: blockIndex,
                     previousStates: prevStates,

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
+using Libplanet.Tx;
 
 namespace Libplanet.Action
 {
@@ -16,6 +17,13 @@ namespace Libplanet.Action
         /// </summary>
         [Pure]
         Address Signer { get; }
+
+        /// <summary>
+        /// <see cref="Transaction{T}.Id"/> of a transaction that an executed <see cref="IAction"/>
+        /// belongs to.  This is <c>null</c> iff <see cref="BlockAction"/> is <c>true</c>.
+        /// </summary>
+        [Pure]
+        TxId? TxId { get; }
 
         /// <summary>
         /// <see cref="Address"/> of a block miner account.

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -76,7 +76,8 @@ namespace Libplanet.Blockchain
         /// be used for that.</param>
         /// <param name="renderers">Listens state changes on the created chain.  Listens nothing
         /// by default or if it is <c>null</c>.  Note that action renderers receive events made
-        /// by unsuccessful transactions too.</param>
+        /// by unsuccessful transactions too; see also <see cref="AtomicActionRenderer{T}"/> for
+        /// workaround.</param>
         /// <param name="stateStore"><see cref="IStateStore"/> to store states.</param>
         /// <exception cref="InvalidGenesisBlockException">Thrown when the <paramref name="store"/>
         /// has a genesis block and it does not match to what the network expects

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -75,7 +75,8 @@ namespace Libplanet.Blockchain
         /// If the <paramref name="store"/> has no genesis block yet this argument will
         /// be used for that.</param>
         /// <param name="renderers">Listens state changes on the created chain.  Listens nothing
-        /// by default or if it is <c>null</c>.</param>
+        /// by default or if it is <c>null</c>.  Note that action renderers receive events made
+        /// by unsuccessful transactions too.</param>
         /// <param name="stateStore"><see cref="IStateStore"/> to store states.</param>
         /// <exception cref="InvalidGenesisBlockException">Thrown when the <paramref name="store"/>
         /// has a genesis block and it does not match to what the network expects

--- a/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
@@ -1,0 +1,179 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// A middleware to make action render events to satisfy transactions' atomicity.
+    /// <para>Decorates an <see cref="IActionRenderer{T}"/> instance and filters out render events
+    /// made by unsuccessful transactions (i.e., transactions with one or more exception-throwing
+    /// actions).</para>
+    /// </summary>
+    /// <remarks>The wrapped <see cref="ActionRenderer"/> will not receive any
+    /// <see cref="IActionRenderer{T}.RenderActionError"/> and
+    /// <see cref="IActionRenderer{T}.UnrenderActionError"/> events except for block actions,
+    /// which do not belong to any transactions.
+    /// </remarks>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
+    public sealed class AtomicActionRenderer<T> : IActionRenderer<T>
+        where T : IAction, new()
+    {
+        private readonly List<(IAction, IActionContext, IAccountStateDelta)> _eventBuffer;
+        private TxId? _lastTxId;
+        private bool _errored;
+
+        /// <summary>
+        /// Creates a new <see cref="AtomicActionRenderer{T}"/> instance decorating the given
+        /// <paramref name="actionRenderer"/>.
+        /// </summary>
+        /// <param name="actionRenderer">The inner action renderer which has the <em>actual</em>
+        /// implementations and expects to receive no <see cref="RenderActionError"/>/<see
+        /// cref="UnrenderActionError"/> events.</param>
+        public AtomicActionRenderer(IActionRenderer<T> actionRenderer)
+        {
+            ActionRenderer = actionRenderer;
+            _lastTxId = null;
+            _eventBuffer = new List<(IAction, IActionContext, IAccountStateDelta)>();
+            _errored = false;
+        }
+
+        /// <summary>
+        /// The inner action renderer which has the <em>actual</em> implementations and expects to
+        /// receive no <see cref="RenderActionError"/>/<see cref="UnrenderActionError"/> events.
+        /// </summary>
+        public IActionRenderer<T> ActionRenderer { get; }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
+        public void RenderBlock(Block<T> oldTip, Block<T> newTip)
+        {
+            FlushBuffer(null, ActionRenderer.UnrenderAction);
+            ActionRenderer.RenderBlock(oldTip, newTip);
+        }
+
+        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block{T}, Block{T})"/>
+        public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip)
+        {
+            FlushBuffer(null, ActionRenderer.RenderAction);
+            ActionRenderer.RenderBlockEnd(oldTip, newTip);
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
+        public void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
+        {
+            ActionRenderer.RenderReorg(oldTip, newTip, branchpoint);
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorgEnd(Block{T}, Block{T}, Block{T})"/>
+        public void RenderReorgEnd(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
+        {
+            ActionRenderer.RenderReorgEnd(oldTip, newTip, branchpoint);
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        )
+        {
+            if (!context.TxId.Equals(_lastTxId))
+            {
+                FlushBuffer(context.TxId, ActionRenderer.RenderAction);
+            }
+
+            if (context.TxId is null)
+            {
+                ActionRenderer.RenderAction(action, context, nextStates);
+            }
+            else if (!_errored)
+            {
+                _eventBuffer.Add((action, context, nextStates));
+            }
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        )
+        {
+            if (!context.TxId.Equals(_lastTxId))
+            {
+                FlushBuffer(context.TxId, ActionRenderer.UnrenderAction);
+            }
+
+            if (context.TxId is null)
+            {
+                ActionRenderer.UnrenderAction(action, context, nextStates);
+            }
+            else if (!_errored)
+            {
+                _eventBuffer.Add((action, context, nextStates));
+            }
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        public void RenderActionError(IAction action, IActionContext context, Exception exception)
+        {
+            if (!context.TxId.Equals(_lastTxId))
+            {
+                FlushBuffer(context.TxId, ActionRenderer.RenderAction);
+            }
+
+            if (context.TxId is null)
+            {
+                ActionRenderer.RenderActionError(action, context, exception);
+            }
+            else
+            {
+                _errored = true;
+            }
+        }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
+        {
+            if (!context.TxId.Equals(_lastTxId))
+            {
+                FlushBuffer(context.TxId, ActionRenderer.UnrenderAction);
+            }
+
+            if (context.TxId is null)
+            {
+                ActionRenderer.RenderActionError(action, context, exception);
+            }
+            else
+            {
+                _errored = true;
+            }
+        }
+
+        private void FlushBuffer(
+            TxId? newTxId,
+            Action<IAction, IActionContext, IAccountStateDelta> render
+        )
+        {
+            if (!_errored)
+            {
+                foreach (var (act, ctx, delta) in _eventBuffer)
+                {
+                    render(act, ctx, delta);
+                }
+            }
+
+            _lastTxId = newTxId;
+            _errored = false;
+            _eventBuffer.Clear();
+        }
+    }
+}

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -274,6 +274,7 @@ namespace Libplanet.Blockchain.Renderers
                 _bufferedActionUnrenders);
         }
 
+        /// <inheritdoc cref="IRenderer{T}.RenderReorgEnd(Block{T}, Block{T}, Block{T})"/>
         public override void RenderReorgEnd(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint)
         {
             base.RenderReorgEnd(oldTip, newTip, branchpoint);

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -40,6 +40,9 @@ namespace Libplanet.Blockchain.Renderers
     /// which means actions are rendered <em>even before</em> whether there are any actions throwing
     /// an exception in the same transaction is determined.  In other words, for <see
     /// cref="IActionRenderer{T}"/>s, it is not guaranteed that actions in a transaction are atomic.
+    /// <para>If your action renderer expects to receive only render events about actions belonging
+    /// successful transactions, wrap your action renderer with
+    /// <see cref="AtomicActionRenderer{T}"/>.</para>
     /// </remarks>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
     /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -2,6 +2,8 @@
 using System;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Renderers
 {
@@ -30,6 +32,15 @@ namespace Libplanet.Blockchain.Renderers
     /// (one time)</description></item>
     /// </list>
     /// </summary>
+    /// <remarks>Although <see cref="Transaction{T}"/>s affect the states in
+    /// the <see cref="IStateStore"/> all or nothing at all (i.e., atomically),
+    /// <see cref="IActionRenderer{T}"/> receives all action-related events
+    /// (<see cref="RenderAction"/>/<see cref="RenderActionError"/>/<see cref="UnrenderAction"
+    /// />/<see cref="UnrenderActionError"/>) <em>immediately</em> without buffering,
+    /// which means actions are rendered <em>even before</em> whether there are any actions throwing
+    /// an exception in the same transaction is determined.  In other words, for <see
+    /// cref="IActionRenderer{T}"/>s, it is not guaranteed that actions in a transaction are atomic.
+    /// </remarks>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
     /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
     public interface IActionRenderer<T> : IRenderer<T>

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -587,8 +587,7 @@ namespace Libplanet.Tx
         /// a unconsumed state.
         /// </returns>
         [Pure]
-        public IEnumerable<ActionEvaluation>
-        EvaluateActionsGradually(
+        public IEnumerable<ActionEvaluation> EvaluateActionsGradually(
             BlockHash blockHash,
             long blockIndex,
             IAccountStateDelta previousStates,


### PR DESCRIPTION
This addresses fixes <https://github.com/planetarium/libplanet/issues/1267>.

Previously, `Transaction<T>.Actions` had been executed and affected states whether the actions throw an exception or not.  However, as the term “transaction” in computer science in general imply it's atomic (i.e., executed all or nothing), this behavior had been quite misleading.

This patch regards such previous behavior as a bug, and fixes it so that if any action in a `Transaction<T>` throws an exception all actions in the transaction do not commit any state changes to the current `IStore`.

However, there is still a quirk for it: `IActionRenderer<T>` receives render events caused by unsuccessful transactions too, as it has done.  In other words, transactions' atomicity still is not guaranteed for action renderers.  In order to work around this quirk, this patch introduces `AtomicActionRenderer<T>` as well.  If an `IActionRenderer<T>` is wrapped by `AtomicActionRenderer<T>` the inner action renderer will receive no `RenderActionError()`/`UnrenderActionError()` events except for block actions (since they do not belong to any transactions).

The reasons why I stick with the existing behavior for action renderers are:

- Ignoring render events from unsuccessful transactions making the current shape of `IActionRenderer<T>` no more natural.  Because `RenderActionError()`/`UnrenderActionError()` methods are no more necessary.
- However, changing the interface breaks backward compatibility.  In particular, `IActionRenderer<T>` is one of the key interfaces game app programmers must implement.  For example, such change on the interface would require many changes on [Nine Chronicles](https://nine-chronicles.com/).
- We may eventually need to refactor the interface when we implement <https://github.com/planetarium/libplanet/issues/1156>.

For details, please read the added changelogs and XML doc comments too.