### PR TITLE
feat: introduce txid->blockhash index on IStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,14 @@ To be released.
      -  Removed `Transaction<T>.EvaluateActions()` method.
  -  Parameters `action`, `inputContext`, and `outputStates` for
     `ActionEvaluation()` constructor can no longer be `null`.  [[#1305]]
+ -  Added `IStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)` method.
+    [[#1294], [#1328]]
+ -  Added `IStore.HasTxIdBlockHashIndex(Guid, TxId)` method.
+    [[#1294], [#1328]]
+ -  Added `IStore.GetTxIdBlockHashIndex(Guid, TxId)` method.
+    [[#1294], [#1328]]
+ -  Added `IStore.DeleteTxIdBlockHashIndex(Guid, TxId)` method.
+    [[#1294], [#1328]]
 
 ### Backward-incompatible network protocol changes
 
@@ -278,10 +286,12 @@ To be released.
 [#1285]: https://github.com/planetarium/libplanet/issues/1285
 [#1287]: https://github.com/planetarium/libplanet/pull/1287
 [#1289]: https://github.com/planetarium/libplanet/pull/1289
+[#1294]: https://github.com/planetarium/libplanet/issues/1294
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
 [#1301]: https://github.com/planetarium/libplanet/issues/1301
 [#1305]: https://github.com/planetarium/libplanet/pull/1305
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
+[#1328]: https://github.com/planetarium/libplanet/pull/1328
 
 
 Version 0.11.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,13 +153,13 @@ To be released.
      -  Removed `Transaction<T>.EvaluateActions()` method.
  -  Parameters `action`, `inputContext`, and `outputStates` for
     `ActionEvaluation()` constructor can no longer be `null`.  [[#1305]]
- -  Added `IStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)` method.
+ -  Added `IStore.PutTxIdBlockHashIndex(TxId, BlockHash)` method.
     [[#1294], [#1328]]
- -  Added `IStore.HasTxIdBlockHashIndex(Guid, TxId)` method.
+ -  Added `IStore.GetFirstTxIdBlockHashIndex(TxId)` method.
     [[#1294], [#1328]]
- -  Added `IStore.GetTxIdBlockHashIndex(Guid, TxId)` method.
+ -  Added `IStore.DeleteTxIdBlockHashIndex(TxId, BlockHash)` method.
     [[#1294], [#1328]]
- -  Added `IStore.DeleteTxIdBlockHashIndex(Guid, TxId)` method.
+-  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.
     [[#1294], [#1328]]
 
 ### Backward-incompatible network protocol changes

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -104,14 +104,14 @@ namespace Libplanet.Explorer.Store
         public void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
             _store.PutTxIdBlockHashIndex(txId, blockHash);
 
-        public bool HasTxIdBlockHashIndex(TxId txId) =>
-            _store.HasTxIdBlockHashIndex(txId);
+        public BlockHash? GetFirstTxIdBlockHashIndex(TxId txId) =>
+            _store.GetFirstTxIdBlockHashIndex(txId);
 
-        public BlockHash? GetTxIdBlockHashIndex(TxId txId) =>
-            _store.GetTxIdBlockHashIndex(txId);
+        public IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId) =>
+            _store.IterateTxIdBlockHashIndex(txId);
 
-        public void DeleteTxIdBlockHashIndex(TxId txId) =>
-            _store.DeleteTxIdBlockHashIndex(txId);
+        public void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
+            _store.DeleteTxIdBlockHashIndex(txId, blockHash);
 
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash)
         {

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -101,6 +101,18 @@ namespace Libplanet.Explorer.Store
         public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
             _store.GetTxExecution(blockHash, txid);
 
+        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash) =>
+            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+
+        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.HasTxIdBlockHashIndex(chainId, txId);
+
+        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.GetTxIdBlockHashIndex(chainId, txId);
+
+        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash)
         {
             return _store.GetBlockPerceivedTime(blockHash);

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -101,17 +101,17 @@ namespace Libplanet.Explorer.Store
         public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
             _store.GetTxExecution(blockHash, txid);
 
-        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash) =>
-            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+        public void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
+            _store.PutTxIdBlockHashIndex(txId, blockHash);
 
-        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.HasTxIdBlockHashIndex(chainId, txId);
+        public bool HasTxIdBlockHashIndex(TxId txId) =>
+            _store.HasTxIdBlockHashIndex(txId);
 
-        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.GetTxIdBlockHashIndex(chainId, txId);
+        public BlockHash? GetTxIdBlockHashIndex(TxId txId) =>
+            _store.GetTxIdBlockHashIndex(txId);
 
-        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+        public void DeleteTxIdBlockHashIndex(TxId txId) =>
+            _store.DeleteTxIdBlockHashIndex(txId);
 
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash)
         {

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -68,14 +68,14 @@ namespace Libplanet.Explorer.Store
         public void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
             _store.PutTxIdBlockHashIndex(txId, blockHash);
 
-        public bool HasTxIdBlockHashIndex(TxId txId) =>
-            _store.HasTxIdBlockHashIndex(txId);
+        public BlockHash? GetFirstTxIdBlockHashIndex(TxId txId) =>
+            _store.GetFirstTxIdBlockHashIndex(txId);
 
-        public BlockHash? GetTxIdBlockHashIndex(TxId txId) =>
-            _store.GetTxIdBlockHashIndex(txId);
+        public IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId) =>
+            _store.IterateTxIdBlockHashIndex(txId);
 
-        public void DeleteTxIdBlockHashIndex(TxId txId) =>
-            _store.DeleteTxIdBlockHashIndex(txId);
+        public void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
+            _store.DeleteTxIdBlockHashIndex(txId, blockHash);
 
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash) =>
             _store.GetBlockPerceivedTime(blockHash);

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -65,6 +65,18 @@ namespace Libplanet.Explorer.Store
         public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
             _store.GetTxExecution(blockHash, txid);
 
+        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash) =>
+            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+
+        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.HasTxIdBlockHashIndex(chainId, txId);
+
+        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.GetTxIdBlockHashIndex(chainId, txId);
+
+        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId) =>
+            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash) =>
             _store.GetBlockPerceivedTime(blockHash);
 

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -65,17 +65,17 @@ namespace Libplanet.Explorer.Store
         public TxExecution GetTxExecution(BlockHash blockHash, TxId txid) =>
             _store.GetTxExecution(blockHash, txid);
 
-        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash) =>
-            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+        public void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash) =>
+            _store.PutTxIdBlockHashIndex(txId, blockHash);
 
-        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.HasTxIdBlockHashIndex(chainId, txId);
+        public bool HasTxIdBlockHashIndex(TxId txId) =>
+            _store.HasTxIdBlockHashIndex(txId);
 
-        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.GetTxIdBlockHashIndex(chainId, txId);
+        public BlockHash? GetTxIdBlockHashIndex(TxId txId) =>
+            _store.GetTxIdBlockHashIndex(txId);
 
-        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId) =>
-            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+        public void DeleteTxIdBlockHashIndex(TxId txId) =>
+            _store.DeleteTxIdBlockHashIndex(txId);
 
         public DateTimeOffset? GetBlockPerceivedTime(BlockHash blockHash) =>
             _store.GetBlockPerceivedTime(blockHash);

--- a/Libplanet.RocksDBStore/MonoRocksDBStore.cs
+++ b/Libplanet.RocksDBStore/MonoRocksDBStore.cs
@@ -544,22 +544,19 @@ namespace Libplanet.RocksDBStore
             return null;
         }
 
-        /// <inheritdoc cref="BaseStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)"/>
-        public override void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash)
+        /// <inheritdoc cref="BaseStore.PutTxIdBlockHashIndex(TxId, BlockHash)"/>
+        public override void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            _chainDb.Put(
+            _txExecutionDb.Put(
                 TxIdIndexKey(txId),
-                blockHash.ToByteArray(),
-                cf
+                blockHash.ToByteArray()
                 );
         }
 
-        /// <inheritdoc cref="BaseStore.GetTxIdBlockHashIndex(Guid, TxId)"/>
-        public override BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId)
+        /// <inheritdoc cref="BaseStore.GetTxIdBlockHashIndex(TxId)"/>
+        public override BlockHash? GetTxIdBlockHashIndex(TxId txId)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            if (!(_chainDb.Get(TxIdIndexKey(txId), cf) is { } blockHashByte))
+            if (!(_txExecutionDb.Get(TxIdIndexKey(txId)) is { } blockHashByte))
             {
                 return null;
             }
@@ -567,13 +564,11 @@ namespace Libplanet.RocksDBStore
             return new BlockHash(blockHashByte);
         }
 
-        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
-        public override void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId)
+        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(TxId)"/>
+        public override void DeleteTxIdBlockHashIndex(TxId txId)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            _chainDb.Remove(
-                TxIdIndexKey(txId),
-                cf
+            _txExecutionDb.Remove(
+                TxIdIndexKey(txId)
             );
         }
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -760,22 +760,19 @@ namespace Libplanet.RocksDBStore
             return false;
         }
 
-        /// <inheritdoc cref="BaseStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)"/>
-        public override void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash)
+        /// <inheritdoc cref="BaseStore.PutTxIdBlockHashIndex(TxId, BlockHash)"/>
+        public override void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            _chainDb.Put(
+            _txExecutionDb.Put(
                 TxIdIndexKey(txId),
-                blockHash.ToByteArray(),
-                cf
+                blockHash.ToByteArray()
                 );
         }
 
-        /// <inheritdoc cref="BaseStore.GetTxIdBlockHashIndex(Guid, TxId)"/>
-        public override BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId)
+        /// <inheritdoc cref="BaseStore.GetTxIdBlockHashIndex(TxId)"/>
+        public override BlockHash? GetTxIdBlockHashIndex(TxId txId)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            if (!(_chainDb.Get(TxIdIndexKey(txId), cf) is { } blockHashByte))
+            if (!(_txExecutionDb.Get(TxIdIndexKey(txId)) is { } blockHashByte))
             {
                 return null;
             }
@@ -783,13 +780,11 @@ namespace Libplanet.RocksDBStore
             return new BlockHash(blockHashByte);
         }
 
-        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
-        public override void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId)
+        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(TxId)"/>
+        public override void DeleteTxIdBlockHashIndex(TxId txId)
         {
-            var cf = GetColumnFamily(_chainDb, chainId);
-            _chainDb.Remove(
-                TxIdIndexKey(txId),
-                cf
+            _txExecutionDb.Remove(
+                TxIdIndexKey(txId)
             );
         }
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -764,28 +764,27 @@ namespace Libplanet.RocksDBStore
         public override void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
             _txExecutionDb.Put(
-                TxIdIndexKey(txId),
+                TxIdBlockHashIndexKey(txId, blockHash),
                 blockHash.ToByteArray()
                 );
         }
 
-        /// <inheritdoc cref="BaseStore.GetTxIdBlockHashIndex(TxId)"/>
-        public override BlockHash? GetTxIdBlockHashIndex(TxId txId)
-        {
-            if (!(_txExecutionDb.Get(TxIdIndexKey(txId)) is { } blockHashByte))
-            {
-                return null;
-            }
-
-            return new BlockHash(blockHashByte);
-        }
-
-        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(TxId)"/>
-        public override void DeleteTxIdBlockHashIndex(TxId txId)
+        /// <inheritdoc cref="BaseStore.DeleteTxIdBlockHashIndex(TxId, BlockHash)"/>
+        public override void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
             _txExecutionDb.Remove(
-                TxIdIndexKey(txId)
+                TxIdBlockHashIndexKey(txId, blockHash)
             );
+        }
+
+        /// <inheritdoc cref="BaseStore.IterateTxIdBlockHashIndex(TxId)"/>
+        public override IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId)
+        {
+            var prefix = TxIdBlockHashIndexTxIdKey(txId);
+            foreach (var it in IterateDb(_txExecutionDb, prefix, null))
+            {
+                yield return new BlockHash(it.Value());
+            }
         }
 
         /// <inheritdoc cref="BaseStore.PutTxExecution(Libplanet.Tx.TxSuccess)"/>
@@ -1005,8 +1004,10 @@ namespace Libplanet.RocksDBStore
         private byte[] TxExecutionKey(TxExecution txExecution) =>
             TxExecutionKey(txExecution.BlockHash, txExecution.TxId);
 
-        private byte[] TxIdIndexKey(in TxId txId) =>
+        private byte[] TxIdBlockHashIndexKey(in TxId txId, in BlockHash blockHash) =>
+            TxIdBlockHashIndexTxIdKey(txId).Concat(blockHash.ByteArray).ToArray();
 
+        private byte[] TxIdBlockHashIndexTxIdKey(in TxId txId) =>
             TxIdBlockHashIndexPrefix.Concat(txId.ByteArray).ToArray();
 
         private byte[] ForkedChainsKey(Guid guid) =>

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -445,46 +445,51 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void TxIdBlockHashIndex()
         {
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId1));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId3));
 
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId1, Fx.Hash1);
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId3));
 
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId2, Fx.Hash2);
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId3, Fx.Hash3);
 
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash1));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash2));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash1));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash2));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash3));
 
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId1, Fx.Hash3);
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId2, Fx.Hash3);
             Fx.Store.PutTxIdBlockHashIndex(Fx.TxId3, Fx.Hash1);
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash1));
+            Assert.Equal(2, Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId1).Count());
+            Assert.Equal(2, Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId2).Count());
+            Assert.Equal(2, Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId3).Count());
 
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId1);
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId2);
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId3);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId1, Fx.Hash1);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId2, Fx.Hash2);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId3, Fx.Hash3);
 
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash1));
+
+            Assert.Single(Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId1));
+            Assert.Single(Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Single(Fx.Store.IterateTxIdBlockHashIndex(Fx.TxId3));
+
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId1, Fx.Hash1);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId2, Fx.Hash2);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId3, Fx.Hash3);
+
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId1, Fx.Hash3);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId2, Fx.Hash3);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId3, Fx.Hash1);
+
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId1));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetFirstTxIdBlockHashIndex(Fx.TxId3));
         }
 
         [SkippableFact]

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -445,52 +445,46 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void TxIdBlockHashIndex()
         {
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
 
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1, Fx.Hash1);
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId1, Fx.Hash1);
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
 
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2, Fx.Hash2);
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3, Fx.Hash3);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId2, Fx.Hash2);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId3, Fx.Hash3);
 
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId1)?.Equals(Fx.Hash1));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId2)?.Equals(Fx.Hash2));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId3)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash1));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash2));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
 
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1, Fx.Hash3);
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2, Fx.Hash3);
-            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3, Fx.Hash1);
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId1)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId2)?.Equals(Fx.Hash3));
-            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
-                Fx.StoreChainId, Fx.TxId3)?.Equals(Fx.Hash1));
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId1, Fx.Hash3);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId2, Fx.Hash3);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.TxId3, Fx.Hash1);
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3)?.Equals(Fx.Hash1));
 
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1);
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2);
-            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId1);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId2);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.TxId3);
 
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
-            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId1));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId1));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.TxId3));
         }
 
         [SkippableFact]

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -443,6 +443,57 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
+        public void TxIdBlockHashIndex()
+        {
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1, Fx.Hash1);
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2, Fx.Hash2);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3, Fx.Hash3);
+
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId1)?.Equals(Fx.Hash1));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId2)?.Equals(Fx.Hash2));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId3)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.True(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1, Fx.Hash3);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2, Fx.Hash3);
+            Fx.Store.PutTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3, Fx.Hash1);
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId1)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId2)?.Equals(Fx.Hash3));
+            Assert.True(Fx.Store.GetTxIdBlockHashIndex(
+                Fx.StoreChainId, Fx.TxId3)?.Equals(Fx.Hash1));
+
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2);
+            Fx.Store.DeleteTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3);
+
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.Null(Fx.Store.GetTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId1));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId2));
+            Assert.False(Fx.Store.HasTxIdBlockHashIndex(Fx.StoreChainId, Fx.TxId3));
+        }
+
+        [SkippableFact]
         public void BlockPerceivedTime()
         {
             Assert.Null(Fx.Store.GetBlockPerceivedTime(Fx.Hash1));

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -71,28 +71,28 @@ namespace Libplanet.Tests.Store
             return _store.GetTxExecution(blockHash, txid);
         }
 
-        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash)
+        public void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
-            Log(nameof(PutTxIdBlockHashIndex), chainId, txId, blockHash);
-            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+            Log(nameof(PutTxIdBlockHashIndex), txId, blockHash);
+            _store.PutTxIdBlockHashIndex(txId, blockHash);
         }
 
-        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId)
+        public bool HasTxIdBlockHashIndex(TxId txId)
         {
-            Log(nameof(HasTxIdBlockHashIndex), chainId, txId);
-            return _store.HasTxIdBlockHashIndex(chainId, txId);
+            Log(nameof(HasTxIdBlockHashIndex), txId);
+            return _store.HasTxIdBlockHashIndex(txId);
         }
 
-        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId)
+        public BlockHash? GetTxIdBlockHashIndex(TxId txId)
         {
-            Log(nameof(GetTxIdBlockHashIndex), chainId, txId);
-            return _store.GetTxIdBlockHashIndex(chainId, txId);
+            Log(nameof(GetTxIdBlockHashIndex), txId);
+            return _store.GetTxIdBlockHashIndex(txId);
         }
 
-        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId)
+        public void DeleteTxIdBlockHashIndex(TxId txId)
         {
-            Log(nameof(DeleteTxIdBlockHashIndex), chainId, txId);
-            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+            Log(nameof(DeleteTxIdBlockHashIndex), txId);
+            _store.DeleteTxIdBlockHashIndex(txId);
         }
 
         public void SetBlockPerceivedTime(BlockHash blockHash, DateTimeOffset perceivedTime)

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -71,6 +71,30 @@ namespace Libplanet.Tests.Store
             return _store.GetTxExecution(blockHash, txid);
         }
 
+        public void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash)
+        {
+            Log(nameof(PutTxIdBlockHashIndex), chainId, txId, blockHash);
+            _store.PutTxIdBlockHashIndex(chainId, txId, blockHash);
+        }
+
+        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId)
+        {
+            Log(nameof(HasTxIdBlockHashIndex), chainId, txId);
+            return _store.HasTxIdBlockHashIndex(chainId, txId);
+        }
+
+        public BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId)
+        {
+            Log(nameof(GetTxIdBlockHashIndex), chainId, txId);
+            return _store.GetTxIdBlockHashIndex(chainId, txId);
+        }
+
+        public void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId)
+        {
+            Log(nameof(DeleteTxIdBlockHashIndex), chainId, txId);
+            _store.DeleteTxIdBlockHashIndex(chainId, txId);
+        }
+
         public void SetBlockPerceivedTime(BlockHash blockHash, DateTimeOffset perceivedTime)
         {
             Log(nameof(SetBlockPerceivedTime), blockHash, perceivedTime);

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -77,22 +77,22 @@ namespace Libplanet.Tests.Store
             _store.PutTxIdBlockHashIndex(txId, blockHash);
         }
 
-        public bool HasTxIdBlockHashIndex(TxId txId)
+        public BlockHash? GetFirstTxIdBlockHashIndex(TxId txId)
         {
-            Log(nameof(HasTxIdBlockHashIndex), txId);
-            return _store.HasTxIdBlockHashIndex(txId);
+            Log(nameof(GetFirstTxIdBlockHashIndex), txId);
+            return _store.GetFirstTxIdBlockHashIndex(txId);
         }
 
-        public BlockHash? GetTxIdBlockHashIndex(TxId txId)
+        public IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId)
         {
-            Log(nameof(GetTxIdBlockHashIndex), txId);
-            return _store.GetTxIdBlockHashIndex(txId);
+            Log(nameof(IterateTxIdBlockHashIndex), txId);
+            return _store.IterateTxIdBlockHashIndex(txId);
         }
 
-        public void DeleteTxIdBlockHashIndex(TxId txId)
+        public void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash)
         {
-            Log(nameof(DeleteTxIdBlockHashIndex), txId);
-            _store.DeleteTxIdBlockHashIndex(txId);
+            Log(nameof(DeleteTxIdBlockHashIndex), txId, blockHash);
+            _store.DeleteTxIdBlockHashIndex(txId, blockHash);
         }
 
         public void SetBlockPerceivedTime(BlockHash blockHash, DateTimeOffset perceivedTime)

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -138,6 +138,22 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IStore.GetTxExecution(BlockHash, TxId)"/>
         public abstract TxExecution GetTxExecution(BlockHash blockHash, TxId txid);
 
+        /// <inheritdoc cref="IStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)"/>
+        public abstract void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash);
+
+        /// <inheritdoc cref="IStore.HasTxIdBlockHashIndex(Guid, TxId)"/>
+        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId)
+        {
+            return GetTxIdBlockHashIndex(chainId, txId) is { };
+        }
+
+        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
+        public abstract BlockHash? GetTxIdBlockHashIndex(
+            Guid chainId, TxId txId);
+
+        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
+        public abstract void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId);
+
         /// <inheritdoc cref="IStore.SetBlockPerceivedTime(BlockHash, DateTimeOffset)"/>
         public abstract void SetBlockPerceivedTime(
             BlockHash blockHash,

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -138,21 +138,20 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IStore.GetTxExecution(BlockHash, TxId)"/>
         public abstract TxExecution GetTxExecution(BlockHash blockHash, TxId txid);
 
-        /// <inheritdoc cref="IStore.PutTxIdBlockHashIndex(Guid, TxId, BlockHash)"/>
-        public abstract void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash);
+        /// <inheritdoc cref="IStore.PutTxIdBlockHashIndex(TxId, BlockHash)"/>
+        public abstract void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
-        /// <inheritdoc cref="IStore.HasTxIdBlockHashIndex(Guid, TxId)"/>
-        public bool HasTxIdBlockHashIndex(Guid chainId, TxId txId)
+        /// <inheritdoc cref="IStore.HasTxIdBlockHashIndex(TxId)"/>
+        public bool HasTxIdBlockHashIndex(TxId txId)
         {
-            return GetTxIdBlockHashIndex(chainId, txId) is { };
+            return GetTxIdBlockHashIndex(txId) is { };
         }
 
-        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
-        public abstract BlockHash? GetTxIdBlockHashIndex(
-            Guid chainId, TxId txId);
+        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(TxId)"/>
+        public abstract BlockHash? GetTxIdBlockHashIndex(TxId txId);
 
-        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(Guid, TxId)"/>
-        public abstract void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId);
+        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(TxId)"/>
+        public abstract void DeleteTxIdBlockHashIndex(TxId txId);
 
         /// <inheritdoc cref="IStore.SetBlockPerceivedTime(BlockHash, DateTimeOffset)"/>
         public abstract void SetBlockPerceivedTime(

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -141,17 +141,26 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IStore.PutTxIdBlockHashIndex(TxId, BlockHash)"/>
         public abstract void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
-        /// <inheritdoc cref="IStore.HasTxIdBlockHashIndex(TxId)"/>
-        public bool HasTxIdBlockHashIndex(TxId txId)
+        public BlockHash? GetFirstTxIdBlockHashIndex(TxId txId)
         {
-            return GetTxIdBlockHashIndex(txId) is { };
+            BlockHash? blockHash;
+            try
+            {
+                blockHash = IterateTxIdBlockHashIndex(txId).First();
+            }
+            catch (InvalidOperationException)
+            {
+                blockHash = null;
+            }
+
+            return blockHash;
         }
 
-        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(TxId)"/>
-        public abstract BlockHash? GetTxIdBlockHashIndex(TxId txId);
+        /// <inheritdoc cref="IStore.IterateTxIdBlockHashIndex(TxId)"/>
+        public abstract IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId);
 
-        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(TxId)"/>
-        public abstract void DeleteTxIdBlockHashIndex(TxId txId);
+        /// <inheritdoc cref="IStore.DeleteTxIdBlockHashIndex(TxId, BlockHash)"/>
+        public abstract void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
         /// <inheritdoc cref="IStore.SetBlockPerceivedTime(BlockHash, DateTimeOffset)"/>
         public abstract void SetBlockPerceivedTime(

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -569,17 +569,7 @@ namespace Libplanet.Store
 
             foreach (var path in _txIdBlockHashIndex.EnumerateFiles(txPath))
             {
-                BlockHash blockHash;
-                try
-                {
-                    blockHash = new BlockHash(ByteUtil.ParseHex(path.GetName()));
-                }
-                catch (Exception)
-                {
-                    continue;
-                }
-
-                yield return blockHash;
+                yield return new BlockHash(ByteUtil.ParseHex(path.GetName()));
             }
         }
 
@@ -797,25 +787,9 @@ namespace Libplanet.Store
             return _db.GetCollection<HashDoc>($"{IndexColPrefix}{FormatChainId(chainId)}");
         }
 
-        private LiteCollection<TxIdBlockHashDoc> TxIdBlockIndexCollection(in Guid chainId)
-        {
-            return _db.GetCollection<TxIdBlockHashDoc>(
-                $"{TxIdBlockIndexPrefix}{FormatChainId(chainId)}");
-        }
-
         private LiteCollection<BsonDocument> TxNonceCollection(Guid chainId)
         {
             return _db.GetCollection<BsonDocument>(TxNonceId(chainId));
-        }
-
-        private class TxIdBlockHashDoc
-        {
-            [BsonId]
-            public long Id { get; set; }
-
-            public TxId TxId { get; set; }
-
-            public BlockHash BlockHash { get; set; }
         }
 
         private class HashDoc

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -236,36 +236,32 @@ namespace Libplanet.Store
         /// If there exist a record for <paramref name="txId"/> already,
         /// it overwrites the record silently.
         /// </summary>
-        /// <param name="chainId">The chain ID of the index.</param>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
         /// <param name="blockHash">The <see cref="BlockHash"/> of the <see cref="Block{T}"/>.
         /// </param>
-        void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash);
+        void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
         /// <summary>
         /// Determines whether the <see cref="IStore"/> contains index to <see cref="BlockHash"/>
         /// with given <paramref name="txId"/>.
         /// </summary>
-        /// <param name="chainId">The chain ID of the index.</param>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
         /// <returns><c>true</c> if the index with given <paramref name="txId"/> is exists.
         /// Otherwise, <c>false</c>.</returns>
-        bool HasTxIdBlockHashIndex(Guid chainId, TxId txId);
+        bool HasTxIdBlockHashIndex(TxId txId);
 
         /// <summary>
         /// Retrieves the <see cref="BlockHash"/> indexed by the <paramref name="txId"/>.
         /// </summary>
-        /// <param name="chainId">The chain ID of the index.</param>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
         /// <returns><see cref="BlockHash"/> if the index exists. Otherwise <c>null</c>.</returns>
-        BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId);
+        BlockHash? GetTxIdBlockHashIndex(TxId txId);
 
         /// <summary>
         /// Deletes the index for the <paramref name="txId"/>.
         /// </summary>
-        /// <param name="chainId">The chain ID of the index.</param>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
-        void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId);
+        void DeleteTxIdBlockHashIndex(TxId txId);
 
         /// <summary>
         /// Records the perceived time of a block.  If there is already a record, it is overwritten.

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -232,6 +232,42 @@ namespace Libplanet.Store
         TxExecution GetTxExecution(BlockHash blockHash, TxId txid);
 
         /// <summary>
+        /// Records a index for given pair <paramref name="txId"/> and <paramref name="blockHash"/>.
+        /// If there exist a record for <paramref name="txId"/> already,
+        /// it overwrites the record silently.
+        /// </summary>
+        /// <param name="chainId">The chain ID of the index.</param>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
+        /// <param name="blockHash">The <see cref="BlockHash"/> of the <see cref="Block{T}"/>.
+        /// </param>
+        void PutTxIdBlockHashIndex(Guid chainId, TxId txId, BlockHash blockHash);
+
+        /// <summary>
+        /// Determines whether the <see cref="IStore"/> contains index to <see cref="BlockHash"/>
+        /// with given <paramref name="txId"/>.
+        /// </summary>
+        /// <param name="chainId">The chain ID of the index.</param>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
+        /// <returns><c>true</c> if the index with given <paramref name="txId"/> is exists.
+        /// Otherwise, <c>false</c>.</returns>
+        bool HasTxIdBlockHashIndex(Guid chainId, TxId txId);
+
+        /// <summary>
+        /// Retrieves the <see cref="BlockHash"/> indexed by the <paramref name="txId"/>.
+        /// </summary>
+        /// <param name="chainId">The chain ID of the index.</param>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
+        /// <returns><see cref="BlockHash"/> if the index exists. Otherwise <c>null</c>.</returns>
+        BlockHash? GetTxIdBlockHashIndex(Guid chainId, TxId txId);
+
+        /// <summary>
+        /// Deletes the index for the <paramref name="txId"/>.
+        /// </summary>
+        /// <param name="chainId">The chain ID of the index.</param>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
+        void DeleteTxIdBlockHashIndex(Guid chainId, TxId txId);
+
+        /// <summary>
         /// Records the perceived time of a block.  If there is already a record, it is overwritten.
         /// </summary>
         /// <param name="blockHash"><see cref="Block{T}.Hash"/> to record its perceived time.

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -242,26 +242,26 @@ namespace Libplanet.Store
         void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
         /// <summary>
-        /// Determines whether the <see cref="IStore"/> contains index to <see cref="BlockHash"/>
-        /// with given <paramref name="txId"/>.
-        /// </summary>
-        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
-        /// <returns><c>true</c> if the index with given <paramref name="txId"/> is exists.
-        /// Otherwise, <c>false</c>.</returns>
-        bool HasTxIdBlockHashIndex(TxId txId);
-
-        /// <summary>
         /// Retrieves the <see cref="BlockHash"/> indexed by the <paramref name="txId"/>.
         /// </summary>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
         /// <returns><see cref="BlockHash"/> if the index exists. Otherwise <c>null</c>.</returns>
-        BlockHash? GetTxIdBlockHashIndex(TxId txId);
+        BlockHash? GetFirstTxIdBlockHashIndex(TxId txId);
 
         /// <summary>
-        /// Deletes the index for the <paramref name="txId"/>.
+        /// Retrieves <see cref="BlockHash"/>es indexed by the <paramref name="txId"/>.
         /// </summary>
         /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
-        void DeleteTxIdBlockHashIndex(TxId txId);
+        /// <returns><see cref="BlockHash"/>es if the index exists.</returns>
+        IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId);
+
+        /// <summary>
+        /// Deletes the index for the <paramref name="txId"/> and <paramref name="blockHash"/>.
+        /// </summary>
+        /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/>.</param>
+        /// <param name="blockHash">The <see cref="BlockHash"/>
+        /// of the <see cref="Block{T}"/>.</param>.
+        void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
 
         /// <summary>
         /// Records the perceived time of a block.  If there is already a record, it is overwritten.

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,15 @@ coverage:
         target: auto
         threshold: 1
         base: auto
+    changes: false
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,5 +20,5 @@ comment:
   layout: "diff, files"
 
 ignore:
-  - "*Tests/*"
-  - "*Benchmarks/*"
+  - "*Tests/**/*"
+  - "*Benchmarks/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,15 +6,6 @@ coverage:
         target: auto
         threshold: 1
         base: auto
-    changes: false
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,5 +20,7 @@ comment:
   layout: "diff, files"
 
 ignore:
+  - "*Tests/*"
   - "*Tests/**/*"
+  - "*Benchmarks/*"
   - "*Benchmarks/**/*"


### PR DESCRIPTION
closes #1294 

### APIs
Following APIs are added to `IStore`

```csharp
void PutTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
BlockHash? GetFirstTxIdBlockHashIndex(TxId txId);
IEnumerable<BlockHash> IterateTxIdBlockHashIndex(TxId txId);
void DeleteTxIdBlockHashIndex(TxId txId, BlockHash blockHash);
```

### Contract
* There exists only one record for a pair <TxId, BlockHash>.
* There are multiple BlockHash paired with the same TxId (consider `reorg` situation.)