### PR TITLE
Enforce AsyncIO in NetMQTransport instead of Swarm<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,8 +147,13 @@ To be released.
 
  -  `ITransport.StartAsync()` and `ITransport.RunAsync()` became to throw
     `TransportException` instead of `SwarmException`.  [[#1242]]
- -  `NetMQTransport` became to enforce `ForceDotNet.Force()` in [AsyncIO]
-    while it's running on Mono runtime instead of `Swarm<T>`.
+ -  `NetMQTransport` became to enforce NetMQ/[AsyncIO] to use its pure .NET
+    implementation instead of Windows'
+    <abbr title="input/output completion port">IOCP</abbr> when it is running
+    on Mono, which powers Unity engine, since Unity does not properly
+    implement the IOCP even on Windows.
+    It had been done by `Swarm<T>`, but as the `ITransport` is now separated
+    from it, this became done by `NetMQTransport` instead of `Swarm<T>`.
     [[#247], [#1278]]
 
 ### Bug fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,9 @@ To be released.
 
  -  `ITransport.StartAsync()` and `ITransport.RunAsync()` became to throw
     `TransportException` instead of `SwarmException`.  [[#1242]]
+ -  `NetMQTransport` became to enforce `ForceDotNet.Force()` in [AsyncIO]
+    while it's running on Mono runtime instead of `Swarm<T>`.
+    [[#247], [#1278]]
 
 ### Bug fixes
 
@@ -160,6 +163,8 @@ To be released.
     hadn't worked idempotently.  [[#1272]]
  -  (Libplanet.RocksDBStore) Fixed a bug where `RocksDBStore.Dispose()` and
     `RocksDBKeyValueStore.Dispose()` hadn't worked idempotently.  [[#1272]]
+ -  Fixed a bug where `NetMQTransport` had hung forever within Mono runtime.
+    [[#1278]]
 
 ### CLI tools
 
@@ -185,6 +190,7 @@ To be released.
 [#1268]: https://github.com/planetarium/libplanet/pull/1268
 [#1272]: https://github.com/planetarium/libplanet/pull/1272
 [#1274]: https://github.com/planetarium/libplanet/pull/1274
+[#1278]: https://github.com/planetarium/libplanet/pull/1278
 
 
 Version 0.11.1

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using AsyncIO;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
@@ -42,14 +41,6 @@ namespace Libplanet.Net
         private ConcurrentDictionary<TxId, BoundPeer> _demandTxIds;
 
         private bool _disposed;
-
-        static Swarm()
-        {
-            if (!(Type.GetType("Mono.Runtime") is null))
-            {
-                ForceDotNet.Force();
-            }
-        }
 
         /// <summary>
         /// Creates a <see cref="Swarm{T}"/>.  This constructor in only itself does not start

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using AsyncIO;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
@@ -68,6 +69,14 @@ namespace Libplanet.Net.Transports
         private DifferentAppProtocolVersionEncountered _differentAppProtocolVersionEncountered;
 
         private bool _disposed;
+
+        static NetMQTransport()
+        {
+            if (!(Type.GetType("Mono.Runtime") is null))
+            {
+                ForceDotNet.Force();
+            }
+        }
 
         /// <summary>
         /// Creates <see cref="NetMQTransport"/> instance.


### PR DESCRIPTION
This PR enforces AsyncIO in `NetMQTransport`, instead of `Swarm<T>` to fix a bug where `NetMQTransport` had hung in Mono runtime without `Swarm<T>`.