### PR TITLE
Fix typo `Block<T>.CalcualteTxHashes()` to `Block<T>.CalculateTxHashes()`

### DIFF
--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -694,7 +694,7 @@ namespace Libplanet.Blocks
                 .Select(tx => tx.Serialize(true).ToImmutableArray()).ToImmutableArray());
         }
 
-        private static HashDigest<SHA256>? CalcualteTxHashes(IEnumerable<Transaction<T>> txs)
+        private static HashDigest<SHA256>? CalculateTxHashes(IEnumerable<Transaction<T>> txs)
         {
             if (!txs.Any())
             {

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -82,7 +82,7 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             Timestamp = timestamp;
             Transactions = transactions.OrderBy(tx => tx.Id).ToArray();
-            TxHash = CalcualteTxHashes(Transactions);
+            TxHash = CalculateTxHashes(Transactions);
 
             PreEvaluationHash = preEvaluationHash ?? Hashcash.Hash(Header.SerializeForHash());
             StateRootHash = stateRootHash;
@@ -675,7 +675,7 @@ namespace Libplanet.Blocks
             }
 
             HashDigest<SHA256>? calculatedTxHash =
-                CalcualteTxHashes(Transactions.OrderBy(tx => tx.Id));
+                CalculateTxHashes(Transactions.OrderBy(tx => tx.Id));
             if (!calculatedTxHash.Equals(TxHash))
             {
                 throw new InvalidBlockTxHashException(


### PR DESCRIPTION
resolves #1303