### PR TITLE
`TxExecution`: transaction execution summary

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -22,8 +22,8 @@ steps:
 - task: Cache@2
   displayName: Cache NuGet packages
   inputs:
-    key: 'nuget | "$(Agent.OS)" | **/*.csproj'
-    restoreKeys: 'nuget | "$(Agent.OS)"'
+    key: 'nuget | "$(Agent.OS)" | "${{ parameters.locale }}" | **/*.csproj'
+    restoreKeys: 'nuget | "$(Agent.OS)" | "${{ parameters.locale }}"'
     path: $(NUGET_PACKAGES)
 
 - task: DotNetCoreCLI@2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,8 @@ To be released.
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]
  -  Added `IStore.GetTxExecution()` method.  [[#1156], [#1289]]
+ -  Removed the optional parameter `Guid? chainId = null` from
+    `IStateStore.GetState()` method.  [[#1289]]
  -  Removed `compress` parameter from `DefaultStore()` constructor.  [[#1289]]
  -  Removed `statesCacheSize` parameter from `DefaultStore()` constructor.
     [[#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,7 @@ To be released.
 
  -  Added `BlockHash` struct.  [[#1192], [#1197]]
  -  Added `HashDigest<T>.DeriveFrom()` method.  [[#1197]]
+ -  Added `BlockChain<T>.GetTxExecution()` method.  [[#1156], [#1289]]
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]
  -  Added `Swarm<T>.AddPeersAsync()` method.  [[#1234]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,8 @@ To be released.
  -  Added `StaticPeers` as the last parameter to
     `RoutingTable(Address, int, int)` constructor.  [[#1230], [#1271]]
  -  Added `AtomicActionRenderer<T>` class.  [[#1267], [#1275]]
+ -  Added `IExtractableException` interface.  [[#1156], [#1289]]
+ -  Added `ExtractableException` static class.  [[#1156], [#1289]]
 
 ### Behavioral changes
 
@@ -215,6 +217,7 @@ To be released.
  -  Added `planet key derive` subcommand to derive the address or
     public key from a private.  [[#1268]]
 
+[#1156]: https://github.com/planetarium/libplanet/issues/1156
 [#1192]: https://github.com/planetarium/libplanet/issues/1192
 [#1197]: https://github.com/planetarium/libplanet/pull/1197
 [#1213]: https://github.com/planetarium/libplanet/issues/1213
@@ -233,6 +236,7 @@ To be released.
 [#1274]: https://github.com/planetarium/libplanet/pull/1274
 [#1275]: https://github.com/planetarium/libplanet/pull/1275
 [#1278]: https://github.com/planetarium/libplanet/pull/1278
+[#1289]: https://github.com/planetarium/libplanet/pull/1289
 
 
 Version 0.11.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,9 +208,10 @@ To be released.
  -  Fixed memory leak due to undisposed `CancellationTokenRegistration`s.
     [[#1228]]
  -  Fixed a bug where `DefaultStore.Dispose()` and `TrieStateStore.Dispose()`
-    hadn't worked idempotently.  [[#1272]]
- -  (Libplanet.RocksDBStore) Fixed a bug where `RocksDBStore.Dispose()` and
-    `RocksDBKeyValueStore.Dispose()` hadn't worked idempotently.  [[#1272]]
+    had not been idempotent.  [[#1272]]
+ -  (Libplanet.RocksDBStore) Fixed a bug where `RocksDBStore.Dispose()`,
+    `MonoRocksDBStore.Dispose()`, and `RocksDBKeyValueStore.Dispose()` had not
+    been idempotent.  [[#1272], [#1289]]
  -  Fixed a bug where `NetMQTransport` had hung forever within Mono runtime.
     [[#1278]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,6 +163,8 @@ To be released.
  -  Added `TxFailure` class.  [[#1156], [#1289]]
  -  Added `IExtractableException` interface.  [[#1156], [#1289]]
  -  Added `ExtractableException` static class.  [[#1156], [#1289]]
+ -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
+ -  Added `Currency.Serialize()` method.  [[#1289]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -168,6 +168,7 @@ To be released.
  -  Added `TxFailure` class.  [[#1156], [#1289]]
  -  Added `IExtractableException` interface.  [[#1156], [#1289]]
  -  Added `ExtractableException` static class.  [[#1156], [#1289]]
+ -  Added `Address(Binary)` overloaded constructor.  [[#1289]]
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,9 @@ To be released.
  -  Added `StaticPeers` as the last parameter to
     `RoutingTable(Address, int, int)` constructor.  [[#1230], [#1271]]
  -  Added `AtomicActionRenderer<T>` class.  [[#1267], [#1275]]
+ -  Added `TxExecution` abstract class.  [[#1156], [#1289]]
+ -  Added `TxSuccess` class.  [[#1156], [#1289]]
+ -  Added `TxFailure` class.  [[#1156], [#1289]]
  -  Added `IExtractableException` interface.  [[#1156], [#1289]]
  -  Added `ExtractableException` static class.  [[#1156], [#1289]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,9 @@ To be released.
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
  -  Added `IActionContext.TxId` property.  [[#1275]]
+ -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
+ -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]
+ -  Added `IStore.GetTxExecution()` method.  [[#1156], [#1289]]
  -  Removed `compress` parameter from `DefaultStore()` constructor.  [[#1289]]
  -  Removed `statesCacheSize` parameter from `DefaultStore()` constructor.
     [[#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,10 @@ To be released.
 
 ### Behavioral changes
 
+ -  `BlockChain<T>.Append()` now records a `TxExecution` for every single
+    transaction in the appended `Block<T>`, whether a transaction is successful
+    (`TxSuccess` is recorded for this case) or not (`TxFailure` is recorded
+    for this case).  [[#1156], [#1289]]
  -  `ITransport.StartAsync()` and `ITransport.RunAsync()` became to throw
     `TransportException` instead of `SwarmException`.  [[#1242]]
  -  When selecting peers for `ITransport.BroadcastMessage()`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,9 @@ To be released.
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
  -  Added `IActionContext.TxId` property.  [[#1275]]
+ -  Removed `compress` parameter from `DefaultStore()` constructor.  [[#1289]]
+ -  Removed `statesCacheSize` parameter from `DefaultStore()` constructor.
+    [[#1289]]
  -  Removed `StunMessage.Parse(Stream)` method.  [[#1228]]
  -  Moved `ITransport` and `NetMQTransport` from `Libplanet.Net` to
     `Libplanet.Net.Transports`.  [[#1235]]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -497,11 +497,7 @@ If omitted (default) explorer only the local blockchain store.")]
             {
             }
 
-            public IValue GetState(
-                string stateKey, BlockHash? blockHash = null, Guid? chainId = null)
-            {
-                return null;
-            }
+            public IValue GetState(string stateKey, BlockHash? blockHash = null) => null;
 
             public bool ContainsBlockStates(BlockHash blockHash) => false;
 

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -89,6 +89,18 @@ namespace Libplanet.Explorer.Store
             return _store.GetBlockIndex(blockHash);
         }
 
+        /// <inheritdoc cref="IStore.PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        public void PutTxExecution(TxSuccess txSuccess) =>
+            _store.PutTxExecution(txSuccess);
+
+        /// <inheritdoc cref="IStore.PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        public void PutTxExecution(TxFailure txFailure) =>
+            _store.PutTxExecution(txFailure);
+
+        /// <inheritdoc cref="IStore.GetTxExecution(BlockHash, TxId)"/>
+        public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
+            _store.GetTxExecution(blockHash, txid);
+
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash)
         {
             return _store.GetBlockPerceivedTime(blockHash);

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -53,6 +53,18 @@ namespace Libplanet.Explorer.Store
         public long? GetBlockIndex(BlockHash blockHash) =>
             _store.GetBlockIndex(blockHash);
 
+        /// <inheritdoc cref="IStore.PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        public void PutTxExecution(TxSuccess txSuccess) =>
+            _store.PutTxExecution(txSuccess);
+
+        /// <inheritdoc cref="IStore.PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        public void PutTxExecution(TxFailure txFailure) =>
+            _store.PutTxExecution(txFailure);
+
+        /// <inheritdoc cref="IStore.GetTxExecution(BlockHash, TxId)"/>
+        public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
+            _store.GetTxExecution(blockHash, txid);
+
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash) =>
             _store.GetBlockPerceivedTime(blockHash);
 

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -223,7 +223,7 @@ namespace Libplanet.Extensions.Cocona.Commands
                             return;
 
                         case Binary bin:
-                            table.Add((key, ByteUtil.Hex(bin.Value)));
+                            table.Add((key, ByteUtil.Hex(bin.ByteArray)));
                             return;
 
                         case Text t:

--- a/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreFixture.cs
+++ b/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreFixture.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tests.Store;
+
+namespace Libplanet.RocksDBStore.Tests
+{
+    public class MonoRocksDBStoreFixture : StoreFixture
+    {
+        public MonoRocksDBStoreFixture()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"rocksdb_test_{Guid.NewGuid()}"
+            );
+
+            var store = new MonoRocksDBStore(Path, blockCacheSize: 2, txCacheSize: 2);
+            Store = store;
+            StateStore = LoadTrieStateStore(Path);
+        }
+
+        public string Path { get; }
+
+        public IStateStore LoadTrieStateStore(string path)
+        {
+            IKeyValueStore stateKeyValueStore =
+                new RocksDBKeyValueStore(System.IO.Path.Combine(path, "states"));
+            IKeyValueStore stateHashKeyValueStore =
+                new RocksDBKeyValueStore(System.IO.Path.Combine(path, "states_hashes"));
+            return new TrieStateStore(stateKeyValueStore, stateHashKeyValueStore);
+        }
+
+        public override void Dispose()
+        {
+            (Store as IDisposable)?.Dispose();
+            (StateStore as IDisposable)?.Dispose();
+
+            if (!(Path is null))
+            {
+                Directory.Delete(Path, true);
+            }
+        }
+    }
+}

--- a/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Store;
+using Libplanet.Tests.Blockchain;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Libplanet.Tests.Store.Trie;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.RocksDBStore.Tests
+{
+    public class MonoRocksDBStoreTest : StoreTest, IDisposable
+    {
+        private readonly MonoRocksDBStoreFixture _fx;
+
+        public MonoRocksDBStoreTest(ITestOutputHelper testOutputHelper)
+        {
+            try
+            {
+                TestOutputHelper = testOutputHelper;
+                Fx = _fx = new MonoRocksDBStoreFixture();
+                FxConstructor = () => new MonoRocksDBStoreFixture();
+            }
+            catch (TypeInitializationException)
+            {
+                throw new SkipException("RocksDB is not available.");
+            }
+        }
+
+        protected override ITestOutputHelper TestOutputHelper { get; }
+
+        protected override StoreFixture Fx { get; }
+
+        protected override Func<StoreFixture> FxConstructor { get; }
+
+        public void Dispose()
+        {
+            _fx?.Dispose();
+        }
+
+        [SkippableFact]
+        public void ReopenStoreAfterDispose()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"rocksdb_test_{Guid.NewGuid()}");
+
+            try
+            {
+                var store = new MonoRocksDBStore(path);
+                var stateStore =
+                    new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
+                var blocks = new BlockChain<DumbAction>(
+                    new NullPolicy<DumbAction>(),
+                    new VolatileStagePolicy<DumbAction>(),
+                    store,
+                    stateStore,
+                    Fx.GenesisBlock
+                );
+                store.Dispose();
+
+                store = new MonoRocksDBStore(path);
+                store.Dispose();
+            }
+            finally
+            {
+                Directory.Delete(path, true);
+            }
+        }
+    }
+}

--- a/Libplanet.RocksDBStore/MonoRocksDBStore.cs
+++ b/Libplanet.RocksDBStore/MonoRocksDBStore.cs
@@ -51,6 +51,7 @@ namespace Libplanet.RocksDBStore
         private readonly RocksDb _txDb;
         private readonly RocksDb _stagedTxDb;
         private readonly RocksDb _chainDb;
+        private bool _disposed = false;
 
         /// <summary>
         /// Creates a new <seealso cref="RocksDBStore"/>.
@@ -613,11 +614,16 @@ namespace Libplanet.RocksDBStore
 
         public override void Dispose()
         {
-            _chainDb?.Dispose();
-            _txDb?.Dispose();
-            _blockDb?.Dispose();
-            _blockPerceptionDb?.Dispose();
-            _stagedTxDb?.Dispose();
+            if (!_disposed)
+            {
+                _chainDb?.Dispose();
+                _txDb?.Dispose();
+                _blockDb?.Dispose();
+                _blockPerceptionDb?.Dispose();
+                _txExecutionDb?.Dispose();
+                _stagedTxDb?.Dispose();
+                _disposed = true;
+            }
         }
 
         private byte[] BlockKey(in BlockHash blockHash) =>

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Bencodex;
 using Libplanet.Blocks;
 using Libplanet.Store;
 using Libplanet.Tx;
@@ -28,6 +29,7 @@ namespace Libplanet.RocksDBStore
         private const string TxDbRootPathName = "tx";
         private const string TxIndexDbName = "txindex";
         private const string StagedTxDbName = "stagedtx";
+        private const string TxExecutionDbName = "txexec";
         private const string ChainDbName = "chain";
         private const int ForkWriteBatchSize = 100000;
 
@@ -36,10 +38,13 @@ namespace Libplanet.RocksDBStore
         private static readonly byte[] TxKeyPrefix = { (byte)'T' };
         private static readonly byte[] TxNonceKeyPrefix = { (byte)'N' };
         private static readonly byte[] StagedTxKeyPrefix = { (byte)'t' };
+        private static readonly byte[] TxExecutionKeyPrefix = { (byte)'e' };
         private static readonly byte[] IndexCountKey = { (byte)'c' };
         private static readonly byte[] CanonicalChainIdIdKey = { (byte)'C' };
 
         private static readonly byte[] EmptyBytes = new byte[0];
+
+        private static readonly Codec Codec = new Codec();
 
         private readonly ILogger _logger;
 
@@ -57,6 +62,7 @@ namespace Libplanet.RocksDBStore
         private readonly RocksDb _txIndexDb;
         private readonly LruCache<string, RocksDb> _txDbCache;
         private readonly RocksDb _stagedTxDb;
+        private readonly RocksDb _txExecutionDb;
         private readonly RocksDb _chainDb;
 
         private readonly ReaderWriterLockSlim _rwTxLock;
@@ -145,6 +151,8 @@ namespace Libplanet.RocksDBStore
                 RocksDBUtils.OpenRocksDb(_options, RocksDbPath(BlockPerceptionDbName));
             _txIndexDb = RocksDBUtils.OpenRocksDb(_options, TxDbPath(TxIndexDbName));
             _stagedTxDb = RocksDBUtils.OpenRocksDb(_options, RocksDbPath(StagedTxDbName));
+            _txExecutionDb =
+                RocksDBUtils.OpenRocksDb(_options, RocksDbPath(TxExecutionDbName));
 
             // When opening a DB in a read-write mode, you need to specify all Column Families that
             // currently exist in a DB. https://github.com/facebook/rocksdb/wiki/Column-Families
@@ -759,6 +767,32 @@ namespace Libplanet.RocksDBStore
             return false;
         }
 
+        /// <inheritdoc cref="BaseStore.PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        public override void PutTxExecution(TxSuccess txSuccess) =>
+            _txExecutionDb.Put(
+                TxExecutionKey(txSuccess),
+                Codec.Encode(SerializeTxExecution(txSuccess))
+            );
+
+        /// <inheritdoc cref="BaseStore.PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        public override void PutTxExecution(TxFailure txFailure) =>
+            _txExecutionDb.Put(
+                TxExecutionKey(txFailure),
+                Codec.Encode(SerializeTxExecution(txFailure))
+            );
+
+        /// <inheritdoc cref="BaseStore.GetTxExecution(BlockHash, TxId)"/>
+        public override TxExecution GetTxExecution(BlockHash blockHash, TxId txid)
+        {
+            byte[] key = TxExecutionKey(blockHash, txid);
+            if (_txExecutionDb.Get(key) is { } bytes)
+            {
+                return DeserializeTxExecution(blockHash, txid, Codec.Decode(bytes), _logger);
+            }
+
+            return null;
+        }
+
         /// <inheritdoc cref="BaseStore.SetBlockPerceivedTime(BlockHash, DateTimeOffset)"/>
         public override void SetBlockPerceivedTime(
             BlockHash blockHash,
@@ -877,6 +911,7 @@ namespace Libplanet.RocksDBStore
                     _blockIndexDb?.Dispose();
                     _blockPerceptionDb?.Dispose();
                     _stagedTxDb?.Dispose();
+                    _txExecutionDb?.Dispose();
                     foreach (var db in _txDbCache.Values)
                     {
                         db.Dispose();
@@ -938,10 +973,16 @@ namespace Libplanet.RocksDBStore
         private byte[] TxNonceKey(in Address address) =>
             TxNonceKeyPrefix.Concat(address.ByteArray).ToArray();
 
-        private byte[] StagedTxKey(in TxId txId)
-        {
-            return StagedTxKeyPrefix.Concat(txId.ToByteArray()).ToArray();
-        }
+        private byte[] StagedTxKey(in TxId txId) =>
+            StagedTxKeyPrefix.Concat(txId.ToByteArray()).ToArray();
+
+        private byte[] TxExecutionKey(in BlockHash blockHash, in TxId txId) =>
+
+            // As BlockHash is not fixed size, place TxId first.
+            TxExecutionKeyPrefix.Concat(txId.ByteArray).Concat(blockHash.ByteArray).ToArray();
+
+        private byte[] TxExecutionKey(TxExecution txExecution) =>
+            TxExecutionKey(txExecution.BlockHash, txExecution.TxId);
 
         private IEnumerable<Iterator> IterateDb(RocksDb db, byte[] prefix, Guid? chainId = null)
         {

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -70,7 +70,6 @@ namespace Libplanet.RocksDBStore
         /// </param>
         /// <param name="blockCacheSize">The capacity of the block cache.</param>
         /// <param name="txCacheSize">The capacity of the transaction cache.</param>
-        /// <param name="statesCacheSize">The capacity of the states cache.</param>
         /// <param name="maxTotalWalSize">The number to configure <c>max_total_wal_size</c> RocksDB
         /// option.</param>
         /// <param name="keepLogFileNum">The number to configure <c>keep_log_file_num</c> RocksDB

--- a/Libplanet.Tests/Action/ExtractableExceptionTest.cs
+++ b/Libplanet.Tests/Action/ExtractableExceptionTest.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Bencodex.Types;
+using Libplanet.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Action
+{
+    public class ExtractableExceptionTest
+    {
+        [Fact]
+        [SuppressMessage(
+            "Major Code Smell",
+            "S3928",
+            Justification = "The ArgumentException instances made here are a just example."
+        )]
+        public void ExtractMetadata()
+        {
+            Assert.Null(ExtractableException.ExtractMetadata(new Exception()));
+            Assert.Equal(
+                Dictionary.Empty.Add("parameterName", "name"),
+                ExtractableException.ExtractMetadata(new ArgumentException("A message", "name"))
+            );
+            Assert.Equal(
+                Dictionary.Empty.Add("parameterName", "name"),
+                ExtractableException.ExtractMetadata(new ArgumentNullException("name"))
+            );
+            Assert.Equal(
+                Dictionary.Empty.Add("foo", 1).Add("bar", 2),
+                ExtractableException.ExtractMetadata(new SampleExtractableException())
+            );
+        }
+
+        public class SampleExtractableException : Exception, IExtractableException
+        {
+            public SampleExtractableException()
+            {
+            }
+
+            public IValue Metadata => Dictionary.Empty
+                .Add("foo", 1)
+                .Add("bar", 2);
+        }
+    }
+}

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Action
                     {
                         [(Text)"weapon"] = (Text)"frying pan",
                         [(Text)"target"] = (Text)"mosquito",
-                        [(Text)"target_address"] = new Binary(addr.ToByteArray()),
+                        [(Text)"target_address"] = new Binary(addr.ByteArray),
                     }),
                 }),
                 pa.PlainValue
@@ -51,7 +51,7 @@ namespace Libplanet.Tests.Action
                     {
                         [(Text)"weapon"] = (Text)"frying pan",
                         [(Text)"target"] = (Text)"mosquito",
-                        [(Text)"target_address"] = new Binary(addr.ToByteArray()),
+                        [(Text)"target_address"] = new Binary(addr.ByteArray),
                     }),
                 })
             );

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using Bencodex.Types;
 using Libplanet.Crypto;
 using Xunit;
 
@@ -137,6 +138,25 @@ namespace Libplanet.Tests
                     new Address(addressBytes)
                 );
             }
+        }
+
+        [Fact]
+        public void ConstructWithBinary()
+        {
+            byte[] addr =
+            {
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab,
+                0xcd, 0xef, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef, 0xab,
+                0xcd, 0xef,
+            };
+
+            Assert.Equal(
+                new Address("0123456789ABcdefABcdEfABcdEFabcDEFabCDEF"),
+                new Address((Binary)addr)
+            );
+
+            var invalidAddr = new byte[19];
+            Assert.Throws<ArgumentException>(() => new Address((Binary)invalidAddr));
         }
 
         [Fact]

--- a/Libplanet.Tests/Assets/CurrencyTest.cs
+++ b/Libplanet.Tests/Assets/CurrencyTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Crypto;
 using Xunit;
@@ -161,6 +162,34 @@ namespace Libplanet.Tests.Assets
             var foo = new Currency(ticker: "FOO", decimalPlaces: 0, minter: null);
             Assert.Equal(new FungibleAssetValue(foo, 123, 0), 123 * foo);
             Assert.Equal(new FungibleAssetValue(foo, -123, 0), foo * -123);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var foo = new Currency("FOO", 2, minters: null);
+            var bar = new Currency("BAR", 0, ImmutableHashSet.Create(AddressA, AddressB));
+
+            Assert.Equal(
+                Dictionary.Empty
+                    .Add("ticker", "FOO")
+                    .Add("decimals", 2)
+                    .Add("minters", Null.Value),
+                foo.Serialize()
+            );
+            Assert.Equal(
+                Dictionary.Empty
+                    .Add("ticker", "BAR")
+                    .Add("decimals", 0)
+                    .Add(
+                        "minters",
+                        (IValue)List.Empty.Add(AddressB.ToByteArray()).Add(AddressA.ToByteArray())
+                    ),
+                bar.Serialize()
+            );
+
+            Assert.Equal(foo, new Currency(foo.Serialize()));
+            Assert.Equal(bar, new Currency(bar.Serialize()));
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -2,11 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Bencodex.Types;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Store;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Serilog;
 using Xunit;
+using FAV = Libplanet.Assets.FungibleAssetValue;
 
 namespace Libplanet.Tests.Blockchain
 {
@@ -109,6 +115,193 @@ namespace Libplanet.Tests.Blockchain
             }
 
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ExecuteActions()
+        {
+            (var addresses, Transaction<DumbAction>[] txs) =
+                MakeFixturesForAppendTests();
+            var genesis = _blockChain.Genesis;
+
+            Block<DumbAction> block1 = TestUtils.MineNext(
+                genesis,
+                txs,
+                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
+            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+
+            _blockChain.Append(
+                block1,
+                DateTimeOffset.UtcNow,
+                evaluateActions: false,
+                renderBlocks: true,
+                renderActions: false
+            );
+
+            IStore store = _blockChain.Store;
+            foreach (Transaction<DumbAction> tx in txs)
+            {
+                Assert.Null(store.GetTxExecution(block1.Hash, tx.Id));
+                Assert.Null(store.GetTxExecution(genesis.Hash, tx.Id));
+                Assert.Null(store.GetTxExecution(_fx.Hash3, tx.Id));
+            }
+
+            var minerAddress = genesis.Miner.GetValueOrDefault();
+
+            var expectedStates = new Dictionary<Address, IValue>
+            {
+                { addresses[0], (Text)"foo" },
+                { addresses[1], (Text)"bar" },
+                { addresses[2], (Text)"baz" },
+                { addresses[3], (Text)"qux" },
+                { minerAddress, (Integer)2 },
+                { MinerReward.RewardRecordAddress, (Text)$"{minerAddress},{minerAddress}" },
+            };
+
+            _blockChain.ExecuteActions(block1);
+            foreach (KeyValuePair<Address, IValue> pair in expectedStates)
+            {
+                Assert.Equal(
+                    pair.Value,
+                    _fx.StateStore.GetState(KeyConverters.ToStateKey(pair.Key), block1.Hash));
+            }
+
+            foreach (Transaction<DumbAction> tx in txs)
+            {
+                var e = store.GetTxExecution(block1.Hash, tx.Id);
+                Assert.IsType<TxSuccess>(e);
+                var s = (TxSuccess)e;
+                Assert.Equal(block1.Hash, s.BlockHash);
+                Assert.Equal(tx.Id, s.TxId);
+                Assert.Equal(tx.UpdatedAddresses, s.UpdatedAddresses);
+                Assert.Equal(
+                    tx.UpdatedAddresses.ToImmutableDictionary(
+                        address => address,
+                        address => expectedStates[address]
+                    ),
+                    s.UpdatedStates
+                );
+                Assert.Empty(s.FungibleAssetsDelta);
+                Assert.Empty(s.UpdatedFungibleAssets);
+
+                Assert.Null(store.GetTxExecution(genesis.Hash, tx.Id));
+                Assert.Null(store.GetTxExecution(_fx.Hash3, tx.Id));
+            }
+
+            var pk = new PrivateKey();
+            Transaction<DumbAction> tx1Transfer = _fx.MakeTransaction(
+                new[]
+                {
+                    new DumbAction(pk.ToAddress(), "foo", pk.ToAddress(), addresses[1], 10),
+                    new DumbAction(addresses[0], "bar", pk.ToAddress(), addresses[2], 20),
+                },
+                nonce: 0,
+                privateKey: pk
+            );
+            Transaction<DumbAction> tx2Error = _fx.MakeTransaction(
+                new[]
+                {
+                    // As it tries to transfer a negative value, it throws
+                    // ArgumentOutOfRangeException:
+                    new DumbAction(pk.ToAddress(), "foo", addresses[0], addresses[1], -5),
+                },
+                nonce: 1,
+                privateKey: pk
+            );
+            Transaction<DumbAction> tx3Transfer = _fx.MakeTransaction(
+                new[]
+                {
+                    new DumbAction(pk.ToAddress(), "foo", pk.ToAddress(), addresses[1], 5),
+                },
+                nonce: 2,
+                privateKey: pk
+            );
+            Block<DumbAction> block2 = TestUtils.MineNext(
+                genesis,
+                new[] { tx1Transfer, tx2Error, tx3Transfer },
+                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
+            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            _blockChain.ExecuteActions(block2);
+            var txExecution1 = store.GetTxExecution(block2.Hash, tx1Transfer.Id);
+            Assert.IsType<TxSuccess>(txExecution1);
+            var txSuccess1 = (TxSuccess)txExecution1;
+            Assert.Equal(
+                addresses.Take(3).Append(pk.ToAddress()).ToImmutableHashSet(),
+                txSuccess1.UpdatedAddresses
+            );
+            Assert.Equal(
+                ImmutableDictionary<Address, IValue>.Empty
+                    .Add(pk.ToAddress(), (Text)"foo")
+                    .Add(addresses[0], (Text)"bar"),
+                txSuccess1.UpdatedStates
+            );
+            Assert.Equal(
+                ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
+                    .Add(
+                        pk.ToAddress(),
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * -30)
+                    )
+                    .Add(
+                        addresses[1],
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * 10)
+                    )
+                    .Add(
+                        addresses[2],
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * 20)
+                    ),
+                txSuccess1.UpdatedFungibleAssets
+            );
+            Assert.Equal(
+                txSuccess1.FungibleAssetsDelta,
+                txSuccess1.UpdatedFungibleAssets
+            );
+            var txExecution2 = store.GetTxExecution(block2.Hash, tx2Error.Id);
+            Assert.IsType<TxFailure>(txExecution2);
+            var txFailure = (TxFailure)txExecution2;
+            Assert.Equal(block2.Hash, txFailure.BlockHash);
+            Assert.Equal(tx2Error.Id, txFailure.TxId);
+            Assert.Equal(
+                $"{nameof(System)}.{nameof(ArgumentOutOfRangeException)}",
+                txFailure.ExceptionName
+            );
+            Assert.Equal(
+                Dictionary.Empty.Add("parameterName", "value"),
+                txFailure.ExceptionMetadata
+            );
+            var txExecution3 = store.GetTxExecution(block2.Hash, tx3Transfer.Id);
+            Assert.IsType<TxSuccess>(txExecution3);
+            var txSuccess3 = (TxSuccess)txExecution3;
+            Assert.Equal(
+                ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
+                    .Add(
+                        pk.ToAddress(),
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * -5)
+                    )
+                    .Add(
+                        addresses[1],
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * 5)
+                    ),
+                txSuccess3.FungibleAssetsDelta
+            );
+            Assert.Equal(
+                ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
+                    .Add(
+                        pk.ToAddress(),
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * -35)
+                    )
+                    .Add(
+                        addresses[1],
+                        ImmutableDictionary<Currency, FAV>.Empty
+                            .Add(DumbAction.DumbCurrency, DumbAction.DumbCurrency * 15)
+                    ),
+                txSuccess3.UpdatedFungibleAssets
+            );
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -698,48 +698,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void ExecuteActions()
-        {
-            (var addresses, Transaction<DumbAction>[] txs) =
-                MakeFixturesForAppendTests();
-            var genesis = _blockChain.Genesis;
-
-            Block<DumbAction> block1 = TestUtils.MineNext(
-                genesis,
-                txs,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
-
-            _blockChain.Append(
-                block1,
-                DateTimeOffset.UtcNow,
-                evaluateActions: false,
-                renderBlocks: true,
-                renderActions: false
-            );
-
-            var minerAddress = genesis.Miner.GetValueOrDefault();
-
-            var expectedStates = new Dictionary<Address, IValue>
-            {
-                { addresses[0], (Text)"foo" },
-                { addresses[1], (Text)"bar" },
-                { addresses[2], (Text)"baz" },
-                { addresses[3], (Text)"qux" },
-                { minerAddress, (Integer)2 },
-                { MinerReward.RewardRecordAddress, (Text)$"{minerAddress},{minerAddress}" },
-            };
-
-            _blockChain.ExecuteActions(block1);
-            foreach (KeyValuePair<Address, IValue> pair in expectedStates)
-            {
-                Assert.Equal(
-                    pair.Value,
-                    _fx.StateStore.GetState(KeyConverters.ToStateKey(pair.Key), block1.Hash));
-            }
-        }
-
-        [Fact]
         public async void FindNextHashes()
         {
             long? offsetIndex;

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Common.Action
         {
             Weapon = (Text)plainValue["weapon"];
             Target = (Text)plainValue["target"];
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -13,7 +13,7 @@ namespace Libplanet.Tests.Common.Action
             {
                 [(Text)"weapon"] = (Text)Weapon,
                 [(Text)"target"] = (Text)Target,
-                [(Text)"target_address"] = new Binary(TargetAddress.ToByteArray()),
+                [(Text)"target_address"] = new Binary(TargetAddress.ByteArray),
             });
 
         public string Weapon { get; set; }
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Common.Action
         {
             Weapon = (Text)plainValue["weapon"];
             Target = (Text)plainValue["target"];
-            TargetAddress = new Address((Binary)plainValue["target_address"]);
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/DetectRehearsal.cs
+++ b/Libplanet.Tests/Common/Action/DetectRehearsal.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Tests.Common.Action
         public override IValue PlainValue =>
             new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
-                { (Text)"target_address", new Binary(TargetAddress.ToByteArray()) },
+                { (Text)"target_address", new Binary(TargetAddress.ByteArray) },
             });
 
         public bool ResultState { get; set; }
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Common.Action
 
         public void LoadPlainValue(Bencodex.Types.Dictionary plainValue)
         {
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/DetectRehearsal.cs
+++ b/Libplanet.Tests/Common/Action/DetectRehearsal.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Common.Action
 
         public void LoadPlainValue(Bencodex.Types.Dictionary plainValue)
         {
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -87,7 +87,7 @@ namespace Libplanet.Tests.Common.Action
                 var plainValue = new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
                 {
                     [(Text)"item"] = (Text)Item,
-                    [(Text)"target_address"] = new Binary(TargetAddress.ToByteArray()),
+                    [(Text)"target_address"] = new Binary(TargetAddress.ByteArray),
                     [(Text)"record_rehearsal"] = new Bencodex.Types.Boolean(RecordRehearsal),
                 });
                 if (RecordRandom)
@@ -105,8 +105,8 @@ namespace Libplanet.Tests.Common.Action
                 if (!(Transfer is null))
                 {
                     plainValue = plainValue
-                        .Add("transfer_from", Transfer.Item1.ToByteArray())
-                        .Add("transfer_to", Transfer.Item2.ToByteArray())
+                        .Add("transfer_from", Transfer.Item1.ByteArray)
+                        .Add("transfer_to", Transfer.Item2.ByteArray)
                         .Add("transfer_amount", (IValue)new Bencodex.Types.Integer(Transfer.Item3));
                 }
 
@@ -207,7 +207,7 @@ namespace Libplanet.Tests.Common.Action
         )
         {
             Item = plainValue.GetValue<Text>("item");
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").Value);
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
             RecordRehearsal = plainValue.GetValue<Boolean>("record_rehearsal").Value;
             RecordRandom =
                 plainValue.ContainsKey((IKey)(Text)"record_random") &&
@@ -227,8 +227,8 @@ namespace Libplanet.Tests.Common.Action
                 a is Integer amount)
             {
                 Transfer = Tuple.Create(
-                    new Address(from.Value),
-                    new Address(to.Value),
+                    new Address(from.ByteArray),
+                    new Address(to.ByteArray),
                     amount.Value
                 );
             }

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -207,7 +207,7 @@ namespace Libplanet.Tests.Common.Action
         )
         {
             Item = plainValue.GetValue<Text>("item");
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address").ByteArray);
+            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
             RecordRehearsal = plainValue.GetValue<Boolean>("record_rehearsal").Value;
             RecordRandom =
                 plainValue.ContainsKey((IKey)(Text)"record_random") &&
@@ -226,11 +226,7 @@ namespace Libplanet.Tests.Common.Action
                 plainValue.TryGetValue((Text)"transfer_amount", out IValue a) &&
                 a is Integer amount)
             {
-                Transfer = Tuple.Create(
-                    new Address(from.ByteArray),
-                    new Address(to.ByteArray),
-                    amount.Value
-                );
+                Transfer = Tuple.Create(new Address(from), new Address(to), amount.Value);
             }
         }
 

--- a/Libplanet.Tests/EnumerableShim.cs
+++ b/Libplanet.Tests/EnumerableShim.cs
@@ -1,0 +1,26 @@
+#pragma warning disable S1128
+using System.Collections.Generic;
+#pragma warning restore S1128 // S1128: Remove this unnecessary 'using'
+
+namespace Libplanet.Tests
+{
+    /// <summary>
+    /// Compatibility shim to fill the lack of extension methods on <see cref="IEnumerable{T}"/>
+    /// in several target frameworks.
+    /// </summary>
+    public static class EnumerableShim
+    {
+#if NETFRAMEWORK && !NET48 && !NET472 && !NET471
+        // Enumerable.Append<T>(IEnumerable<T>, T) is introduced since .NET Framework 4.7.1
+        public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T element)
+        {
+            foreach (T e in source)
+            {
+                yield return e;
+            }
+
+            yield return element;
+        }
+#endif
+    }
+}

--- a/Libplanet.Tests/KeyValuePairExtensionsTest.cs
+++ b/Libplanet.Tests/KeyValuePairExtensionsTest.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Libplanet.Tests
+{
+    public class KeyValuePairExtensionsTest
+    {
+        [Fact]
+        public void ReplaceKey()
+        {
+            Assert.Equal(
+                new KeyValuePair<string, int>("FOO", 1),
+                new KeyValuePair<string, int>("foo", 1).ReplaceKey("FOO")
+            );
+            Assert.Equal(
+                new KeyValuePair<string, int>("baz", 2),
+                new KeyValuePair<string, int>("bar", 2).ReplaceKey("baz")
+            );
+        }
+
+        [Fact]
+        public void ReplaceValue()
+        {
+            Assert.Equal(
+                new KeyValuePair<string, int>("foo", 0),
+                new KeyValuePair<string, int>("foo", 1).ReplaceValue(0)
+            );
+            Assert.Equal(
+                new KeyValuePair<string, int>("bar", 3),
+                new KeyValuePair<string, int>("bar", 2).ReplaceValue(3)
+            );
+        }
+
+        [Fact]
+        public void SelectWithinKeys()
+        {
+            var @in = ImmutableDictionary<string, int>.Empty.Add("foo", 1).Add("bar", 2);
+            var @out = @in.SelectWithinKeys(k => k.ToUpperInvariant()).ToImmutableDictionary();
+            Assert.Equal(
+                new Dictionary<string, int> { ["FOO"] = 1, ["BAR"] = 2 }.ToImmutableDictionary(),
+                @out
+            );
+        }
+
+        [Fact]
+        public void SelectWithinValues()
+        {
+            var @in = ImmutableDictionary<string, int>.Empty.Add("foo", 1).Add("bar", 2);
+            var @out = @in.SelectWithinValues(v => -v * 2).ToImmutableDictionary();
+            Assert.Equal(
+                new Dictionary<string, int> { ["foo"] = -2, ["bar"] = -4 }.ToImmutableDictionary(),
+                @out
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/RandomExtensions.cs
+++ b/Libplanet.Tests/RandomExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using Libplanet.Blocks;
 using Libplanet.Tx;
 
 namespace Libplanet.Tests
@@ -23,5 +24,8 @@ namespace Libplanet.Tests
             where T : HashAlgorithm
         =>
             new HashDigest<T>(random.NextBytes(HashDigest<T>.Size));
+
+        public static BlockHash NextBlockHash(this Random random, int size) =>
+            new BlockHash(random.NextBytes(size));
     }
 }

--- a/Libplanet.Tests/Store/StateStoreTracker.cs
+++ b/Libplanet.Tests/Store/StateStoreTracker.cs
@@ -25,10 +25,10 @@ namespace Libplanet.Tests.Store
             _stateStore.SetStates(blockHash, states);
         }
 
-        public IValue GetState(string stateKey, BlockHash? blockHash = null, Guid? chainId = null)
+        public IValue GetState(string stateKey, BlockHash? blockHash = null)
         {
-            Log(nameof(GetState), stateKey, blockHash, chainId);
-            return _stateStore.GetState(stateKey, blockHash, chainId);
+            Log(nameof(GetState), stateKey, blockHash);
+            return _stateStore.GetState(stateKey, blockHash);
         }
 
         public bool ContainsBlockStates(BlockHash blockHash)

--- a/Libplanet.Tests/Store/StateStoreTrackerTest.cs
+++ b/Libplanet.Tests/Store/StateStoreTrackerTest.cs
@@ -27,10 +27,9 @@ namespace Libplanet.Tests.Store
         public void MethodCallsAreLogged()
         {
             var blockHash = default(BlockHash);
-            var chainId = default(Guid);
-            _tracker.GetState("stateKey", blockHash, chainId);
+            _tracker.GetState("stateKey", blockHash);
             StoreTrackLog storeTrackLog = StoreTrackLog.Create(
-                nameof(_tracker.GetState), "stateKey", blockHash, chainId);
+                nameof(_tracker.GetState), "stateKey", blockHash);
             Assert.Equal(1, _tracker.Logs.Count);
             Assert.Equal(
                 storeTrackLog,
@@ -49,8 +48,7 @@ namespace Libplanet.Tests.Store
         public void ClearLogs()
         {
             var blockHash = default(BlockHash);
-            var chainId = default(Guid);
-            _tracker.GetState("stateKey", blockHash, chainId);
+            _tracker.GetState("stateKey", blockHash);
             var randomHash = new BlockHash(TestUtils.GetRandomBytes(32));
             _tracker.ContainsBlockStates(randomHash);
             Assert.Equal(2, _tracker.Logs.Count);
@@ -66,11 +64,7 @@ namespace Libplanet.Tests.Store
             {
             }
 
-            public IValue GetState(
-                string stateKey, BlockHash? blockHash = null, Guid? chainId = null)
-            {
-                return null;
-            }
+            public IValue GetState(string stateKey, BlockHash? blockHash = null) => null;
 
             public bool ContainsBlockStates(BlockHash blockHash) => false;
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -19,6 +19,7 @@ using Serilog;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
+using FAV = Libplanet.Assets.FungibleAssetValue;
 
 namespace Libplanet.Tests.Store
 {
@@ -177,8 +178,7 @@ namespace Libplanet.Tests.Store
                 var success = (TxSuccess)actual;
                 Assert.Equal(expected.TxId, success.TxId);
                 Assert.Equal(expected.BlockHash, success.BlockHash);
-                Assert.Equal(expected.StateRootHash, success.StateRootHash);
-                Assert.Equal(expected.StateUpdatedAddresses, success.StateUpdatedAddresses);
+                Assert.Equal(expected.UpdatedStates, success.UpdatedStates);
                 Assert.Equal(expected.UpdatedFungibleAssets, success.UpdatedFungibleAssets);
             }
 
@@ -201,12 +201,17 @@ namespace Libplanet.Tests.Store
             var inputA = new TxSuccess(
                 Fx.Hash1,
                 Fx.TxId1,
-                random.NextHashDigest<SHA256>(),
-                ImmutableHashSet<Address>.Empty.Add(random.NextAddress()),
-                ImmutableDictionary<Address, IImmutableSet<Currency>>.Empty
+                ImmutableDictionary<Address, IValue>.Empty.Add(
+                    random.NextAddress(),
+                    (Text)"state value"
+                ),
+                ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
                     .Add(
                         random.NextAddress(),
-                        ImmutableHashSet<Currency>.Empty.Add(DumbAction.DumbCurrency)
+                        ImmutableDictionary<Currency, FAV>.Empty.Add(
+                            DumbAction.DumbCurrency,
+                            DumbAction.DumbCurrency * 10
+                        )
                     )
             );
             Fx.Store.PutTxExecution(inputA);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -802,8 +802,8 @@ namespace Libplanet.Tests.Store
             public IValue PlainValue =>
                 new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
                 {
-                    { (Text)"bytes", new Binary(ArbitraryBytes.ToArray()) },
-                    { (Text)"md5", new Binary(Md5Digest.ToArray()) },
+                    { (Text)"bytes", new Binary(ArbitraryBytes) },
+                    { (Text)"md5", new Binary(Md5Digest) },
                 });
 
             public void LoadPlainValue(IValue plainValue)
@@ -813,8 +813,8 @@ namespace Libplanet.Tests.Store
 
             public void LoadPlainValue(Dictionary plainValue)
             {
-                ArbitraryBytes = plainValue.GetValue<Binary>("bytes").ToImmutableArray();
-                Md5Digest = plainValue.GetValue<Binary>("md5").ToImmutableArray();
+                ArbitraryBytes = plainValue.GetValue<Binary>("bytes").ByteArray;
+                Md5Digest = plainValue.GetValue<Binary>("md5").ByteArray;
             }
 
             public IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -179,6 +179,7 @@ namespace Libplanet.Tests.Store
                 Assert.Equal(expected.TxId, success.TxId);
                 Assert.Equal(expected.BlockHash, success.BlockHash);
                 Assert.Equal(expected.UpdatedStates, success.UpdatedStates);
+                Assert.Equal(expected.FungibleAssetsDelta, success.FungibleAssetsDelta);
                 Assert.Equal(expected.UpdatedFungibleAssets, success.UpdatedFungibleAssets);
             }
 
@@ -205,6 +206,14 @@ namespace Libplanet.Tests.Store
                     random.NextAddress(),
                     (Text)"state value"
                 ),
+                ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
+                    .Add(
+                        random.NextAddress(),
+                        ImmutableDictionary<Currency, FAV>.Empty.Add(
+                            DumbAction.DumbCurrency,
+                            DumbAction.DumbCurrency * 5
+                        )
+                    ),
                 ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>.Empty
                     .Add(
                         random.NextAddress(),

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -53,6 +53,24 @@ namespace Libplanet.Tests.Store
             return _store.ContainsBlock(blockHash);
         }
 
+        public void PutTxExecution(TxSuccess txSuccess)
+        {
+            Log(nameof(PutTxExecution), txSuccess);
+            _store.PutTxExecution(txSuccess);
+        }
+
+        public void PutTxExecution(TxFailure txFailure)
+        {
+            Log(nameof(PutTxExecution), txFailure);
+            _store.PutTxExecution(txFailure);
+        }
+
+        public TxExecution GetTxExecution(BlockHash blockHash, TxId txid)
+        {
+            Log(nameof(GetTxExecution), blockHash, txid);
+            return _store.GetTxExecution(blockHash, txid);
+        }
+
         public void SetBlockPerceivedTime(BlockHash blockHash, DateTimeOffset perceivedTime)
         {
             Log(nameof(SetBlockPerceivedTime), blockHash, perceivedTime);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -502,9 +502,9 @@ namespace Libplanet.Tests.Tx
 
             var targetAddress =
                 ((Bencodex.Types.Dictionary)tx.Actions[0].InnerAction.PlainValue)
-                    .GetValue<Binary>("target_address").Value;
+                    .GetValue<Binary>("target_address").ByteArray;
             AssertBytesEqual(
-                new Address(publicKey).ToByteArray(),
+                new Address(publicKey).ByteArray,
                 targetAddress
             );
             Assert.Equal(

--- a/Libplanet.Tests/Tx/TxFailureTest.cs
+++ b/Libplanet.Tests/Tx/TxFailureTest.cs
@@ -30,12 +30,22 @@ namespace Libplanet.Tests.Tx
         }
 
         [Fact]
-        public void Constructor()
+        public void ConstructorWithExceptionObject()
         {
             Assert.Equal(_blockHash, _fx.BlockHash);
             Assert.Equal(_txid, _fx.TxId);
             Assert.Equal($"{nameof(System)}.{nameof(ArgumentNullException)}", _fx.ExceptionName);
             Assert.Equal(Dictionary.Empty.Add("parameterName", "foo"), _fx.ExceptionMetadata);
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            var f = new TxFailure(_blockHash, _txid, nameof(ArgumentNullException), (Text)"foo");
+            Assert.Equal(_blockHash, f.BlockHash);
+            Assert.Equal(_txid, f.TxId);
+            Assert.Equal(nameof(ArgumentNullException), f.ExceptionName);
+            Assert.Equal((Text)"foo", f.ExceptionMetadata);
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TxFailureTest.cs
+++ b/Libplanet.Tests/Tx/TxFailureTest.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Tests.Tx
+{
+    public class TxFailureTest
+    {
+        private readonly BlockHash _blockHash;
+        private readonly TxId _txid;
+        private readonly TxFailure _fx;
+
+        [SuppressMessage(
+            "Major Code Smell",
+            "S3928",
+            Justification = "The ArgumentNullException instance made here is a just example."
+        )]
+        public TxFailureTest()
+        {
+            var random = new Random();
+            _blockHash = random.NextBlockHash(HashDigest<SHA256>.Size);
+            _txid = random.NextTxId();
+            _fx = new TxFailure(_blockHash, _txid, new ArgumentNullException("foo"));
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Equal(_blockHash, _fx.BlockHash);
+            Assert.Equal(_txid, _fx.TxId);
+            Assert.Equal($"{nameof(System)}.{nameof(ArgumentNullException)}", _fx.ExceptionName);
+            Assert.Equal(Dictionary.Empty.Add("parameterName", "foo"), _fx.ExceptionMetadata);
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var formatter = new BinaryFormatter();
+            var stream = new MemoryStream();
+            formatter.Serialize(stream, _fx);
+            stream.Seek(0, SeekOrigin.Begin);
+            object deserialized = formatter.Deserialize(stream);
+            Assert.IsType<TxFailure>(deserialized);
+            var f = (TxFailure)deserialized;
+            Assert.Equal(_blockHash, f.BlockHash);
+            Assert.Equal(_txid, f.TxId);
+            Assert.Equal(_fx.ExceptionName, f.ExceptionName);
+            Assert.Equal(_fx.ExceptionMetadata, f.ExceptionMetadata);
+        }
+    }
+}

--- a/Libplanet.Tests/Tx/TxSuccessTest.cs
+++ b/Libplanet.Tests/Tx/TxSuccessTest.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 using Xunit;
+using FAV = Libplanet.Assets.FungibleAssetValue;
 
 namespace Libplanet.Tests.Tx
 {
@@ -18,9 +20,8 @@ namespace Libplanet.Tests.Tx
 
         private readonly BlockHash _blockHash;
         private readonly TxId _txid;
-        private readonly HashDigest<SHA256> _stateRootHash;
-        private readonly ImmutableHashSet<Address> _stateUpdatedAddresses;
-        private readonly ImmutableDictionary<Address, IImmutableSet<Currency>>
+        private readonly ImmutableDictionary<Address, IValue> _updatedStates;
+        private readonly ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
             _updatedFungibleAssets;
 
         private readonly TxSuccess _fx;
@@ -30,25 +31,32 @@ namespace Libplanet.Tests.Tx
             var random = new Random();
             _blockHash = random.NextBlockHash(HashDigest<SHA256>.Size);
             _txid = random.NextTxId();
-            _stateRootHash = random.NextHashDigest<SHA256>();
-            _stateUpdatedAddresses = Enumerable.Repeat(random, 5)
-                .Select(RandomExtensions.NextAddress)
-                .ToImmutableHashSet();
-            _updatedFungibleAssets = Enumerable.Repeat(0, 5)
-                .Select(_ =>
-                    new KeyValuePair<Address, IImmutableSet<Currency>>(
-                        random.NextAddress(),
-                        Enumerable.Repeat(0, random.Next(Currencies.Length) + 1)
-                            .Select(__ => Currencies[random.Next(Currencies.Length)])
-                            .ToImmutableHashSet()
+            _updatedStates = Enumerable.Repeat(random, 5).ToImmutableDictionary(
+                RandomExtensions.NextAddress,
+                _ => (IValue)new Bencodex.Types.Integer(random.Next())
+            );
+            var currencies = Currencies.ToList();
+            _updatedFungibleAssets = Enumerable.Repeat(random, 5).ToImmutableDictionary(
+                RandomExtensions.NextAddress,
+                _ => (IImmutableDictionary<Currency, FAV>)Enumerable.Repeat(
+                        0,
+                        random.Next(currencies.Count))
+                    .Select(__ =>
+                    {
+                        int i = random.Next(currencies.Count);
+                        Currency c = currencies[i];
+                        currencies.RemoveAt(i);
+                        return c;
+                    })
+                    .ToImmutableDictionary(
+                        c => c,
+                        c => c * random.Next()
                     )
-                )
-                .ToImmutableDictionary();
+            );
             _fx = new TxSuccess(
                 _blockHash,
                 _txid,
-                _stateRootHash,
-                _stateUpdatedAddresses,
+                _updatedStates,
                 _updatedFungibleAssets
             );
         }
@@ -58,8 +66,7 @@ namespace Libplanet.Tests.Tx
         {
             Assert.Equal(_blockHash, _fx.BlockHash);
             Assert.Equal(_txid, _fx.TxId);
-            Assert.Equal(_stateRootHash, _fx.StateRootHash);
-            Assert.Equal(_stateUpdatedAddresses, _fx.StateUpdatedAddresses);
+            Assert.Equal(_updatedStates, _fx.UpdatedStates);
             Assert.Equal(_updatedFungibleAssets, _fx.UpdatedFungibleAssets);
         }
     }

--- a/Libplanet.Tests/Tx/TxSuccessTest.cs
+++ b/Libplanet.Tests/Tx/TxSuccessTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Tests.Tx
+{
+    public class TxSuccessTest
+    {
+        private static readonly Currency[] Currencies = new[] { "FOO", "BAR", "BAZ", "QUX" }
+            .Select(ticker => new Currency(ticker, 0, minters: null))
+            .ToArray();
+
+        private readonly BlockHash _blockHash;
+        private readonly TxId _txid;
+        private readonly HashDigest<SHA256> _stateRootHash;
+        private readonly ImmutableHashSet<Address> _stateUpdatedAddresses;
+        private readonly ImmutableDictionary<Address, IImmutableSet<Currency>>
+            _updatedFungibleAssets;
+
+        private readonly TxSuccess _fx;
+
+        public TxSuccessTest()
+        {
+            var random = new Random();
+            _blockHash = random.NextBlockHash(HashDigest<SHA256>.Size);
+            _txid = random.NextTxId();
+            _stateRootHash = random.NextHashDigest<SHA256>();
+            _stateUpdatedAddresses = Enumerable.Repeat(random, 5)
+                .Select(RandomExtensions.NextAddress)
+                .ToImmutableHashSet();
+            _updatedFungibleAssets = Enumerable.Repeat(0, 5)
+                .Select(_ =>
+                    new KeyValuePair<Address, IImmutableSet<Currency>>(
+                        random.NextAddress(),
+                        Enumerable.Repeat(0, random.Next(Currencies.Length) + 1)
+                            .Select(__ => Currencies[random.Next(Currencies.Length)])
+                            .ToImmutableHashSet()
+                    )
+                )
+                .ToImmutableDictionary();
+            _fx = new TxSuccess(
+                _blockHash,
+                _txid,
+                _stateRootHash,
+                _stateUpdatedAddresses,
+                _updatedFungibleAssets
+            );
+        }
+
+        [Fact]
+        public void ConstructorBuilder()
+        {
+            Assert.Equal(_blockHash, _fx.BlockHash);
+            Assert.Equal(_txid, _fx.TxId);
+            Assert.Equal(_stateRootHash, _fx.StateRootHash);
+            Assert.Equal(_stateUpdatedAddresses, _fx.StateUpdatedAddresses);
+            Assert.Equal(_updatedFungibleAssets, _fx.UpdatedFungibleAssets);
+        }
+    }
+}

--- a/Libplanet/Action/AccountStateDeltaExtensions.cs
+++ b/Libplanet/Action/AccountStateDeltaExtensions.cs
@@ -8,7 +8,7 @@ using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Action
 {
-    internal static class IAccountStateDeltaExtensions
+    internal static class AccountStateDeltaExtensions
     {
         internal static IImmutableDictionary<Address, IValue> GetUpdatedStates(
             this IAccountStateDelta delta

--- a/Libplanet/Action/ExtractableException.cs
+++ b/Libplanet/Action/ExtractableException.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.Diagnostics.Contracts;
+using Bencodex.Types;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// Extension methods for <see cref="IExtractableException"/> and other <see cref="Exception"/>s
+    /// that do not implement <see cref="IExtractableException"/>.
+    /// </summary>
+    public static class ExtractableException
+    {
+        /// <summary>
+        /// Extracts metadata from any exception in a general way.
+        /// </summary>
+        /// <param name="exception">An exception to extract its metadata from.</param>
+        /// <returns>Extracted metadata.  If there is not its metadata at all, or it does not
+        /// support metadata extraction, it can return <c>null</c> instead.</returns>
+        [Pure]
+        public static IValue? ExtractMetadata(this Exception exception) =>
+            exception switch
+            {
+                IExtractableException extractable =>
+                    extractable.Metadata,
+                ArgumentException argExc =>
+                    Dictionary.Empty.Add(
+                        "parameterName",
+                        argExc.ParamName is { } name ? (Text)name : (IValue)Null.Value
+                    ),
+                _ =>
+                    null,
+            };
+    }
+}

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -142,7 +142,7 @@ namespace Libplanet.Action
     ///         var dictionary = (Bencodex.Types.Dictionary)plainValue;
     ///         Type = (ActType)(int)dictionary.GetValue<Integer>("type");
     ///         TargetAddress =
-    ///             new Address(dictionary.GetValue<Binary>("target_address").Value);
+    ///             new Address(dictionary.GetValue<Binary>("target_address"));
     ///     }
     /// }
     /// ]]></code>

--- a/Libplanet/Action/IExtractableException.cs
+++ b/Libplanet/Action/IExtractableException.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System.Diagnostics.Contracts;
+using Bencodex.Types;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// Marks an exception type as able to extract its metadata.
+    /// </summary>
+    public interface IExtractableException
+    {
+        /// <summary>
+        /// Metadata of the exception.
+        /// </summary>
+        /// <remarks>As every metadata becomes a part of blockchain, which is replicated database
+        /// on the network, for the equivalent exception, the same metadata should be extracted.
+        /// </remarks>
+        [Pure]
+        public IValue Metadata { get; }
+    }
+}

--- a/Libplanet/Action/IExtractableException.cs
+++ b/Libplanet/Action/IExtractableException.cs
@@ -1,16 +1,20 @@
 #nullable enable
 using System.Diagnostics.Contracts;
 using Bencodex.Types;
+using Libplanet.Tx;
 
 namespace Libplanet.Action
 {
     /// <summary>
-    /// Marks an exception type as able to extract its metadata.
+    /// Marks an exception type as able to extract its metadata, so that these metadata can be
+    /// stored as a part of <see cref="TxFailure"/>.
     /// </summary>
+    /// <seealso cref="TxFailure.ExceptionMetadata"/>
     public interface IExtractableException
     {
         /// <summary>
-        /// Metadata of the exception.
+        /// Metadata of the exception.  It purposes to store these metadata as a part of
+        /// <see cref="TxFailure"/>.
         /// </summary>
         /// <remarks>As every metadata becomes a part of blockchain, which is replicated database
         /// on the network, for the equivalent exception, the same metadata should be extracted.

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
 using Org.BouncyCastle.Crypto.Digests;
@@ -129,6 +130,20 @@ namespace Libplanet
         /// >EIP 55</a>.</param>
         public Address(string hex)
             : this(DeriveAddress(hex))
+        {
+        }
+
+        /// <summary>
+        /// Creates an <see cref="Address"/> instance from the given Bencodex <see cref="Binary"/>
+        /// (i.e., <paramref name="address"/>).
+        /// </summary>
+        /// <param name="address">A Bencodex <see cref="Binary"/> of 20 <see cref="byte"/>s which
+        /// represents an <see cref="Address"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">Thrown when the given <paramref name="address"/>
+        /// did not lengthen 20 bytes.</exception>
+        public Address(Binary address)
+            : this(address.ByteArray)
         {
         }
 

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -157,7 +157,7 @@ namespace Libplanet.Assets
             {
                 Minters = l.Select(
                     m => m is Binary b
-                        ? new Address(b)
+                        ? new Address(b.ByteArray)
                         : throw new ArgumentException(
                             "Expected \"minters\" to be a list of binary arrays.",
                             nameof(serialized))
@@ -268,7 +268,7 @@ namespace Libplanet.Assets
         public IValue Serialize()
         {
             IValue minters = Minters is ImmutableHashSet<Address> a
-                ? new List(a.OrderBy(m => m).Select(m => (IValue)new Binary(m.ToByteArray())))
+                ? new List(a.OrderBy(m => m).Select(m => (IValue)new Binary(m.ByteArray)))
                 : (IValue)Null.Value;
             return Dictionary.Empty
                 .Add("ticker", Ticker)

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -111,6 +111,66 @@ namespace Libplanet.Assets
         {
         }
 
+        /// <summary>
+        /// Deserializes a <see cref="Currency"/> type from a Bencodex value.
+        /// </summary>
+        /// <param name="serialized">The Bencodex value serialized by <see cref="Serialize()"/>
+        /// method.</param>
+        /// <seealso cref="Serialize()"/>
+        public Currency(IValue serialized)
+        {
+            if (!(serialized is Dictionary d))
+            {
+                throw new ArgumentException("Expected a Bencodex dictionary.", nameof(serialized));
+            }
+
+            if (!(d.ContainsKey("ticker") && d["ticker"] is Text ticker))
+            {
+                throw new ArgumentException(
+                    "Expected a text field named \"ticker\".",
+                    nameof(serialized)
+                );
+            }
+
+            if (!(d.ContainsKey("decimals") && d["decimals"] is Integer decimals))
+            {
+                throw new ArgumentException(
+                    "Expected an integer field named \"decimals\".",
+                    nameof(serialized)
+                );
+            }
+
+            if (!d.ContainsKey("minters") ||
+                !(d["minters"] is { } minters) ||
+                !(minters is Null || minters is List))
+            {
+                throw new ArgumentException(
+                    "Expected a nullable list field named \"minters\".",
+                    nameof(serialized)
+                );
+            }
+
+            Ticker = ticker;
+            DecimalPlaces = (byte)(long)decimals;
+
+            if (minters is List l)
+            {
+                Minters = l.Select(
+                    m => m is Binary b
+                        ? new Address(b)
+                        : throw new ArgumentException(
+                            "Expected \"minters\" to be a list of binary arrays.",
+                            nameof(serialized))
+                ).ToImmutableHashSet();
+            }
+            else
+            {
+                Minters = null;
+            }
+
+            Hash = GetHash();
+        }
+
         private Currency(SerializationInfo info, StreamingContext context)
         {
             Ticker = info.GetValue<string>(nameof(Ticker));
@@ -200,6 +260,22 @@ namespace Libplanet.Assets
         public bool Equals(Currency other) =>
             Hash.Equals(other.Hash);
 
+        /// <summary>
+        /// Serializes the currency into a Bencodex value.
+        /// </summary>
+        /// <returns>The serialized Bencodex value.</returns>
+        [Pure]
+        public IValue Serialize()
+        {
+            IValue minters = Minters is ImmutableHashSet<Address> a
+                ? new List(a.OrderBy(m => m).Select(m => (IValue)new Binary(m.ToByteArray())))
+                : (IValue)Null.Value;
+            return Dictionary.Empty
+                .Add("ticker", Ticker)
+                .Add("decimals", DecimalPlaces)
+                .Add("minters", minters);
+        }
+
         [Pure]
         private HashDigest<SHA1> GetHash()
         {
@@ -207,16 +283,7 @@ namespace Libplanet.Assets
             using var sha1 = new SHA1CryptoServiceProvider();
             using var stream = new CryptoStream(buffer, sha1, CryptoStreamMode.Write);
             var codec = new Codec();
-#pragma warning disable SA1129  // See also: https://github.com/planetarium/bencodex.net/issues/20
-            IValue minters = Minters is ImmutableHashSet<Address> a
-                ? new List(a.OrderBy(m => m).Select(m => (IValue)new Binary(m.ToByteArray())))
-                : (IValue)new Null();
-#pragma warning restore SA1129
-            IValue serialized = Dictionary.Empty
-                .Add("ticker", Ticker)
-                .Add("decimals", DecimalPlaces)
-                .Add("minters", minters);
-            codec.Encode(serialized, stream);
+            codec.Encode(Serialize(), stream);
             stream.FlushFinalBlock();
             return new HashDigest<SHA1>(sha1.Hash);
         }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -545,6 +545,9 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Adds a <paramref name="block"/> to the end of this chain.
+        /// <para><see cref="Block{T}.Transactions"/> in the <paramref name="block"/> updates
+        /// states and balances in the blockchain, and <see cref="TxExecution"/>s for
+        /// transactions are recorded.</para>
         /// <para>Note that <see cref="Renderers"/> receive events right after the <paramref
         /// name="block"/> is confirmed (and thus all states reflect changes in the <paramref
         /// name="block"/>).</para>
@@ -572,6 +575,9 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Adds a <paramref name="block"/> to the end of this chain.
+        /// <para><see cref="Block{T}.Transactions"/> in the <paramref name="block"/> updates
+        /// states and balances in the blockchain, and <see cref="TxExecution"/>s for
+        /// transactions are recorded.</para>
         /// <para>Note that <see cref="Renderers"/> receive events right after the <paramref
         /// name="block"/> is confirmed (and thus all states reflect changes in the <paramref
         /// name="block"/>).</para>
@@ -1434,9 +1440,55 @@ namespace Libplanet.Blockchain
             double evalDuration = (DateTimeOffset.Now - evaluateActionStarted).TotalMilliseconds;
             _logger.Debug(evalEndMsg, block.Index, block.Hash, evalDuration);
 
+            // Prepare TxExecutions
+            var txExecutions = new List<TxExecution>();
+            IEnumerable<IGrouping<TxId, ActionEvaluation>> evaluationsPerTxs = evaluations
+                .Where(e => e.InputContext.TxId is { })
+                .GroupBy(e => e.InputContext.TxId.Value);
+            foreach (IGrouping<TxId, ActionEvaluation> txEvals in evaluationsPerTxs)
+            {
+                TxId txid = txEvals.Key;
+                IAccountStateDelta prevStates = txEvals.First().InputContext.PreviousStates;
+                ActionEvaluation evalSum = txEvals.Last();
+                TxExecution txExecution;
+                if (evalSum.Exception is { } e)
+                {
+                    txExecution = new TxFailure(block.Hash, txid, e.InnerException ?? e);
+                }
+                else
+                {
+                    IAccountStateDelta outputStates = evalSum.OutputStates;
+                    txExecution = new TxSuccess(
+                        block.Hash,
+                        txid,
+                        outputStates.GetUpdatedStates(),
+                        outputStates.UpdatedFungibleAssets.ToImmutableDictionary(
+                            kv => kv.Key,
+                            kv => (IImmutableDictionary<Currency, FungibleAssetValue>)kv.Value
+                                .ToImmutableDictionary(
+                                    currency => currency,
+                                    currency => outputStates.GetBalance(kv.Key, currency) -
+                                        prevStates.GetBalance(kv.Key, currency)
+                                )
+                        ),
+                        outputStates.UpdatedFungibleAssets.ToImmutableDictionary(
+                            kv => kv.Key,
+                            kv => (IImmutableDictionary<Currency, FungibleAssetValue>)kv.Value
+                                .ToImmutableDictionary(
+                                    currency => currency,
+                                    currency => outputStates.GetBalance(kv.Key, currency)
+                                )
+                        )
+                    );
+                }
+
+                txExecutions.Add(txExecution);
+            }
+
             _rwlock.EnterWriteLock();
             try
             {
+                // Update states
                 DateTimeOffset setStatesStarted = DateTimeOffset.Now;
                 if (StateStore is TrieStateStore trieStateStore)
                 {
@@ -1477,6 +1529,23 @@ namespace Libplanet.Blockchain
                     "(duration: {DurationMs}ms).";
                 double duration = (DateTimeOffset.Now - setStatesStarted).TotalMilliseconds;
                 _logger.Debug(endMsg, block.Index, block.Hash, duration);
+
+                // Update TxExecutions
+                foreach (TxExecution txExecution in txExecutions)
+                {
+                    // Note that there are two overloaded methods of the same name PutTxExecution()
+                    // in IStore.  As those two have different signatures, run-time polymorphism
+                    // does not work.  Instead, we need the following hard-coded branch:
+                    switch (txExecution)
+                    {
+                        case TxSuccess s:
+                            Store.PutTxExecution(s);  // IStore.PutTxExecution(TxSuccess)
+                            break;
+                        case TxFailure f:
+                            Store.PutTxExecution(f);  // IStore.PutTxExecution(TxFailure)
+                            break;
+                    }
+                }
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -2125,7 +2125,7 @@ namespace Libplanet.Blockchain
                 offset ??= Tip.Hash;
 
                 return StateStore.ContainsBlockStates(offset.Value)
-                    ? StateStore.GetState(key, offset, Id)
+                    ? StateStore.GetState(key, offset)
                     : rawStateCompleter(this, offset.Value);
             }
             finally

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -544,6 +544,19 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
+        /// Queries the recorded <see cref="TxExecution"/> for a successful or failed
+        /// <see cref="Transaction{T}"/> within a <see cref="Block{T}"/>.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/>
+        /// that the <see cref="Transaction{T}"/> is executed within.</param>
+        /// <param name="txid">The executed <see cref="Transaction{T}"/>'s
+        /// <see cref="Transaction{T}.Id"/>.</param>
+        /// <returns>The recorded <see cref="TxExecution"/>.  If the transaction has never been
+        /// executed within the block, it returns <c>null</c> instead.</returns>
+        public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
+            Store.GetTxExecution(blockHash, txid);
+
+        /// <summary>
         /// Adds a <paramref name="block"/> to the end of this chain.
         /// <para><see cref="Block{T}.Transactions"/> in the <paramref name="block"/> updates
         /// states and balances in the blockchain, and <see cref="TxExecution"/>s for

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -485,8 +485,12 @@ namespace Libplanet.Blocks
         /// <see cref="Transaction{T}.Actions"/> (e.g., tx&#xb9;-act&#xb9;,
         /// tx&#xb9;-act&#xb2;, tx&#xb2;-act&#xb9;, tx&#xb2;-act&#xb2;,
         /// &#x2026;).
-        /// Note that each <see cref="IActionContext.Random"/> object has
-        /// a unconsumed state.
+        /// <para>If a <see cref="Transaction{T}"/> has multiple
+        /// <see cref="Transaction{T}.Actions"/>, each <see cref="ActionEvaluation"/> includes
+        /// all previous <see cref="ActionEvaluation"/>s' delta in the same
+        /// <see cref="Transaction{T}"/> besides its own delta.</para>
+        /// <para>Note that each <see cref="IActionContext.Random"/> object has a unconsumed state.
+        /// </para>
         /// </returns>
         [Pure]
         public

--- a/Libplanet/KeyValuePairExtensions.cs
+++ b/Libplanet/KeyValuePairExtensions.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+namespace Libplanet
+{
+    /// <summary>
+    /// Extension methods that help you to write more fluent dictionary-manipulating code.
+    /// </summary>
+    /// <example>
+    /// The following example shows how an immutable dictionary can transform only its keys or
+    /// its values:
+    /// <code><![CDATA[
+    /// var a = ImmutableDictionary<string, int>.Empty.Add("foo", 1).Add("bar", 2);
+    /// // a: foo => 1, bar => 2
+    /// var b = a.SelectWithinKeys(k => k.ToUpperInvariant()).ToImmutableDictionary();
+    /// // b: FOO => 1, BAR => 2
+    /// var c = a.SelectWithinValues(v => -v * 2).ToImmutableDictionary();
+    /// // c: foo => -2, bar => -4
+    /// ]]></code>
+    /// </example>
+    internal static class KeyValuePairExtensions
+    {
+        [Pure]
+        public static KeyValuePair<TNewKey, TValue> ReplaceKey<TOldKey, TValue, TNewKey>(
+            this KeyValuePair<TOldKey, TValue> pair,
+            TNewKey newKey
+        ) =>
+            new KeyValuePair<TNewKey, TValue>(newKey, pair.Value);
+
+        [Pure]
+        public static KeyValuePair<TKey, TNewValue> ReplaceValue<TKey, TOldValue, TNewValue>(
+            this KeyValuePair<TKey, TOldValue> pair,
+            TNewValue newValue
+        ) =>
+            new KeyValuePair<TKey, TNewValue>(pair.Key, newValue);
+
+        [Pure]
+        public static IEnumerable<KeyValuePair<TNewKey, TValue>>
+        SelectWithinKeys<TOldKey, TValue, TNewKey>(
+            this IEnumerable<KeyValuePair<TOldKey, TValue>> source,
+            Func<TOldKey, TNewKey> selector
+        ) =>
+            source.Select(pair => pair.ReplaceKey(selector(pair.Key)));
+
+        [Pure]
+        public static IEnumerable<KeyValuePair<TKey, TNewValue>>
+        SelectWithinValues<TKey, TOldValue, TNewValue>(
+            this IEnumerable<KeyValuePair<TKey, TOldValue>> source,
+            Func<TOldValue, TNewValue> selector
+        ) =>
+            source.Select(pair => pair.ReplaceValue(selector(pair.Value)));
+    }
+}

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -61,7 +61,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.3.0-dev.bfb071c07728e25c3f2d8bd7cbee8f7ddf5d33eb" />
+    <PackageReference Include="Bencodex" Version="0.3.0-dev.d6bdbb581c5d9cd024c0b428e1c9404cdf671b75" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />
     <PackageReference Include="Fody" Version="6.1.1">

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -61,7 +61,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.3.0-dev.b5db4271db327b0f1e1647848f868c7b543756cd" />
+    <PackageReference Include="Bencodex" Version="0.3.0-dev.bfb071c07728e25c3f2d8bd7cbee8f7ddf5d33eb" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />
     <PackageReference Include="Fody" Version="6.1.1">

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -239,12 +239,12 @@ namespace Libplanet.Store
 
                 ImmutableDictionary<Address, IValue> sDelta = d.GetValue<Dictionary>("sDelta")
                     .ToImmutableDictionary(
-                        kv => new Address(((Binary)kv.Key).ByteArray),
+                        kv => new Address((Binary)kv.Key),
                         kv => kv.Value is List l && l.Any() ? l[0] : null
                     );
                 ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
                     updatedFungibleAssets = d.GetValue<Dictionary>("aDelta").ToImmutableDictionary(
-                        kv => new Address(((Binary)kv.Key).ByteArray),
+                        kv => new Address((Binary)kv.Key),
                         kv => (IImmutableDictionary<Currency, FAV>)((List)kv.Value).Select(pList =>
                         {
                             var pair = (List)pList;

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -218,22 +218,22 @@ namespace Libplanet.Store
 
             try
             {
-                bool fail = (Bencodex.Types.Boolean)d["fail"];
+                bool fail = d.GetValue<Bencodex.Types.Boolean>("fail");
                 if (fail)
                 {
-                    string excName = (Text)d["exc"];
+                    string excName = d.GetValue<Text>("exc");
                     IValue excMetadata = d.ContainsKey("excMeta") ? d["excMeta"] : null;
                     return new TxFailure(blockHash, txid, excName, excMetadata);
                 }
 
-                var stateRootHash = new HashDigest<SHA256>((Binary)d["sRoot"]);
+                var stateRootHash = new HashDigest<SHA256>(((Binary)d["sRoot"]).ByteArray);
                 ImmutableHashSet<Address> stateUpdatedAddresses = ((List)d["sDelta"])
-                    .Select(v => new Address((Binary)v))
+                    .Select(v => new Address(((Binary)v).ByteArray))
                     .ToImmutableHashSet();
                 ImmutableDictionary<Address, IImmutableSet<Currency>> updatedFungibleAssets =
-                    ((Dictionary)d["aDelta"]).Select(kv =>
+                    d.GetValue<Dictionary>("aDelta").Select(kv =>
                         new KeyValuePair<Address, IImmutableSet<Currency>>(
-                            new Address((Binary)kv.Key),
+                            new Address(((Binary)kv.Key).ByteArray),
                             ((List)kv.Value).Select(v => new Currency(v)).ToImmutableHashSet()
                         )
                     ).ToImmutableDictionary();

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -31,13 +31,16 @@ namespace Libplanet.Store
 
         private static readonly UPath TxRootPath = UPath.Root / "tx";
         private static readonly UPath BlockRootPath = UPath.Root / "block";
+        private static readonly UPath TxExecutionRootPath = UPath.Root / "txexec";
         private static readonly UPath BlockPerceptionRootPath = UPath.Root / "blockpercept";
+        private static readonly Codec Codec = new Codec();
 
         private readonly ILogger _logger;
 
         private readonly IFileSystem _root;
         private readonly SubFileSystem _txs;
         private readonly SubFileSystem _blocks;
+        private readonly SubFileSystem _txExecutions;
         private readonly SubFileSystem _blockPerceptions;
         private readonly LruCache<TxId, object> _txCache;
         private readonly LruCache<BlockHash, BlockDigest> _blockCache;
@@ -138,6 +141,8 @@ namespace Libplanet.Store
             _txs = new SubFileSystem(_root, TxRootPath, owned: false);
             _root.CreateDirectory(BlockRootPath);
             _blocks = new SubFileSystem(_root, BlockRootPath, owned: false);
+            _root.CreateDirectory(TxExecutionRootPath);
+            _txExecutions = new SubFileSystem(_root, TxExecutionRootPath, owned: false);
             _root.CreateDirectory(BlockPerceptionRootPath);
             _blockPerceptions = new SubFileSystem(_root, BlockPerceptionRootPath, owned: false);
 
@@ -421,7 +426,7 @@ namespace Libplanet.Store
             BlockDigest blockDigest;
             try
             {
-                IValue value = new Codec().Decode(_blocks.ReadAllBytes(path));
+                IValue value = Codec.Decode(_blocks.ReadAllBytes(path));
                 if (!(value is Bencodex.Types.Dictionary dict))
                 {
                     throw new DecodingException(
@@ -487,6 +492,57 @@ namespace Libplanet.Store
 
             UPath blockPath = BlockPath(blockHash);
             return _blocks.FileExists(blockPath);
+        }
+
+        /// <inheritdoc cref="BaseStore.PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        public override void PutTxExecution(TxSuccess txSuccess)
+        {
+            UPath path = TxExecutionPath(txSuccess);
+            UPath dirPath = path.GetDirectory();
+            CreateDirectoryRecursively(_txExecutions, dirPath);
+            using Stream f =
+                _txExecutions.OpenFile(path, System.IO.FileMode.OpenOrCreate, FileAccess.Write);
+            Codec.Encode(SerializeTxExecution(txSuccess), f);
+        }
+
+        /// <inheritdoc cref="BaseStore.PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        public override void PutTxExecution(TxFailure txFailure)
+        {
+            UPath path = TxExecutionPath(txFailure);
+            UPath dirPath = path.GetDirectory();
+            CreateDirectoryRecursively(_txExecutions, dirPath);
+            using Stream f =
+                _txExecutions.OpenFile(path, System.IO.FileMode.OpenOrCreate, FileAccess.Write);
+            Codec.Encode(SerializeTxExecution(txFailure), f);
+        }
+
+        /// <inheritdoc cref="BaseStore.GetTxExecution(BlockHash, TxId)"/>
+        public override TxExecution GetTxExecution(BlockHash blockHash, TxId txid)
+        {
+            UPath path = TxExecutionPath(blockHash, txid);
+            if (_txExecutions.FileExists(path))
+            {
+                IValue decoded;
+                using (Stream f = _txExecutions.OpenFile(
+                    path, System.IO.FileMode.Open, FileAccess.Read))
+                {
+                    try
+                    {
+                        decoded = Codec.Decode(f);
+                    }
+                    catch (DecodingException e)
+                    {
+                        const string msg =
+                            "Uncaught exception during " + nameof(GetTxExecution) + ": {Exception}";
+                        _logger.Error(e, msg, e);
+                        return null;
+                    }
+                }
+
+                return DeserializeTxExecution(blockHash, txid, decoded, _logger);
+            }
+
+            return null;
         }
 
         /// <inheritdoc cref="BaseStore.SetBlockPerceivedTime(BlockHash, DateTimeOffset)"/>
@@ -673,6 +729,12 @@ namespace Libplanet.Store
             string idHex = txid.ToHex();
             return UPath.Root / idHex.Substring(0, 2) / idHex.Substring(2);
         }
+
+        private UPath TxExecutionPath(in BlockHash blockHash, in TxId txid) =>
+            BlockPath(blockHash) / txid.ToHex();
+
+        private UPath TxExecutionPath(TxExecution txExecution) =>
+            TxExecutionPath(txExecution.BlockHash, txExecution.TxId);
 
         private string TxNonceId(in Guid chainId)
         {

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -53,25 +53,21 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="path">The path of the directory where the storage files will be saved.
         /// If the path is <c>null</c>, the database is created in memory.</param>
-        /// <param name="compress">Whether to compress data.  Does not compress by default.</param>
         /// <param name="journal">
         /// Enables or disables double write check to ensure durability.
         /// </param>
         /// <param name="indexCacheSize">Max number of pages in the index cache.</param>
         /// <param name="blockCacheSize">The capacity of the block cache.</param>
         /// <param name="txCacheSize">The capacity of the transaction cache.</param>
-        /// <param name="statesCacheSize">The capacity of the states cache.</param>
         /// <param name="flush">Writes data direct to disk avoiding OS cache.  Turned on by default.
         /// </param>
         /// <param name="readOnly">Opens database readonly mode. Turned off by default.</param>
         public DefaultStore(
             string path,
-            bool compress = false,
             bool journal = true,
             int indexCacheSize = 50000,
             int blockCacheSize = 512,
             int txCacheSize = 1024,
-            int statesCacheSize = 10000,
             bool flush = true,
             bool readOnly = false
         )

--- a/Libplanet/Store/IStateStore.cs
+++ b/Libplanet/Store/IStateStore.cs
@@ -34,10 +34,9 @@ namespace Libplanet.Store
         /// <param name="stateKey">The key to query state.</param>
         /// <param name="blockHash">The <see cref="Block{T}.Hash"/> which the point to query by
         /// <paramref name="stateKey"/> at.</param>
-        /// <param name="chainId">The <see cref="BlockChain{T}.Id"/> of wanted got.</param>
         /// <returns>The state queried from <paramref name="blockHash"/> and
         /// <paramref name="stateKey"/>. If it couldn't find state, returns <c>null</c>.</returns>
-        IValue? GetState(string stateKey, BlockHash? blockHash = null, Guid? chainId = null);
+        IValue? GetState(string stateKey, BlockHash? blockHash = null);
 
         /// <summary>
         /// Checks if the states corresponded to the block derived from <paramref name="blockHash"/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -195,6 +195,8 @@ namespace Libplanet.Store
         /// <summary>
         /// Records the given <paramref name="txSuccess"/>.
         /// </summary>
+        /// <remarks>If there is already the record for the same <see cref="TxExecution.BlockHash"/>
+        /// and <see cref="TxExecution.TxId"/>, the record is silently overwritten.</remarks>
         /// <param name="txSuccess">The successful transaction execution summary to record.
         /// Must not be <c>null</c>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="txSuccess"/> is
@@ -206,6 +208,8 @@ namespace Libplanet.Store
         /// <summary>
         /// Records the given <paramref name="txFailure"/>.
         /// </summary>
+        /// <remarks>If there is already the record for the same <see cref="TxExecution.BlockHash"/>
+        /// and <see cref="TxExecution.TxId"/>, the record is silently overwritten.</remarks>
         /// <param name="txFailure">The failed transaction execution summary to record.
         /// Must not be <c>null</c>.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="txFailure"/> is

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -193,6 +193,41 @@ namespace Libplanet.Store
         bool ContainsBlock(BlockHash blockHash);
 
         /// <summary>
+        /// Records the given <paramref name="txSuccess"/>.
+        /// </summary>
+        /// <param name="txSuccess">The successful transaction execution summary to record.
+        /// Must not be <c>null</c>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="txSuccess"/> is
+        /// <c>null</c>.</exception>
+        /// <seealso cref="PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        /// <seealso cref="GetTxExecution(BlockHash, TxId)"/>
+        void PutTxExecution(TxSuccess txSuccess);
+
+        /// <summary>
+        /// Records the given <paramref name="txFailure"/>.
+        /// </summary>
+        /// <param name="txFailure">The failed transaction execution summary to record.
+        /// Must not be <c>null</c>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="txFailure"/> is
+        /// <c>null</c>.</exception>
+        /// <seealso cref="PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        /// <seealso cref="GetTxExecution(BlockHash, TxId)"/>
+        void PutTxExecution(TxFailure txFailure);
+
+        /// <summary>
+        /// Retrieves the recorded transaction execution summary.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the recorded transaction
+        /// execution to retrieve.</param>
+        /// <param name="txid">The <see cref="Transaction{T}.Id"/> of the recorded transaction
+        /// execution to retrieve.</param>
+        /// <returns>The recorded transaction execution summary.  If it has been never recorded
+        /// <c>null</c> is returned instead.</returns>
+        /// <seealso cref="PutTxExecution(Libplanet.Tx.TxFailure)"/>
+        /// <seealso cref="PutTxExecution(Libplanet.Tx.TxSuccess)"/>
+        TxExecution GetTxExecution(BlockHash blockHash, TxId txid);
+
+        /// <summary>
         /// Records the perceived time of a block.  If there is already a record, it is overwritten.
         /// </summary>
         /// <param name="blockHash"><see cref="Block{T}.Hash"/> to record its perceived time.

--- a/Libplanet/Store/Trie/Nodes/NodeDecoder.cs
+++ b/Libplanet/Store/Trie/Nodes/NodeDecoder.cs
@@ -65,7 +65,7 @@ namespace Libplanet.Store.Trie.Nodes
             // Get referenced node corresponding.
             var refNode = DecodeRef(list[1]);
 
-            return new ShortNode(path, refNode);
+            return new ShortNode(path.ByteArray, refNode);
         }
 
         private static INode? DecodeRef(IValue value)
@@ -81,9 +81,9 @@ namespace Libplanet.Store.Trie.Nodes
                     return Decode(list);
 
                 case Binary binary:
-                    if (binary.Value.Length == HashDigest<SHA256>.Size)
+                    if (binary.ByteArray.Length == HashDigest<SHA256>.Size)
                     {
-                        var hashDigest = new HashDigest<SHA256>(binary.Value);
+                        var hashDigest = new HashDigest<SHA256>(binary.ByteArray);
 
                         // Get referenced node corresponding.
                         return new HashNode(hashDigest);

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -56,7 +56,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
-        public IValue? GetState(string stateKey, BlockHash? blockHash = null, Guid? chainId = null)
+        public IValue? GetState(string stateKey, BlockHash? blockHash = null)
         {
             if (blockHash is null)
             {

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -582,9 +582,11 @@ namespace Libplanet.Tx
         /// </param>
         /// <returns>Enumerates <see cref="ActionEvaluation"/>s for each one in
         /// <see cref="Actions"/>.
-        /// The order is the same to the <see cref="Actions"/>.
-        /// Note that each <see cref="IActionContext.Random"/> object has
-        /// a unconsumed state.
+        /// <para>The order is the same to the <see cref="Actions"/>.</para>
+        /// <para>Each <see cref="ActionEvaluation"/> includes its previous
+        /// <see cref="ActionEvaluation"/>s' delta besides its own delta.</para>
+        /// <para>Note that each <see cref="IActionContext.Random"/> object has a unconsumed state.
+        /// </para>
         /// </returns>
         [Pure]
         public IEnumerable<ActionEvaluation> EvaluateActionsGradually(

--- a/Libplanet/Tx/TxExecution.cs
+++ b/Libplanet/Tx/TxExecution.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
+using Libplanet.Blocks;
+using Libplanet.Serialization;
+
+namespace Libplanet.Tx
+{
+    /// <summary>
+    /// Summarizes an execution result of a <see cref="Transaction{T}"/>.
+    /// <para>Note that <see cref="Transaction{T}"/>s cannot be executed without belonging to
+    /// a <see cref="Block{T}"/>, and even if it's the same <see cref="Transaction{T}"/> its
+    /// result can vary depending on <see cref="Block{T}"/> that it is executed within.</para>
+    /// </summary>
+    /// <seealso cref="TxSuccess"/>
+    /// <seealso cref="TxFailure"/>
+    public abstract class TxExecution : ISerializable
+    {
+        protected TxExecution(SerializationInfo info, StreamingContext context)
+            : this(info.GetValue<BlockHash>(nameof(BlockHash)), info.GetValue<TxId>(nameof(TxId)))
+        {
+        }
+
+        private protected TxExecution(BlockHash blockHash, TxId txId)
+        {
+            BlockHash = blockHash;
+            TxId = txId;
+        }
+
+        /// <summary>
+        /// The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/> that
+        /// the <see cref="Transaction{T}"/> is executed within.
+        /// </summary>
+        [Pure]
+        public BlockHash BlockHash { get; }
+
+        /// <summary>
+        /// The executed <see cref="Transaction{T}"/>'s <see cref="Transaction{T}.Id"/>.
+        /// </summary>
+        [Pure]
+        public TxId TxId { get; }
+
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(BlockHash), BlockHash);
+            info.AddValue(nameof(TxId), TxId);
+        }
+    }
+}

--- a/Libplanet/Tx/TxExecution.cs
+++ b/Libplanet/Tx/TxExecution.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Blocks;
 using Libplanet.Serialization;
 
@@ -16,6 +17,8 @@ namespace Libplanet.Tx
     /// <seealso cref="TxFailure"/>
     public abstract class TxExecution : ISerializable
     {
+        protected static readonly Codec Codec = new Codec();
+
         protected TxExecution(SerializationInfo info, StreamingContext context)
             : this(info.GetValue<BlockHash>(nameof(BlockHash)), info.GetValue<TxId>(nameof(TxId)))
         {

--- a/Libplanet/Tx/TxFailure.cs
+++ b/Libplanet/Tx/TxFailure.cs
@@ -19,12 +19,45 @@ namespace Libplanet.Tx
     {
         private static readonly Codec _codec = new Codec();
 
-        internal TxFailure(BlockHash blockHash, TxId txId, Exception exception)
+        /// <summary>
+        /// Creates a <see cref="TxFailure"/> instance.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/>
+        /// that the <see cref="Transaction{T}"/> is executed within.</param>
+        /// <param name="txId">The executed <see cref="Transaction{T}"/>'s <see
+        /// cref="Transaction{T}.Id"/>.</param>
+        /// <param name="exceptionName">The name of the exception type,
+        /// e.g., <c>System.ArgumentException</c>.</param>
+        /// <param name="exceptionMetadata">Optional metadata about the exception.</param>
+        public TxFailure(
+            BlockHash blockHash,
+            TxId txId,
+            string exceptionName,
+            IValue? exceptionMetadata
+        )
             : base(blockHash, txId)
         {
-            Type excType = exception.GetType();
-            ExceptionName = excType.FullName ?? string.Empty;
-            ExceptionMetadata = exception.ExtractMetadata();
+            ExceptionName = exceptionName;
+            ExceptionMetadata = exceptionMetadata;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TxFailure"/> instance.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/>
+        /// that the <see cref="Transaction{T}"/> is executed within.</param>
+        /// <param name="txId">The executed <see cref="Transaction{T}"/>'s <see
+        /// cref="Transaction{T}.Id"/>.</param>
+        /// <param name="exception">The uncaught exception thrown by an action in the transaction.
+        /// </param>
+        public TxFailure(BlockHash blockHash, TxId txId, Exception exception)
+            : this(
+                blockHash,
+                txId,
+                exception.GetType().FullName ?? string.Empty,
+                exception.ExtractMetadata()
+            )
+        {
         }
 
         private TxFailure(SerializationInfo info, StreamingContext context)
@@ -38,7 +71,7 @@ namespace Libplanet.Tx
         }
 
         /// <summary>
-        /// The name of the exception type, e.g., <c>ArgumentException</c>.
+        /// The name of the exception type, e.g., <c>System.ArgumentException</c>.
         /// </summary>
         [Pure]
         public string ExceptionName { get; }

--- a/Libplanet/Tx/TxFailure.cs
+++ b/Libplanet/Tx/TxFailure.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Serialization;
+
+namespace Libplanet.Tx
+{
+    /// <summary>
+    /// Summarizes an execution result of a <see cref="Transaction{T}"/> with any exception-throwing
+    /// actions.
+    /// </summary>
+    [Serializable]
+    public sealed class TxFailure : TxExecution
+    {
+        private static readonly Codec _codec = new Codec();
+
+        internal TxFailure(BlockHash blockHash, TxId txId, Exception exception)
+            : base(blockHash, txId)
+        {
+            Type excType = exception.GetType();
+            ExceptionName = excType.FullName ?? string.Empty;
+            ExceptionMetadata = exception.ExtractMetadata();
+        }
+
+        private TxFailure(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            ExceptionName = info.GetString(nameof(ExceptionName)) ?? string.Empty;
+            ExceptionMetadata
+                = info.GetValue<byte[]?>(nameof(ExceptionMetadata)) is { } bytes
+                ? _codec.Decode(bytes)
+                : null;
+        }
+
+        /// <summary>
+        /// The name of the exception type, e.g., <c>ArgumentException</c>.
+        /// </summary>
+        [Pure]
+        public string ExceptionName { get; }
+
+        /// <summary>
+        /// Optional metadata about the exception.
+        /// </summary>
+        [Pure]
+        public IValue? ExceptionMetadata { get; }
+
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(ExceptionName), ExceptionName);
+            info.AddValue(
+                nameof(ExceptionMetadata),
+                ExceptionMetadata is { } m ? _codec.Encode(m) : null
+            );
+        }
+    }
+}

--- a/Libplanet/Tx/TxFailure.cs
+++ b/Libplanet/Tx/TxFailure.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -17,8 +16,6 @@ namespace Libplanet.Tx
     [Serializable]
     public sealed class TxFailure : TxExecution
     {
-        private static readonly Codec _codec = new Codec();
-
         /// <summary>
         /// Creates a <see cref="TxFailure"/> instance.
         /// </summary>
@@ -66,7 +63,7 @@ namespace Libplanet.Tx
             ExceptionName = info.GetString(nameof(ExceptionName)) ?? string.Empty;
             ExceptionMetadata
                 = info.GetValue<byte[]?>(nameof(ExceptionMetadata)) is { } bytes
-                ? _codec.Decode(bytes)
+                ? Codec.Decode(bytes)
                 : null;
         }
 
@@ -89,7 +86,7 @@ namespace Libplanet.Tx
             info.AddValue(nameof(ExceptionName), ExceptionName);
             info.AddValue(
                 nameof(ExceptionMetadata),
-                ExceptionMetadata is { } m ? _codec.Encode(m) : null
+                ExceptionMetadata is { } m ? Codec.Encode(m) : null
             );
         }
     }

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Tx
             var updatedStates =
                 (Dictionary)Codec.Decode(info.GetValue<byte[]>(nameof(UpdatedAddresses)));
             UpdatedStates = updatedStates.ToImmutableDictionary(
-                kv => new Address(((Binary)kv.Key).ByteArray),
+                kv => new Address((Binary)kv.Key),
                 kv => kv.Value is List l && l.Any() ? l[0] : null
             );
             UpdatedFungibleAssets = info

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Security.Cryptography;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Serialization;
+
+namespace Libplanet.Tx
+{
+    /// <summary>
+    /// Summarizes an execution result of a successful <see cref="Transaction{T}"/>.
+    /// </summary>
+    [Serializable]
+    public sealed class TxSuccess : TxExecution, ISerializable
+    {
+        internal TxSuccess(
+            BlockHash blockHash,
+            TxId txId,
+            HashDigest<SHA256> stateRootHash,
+            IImmutableSet<Address> stateUpdatedAddresses,
+            IImmutableDictionary<Address, IImmutableSet<Currency>> updatedFungibleAssets
+        )
+            : base(blockHash, txId)
+        {
+            StateRootHash = stateRootHash;
+            StateUpdatedAddresses = stateUpdatedAddresses;
+            UpdatedFungibleAssets = updatedFungibleAssets;
+        }
+
+        private TxSuccess(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            StateRootHash = info.GetValue<HashDigest<SHA256>>(nameof(StateRootHash));
+            StateUpdatedAddresses = info
+                .GetValue<HashSet<Address>>(nameof(UpdatedAddresses))
+                .ToImmutableHashSet();
+            UpdatedFungibleAssets = info
+                .GetValue<Dictionary<Address, HashSet<Currency>>>(nameof(UpdatedFungibleAssets))
+                .SelectWithinValues(c => (IImmutableSet<Currency>)c.ToImmutableHashSet())
+                .ToImmutableDictionary();
+        }
+
+        /// <summary>
+        /// The state root hash of the immediately after the transaction is executed.
+        /// </summary>
+        [Pure]
+        public HashDigest<SHA256> StateRootHash { get; }
+
+        /// <summary>
+        /// The keys of the states updated by the actions in the transaction within the block.
+        /// </summary>
+        [Pure]
+        public IImmutableSet<Address> StateUpdatedAddresses { get; }
+
+        /// <summary>
+        /// <see cref="Address"/>es and sets of <see cref="Currency"/> whose fungible assets have
+        /// been updated by the actions in the transaction within the block.
+        /// </summary>
+        [Pure]
+        public IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets { get; }
+
+        /// <summary>
+        /// All <seealso cref="Address"/>es of the accounts that have been updated by the actions
+        /// in the transaction within the block.
+        /// </summary>
+        [Pure]
+        public IImmutableSet<Address> UpdatedAddresses =>
+            StateUpdatedAddresses.Union(UpdatedFungibleAssets.Keys);
+
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(StateRootHash), StateRootHash.ToByteArray());
+            info.AddValue(nameof(StateUpdatedAddresses), StateUpdatedAddresses.ToList());
+            info.AddValue(
+                nameof(UpdatedFungibleAssets),
+                UpdatedFungibleAssets.ToDictionary(
+                    kv => kv.Key,
+                    kv => new HashSet<Currency>(kv.Value)
+                )
+            );
+        }
+    }
+}

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -18,7 +18,21 @@ namespace Libplanet.Tx
     [Serializable]
     public sealed class TxSuccess : TxExecution, ISerializable
     {
-        internal TxSuccess(
+        /// <summary>
+        /// Creates a <see cref="TxSuccess"/> instance.
+        /// </summary>
+        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/>
+        /// that the <see cref="Transaction{T}"/> is executed within.</param>
+        /// <param name="txId">The executed <see cref="Transaction{T}"/>'s <see
+        /// cref="Transaction{T}.Id"/>.</param>
+        /// <param name="stateRootHash">The state root hash of the immediately after the transaction
+        /// is executed.</param>
+        /// <param name="stateUpdatedAddresses">The keys of the states updated by the actions in
+        /// the transaction within the block.</param>
+        /// <param name="updatedFungibleAssets"><see cref="Address"/>es and sets of
+        /// <see cref="Currency"/> whose fungible assets have been updated by the actions in
+        /// the transaction within the block.</param>
+        public TxSuccess(
             BlockHash blockHash,
             TxId txId,
             HashDigest<SHA256> stateRootHash,

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.Serialization;
 using Bencodex.Types;
 using Libplanet.Assets;
@@ -28,6 +29,10 @@ namespace Libplanet.Tx
         /// cref="Transaction{T}.Id"/>.</param>
         /// <param name="updatedStates">The states delta made by the actions in
         /// the transaction within the block.</param>
+        /// <param name="fungibleAssetsDelta"><see cref="Address"/>es and sets of
+        /// <see cref="Currency"/> whose fungible assets have been updated by the actions in
+        /// the transaction within the block.  Included <see cref="FungibleAssetValue"/>s are
+        /// the delta values (plus or minus) that the transaction makes.</param>
         /// <param name="updatedFungibleAssets"><see cref="Address"/>es and sets of
         /// <see cref="Currency"/> whose fungible assets have been updated by the actions in
         /// the transaction within the block.  Included <see cref="FungibleAssetValue"/>s are
@@ -36,11 +41,13 @@ namespace Libplanet.Tx
             BlockHash blockHash,
             TxId txId,
             IImmutableDictionary<Address, IValue?> updatedStates,
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> fungibleAssetsDelta,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> updatedFungibleAssets
         )
             : base(blockHash, txId)
         {
             UpdatedStates = updatedStates;
+            FungibleAssetsDelta = fungibleAssetsDelta;
             UpdatedFungibleAssets = updatedFungibleAssets;
         }
 
@@ -48,17 +55,17 @@ namespace Libplanet.Tx
             : base(info, context)
         {
             var updatedStates =
-                (Dictionary)Codec.Decode(info.GetValue<byte[]>(nameof(UpdatedAddresses)));
+                (Dictionary)Codec.Decode(info.GetValue<byte[]>(nameof(UpdatedStates)));
             UpdatedStates = updatedStates.ToImmutableDictionary(
                 kv => new Address((Binary)kv.Key),
                 kv => kv.Value is List l && l.Any() ? l[0] : null
             );
-            UpdatedFungibleAssets = info
-                .GetValue<Dictionary<Address, Dictionary<Currency, FAV>>>(
-                    nameof(UpdatedFungibleAssets))
-                .SelectWithinValues(c =>
-                    (IImmutableDictionary<Currency, FAV>)c.ToImmutableDictionary())
-                .ToImmutableDictionary();
+            FungibleAssetsDelta = DecodeFungibleAssetGroups(
+                info.GetValue<byte[]>(nameof(FungibleAssetsDelta))
+            );
+            UpdatedFungibleAssets = DecodeFungibleAssetGroups(
+                info.GetValue<byte[]>(nameof(UpdatedFungibleAssets))
+            );
         }
 
         /// <summary>
@@ -66,6 +73,16 @@ namespace Libplanet.Tx
         /// </summary>
         [Pure]
         public IImmutableDictionary<Address, IValue?> UpdatedStates { get; }
+
+        /// <summary>
+        /// <see cref="Address"/>es and sets of
+        /// <see cref="Currency"/> whose fungible assets have been updated by the actions in
+        /// the transaction within the block.  Included <see cref="FungibleAssetValue"/>s are
+        /// the delta values (plus or minus) that the transaction makes.
+        /// </summary>
+        [Pure]
+        public IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
+            FungibleAssetsDelta { get; }
 
         /// <summary>
         /// <see cref="Address"/>es and sets of <see cref="Currency"/> whose fungible assets have
@@ -103,12 +120,46 @@ namespace Libplanet.Tx
                 )
             );
             info.AddValue(
+                nameof(FungibleAssetsDelta),
+                EncodeFungibleAssetGroups(FungibleAssetsDelta)
+            );
+            info.AddValue(
                 nameof(UpdatedFungibleAssets),
-                UpdatedFungibleAssets.ToDictionary(
-                    kv => kv.Key,
-                    kv => kv.Value.ToDictionary(kv => kv.Key, kv => kv.Value)
-                )
+                EncodeFungibleAssetGroups(UpdatedFungibleAssets)
             );
         }
+
+        private static byte[] EncodeFungibleAssetGroups(
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> g
+        ) =>
+            Codec.Encode(
+                new Dictionary(
+                    g.Select(kv =>
+                        new KeyValuePair<IKey, IValue>(
+                            (Binary)kv.Key.ByteArray,
+                            new List(
+                                kv.Value.Select(fav =>
+                                    (IValue)List.Empty
+                                        .Add(fav.Key.Serialize())
+                                        .Add(fav.Value.RawValue)
+                                )
+                            )
+                        )
+                    )
+                )
+            );
+
+        private static IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
+        DecodeFungibleAssetGroups(byte[] encoded) =>
+            ((Dictionary)Codec.Decode(encoded)).ToImmutableDictionary(
+                kv => new Address((Binary)kv.Key),
+                kv => (IImmutableDictionary<Currency, FAV>)((List)kv.Value)
+                    .Cast<List>()
+                    .Select(pair => (new Currency(pair[0]), (Bencodex.Types.Integer)pair[1]))
+                    .ToImmutableDictionary(
+                        pair => pair.Item1,
+                        pair => FungibleAssetValue.FromRawValue(pair.Item1, (BigInteger)pair.Item2)
+                    )
+            );
     }
 }


### PR DESCRIPTION
This patch addresses #1156.

In order to query if a transaction was succeeded or failed, `TxExecution` type was introduced.  This is an abstract class, and has only two concrete classes:

- `TxSuccess` records what states and asset states was affected by the transaction.
- `TxFailure` records what error was occurred.

(Note that `TxExecution` cannot be subclassed from external assemblies, and `TxSuccess` & `TxFailure` are sealed classes.)

Execution summaries are recorded when a block is appended.  Once a `TxExecution` is recorded, it can be queried using `BlockChain<T>.GetTxExecution(BlockHash, TxId)`, even  if the transaction or the block it was executed within is detached from the blockchain due to reorg.

Please read the added changelogs and tests for details.