### PR TITLE
Refactor/header caching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -261,6 +261,8 @@ To be released.
     if `OutOfMemoryException` is caught from `IAction.Execute()`.
     [[#1320], [#1343]]
  -  Improved performance of broadcasting using `Swarm<T>`.  [[#1334]]
+ -  `Block<T>.Header` is now cached instead of creating a new instance every
+    call. [[#1347]]
 
 ### Bug fixes
 
@@ -364,6 +366,7 @@ To be released.
 [#1341]: https://github.com/planetarium/libplanet/pull/1341
 [#1342]: https://github.com/planetarium/libplanet/pull/1342
 [#1343]: https://github.com/planetarium/libplanet/pull/1343
+[#1347]: https://github.com/planetarium/libplanet/pull/1347
 [#1348]: https://github.com/planetarium/libplanet/pull/1348
 [#1349]: https://github.com/planetarium/libplanet/issues/1349
 [#1350]: https://github.com/planetarium/libplanet/pull/1350

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 new BlockHash(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
                 DateTimeOffset.UtcNow,
                 ImmutableArray<Transaction<NoOpAction>>.Empty,
-                HashAlgorithmType.Of<SHA256>(),
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>(),
                 stateRootHash: new HashDigest<SHA256>(
                     TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
             var query =

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -22,14 +22,15 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 1,
                 1,
                 1,
-                new Nonce(new byte[] {0x01, 0x23, 0x45, 0x56}),
+                new Nonce(new byte[] { 0x01, 0x23, 0x45, 0x56 }),
                 new Address(TestUtils.GetRandomBytes(Address.Size)),
                 new BlockHash(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
                 DateTimeOffset.UtcNow,
                 ImmutableArray<Transaction<NoOpAction>>.Empty,
-                hashAlgorithm: HashAlgorithmType.Of<SHA256>(),
-                stateRootHash: new HashDigest<SHA256>(
-                    TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>());
+            block = new Block<NoOpAction>(
+                block,
+                new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
             var query =
                 @"{
                     index

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -201,8 +201,7 @@ namespace Libplanet.Tests.Blocks
                 miner: ImmutableArray<byte>.Empty,
                 timestamp: future,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
-            );
+                stateRootHash: TestUtils.GetRandomBytes(32).ToImmutableArray());
 
             Assert.Throws<InvalidBlockTimestampException>(
                 () => { header.Validate(hashAlgorithm, now); });
@@ -376,33 +375,18 @@ namespace Libplanet.Tests.Blocks
             ImmutableArray<byte> stateRootHash
         )
         {
-            ImmutableArray<byte> hash = hashAlgorithm.Digest(
-                BlockHeader.SerializeForHash(
-                    protocolVersion,
-                    index,
-                    timestamp,
-                    difficulty,
-                    nonce,
-                    miner,
-                    previousHash,
-                    txHash,
-                    stateRootHash
-                )
-            ).ToImmutableArray();
             return new BlockHeader(
-                protocolVersion,
-                index,
-                timestamp,
-                nonce,
-                miner,
-                difficulty,
-                totalDifficulty,
-                previousHash,
-                txHash,
-                hash,
-                preEvaluationHash,
-                stateRootHash
-            );
+                protocolVersion: protocolVersion,
+                index: index,
+                timestamp: timestamp,
+                nonce: nonce,
+                miner: miner,
+                difficulty: difficulty,
+                totalDifficulty: totalDifficulty,
+                previousHash: previousHash,
+                txHash: txHash,
+                preEvaluationHash: preEvaluationHash,
+                stateRootHash: stateRootHash);
         }
     }
 }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -555,24 +555,6 @@ namespace Libplanet.Blocks
                 tx.Validate();
             }
 
-            if (ProtocolVersion > 0)
-            {
-                byte[] expectedPreEvaluationHash =
-                    hashAlgorithm.Digest(Header.SerializeForHash(includeStateRootHash: false));
-                if (!ByteUtil.TimingSafelyCompare(expectedPreEvaluationHash, PreEvaluationHash))
-                {
-                    string message =
-                        $"The expected pre evaluation hash of block {Hash} is " +
-                        $"{ByteUtil.Hex(expectedPreEvaluationHash)}, but its pre evaluation hash " +
-                        $"is {ByteUtil.Hex(PreEvaluationHash)}.";
-                    throw new InvalidBlockPreEvaluationHashException(
-                        PreEvaluationHash,
-                        expectedPreEvaluationHash.ToImmutableArray(),
-                        message
-                    );
-                }
-            }
-
             HashDigest<SHA256>? calculatedTxHash =
                 CalculateTxHashes(Transactions.OrderBy(tx => tx.Id));
             if (!calculatedTxHash.Equals(TxHash))

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -28,8 +28,8 @@ namespace Libplanet.Blocks
         private int? _bytesLength = null;
 
         /// <summary>
-        /// Creates a <see cref="Block{T}"/> instance by manually filling all field values.
-        /// For a more automated way, see also <see cref="Mine"/> method.
+        /// Creates a <see cref="Block{T}"/> instance by manually filling field values.
+        /// For a more automated way, see also the <see cref="Mine"/> method.
         /// </summary>
         /// <param name="index">The height of the block to create.  Goes to the <see cref="Index"/>.
         /// </param>
@@ -60,12 +60,17 @@ namespace Libplanet.Blocks
         /// </param>
         /// <param name="protocolVersion">The protocol version. <see cref="CurrentProtocolVersion"/>
         /// by default.</param>
-        /// <exception cref="ArgumentNullException">Thrown when both
-        /// <paramref name="hashAlgorithm"/> and <paramref name="preEvaluationHash"/> are omitted.
+        /// <exception cref="ArgumentException">Thrown when either both
+        /// <paramref name="hashAlgorithm"/> and <paramref name="preEvaluationHash"/> are present
+        /// or both are missing.
+        /// <exception cref="ArgumentException">Thrown when the null-ness of
+        /// <paramref name="preEvaluationHash"/> and <paramref name="stateRootHash"/> do not match.
         /// </exception>
-        /// <exception cref="ArgumentException">Thrown when both <paramref name="hashAlgorithm"/>
-        /// and <paramref name="preEvaluationHash"/>, which are mutually exclusive, are present.
         /// </exception>
+        /// <remarks>
+        /// Due to historic reasons, there is non-trivial implicit logic embedded inside this
+        /// constructor.  It is strongly recommended to use <see cref="Mine"/> instead.
+        /// </remarks>
         /// <seealso cref="Mine"/>
         public Block(
             long index,
@@ -92,7 +97,7 @@ namespace Libplanet.Blocks
             {
                 throw new ArgumentException(
                     $"Exactly one of {nameof(hashAlgorithm)} " +
-                    $"and {nameof(preEvaluationHash)} must be null.");
+                    $"and {nameof(preEvaluationHash)} should be provided as non-null.");
             }
 
             if (preEvaluationHash is { } ^ stateRootHash is { } srh)
@@ -196,74 +201,39 @@ namespace Libplanet.Blocks
         {
         }
 
-        private Block(RawBlock rb)
-            : this(
-#pragma warning disable SA1118
-                rb.Header.ProtocolVersion,
-                new BlockHash(rb.Header.Hash),
-                rb.Header.Index,
-                rb.Header.Difficulty,
-                rb.Header.TotalDifficulty,
-                new Nonce(rb.Header.Nonce.ToArray()),
-                new Address(rb.Header.Miner),
-                rb.Header.PreviousHash.Any()
-                    ? new BlockHash(rb.Header.PreviousHash)
-                    : (BlockHash?)null,
-                DateTimeOffset.ParseExact(
-                    rb.Header.Timestamp,
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture).ToUniversalTime(),
-                rb.Header.TxHash.Any()
-                    ? new HashDigest<SHA256>(rb.Header.TxHash)
-                    : (HashDigest<SHA256>?)null,
-                rb.Transactions
-                    .Select(tx => Transaction<T>.Deserialize(tx.ToArray(), false))
-                    .ToList(),
-                rb.Header.PreEvaluationHash.Any()
-                    ? rb.Header.PreEvaluationHash
-                    : (ImmutableArray<byte>?)null,
-                rb.Header.StateRootHash.Any()
-                    ? new HashDigest<SHA256>(rb.Header.StateRootHash)
-                    : (HashDigest<SHA256>?)null)
-#pragma warning restore SA1118
+        private Block(RawBlock rawBlock)
         {
-        }
+            ProtocolVersion = rawBlock.Header.ProtocolVersion;
+            Index = rawBlock.Header.Index;
+            Difficulty = rawBlock.Header.Difficulty;
+            TotalDifficulty = rawBlock.Header.TotalDifficulty;
+            Nonce = new Nonce(rawBlock.Header.Nonce.ToArray());
+            Miner = new Address(rawBlock.Header.Miner);
+            PreviousHash = rawBlock.Header.PreviousHash.Any()
+                ? new BlockHash(rawBlock.Header.PreviousHash)
+                : (BlockHash?)null;
+            Timestamp = DateTimeOffset.ParseExact(
+                rawBlock.Header.Timestamp,
+                BlockHeader.TimestampFormat,
+                CultureInfo.InvariantCulture).ToUniversalTime();
+            TxHash = rawBlock.Header.TxHash.Any()
+                ? new HashDigest<SHA256>(rawBlock.Header.TxHash)
+                : (HashDigest<SHA256>?)null;
+            Transactions = rawBlock.Transactions
+                .Select(tx => Transaction<T>.Deserialize(tx.ToArray(), false))
+                .ToImmutableList();
 
-        private Block(
-            int protocolVersion,
-            BlockHash hash,
-            long index,
-            long difficulty,
-            BigInteger totalDifficulty,
-            Nonce nonce,
-            Address miner,
-            BlockHash? previousHash,
-            DateTimeOffset timestamp,
-            HashDigest<SHA256>? txHash,
-            IReadOnlyList<Transaction<T>> transactions,
-            ImmutableArray<byte>? preEvaluationHash,
-            HashDigest<SHA256>? stateRootHash
-        )
-        {
-            ProtocolVersion = protocolVersion;
-            Index = index;
-            Difficulty = difficulty;
-            TotalDifficulty = totalDifficulty;
-            Nonce = nonce;
-            Miner = miner;
-            PreviousHash = previousHash;
-            Timestamp = timestamp;
-            Hash = hash;
-            PreEvaluationHash = preEvaluationHash ??
-                throw new ArgumentNullException(nameof(preEvaluationHash));
+            PreEvaluationHash = rawBlock.Header.PreEvaluationHash.Any()
+                ? rawBlock.Header.PreEvaluationHash
+                : throw new ArgumentNullException(nameof(Header.PreEvaluationHash));
 
             // See also: https://github.com/planetarium/libplanet/pull/1116#discussion_r535836480
             // FIXME: we should convert `StateRootHash`'s type to `HashDisgest<SHA256>` after
             // removing `IBlockStateStore`.
-            StateRootHash = stateRootHash;
-
-            TxHash = txHash;
-            Transactions = transactions.ToImmutableArray();
+            StateRootHash = rawBlock.Header.StateRootHash.Any()
+                ? new HashDigest<SHA256>(rawBlock.Header.StateRootHash)
+                : (HashDigest<SHA256>?)null;
+            Hash = new BlockHash(rawBlock.Header.Hash);
         }
 
         /// <summary>

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Blocks
         /// </summary>
         public const int CurrentProtocolVersion = BlockHeader.CurrentProtocolVersion;
 
-        private int _bytesLength;
+        private int? _bytesLength = null;
 
         /// <summary>
         /// Creates a <see cref="Block{T}"/> instance by manually filling all field values.
@@ -334,9 +334,7 @@ namespace Libplanet.Blocks
         {
             get
             {
-                // Note that Serialize() by itself caches _byteLength, so that this ByteLength
-                // property never invokes Serialize() more than once.
-                return _bytesLength > 0 ? _bytesLength : Serialize().Length;
+                return _bytesLength ?? (int)(_bytesLength = Serialize().Length);
             }
         }
 
@@ -500,7 +498,6 @@ namespace Libplanet.Blocks
         {
             var codec = new Codec();
             byte[] serialized = codec.Encode(ToBencodex());
-            _bytesLength = serialized.Length;
             return serialized;
         }
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -66,8 +66,8 @@ namespace Libplanet.Blocks
         /// <exception cref="ArgumentException">Thrown when either both
         /// <paramref name="hashAlgorithm"/> and <paramref name="preEvaluationHash"/> are present
         /// or both are missing.
-        /// <exception cref="ArgumentException">Thrown when the null-ness of
-        /// <paramref name="preEvaluationHash"/> and <paramref name="stateRootHash"/> do not match.
+        /// <exception cref="ArgumentException">Thrown when <paramref name="stateRootHash"/>
+        /// is null while <paramref name="preEvaluationHash"/> is not null.
         /// </exception>
         /// </exception>
         /// <remarks>

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -62,10 +62,10 @@ namespace Libplanet.Blocks
         /// <param name="miner">The miner of the block.  Goes to <see cref="Miner"/>.</param>
         /// <param name="difficulty">The mining difficulty that <paramref name="nonce"/>
         /// has to satisfy.  Goes to <see cref="Difficulty"/>.</param>
-        /// <param name="totalDifficulty">The total mining difficulty since the genesis
+        /// <param name="totalDifficulty">The total mining difficulty since the genesis,
         /// including the block's difficulty.  See also <see cref="Difficulty"/>.</param>
         /// <param name="previousHash">The previous block's <see cref="Hash"/>.  If it's a genesis
-        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be <c>null</c>.
+        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be empty.
         /// Goes to <see cref="PreviousHash"/>.</param>
         /// <param name="txHash">The result of hashing the transactions the block has.
         /// Goes to <see cref="TxHash"/>.</param>
@@ -165,7 +165,7 @@ namespace Libplanet.Blocks
         /// <param name="totalDifficulty">The total mining difficulty since the genesis
         /// including the block's difficulty.  See also <see cref="Difficulty"/>.</param>
         /// <param name="previousHash">The previous block's <see cref="Hash"/>.  If it's a genesis
-        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be <c>null</c>.
+        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be empty.
         /// Goes to <see cref="PreviousHash"/>.</param>
         /// <param name="txHash">The result of hashing the transactions the block has.
         /// Goes to <see cref="TxHash"/>.</param>
@@ -215,7 +215,7 @@ namespace Libplanet.Blocks
         /// <param name="totalDifficulty">The total mining difficulty since the genesis
         /// including the block's difficulty.  See also <see cref="Difficulty"/>.</param>
         /// <param name="previousHash">The previous block's <see cref="Hash"/>.  If it's a genesis
-        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be <c>null</c>.
+        /// block (i.e., its <see cref="Block{T}.Index"/> is 0) this should be empty.
         /// Goes to <see cref="PreviousHash"/>.</param>
         /// <param name="txHash">The result of hashing the transactions the block has.
         /// Goes to <see cref="TxHash"/>.</param>
@@ -499,16 +499,12 @@ namespace Libplanet.Blocks
                 .Add("index", Index)
                 .Add("timestamp", Timestamp)
                 .Add("difficulty", Difficulty)
-                .Add("nonce", Nonce.ToArray());
+                .Add("nonce", Nonce.ToArray())
+                .Add("reward_beneficiary", Miner.ToArray());
 
             if (ProtocolVersion != 0)
             {
                 dict = dict.Add("protocol_version", ProtocolVersion);
-            }
-
-            if (!Miner.IsEmpty)
-            {
-                dict = dict.Add("reward_beneficiary", Miner.ToArray());
             }
 
             if (!PreviousHash.IsEmpty)

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -104,69 +104,6 @@ namespace Libplanet.Blocks
             StateRootHash = stateRootHash;
         }
 
-        public BlockHeader(
-            int protocolVersion,
-            long index,
-            string timestamp,
-            ImmutableArray<byte> nonce,
-            ImmutableArray<byte> miner,
-            long difficulty,
-            BigInteger totalDifficulty,
-            ImmutableArray<byte> previousHash,
-            ImmutableArray<byte> txHash)
-        {
-            ProtocolVersion = protocolVersion;
-            Index = index;
-            Timestamp = timestamp;
-            Nonce = nonce;
-            Miner = miner;
-            Difficulty = difficulty;
-            TotalDifficulty = totalDifficulty;
-            PreviousHash = previousHash;
-            TxHash = txHash;
-            PreEvaluationHash = BlockHash.DeriveFrom(SerializeForPreEvaluationHash()).ByteArray;
-            StateRootHash = ImmutableArray<byte>.Empty;
-            Hash = ImmutableArray<byte>.Empty;
-        }
-
-        public BlockHeader(
-            int protocolVersion,
-            long index,
-            string timestamp,
-            ImmutableArray<byte> nonce,
-            ImmutableArray<byte> miner,
-            long difficulty,
-            BigInteger totalDifficulty,
-            ImmutableArray<byte> previousHash,
-            ImmutableArray<byte> txHash,
-            ImmutableArray<byte> preEvaluationHash,
-            ImmutableArray<byte> stateRootHash)
-        {
-            if (preEvaluationHash.IsEmpty)
-            {
-                throw new ArgumentException("preEvaluationHash cannot be empty.");
-            }
-
-            if (stateRootHash.IsEmpty)
-            {
-                throw new ArgumentException("stateRootHash cannot be empty.");
-            }
-
-            ProtocolVersion = protocolVersion;
-            Index = index;
-            Timestamp = timestamp;
-            Nonce = nonce;
-            Miner = miner;
-            Difficulty = difficulty;
-            TotalDifficulty = totalDifficulty;
-            PreviousHash = previousHash;
-            TxHash = txHash;
-
-            PreEvaluationHash = preEvaluationHash;
-            StateRootHash = stateRootHash;
-            Hash = BlockHash.DeriveFrom(SerializeForHash()).ByteArray;
-        }
-
         public BlockHeader(Bencodex.Types.Dictionary dict)
         {
             ProtocolVersion = dict.ContainsKey(ProtocolVersionKey)
@@ -198,6 +135,59 @@ namespace Libplanet.Blocks
             StateRootHash = dict.ContainsKey((IKey)(Binary)StateRootHashKey)
                 ? dict.GetValue<Binary>(StateRootHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
+        }
+
+        internal BlockHeader(
+            int protocolVersion,
+            long index,
+            string timestamp,
+            ImmutableArray<byte> nonce,
+            ImmutableArray<byte> miner,
+            long difficulty,
+            BigInteger totalDifficulty,
+            ImmutableArray<byte> previousHash,
+            ImmutableArray<byte> txHash)
+        {
+            ProtocolVersion = protocolVersion;
+            Index = index;
+            Timestamp = timestamp;
+            Nonce = nonce;
+            Miner = miner;
+            Difficulty = difficulty;
+            TotalDifficulty = totalDifficulty;
+            PreviousHash = previousHash;
+            TxHash = txHash;
+            PreEvaluationHash = BlockHash.DeriveFrom(SerializeForPreEvaluationHash()).ByteArray;
+            StateRootHash = ImmutableArray<byte>.Empty;
+            Hash = PreEvaluationHash;
+        }
+
+        internal BlockHeader(
+            int protocolVersion,
+            long index,
+            string timestamp,
+            ImmutableArray<byte> nonce,
+            ImmutableArray<byte> miner,
+            long difficulty,
+            BigInteger totalDifficulty,
+            ImmutableArray<byte> previousHash,
+            ImmutableArray<byte> txHash,
+            ImmutableArray<byte> preEvaluationHash,
+            ImmutableArray<byte> stateRootHash)
+        {
+            ProtocolVersion = protocolVersion;
+            Index = index;
+            Timestamp = timestamp;
+            Nonce = nonce;
+            Miner = miner;
+            Difficulty = difficulty;
+            TotalDifficulty = totalDifficulty;
+            PreviousHash = previousHash;
+            TxHash = txHash;
+
+            PreEvaluationHash = preEvaluationHash;
+            StateRootHash = stateRootHash;
+            Hash = BlockHash.DeriveFrom(SerializeForHash()).ByteArray;
         }
 
         /// <summary>

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -134,16 +134,16 @@ namespace Libplanet.Blocks
                 ? dict.GetValue<Binary>(TxHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
 
-            Hash = dict.ContainsKey((IKey)(Binary)HashKey)
-                ? dict.GetValue<Binary>(HashKey).ToImmutableArray()
-                : ImmutableArray<byte>.Empty;
-
             PreEvaluationHash = dict.ContainsKey((IKey)(Binary)PreEvaluationHashKey)
                 ? dict.GetValue<Binary>(PreEvaluationHashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
 
             StateRootHash = dict.ContainsKey((IKey)(Binary)StateRootHashKey)
                 ? dict.GetValue<Binary>(StateRootHashKey).ToImmutableArray()
+                : ImmutableArray<byte>.Empty;
+
+            Hash = dict.ContainsKey((IKey)(Binary)HashKey)
+                ? dict.GetValue<Binary>(HashKey).ToImmutableArray()
                 : ImmutableArray<byte>.Empty;
         }
 
@@ -192,10 +192,10 @@ namespace Libplanet.Blocks
             PreviousHash = previousHash;
             TxHash = txHash;
 
-            PreEvaluationHash =
-                hashAlgorithm.Digest(SerializeForPreEvaluationHash()).ToImmutableArray();
+            byte[] serialized = SerializeForPreEvaluationHash();
+            PreEvaluationHash = hashAlgorithm.Digest(serialized).ToImmutableArray();
             StateRootHash = ImmutableArray<byte>.Empty;
-            Hash = hashAlgorithm.Digest(SerializeForHash()).ToImmutableArray();
+            Hash = BlockHash.DeriveFrom(serialized).ByteArray;
         }
 
         /// <summary>

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -175,6 +175,9 @@ namespace Libplanet.Blocks
             ImmutableArray<byte> preEvaluationHash,
             ImmutableArray<byte> stateRootHash)
         {
+            // FIXME: Basic sanity check to prevent improper usage should be present.
+            // For the same reason as Block<T>() constructor comment, should be added in
+            // on furter refactoring.
             ProtocolVersion = protocolVersion;
             Index = index;
             Timestamp = timestamp;
@@ -400,6 +403,8 @@ namespace Libplanet.Blocks
                 );
             }
 
+            // PreEvaluationHash comparison between the actual and the expected was not
+            // implemented in ProtocolVersion == 0.
             if (ProtocolVersion > 0)
             {
                 byte[] expectedPreEvaluationHash =


### PR DESCRIPTION
This PR caches `BlockHeader` when creating a `Block<T>` instance. This is in preparation for dealing with #1164, like #1326 and #1341. Other than caching, this includes the following changes:

- Internally, on-the-fly hash computation is now done by `BlockHeader` instead of `Block<T>`.
- `PreEvaluationHash` validation moved to `BlockHeader`.
- Partial argument constraints are added for a `Block<T>` constructor.

Several new constructors for `BlockHeader` have been introduced to convert some implicit logic more explicit. The main issue remains where there is still too much implicit logic embedded in the "manual" constructor for `Block<T>`. As left in the `FIXME` comments, this should be resolved on further refactoring. The first `Block<T>` constructor in the code should be separated into at least two, one where the constructor is purely used for manual creation of a `Block<T>` instance (possibly intended for testing) and another intended for block generation through mining.