### PR TITLE
Find blocks in store instead of in chain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,13 @@ To be released.
 
 ### Bug fixes
 
+ -  `Swarm<T>.PreloadAsync()` now checks the existence of blocks in the storage
+    (was in the blockchain).  [[#1324]]
+
 ### CLI tools
+
+[#1324]: https://github.com/planetarium/libplanet/pull/1324
+
 
 Version 0.12.0
 --------------

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -572,7 +572,7 @@ namespace Libplanet.Net
                 FillBlocksAsyncStarted.Set();
 
                 var blockCompletion = new BlockCompletion<BoundPeer, T>(
-                    completionPredicate: workspace.ContainsBlock,
+                    completionPredicate: wStore.ContainsBlock,
                     window: InitialBlockDownloadWindow
                 );
 


### PR DESCRIPTION
This PR changes the `BlockCompletion` predicate to use the `ContainsBlock` method of `IStore` instead of `BlockChain`. This way, `Swarm` won't have to download blocks again if preloading is aborted during the `Block Execution` stage.