### PR TITLE
Add `SwarmOptions.BranchpointThreshold`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,7 @@ To be released.
  -  Added `BoundPeer.Parse()` static method.  [[#1240]]
  -  Added `TransportException` class.  [[#1242]]
  -  Added `SwarmOptions.StaticPeers` property.  [[#1230], [#1271]]
+ -  Added `SwarmOptions.BranchpointThreshold` property.  [[#1348]]
  -  Added `StaticPeers` as the last parameter to
     `RoutingTable(Address, int, int)` constructor.  [[#1230], [#1271]]
  -  Added `AtomicActionRenderer<T>` class.  [[#1267], [#1275]]
@@ -304,6 +305,7 @@ To be released.
 [#1339]: https://github.com/planetarium/libplanet/issues/1339
 [#1342]: https://github.com/planetarium/libplanet/pull/1342
 [#1343]: https://github.com/planetarium/libplanet/pull/1343
+[#1348]: https://github.com/planetarium/libplanet/pull/1348
 
 
 Version 0.11.1

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -237,7 +237,7 @@ namespace Libplanet.Net
                         logSessionId,
                         subSessionId
                     );
-                    BlockLocator locator = workspace.GetBlockLocator();
+                    BlockLocator locator = workspace.GetBlockLocator(Options.BranchpointThreshold);
                     _logger.Debug(
                         "{SessionId}/{SubSessionId}: Locator's length: {LocatorLength}",
                         logSessionId,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -513,7 +513,7 @@ namespace Libplanet.Net
             );
 
             Block<T> initialTip = BlockChain.Tip;
-            BlockLocator initialLocator = BlockChain.GetBlockLocator();
+            BlockLocator initialLocator = BlockChain.GetBlockLocator(Options.BranchpointThreshold);
             _logger.Debug(
                 "The tip before preloading begins: #{TipIndex} {TipHash}",
                 BlockChain.Tip.Index,
@@ -1123,7 +1123,7 @@ namespace Libplanet.Net
         )
         {
             long currentTipIndex = blockChain.Tip?.Index ?? -1;
-            BlockLocator locator = blockChain.GetBlockLocator();
+            BlockLocator locator = blockChain.GetBlockLocator(Options.BranchpointThreshold);
             int peersCount = peersWithHeight.Count;
             int i = 0;
             var exceptions = new List<Exception>();

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
@@ -67,5 +68,12 @@ namespace Libplanet.Net
         /// </summary>
         public IImmutableSet<BoundPeer> StaticPeers { get; set; } =
             ImmutableHashSet<BoundPeer>.Empty;
+
+        /// <summary>
+        /// The threshold for detecting branchpoint when block synchronization.
+        /// If the branch point is outside threshold from the <see cref="BlockChain{T}.Tip" />,
+        /// using an approximated value.
+        /// </summary>
+        public int BranchpointThreshold { get; set; } = 10;
     }
 }


### PR DESCRIPTION
This PR adds `SwarmOptions.BranchpointThreshold` to enables API users to set a threshold value for branchpoint detecting.