### PR TITLE
Scalarize fields in log

### DIFF
--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -63,6 +63,7 @@ https://docs.libplanet.io/</Description>
   <ItemGroup>
     <PackageReference Include="Bencodex" Version="0.3.0-dev.d6bdbb581c5d9cd024c0b428e1c9404cdf671b75" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
+    <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />
     <PackageReference Include="Fody" Version="6.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Libplanet/Net/BoundPeer.cs
+++ b/Libplanet/Net/BoundPeer.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Net;
 using System.Runtime.Serialization;
+using Destructurama.Attributed;
 using Libplanet.Crypto;
 
 namespace Libplanet.Net
@@ -45,6 +46,7 @@ namespace Libplanet.Net
         /// <summary>
         /// The corresponding <see cref="DnsEndPoint"/> of this peer.
         /// </summary>
+        [LogAsScalar]
         [Pure]
         public DnsEndPoint EndPoint { get; }
 

--- a/Libplanet/Net/Messages/BlockHashes.cs
+++ b/Libplanet/Net/Messages/BlockHashes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Destructurama.Attributed;
 using Libplanet.Blocks;
 using NetMQ;
 
@@ -54,6 +55,7 @@ namespace Libplanet.Net.Messages
         /// <summary>
         /// The continuous block hashes, from the lowest index to the highest index.
         /// </summary>
+        [LogAsScalar]
         public IEnumerable<BlockHash> Hashes { get; }
 
         protected override MessageType Type => MessageType.BlockHashes;

--- a/Libplanet/Net/Messages/ChainStatus.cs
+++ b/Libplanet/Net/Messages/ChainStatus.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Numerics;
+using Destructurama.Attributed;
 using Libplanet.Blocks;
 using NetMQ;
 
@@ -32,16 +33,19 @@ namespace Libplanet.Net.Messages
 
         public int ProtocolVersion { get; }
 
+        [LogAsScalar]
         public BlockHash GenesisHash { get; }
 
         public long TipIndex { get; }
 
+        [LogAsScalar]
         public BlockHash TipHash { get; }
 
         public BigInteger TotalDifficulty { get; }
 
         long IBlockExcerpt.Index => TipIndex;
 
+        [LogAsScalar]
         BlockHash IBlockExcerpt.Hash => TipHash;
 
         protected override Message.MessageType Type => Message.MessageType.ChainStatus;

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using Destructurama.Attributed;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Transports;
@@ -147,6 +148,7 @@ namespace Libplanet.Net.Messages
         /// <see cref="AppProtocolVersion"/>-typed version of the
         /// <see cref="Remote"/>'s transport layer.
         /// </summary>
+        [LogAsScalar]
         public AppProtocolVersion Version { get; set; }
 
         /// <summary>
@@ -157,6 +159,7 @@ namespace Libplanet.Net.Messages
         /// <summary>
         /// The sender <see cref="Peer"/> of the message.
         /// </summary>
+        [LogAsScalar]
         public Peer Remote { get; set; }
 
         protected abstract MessageType Type { get; }

--- a/Libplanet/Net/Messages/Neighbors.cs
+++ b/Libplanet/Net/Messages/Neighbors.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Destructurama.Attributed;
 using NetMQ;
 
 namespace Libplanet.Net.Messages
@@ -20,6 +21,7 @@ namespace Libplanet.Net.Messages
                 .ToImmutableList();
         }
 
+        [LogAsScalar]
         public IImmutableList<BoundPeer> Found { get; }
 
         protected override MessageType Type => MessageType.Neighbors;

--- a/Libplanet/Net/Peer.cs
+++ b/Libplanet/Net/Peer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.Contracts;
 using System.Net;
 using System.Runtime.Serialization;
+using Destructurama.Attributed;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
 
@@ -43,6 +44,7 @@ namespace Libplanet.Net
         /// The corresponding <see cref="Libplanet.Crypto.PublicKey"/> of
         /// this peer.
         /// </summary>
+        [LogAsScalar]
         [Pure]
         public PublicKey PublicKey { get; }
 
@@ -50,10 +52,12 @@ namespace Libplanet.Net
         /// its <see cref="PublicKey"/>.
         /// </summary>
         /// <seealso cref="PublicKey"/>
+        [LogAsScalar]
         [IgnoreDuringEquals]
         [Pure]
         public Address Address => new Address(PublicKey);
 
+        [LogAsScalar]
         [Pure]
         public IPAddress PublicIPAddress { get; }
 


### PR DESCRIPTION
This PR addresses #1309 by using `LogAsScalar` in [Destructurama.Attributed](https://github.com/destructurama/attributed).

I skipped the changelog since couldn't find the previous changelog about log restructuring. (if there is, please let me know).