### PR TITLE
Patch/transaction ordering update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -254,6 +254,8 @@ To be released.
  -  `BlockChain<T>.Append()` cumulates indexes for pairs (TxId and BlockHash).
     A transaction inclusion for a block is retrievable by using this index.
     [[#1315], [#1329]]
+ -  `Block<T>.Transactions` will be ordered using a different scheme once
+    the protocol version is bumped to `2`.  [[#1322], [#1323], [#1326]]
  -  `ActionEvaluator<T>.EvaluateActions()` now throws an unmanaged exception
     if `OutOfMemoryException` is caught from `IAction.Execute()`.
     [[#1320], [#1343]]
@@ -358,7 +360,10 @@ To be released.
 [#1315]: https://github.com/planetarium/libplanet/issues/1315
 [#1316]: https://github.com/planetarium/libplanet/issues/1316
 [#1320]: https://github.com/planetarium/libplanet/issues/1320
+[#1322]: https://github.com/planetarium/libplanet/issues/1322
+[#1323]: https://github.com/planetarium/libplanet/issues/1323
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
+[#1326]: https://github.com/planetarium/libplanet/pull/1326
 [#1328]: https://github.com/planetarium/libplanet/pull/1328
 [#1329]: https://github.com/planetarium/libplanet/pull/1329
 [#1334]: https://github.com/planetarium/libplanet/pull/1334

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -511,6 +511,96 @@ namespace Libplanet.Tests.Blocks
         }
 
         [Fact]
+        public void OrderTxsForEvaluation()
+        {
+            const int numSigners = 5;
+            const int numTxsPerSigner = 3;
+
+            ImmutableArray<PrivateKey> signers = ImmutableArray.Create(new PrivateKey[]
+                {
+                    _fx.TxFixture.PrivateKey1,
+                    _fx.TxFixture.PrivateKey2,
+                    _fx.TxFixture.PrivateKey3,
+                    _fx.TxFixture.PrivateKey4,
+                    _fx.TxFixture.PrivateKey5,
+                });
+            ImmutableArray<ImmutableArray<int>> noncesPerSigner = ImmutableArray.Create(
+                new ImmutableArray<int>[]
+                    {
+                        ImmutableArray.Create(new int[] { 0, 2, 1 }),
+                        ImmutableArray.Create(new int[] { 1, 0, 2 }),
+                        ImmutableArray.Create(new int[] { 1, 2, 0 }),
+                        ImmutableArray.Create(new int[] { 2, 0, 1 }),
+                        ImmutableArray.Create(new int[] { 2, 1, 0 }),
+                    });
+            // Unix Epoch used for hard coded timestamp.
+            ImmutableArray<Transaction<RandomAction>> txs =
+                signers.Zip(noncesPerSigner, (signer, nonces) => (signer, nonces))
+                    .SelectMany(
+                        signerNoncesPair => signerNoncesPair.nonces,
+                        (signerNoncesPair, nonce) => (signerNoncesPair.signer, nonce))
+                    .Select(signerNoncePair => Transaction<RandomAction>.Create(
+                        nonce: signerNoncePair.nonce,
+                        privateKey: signerNoncePair.signer,
+                        genesisHash: null,
+                        actions: new[] { new RandomAction(signerNoncePair.signer.ToAddress()) },
+                        timestamp: DateTimeOffset.UnixEpoch)).ToImmutableArray();
+            // Rearrange transactions so that transactions are not grouped by signers
+            // while keeping the hard coded mixed order nonces above.
+            txs = txs
+                .Where((tx, i) => i % numTxsPerSigner == 0)
+                .Concat(txs.Where((tx, i) => i % numTxsPerSigner != 0)).ToImmutableArray();
+            byte[] preEvaluationHashBytes =
+            {
+                0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
+                0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
+            };
+            BlockHash blockHash = new BlockHash(preEvaluationHashBytes);
+
+            var orderedTxs = Block<RandomAction>.OrderTxsForEvaluation(
+                txs: txs,
+                preEvaluationHash: blockHash).ToImmutableArray();
+
+            // Check signers are grouped together.
+            for (int i = 0; i < numSigners; i++)
+            {
+                var signerTxs = orderedTxs.Skip(i * numTxsPerSigner).Take(numTxsPerSigner);
+                Assert.True(signerTxs.Select(tx => tx.Signer).Distinct().Count() == 1);
+            }
+
+            // Check nonces are ordered.
+            foreach (var signer in signers)
+            {
+                var signerTxs = orderedTxs.Where(tx => tx.Signer == signer.ToAddress());
+                Assert.Equal(signerTxs.OrderBy(tx => tx.Nonce).ToArray(), signerTxs.ToArray());
+            }
+
+            string[] originalAddresses =
+            {
+                "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
+                "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
+                "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
+                "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
+                "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
+            };
+            string[] orderedAddresses =
+            {
+                "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
+                "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
+                "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
+                "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
+                "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
+            };
+
+            Assert.True(originalAddresses.SequenceEqual(
+                signers.Select(signer => signer.ToAddress().ToString())));
+            Assert.True(orderedAddresses.SequenceEqual(
+                orderedTxs
+                    .Where((tx, i) => i % numTxsPerSigner == 0)
+                    .Select(tx => tx.Signer.ToString())));
+        }
+
+        [Fact]
         public void TransactionOrderIdempotent()
         {
             const int signerCount = 5;
@@ -519,7 +609,7 @@ namespace Libplanet.Tests.Blocks
             ImmutableArray<Transaction<RandomAction>> txs = signers.Select(signer =>
                 Transaction<RandomAction>.Create(
                     0,
-                    new PrivateKey(),
+                    signer,
                     null,
                     new[] { new RandomAction(signer.ToAddress()) })).ToImmutableArray();
             HashAlgorithmGetter algoGetter = _ => HashAlgorithmType.Of<SHA256>();

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -513,6 +513,7 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void OrderTxsForEvaluation()
         {
+            const int protocolVersion = 1;
             const int numSigners = 5;
             const int numTxsPerSigner = 3;
 
@@ -558,6 +559,7 @@ namespace Libplanet.Tests.Blocks
             BlockHash blockHash = new BlockHash(preEvaluationHashBytes);
 
             var orderedTxs = Block<RandomAction>.OrderTxsForEvaluation(
+                protocolVersion: protocolVersion,
                 txs: txs,
                 preEvaluationHash: blockHash).ToImmutableArray();
 

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -558,12 +558,12 @@ namespace Libplanet.Tests.Blocks
                 0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
                 0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
             };
-            BlockHash blockHash = new BlockHash(preEvaluationHashBytes);
+            ImmutableArray<byte> preEvaluationHash = preEvaluationHashBytes.ToImmutableArray();
 
             var orderedTxs = Block<RandomAction>.OrderTxsForEvaluation(
                 protocolVersion: protocolVersion,
                 txs: txs,
-                preEvaluationHash: blockHash).ToImmutableArray();
+                preEvaluationHash: preEvaluationHash).ToImmutableArray();
 
             // Check signers are grouped together.
             for (int i = 0; i < numSigners; i++)

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -618,7 +618,7 @@ namespace Libplanet.Tests.Blocks
                     new[] { new RandomAction(signer.ToAddress()) })).ToImmutableArray();
             HashAlgorithmGetter algoGetter = _ => HashAlgorithmType.Of<SHA256>();
             var blockA = MineGenesis(algoGetter, timestamp: timestamp, transactions: txs);
-            var blockB = MineGenesis(algoGetter, timestamp: timestamp,  transactions: txs);
+            var blockB = MineGenesis(algoGetter, timestamp: timestamp, transactions: txs);
 
             Assert.True(blockA.Transactions.SequenceEqual(blockB.Transactions));
         }

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -513,9 +513,11 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void OrderTxsForEvaluation()
         {
-            const int protocolVersion = 1;
+            // New test should be written once this breaks with a protocol version bump.
+            const int protocolVersion = BlockHeader.CurrentProtocolVersion;
             const int numSigners = 5;
             const int numTxsPerSigner = 3;
+            var epoch = DateTimeOffset.FromUnixTimeSeconds(0);
 
             ImmutableArray<PrivateKey> signers = ImmutableArray.Create(new PrivateKey[]
                 {
@@ -545,7 +547,7 @@ namespace Libplanet.Tests.Blocks
                         privateKey: signerNoncePair.signer,
                         genesisHash: null,
                         actions: new[] { new RandomAction(signerNoncePair.signer.ToAddress()) },
-                        timestamp: DateTimeOffset.UnixEpoch)).ToImmutableArray();
+                        timestamp: epoch)).ToImmutableArray();
             // Rearrange transactions so that transactions are not grouped by signers
             // while keeping the hard coded mixed order nonces above.
             txs = txs

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -494,6 +494,42 @@ namespace Libplanet.Blocks
             return Hash.ToString();
         }
 
+        internal static IEnumerable<Transaction<T>> OrderTxsForEvaluation(
+            IEnumerable<Transaction<T>> txs,
+            BlockHash preEvaluationHash)
+        {
+            // As the order of transactions should be unpredictable until a block is mined,
+            // the sorter key should be derived from both a block hash and a txid.
+            var hashInteger = new BigInteger(preEvaluationHash.ToByteArray());
+
+            // If there are multiple transactions for the same signer these should be ordered by
+            // their tx nonces.  So transactions of the same signer should have the same sort key.
+            // The following logic "flattens" multiple tx ids having the same signer into a single
+            // txid by applying XOR between them.
+            IImmutableDictionary<Address, IImmutableSet<Transaction<T>>> signerTxs = txs
+                .GroupBy(tx => tx.Signer)
+                .ToImmutableDictionary(
+                    g => g.Key,
+                    g => (IImmutableSet<Transaction<T>>)g.ToImmutableHashSet());
+            IImmutableDictionary<Address, BigInteger> signerTxIds = signerTxs
+                .ToImmutableDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value
+                        .Select(tx => new BigInteger(tx.Id.ToByteArray()))
+                        .OrderBy(txid => txid)
+                        .Aggregate((a, b) => a ^ b));
+
+            // Order signers by values derivied from both block hash and their "flatten" txid:
+            IImmutableList<Address> signers = signerTxIds
+                .OrderBy(pair => pair.Value ^ hashInteger)
+                .Select(pair => pair.Key)
+                .ToImmutableArray();
+
+            // Order transactions for each signer by their tx nonces:
+            return signers
+                .SelectMany(signer => signerTxs[signer].OrderBy(tx => tx.Nonce));
+        }
+
         /// <summary>
         /// Validates this <see cref="Block{T}"/> and throws an appropriate exception
         /// if not valid.

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -523,8 +523,8 @@ namespace Libplanet.Blocks
             ImmutableArray<byte> preEvaluationHash)
         {
             return protocolVersion > 1
-                ? OrderTxsForEvaluationV2(protocolVersion, txs, preEvaluationHash)
-                : OrderTxsForEvaluationV0(protocolVersion, txs, preEvaluationHash);
+                ? OrderTxsForEvaluationV2(txs, preEvaluationHash)
+                : OrderTxsForEvaluationV0(txs, preEvaluationHash);
         }
 
         /// <summary>
@@ -607,7 +607,6 @@ namespace Libplanet.Blocks
         }
 
         private static IEnumerable<Transaction<T>> OrderTxsForEvaluationV0(
-            int protocolVersion,
             IEnumerable<Transaction<T>> txs,
             ImmutableArray<byte> preEvaluationHash)
         {
@@ -629,16 +628,21 @@ namespace Libplanet.Blocks
         }
 
         private static IEnumerable<Transaction<T>> OrderTxsForEvaluationV2(
-            int protocolVersion,
             IEnumerable<Transaction<T>> txs,
             ImmutableArray<byte> preEvaluationHash)
         {
             using SHA256 sha256 = SHA256.Create();
-            var mask = new BigInteger(sha256.ComputeHash(preEvaluationHash.ToBuilder().ToArray()));
-            var numShiftBits = sizeof(long) * 8;
+            var maskInteger = new BigInteger(
+                sha256.ComputeHash(preEvaluationHash.ToBuilder().ToArray()));
 
-            return txs.OrderBy(tx =>
-                ((new BigInteger(tx.Signer.ToByteArray()) ^ mask) << numShiftBits) + tx.Nonce);
+            // Transactions with the same signers are grouped first and the ordering of the groups
+            // is determined by the signer's address with XOR bitmask applied using
+            // the pre-evaluation hash provided.  Then within each group, transactions
+            // are ordered by nonce.
+            return txs
+                .GroupBy(tx => tx.Signer)
+                .OrderBy(group => maskInteger ^ new BigInteger(group.Key.ToByteArray()))
+                .SelectMany(group => group.OrderBy(tx => tx.Nonce));
         }
 
         private readonly struct BlockSerializationContext


### PR DESCRIPTION
Closes #1322
Closes #1323

Ordering `Transaction<T>`s for evaluation has been separated from `Block<T>()` constructor as `Block<T>.OrderTxsForEvaluation()` `static` method. Additionally, in preparation for #1314, a new ordering algorithm has been introduced. New algorithm will kick in once `ProtocalVersion` gets increased to at least `2`. Finally, pre-existing algorithm has been optimized for time and memory.

Here are some scripted benchmark results:
```
Number of Signers: 10
Number of Txs per Signer: 10
Running 1000 trials...

Old shuffling time: 2452 ticks
NewV0 shuffling time: 776 ticks
NewV2 shuffling time: 379 ticks

Number of Signers: 100
Number of Txs per Signer: 100
Running 1000 trials...

Old shuffling time: 190516 ticks
NewV0 shuffling time: 103822 ticks
NewV2 shuffling time: 26516 ticks
```