### PR TITLE
Introduce TCP based transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,12 @@
 **/.idea/**/dynamic.xml
 
 # Rider
-# Rider auto-generates .iml files, contentModel.xml, and projectSettingsUpdater.xml
+# Rider auto-generates .iml files, contentModel.xml, projectSettingsUpdater.xml, and indexLayout.xml
 **/.idea/**/*.iml
 **/.idea/**/contentModel.xml
 **/.idea/**/modules.xml
 **/.idea/**/projectSettingsUpdater.xml
+**/.idea/**/indexLayout.xml
 
 *.suo
 *.user

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,17 +8,37 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `ITransport.RunAsync()` method.
+    `ITransport.StartAsync()` now conducts operation that
+    `ITransport.RunAsync()` used to conduct.  [[#1288]]
+ -  Removed `ITransport.ReplyMessage()` method which was non-blocking.
+    Instead, added `ITransport.ReplyMessageAsync()` asynchronous method
+    which is awaited until the reply message is sent.  [[#1288]]
+ -  The type of `ITransport.ProcessMessageHandler` became
+    `AsyncDelegate<T>` (which was `EventHandler`).  [[#1288]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
 
+ -  Added `ITransport.MessageHistory` property.  [[#1288]]
+ -  Added `ITransport.WaitForRunning()` method.  [[#1288]]
+ -  Added `TcpTransport` class which implements `ITransport` interface.
+    [[#1288]]
+ -  Added `SwarmOptions.Type` property.  [[#1288]]
+ -  Added `SwarmOptions.TransportType` enum.  [[#1288]]
+ -  Added `AsyncDelegate<T>` class.  [[#1288]]
+ -  Added `InvalidMagicCookieException` class.  [[#1288]]
+
 ### Behavioral changes
 
 ### Bug fixes
 
 ### CLI tools
+
+[#1288]: https://github.com/planetarium/libplanet/pull/1288
 
 
 Version 0.13.0

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
 using global::Cocona;
@@ -280,7 +281,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         }
 
         [Command(Description = "Query app protocol version (a.k.a. APV) of target node.")]
-        public void Query(
+        public async Task Query(
             [Argument(
                 Name = "TARGET",
 #pragma warning disable MEN002 // Line is too long
@@ -302,7 +303,7 @@ namespace Libplanet.Extensions.Cocona.Commands
 
             try
             {
-                apv = peer.QueryAppProtocolVersion();
+                apv = await peer.QueryAppProtocolVersionTcp();
             }
             catch
             {

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -194,5 +194,33 @@ namespace Libplanet.Tests.Net.Messages
                     TimeSpan.FromSeconds(1));
             });
         }
+
+        [Fact]
+        public void Serialize()
+        {
+            var privateKey = new PrivateKey();
+            var peer = new Peer(privateKey.PublicKey);
+            var dateTimeOffset = DateTimeOffset.UtcNow;
+            var appProtocolVersion = new AppProtocolVersion(
+                1,
+                new Bencodex.Types.Integer(0),
+                ImmutableArray<byte>.Empty,
+                default(Address));
+            var message = new Ping();
+            var id = Guid.NewGuid();
+            message.Identity = id.ToByteArray();
+            byte[] serialized =
+                message.Serialize(privateKey, peer, dateTimeOffset, appProtocolVersion);
+            Message deserialized = Message.Deserialize(
+                serialized,
+                appProtocolVersion,
+                null,
+                null,
+                null);
+            Assert.Equal(peer, deserialized.Remote);
+            Assert.Equal(appProtocolVersion, deserialized.Version);
+            Assert.Equal(dateTimeOffset, deserialized.Timestamp);
+            Assert.Equal(id.ToByteArray(), deserialized.Identity);
+        }
     }
 }

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -191,7 +191,7 @@ namespace Libplanet.Tests.Net.Messages
                     validAppProtocolVersion,
                     ImmutableHashSet<PublicKey>.Empty,
                     null,
-                    TimeSpan.FromSeconds(1));
+                    TimeSpan.FromSeconds(5));
             });
         }
 

--- a/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
+++ b/Libplanet.Tests/Net/Protocols/ProtocolTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -58,7 +59,7 @@ namespace Libplanet.Tests.Net.Protocols
             var transportA = CreateTestTransport();
             var transportB = CreateTestTransport();
 
-            Assert.Throws<SwarmException>(() => transportA.SendPing(transportB.AsPeer));
+            Assert.Throws<TransportException>(() => transportA.SendPing(transportB.AsPeer));
             await StartTestTransportAsync(transportA);
             await Assert.ThrowsAsync<TimeoutException>(() =>
                 transportA.AddPeersAsync(
@@ -148,9 +149,9 @@ namespace Libplanet.Tests.Net.Protocols
 
             Assert.Contains(transportB.AsPeer, transportA.Peers);
 
-            await transportA.StopAsync(TimeSpan.Zero);
-            await transportB.StopAsync(TimeSpan.Zero);
-            await transportC.StopAsync(TimeSpan.Zero);
+            transportA.Dispose();
+            transportB.Dispose();
+            transportC.Dispose();
         }
 
         [Fact(Timeout = Timeout)]
@@ -159,12 +160,15 @@ namespace Libplanet.Tests.Net.Protocols
             var transportA = CreateTestTransport();
             var transportB = CreateTestTransport();
 
-            await Assert.ThrowsAsync<SwarmException>(
+            await Assert.ThrowsAsync<TransportException>(
                 () => transportB.BootstrapAsync(
                     new[] { transportA.AsPeer },
                     TimeSpan.FromSeconds(3),
                     TimeSpan.FromSeconds(3))
             );
+
+            transportA.Dispose();
+            transportB.Dispose();
         }
 
         [Fact(Timeout = Timeout)]
@@ -198,9 +202,9 @@ namespace Libplanet.Tests.Net.Protocols
             }
             finally
             {
-                await transportA.StopAsync(TimeSpan.Zero);
-                await transportB.StopAsync(TimeSpan.Zero);
-                await transportC.StopAsync(TimeSpan.Zero);
+                transportA.Dispose();
+                transportB.Dispose();
+                transportC.Dispose();
             }
         }
 
@@ -220,7 +224,9 @@ namespace Libplanet.Tests.Net.Protocols
             await Task.Delay(100);
             await transportA.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
             Assert.Empty(transportA.Peers);
-            await transportA.StopAsync(TimeSpan.Zero);
+
+            transportA.Dispose();
+            transportB.Dispose();
         }
 
         [Fact(Timeout = Timeout)]
@@ -245,10 +251,10 @@ namespace Libplanet.Tests.Net.Protocols
             Assert.DoesNotContain(transportB.AsPeer, transport.Peers);
             Assert.DoesNotContain(transportC.AsPeer, transport.Peers);
 
-            await transport.StopAsync(TimeSpan.Zero);
-            await transportA.StopAsync(TimeSpan.Zero);
-            await transportB.StopAsync(TimeSpan.Zero);
-            await transportC.StopAsync(TimeSpan.Zero);
+            transport.Dispose();
+            transportA.Dispose();
+            transportB.Dispose();
+            transportC.Dispose();
         }
 
         [Fact(Timeout = Timeout)]
@@ -282,9 +288,10 @@ namespace Libplanet.Tests.Net.Protocols
             Assert.Contains(transportB.AsPeer, transport.Peers);
             Assert.DoesNotContain(transportC.AsPeer, transport.Peers);
 
-            await transport.StopAsync(TimeSpan.Zero);
-            await transportB.StopAsync(TimeSpan.Zero);
-            await transportC.StopAsync(TimeSpan.Zero);
+            transport.Dispose();
+            transportA.Dispose();
+            transportB.Dispose();
+            transportC.Dispose();
         }
 
         [Fact(Timeout = Timeout)]
@@ -319,8 +326,10 @@ namespace Libplanet.Tests.Net.Protocols
             Assert.DoesNotContain(transportB.AsPeer, transport.Peers);
             Assert.Contains(transportC.AsPeer, transport.Peers);
 
-            await transport.StopAsync(TimeSpan.Zero);
-            await transportC.StopAsync(TimeSpan.Zero);
+            transport.Dispose();
+            transportA.Dispose();
+            transportB.Dispose();
+            transportC.Dispose();
         }
 
         [Theory(Timeout = 2 * Timeout)]
@@ -358,10 +367,11 @@ namespace Libplanet.Tests.Net.Protocols
             }
             finally
             {
+                seed.Dispose();
                 foreach (var transport in transports)
                 {
                     Assert.True(transport.ReceivedTestMessageOfData("foo"));
-                    await transport.StopAsync(TimeSpan.Zero);
+                    transport.Dispose();
                 }
             }
         }
@@ -449,9 +459,9 @@ namespace Libplanet.Tests.Net.Protocols
             }
             finally
             {
-                await seed.StopAsync(TimeSpan.Zero);
-                await t1.StopAsync(TimeSpan.Zero);
-                await t2.StopAsync(TimeSpan.Zero);
+                seed.Dispose();
+                t1.Dispose();
+                t2.Dispose();
             }
         }
 
@@ -480,9 +490,9 @@ namespace Libplanet.Tests.Net.Protocols
             }
             finally
             {
-                await transportA.StopAsync(TimeSpan.Zero);
-                await transportB.StopAsync(TimeSpan.Zero);
-                await transportC.StopAsync(TimeSpan.Zero);
+                transportA.Dispose();
+                transportB.Dispose();
+                transportC.Dispose();
             }
         }
 
@@ -532,14 +542,12 @@ namespace Libplanet.Tests.Net.Protocols
             }
             finally
             {
-                await transport.StopAsync(TimeSpan.Zero);
+                transport.Dispose();
                 foreach (var t in transports)
                 {
-                    await t.StopAsync(TimeSpan.Zero);
+                    t.Dispose();
                 }
             }
-
-            Assert.True(true);
         }
 
         private TestTransport CreateTestTransport(
@@ -558,12 +566,12 @@ namespace Libplanet.Tests.Net.Protocols
                 networkDelay);
         }
 
-        private async Task<Task> StartTestTransportAsync(
+        private async Task StartTestTransportAsync(
             TestTransport transport,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            await transport.StartAsync(cancellationToken);
-            return transport.RunAsync(cancellationToken);
+            _ = transport.StartAsync(cancellationToken);
+            await transport.WaitForRunningAsync();
         }
     }
 }

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -61,6 +61,7 @@ namespace Libplanet.Tests.Net.Protocols
             _random = new Random();
             Table = new RoutingTable(Address, tableSize, bucketSize);
             Protocol = new KademliaProtocol(Table, this, Address);
+            MessageHistory = new FixedSizedQueue<Message>(30);
         }
 
         public event EventHandler<Message> ProcessMessageHandler;
@@ -78,6 +79,8 @@ namespace Libplanet.Tests.Net.Protocols
         public DateTimeOffset? LastMessageTimestamp { get; private set; }
 
         public bool Running => !(_swarmCancellationTokenSource is null);
+
+        public ConcurrentQueue<Message> MessageHistory { get; }
 
         internal ConcurrentBag<Message> ReceivedMessages { get; }
 
@@ -117,6 +120,11 @@ namespace Libplanet.Tests.Net.Protocols
             _logger.Debug("Stopping transport of {Peer}.", AsPeer);
             _swarmCancellationTokenSource.Cancel();
             await Task.Delay(waitFor, cancellationToken);
+        }
+
+        public Task WaitForRunningAsync()
+        {
+            return Task.CompletedTask;
         }
 
         public async Task BootstrapAsync(
@@ -353,6 +361,7 @@ namespace Libplanet.Tests.Net.Protocols
                     message.Identity);
                 LastMessageTimestamp = DateTimeOffset.UtcNow;
                 ReceivedMessages.Add(reply);
+                MessageHistory.Enqueue(reply);
                 MessageReceived.Set();
                 return reply;
             }
@@ -433,6 +442,7 @@ namespace Libplanet.Tests.Net.Protocols
                 throw new ArgumentException("Sender of message is not a BoundPeer.");
             }
 
+            MessageHistory.Enqueue(message);
             if (message is TestMessage testMessage)
             {
                 if (_ignoreTestMessageWithData.Contains(testMessage.Data))

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -32,8 +32,10 @@ namespace Libplanet.Tests.Net.Protocols
         private readonly Random _random;
         private readonly bool _blockBroadcast;
 
+        private TaskCompletionSource<object> _runningEvent;
         private CancellationTokenSource _swarmCancellationTokenSource;
         private TimeSpan _networkDelay;
+        private bool _disposed;
 
         public TestTransport(
             Dictionary<Address, TestTransport> transports,
@@ -43,6 +45,7 @@ namespace Libplanet.Tests.Net.Protocols
             int bucketSize,
             TimeSpan? networkDelay)
         {
+            _runningEvent = new TaskCompletionSource<object>();
             _privateKey = privateKey;
             _blockBroadcast = blockBroadcast;
             var loggerId = _privateKey.ToAddress().ToHex();
@@ -60,11 +63,12 @@ namespace Libplanet.Tests.Net.Protocols
             _ignoreTestMessageWithData = new List<string>();
             _random = new Random();
             Table = new RoutingTable(Address, tableSize, bucketSize);
+            ProcessMessageHandler = new AsyncDelegate<Message>();
             Protocol = new KademliaProtocol(Table, this, Address);
             MessageHistory = new FixedSizedQueue<Message>(30);
         }
 
-        public event EventHandler<Message> ProcessMessageHandler;
+        public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         public AsyncAutoResetEvent MessageReceived { get; }
 
@@ -78,7 +82,22 @@ namespace Libplanet.Tests.Net.Protocols
 
         public DateTimeOffset? LastMessageTimestamp { get; private set; }
 
-        public bool Running => !(_swarmCancellationTokenSource is null);
+        public bool Running
+        {
+            get => _runningEvent.Task.Status == TaskStatus.RanToCompletion;
+
+            private set
+            {
+                if (value)
+                {
+                    _runningEvent.TrySetResult(null);
+                }
+                else
+                {
+                    _runningEvent = new TaskCompletionSource<object>();
+                }
+            }
+        }
 
         public ConcurrentQueue<Message> MessageHistory { get; }
 
@@ -90,26 +109,31 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void Dispose()
         {
+            if (!_disposed)
+            {
+                _swarmCancellationTokenSource?.Cancel();
+                Running = false;
+                _disposed = true;
+            }
         }
 
-#pragma warning disable CS1998 // Method need to implement ITransport but it isn't be async
         public async Task StartAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             _logger.Debug("Starting transport of {Peer}.", AsPeer);
             _swarmCancellationTokenSource = new CancellationTokenSource();
-        }
-#pragma warning restore CS1998
-
-        public async Task RunAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
             CancellationToken token = cancellationToken.Equals(CancellationToken.None)
                 ? _swarmCancellationTokenSource.Token
                 : CancellationTokenSource
                     .CreateLinkedTokenSource(
                         _swarmCancellationTokenSource.Token, cancellationToken)
                     .Token;
+            Running = true;
             await ProcessRuntime(token);
         }
 
@@ -117,15 +141,23 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan waitFor,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            _logger.Debug("Stopping transport of {Peer}.", AsPeer);
-            _swarmCancellationTokenSource.Cancel();
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
+            if (Running)
+            {
+                _logger.Debug("Stopping transport of {Peer}.", AsPeer);
+                _swarmCancellationTokenSource.Cancel();
+                Running = false;
+            }
+
             await Task.Delay(waitFor, cancellationToken);
         }
 
-        public Task WaitForRunningAsync()
-        {
-            return Task.CompletedTask;
-        }
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
+        public Task WaitForRunningAsync() => _runningEvent.Task;
 
         public async Task BootstrapAsync(
             IEnumerable<Peer> bootstrapPeers,
@@ -134,6 +166,11 @@ namespace Libplanet.Tests.Net.Protocols
             int depth = 3,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             IEnumerable<BoundPeer> peers = bootstrapPeers.OfType<BoundPeer>();
 
             await BootstrapAsync(
@@ -152,9 +189,14 @@ namespace Libplanet.Tests.Net.Protocols
             int depth = 3,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (bootstrapPeers is null)
@@ -185,9 +227,14 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (peers is null)
@@ -247,9 +294,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void SendPing(Peer target, TimeSpan? timeSpan = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (!(target is BoundPeer boundPeer))
@@ -268,9 +320,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void BroadcastTestMessage(Address? except, string data)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             var message = new TestMessage(data) { Remote = AsPeer };
@@ -280,6 +337,11 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void BroadcastMessage(Address? except, Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             var peers = Table.PeersToBroadcast(except);
             var peersString = string.Join(", ", peers.Select(peer => peer.Address));
             _logger.Debug(
@@ -305,9 +367,14 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (!(peer is BoundPeer boundPeer))
@@ -390,9 +457,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             _logger.Debug("Replying {Message}...", message);
@@ -406,9 +478,14 @@ namespace Libplanet.Tests.Net.Protocols
             string data,
             CancellationToken token = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             while (!token.IsCancellationRequested && !ReceivedTestMessageOfData(data))
@@ -419,9 +496,9 @@ namespace Libplanet.Tests.Net.Protocols
 
         public bool ReceivedTestMessageOfData(string data)
         {
-            if (!Running)
+            if (_disposed)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new ObjectDisposedException(nameof(TestTransport));
             }
 
             return ReceivedMessages.OfType<TestMessage>().Any(msg => msg.Data == data);
@@ -462,20 +539,9 @@ namespace Libplanet.Tests.Net.Protocols
                 _peersToReply[message.Identity] = boundPeer.Address;
             }
 
-            if (message is Ping)
-            {
-                _ = ReplyMessageAsync(
-                    new Pong
-                    {
-                        Identity = message.Identity,
-                        Remote = AsPeer,
-                    },
-                    default);
-            }
-
             LastMessageTimestamp = DateTimeOffset.UtcNow;
             ReceivedMessages.Add(message);
-            ProcessMessageHandler?.Invoke(this, message);
+            _ = ProcessMessageHandler.InvokeAsync(message);
             MessageReceived.Set();
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Tests.Net
                 await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
                 Block<DumbAction> block = await seedChain.MineBlock(seedSwarm.Address);
                 seedSwarm.BroadcastBlock(block);
-                while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
+                while (receiverSwarm.Transport.MessageHistory
                     .Any(msg => msg is BlockHeaderMessage))
                 {
                     await Task.Delay(100);

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -279,6 +279,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
 
                 await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                Assert.Contains(swarmC.AsPeer, swarmA.Peers);
+                Assert.Contains(swarmA.AsPeer, swarmC.Peers);
 
                 for (var i = 0; i < 100; i++)
                 {

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -122,8 +122,15 @@ namespace Libplanet.Tests.Net
                 options);
             _finalizers.Add(async () =>
             {
-                await StopAsync(swarm);
-                swarm.Dispose();
+                try
+                {
+                    await StopAsync(swarm);
+                    swarm.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                    _logger.Debug("Swarm {Swarm} is already disposed.", swarm);
+                }
             });
             return swarm;
         }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1582,7 +1582,7 @@ namespace Libplanet.Tests.Net
 
                 // Awaits 1 second because receiver swarm may tried to fill again after filled.
                 await Task.Delay(1000);
-                var transport = receiver.Transport as NetMQTransport;
+                var transport = receiver.Transport;
                 Log.Debug("Messages: {@Message}", transport.MessageHistory);
                 Assert.Single(
                     transport.MessageHistory.Where(msg => msg is Libplanet.Net.Messages.Blocks));

--- a/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
@@ -15,8 +15,10 @@ namespace Libplanet.Tests.Net.Transports
 {
     public class BoundPeerExtensionsTest
     {
-        [Fact(Timeout = 60 * 1000)]
-        public async Task QueryAppProtocolVersion()
+        [Theory(Timeout = 60 * 1000)]
+        [InlineData(SwarmOptions.TransportType.NetMQTransport)]
+        [InlineData(SwarmOptions.TransportType.TcpTransport)]
+        public async Task QueryAppProtocolVersion(SwarmOptions.TransportType transportType)
         {
             var fx = new DefaultStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
@@ -28,12 +30,18 @@ namespace Libplanet.Tests.Net.Transports
             string host = IPAddress.Loopback.ToString();
             int port = FreeTcpPort();
 
+            var option = new SwarmOptions
+            {
+                Type = transportType,
+            };
+
             using (var swarm = new Swarm<DumbAction>(
                 blockchain,
                 swarmKey,
                 apv,
                 host: host,
-                listenPort: port))
+                listenPort: port,
+                options: option))
             {
                 var peer = new BoundPeer(swarmKey.PublicKey, new DnsEndPoint(host, port));
                 // Before swarm starting...

--- a/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
@@ -9,12 +9,13 @@ using Libplanet.Net.Transports;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Libplanet.Tests.Net.Transports
 {
     public class BoundPeerExtensionsTest
     {
-        [Fact]
+        [Fact(Timeout = 60 * 1000)]
         public async Task QueryAppProtocolVersion()
         {
             var fx = new DefaultStoreFixture();
@@ -43,7 +44,21 @@ namespace Libplanet.Tests.Net.Transports
                 _ = swarm.StartAsync();
                 try
                 {
-                    AppProtocolVersion receivedAPV = peer.QueryAppProtocolVersion();
+                    AppProtocolVersion receivedAPV = default;
+                    if (swarm.Transport is NetMQTransport)
+                    {
+                        receivedAPV = peer.QueryAppProtocolVersion();
+                    }
+                    else if (swarm.Transport is TcpTransport)
+                    {
+                        receivedAPV = await peer.QueryAppProtocolVersionTcp();
+                    }
+                    else
+                    {
+                        throw new XunitException(
+                            "Each type of transport must have corresponding test case.");
+                    }
+
                     Assert.Equal(apv, receivedAPV);
                 }
                 finally

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -63,10 +63,11 @@ namespace Libplanet.Tests.Net.Transports
             var transportB = CreateNetMQTransport();
 
             var messageReceived = new AsyncAutoResetEvent();
-            transportB.ProcessMessageHandler += (sender, message) =>
+            transportB.ProcessMessageHandler.Register(async message =>
             {
                 messageReceived.Set();
-            };
+                await Task.Yield();
+            });
 
             try
             {

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -52,8 +52,8 @@ namespace Libplanet.Tests.Net.Transports
                 .Enrich.WithThreadId()
                 .WriteTo.TestOutput(testOutputHelper, outputTemplate: outputTemplate)
                 .CreateLogger()
-                .ForContext<TransportTest>();
-            Logger = Log.ForContext<TransportTest>();
+                .ForContext<NetMQTransportTest>();
+            Logger = Log.ForContext<NetMQTransportTest>();
         }
 
         [SkippableFact(Timeout = Timeout, Skip = "Target method is broken.")]

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -9,6 +9,7 @@ using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
+using NetMQ;
 using Nito.AsyncEx;
 using Serilog;
 using Xunit;
@@ -16,7 +17,8 @@ using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Net.Transports
 {
-    public class NetMQTransportTest : TransportTest
+    [Collection("NetMQConfiguration")]
+    public class NetMQTransportTest : TransportTest, IDisposable
     {
         public NetMQTransportTest(ITestOutputHelper testOutputHelper)
         {
@@ -54,6 +56,11 @@ namespace Libplanet.Tests.Net.Transports
                 .CreateLogger()
                 .ForContext<NetMQTransportTest>();
             Logger = Log.ForContext<NetMQTransportTest>();
+        }
+
+        public void Dispose()
+        {
+            NetMQConfig.Cleanup(false);
         }
 
         [SkippableFact(Timeout = Timeout, Skip = "Target method is broken.")]

--- a/Libplanet.Tests/Net/Transports/TcpTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TcpTransportTest.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Net.Transports
+{
+    public class TcpTransportTest : TransportTest
+    {
+        public TcpTransportTest(ITestOutputHelper testOutputHelper)
+        {
+            TransportConstructor = CreateTcpTransport;
+
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffff}[{ThreadId}] - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(testOutputHelper, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<TransportTest>();
+            Logger = Log.ForContext<TransportTest>();
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task ReadWriteMessageWithInvalidMagicCookieAsync()
+        {
+            byte[] invalidCookie = { 0x01, 0x02 };
+            Assert.False(TcpTransport.MagicCookie.SequenceEqual(invalidCookie));
+
+            var listener = new TcpListener(IPAddress.Any, 0);
+            listener.Start();
+            var client = new TcpClient();
+            await client.ConnectAsync("127.0.0.1", ((IPEndPoint)listener.LocalEndpoint).Port);
+            TcpClient listenerSocket = await listener.AcceptTcpClientAsync();
+
+            AppProtocolVersion version = AppProtocolVersion.Sign(new PrivateKey(), 1);
+            TcpTransport transport = CreateTcpTransport(appProtocolVersion: version);
+            try
+            {
+                var message = new Ping
+                {
+                    Identity = Guid.NewGuid().ToByteArray(),
+                };
+
+                byte[] serialized = message.Serialize(
+                    new PrivateKey(),
+                    transport.AsPeer,
+                    DateTimeOffset.UtcNow,
+                    version);
+                int length = serialized.Length;
+                var buffer = new byte[invalidCookie.Length + sizeof(int) + length];
+                invalidCookie.CopyTo(buffer, 0);
+                BitConverter.GetBytes(length).CopyTo(buffer, invalidCookie.Length);
+                serialized.CopyTo(buffer, invalidCookie.Length + sizeof(int));
+                NetworkStream stream = client.GetStream();
+                await stream.WriteAsync(buffer, 0, buffer.Length, default);
+                await Assert.ThrowsAsync<InvalidMagicCookieException>(
+                    async () => await transport.ReadMessageAsync(listenerSocket, default));
+
+                byte[] shortBuffer = { 0x00 };
+                await stream.WriteAsync(shortBuffer, 0, shortBuffer.Length, default);
+                await Assert.ThrowsAsync<InvalidMagicCookieException>(
+                    async () => await transport.ReadMessageAsync(listenerSocket, default));
+            }
+            finally
+            {
+                listenerSocket.Dispose();
+                client.Dispose();
+            }
+        }
+
+        private TcpTransport CreateTcpTransport(
+            PrivateKey privateKey = null,
+            int tableSize = 160,
+            int bucketSize = 16,
+            AppProtocolVersion appProtocolVersion = default,
+            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners = null,
+            string host = null,
+            int? listenPort = null,
+            IEnumerable<IceServer> iceServers = null,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
+            int minimumBroadcastTarget = 10,
+            TimeSpan? messageLifespan = null
+        )
+        {
+            privateKey = privateKey ?? new PrivateKey();
+            host = host ?? IPAddress.Loopback.ToString();
+            trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners ??
+                                               ImmutableHashSet<PublicKey>.Empty;
+            iceServers = iceServers ?? new IceServer[] { };
+            var table = new RoutingTable(privateKey.ToAddress(), tableSize, bucketSize);
+
+            return CreateTcpTransport(
+                table,
+                privateKey,
+                appProtocolVersion,
+                trustedAppProtocolVersionSigners,
+                host,
+                listenPort,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                minimumBroadcastTarget,
+                messageLifespan);
+        }
+
+        private TcpTransport CreateTcpTransport(
+            RoutingTable table,
+            PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
+            string host,
+            int? listenPort,
+            IEnumerable<IceServer> iceServers,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
+            int minimumBroadcastTarget,
+            TimeSpan? messageLifespan
+        )
+        {
+            return new TcpTransport(
+                table,
+                privateKey,
+                appProtocolVersion,
+                trustedAppProtocolVersionSigners,
+                host,
+                listenPort,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                minimumBroadcastTarget,
+                messageLifespan);
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
@@ -343,11 +344,16 @@ namespace Libplanet.Tests.Net.Transports
             try
             {
                 await InitializeAsync(transport);
+                // Make sure the tcp port is invalid.
+                var l = new TcpListener(IPAddress.Loopback, 0);
+                l.Start();
+                int port = ((IPEndPoint)l.LocalEndpoint).Port;
+                l.Stop();
                 var peer = new BoundPeer(
                     new PrivateKey().PublicKey,
                     new DnsEndPoint(
                         "0.0.0.0",
-                        ((BoundPeer)transport.AsPeer).EndPoint.Port + 1));
+                        port));
                 Task task = transport.SendMessageWithReplyAsync(
                     peer,
                     new Ping(),

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -98,8 +98,8 @@ namespace Libplanet.Tests.Net.Transports
                         default));
                 Assert.Throws<ObjectDisposedException>(
                     () => transport.BroadcastMessage(null, message));
-                Assert.Throws<ObjectDisposedException>(
-                    () => transport.ReplyMessage(message));
+                await Assert.ThrowsAsync<ObjectDisposedException>(
+                    async () => await transport.ReplyMessageAsync(message, default));
 
                 // To check multiple Dispose() throws error or not.
                 transport.Dispose();
@@ -187,7 +187,7 @@ namespace Libplanet.Tests.Net.Transports
             }
         }
 
-        // This also tests ITransport.ReplyMessage at the same time.
+        // This also tests ITransport.ReplyMessageAsync at the same time.
         [SkippableFact(Timeout = Timeout)]
         public async Task SendMessageWithReplyAsync()
         {
@@ -198,10 +198,12 @@ namespace Libplanet.Tests.Net.Transports
             {
                 if (message is Ping)
                 {
-                    transportB.ReplyMessage(new Pong
-                    {
-                        Identity = message.Identity,
-                    });
+                    _ = transportB.ReplyMessageAsync(
+                        new Pong
+                        {
+                            Identity = message.Identity,
+                        },
+                        CancellationToken.None);
                 }
             };
 

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -50,13 +50,11 @@ namespace Libplanet.Tests.Net.Transports
 
             try
             {
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
                 await transport.StopAsync(TimeSpan.Zero);
                 Assert.False(transport.Running);
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
             }
             finally
@@ -72,8 +70,7 @@ namespace Libplanet.Tests.Net.Transports
 
             try
             {
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
                 transport.Dispose();
                 var boundPeer = new BoundPeer(
@@ -296,18 +293,12 @@ namespace Libplanet.Tests.Net.Transports
             }
         }
 
-        protected async Task<Task> InitializeAsync(
+        protected async Task InitializeAsync(
             ITransport transport,
             CancellationToken cts = default)
         {
-            Task task = transport.StartAsync(cts);
-
-            while (!transport.Running)
-            {
-                await Task.Delay(100, cts);
-            }
-
-            return task;
+            _ = transport.StartAsync(cts);
+            await transport.WaitForRunningAsync();
         }
 
         private ITransport CreateTransport(

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -10,6 +10,7 @@ using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
+using NetMQ;
 using Serilog;
 using Xunit;
 using Xunit.Sdk;
@@ -54,6 +55,11 @@ namespace Libplanet.Tests.Net.Transports
                 Assert.True(transport.Running);
                 await transport.StopAsync(TimeSpan.Zero);
                 Assert.False(transport.Running);
+                if (transport is NetMQTransport)
+                {
+                    NetMQConfig.Cleanup(false);
+                }
+
                 await InitializeAsync(transport);
                 Assert.True(transport.Running);
             }
@@ -227,6 +233,81 @@ namespace Libplanet.Tests.Net.Transports
             }
         }
 
+        [SkippableFact(Timeout = Timeout)]
+        public async Task SendMessageWithReplyCancelAsync()
+        {
+            ITransport transportA = CreateTransport();
+            ITransport transportB = CreateTransport();
+            var cts = new CancellationTokenSource();
+
+            try
+            {
+                await InitializeAsync(transportA, default);
+                await InitializeAsync(transportB, default);
+
+                cts.CancelAfter(TimeSpan.FromSeconds(1));
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    async () => await transportA.SendMessageWithReplyAsync(
+                        (BoundPeer)transportB.AsPeer,
+                        new Ping(),
+                        null,
+                        cts.Token));
+            }
+            finally
+            {
+                transportA.Dispose();
+                transportB.Dispose();
+                cts.Dispose();
+            }
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task SendMessageWithMultipleRepliesAsync()
+        {
+            ITransport transportA = CreateTransport();
+            ITransport transportB = CreateTransport();
+
+            transportB.ProcessMessageHandler += (sender, message) =>
+            {
+                if (message is Ping)
+                {
+                    _ = transportB.ReplyMessageAsync(
+                        new Ping
+                        {
+                            Identity = message.Identity,
+                        },
+                        default);
+                    _ = transportB.ReplyMessageAsync(
+                        new Pong
+                        {
+                            Identity = message.Identity,
+                        },
+                        default);
+                }
+            };
+
+            try
+            {
+                await InitializeAsync(transportA);
+                await InitializeAsync(transportB);
+
+                var replies = (await transportA.SendMessageWithReplyAsync(
+                    (BoundPeer)transportB.AsPeer,
+                    new Ping(),
+                    TimeSpan.FromSeconds(3),
+                    2,
+                    CancellationToken.None)).ToArray();
+
+                Assert.Contains(replies, message => message is Ping);
+                Assert.Contains(replies, message => message is Pong);
+            }
+            finally
+            {
+                transportA.Dispose();
+                transportB.Dispose();
+            }
+        }
+
         // This also tests ITransport.ReplyMessage at the same time.
         [SkippableFact(Timeout = Timeout)]
         public async Task SendMessageWithReplyAsyncTimeout()
@@ -250,6 +331,34 @@ namespace Libplanet.Tests.Net.Transports
             {
                 transportA.Dispose();
                 transportB.Dispose();
+            }
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task SendMessageToInvalidPeerAsync()
+        {
+            ITransport transport = CreateTransport();
+
+            try
+            {
+                await InitializeAsync(transport);
+                var peer = new BoundPeer(
+                    new PrivateKey().PublicKey,
+                    new DnsEndPoint(
+                        "0.0.0.0",
+                        ((BoundPeer)transport.AsPeer).EndPoint.Port + 1));
+                Task task = transport.SendMessageWithReplyAsync(
+                    peer,
+                    new Ping(),
+                    TimeSpan.FromSeconds(5),
+                    default);
+
+                // Sending request to the invalid peer throws TimeoutException.
+                await Assert.ThrowsAsync<TimeoutException>(async () => await task);
+            }
+            finally
+            {
+                transport.Dispose();
             }
         }
 

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -215,10 +215,36 @@ namespace Libplanet.Tests.Net.Transports
                 Message reply = await transportA.SendMessageWithReplyAsync(
                     (BoundPeer)transportB.AsPeer,
                     new Ping(),
-                    null,
+                    TimeSpan.FromSeconds(3),
                     CancellationToken.None);
 
                 Assert.IsType<Pong>(reply);
+            }
+            finally
+            {
+                transportA.Dispose();
+                transportB.Dispose();
+            }
+        }
+
+        // This also tests ITransport.ReplyMessage at the same time.
+        [SkippableFact(Timeout = Timeout)]
+        public async Task SendMessageWithReplyAsyncTimeout()
+        {
+            ITransport transportA = CreateTransport();
+            ITransport transportB = CreateTransport();
+
+            try
+            {
+                await InitializeAsync(transportA);
+                await InitializeAsync(transportB);
+
+                await Assert.ThrowsAsync<TimeoutException>(
+                    async () => await transportA.SendMessageWithReplyAsync(
+                        (BoundPeer)transportB.AsPeer,
+                        new Ping(),
+                        TimeSpan.FromSeconds(3),
+                        CancellationToken.None));
             }
             finally
             {

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -30,13 +30,14 @@ namespace Libplanet.Tests.Net.Transports
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
-        public void StartAsync()
+        public async void StartAsync()
         {
             ITransport transport = CreateTransport();
 
             try
             {
                 _ = transport.StartAsync();
+                await transport.WaitForRunningAsync();
                 Assert.True(transport.Running);
             }
             finally
@@ -71,7 +72,7 @@ namespace Libplanet.Tests.Net.Transports
         }
 
         [SkippableFact(Timeout = Timeout)]
-        public async void Dispose()
+        public async void DisposeTest()
         {
             ITransport transport = CreateTransport();
 

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -28,18 +28,13 @@ namespace Libplanet.Tests.Net.Transports
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
-        public async Task RunAsync()
+        public void StartAsync()
         {
             ITransport transport = CreateTransport();
 
             try
             {
-                // RunAsync() throws NRE if it is not started yet.
-                await Assert.ThrowsAsync<TransportException>(
-                    async () => await transport.RunAsync());
-                await transport.StartAsync();
-                Assert.False(transport.Running);
-                _ = transport.RunAsync();
+                _ = transport.StartAsync();
                 Assert.True(transport.Running);
             }
             finally
@@ -235,8 +230,7 @@ namespace Libplanet.Tests.Net.Transports
             ITransport transport,
             CancellationToken cts = default)
         {
-            await transport.StartAsync(cts);
-            Task task = transport.RunAsync(cts);
+            Task task = transport.StartAsync(cts);
 
             while (!transport.Running)
             {

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -364,6 +364,38 @@ namespace Libplanet.Tests.Net.Transports
         }
 
         [SkippableFact(Timeout = Timeout)]
+        public async Task SendMessageAsyncCancelWhenTransportStop()
+        {
+            ITransport transportA = CreateTransport();
+            ITransport transportB = CreateTransport();
+
+            try
+            {
+                await InitializeAsync(transportA);
+                await InitializeAsync(transportB);
+
+                Task t = transportA.SendMessageWithReplyAsync(
+                        (BoundPeer)transportB.AsPeer,
+                        new Ping(),
+                        null,
+                        CancellationToken.None);
+
+                // For context change
+                await Task.Delay(100);
+
+                await transportA.StopAsync(TimeSpan.Zero);
+                Assert.False(transportA.Running);
+                await Assert.ThrowsAsync<TaskCanceledException>(async () => await t);
+                Assert.True(t.IsCanceled);
+            }
+            finally
+            {
+                transportA.Dispose();
+                transportB.Dispose();
+            }
+        }
+
+        [SkippableFact(Timeout = Timeout)]
         public async Task BroadcastMessage()
         {
             var address = new PrivateKey().ToAddress();

--- a/Libplanet/Net/AsyncDelegate.cs
+++ b/Libplanet/Net/AsyncDelegate.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Libplanet.Net
+{
+    public class AsyncDelegate<T>
+    {
+        private IEnumerable<Func<T, Task>> _functions;
+
+        public AsyncDelegate()
+        {
+            _functions = new List<Func<T, Task>>();
+        }
+
+        public void Register(Func<T, Task> func)
+        {
+#pragma warning disable PC002
+            // Usage of a .NET Standard API that isn’t available on the .NET Framework 4.6.1
+#if NETFRAMEWORK && !NET48 && !NET472 && !NET471
+            _functions = _functions.Concat(new[] { func });
+#else
+            _functions = _functions.Append(func);
+#endif
+#pragma warning restore PC002
+        }
+
+        public void Unregister(Func<T, Task> func)
+        {
+            _functions = _functions.Where(f => !f.Equals(func));
+        }
+
+        public async Task InvokeAsync(T arg)
+        {
+            IEnumerable<Task> tasks = _functions.Select(f => f(arg));
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -703,7 +703,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            _transport.ReplyMessage(pong);
+            _ = _transport.ReplyMessageAsync(pong, default);
         }
 
         /// <summary>
@@ -852,7 +852,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            _transport.ReplyMessage(neighbors);
+            _ = _transport.ReplyMessageAsync(neighbors, default);
         }
     }
 }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -57,7 +57,7 @@ namespace Libplanet.Net.Protocols
             _requestTimeout =
                 requestTimeout ??
                 TimeSpan.FromMilliseconds(5000);
-            _transport.ProcessMessageHandler += ProcessMessageHandler;
+            _transport.ProcessMessageHandler.Register(ProcessMessageHandler);
         }
 
         /// <inheritdoc />
@@ -488,19 +488,19 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        private void ProcessMessageHandler(object target, Message message)
+        private async Task ProcessMessageHandler(Message message)
         {
             switch (message)
             {
                 case Ping ping:
                 {
-                    ReceivePing(ping);
+                    await ReceivePingAsync(ping);
                     break;
                 }
 
                 case FindNeighbors findPeer:
                 {
-                    ReceiveFindPeer(findPeer);
+                    await ReceiveFindPeerAsync(findPeer);
                     break;
                 }
             }
@@ -690,7 +690,7 @@ namespace Libplanet.Net.Protocols
         }
 
         // Send pong back to remote
-        private void ReceivePing(Ping ping)
+        private async Task ReceivePingAsync(Ping ping)
         {
             if (ping.Remote.Address.Equals(_address))
             {
@@ -703,7 +703,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            _ = _transport.ReplyMessageAsync(pong, default);
+            await _transport.ReplyMessageAsync(pong, default);
         }
 
         /// <summary>
@@ -842,7 +842,7 @@ namespace Libplanet.Net.Protocols
 
         // FIXME: this method is not safe from amplification attack
         // maybe ping/pong/ping/pong is required
-        private void ReceiveFindPeer(FindNeighbors findNeighbors)
+        private async Task ReceiveFindPeerAsync(FindNeighbors findNeighbors)
         {
             IEnumerable<BoundPeer> found =
                 _table.Neighbors(findNeighbors.Target, _table.BucketSize, true);
@@ -852,7 +852,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            _ = _transport.ReplyMessageAsync(neighbors, default);
+            await _transport.ReplyMessageAsync(neighbors, default);
         }
     }
 }

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -247,7 +247,8 @@ namespace Libplanet.Net
                         logSessionIds: (logSessionId, subSessionId),
                         cancellationToken: cancellationToken
                     );
-                    IEnumerable<Tuple<long, BlockHash>> hashes = await hashesAsync.ToArrayAsync();
+                    IEnumerable<Tuple<long, BlockHash>> hashes =
+                        await hashesAsync.ToArrayAsync(cancellationToken);
 
                     if (!hashes.Any())
                     {

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Net
                         Identity = getChainStatus.Identity,
                     };
 
-                    Transport.ReplyMessage(chainStatus);
+                    _ = Transport.ReplyMessageAsync(chainStatus, default);
                     break;
                 }
 
@@ -65,7 +65,7 @@ namespace Libplanet.Net
                     {
                         Identity = getBlockHashes.Identity,
                     };
-                    Transport.ReplyMessage(reply);
+                    _ = Transport.ReplyMessageAsync(reply, default);
                     break;
                 }
 
@@ -189,7 +189,7 @@ namespace Libplanet.Net
                 {
                     Identity = getTxs.Identity,
                 };
-                Transport.ReplyMessage(response);
+                _ = Transport.ReplyMessageAsync(response, default);
             }
         }
 
@@ -269,7 +269,7 @@ namespace Libplanet.Net
                         i,
                         total
                     );
-                    Transport.ReplyMessage(response);
+                    _ = Transport.ReplyMessageAsync(response, default);
                     blocks.Clear();
                 }
 
@@ -288,7 +288,7 @@ namespace Libplanet.Net
                     total,
                     identityHex
                 );
-                Transport.ReplyMessage(response);
+                _ = Transport.ReplyMessageAsync(response, default);
             }
 
             _logger.Debug("Blocks were transferred to {Identity}.", identityHex);

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -13,7 +13,7 @@ namespace Libplanet.Net
 {
     public partial class Swarm<T>
     {
-        private void ProcessMessageHandler(object target, Message message)
+        private async Task ProcessMessageHandlerAsync(Message message)
         {
             switch (message)
             {
@@ -38,7 +38,7 @@ namespace Libplanet.Net
                         Identity = getChainStatus.Identity,
                     };
 
-                    _ = Transport.ReplyMessageAsync(chainStatus, default);
+                    await Transport.ReplyMessageAsync(chainStatus, default);
                     break;
                 }
 
@@ -65,16 +65,16 @@ namespace Libplanet.Net
                     {
                         Identity = getBlockHashes.Identity,
                     };
-                    _ = Transport.ReplyMessageAsync(reply, default);
+                    await Transport.ReplyMessageAsync(reply, default);
                     break;
                 }
 
                 case GetBlocks getBlocks:
-                    TransferBlocks(getBlocks);
+                    await TransferBlocksAsync(getBlocks);
                     break;
 
                 case GetTxs getTxs:
-                    TransferTxs(getTxs);
+                    await TransferTxsAsync(getTxs);
                     break;
 
                 case TxIds txIds:
@@ -86,10 +86,7 @@ namespace Libplanet.Net
                     break;
 
                 case BlockHeaderMessage blockHeader:
-                    Task.Run(
-                        async () => await ProcessBlockHeader(blockHeader, _cancellationToken),
-                        _cancellationToken
-                    );
+                    await ProcessBlockHeader(blockHeader, _cancellationToken);
                     break;
 
                 default:
@@ -174,7 +171,7 @@ namespace Libplanet.Net
             }
         }
 
-        private void TransferTxs(GetTxs getTxs)
+        private async Task TransferTxsAsync(GetTxs getTxs)
         {
             foreach (TxId txid in getTxs.TxIds)
             {
@@ -189,7 +186,7 @@ namespace Libplanet.Net
                 {
                     Identity = getTxs.Identity,
                 };
-                _ = Transport.ReplyMessageAsync(response, default);
+                await Transport.ReplyMessageAsync(response, default);
             }
         }
 
@@ -232,7 +229,7 @@ namespace Libplanet.Net
             }
         }
 
-        private void TransferBlocks(GetBlocks getData)
+        private async Task TransferBlocksAsync(GetBlocks getData)
         {
             string identityHex = ByteUtil.Hex(getData.Identity);
             _logger.Verbose(
@@ -269,7 +266,7 @@ namespace Libplanet.Net
                         i,
                         total
                     );
-                    _ = Transport.ReplyMessageAsync(response, default);
+                    await Transport.ReplyMessageAsync(response, default);
                     blocks.Clear();
                 }
 
@@ -288,7 +285,7 @@ namespace Libplanet.Net
                     total,
                     identityHex
                 );
-                _ = Transport.ReplyMessageAsync(response, default);
+                await Transport.ReplyMessageAsync(response, default);
             }
 
             _logger.Debug("Blocks were transferred to {Identity}.", identityHex);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -104,18 +104,12 @@ namespace Libplanet.Net
 
             Options = options ?? new SwarmOptions();
             RoutingTable = new RoutingTable(Address, Options.TableSize, Options.BucketSize);
-            Transport = new NetMQTransport(
-                RoutingTable,
-                _privateKey,
-                _appProtocolVersion,
-                TrustedAppProtocolVersionSigners,
+            Transport = InitializeTransport(
                 workers,
                 host,
                 listenPort,
                 iceServers,
-                differentAppProtocolVersionEncountered,
-                Options.MinimumBroadcastTarget,
-                Options.MessageLifespan);
+                differentAppProtocolVersionEncountered);
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
         }
@@ -1272,6 +1266,47 @@ namespace Libplanet.Net
                     "Failed to fetch demand block hashes from {Peer}; " +
                     "retry with another peer...\n";
                 _logger.Debug(error, message, peer, error);
+            }
+        }
+
+        private ITransport InitializeTransport(
+            int workers,
+            string host,
+            int? listenPort,
+            IEnumerable<IceServer> iceServers,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered)
+        {
+            switch (Options.Type)
+            {
+                case SwarmOptions.TransportType.NetMQTransport:
+                    return new NetMQTransport(
+                        RoutingTable,
+                        _privateKey,
+                        _appProtocolVersion,
+                        TrustedAppProtocolVersionSigners,
+                        workers,
+                        host,
+                        listenPort,
+                        iceServers ?? new IceServer[0],
+                        differentAppProtocolVersionEncountered,
+                        Options.MinimumBroadcastTarget,
+                        Options.MessageLifespan);
+
+                case SwarmOptions.TransportType.TcpTransport:
+                    return new TcpTransport(
+                        RoutingTable,
+                        _privateKey,
+                        _appProtocolVersion,
+                        TrustedAppProtocolVersionSigners,
+                        host,
+                        listenPort,
+                        iceServers ?? new IceServer[0],
+                        differentAppProtocolVersionEncountered,
+                        Options.MinimumBroadcastTarget,
+                        Options.MessageLifespan);
+
+                default:
+                    throw new ArgumentException(nameof(SwarmOptions.Type));
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -131,7 +131,7 @@ namespace Libplanet.Net
             }
         }
 
-        public bool Running => Transport is NetMQTransport p && p.Running;
+        public bool Running => Transport.Running;
 
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
@@ -189,10 +189,10 @@ namespace Libplanet.Net
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.
         /// </summary>
-        /// <seealso cref="NetMQTransport.WaitForRunningAsync()"/>
-        /// <returns>A <see cref="Task"/> completed when <see cref="NetMQTransport.Running"/>
+        /// <seealso cref="ITransport.WaitForRunningAsync()"/>
+        /// <returns>A <see cref="Task"/> completed when <see cref="ITransport.Running"/>
         /// property becomes <c>true</c>.</returns>
-        public Task WaitForRunningAsync() => (Transport as NetMQTransport)?.WaitForRunningAsync();
+        public Task WaitForRunningAsync() => Transport?.WaitForRunningAsync();
 
         public void Dispose()
         {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Net
                 differentAppProtocolVersionEncountered,
                 Options.MinimumBroadcastTarget,
                 Options.MessageLifespan);
-            Transport.ProcessMessageHandler += ProcessMessageHandler;
+            Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -131,13 +131,13 @@ namespace Libplanet.Net
             }
         }
 
-        public bool Running => Transport.Running;
+        public bool Running => Transport?.Running ?? false;
 
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
         public Address Address => _privateKey.ToAddress();
 
-        public Peer AsPeer => Transport.AsPeer;
+        public Peer AsPeer => Transport?.AsPeer;
 
         /// <summary>
         /// The last time when any message was arrived.

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -308,13 +308,9 @@ namespace Libplanet.Net
                 ).Token;
             BlockDemand = null;
             _demandTxIds = new ConcurrentDictionary<TxId, BoundPeer>();
-            try
+            if (Transport.Running)
             {
-                await Transport.StartAsync(_cancellationToken);
-            }
-            catch (TransportException te)
-            {
-                throw new SwarmException("Swarm is already running.", innerException: te);
+                throw new SwarmException("Swarm is already running.");
             }
 
             _logger.Debug("Starting swarm...");
@@ -328,7 +324,7 @@ namespace Libplanet.Net
                         Options.RefreshLifespan,
                         _cancellationToken));
                 tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
-                tasks.Add(Transport.RunAsync(_cancellationToken));
+                tasks.Add(Transport.StartAsync(_cancellationToken));
                 tasks.Add(BroadcastBlockAsync(broadcastBlockInterval, _cancellationToken));
                 tasks.Add(BroadcastTxAsync(broadcastTxInterval, _cancellationToken));
                 tasks.Add(ProcessFillBlocks(dialTimeout, _cancellationToken));

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -5,12 +5,29 @@ using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Libplanet.Tx;
 
 namespace Libplanet.Net
 {
     public class SwarmOptions
     {
+        /// <summary>
+        /// <c>Enum</c> represents the type of the <see cref="ITransport"/>.
+        /// </summary>
+        public enum TransportType : byte
+        {
+            /// <summary>
+            /// NetMQ based transport.
+            /// </summary>
+            NetMQTransport = 0x01,
+
+            /// <summary>
+            /// TCP based transport.
+            /// </summary>
+            TcpTransport = 0x02,
+        }
+
         /// <summary>
         /// The maximum timeout used in <see cref="Swarm{T}"/>.
         /// </summary>
@@ -100,5 +117,10 @@ namespace Libplanet.Net
         /// </summary>
         /// <seealso cref="RoutingTable"/>
         public int BucketSize { get; set; } = Kademlia.BucketSize;
+
+        /// <summary>
+        /// The type of <see cref="ITransport"/> used in <see cref="Swarm{T}"/>.
+        /// </summary>
+        public TransportType Type { get; set; } = TransportType.TcpTransport;
     }
 }

--- a/Libplanet/Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet/Net/Transports/BoundPeerExtensions.cs
@@ -16,7 +16,8 @@ namespace Libplanet.Net.Transports
     public static class BoundPeerExtensions
     {
         /// <summary>
-        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>.
+        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>
+        /// specialized for NetMQ based transport.
         /// </summary>
         /// <param name="peer">The <see cref="BoundPeer"/> to query
         /// <see cref="AppProtocolVersion"/>.</param>

--- a/Libplanet/Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet/Net/Transports/BoundPeerExtensions.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using NetMQ;
@@ -47,6 +50,75 @@ namespace Libplanet.Net.Transports
             throw new TimeoutException(
                 $"Peer[{peer}] didn't respond within the specified time[{timeout}]."
             );
+        }
+
+        /// <summary>
+        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>
+        /// specialized for TCP based transport.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to query
+        /// <see cref="AppProtocolVersion"/>.</param>
+        /// <param name="timeout">Timeout value for request.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns><see cref="AppProtocolVersion"/> of given peer. </returns>
+        public static async Task<AppProtocolVersion> QueryAppProtocolVersionTcp(
+            this BoundPeer peer,
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+            client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
+            using var stream = client.GetStream();
+            var key = new PrivateKey();
+            var ping = new Ping
+            {
+                Identity = Guid.NewGuid().ToByteArray(),
+            };
+
+            byte[] serialized = ping.Serialize(
+                key,
+                peer,
+                DateTimeOffset.UtcNow,
+                default);
+            int length = serialized.Length;
+            var buffer = new byte[TcpTransport.MagicCookie.Length + sizeof(int) + length];
+            TcpTransport.MagicCookie.CopyTo(buffer, 0);
+            BitConverter.GetBytes(length).CopyTo(buffer, TcpTransport.MagicCookie.Length);
+            serialized.CopyTo(buffer, TcpTransport.MagicCookie.Length + sizeof(int));
+            await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+
+            buffer = new byte[1000000];
+            int bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+            var magicCookieBuffer = new byte[TcpTransport.MagicCookie.Length];
+            Array.Copy(buffer, 0, magicCookieBuffer, 0, TcpTransport.MagicCookie.Length);
+            var sizeBuffer = new byte[sizeof(int)];
+            Array.Copy(buffer, TcpTransport.MagicCookie.Length, sizeBuffer, 0, sizeof(int));
+            length = BitConverter.ToInt32(sizeBuffer, 0);
+            var contentBuffer = new byte[length];
+            Array.Copy(
+                buffer,
+                TcpTransport.MagicCookie.Length + sizeof(int),
+                contentBuffer,
+                0,
+                length);
+
+            // length of identity
+            Array.Copy(contentBuffer, 4, sizeBuffer, 0, 4);
+            length = BitConverter.ToInt32(sizeBuffer, 0);
+
+            // length of apv token
+            Array.Copy(contentBuffer, 4 + 4 + length, sizeBuffer, 0, 4);
+            int apvLength = BitConverter.ToInt32(sizeBuffer, 0);
+            var apvBytes = new byte[apvLength];
+            Array.Copy(contentBuffer, 4 + 4 + length + 4, apvBytes, 0, apvLength);
+            var frame = new NetMQFrame(apvBytes);
+            string token = frame.ConvertToString();
+            AppProtocolVersion version = AppProtocolVersion.FromToken(token);
+            return version;
         }
 
         internal static string ToNetMQAddress(this BoundPeer peer)

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -40,23 +40,13 @@ namespace Libplanet.Net.Transports
         bool Running { get; }
 
         /// <summary>
-        /// Initiates transport layer.
+        /// Initiates and runs transport layer.
         /// </summary>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
         Task StartAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Starts running transport layer. To <see cref="RunAsync"/>, you should call
-        /// <see cref="StartAsync"/> first.
-        /// </summary>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.</param>
-        /// <returns>An awaitable task without value.</returns>
-        Task RunAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stops running transport layer.

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -142,6 +142,10 @@ namespace Libplanet.Net.Transports
         /// <paramref name="message"/>.
         /// </remarks>
         /// <param name="message">A <see cref="Message"/> to reply.</param>
-        void ReplyMessage(Message message);
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
+        Task ReplyMessageAsync(Message message, CancellationToken cancellationToken);
     }
 }

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -15,11 +15,11 @@ namespace Libplanet.Net.Transports
     public interface ITransport : IDisposable
     {
         /// <summary>
-        /// The <see cref="EventHandler"/> invoked when a message that is not
+        /// The list of tasks invoked when a message that is not
         /// a reply is received. To handle reply, please use <see cref=
         /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
         /// </summary>
-        event EventHandler<Message> ProcessMessageHandler;
+        AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <summary>
         /// <see cref="Peer"/> representation of <see cref="ITransport"/>.

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -54,6 +54,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task StartAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -65,6 +67,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default);
@@ -85,6 +89,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
 
         /// <summary>
@@ -99,6 +105,8 @@ namespace Libplanet.Net.Transports
         /// operation should be canceled.</param>
         /// <returns>The replies of the <paramref name="message"/>
         /// sent by <paramref name="peer"/>.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -118,6 +126,8 @@ namespace Libplanet.Net.Transports
         /// operation should be canceled.</param>
         /// <returns>The replies of the <paramref name="message"/>
         /// sent by <paramref name="peer"/>.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -131,6 +141,8 @@ namespace Libplanet.Net.Transports
         /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
         /// If <c>null</c> is given, no peers will be excluded.</param>
         /// <param name="message">A <see cref="Message"/> to broadcast.</param>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         void BroadcastMessage(Address? except, Message message);
 
         /// <summary>
@@ -146,6 +158,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task ReplyMessageAsync(Message message, CancellationToken cancellationToken);
     }
 }

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading;
@@ -40,6 +41,13 @@ namespace Libplanet.Net.Transports
         bool Running { get; }
 
         /// <summary>
+        /// A fixed sized queue that keeps history of <see cref="Message"/> received.
+        /// It saves at most 30 recent <see cref="Message"/>s.
+        /// </summary>
+        [Pure]
+        ConcurrentQueue<Message> MessageHistory { get; }
+
+        /// <summary>
         /// Initiates and runs transport layer.
         /// </summary>
         /// <param name="cancellationToken">
@@ -60,6 +68,13 @@ namespace Libplanet.Net.Transports
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Waits until this <see cref="ITransport"/> instance gets started to run.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> completed when <see cref="ITransport.Running"/>
+        /// property becomes <c>true</c>.</returns>
+        Task WaitForRunningAsync();
 
         /// <summary>
         /// Sends the <paramref name="message"/> to given <paramref name="peer"/>.

--- a/Libplanet/Net/Transports/InvalidMagicCookieException.cs
+++ b/Libplanet/Net/Transports/InvalidMagicCookieException.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Libplanet.Net.Transports
+{
+    public class InvalidMagicCookieException : Exception
+    {
+        public InvalidMagicCookieException(IEnumerable<byte> expected, IEnumerable<byte> actual)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        public InvalidMagicCookieException(
+            IEnumerable<byte> expected,
+            IEnumerable<byte> actual,
+            string message)
+            : base(message)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        public InvalidMagicCookieException(
+            IEnumerable<byte> expected,
+            IEnumerable<byte> actual,
+            string message,
+            Exception innerException)
+            : base(message, innerException)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        public ImmutableArray<byte> Expected { get; private set; }
+
+        public ImmutableArray<byte> Actual { get; private set; }
+    }
+}

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -201,13 +201,14 @@ namespace Libplanet.Net.Transports
             );
 
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
+            ProcessMessageHandler = new AsyncDelegate<Message>();
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
             _replyCompletionSources =
                 new ConcurrentDictionary<string, TaskCompletionSource<object>>();
         }
 
         /// <inheritdoc />
-        public event EventHandler<Message> ProcessMessageHandler;
+        public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <inheritdoc cref="ITransport.AsPeer"/>
         public Peer AsPeer => EndPoint is null
@@ -582,7 +583,7 @@ namespace Libplanet.Net.Transports
 
                 try
                 {
-                    ProcessMessageHandler?.Invoke(this, message);
+                    _ = ProcessMessageHandler.InvokeAsync(message);
                 }
                 catch (Exception exc)
                 {

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -285,21 +285,6 @@ namespace Libplanet.Net.Transports
             _router.ReceiveReady += ReceiveMessage;
             _replyQueue.ReceiveReady += DoReply;
             _broadcastQueue.ReceiveReady += DoBroadcast;
-        }
-
-        /// <inheritdoc />
-        public async Task RunAsync(CancellationToken cancellationToken)
-        {
-            if (Running)
-            {
-                throw new TransportException("Transport is already running.");
-            }
-
-            if (_router is null)
-            {
-                throw new TransportException(
-                    $"Transport needs to be started before {nameof(RunAsync)}().");
-            }
 
             List<Task> tasks = new List<Task>();
 

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -241,6 +241,11 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             if (Running)
             {
                 throw new TransportException("Transport is already running.");
@@ -305,6 +310,11 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken = default
         )
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             if (Running)
             {
                 await Task.Delay(waitFor, cancellationToken);
@@ -399,6 +409,11 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken = default
         )
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             if (!(_turnClient is null) && _turnClient.BehindNAT)
             {
                 await CreatePermission(peer);
@@ -507,12 +522,22 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc />
         public void BroadcastMessage(Address? except, Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             _broadcastQueue.Enqueue((except, message));
         }
 
         /// <inheritdoc />
         public void ReplyMessage(Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             string identityHex = ByteUtil.Hex(message.Identity);
             _logger.Debug("Reply {Message} to {Identity}...", message, identityHex);
             _replyQueue.Enqueue(message.ToNetMQMessage(

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -232,7 +232,8 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        internal FixedSizedQueue<Message> MessageHistory { get; }
+        /// <inheritdoc cref="ITransport.MessageHistory"/>
+        public ConcurrentQueue<Message> MessageHistory { get; }
 
         internal IPAddress PublicIPAddress => _turnClient?.PublicAddress;
 
@@ -366,12 +367,7 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        /// <summary>
-        /// Waits until this <see cref="NetMQTransport"/> instance gets started to run.
-        /// </summary>
-        /// <seealso cref="Swarm{T}.WaitForRunningAsync()"/>
-        /// <returns>A <see cref="Task"/> completed when <see cref="Running"/>
-        /// property becomes <c>true</c>.</returns>
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
         /// <inheritdoc />

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -53,12 +53,12 @@ namespace Libplanet.Net.Transports
 
         private Channel<MessageRequest> _requests;
         private long _requestCount;
+        private CancellationTokenSource _runtimeProcessorCancellationTokenSource;
         private CancellationTokenSource _runtimeCancellationTokenSource;
         private CancellationTokenSource _turnCancellationTokenSource;
         private Task _runtimeProcessor;
 
         private TaskCompletionSource<object> _runningEvent;
-        private CancellationToken _cancellationToken;
         private ConcurrentDictionary<Address, DealerSocket> _dealers;
         private ConcurrentDictionary<string, TaskCompletionSource<object>> _replyCompletionSources;
 
@@ -158,6 +158,7 @@ namespace Libplanet.Net.Transports
             _logger = Log.ForContext<NetMQTransport>();
 
             _requests = Channel.CreateUnbounded<MessageRequest>();
+            _runtimeProcessorCancellationTokenSource = new CancellationTokenSource();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
             _requestCount = 0;
@@ -174,7 +175,7 @@ namespace Libplanet.Net.Transports
                         for (int i = 0; i < workers; i++)
                         {
                             workerTasks[i] = ProcessRuntime(
-                                _runtimeCancellationTokenSource.Token
+                                _runtimeProcessorCancellationTokenSource.Token
                             );
                         }
 
@@ -269,16 +270,18 @@ namespace Libplanet.Net.Transports
             }
 
             _logger.Information($"Listen on {_listenPort}");
+            _runtimeCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _turnCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             if (_host is null && !(_iceServers is null))
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
                 await _turnClient.StartAsync(_listenPort.Value, cancellationToken);
 
-                _ = RefreshPermissions(cancellationToken);
+                _ = RefreshPermissions(_runtimeCancellationTokenSource.Token);
             }
-
-            _cancellationToken = cancellationToken;
 
             if (_turnClient is null || !_turnClient.BehindNAT)
             {
@@ -300,7 +303,7 @@ namespace Libplanet.Net.Transports
 
             tasks.Add(DisposeUnusedDealerSockets(
                 TimeSpan.FromSeconds(10),
-                _cancellationToken));
+                _runtimeCancellationTokenSource.Token));
             tasks.Add(RunPoller(_routerPoller));
             tasks.Add(RunPoller(_broadcastPoller));
 
@@ -351,6 +354,8 @@ namespace Libplanet.Net.Transports
 
                 _dealers.Clear();
 
+                _runtimeCancellationTokenSource.Cancel();
+
                 Running = false;
             }
         }
@@ -361,10 +366,12 @@ namespace Libplanet.Net.Transports
             if (!_disposed)
             {
                 _requests.Writer.Complete();
+                _runtimeProcessorCancellationTokenSource.Cancel();
                 _runtimeCancellationTokenSource.Cancel();
                 _turnCancellationTokenSource.Cancel();
                 _runtimeProcessor.Wait();
 
+                _runtimeProcessorCancellationTokenSource.Dispose();
                 _runtimeCancellationTokenSource.Dispose();
                 _turnCancellationTokenSource.Dispose();
                 _disposed = true;
@@ -419,6 +426,10 @@ namespace Libplanet.Net.Transports
                 await CreatePermission(peer);
             }
 
+            using CancellationTokenSource cts =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    _runtimeCancellationTokenSource.Token,
+                    cancellationToken);
             Guid reqId = Guid.NewGuid();
             try
             {
@@ -434,10 +445,10 @@ namespace Libplanet.Net.Transports
 
                 // FIXME should we also cancel tcs sender side too?
                 using CancellationTokenRegistration ctr =
-                    cancellationToken.Register(() => tcs.TrySetCanceled());
+                    cts.Token.Register(() => tcs.TrySetCanceled());
                 await _requests.Writer.WriteAsync(
                     new MessageRequest(reqId, message, peer, now, timeout, expectedResponses, tcs),
-                    cancellationToken
+                    cts.Token
                 );
                 _logger.Verbose(
                     "Enqueued a request {RequestId} to the peer {Peer}: {@Message}; " +
@@ -564,7 +575,7 @@ namespace Libplanet.Net.Transports
                     raw.FrameCount
                 );
 
-                if (_cancellationToken.IsCancellationRequested)
+                if (_runtimeCancellationTokenSource.IsCancellationRequested)
                 {
                     return;
                 }
@@ -600,13 +611,14 @@ namespace Libplanet.Net.Transports
                 {
                     Identity = dapve.Identity,
                 };
-                _ = ReplyMessageAsync(differentVersion, _cancellationToken);
+                _ = ReplyMessageAsync(differentVersion, _runtimeCancellationTokenSource.Token);
                 _logger.Debug("Message from peer with different version received.");
             }
             catch (InvalidTimestampException ite)
             {
-                const string logMsg = "The received message is stale. " +
-                            "(timestamp: {Timestamp}, lifespan: {Lifespan}, current: {Current})";
+                const string logMsg =
+                    "The received message is stale. " +
+                    "(timestamp: {Timestamp}, lifespan: {Lifespan}, current: {Current})";
                 _logger.Debug(logMsg, ite.CreatedOffset, ite.Lifespan, ite.CurrentOffset);
             }
             catch (InvalidMessageException ex)

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -60,6 +60,7 @@ namespace Libplanet.Net.Transports
         private TaskCompletionSource<object> _runningEvent;
         private CancellationToken _cancellationToken;
         private ConcurrentDictionary<Address, DealerSocket> _dealers;
+        private ConcurrentDictionary<string, TaskCompletionSource<object>> _replyCompletionSources;
 
         private RoutingTable _table;
 
@@ -201,6 +202,8 @@ namespace Libplanet.Net.Transports
 
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
+            _replyCompletionSources =
+                new ConcurrentDictionary<string, TaskCompletionSource<object>>();
         }
 
         /// <inheritdoc />
@@ -527,7 +530,7 @@ namespace Libplanet.Net.Transports
         }
 
         /// <inheritdoc />
-        public void ReplyMessage(Message message)
+        public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -535,12 +538,19 @@ namespace Libplanet.Net.Transports
             }
 
             string identityHex = ByteUtil.Hex(message.Identity);
+            var tcs = new TaskCompletionSource<object>();
+            using CancellationTokenRegistration ctr =
+                cancellationToken.Register(() => tcs.TrySetCanceled());
+            _replyCompletionSources.TryAdd(identityHex, tcs);
             _logger.Debug("Reply {Message} to {Identity}...", message, identityHex);
             _replyQueue.Enqueue(message.ToNetMQMessage(
                 _privateKey,
                 AsPeer,
                 DateTimeOffset.UtcNow,
                 _appProtocolVersion));
+
+            await tcs.Task;
+            _replyCompletionSources.TryRemove(identityHex, out _);
         }
 
         private void ReceiveMessage(object sender, NetMQSocketEventArgs e)
@@ -589,7 +599,7 @@ namespace Libplanet.Net.Transports
                 {
                     Identity = dapve.Identity,
                 };
-                ReplyMessage(differentVersion);
+                _ = ReplyMessageAsync(differentVersion, _cancellationToken);
                 _logger.Debug("Message from peer with different version received.");
             }
             catch (InvalidTimestampException ite)
@@ -697,6 +707,9 @@ namespace Libplanet.Net.Transports
             {
                 _logger.Debug("Failed to reply to {Identity}", identityHex);
             }
+
+            _replyCompletionSources.TryGetValue(identityHex, out TaskCompletionSource<object> tcs);
+            tcs?.TrySetResult(null);
         }
 
         private async Task RefreshPermissions(

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -1,0 +1,837 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
+using Libplanet.Stun;
+using Nito.AsyncEx;
+using Serilog;
+
+namespace Libplanet.Net.Transports
+{
+    public class TcpTransport : ITransport
+    {
+        public static readonly byte[] MagicCookie = { 0x4c, 0x50 }; // 'L', 'P'
+
+        private const int MessageHistoryCapacity = 30;
+        private const int ListenerBacklog = 100;
+        private const int MaxReplyStreams = 3000;
+
+        // TODO: Should be configurable (ex. SwarmOptions.MaxTimeout)
+        private static readonly TimeSpan ListenerLifetime = TimeSpan.FromMinutes(2);
+
+        // TURN Permission lifetime was defined in RFC 5766
+        // see also https://tools.ietf.org/html/rfc5766#section-8
+        private static readonly TimeSpan TurnPermissionLifetime =
+            TimeSpan.FromMinutes(5);
+
+        private readonly RoutingTable _table;
+        private readonly PrivateKey _privateKey;
+        private readonly AppProtocolVersion _appProtocolVersion;
+        private readonly IImmutableSet<PublicKey>? _trustedAppProtocolVersionSigners;
+        private readonly string? _host;
+        private readonly DifferentAppProtocolVersionEncountered?
+            _differentAppProtocolVersionEncountered;
+
+        private readonly IList<IceServer>? _iceServers;
+        private readonly ILogger _logger;
+        private readonly int _minimumBroadcastTarget;
+        private readonly TimeSpan? _messageLifespan;
+
+        private readonly CancellationTokenSource _turnCancellationTokenSource;
+
+        private readonly ConcurrentDictionary<Guid, ReplyStream> _streams;
+
+        private TaskCompletionSource<object> _runningEvent;
+        private CancellationTokenSource _runtimeCancellationTokenSource;
+        private CancellationToken _cancellationToken;
+
+        private int _listenPort;
+        private DnsEndPoint? _hostEndPoint;
+        private TcpListener? _listener;
+        private TurnClient? _turnClient;
+
+        private bool _disposed;
+
+        public TcpTransport(
+            RoutingTable table,
+            PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
+            string? host,
+            int? listenPort,
+            IEnumerable<IceServer> iceServers,
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            int minimumBroadcastTarget,
+            TimeSpan? messageLifespan = null)
+        {
+            _runningEvent = null!;
+            Running = false;
+
+            _table = table;
+            _privateKey = privateKey;
+            _appProtocolVersion = appProtocolVersion;
+            _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
+            _host = host;
+            _listenPort = listenPort ?? 0;
+            _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
+            _iceServers = iceServers?.ToList();
+            _minimumBroadcastTarget = minimumBroadcastTarget;
+            _messageLifespan = messageLifespan;
+            _streams = new ConcurrentDictionary<Guid, ReplyStream>();
+
+            if (!(_host is null) && listenPort is { } listenPortAsInt)
+            {
+                _hostEndPoint = new DnsEndPoint(_host, listenPortAsInt);
+            }
+
+            if (_host == null && (_iceServers == null || !_iceServers.Any()))
+            {
+                throw new ArgumentException(
+                    $"Swarm requires either {nameof(host)} or " +
+                    $"{nameof(iceServers)}."
+                );
+            }
+
+            _logger = Log.ForContext<TcpTransport>();
+            _runtimeCancellationTokenSource = new CancellationTokenSource();
+            _turnCancellationTokenSource = new CancellationTokenSource();
+            MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
+        }
+
+        public event EventHandler<Message> ProcessMessageHandler = null!;
+
+        /// <inheritdoc cref="ITransport.AsPeer"/>
+        public Peer AsPeer => EndPoint is null
+            ? new Peer(_privateKey.PublicKey, PublicIPAddress)
+            : new BoundPeer(_privateKey.PublicKey, EndPoint, PublicIPAddress);
+
+        /// <inheritdoc cref="ITransport.Running"/>
+        public DateTimeOffset? LastMessageTimestamp { get; private set; }
+
+        public bool Running
+        {
+            get => _runningEvent?.Task.Status == TaskStatus.RanToCompletion;
+
+            private set
+            {
+                if (value)
+                {
+                    _runningEvent?.TrySetResult(null!);
+                }
+                else
+                {
+                    _runningEvent = new TaskCompletionSource<object>();
+                }
+            }
+        }
+
+        public ConcurrentQueue<Message> MessageHistory { get; }
+
+        internal IPAddress? PublicIPAddress => _turnClient?.PublicAddress;
+
+        internal DnsEndPoint? EndPoint => _turnClient?.EndPoint ?? _hostEndPoint;
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _listener?.Stop();
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+
+                _runtimeCancellationTokenSource.Dispose();
+                _turnCancellationTokenSource.Dispose();
+                StopAllStreams();
+                Running = false;
+                _disposed = true;
+            }
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (Running)
+            {
+                throw new TransportException("Transport is already running.");
+            }
+
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, _listenPort));
+            _listener.Start(ListenerBacklog);
+
+            // _listenPort might be 0, which is any, so it should be re-set.
+            _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            _logger.Information("Listen on {Port}", _listenPort);
+
+            if (_host is null && !(_iceServers is null))
+            {
+                _turnClient = await IceServer.CreateTurnClient(_iceServers);
+                await _turnClient.StartAsync(_listenPort, cancellationToken);
+
+                _ = RefreshPermissions(cancellationToken);
+            }
+
+            _runtimeCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _cancellationToken = _runtimeCancellationTokenSource.Token;
+
+            if (_turnClient is null || !_turnClient.BehindNAT)
+            {
+                string? host = _host ?? PublicIPAddress?.ToString();
+                if (host is null)
+                {
+                    throw new TransportException("Host is null.");
+                }
+
+                _hostEndPoint = new DnsEndPoint(host, _listenPort);
+            }
+
+            List<Task> tasks = new List<Task>();
+
+            tasks.Add(ReceiveMessageAsync(_cancellationToken));
+            tasks.Add(ProcessRuntime(_cancellationToken));
+
+            Running = true;
+            _logger.Debug("Start to run. TurnClient: {Client}", _turnClient);
+
+            await await Task.WhenAny(tasks);
+        }
+
+        public async Task StopAsync(TimeSpan waitFor, CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (Running)
+            {
+                await Task.Delay(waitFor, cancellationToken);
+                _listener?.Stop();
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+                StopAllStreams();
+                Running = false;
+            }
+        }
+
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
+        public Task WaitForRunningAsync() => _runningEvent.Task;
+
+        public Task SendMessageAsync(
+            BoundPeer peer,
+            Message message,
+            CancellationToken cancellationToken)
+            => SendMessageWithReplyAsync(
+                peer,
+                message,
+                TimeSpan.FromSeconds(3),
+                0,
+                cancellationToken);
+
+        public async Task<Message> SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<Message> replies =
+                await SendMessageWithReplyAsync(peer, message, timeout, 1, cancellationToken);
+            Message reply = replies.First();
+
+            return reply;
+        }
+
+        public async Task<IEnumerable<Message>> SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            int expectedResponses,
+            CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (!(_turnClient is null) && _turnClient.BehindNAT)
+            {
+                await CreatePermission(peer);
+            }
+
+            if (expectedResponses < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(expectedResponses));
+            }
+
+            Guid reqId;
+            if (message.Identity is null)
+            {
+                reqId = Guid.NewGuid();
+                message.Identity = reqId.ToByteArray();
+            }
+            else
+            {
+                reqId = new Guid(message.Identity);
+            }
+
+            _logger.Verbose(
+                "Start to request {RequestId} to {Peer}: {Message}. (expected responses: {Count})",
+                reqId,
+                peer,
+                message,
+                expectedResponses
+            );
+
+            using var client = new TcpClient { LingerState = new LingerOption(true, 1) };
+            try
+            {
+                await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+                client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
+                await WriteMessageAsync(message, client, cancellationToken);
+                _logger.Verbose(
+                    "Successfully sent request {RequestId} to {Peer}: {Message}.",
+                    reqId,
+                    peer,
+                    message
+                );
+
+                var replies = new List<Message>();
+                using var timeoutCts = new CancellationTokenSource();
+                if (expectedResponses != 0 && !(timeout is null))
+                {
+                    timeoutCts.CancelAfter(
+                        (int)timeout.Value.TotalMilliseconds * expectedResponses);
+                }
+
+                using CancellationTokenSource linkedTcs =
+                    CancellationTokenSource.CreateLinkedTokenSource(
+                        timeoutCts.Token,
+                        cancellationToken);
+                while (expectedResponses > 0)
+                {
+                    try
+                    {
+                        // TODO: Should consider case where stream bytes exceeds buffer size.
+                        Message received = await ReadMessageAsync(
+                            client,
+                            linkedTcs.Token);
+                        _logger.Verbose(
+                            "Received message was {Message}. Total: {Count}",
+                            received,
+                            replies.Count);
+                        MessageHistory.Enqueue(received);
+                        replies.Add(received);
+                        expectedResponses--;
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        if (timeoutCts.IsCancellationRequested)
+                        {
+                            var msg =
+                                $"{nameof(SendMessageWithReplyAsync)}() timed out after " +
+                                "{Timeout} of waiting a reply to {MessageType} ({RequestId}) " +
+                                "from {PeerAddress}.";
+                            _logger.Debug(
+                                msg,
+                                timeout,
+                                message.GetType().Name,
+                                reqId,
+                                peer.Address);
+                            throw new TimeoutException();
+                        }
+
+                        throw;
+                    }
+                }
+
+                if (replies.Any())
+                {
+                    const string logMsg =
+                        "Received {ReplyMessageCount} reply messages to {RequestId} " +
+                        "from the {Peer}: {ReplyMessages}.";
+                    _logger.Debug(logMsg, replies.Count, reqId, peer, replies);
+                }
+
+                return replies;
+            }
+            catch (DifferentAppProtocolVersionException e)
+            {
+                const string logMsg =
+                    "{PeerAddress} sent a reply to {RequestId} with " +
+                    "a different app protocol version; " +
+                    "expected: {ExpectedVersion}; actual: {ActualVersion}.";
+                _logger.Error(e, logMsg, peer.Address, reqId, e.ExpectedVersion, e.ActualVersion);
+                throw;
+            }
+            catch (ArgumentException e)
+            {
+                // This exception is thrown on .NET framework when the given peer is invalid.
+                _logger.Error(
+                    e,
+                    "ArgumentException occurred during {FName} to {RequestId}. {E}",
+                    nameof(SendMessageWithReplyAsync),
+                    reqId,
+                    e);
+
+                // To match with previous implementation, throws TimeoutException when it failed to
+                // find peer to send message.
+                throw new TimeoutException($"Cannot find peer {peer}.", e);
+            }
+            catch (SocketException e)
+            {
+                // This exception is thrown on .NET core when the given peer is invalid.
+                _logger.Error(
+                    e,
+                    "SocketException occurred during {FName} to {RequestId}. {E}",
+                    nameof(SendMessageWithReplyAsync),
+                    reqId,
+                    e);
+
+                // To match with previous implementation, throws TimeoutException when it failed to
+                // find peer to send message.
+                throw new TimeoutException($"Cannot find peer {peer}.", e);
+            }
+            catch (InvalidMagicCookieException e)
+            {
+                _logger.Verbose(
+                    "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
+                    e.Expected,
+                    e.Actual);
+                throw;
+            }
+        }
+
+        public void BroadcastMessage(Address? except, Message message)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            foreach (var peer in _table.PeersToBroadcast(except, _minimumBroadcastTarget))
+            {
+                _ = SendMessageAsync(peer, message, _cancellationToken);
+            }
+        }
+
+        public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            var id = new Guid(message.Identity);
+            _logger.Verbose("Trying to reply message. ID: {Id}", id);
+            if (_streams.TryGetValue(id, out ReplyStream stream))
+            {
+                _logger.Verbose("Send reply message {Message}", message);
+                try
+                {
+                    _logger.Verbose("Start to writing reply {Message}.", message);
+                    using var @lock = stream.Lock.Lock();
+                    await WriteMessageAsync(message, stream.Client, _cancellationToken);
+                }
+                catch (IOException)
+                {
+                    _logger.Verbose("Connection is lost");
+                    _ = TryRemoveStreamAsync(id, _cancellationToken);
+                }
+            }
+        }
+
+        internal async Task WriteMessageAsync(
+            Message message,
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            byte[] serialized = message.Serialize(
+                _privateKey,
+                AsPeer,
+                DateTimeOffset.UtcNow,
+                _appProtocolVersion);
+            int length = serialized.Length;
+            var buffer = new byte[MagicCookie.Length + sizeof(int) + length];
+            MagicCookie.CopyTo(buffer, 0);
+            BitConverter.GetBytes(length).CopyTo(buffer, MagicCookie.Length);
+            serialized.CopyTo(buffer, MagicCookie.Length + sizeof(int));
+            NetworkStream stream = client.GetStream();
+
+            // NOTE: Stream is forced to be closed because NetStream.WriteAsync()'s
+            // cancellation token never works in .NET Framework.
+            using (cancellationToken.Register(() => stream.Close()))
+            {
+                try
+                {
+                    await stream.WriteAsync(buffer, 0, buffer.Length, default);
+                }
+                catch (Exception)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        internal async Task<Message> ReadMessageAsync(
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            var content = new List<byte>();
+            byte[] buffer = new byte[1000];
+            NetworkStream stream = client.GetStream();
+
+            // NOTE: Stream is forced to be closed because NetStream.ReadAsync()'s
+            // cancellation token never works in .NET Framework.
+            using (cancellationToken.Register(() => stream.Close()))
+            {
+                try
+                {
+                    // May read shorter than MagicCookie's length just by network condition
+                    int bytesRead = await stream.ReadAsync(buffer, 0, MagicCookie.Length, default);
+                    if (bytesRead < MagicCookie.Length ||
+                        !buffer.Take(MagicCookie.Length).SequenceEqual(MagicCookie))
+                    {
+                        throw new InvalidMagicCookieException(MagicCookie, buffer.Take(bytesRead));
+                    }
+
+                    await stream.ReadAsync(buffer, 0, sizeof(int), default);
+                    int bytesLeft = BitConverter.ToInt32(buffer.Take(sizeof(int)).ToArray(), 0);
+
+                    while (bytesLeft != 0)
+                    {
+                        bytesRead = await stream.ReadAsync(
+                            buffer,
+                            0,
+                            bytesLeft < 1000 ? bytesLeft : 1000,
+                            default);
+                        content.AddRange(buffer.Take(bytesRead));
+                        bytesLeft -= bytesRead;
+                    }
+                }
+                catch (InvalidMagicCookieException)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    _logger.Error(
+                        e,
+                        "Error occurred during {FName}() {E}",
+                        nameof(ReadMessageAsync),
+                        e);
+                    throw;
+                }
+            }
+
+            _logger.Verbose("Received {Bytes} bytes from network stream.", content.Count);
+
+            Message message = Message.Deserialize(
+                content.ToArray(),
+                _appProtocolVersion,
+                _trustedAppProtocolVersionSigners,
+                _differentAppProtocolVersionEncountered,
+                _messageLifespan);
+
+            _logger.Verbose(
+                "ReadMessageAsync success. Received message {Message} from network stream.",
+                message);
+            return message;
+        }
+
+        private async Task ReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            while (!(cancellationToken.IsCancellationRequested || _listener is null))
+            {
+                try
+                {
+                    TcpClient client = await _listener.AcceptTcpClientAsync();
+                    client.LingerState = new LingerOption(true, 1);
+                    _logger.Verbose("Connected to tcp client.");
+                    Guid guid = Guid.NewGuid();
+                    _logger.Verbose("Start to accept message of {Id}.", guid);
+
+                    // TODO: Maximum message processor should be limited.
+                    _ = AcceptAsync(client, cancellationToken)
+                        .ContinueWith<Task>(
+                            async t =>
+                            {
+                                _logger.Verbose("Ended to accept message of {Id}.", guid);
+                                try
+                                {
+                                    // Wait 15 seconds to close client to receive ACK from TURN.
+                                    await Task.Delay(
+                                        15 * 1000,
+                                        _runtimeCancellationTokenSource.Token);
+                                }
+                                finally
+                                {
+                                    client.Close();
+                                    await TryRemoveStreamAsync(guid, cancellationToken);
+                                }
+                            },
+                            cancellationToken);
+                }
+                catch (ObjectDisposedException)
+                {
+                    _logger.Warning("TCPListener is disposed.");
+                    break;
+                }
+            }
+        }
+
+        private async Task AcceptAsync(
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.Verbose("Trying to receive message");
+                Message message = await ReadMessageAsync(client, cancellationToken);
+                MessageHistory.Enqueue(message);
+                LastMessageTimestamp = DateTimeOffset.UtcNow;
+                _logger.Debug(
+                    "A message has parsed: {Message}, from {Remove}",
+                    message,
+                    message.Remote);
+
+                var id = new Guid(message.Identity);
+                await TryAddStreamAsync(id, client, cancellationToken);
+
+                ProcessMessageHandler?.Invoke(this, message);
+            }
+            catch (DifferentAppProtocolVersionException dapve)
+            {
+                _logger.Debug("Message from peer with different version received.");
+                var differentVersion = new DifferentVersion
+                {
+                    Identity = dapve.Identity,
+                };
+
+                await WriteMessageAsync(differentVersion, client, cancellationToken);
+            }
+            catch (IOException)
+            {
+                _logger.Verbose("Connection is lost.");
+            }
+            catch (InvalidMagicCookieException e)
+            {
+                _logger.Verbose(
+                    "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
+                    e.Expected,
+                    e.Actual);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    e,
+                    "Unexpected exception occurred during {FName}(). {E}",
+                    nameof(AcceptAsync),
+                    e);
+                throw;
+            }
+        }
+
+        private async Task RefreshPermissions(
+            CancellationToken cancellationToken)
+        {
+            TimeSpan lifetime = TurnPermissionLifetime;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(lifetime - TimeSpan.FromMinutes(1), cancellationToken);
+                    _logger.Debug("Refreshing permissions...");
+                    await Task.WhenAll(_table.Peers.Select(CreatePermission));
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+                catch (OperationCanceledException e)
+                {
+                    _logger.Warning(e, "{FName}() is cancelled.", nameof(RefreshPermissions));
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    _logger.Error(
+                        e,
+                        "An unexpected exception occurred during {FName}(): {E}",
+                        nameof(RefreshPermissions),
+                        e);
+                }
+            }
+        }
+
+        private async Task CreatePermission(BoundPeer peer)
+        {
+            if (_turnClient is null)
+            {
+                throw new TransportException(
+                    "CreatePermission should not be called when the turn client does not exists");
+            }
+
+            using var cts = new CancellationTokenSource();
+            IPAddress[] ips;
+
+            // Cancellation After 2.5 sec
+            cts.CancelAfter(2500);
+            if (peer.PublicIPAddress is null)
+            {
+                string peerHost = peer.EndPoint.Host;
+                if (IPAddress.TryParse(peerHost, out IPAddress asIp))
+                {
+                    ips = new[] { asIp };
+                }
+                else
+                {
+                    ips = await Dns.GetHostAddressesAsync(peerHost);
+                }
+            }
+            else
+            {
+                ips = new[] { peer.PublicIPAddress };
+            }
+
+            try
+            {
+                foreach (IPAddress ip in ips)
+                {
+                    var ep = new IPEndPoint(ip, peer.EndPoint.Port);
+                    if (IPAddress.IsLoopback(ip))
+                    {
+                        // This translation is only used in test case because a
+                        // seed node exposes loopback address as public address to
+                        // other node in test case
+                        ep = await _turnClient.GetMappedAddressAsync(cts.Token);
+                    }
+
+                    // FIXME Can we really ignore IPv6 case?
+                    if (ip.AddressFamily.Equals(AddressFamily.InterNetwork))
+                    {
+                        await _turnClient.CreatePermissionAsync(ep, cts.Token);
+                    }
+                }
+            }
+            catch (TaskCanceledException tce)
+            {
+                if (cts.IsCancellationRequested)
+                {
+                    _logger.Debug(
+                        tce,
+                        "Timeout occurred during {FName}",
+                        nameof(CreatePermission));
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private async Task ProcessRuntime(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                foreach (KeyValuePair<Guid, ReplyStream> pair in _streams)
+                {
+                    // FIXME: This lifetime related disposing logic can be tested?
+                    if (pair.Value.SpawnAt + ListenerLifetime < DateTimeOffset.UtcNow)
+                    {
+                        _ = TryRemoveStreamAsync(pair.Key, cancellationToken);
+                    }
+                }
+
+                await Task.Delay(100, cancellationToken);
+            }
+        }
+
+        private async Task TryAddStreamAsync(
+            Guid id,
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            while (_streams.Count > MaxReplyStreams && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(100, cancellationToken);
+            }
+
+            _streams.TryAdd(id, new ReplyStream(client, DateTimeOffset.UtcNow));
+            _logger.Verbose("Added stream to the collection. {Id}", id);
+        }
+
+        private async Task TryRemoveStreamAsync(Guid id, CancellationToken cancellationToken)
+        {
+            if (!_streams.TryRemove(id, out ReplyStream stream))
+            {
+                return;
+            }
+
+            using var @lock = await stream.Lock.LockAsync(cancellationToken);
+            try
+            {
+                stream.Client.Close();
+                stream.Client.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            _logger.Verbose("Removed stream from the collection. {Id}", id);
+        }
+
+        private void StopAllStreams()
+        {
+            List<Task> tasks = new List<Task>();
+            foreach (var id in _streams.Keys)
+            {
+                tasks.Add(TryRemoveStreamAsync(id, default));
+            }
+
+            Task.WhenAll(tasks).Wait();
+        }
+
+        private struct ReplyStream
+        {
+            public ReplyStream(TcpClient client, DateTimeOffset spawnAt)
+            {
+                Client = client;
+                SpawnAt = spawnAt;
+                Lock = new AsyncLock();
+            }
+
+            public DateTimeOffset SpawnAt { get; }
+
+            public TcpClient Client { get; }
+
+            public AsyncLock Lock { get; }
+        }
+    }
+}

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -105,10 +105,12 @@ namespace Libplanet.Net.Transports
             _logger = Log.ForContext<TcpTransport>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
+            ProcessMessageHandler = new AsyncDelegate<Message>();
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
         }
 
-        public event EventHandler<Message> ProcessMessageHandler = null!;
+        /// <inheritdoc cref="ITransport.ProcessMessageHandler"/>
+        public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <inheritdoc cref="ITransport.AsPeer"/>
         public Peer AsPeer => EndPoint is null
@@ -626,8 +628,7 @@ namespace Libplanet.Net.Transports
 
                 var id = new Guid(message.Identity);
                 await TryAddStreamAsync(id, client, cancellationToken);
-
-                ProcessMessageHandler?.Invoke(this, message);
+                await ProcessMessageHandler.InvokeAsync(message);
             }
             catch (DifferentAppProtocolVersionException dapve)
             {

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -53,9 +53,8 @@ namespace Libplanet.Net.Transports
         private CancellationTokenSource _runtimeCancellationTokenSource;
         private CancellationTokenSource _turnCancellationTokenSource;
 
-        private int _listenPort;
         private DnsEndPoint? _hostEndPoint;
-        private TcpListener? _listener;
+        private TcpListener _listener;
         private TurnClient? _turnClient;
 
         private bool _disposed;
@@ -80,7 +79,6 @@ namespace Libplanet.Net.Transports
             _appProtocolVersion = appProtocolVersion;
             _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
             _host = host;
-            _listenPort = listenPort ?? 0;
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
             _iceServers = iceServers?.ToList();
             _minimumBroadcastTarget = minimumBroadcastTarget;
@@ -103,6 +101,7 @@ namespace Libplanet.Net.Transports
             _logger = Log.ForContext<TcpTransport>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, listenPort ?? 0));
             ProcessMessageHandler = new AsyncDelegate<Message>();
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
         }
@@ -145,7 +144,7 @@ namespace Libplanet.Net.Transports
         {
             if (!_disposed)
             {
-                _listener?.Stop();
+                _listener.Stop();
                 _runtimeCancellationTokenSource.Cancel();
                 _turnCancellationTokenSource.Cancel();
 
@@ -169,13 +168,10 @@ namespace Libplanet.Net.Transports
                 throw new TransportException("Transport is already running.");
             }
 
-            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, _listenPort));
             _listener.Start(ListenerBacklog);
+            int listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
 
-            // _listenPort might be 0, which is any, so it should be re-set.
-            _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
-
-            _logger.Information("Listen on {Port}", _listenPort);
+            _logger.Information("Listen on {Port}", listenPort);
             _runtimeCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _turnCancellationTokenSource =
@@ -184,7 +180,7 @@ namespace Libplanet.Net.Transports
             if (_host is null && !(_iceServers is null))
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
-                await _turnClient.StartAsync(_listenPort, cancellationToken);
+                await _turnClient.StartAsync(listenPort, cancellationToken);
 
                 _ = RefreshPermissions(_runtimeCancellationTokenSource.Token);
             }
@@ -197,7 +193,7 @@ namespace Libplanet.Net.Transports
                     throw new TransportException("Host is null.");
                 }
 
-                _hostEndPoint = new DnsEndPoint(host, _listenPort);
+                _hostEndPoint = new DnsEndPoint(host, listenPort);
             }
 
             List<Task> tasks = new List<Task>();
@@ -221,7 +217,7 @@ namespace Libplanet.Net.Transports
             if (Running)
             {
                 await Task.Delay(waitFor, cancellationToken);
-                _listener?.Stop();
+                _listener.Stop();
                 _runtimeCancellationTokenSource.Cancel();
                 StopAllStreams();
                 Running = false;
@@ -606,7 +602,7 @@ namespace Libplanet.Net.Transports
 
         private async Task ReceiveMessageAsync(CancellationToken cancellationToken)
         {
-            while (!(cancellationToken.IsCancellationRequested || _listener is null))
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {


### PR DESCRIPTION
This PR adds `TcpTransport` which implements `ITransport` interface. `NetMQTransport` is still supported, but it is not a default option anymore. In order to use `NetMQTransport`, please set `SwarmOptions.Type` to `SwarmOptions.TransportType.NetMQTransport`.

**Please be aware of compatibility**, since tcp-based transport cannot exchange data with netmq-based transport.