### PR TITLE
Fix IterateIndexes() bug 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -228,6 +228,8 @@ To be released.
     been idempotent.  [[#1272], [#1289]]
  -  Fixed a bug where `NetMQTransport` had hung forever within Mono runtime.
     [[#1278]]
+ -  Fixed a bug where `DefaultStore.ForkBlockIndexes()` hadn't copied genesis
+    block.  [[#1325]]
 
 ### CLI tools
 
@@ -267,6 +269,7 @@ To be released.
 [#1287]: https://github.com/planetarium/libplanet/pull/1287
 [#1289]: https://github.com/planetarium/libplanet/pull/1289
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
+[#1325]: https://github.com/planetarium/libplanet/pull/1325
 
 
 Version 0.11.1

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1079,11 +1079,10 @@ namespace Libplanet.RocksDBStore
                 Guid prevId = chainInfo.Item1;
                 long pi = chainInfo.Item2;
 
-                int? expectedCount = null;
-
-                if (limit is { } limitNotNull)
+                int expectedCount = (int)(pi - offset + 1);
+                if (limit is { } limitNotNull && limitNotNull < expectedCount)
                 {
-                    expectedCount = (int)Math.Min(limitNotNull, pi - offset + 1);
+                    expectedCount = limitNotNull;
                 }
 
                 foreach (BlockHash hash in IterateIndexes(prevId, offset, expectedCount, true))

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1076,8 +1076,17 @@ namespace Libplanet.RocksDBStore
 
             if (GetPreviousChainInfo(cf) is { } chainInfo)
             {
+                Guid prevId = chainInfo.Item1;
                 long pi = chainInfo.Item2;
-                foreach (BlockHash hash in IterateIndexes(chainInfo.Item1, offset, null, true))
+
+                int? expectedCount = null;
+
+                if (limit is { } limitNotNull)
+                {
+                    expectedCount = (int)Math.Min(limitNotNull, pi - offset + 1);
+                }
+
+                foreach (BlockHash hash in IterateIndexes(prevId, offset, expectedCount, true))
                 {
                     if (count >= limit)
                     {
@@ -1086,14 +1095,9 @@ namespace Libplanet.RocksDBStore
 
                     yield return hash;
                     count += 1;
-
-                    if (offset + count > pi)
-                    {
-                        break;
-                    }
                 }
 
-                offset = (int)Math.Max(0, offset - pi);
+                offset = (int)Math.Max(0, offset - pi - 1);
             }
 
             byte[] prefix = IndexKeyPrefix;

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -968,6 +968,14 @@ namespace Libplanet.Tests.Store
                 },
                 store.IterateIndexes(chainB, 2, 2)
             );
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block2.Hash,
+                    anotherBlock3.Hash,
+                },
+                store.IterateIndexes(chainB, 2)
+            );
 
             Assert.Equal(
                 new[]
@@ -975,6 +983,14 @@ namespace Libplanet.Tests.Store
                     anotherBlock3.Hash,
                 },
                 store.IterateIndexes(chainB, 3, 1)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    anotherBlock3.Hash,
+                },
+                store.IterateIndexes(chainB, 3)
             );
         }
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -249,8 +249,8 @@ namespace Libplanet.Store
                 return;
             }
 
-            destColl.InsertBulk(srcColl.FindAll()
-                .TakeWhile(i => !i.Hash.Equals(branchpoint)).Skip(1));
+            destColl.Delete(Query.All());
+            destColl.InsertBulk(srcColl.FindAll().TakeWhile(i => !i.Hash.Equals(branchpoint)));
 
             AppendIndex(destinationChainId, branchpoint);
         }


### PR DESCRIPTION
This PR fixes a bug where `RocksDBStore.IterateIndexes()` had followed the previous branch even if has been forked.
And it also fixes a bug where `DefaultStore.ForkBlockIndexes()` hadn't copied the genesis block index.

* I skipped changelog because we didn't release the new version contains #1287