### PR TITLE
feat: indexing TxId->BlockHash when appending block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -214,6 +214,9 @@ To be released.
  -  (Libplanet.RocksDBStore) `RocksDBStore.ForkBlockIndexes()` became to share
     common ancestors between forks rather than duplicating them so that much
     less space is used.  [[#1280], [#1287]]
+ -  `BlockChain<T>.Append()` cumulates indexes for pairs (TxId and BlockHash).
+    A transaction inclusion for a block is retrievable by using this index.
+    [[#1317], [#1329]]
  -  `ActionEvaluator<T>.EvaluateActions()` now throws an unmanaged exception
     if `OutOfMemoryException` is caught from `IAction.Execute()`.
     [[#1320], [#1343]]
@@ -298,9 +301,11 @@ To be released.
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
 [#1301]: https://github.com/planetarium/libplanet/issues/1301
 [#1305]: https://github.com/planetarium/libplanet/pull/1305
+[#1317]: https://github.com/planetarium/libplanet/issues/1317
 [#1320]: https://github.com/planetarium/libplanet/issues/1320
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
 [#1328]: https://github.com/planetarium/libplanet/pull/1328
+[#1329]: https://github.com/planetarium/libplanet/pull/1329
 [#1334]: https://github.com/planetarium/libplanet/pull/1334
 [#1339]: https://github.com/planetarium/libplanet/issues/1339
 [#1342]: https://github.com/planetarium/libplanet/pull/1342

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -216,7 +216,7 @@ To be released.
     less space is used.  [[#1280], [#1287]]
  -  `BlockChain<T>.Append()` cumulates indexes for pairs (TxId and BlockHash).
     A transaction inclusion for a block is retrievable by using this index.
-    [[#1317], [#1329]]
+    [[#1315], [#1329]]
  -  `ActionEvaluator<T>.EvaluateActions()` now throws an unmanaged exception
     if `OutOfMemoryException` is caught from `IAction.Execute()`.
     [[#1320], [#1343]]
@@ -301,7 +301,7 @@ To be released.
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
 [#1301]: https://github.com/planetarium/libplanet/issues/1301
 [#1305]: https://github.com/planetarium/libplanet/pull/1305
-[#1317]: https://github.com/planetarium/libplanet/issues/1317
+[#1315]: https://github.com/planetarium/libplanet/issues/1315
 [#1320]: https://github.com/planetarium/libplanet/issues/1320
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
 [#1328]: https://github.com/planetarium/libplanet/pull/1328

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -62,15 +62,14 @@ namespace Libplanet.Tests.Blockchain
 
             foreach (var tx in txs)
             {
-                Assert.False(_fx.Store.HasTxIdBlockHashIndex(_blockChain.Id, tx.Id));
+                Assert.Null(_fx.Store.GetFirstTxIdBlockHashIndex(tx.Id));
             }
 
             _blockChain.Append(block2);
 
             foreach (var tx in txs)
             {
-                Assert.True(_fx.Store.GetTxIdBlockHashIndex(_blockChain.Id, tx.Id).
-                    Equals(block2.Hash));
+                Assert.True(_fx.Store.GetFirstTxIdBlockHashIndex(tx.Id)?.Equals(block2.Hash));
             }
 
             Assert.True(_blockChain.ContainsBlock(block2.Hash));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -60,7 +60,18 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Null(getTxExecution(block2.Hash, tx.Id));
             }
 
+            foreach (var tx in txs)
+            {
+                Assert.False(_fx.Store.HasTxIdBlockHashIndex(_blockChain.Id, tx.Id));
+            }
+
             _blockChain.Append(block2);
+
+            foreach (var tx in txs)
+            {
+                Assert.True(_fx.Store.GetTxIdBlockHashIndex(_blockChain.Id, tx.Id).
+                    Equals(block2.Hash));
+            }
 
             Assert.True(_blockChain.ContainsBlock(block2.Hash));
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1245,6 +1245,11 @@ namespace Libplanet.Blockchain
 
                     Store.AppendIndex(Id, block.Hash);
 
+                    foreach (var tx in block.Transactions)
+                    {
+                        Store.PutTxIdBlockHashIndex(Id, tx.Id, block.Hash);
+                    }
+
                     const string unstageStartMsg =
                         "Unstaging {Txs} transaction(s) which belong to the block " +
                         "#{BlockIndex} {BlockHash}...";

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1247,7 +1247,7 @@ namespace Libplanet.Blockchain
 
                     foreach (var tx in block.Transactions)
                     {
-                        Store.PutTxIdBlockHashIndex(Id, tx.Id, block.Hash);
+                        Store.PutTxIdBlockHashIndex(tx.Id, block.Hash);
                     }
 
                     const string unstageStartMsg =


### PR DESCRIPTION
closes #1315 

`BlockChain<T>.Append()` cumulates indexes for pairs (TxId and BlockHash).
A transaction inclusion for a block is retrievable by using this index.