### PR TITLE
[skip changelog] Use wget over curl if possible

### DIFF
--- a/Docs/build.ps1
+++ b/Docs/build.ps1
@@ -38,10 +38,10 @@ function Download-File ($From, $To) {
   # Why we prefer curl/wget here?  Because in some environments
   # (e.g., Travis CI) .NET's root certificates are seemingly outdated,
   # or at least, an error "Could not create SSL/TLS secure channel" occurs.
-  if (Get-Command curl -ErrorAction SilentlyContinue) {
-    curl -L -o "$To" "$From"
-  } elseif (Get-Command wget -ErrorAction SilentlyContinue) {
+  if (Get-Command wget -ErrorAction SilentlyContinue) {
     wget -O "$To" "$From"
+  } elseif (Get-Command curl -ErrorAction SilentlyContinue) {
+    curl -L -o "$To" "$From"
   } else {
     Invoke-WebRequest -OutFile "$To" "$From"
   }


### PR DESCRIPTION
Closes #1327 

From what I have checked, simply running `build.ps1` under Windows 10 with PowerShell 5.1, which is the current default version, seems to fail. This is due to variable scoping in the script.

Invoking

```
Remove-Item Alias:curl
```

once only removes the script scoped alias. However, globally scoped alias for `curl` persists, resulting in failure to run "actual" `curl` instead of `Invoke-WebRequest` cmdlet.

There are three ways to mitigate the issue:
- Invoke `Remove-Item Alias:curl` twice.
- Run the script with `. .\build.ps1` instead of `.\build.ps1` for the script to have the same environment as the invoking shell.
- Use "`wget`" instead of `curl`.

Of the three, the first two have the undesirable side-effect of having the alias removed from the invoking shell environment. Although not a proper fix, this PR implements the third option. Under normal circumstances, even though `wget` alias is not removed properly and `Invoke-WebRequest` is called instead of `wget`, the solution works since the syntax is the same for retrieving `docfx.zip` from the web.