### PR TITLE
Patch: Throw an unmanaged exception for critical failure during evaluation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -303,6 +303,7 @@ To be released.
 [#1342]: https://github.com/planetarium/libplanet/pull/1342
 [#1343]: https://github.com/planetarium/libplanet/pull/1343
 
+
 Version 0.11.1
 -------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -213,6 +213,9 @@ To be released.
  -  (Libplanet.RocksDBStore) `RocksDBStore.ForkBlockIndexes()` became to share
     common ancestors between forks rather than duplicating them so that much
     less space is used.  [[#1280], [#1287]]
+ -  `ActionEvaluator<T>.EvaluateActions()` now throws an unmanaged exception
+    if `OutOfMemoryException` is caught from `IAction.Execute()`.
+    [[#1320], [#1343]]
 
 ### Bug fixes
 
@@ -293,11 +296,12 @@ To be released.
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
 [#1301]: https://github.com/planetarium/libplanet/issues/1301
 [#1305]: https://github.com/planetarium/libplanet/pull/1305
+[#1320]: https://github.com/planetarium/libplanet/issues/1320
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
 [#1328]: https://github.com/planetarium/libplanet/pull/1328
 [#1339]: https://github.com/planetarium/libplanet/issues/1339
 [#1342]: https://github.com/planetarium/libplanet/pull/1342
-
+[#1343]: https://github.com/planetarium/libplanet/pull/1343
 
 Version 0.11.1
 -------------

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -172,6 +172,10 @@ namespace Libplanet.Tests.Action
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
             Assert.NotNull(evaluations.Single().Exception);
+            Assert.IsType<UnexpectedlyTerminatedActionException>(
+                evaluations.Single().Exception);
+            Assert.IsType<ThrowException.SomeException>(
+                evaluations.Single().Exception.InnerException);
         }
 
         [SuppressMessage(

--- a/Libplanet.Tests/Common/Action/ThrowException.cs
+++ b/Libplanet.Tests/Common/Action/ThrowException.cs
@@ -16,6 +16,8 @@ namespace Libplanet.Tests.Common.Action
 
         public bool ThrowOnExecution { get; set; }
 
+        public Type ExceptionTypeToThrow { get; set; } = typeof(SomeException);
+
         public IValue PlainValue =>
             new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue>
             {
@@ -38,7 +40,8 @@ namespace Libplanet.Tests.Common.Action
         {
             if (context.Rehearsal ? ThrowOnRehearsal : ThrowOnExecution)
             {
-                throw new SomeException("An expected exception.");
+                throw (Exception)Activator.CreateInstance(
+                    ExceptionTypeToThrow, "An expected exception.");
             }
 
             return context.PreviousStates;

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -263,18 +263,20 @@ namespace Libplanet.Action
                     TimeSpan spent = DateTimeOffset.Now - actionExecutionStarted;
                     _logger.Verbose($"{action} execution spent {spent.TotalMilliseconds} ms.");
                 }
+                catch (OutOfMemoryException e)
+                {
+                    // Because OutOfMemory is thrown non-deterministically depending on the state
+                    // of the node, we should throw without further handling. 
+                    var message = 
+                        $"The action {action} (block #{blockIndex}, pre-evaluation hash " +
+                        $"{preEvaluationHash}, tx {txid}) threw an exception " +
+                        "during execution:\n" +
+                        $"{e}";
+                    _logger.Error(e, message);
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e is OutOfMemoryException)
-                    {
-                        var message =
-                            $"The action {action} (block #{blockIndex}, pre-evaluation hash " +
-                            $"{preEvaluationHash}, tx {txid}) threw an exception " +
-                            "during execution:\n" +
-                            $"{e}";
-                        _logger.Error(e, message);
-                        throw;
-                    }
 
                     if (rehearsal)
                     {

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -266,8 +266,8 @@ namespace Libplanet.Action
                 catch (OutOfMemoryException e)
                 {
                     // Because OutOfMemory is thrown non-deterministically depending on the state
-                    // of the node, we should throw without further handling. 
-                    var message = 
+                    // of the node, we should throw without further handling.
+                    var message =
                         $"The action {action} (block #{blockIndex}, pre-evaluation hash " +
                         $"{preEvaluationHash}, tx {txid}) threw an exception " +
                         "during execution:\n" +
@@ -277,7 +277,6 @@ namespace Libplanet.Action
                 }
                 catch (Exception e)
                 {
-
                     if (rehearsal)
                     {
                         var message =


### PR DESCRIPTION
Closes #1320.

Pretty lousy implementation at the moment. 😶 
There are two main concerns.

I thought about repackaging a caught exception to something like `CriticallyTerminatedActionException`, but for a critical exception such as `OutOfMemoryException`, decided it would be better not to try and instantiate any new exception.

Testing is flimsy. It would be much better to see if thrown exception gets caught on a higher level, such as `BlockChain<T>.Mine()` or `BlockChain<T>.Append()`, but this is made rather hard to test as actions are run with `rehearsal` set to `true` for creation of transactions and run with `rehearsal` set to `false` for creation of blocks through these methods. The best I could do was to observe a thrown exception from `ActionEvaluator<T>.Evaluate()`.