### PR TITLE
Remove `IActionContext.BlockHash` property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "runtimes",
     "secp256k1",
     "struct",
+    "txid",
     "unstage",
     "unstaged",
     "unrender",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,7 +119,6 @@ To be released.
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
  -  Added `IActionContext.TxId` property.  [[#1275]]
- -  Added `IActionContext.BlockHash` property.  [[#1295], [#1296]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]
  -  Added `IStore.GetTxExecution()` method.  [[#1156], [#1289]]
@@ -258,8 +257,6 @@ To be released.
 [#1275]: https://github.com/planetarium/libplanet/pull/1275
 [#1278]: https://github.com/planetarium/libplanet/pull/1278
 [#1289]: https://github.com/planetarium/libplanet/pull/1289
-[#1295]: https://github.com/planetarium/libplanet/issues/1295
-[#1296]: https://github.com/planetarium/libplanet/pull/1296
 
 
 Version 0.11.1

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
-using Libplanet.Blocks;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Store.Trie;
 using Libplanet.Tx;
@@ -18,14 +16,12 @@ namespace Libplanet.Tests.Action
         private readonly System.Random _random;
         private readonly Address _address;
         private readonly TxId _txid;
-        private readonly BlockHash _blockHash;
 
         public ActionContextTest()
         {
             _random = new System.Random();
             _address = _random.NextAddress();
             _txid = _random.NextTxId();
-            _blockHash = new BlockHash(_random.NextBytes(HashDigest<SHA256>.Size));
         }
 
         [Fact]
@@ -42,7 +38,6 @@ namespace Libplanet.Tests.Action
                     signer: _address,
                     txid: _txid,
                     miner: _address,
-                    blockHash: _blockHash,
                     blockIndex: 1,
                     previousStates: new DumbAccountStateDelta(),
                     randomSeed: seed
@@ -59,7 +54,6 @@ namespace Libplanet.Tests.Action
                 signer: _address,
                 txid: _txid,
                 miner: _address,
-                blockHash: _blockHash,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
                 randomSeed: 0
@@ -69,7 +63,6 @@ namespace Libplanet.Tests.Action
                 signer: _address,
                 txid: _txid,
                 miner: _address,
-                blockHash: _blockHash,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
                 randomSeed: 0
@@ -79,7 +72,6 @@ namespace Libplanet.Tests.Action
                 signer: _address,
                 txid: _txid,
                 miner: _address,
-                blockHash: _blockHash,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
                 randomSeed: 1
@@ -114,7 +106,6 @@ namespace Libplanet.Tests.Action
                     signer: _address,
                     txid: _txid,
                     miner: _address,
-                    blockHash: _blockHash,
                     blockIndex: 1,
                     previousStates: new DumbAccountStateDelta(),
                     randomSeed: i
@@ -133,7 +124,6 @@ namespace Libplanet.Tests.Action
                 signer: _address,
                 txid: _txid,
                 miner: _address,
-                blockHash: _blockHash,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
                 randomSeed: _random.Next()
@@ -166,7 +156,6 @@ namespace Libplanet.Tests.Action
                 signer: _address,
                 txid: _txid,
                 miner: _address,
-                blockHash: _blockHash,
                 blockIndex: 1,
                 previousStates: new DumbAccountStateDelta(),
                 randomSeed: _random.Next(),

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -34,17 +33,14 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void Constructor()
         {
-            var random = new System.Random();
-            var txid = random.NextTxId();
+            var txid = new System.Random().NextTxId();
             Address address = new PrivateKey().ToAddress();
-            var blockHash = new BlockHash(random.NextBytes(HashDigest<SHA256>.Size));
             var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(
                     address,
                     txid,
                     address,
-                    blockHash,
                     1,
                     new AccountStateDeltaImpl(
                         _ => null,
@@ -67,7 +63,6 @@ namespace Libplanet.Tests.Action
             Assert.Equal(address, evaluation.InputContext.Signer);
             Assert.Equal(txid, evaluation.InputContext.TxId);
             Assert.Equal(address, evaluation.InputContext.Miner);
-            Assert.Equal(blockHash, evaluation.InputContext.BlockHash);
             Assert.Equal(1, evaluation.InputContext.BlockIndex);
             Assert.Null(
                 evaluation.InputContext.PreviousStates.GetState(address)
@@ -118,7 +113,6 @@ namespace Libplanet.Tests.Action
                 IActionContext context = eval.InputContext;
                 Assert.Equal(a.Id, context.TxId);
                 Assert.Equal(blockA.Miner, context.Miner);
-                Assert.Equal(blockA.Hash, context.BlockHash);
                 Assert.Equal(blockA.Index, context.BlockIndex);
                 Assert.Equal(
                     deltaA[i].RootHash,
@@ -173,7 +167,6 @@ namespace Libplanet.Tests.Action
                 IActionContext context = eval.InputContext;
                 Assert.Equal(b.Id, context.TxId);
                 Assert.Equal(blockB.Miner, context.Miner);
-                Assert.Equal(blockB.Hash, context.BlockHash);
                 Assert.Equal(blockB.Index, context.BlockIndex);
                 Assert.Equal(
                     deltaB[i].RootHash,

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
@@ -16,15 +15,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
 
         private static IActionContext _actionContext =
-            new ActionContext(
-                signer: default,
-                txid: default,
-                miner: default,
-                blockHash: new BlockHash(new byte[HashDigest<SHA256>.Size]),
-                blockIndex: default,
-                previousStates: _stateDelta,
-                randomSeed: default
-            );
+            new ActionContext(default, default, default, default, _stateDelta, default);
 
         private static Exception _exception = new Exception();
 

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -739,14 +738,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         private IActionContext FakeContext(long blockIndex = 1) =>
-            new ActionContext(
-                signer: default,
-                txid: default,
-                miner: default,
-                blockHash: new BlockHash(new byte[HashDigest<SHA256>.Size]),
-                blockIndex: blockIndex,
-                previousStates: _emptyStates,
-                randomSeed: 0
-            );
+            new ActionContext(default, default, default, blockIndex, _emptyStates, 0);
     }
 }

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
-using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
 using Serilog;
 using Serilog.Events;
@@ -73,16 +71,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
         {
             bool called = false;
             LogEvent firstLog = null;
-            IActionContext actionContext = new ActionContext(
-                signer: default,
-                txid: default,
-                miner: default,
-                blockHash: new BlockHash(new byte[HashDigest<SHA256>.Size]),
-                blockIndex: 123,
-                previousStates: _stateDelta,
-                randomSeed: default,
-                rehearsal: rehearsal
-            );
+            IActionContext actionContext =
+                new ActionContext(default, default, default, 123, _stateDelta, default, rehearsal);
             Exception actionError = new Exception();
             IActionRenderer<DumbAction> actionRenderer;
             if (error)

--- a/Libplanet.sln.DotSettings
+++ b/Libplanet.sln.DotSettings
@@ -28,6 +28,7 @@
   <s:Boolean x:Key="/Default/UserDictionary/Words/=runtimes/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=secp256k1/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=struct/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=txid/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unstage/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unstaged/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=unrender/@EntryIndexedValue">True</s:Boolean>

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
-using Libplanet.Blocks;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
 
@@ -18,7 +17,6 @@ namespace Libplanet.Action
             Address signer,
             TxId? txid,
             Address miner,
-            BlockHash blockHash,
             long blockIndex,
             IAccountStateDelta previousStates,
             int randomSeed,
@@ -30,7 +28,6 @@ namespace Libplanet.Action
             Signer = signer;
             TxId = txid;
             Miner = miner;
-            BlockHash = blockHash;
             BlockIndex = blockIndex;
             Rehearsal = rehearsal;
             PreviousStates = previousStates;
@@ -45,8 +42,6 @@ namespace Libplanet.Action
         public TxId? TxId { get; }
 
         public Address Miner { get; }
-
-        public BlockHash BlockHash { get; }
 
         public long BlockIndex { get; }
 
@@ -75,7 +70,6 @@ namespace Libplanet.Action
                 Signer,
                 TxId,
                 Miner,
-                BlockHash,
                 BlockIndex,
                 PreviousStates,
                 _randomSeed,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -116,7 +116,6 @@ namespace Libplanet.Action
                     signer: signer,
                     txid: txid,
                     miner: minerAddress,
-                    blockHash: blockHash,
                     blockIndex: blockIndex,
                     previousStates: prevStates,
                     randomSeed: randomSeed,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -68,8 +68,8 @@ namespace Libplanet.Action
         /// Executes the <paramref name="actions"/> step by step, and emits
         /// <see cref="ActionEvaluation"/> for each step.
         /// </summary>
-        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of <see cref="Block{T}"/> that
-        /// <paramref name="actions"/> belongs to.</param>
+        /// <param name="preEvaluationHash">The <see cref="Block{T}.PreEvaluationHash"/> of
+        /// <see cref="Block{T}"/> that <paramref name="actions"/> belongs to.</param>
         /// <param name="blockIndex">The <see cref="Block{T}.Index"/> of <see cref="Block{T}"/> that
         /// <paramref name="actions"/> belongs to.</param>
         /// <param name="txid">The <see cref="Transaction{T}.Id"/> of <see cref="Transaction{T}"/>
@@ -96,7 +96,7 @@ namespace Libplanet.Action
         /// has a unconsumed state.
         /// </returns>
         internal static IEnumerable<ActionEvaluation> EvaluateActionsGradually(
-            BlockHash blockHash,
+            BlockHash preEvaluationHash,
             long blockIndex,
             TxId? txid,
             IAccountStateDelta previousStates,
@@ -130,9 +130,9 @@ namespace Libplanet.Action
                 hashedSignature = hasher.ComputeHash(signature);
             }
 
-            byte[] blockHashBytes = blockHash.ToByteArray();
+            byte[] preEvalHashBytes = preEvaluationHash.ToByteArray();
             int seed =
-                (blockHashBytes.Length > 0 ? BitConverter.ToInt32(blockHashBytes, 0) : 0) ^
+                (preEvalHashBytes.Length > 0 ? BitConverter.ToInt32(preEvalHashBytes, 0) : 0) ^
                 (signature.Any() ? BitConverter.ToInt32(hashedSignature, 0) : 0);
 
             IAccountStateDelta states = previousStates;
@@ -169,13 +169,21 @@ namespace Libplanet.Action
                     else
                     {
                         var stateRootHash = context.PreviousStateRootHash;
+                        const string logMsg =
+                            "The action {Action} (block #{BlockIndex}, pre-evaluation hash " +
+                            "{PreEvaluationHash}, tx {TxId}, previous state root hash " +
+                            "{StateRootHash}) threw an exception during execution:\n" +
+                            "{InnerException}";
+                        logger.Error(
+                            e, logMsg, action, blockIndex, preEvaluationHash, txid, stateRootHash, e
+                        );
                         var msg =
-                            $"The action {action} (block #{blockIndex} {blockHash}, tx {txid}, " +
-                            $"state root hash {stateRootHash}) threw an exception " +
-                            "during execution.  See also this exception's InnerException property.";
-                        logger.Error("{Message}\nInnerException: {ExcMessage}", msg, e.Message);
+                            $"The action {action} (block #{blockIndex}, pre-evaluation hash " +
+                            $"{preEvaluationHash}, tx {txid}, previous state root hash " +
+                            $"{stateRootHash}) threw an exception during execution.  " +
+                            "See also this exception's InnerException property.";
                         exc = new UnexpectedlyTerminatedActionException(
-                            blockHash, blockIndex, txid, stateRootHash, action, msg, e
+                            preEvaluationHash, blockIndex, txid, stateRootHash, action, msg, e
                         );
                     }
                 }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -33,13 +33,6 @@ namespace Libplanet.Action
         Address Miner { get; }
 
         /// <summary>
-        /// <see cref="Block{T}"/>.<see cref="Block{T}.Hash"/> of a transaction that an executed
-        /// <see cref="IAction"/> belongs to.
-        /// </summary>
-        [Pure]
-        BlockHash BlockHash { get; }
-
-        /// <summary>
         /// <see cref="Block{T}"/>.<see cref="Block{T}.Index"/> of a transaction that an executed
         /// <see cref="IAction"/> belongs to.
         /// </summary>


### PR DESCRIPTION
Context: <https://github.com/planetarium/libplanet/issues/1295#issuecomment-842764538>

This reverts the PR #1296, and renames several misleading names.