### PR TITLE
feat(explorer): use directly chain & store, from context

### DIFF
--- a/.idea/.idea.Libplanet/.idea/indexLayout.xml
+++ b/.idea/.idea.Libplanet/.idea/indexLayout.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ContentModelUserStore">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
   <component name="UserContentModel">
     <attachedFolders />
     <explicitIncludes />


### PR DESCRIPTION
This pull request makes `Libplanet.Explorer.Queries.Query` to use chain & store directly from the source `IBlockChainContext<T>`. And it can be a bug in somewhere like [planetarium/NineChronicles.Headless](https://github.com/planetarium/NineChronicles.Headless), when the dependency injection order is not determined.
Though I thought the best way is to use `IStore` and `BlockChain<T>` through dependency injection pattern and to remove `Libplanet.Explorer.Query`'s static members, but I opened this pull request which fixed the bug simply because I have other my own other task 😢 