### PR TITLE
Make `Hashcash` algorithm configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,6 +162,9 @@ To be released.
  -  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.  [[#1294], [#1328]]
  -  `Swarm<T>.StartAsync()` method became to receive `broadcastBlockInterval`
     (or `millisecondsBroadcastBlockInterval`) parameter.  [[#1351]]
+ -  Replaced `Hashcash.Answer(Stamp, long, CancellationToken)` method with
+    `Hashcash.Answer<T>(Stamp, HashAlgorithm, long, CancellationToken)` method.
+    [[#1314], [#1352]]
  -  Removed `Hashcash.Hash()` method.  [[#1314], [#1352]]
 
 ### Backward-incompatible network protocol changes
@@ -195,8 +198,6 @@ To be released.
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
  -  Added `ByteUtil.TimingSafelyCompare()` method.  [[#1314], [#1352]]
- -  Added `Hashcash.Answer(Stamp, HashAlgorithm, long, CancellationToken)`
-    overloaded method.  [[#1314], [#1352]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,7 +109,7 @@ To be released.
  -  Hash algorithm for <abbr title="proof-of-work">PoW</abbr> (Hashcash) became
     configurable.  [#1314], [#1352]
      -  Added `IBlockPolicy<T>.GetHashAlgorithm()` method.
-     -  Added optional `HashAlgorithmType? hashAlgorithm` parameter to
+     -  Added an optional `HashAlgorithmType? hashAlgorithm` parameter to
         `Block<T>(long, long, BigInteger, Nonce, Address?, BlockHash?,
         DateTimeOffset, IReadOnlyList<Transaction<T>>, ImmutableArray<byte>?,
         HashDigest<SHA256>?, int protocolVersion)` constructor.
@@ -144,6 +144,8 @@ To be released.
      -  Added `hashAlgorithmGetter` parameter to `BlockSet<T>()` constructor.
      -  Added `hashAlgorithm` parameter to `BlockChain<T>.MakeGenesisBlock()`
         method.
+     -  Added an optional `hashAlgorithmGetter` parameter to `BlockPolicy<T>()`
+        constructor.
  -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -191,6 +191,7 @@ To be released.
  -  Added `BlockHash` struct.  [[#1192], [#1197]]
  -  Added `HashDigest<T>.DeriveFrom()` method.  [[#1197]]
  -  Added `HashAlgorithmType` class.  [[#1314], [#1352]]
+ -  Added `HashAlgorithmGetter` delegate.  [[#1314], [#1352]]
  -  Added `BlockChain<T>.GetTxExecution()` method.  [[#1156], [#1289]]
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -194,6 +194,7 @@ To be released.
  -  Added `Address(Binary)` overloaded constructor.  [[#1289]]
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
+ -  Added `ByteUtil.TimingSafelyCompare()` method.  [[#1314], [#1352]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -200,6 +200,7 @@ To be released.
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
  -  Added `ByteUtil.TimingSafelyCompare()` method.  [[#1314], [#1352]]
+ -  Added `ByteUtil.Satisfies()` method.  [[#1314], [#1352]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,7 +140,9 @@ To be released.
      -  Removed `Hashcash.Hash()` method.
      -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
         `ByteUtil.Satisfies()` method instead.  [[#1192], [#1197]]
-     -  Added `hashAlgorithmGetter` parameter to `BlockSet()` constructor.
+     -  Added `hashAlgorithmGetter` parameter to `BlockSet<T>()` constructor.
+     -  Added `hashAlgorithm` parameter to `BlockChain<T>.MakeGenesisBlock()`
+        method.
  -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,6 @@ To be released.
  -  Block hashes are now represented as `BlockHash`, which was introduced in
     this release, which has been done as `HashDigest<SHA256>`.
     [[#1192], [#1197]]
-     -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
-        `BlockHash.Satisfies()` method instead.
      -  The type of `Block<T>.Hash` property became `BlockHash`
         (was `HashDigest<SHA256>`).
      -  The type of `Block<T>.PreviousHash` property became `BlockHash?`
@@ -168,6 +166,8 @@ To be released.
     `Hashcash.Answer<T>(Stamp, HashAlgorithm, long, CancellationToken)` method.
     [[#1314], [#1352]]
  -  Removed `Hashcash.Hash()` method.  [[#1314], [#1352]]
+ -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
+    `ByteUtil.Satisfies()` method instead.  [[#1192], [#1197], [#1314], [#1352]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -195,6 +195,8 @@ To be released.
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
  -  Added `ByteUtil.TimingSafelyCompare()` method.  [[#1314], [#1352]]
+ -  Added `Hashcash.Answer(Stamp, HashAlgorithm, long, CancellationToken)`
+    overloaded method.  [[#1314], [#1352]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,7 @@ To be released.
  -  Added `HashDigest<T>.DeriveFrom()` method.  [[#1197]]
  -  Added `HashAlgorithmType` class.  [[#1314], [#1352]]
  -  Added `HashAlgorithmGetter` delegate.  [[#1314], [#1352]]
+ -  Added `HashAlgorithmTable` static class.  [[#1314], [#1352]]
  -  Added `BlockChain<T>.GetTxExecution()` method.  [[#1156], [#1289]]
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,10 @@ To be released.
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
  -  Hash algorithm for <abbr title="proof-of-work">PoW</abbr> (Hashcash) became
     configurable.  [#1314], [#1352]
+     -  Added optional `HashAlgorithmType? hashAlgorithm` parameter to
+        `Block<T>(long, long, BigInteger, Nonce, Address?, BlockHash?,
+        DateTimeOffset, IReadOnlyList<Transaction<T>>, ImmutableArray<byte>?,
+        HashDigest<SHA256>?, int protocolVersion)` constructor.
      -  Added `HashAlgorithmType hashAlgorithm` parameter to
         `Block<T>.MineBlock()` method.
      -  The type of `Block<T>.PreEvaluationHash` property became

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -136,6 +136,7 @@ To be released.
      -  Removed `Hashcash.Hash()` method.
      -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
         `ByteUtil.Satisfies()` method instead.  [[#1192], [#1197]]
+     -  Added `hashAlgorithmGetter` parameter to `BlockSet()` constructor.
  -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,6 +118,8 @@ To be released.
      -  The type of `TrieStateStore.PruneStates()` method's `excludeBlockHashes`
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
+ -  Added `HashAlgorithmType hashAlgorithm` parameter to `Block<T>.MineBlock()`
+    method.  [[#1314], [#1352]]
  -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,7 @@ To be released.
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
  -  Hash algorithm for <abbr title="proof-of-work">PoW</abbr> (Hashcash) became
     configurable.  [#1314], [#1352]
+     -  Added `IBlockPolicy<T>.GetHashAlgorithm()` method.
      -  Added optional `HashAlgorithmType? hashAlgorithm` parameter to
         `Block<T>(long, long, BigInteger, Nonce, Address?, BlockHash?,
         DateTimeOffset, IReadOnlyList<Transaction<T>>, ImmutableArray<byte>?,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,8 +106,36 @@ To be released.
      -  The type of `TrieStateStore.PruneStates()` method's `excludeBlockHashes`
         parameter became `IImmutableSet<BlockHash>`
         (was `ImmutableHashSet<HashDigest<SHA256>>`).
- -  Added `HashAlgorithmType hashAlgorithm` parameter to `Block<T>.MineBlock()`
-    method.  [[#1314], [#1352]]
+ -  Hash algorithm for <abbr title="proof-of-work">PoW</abbr> (Hashcash) became
+    configurable.  [#1314], [#1352]
+     -  Added `HashAlgorithmType hashAlgorithm` parameter to
+        `Block<T>.MineBlock()` method.
+     -  The type of `Block<T>.PreEvaluationHash` property became
+        `ImmutableArray<byte>?` (was `HashDigest<SHA256>?`).
+        [[#1192], [#1197]]
+     -  The types of `Block<T>()` constructors' `preEvaluationHash` parameter
+        became `ImmutableArray<byte>?` (were `HashDigest<SHA256>?`).
+        [[#1192], [#1197]]
+     -  The type of
+        `InvalidBlockPreEvaluationHashException.ActualPreEvaluationHash` and
+        `ExpectedPreEvaluationHash` properties became `ImmutableArray<byte>`
+        (were `HashDigest<SHA256>`).  [[#1192], [#1197]]
+     -  The type of `InvalidBlockPreEvaluationHashException()` constructor's
+        `actualPreEvaluationHash` and and `expectedPreEvaluationHash` parameters
+        became `ImmutableArray<byte>` (were `HashDigest<SHA256>`).
+        [[#1192], [#1197]]
+     -  Replaced `UnexpectedlyTerminatedActionException()` constructor's
+        `HashDigest<SHA256>? blockHash` parameter with
+        `ImmutableArray<byte>? preEvaluationHash`.
+        [[#1192], [#1197]]
+     -  Replaced `UnexpectedlyTerminatedActionException.BlockHash` property with
+        `PreEvaluationHash.`  [[#1192], [#1197]]
+     -  Replaced `Hashcash.Answer(Stamp, long, CancellationToken)` method with
+        `Hashcash.Answer<T>(Stamp, HashAlgorithm, long, CancellationToken)`
+        method.
+     -  Removed `Hashcash.Hash()` method.
+     -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
+        `ByteUtil.Satisfies()` method instead.  [[#1192], [#1197]]
  -  Added `IActionContext.TxId` property.  [[#1275]]
  -  Added `IStore.PutTxExecution(TxSuccess)` method.  [[#1156], [#1289]]
  -  Added `IStore.PutTxExecution(TxFailure)` method.  [[#1156], [#1289]]
@@ -152,31 +180,6 @@ To be released.
  -  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.  [[#1294], [#1328]]
  -  `Swarm<T>.StartAsync()` method became to receive `broadcastBlockInterval`
     (or `millisecondsBroadcastBlockInterval`) parameter.  [[#1351]]
- -  The type of `Block<T>.PreEvaluationHash` property became
-    `ImmutableArray<byte>?` (was `HashDigest<SHA256>?`).
-    [[#1192], [#1197], [#1314], [#1352]]
- -  The types of `Block<T>()` constructors' `preEvaluationHash` parameter
-    became `ImmutableArray<byte>?` (were `HashDigest<SHA256>?`).
-    [[#1192], [#1197], [#1314], [#1352]]
- -  The type of `InvalidBlockPreEvaluationHashException.ActualPreEvaluationHash`
-    and `ExpectedPreEvaluationHash` properties became `ImmutableArray<byte>`
-    (were `HashDigest<SHA256>`).  [[#1192], [#1197], [#1314], [#1352]]
- -  The type of `InvalidBlockPreEvaluationHashException()` constructor's
-    `actualPreEvaluationHash` and and `expectedPreEvaluationHash` parameters
-    became `ImmutableArray<byte>` (were `HashDigest<SHA256>`).
-    [[#1192], [#1197], [#1314], [#1352]]
- -  Replaced `UnexpectedlyTerminatedActionException()` constructor's
-    `HashDigest<SHA256>? blockHash` parameter with
-    `ImmutableArray<byte>? preEvaluationHash`.
-    [[#1192], [#1197], [#1314], [#1352]]
- -  Replaced `UnexpectedlyTerminatedActionException.BlockHash` property with
-    `PreEvaluationHash.`  [[#1192], [#1197], [#1314], [#1352]]
- -  Replaced `Hashcash.Answer(Stamp, long, CancellationToken)` method with
-    `Hashcash.Answer<T>(Stamp, HashAlgorithm, long, CancellationToken)` method.
-    [[#1314], [#1352]]
- -  Removed `Hashcash.Hash()` method.  [[#1314], [#1352]]
- -  Removed `HashDigest<T>.Satisfies()` method.  This was replaced by
-    `ByteUtil.Satisfies()` method instead.  [[#1192], [#1197], [#1314], [#1352]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -173,6 +173,7 @@ To be released.
  -  Added `ActionEvaluator` class.  [[#1301], [#1305]]
  -  Added `BlockHash` struct.  [[#1192], [#1197]]
  -  Added `HashDigest<T>.DeriveFrom()` method.  [[#1197]]
+ -  Added `HashAlgorithmType` class.  [[#1314], [#1352]]
  -  Added `BlockChain<T>.GetTxExecution()` method.  [[#1156], [#1289]]
  -  Added `StunMessage.ParseAsync(Stream, CancellationToken)` method.
     [[#1228]]
@@ -313,6 +314,7 @@ To be released.
 [#1298]: https://github.com/planetarium/libplanet/pull/1298
 [#1301]: https://github.com/planetarium/libplanet/issues/1301
 [#1305]: https://github.com/planetarium/libplanet/pull/1305
+[#1314]: https://github.com/planetarium/libplanet/issues/1314
 [#1315]: https://github.com/planetarium/libplanet/issues/1315
 [#1316]: https://github.com/planetarium/libplanet/issues/1316
 [#1320]: https://github.com/planetarium/libplanet/issues/1320
@@ -328,6 +330,7 @@ To be released.
 [#1349]: https://github.com/planetarium/libplanet/issues/1349
 [#1350]: https://github.com/planetarium/libplanet/pull/1350
 [#1351]: https://github.com/planetarium/libplanet/pull/1351
+[#1352]: https://github.com/planetarium/libplanet/pull/1352
 [#1353]: https://github.com/planetarium/libplanet/pull/1353
 [#1360]: https://github.com/planetarium/libplanet/pull/1360
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,14 +15,10 @@ To be released.
         (was `HashDigest<SHA256>`).
      -  The type of `Block<T>.PreviousHash` property became `BlockHash?`
         (was `HashDigest<SHA256>?`).
-     -  The type of `Block<T>.PreEvaluationHash` property became `BlockHash?`
-        (was `HashDigest<SHA256>?`).
      -  The types of `Block<T>()` constructors' `hash` parameter became
         `BlockHash` (were `HashDigest<SHA256>`).
      -  The types of `Block<T>()` constructors' `previousHash` parameter became
         `BlockHash?` (were `HashDigest<SHA256>?`).
-     -  The types of `Block<T>()` constructors' `preEvaluationHash` parameter
-        became `BlockHash?` (were `HashDigest<SHA256>?`).
      -  The type of `Block<T>.Mine()` method's `previousHash` parameter became
         `BlockHash?` (was `HashDigest<SHA256>?`).
      -  The return type of `HashCash.Hash()` method became `BlockHash`
@@ -60,12 +56,6 @@ To be released.
         `BlockHash` (was `HashDigest<SHA256>`).
      -  The type of `BlockVerificationState.VerifiedBlockHash` property became
         `BlockHash` (was `HashDigest<SHA256>`).
-     -  The type of `ActionEvaluation.EvaluateActionsGradually()` method's
-        `blockHash` parameter became `BlockHash` (was `HashDigest<SHA256>`).
-     -  The type of `UnexpectedlyTerminatedActionException()` constructor's
-        `blockHash` parameter became `BlockHash?` (was `HashDigest<SHA256>?`).
-     -  The type of `UnexpectedlyTerminatedActionException.BlockHash` property
-        became `BlockHash?` (was `HashDigest<SHA256>?`).
      -  The type of `IncompleteBlockStatesException()` constructor's
         `blockHash` parameter became `BlockHash` (was `HashDigest<SHA256>`).
      -  The type of `IncompleteBlockStatesException.BlockHash` property
@@ -162,6 +152,25 @@ To be released.
  -  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.  [[#1294], [#1328]]
  -  `Swarm<T>.StartAsync()` method became to receive `broadcastBlockInterval`
     (or `millisecondsBroadcastBlockInterval`) parameter.  [[#1351]]
+ -  The type of `Block<T>.PreEvaluationHash` property became
+    `ImmutableArray<byte>?` (was `HashDigest<SHA256>?`).
+    [[#1192], [#1197], [#1314], [#1352]]
+ -  The types of `Block<T>()` constructors' `preEvaluationHash` parameter
+    became `ImmutableArray<byte>?` (were `HashDigest<SHA256>?`).
+    [[#1192], [#1197], [#1314], [#1352]]
+ -  The type of `InvalidBlockPreEvaluationHashException.ActualPreEvaluationHash`
+    and `ExpectedPreEvaluationHash` properties became `ImmutableArray<byte>`
+    (were `HashDigest<SHA256>`).  [[#1192], [#1197], [#1314], [#1352]]
+ -  The type of `InvalidBlockPreEvaluationHashException()` constructor's
+    `actualPreEvaluationHash` and and `expectedPreEvaluationHash` parameters
+    became `ImmutableArray<byte>` (were `HashDigest<SHA256>`).
+    [[#1192], [#1197], [#1314], [#1352]]
+ -  Replaced `UnexpectedlyTerminatedActionException()` constructor's
+    `HashDigest<SHA256>? blockHash` parameter with
+    `ImmutableArray<byte>? preEvaluationHash`.
+    [[#1192], [#1197], [#1314], [#1352]]
+ -  Replaced `UnexpectedlyTerminatedActionException.BlockHash` property with
+    `PreEvaluationHash.`  [[#1192], [#1197], [#1314], [#1352]]
  -  Replaced `Hashcash.Answer(Stamp, long, CancellationToken)` method with
     `Hashcash.Answer<T>(Stamp, HashAlgorithm, long, CancellationToken)` method.
     [[#1314], [#1352]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,10 +159,10 @@ To be released.
     [[#1294], [#1328]]
  -  Added `IStore.DeleteTxIdBlockHashIndex(TxId, BlockHash)` method.
     [[#1294], [#1328]]
- -  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.
-    [[#1294], [#1328]]
+ -  Added `IStore.IterateTxIdBlockHashIndex(TxId)` method.  [[#1294], [#1328]]
  -  `Swarm<T>.StartAsync()` method became to receive `broadcastBlockInterval`
     (or `millisecondsBroadcastBlockInterval`) parameter.  [[#1351]]
+ -  Removed `Hashcash.Hash()` method.  [[#1314], [#1352]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
@@ -36,7 +37,7 @@ namespace Libplanet.Benchmarks
                 {
                     blockTxs.Add(Transaction<DumbAction>.Create(nonce++, key, genesis.Hash, new DumbAction[0]));
                 }
-                block = TestUtils.MineNext(block, blockTxs);
+                block = TestUtils.MineNext(block, HashAlgorithmType.Of<SHA256>(), blockTxs);
                 blocks.Add(block);
                 txs.AddRange(blockTxs);
             }

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Benchmarks
         {
             var blocks = new List<Block<DumbAction>>();
             var txs = new List<Transaction<DumbAction>>();
-            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(HashAlgorithmType);
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(_ => HashAlgorithmType);
             blocks.Add(genesis);
             Block<DumbAction> block = genesis;
             var key = new PrivateKey();
@@ -38,7 +38,7 @@ namespace Libplanet.Benchmarks
                 {
                     blockTxs.Add(Transaction<DumbAction>.Create(nonce++, key, genesis.Hash, new DumbAction[0]));
                 }
-                block = TestUtils.MineNext(block, HashAlgorithmType.Of<SHA256>(), blockTxs);
+                block = TestUtils.MineNext(block, _ => HashAlgorithmType, blockTxs);
                 blocks.Add(block);
                 txs.AddRange(blockTxs);
             }

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -14,6 +14,7 @@ namespace Libplanet.Benchmarks
 {
     public class Store
     {
+        private readonly HashAlgorithmType HashAlgorithmType = HashAlgorithmType.Of<SHA256>();
         private readonly ImmutableArray<Block<DumbAction>> Blocks = default;
         private readonly int BlocksCount = default;
         private readonly ImmutableArray<Transaction<DumbAction>> Txs = default;
@@ -25,7 +26,7 @@ namespace Libplanet.Benchmarks
         {
             var blocks = new List<Block<DumbAction>>();
             var txs = new List<Transaction<DumbAction>>();
-            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>();
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(HashAlgorithmType);
             blocks.Add(genesis);
             Block<DumbAction> block = genesis;
             var key = new PrivateKey();

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -58,7 +58,7 @@ namespace Libplanet.Benchmarks
             _blockChains = new BlockChain<DumbAction>[SwarmNumber];
             _swarms = new Swarm<DumbAction>[SwarmNumber];
 
-            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
+            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(_hashAlgorithm);
             var tasks = new List<Task>();
             for (int i = 0; i < SwarmNumber; i++)
             {

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -38,12 +38,12 @@ namespace Libplanet.Benchmarks
         {
             _policy = new NullPolicy<DumbAction>();
             _stagePolicy = new VolatileStagePolicy<DumbAction>();
+            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             _blocks = new List<Block<DumbAction>>
             {
-                TestUtils.MineGenesis<DumbAction>(),
+                TestUtils.MineGenesis<DumbAction>(_hashAlgorithm),
             };
             _appProtocolVersion = AppProtocolVersion.Sign(new PrivateKey(), 1);
-            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             _blocks.Add(TestUtils.MineNext(_blocks[0], _hashAlgorithm));
             _blocks.Add(TestUtils.MineNext(_blocks[1], _hashAlgorithm));
             _blocks.Add(TestUtils.MineNext(_blocks[2], _hashAlgorithm));

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -28,7 +28,6 @@ namespace Libplanet.Benchmarks
         private readonly IStagePolicy<DumbAction> _stagePolicy;
         private readonly List<Block<DumbAction>> _blocks;
         private readonly AppProtocolVersion _appProtocolVersion;
-        private readonly HashAlgorithmType _hashAlgorithm;
         private PrivateKey[] _keys;
         private DefaultStoreFixture[] _fxs;
         private BlockChain<DumbAction>[] _blockChains;
@@ -38,16 +37,15 @@ namespace Libplanet.Benchmarks
         {
             _policy = new NullPolicy<DumbAction>();
             _stagePolicy = new VolatileStagePolicy<DumbAction>();
-            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             _blocks = new List<Block<DumbAction>>
             {
-                TestUtils.MineGenesis<DumbAction>(_hashAlgorithm),
+                TestUtils.MineGenesis<DumbAction>(_policy.GetHashAlgorithm),
             };
             _appProtocolVersion = AppProtocolVersion.Sign(new PrivateKey(), 1);
-            _blocks.Add(TestUtils.MineNext(_blocks[0], _hashAlgorithm));
-            _blocks.Add(TestUtils.MineNext(_blocks[1], _hashAlgorithm));
-            _blocks.Add(TestUtils.MineNext(_blocks[2], _hashAlgorithm));
-            _blocks.Add(TestUtils.MineNext(_blocks[3], _hashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[0], _policy.GetHashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[1], _policy.GetHashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[2], _policy.GetHashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[3], _policy.GetHashAlgorithm));
         }
 
         [IterationSetup(Targets = new[] {"BroadcastBlock", "BroadcastBlockWithoutFill"})]
@@ -58,7 +56,9 @@ namespace Libplanet.Benchmarks
             _blockChains = new BlockChain<DumbAction>[SwarmNumber];
             _swarms = new Swarm<DumbAction>[SwarmNumber];
 
-            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(_hashAlgorithm);
+            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(
+                _blockChains[SwarmNumber].Policy.GetHashAlgorithm(0)
+            );
             var tasks = new List<Task>();
             for (int i = 0; i < SwarmNumber; i++)
             {

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -27,6 +28,7 @@ namespace Libplanet.Benchmarks
         private readonly IStagePolicy<DumbAction> _stagePolicy;
         private readonly List<Block<DumbAction>> _blocks;
         private readonly AppProtocolVersion _appProtocolVersion;
+        private readonly HashAlgorithmType _hashAlgorithm;
         private PrivateKey[] _keys;
         private DefaultStoreFixture[] _fxs;
         private BlockChain<DumbAction>[] _blockChains;
@@ -41,10 +43,11 @@ namespace Libplanet.Benchmarks
                 TestUtils.MineGenesis<DumbAction>(),
             };
             _appProtocolVersion = AppProtocolVersion.Sign(new PrivateKey(), 1);
-            _blocks.Add(TestUtils.MineNext(_blocks[0]));
-            _blocks.Add(TestUtils.MineNext(_blocks[1]));
-            _blocks.Add(TestUtils.MineNext(_blocks[2]));
-            _blocks.Add(TestUtils.MineNext(_blocks[3]));
+            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            _blocks.Add(TestUtils.MineNext(_blocks[0], _hashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[1], _hashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[2], _hashAlgorithm));
+            _blocks.Add(TestUtils.MineNext(_blocks[3], _hashAlgorithm));
         }
 
         [IterationSetup(Targets = new[] {"BroadcastBlock", "BroadcastBlockWithoutFill"})]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -433,6 +433,9 @@ If omitted (default) explorer only the local blockchain store.")]
             {
                 return _impl.ValidateNextBlock(blocks, nextBlock);
             }
+
+            public HashAlgorithmType GetHashAlgorithm(long index) =>
+                _impl.GetHashAlgorithm(index);
         }
 
         internal class AppAgnosticAction : IAction

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -27,6 +27,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 new BlockHash(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
                 DateTimeOffset.UtcNow,
                 ImmutableArray<Transaction<NoOpAction>>.Empty,
+                HashAlgorithmType.Of<SHA256>(),
                 stateRootHash: new HashDigest<SHA256>(
                     TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
             var query =

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Security.Cryptography;
 using Cocona;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
@@ -17,6 +18,7 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
     {
         private readonly ImmutableArray<StoreFixture> _storeFixtures;
         private readonly TextWriter _originalWriter;
+        private readonly HashAlgorithmType _hashAlgorithm;
         private readonly Block<Utils.DummyAction> _genesisBlock;
         private readonly Block<Utils.DummyAction> _block1;
         private readonly Block<Utils.DummyAction> _block2;
@@ -51,11 +53,12 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
             _transaction3 = DummyTransaction();
             _transaction4 = DummyTransaction();
 
-            _block1 = TestUtils.MineNext(_genesisBlock, new[] { _transaction1 });
-            _block2 = TestUtils.MineNext(_block1, new[] { _transaction2 });
-            _block3 = TestUtils.MineNext(_block2, new[] { _transaction3 });
-            _block4 = TestUtils.MineNext(_block3, new[] { _transaction3 });
-            _block5 = TestUtils.MineNext(_block4);
+            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            _block1 = TestUtils.MineNext(_genesisBlock, _hashAlgorithm, new[] { _transaction1 });
+            _block2 = TestUtils.MineNext(_block1, _hashAlgorithm, new[] { _transaction2 });
+            _block3 = TestUtils.MineNext(_block2, _hashAlgorithm, new[] { _transaction3 });
+            _block4 = TestUtils.MineNext(_block3, _hashAlgorithm, new[] { _transaction3 });
+            _block5 = TestUtils.MineNext(_block4, _hashAlgorithm);
 
             var guid = Guid.NewGuid();
             foreach (var v in _storeFixtures)

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -47,13 +47,13 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 throw new SkipException("RocksDB is not available.");
             }
 
-            _genesisBlock = TestUtils.MineGenesis<Utils.DummyAction>();
+            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            _genesisBlock = TestUtils.MineGenesis<Utils.DummyAction>(_hashAlgorithm);
             _transaction1 = DummyTransaction();
             _transaction2 = DummyTransaction();
             _transaction3 = DummyTransaction();
             _transaction4 = DummyTransaction();
 
-            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             _block1 = TestUtils.MineNext(_genesisBlock, _hashAlgorithm, new[] { _transaction1 });
             _block2 = TestUtils.MineNext(_block1, _hashAlgorithm, new[] { _transaction2 });
             _block3 = TestUtils.MineNext(_block2, _hashAlgorithm, new[] { _transaction3 });

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -18,7 +18,6 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
     {
         private readonly ImmutableArray<StoreFixture> _storeFixtures;
         private readonly TextWriter _originalWriter;
-        private readonly HashAlgorithmType _hashAlgorithm;
         private readonly Block<Utils.DummyAction> _genesisBlock;
         private readonly Block<Utils.DummyAction> _block1;
         private readonly Block<Utils.DummyAction> _block2;
@@ -47,18 +46,17 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 throw new SkipException("RocksDB is not available.");
             }
 
-            _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            _genesisBlock = TestUtils.MineGenesis<Utils.DummyAction>(_hashAlgorithm);
+            _genesisBlock = TestUtils.MineGenesis<Utils.DummyAction>(GetHashAlgorithm);
             _transaction1 = DummyTransaction();
             _transaction2 = DummyTransaction();
             _transaction3 = DummyTransaction();
             _transaction4 = DummyTransaction();
 
-            _block1 = TestUtils.MineNext(_genesisBlock, _hashAlgorithm, new[] { _transaction1 });
-            _block2 = TestUtils.MineNext(_block1, _hashAlgorithm, new[] { _transaction2 });
-            _block3 = TestUtils.MineNext(_block2, _hashAlgorithm, new[] { _transaction3 });
-            _block4 = TestUtils.MineNext(_block3, _hashAlgorithm, new[] { _transaction3 });
-            _block5 = TestUtils.MineNext(_block4, _hashAlgorithm);
+            _block1 = TestUtils.MineNext(_genesisBlock, GetHashAlgorithm, new[] { _transaction1 });
+            _block2 = TestUtils.MineNext(_block1, GetHashAlgorithm, new[] { _transaction2 });
+            _block3 = TestUtils.MineNext(_block2, GetHashAlgorithm, new[] { _transaction3 });
+            _block4 = TestUtils.MineNext(_block3, GetHashAlgorithm, new[] { _transaction3 });
+            _block5 = TestUtils.MineNext(_block4, GetHashAlgorithm);
 
             var guid = Guid.NewGuid();
             foreach (var v in _storeFixtures)
@@ -312,6 +310,9 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
         {
             Console.SetOut(_originalWriter);
         }
+
+        private HashAlgorithmType GetHashAlgorithm(long blockIndex) =>
+            HashAlgorithmType.Of<SHA256>();
 
         private Transaction<Utils.DummyAction> DummyTransaction()
         {

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -61,11 +61,7 @@ namespace Libplanet.Tests.Action
                     chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(
-                    chain.Policy.GetHashAlgorithm,
-                    chain.StateStore,
-                    chain.Policy.BlockAction
-                )
+                ).AttachStateRootHash(chain.StateStore, chain.Policy)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -55,12 +56,14 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
+                    hashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(chain.StateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(hashAlgorithm, chain.StateStore, chain.Policy.BlockAction)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -56,14 +55,17 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
-                    hashAlgorithm,
+                    chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(hashAlgorithm, chain.StateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(
+                    chain.Policy.GetHashAlgorithm,
+                    chain.StateStore,
+                    chain.Policy.BlockAction
+                )
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Tests.Common.Action;
@@ -54,12 +55,14 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
+                    hashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(chain.StateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(hashAlgorithm, chain.StateStore, chain.Policy.BlockAction)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Tests.Common.Action;
@@ -55,14 +54,17 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
-                    hashAlgorithm,
+                    chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(hashAlgorithm, chain.StateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(
+                    chain.Policy.GetHashAlgorithm,
+                    chain.StateStore,
+                    chain.Policy.BlockAction
+                )
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -60,11 +60,7 @@ namespace Libplanet.Tests.Action
                     chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(
-                    chain.Policy.GetHashAlgorithm,
-                    chain.StateStore,
-                    chain.Policy.BlockAction
-                )
+                ).AttachStateRootHash(chain.StateStore, chain.Policy)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -221,11 +221,7 @@ namespace Libplanet.Tests.Action
                     chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(
-                    chain.Policy.GetHashAlgorithm,
-                    stateStore,
-                    chain.Policy.BlockAction
-                )
+                ).AttachStateRootHash(stateStore, chain.Policy)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -208,6 +209,7 @@ namespace Libplanet.Tests.Action
                 protocolVersion: ProtocolVersion
             );
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             DumbAction action = new DumbAction(_addr[0], "a", _addr[1], _addr[0], 5);
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -218,9 +220,10 @@ namespace Libplanet.Tests.Action
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
+                    hashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(stateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(hashAlgorithm, stateStore, chain.Policy.BlockAction)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -209,7 +208,6 @@ namespace Libplanet.Tests.Action
                 protocolVersion: ProtocolVersion
             );
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             DumbAction action = new DumbAction(_addr[0], "a", _addr[1], _addr[0], 5);
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
@@ -220,10 +218,14 @@ namespace Libplanet.Tests.Action
             chain.Append(
                 TestUtils.MineNext(
                     chain.Tip,
-                    hashAlgorithm,
+                    chain.Policy.GetHashAlgorithm,
                     new[] { tx },
                     protocolVersion: ProtocolVersion
-                ).AttachStateRootHash(hashAlgorithm, stateStore, chain.Policy.BlockAction)
+                ).AttachStateRootHash(
+                    chain.Policy.GetHashAlgorithm,
+                    stateStore,
+                    chain.Policy.BlockAction
+                )
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -207,6 +208,7 @@ namespace Libplanet.Tests.Action
                 actions: new[] { action });
             var block = Block<ThrowException>.Mine(
                 index: 1,
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>(),
                 difficulty: 1,
                 previousTotalDifficulty: genesis.TotalDifficulty,
                 miner: _storeFx.Address1,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -76,6 +76,7 @@ namespace Libplanet.Tests.Action
                 transactions: txs).AttachStateRootHash(stateStore, null);
             var actionEvaluator =
                 new ActionEvaluator<RandomAction>(
+                    hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                     policyBlockAction: null,
                     stateGetter: ActionEvaluator<RandomAction>.NullStateGetter,
                     balanceGetter: ActionEvaluator<RandomAction>.NullBalanceGetter,
@@ -272,6 +273,7 @@ namespace Libplanet.Tests.Action
             };
             Block<DumbAction> genesis = MineGenesis<DumbAction>();
             ActionEvaluator<DumbAction> actionEvaluator = new ActionEvaluator<DumbAction>(
+                hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
                 stateGetter: ActionEvaluator<DumbAction>.NullStateGetter,
                 balanceGetter: ActionEvaluator<DumbAction>.NullBalanceGetter,
@@ -569,6 +571,7 @@ namespace Libplanet.Tests.Action
                 timestamp: DateTimeOffset.UtcNow,
                 transactions: ImmutableArray.Create(tx));
             var actionEvaluator = new ActionEvaluator<DumbAction>(
+                hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
                 stateGetter: ActionEvaluator<DumbAction>.NullStateGetter,
                 balanceGetter: ActionEvaluator<DumbAction>.NullBalanceGetter,
@@ -721,6 +724,7 @@ namespace Libplanet.Tests.Action
                 txs: new List<Transaction<PolymorphicAction<BaseAction>>> { invalidTx });
 
             var actionEvaluator = new ActionEvaluator<PolymorphicAction<BaseAction>>(
+                hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
                 stateGetter: ActionEvaluator<PolymorphicAction<BaseAction>>.NullStateGetter,
                 balanceGetter: ActionEvaluator<PolymorphicAction<BaseAction>>.NullBalanceGetter,
@@ -758,6 +762,7 @@ namespace Libplanet.Tests.Action
                 DateTimeOffset.UtcNow);
             var hash = new BlockHash(GetRandomBytes(32));
             var actionEvaluator = new ActionEvaluator<ThrowException>(
+                hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
                 stateGetter: ActionEvaluator<ThrowException>.NullStateGetter,
                 balanceGetter: ActionEvaluator<ThrowException>.NullBalanceGetter,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -76,10 +76,10 @@ namespace Libplanet.Tests.Action
             var stateRootBlock = TestUtils.MineGenesis(
                 hashAlgorithmGetter: hashAlgorithmGetter,
                 timestamp: timestamp,
-                transactions: txs).AttachStateRootHash(hashAlgorithmGetter, stateStore, null);
+                transactions: txs).AttachStateRootHash(hashAlgorithmGetter(0), stateStore, null);
             var actionEvaluator =
                 new ActionEvaluator<RandomAction>(
-                    hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
+                    hashAlgorithmGetter: hashAlgorithmGetter,
                     policyBlockAction: null,
                     stateGetter: ActionEvaluator<RandomAction>.NullStateGetter,
                     balanceGetter: ActionEvaluator<RandomAction>.NullBalanceGetter,
@@ -933,7 +933,7 @@ namespace Libplanet.Tests.Action
                 _policy.GetHashAlgorithm,
                 txs,
                 difficulty: chain.Policy.GetNextBlockDifficulty(chain)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, chain.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(chain.StateStore, _policy);
             var stateCompleterSet = StateCompleterSet<DumbAction>.Recalculate;
 
             AccountStateGetter accountStateGetter =

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -83,7 +83,7 @@ namespace Libplanet.Tests.Action
             var generatedRandomNumbers = new List<int>();
 
             Assert.NotEqual(stateRootBlock.Hash, noStateRootBlock.Hash);
-            Assert.Equal(stateRootBlock.PreEvaluationHash, noStateRootBlock.PreEvaluationHash);
+            AssertBytesEqual(stateRootBlock.PreEvaluationHash, noStateRootBlock.PreEvaluationHash);
 
             for (int i = 0; i < repeatCount; ++i)
             {
@@ -799,7 +799,7 @@ namespace Libplanet.Tests.Action
 
             Block<Arithmetic> blockA = await fx.Mine();
             ActionEvaluation[] evalsA = ActionEvaluator<DumbAction>.EvaluateActions(
-                blockA.Hash,
+                blockA.PreEvaluationHash,
                 blockIndex: blockA.Index,
                 txid: txA.Id,
                 previousStates: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
@@ -848,7 +848,7 @@ namespace Libplanet.Tests.Action
 
             Block<Arithmetic> blockB = await fx.Mine();
             ActionEvaluation[] evalsB = ActionEvaluator<DumbAction>.EvaluateActions(
-                blockB.Hash,
+                blockB.PreEvaluationHash,
                 blockIndex: blockB.Index,
                 txid: txB.Id,
                 previousStates: fx.CreateAccountStateDelta(0, blockB.PreviousHash),

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -70,9 +70,11 @@ namespace Libplanet.Tests.Action
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var noStateRootBlock = TestUtils.MineGenesis(
+                hashAlgorithm: hashAlgorithm,
                 timestamp: timestamp,
                 transactions: txs);
             var stateRootBlock = TestUtils.MineGenesis(
+                hashAlgorithm: hashAlgorithm,
                 timestamp: timestamp,
                 transactions: txs).AttachStateRootHash(hashAlgorithm, stateStore, null);
             var actionEvaluator =
@@ -273,7 +275,7 @@ namespace Libplanet.Tests.Action
                 _txFx.Address5,
             };
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            Block<DumbAction> genesis = MineGenesis<DumbAction>();
+            Block<DumbAction> genesis = MineGenesis<DumbAction>(hashAlgorithm);
             ActionEvaluator<DumbAction> actionEvaluator = new ActionEvaluator<DumbAction>(
                 hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
@@ -571,7 +573,9 @@ namespace Libplanet.Tests.Action
                 miner: addresses[0],
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
-                transactions: ImmutableArray.Create(tx));
+                transactions: ImmutableArray.Create(tx),
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>()
+            );
             var actionEvaluator = new ActionEvaluator<DumbAction>(
                 hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
                 policyBlockAction: null,
@@ -697,7 +701,7 @@ namespace Libplanet.Tests.Action
                 _txFx.TxWithActions
                     .ToRawTransaction(false).Actions.ToImmutableArray();
             Block<PolymorphicAction<BaseAction>> genesis =
-                TestUtils.MineGenesis<PolymorphicAction<BaseAction>>();
+                TestUtils.MineGenesis<PolymorphicAction<BaseAction>>(hashAlgorithm);
             RawTransaction rawTxWithoutSig = new RawTransaction(
                 0,
                 _txFx.Address1.ByteArray,
@@ -779,7 +783,9 @@ namespace Libplanet.Tests.Action
                 miner: GenesisMinerAddress,
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
-                transactions: ImmutableArray.Create(tx));
+                transactions: ImmutableArray.Create(tx),
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>()
+            );
             var nextStates = actionEvaluator.EvaluateTxResult(
                 block: block,
                 tx: tx,

--- a/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
+++ b/Libplanet.Tests/Action/UnexpectedlyTerminatedActionExceptionTest.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using Libplanet.Action;
-using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
@@ -16,7 +16,8 @@ namespace Libplanet.Tests.Action
         public void Serializable()
         {
             var innerExc = new Exception("inner");
-            var blockHash = new BlockHash(TestUtils.GetRandomBytes(32));
+            ImmutableArray<byte> preEvaluationHash =
+                TestUtils.GetRandomBytes(32).ToImmutableArray();
             long blockIndex = 100;
             var txId = new TxId(TestUtils.GetRandomBytes(TxId.Size));
             var previousStateRootHash = new HashDigest<SHA256>(
@@ -28,7 +29,7 @@ namespace Libplanet.Tests.Action
             };
 
             var exc = new UnexpectedlyTerminatedActionException(
-                blockHash,
+                preEvaluationHash,
                 blockIndex,
                 txId,
                 previousStateRootHash,
@@ -48,7 +49,7 @@ namespace Libplanet.Tests.Action
                 Assert.IsType<Exception>(deserialized.InnerException);
                 Assert.Equal(innerExc.Message, deserialized.InnerException.Message);
 
-                Assert.Equal(blockHash, deserialized.BlockHash);
+                Assert.Equal(preEvaluationHash, deserialized.PreEvaluationHash);
                 Assert.Equal(blockIndex, deserialized.BlockIndex);
                 Assert.Equal(txId, deserialized.TxId);
                 Assert.Equal(previousStateRootHash, deserialized.PreviousStateRootHash);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -47,11 +47,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: addresses[4],
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block1);
             Block<DumbAction> block2 = TestUtils.MineNext(
                 block1,
@@ -59,11 +55,7 @@ namespace Libplanet.Tests.Blockchain
                 txs,
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             foreach (Transaction<DumbAction> tx in txs)
             {
                 Assert.Null(getTxExecution(genesis.Hash, tx.Id));
@@ -214,11 +206,7 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.Policy.GetHashAlgorithm,
                 new[] { tx1Transfer, tx2Error, tx3Transfer },
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
-            ).AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block3);
             var txExecution1 = getTxExecution(block3.Hash, tx1Transfer.Id);
             _logger.Verbose(nameof(txExecution1) + " = {@TxExecution}", txExecution1);
@@ -479,11 +467,7 @@ namespace Libplanet.Tests.Blockchain
                     miner: miner,
                     difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(
-                    policy.GetHashAlgorithm,
-                    blockChain.StateStore,
-                    policy.BlockAction
-                );
+                ).AttachStateRootHash(blockChain.StateStore, policy);
 
                 blockChain.Append(block1);
 
@@ -494,11 +478,7 @@ namespace Libplanet.Tests.Blockchain
                     miner: miner,
                     difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(
-                    policy.GetHashAlgorithm,
-                    blockChain.StateStore,
-                    policy.BlockAction
-                );
+                ).AttachStateRootHash(blockChain.StateStore, policy);
 
                 Assert.Throws<TxViolatingBlockPolicyException>(() => blockChain.Append(block2));
             }
@@ -518,11 +498,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: addresses[4],
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10))
-            .AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            .AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block1);
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
@@ -536,11 +512,7 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block2);
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
             StageTransactions(txs);
@@ -560,11 +532,7 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(
-                _blockChain.Policy.GetHashAlgorithm,
-                _fx.StateStore,
-                _policy.BlockAction
-            );
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block3);
             Assert.Empty(_blockChain.GetStagedTransactionIds());
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -128,7 +128,7 @@ namespace Libplanet.Tests.Blockchain
                 _policy.GetHashAlgorithm,
                 txs,
                 difficulty: _policy.GetNextBlockDifficulty(_blockChain)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
 
             _blockChain.Append(
                 block1,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
@@ -123,11 +124,13 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<DumbAction> block1 = TestUtils.MineNext(
                 genesis,
+                hashAlgorithm,
                 txs,
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(hashAlgorithm, _fx.StateStore, _policy.BlockAction);
 
             _blockChain.Append(
                 block1,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
@@ -124,13 +123,12 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<DumbAction> block1 = TestUtils.MineNext(
                 genesis,
-                hashAlgorithm,
+                _policy.GetHashAlgorithm,
                 txs,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
-            ).AttachStateRootHash(hashAlgorithm, _fx.StateStore, _policy.BlockAction);
+                difficulty: _policy.GetNextBlockDifficulty(_blockChain)
+            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
 
             _blockChain.Append(
                 block1,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MultiAlgorithms.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MultiAlgorithms.cs
@@ -43,13 +43,13 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     new DumbAction[0]
                 );
-                HashAlgorithmGetter invalidAlgoGetter = _ => HashAlgorithmType.Of<SHA1>();
-                Block<DumbAction> invalid1 = TestUtils.MineNext(chain.Genesis, invalidAlgoGetter)
-                    .AttachStateRootHash(invalidAlgoGetter, fx.StateStore, policy.BlockAction);
+                HashAlgorithmType invalidAlgo = HashAlgorithmType.Of<SHA1>();
+                Block<DumbAction> invalid1 = TestUtils.MineNext(chain.Genesis, _ => invalidAlgo)
+                    .AttachStateRootHash(invalidAlgo, fx.StateStore, policy.BlockAction);
                 Assert.Throws<InvalidBlockPreEvaluationHashException>(() => chain.Append(invalid1));
-                HashAlgorithmGetter validAlgoGetter = _ => HashAlgorithmType.Of<MD5>();
-                Block<DumbAction> valid1 = TestUtils.MineNext(chain.Genesis, validAlgoGetter)
-                    .AttachStateRootHash(validAlgoGetter, fx.StateStore, policy.BlockAction);
+                HashAlgorithmType validAlgo = HashAlgorithmType.Of<MD5>();
+                Block<DumbAction> valid1 = TestUtils.MineNext(chain.Genesis, _ => validAlgo)
+                    .AttachStateRootHash(validAlgo, fx.StateStore, policy.BlockAction);
                 chain.Append(valid1);
             }
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MultiAlgorithms.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MultiAlgorithms.cs
@@ -1,0 +1,64 @@
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain
+{
+    public partial class BlockChainTest
+    {
+        [Fact]
+        public async Task MineBlockWithMultipleAlgorithms()
+        {
+            using (var fx = new DefaultStoreFixture())
+            {
+                IBlockPolicy<DumbAction> policy = new MultiAlgoPolicy<DumbAction>();
+                BlockChain<DumbAction> chain = TestUtils.MakeBlockChain(
+                    policy,
+                    fx.Store,
+                    fx.StateStore,
+                    new DumbAction[0]
+                );
+                Block<DumbAction> block1 = await chain.MineBlock(default);
+                Assert.Equal(16, block1.PreEvaluationHash.Length);
+                Block<DumbAction> block2 = await chain.MineBlock(default);
+                Assert.Equal(20, block2.PreEvaluationHash.Length);
+            }
+        }
+
+        [Fact]
+        public void ValidateWithMultipleAlgorithms()
+        {
+            using (var fx = new DefaultStoreFixture())
+            {
+                IBlockPolicy<DumbAction> policy = new MultiAlgoPolicy<DumbAction>();
+                BlockChain<DumbAction> chain = TestUtils.MakeBlockChain(
+                    policy,
+                    fx.Store,
+                    fx.StateStore,
+                    new DumbAction[0]
+                );
+                HashAlgorithmGetter invalidAlgoGetter = _ => HashAlgorithmType.Of<SHA1>();
+                Block<DumbAction> invalid1 = TestUtils.MineNext(chain.Genesis, invalidAlgoGetter)
+                    .AttachStateRootHash(invalidAlgoGetter, fx.StateStore, policy.BlockAction);
+                Assert.Throws<InvalidBlockPreEvaluationHashException>(() => chain.Append(invalid1));
+                HashAlgorithmGetter validAlgoGetter = _ => HashAlgorithmType.Of<MD5>();
+                Block<DumbAction> valid1 = TestUtils.MineNext(chain.Genesis, validAlgoGetter)
+                    .AttachStateRootHash(validAlgoGetter, fx.StateStore, policy.BlockAction);
+                chain.Append(valid1);
+            }
+        }
+
+        private class MultiAlgoPolicy<T> : NullPolicy<T>
+            where T : IAction, new()
+        {
+            public override HashAlgorithmType GetHashAlgorithm(long index) =>
+                index % 2 == 1 ? HashAlgorithmType.Of<MD5>() : HashAlgorithmType.Of<SHA1>();
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -18,6 +18,7 @@ namespace Libplanet.Tests.Blockchain
         {
             Block<DumbAction> validNextBlock = Block<DumbAction>.Mine(
                 1,
+                HashAlgorithmType.Of<SHA256>(),
                 1024,
                 _fx.GenesisBlock.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -34,6 +35,7 @@ namespace Libplanet.Tests.Blockchain
         {
             Block<DumbAction> block1 = Block<DumbAction>.Mine(
                 1,
+                HashAlgorithmType.Of<SHA256>(),
                 1024,
                 _fx.GenesisBlock.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -46,6 +48,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block2 = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1024,
                 block1.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -60,6 +63,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 Block<DumbAction> block3 = Block<DumbAction>.Mine(
                     2,
+                    HashAlgorithmType.Of<SHA256>(),
                     1024,
                     block1.TotalDifficulty,
                     _fx.GenesisBlock.Miner.Value,
@@ -80,6 +84,7 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> prev = _blockChain.Tip;
             Block<DumbAction> blockWithAlreadyUsedIndex = Block<DumbAction>.Mine(
                 prev.Index,
+                HashAlgorithmType.Of<SHA256>(),
                 1,
                 prev.TotalDifficulty,
                 prev.Miner.Value,
@@ -93,6 +98,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> blockWithIndexAfterNonexistentIndex = Block<DumbAction>.Mine(
                 prev.Index + 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1,
                 prev.TotalDifficulty,
                 prev.Miner.Value,
@@ -112,6 +118,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidDifficultyBlock = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -129,6 +136,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidTotalDifficultyBlock = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 _policy.GetNextBlockDifficulty(_blockChain),
                 _validNext.TotalDifficulty - 1,
                 _fx.GenesisBlock.Miner.Value,
@@ -146,6 +154,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidPreviousHashBlock = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1032,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -163,6 +172,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidPreviousTimestamp = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1032,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -196,6 +206,7 @@ namespace Libplanet.Tests.Blockchain
 
             var validNext = Block<DumbAction>.Mine(
                 1,
+                HashAlgorithmType.Of<SHA256>(),
                 1024,
                 genesisBlock.TotalDifficulty,
                 genesisBlock.Miner.Value,
@@ -207,6 +218,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidStateRootHash = Block<DumbAction>.Mine(
                 2,
+                HashAlgorithmType.Of<SHA256>(),
                 1032,
                 validNext.TotalDifficulty,
                 genesisBlock.Miner.Value,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -18,14 +18,14 @@ namespace Libplanet.Tests.Blockchain
         {
             Block<DumbAction> validNextBlock = Block<DumbAction>.Mine(
                 1,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(1),
                 1024,
                 _fx.GenesisBlock.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
                 _fx.GenesisBlock.Hash,
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             _blockChain.Append(validNextBlock);
             Assert.Equal(_blockChain.Tip, validNextBlock);
         }
@@ -35,7 +35,7 @@ namespace Libplanet.Tests.Blockchain
         {
             Block<DumbAction> block1 = Block<DumbAction>.Mine(
                 1,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(1),
                 1024,
                 _fx.GenesisBlock.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -43,12 +43,12 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 1
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             _blockChain.Append(block1);
 
             Block<DumbAction> block2 = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(2),
                 1024,
                 block1.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -56,14 +56,14 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 0
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockProtocolVersionException>(() => _blockChain.Append(block2));
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
             {
                 Block<DumbAction> block3 = Block<DumbAction>.Mine(
                     2,
-                    HashAlgorithmType.Of<SHA256>(),
+                    _fx.GetHashAlgorithm(2),
                     1024,
                     block1.TotalDifficulty,
                     _fx.GenesisBlock.Miner.Value,
@@ -71,7 +71,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.GenesisBlock.Timestamp.AddDays(1),
                     _emptyTransaction,
                     protocolVersion: Block<DumbAction>.CurrentProtocolVersion + 1
-                ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+                ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
                 _blockChain.Append(block3);
             });
         }
@@ -84,28 +84,28 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> prev = _blockChain.Tip;
             Block<DumbAction> blockWithAlreadyUsedIndex = Block<DumbAction>.Mine(
                 prev.Index,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(prev.Index),
                 1,
                 prev.TotalDifficulty,
                 prev.Miner.Value,
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithAlreadyUsedIndex)
             );
 
             Block<DumbAction> blockWithIndexAfterNonexistentIndex = Block<DumbAction>.Mine(
                 prev.Index + 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(prev.Index + 2),
                 1,
                 prev.TotalDifficulty,
                 prev.Miner.Value,
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithIndexAfterNonexistentIndex)
             );
@@ -118,14 +118,14 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidDifficultyBlock = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(2),
                 1,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockDifficultyException>(() =>
                     _blockChain.Append(invalidDifficultyBlock));
         }
@@ -137,14 +137,14 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidTotalDifficultyBlock = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(2),
                 _policy.GetNextBlockDifficulty(_blockChain),
                 _validNext.TotalDifficulty - 1,
                 _fx.GenesisBlock.Miner.Value,
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
                     _blockChain.Append(invalidTotalDifficultyBlock));
         }
@@ -156,7 +156,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidPreviousHashBlock = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(2),
                 1032,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -174,7 +174,7 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidPreviousTimestamp = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.GetHashAlgorithm(2),
                 1032,
                 _validNext.TotalDifficulty,
                 _fx.GenesisBlock.Miner.Value,
@@ -196,8 +196,8 @@ namespace Libplanet.Tests.Blockchain
             //        Actually, it depends on BlockChain<T> to update states and it makes hard to
             //        calculate state root hash. To resolve this problem,
             //        it should be moved into StateStore.
-            var genesisBlock = TestUtils.MineGenesis<DumbAction>(_fx.HashAlgorithm)
-                .AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, policy.BlockAction);
+            var genesisBlock = TestUtils.MineGenesis<DumbAction>(_fx.GetHashAlgorithm)
+                .AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, policy.BlockAction);
             var store = new DefaultStore(null);
             var chain = new BlockChain<DumbAction>(
                 policy,
@@ -208,20 +208,21 @@ namespace Libplanet.Tests.Blockchain
 
             var validNext = Block<DumbAction>.Mine(
                 1,
-                HashAlgorithmType.Of<SHA256>(),
+                policy.GetHashAlgorithm(1),
                 1024,
                 genesisBlock.TotalDifficulty,
                 genesisBlock.Miner.Value,
                 genesisBlock.Hash,
                 genesisBlock.Timestamp.AddSeconds(1),
-                _emptyTransaction)
-                    .AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction)
-                    .AttachStateRootHash(_fx.HashAlgorithm, chain.StateStore, policy.BlockAction);
+                _emptyTransaction
+            )
+                .AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction)
+                .AttachStateRootHash(policy.GetHashAlgorithm, chain.StateStore, policy.BlockAction);
             chain.Append(validNext);
 
             var invalidStateRootHash = Block<DumbAction>.Mine(
                 2,
-                HashAlgorithmType.Of<SHA256>(),
+                policy.GetHashAlgorithm(2),
                 1032,
                 validNext.TotalDifficulty,
                 genesisBlock.Miner.Value,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -196,7 +196,7 @@ namespace Libplanet.Tests.Blockchain
             //        Actually, it depends on BlockChain<T> to update states and it makes hard to
             //        calculate state root hash. To resolve this problem,
             //        it should be moved into StateStore.
-            var genesisBlock = TestUtils.MineGenesis<DumbAction>()
+            var genesisBlock = TestUtils.MineGenesis<DumbAction>(_fx.HashAlgorithm)
                 .AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, policy.BlockAction);
             var store = new DefaultStore(null);
             var chain = new BlockChain<DumbAction>(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Hash,
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             _blockChain.Append(validNextBlock);
             Assert.Equal(_blockChain.Tip, validNextBlock);
         }
@@ -43,7 +43,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 1
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             _blockChain.Append(block1);
 
             Block<DumbAction> block2 = Block<DumbAction>.Mine(
@@ -56,7 +56,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 0
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockProtocolVersionException>(() => _blockChain.Append(block2));
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
@@ -71,7 +71,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.GenesisBlock.Timestamp.AddDays(1),
                     _emptyTransaction,
                     protocolVersion: Block<DumbAction>.CurrentProtocolVersion + 1
-                ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+                ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
                 _blockChain.Append(block3);
             });
         }
@@ -91,7 +91,7 @@ namespace Libplanet.Tests.Blockchain
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithAlreadyUsedIndex)
             );
@@ -105,7 +105,7 @@ namespace Libplanet.Tests.Blockchain
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithIndexAfterNonexistentIndex)
             );
@@ -124,7 +124,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Miner.Value,
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
-                _emptyTransaction).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+                _emptyTransaction
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockDifficultyException>(() =>
                     _blockChain.Append(invalidDifficultyBlock));
         }
@@ -142,7 +143,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Miner.Value,
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
-                _emptyTransaction).AttachStateRootHash(_fx.StateStore, _policy.BlockAction);
+                _emptyTransaction
+            ).AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction);
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
                     _blockChain.Append(invalidTotalDifficultyBlock));
         }
@@ -195,7 +197,7 @@ namespace Libplanet.Tests.Blockchain
             //        calculate state root hash. To resolve this problem,
             //        it should be moved into StateStore.
             var genesisBlock = TestUtils.MineGenesis<DumbAction>()
-                .AttachStateRootHash(_fx.StateStore, policy.BlockAction);
+                .AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, policy.BlockAction);
             var store = new DefaultStore(null);
             var chain = new BlockChain<DumbAction>(
                 policy,
@@ -212,8 +214,9 @@ namespace Libplanet.Tests.Blockchain
                 genesisBlock.Miner.Value,
                 genesisBlock.Hash,
                 genesisBlock.Timestamp.AddSeconds(1),
-                _emptyTransaction).AttachStateRootHash(_fx.StateStore, _policy.BlockAction)
-                .AttachStateRootHash(chain.StateStore, policy.BlockAction);
+                _emptyTransaction)
+                    .AttachStateRootHash(_fx.HashAlgorithm, _fx.StateStore, _policy.BlockAction)
+                    .AttachStateRootHash(_fx.HashAlgorithm, chain.StateStore, policy.BlockAction);
             chain.Append(validNext);
 
             var invalidStateRootHash = Block<DumbAction>.Mine(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Hash,
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(validNextBlock);
             Assert.Equal(_blockChain.Tip, validNextBlock);
         }
@@ -43,7 +43,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 1
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block1);
 
             Block<DumbAction> block2 = Block<DumbAction>.Mine(
@@ -56,7 +56,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Timestamp.AddDays(1),
                 _emptyTransaction,
                 protocolVersion: 0
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidBlockProtocolVersionException>(() => _blockChain.Append(block2));
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
@@ -71,7 +71,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.GenesisBlock.Timestamp.AddDays(1),
                     _emptyTransaction,
                     protocolVersion: Block<DumbAction>.CurrentProtocolVersion + 1
-                ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+                ).AttachStateRootHash(_fx.StateStore, _policy);
                 _blockChain.Append(block3);
             });
         }
@@ -91,7 +91,7 @@ namespace Libplanet.Tests.Blockchain
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithAlreadyUsedIndex)
             );
@@ -105,7 +105,7 @@ namespace Libplanet.Tests.Blockchain
                 prev.Hash,
                 prev.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidBlockIndexException>(
                 () => _blockChain.Append(blockWithIndexAfterNonexistentIndex)
             );
@@ -125,7 +125,7 @@ namespace Libplanet.Tests.Blockchain
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidBlockDifficultyException>(() =>
                     _blockChain.Append(invalidDifficultyBlock));
         }
@@ -144,7 +144,7 @@ namespace Libplanet.Tests.Blockchain
                 _validNext.Hash,
                 _validNext.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
                     _blockChain.Append(invalidTotalDifficultyBlock));
         }
@@ -197,7 +197,7 @@ namespace Libplanet.Tests.Blockchain
             //        calculate state root hash. To resolve this problem,
             //        it should be moved into StateStore.
             var genesisBlock = TestUtils.MineGenesis<DumbAction>(_fx.GetHashAlgorithm)
-                .AttachStateRootHash(_fx.GetHashAlgorithm, _fx.StateStore, policy.BlockAction);
+                .AttachStateRootHash(_fx.StateStore, policy);
             var store = new DefaultStore(null);
             var chain = new BlockChain<DumbAction>(
                 policy,
@@ -216,8 +216,8 @@ namespace Libplanet.Tests.Blockchain
                 genesisBlock.Timestamp.AddSeconds(1),
                 _emptyTransaction
             )
-                .AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction)
-                .AttachStateRootHash(policy.GetHashAlgorithm, chain.StateStore, policy.BlockAction);
+                .AttachStateRootHash(_fx.StateStore, _policy)
+                .AttachStateRootHash(chain.StateStore, policy);
             chain.Append(validNext);
 
             var invalidStateRootHash = Block<DumbAction>.Mine(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -583,12 +583,8 @@ namespace Libplanet.Tests.Blockchain
                 new MemoryKeyValueStore(), new MemoryKeyValueStore()))
             {
                 var genesis = TestUtils.MineGenesis(
-                    transactions: new[]
-                    {
-                        _fx.MakeTransaction(
-                            new[] { action }
-                        ),
-                    }
+                    hashAlgorithm,
+                    transactions: new[] { _fx.MakeTransaction(new[] { action }) }
                 ).AttachStateRootHash(hashAlgorithm, stateStore, _policy.BlockAction);
                 store.PutBlock(genesis);
                 var renderer = new RecordingActionRenderer<DumbAction>();
@@ -1016,9 +1012,10 @@ namespace Libplanet.Tests.Blockchain
                 memory: true, blockAction: _policy.BlockAction))
             {
                 HashAlgorithmType hashAlgorithm = fx2.HashAlgorithm;
-                Block<DumbAction> genesis2 =
-                    TestUtils.MineGenesis<DumbAction>(timestamp: DateTimeOffset.UtcNow)
-                        .AttachStateRootHash(hashAlgorithm, fx2.StateStore, _policy.BlockAction);
+                Block<DumbAction> genesis2 = TestUtils.MineGenesis<DumbAction>(
+                    hashAlgorithm,
+                    timestamp: DateTimeOffset.UtcNow
+                ).AttachStateRootHash(hashAlgorithm, fx2.StateStore, _policy.BlockAction);
                 var chain2 = new BlockChain<DumbAction>(
                     _blockChain.Policy,
                     _blockChain.StagePolicy,
@@ -1553,7 +1550,7 @@ namespace Libplanet.Tests.Blockchain
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             store = new StoreTracker(store);
             Guid chainId = Guid.NewGuid();
-            Block<DumbAction> genesisBlock = TestUtils.MineGenesis<DumbAction>()
+            Block<DumbAction> genesisBlock = TestUtils.MineGenesis<DumbAction>(hashAlgorithm)
                 .AttachStateRootHash(hashAlgorithm, stateStore, blockPolicy.BlockAction);
             var chain = new BlockChain<DumbAction>(
                 blockPolicy,
@@ -1845,7 +1842,7 @@ namespace Libplanet.Tests.Blockchain
             var store = new DefaultStore(null);
             var stateStore = new TrieStateStore(
                 new MemoryKeyValueStore(), new MemoryKeyValueStore());
-            var genesisBlock = TestUtils.MineGenesis<DumbAction>();
+            var genesisBlock = TestUtils.MineGenesis<DumbAction>(HashAlgorithmType.Of<SHA256>());
             BlockChain<DumbAction> blockChain = TestUtils.MakeBlockChain(
                 _blockChain.Policy, store, stateStore, genesisBlock: genesisBlock);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -181,7 +181,9 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public async void ProcessActions()
         {
-            var genesisBlock = BlockChain<PolymorphicAction<BaseAction>>.MakeGenesisBlock();
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            Block<PolymorphicAction<BaseAction>> genesisBlock =
+                BlockChain<PolymorphicAction<BaseAction>>.MakeGenesisBlock(hashAlgorithm);
             var store = new DefaultStore(path: null);
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
@@ -1136,11 +1138,11 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public async void GetStateReturnsValidStateAfterFork()
         {
-            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(
-                new[]
-                {
-                    new DumbAction(_fx.Address1, "item0.0", idempotent: true),
-                });
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            Block<DumbAction> genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(
+                hashAlgorithm,
+                new[] { new DumbAction(_fx.Address1, "item0.0", idempotent: true) }
+            );
             var privateKey = new PrivateKey();
             var store = new DefaultStore(path: null);
             var stateStore =
@@ -1226,6 +1228,7 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public async void FindBranchPoint()
         {
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<DumbAction> b1 = await _blockChain.MineBlock(_fx.Address1);
             Block<DumbAction> b2 = await _blockChain.MineBlock(_fx.Address1);
             Block<DumbAction> b3 = await _blockChain.MineBlock(_fx.Address1);
@@ -1241,7 +1244,7 @@ namespace Libplanet.Tests.Blockchain
             using (var forkFx = new DefaultStoreFixture(
                 memory: true, blockAction: _policy.BlockAction))
             {
-                var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
+                var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(hashAlgorithm);
                 var emptyChain = new BlockChain<DumbAction>(
                     _blockChain.Policy,
                     new VolatileStagePolicy<DumbAction>(),
@@ -1754,6 +1757,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var storeFixture = new DefaultStoreFixture();
             var policy = new NullPolicy<DumbAction>();
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
             var addresses = ImmutableList<Address>.Empty
                 .Add(storeFixture.Address1)
@@ -1770,7 +1774,7 @@ namespace Libplanet.Tests.Blockchain
                     new VolatileStagePolicy<DumbAction>(),
                     storeFixture.Store,
                     storeFixture.StateStore,
-                    BlockChain<DumbAction>.MakeGenesisBlock(actions));
+                    BlockChain<DumbAction>.MakeGenesisBlock(hashAlgorithm, actions));
 
             Assert.Equal(addresses, blockChain.Genesis.Transactions.First().UpdatedAddresses);
 
@@ -1786,12 +1790,13 @@ namespace Libplanet.Tests.Blockchain
         private void ConstructWithUnexpectedGenesisBlock()
         {
             var policy = new NullPolicy<DumbAction>();
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var stagePolicy = new VolatileStagePolicy<DumbAction>();
             var store = new DefaultStore(null);
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
-            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock();
-            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock();
+            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock(hashAlgorithm);
+            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock(hashAlgorithm);
 
             var blockChain = new BlockChain<DumbAction>(
                 policy,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -65,6 +66,7 @@ namespace Libplanet.Tests.Blockchain
             _emptyTransaction = new List<Transaction<DumbAction>>();
             _validNext = Block<DumbAction>.Mine(
                     1,
+                    HashAlgorithmType.Of<SHA256>(),
                     1024,
                     _fx.GenesisBlock.TotalDifficulty,
                     _fx.GenesisBlock.Miner.Value,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -73,7 +73,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock.Hash,
                 _fx.GenesisBlock.Timestamp.AddSeconds(1),
                 _emptyTransaction
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
         }
 
         public void Dispose()
@@ -308,7 +308,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { tx },
                     miner: miner,
                     difficulty: policy.GetNextBlockDifficulty(_blockChain)
-                ).AttachStateRootHash(policy.GetHashAlgorithm, fx.StateStore, policy.BlockAction);
+                ).AttachStateRootHash(fx.StateStore, policy);
                 chain.Append(block);
                 var forked = chain.Fork(chain.Genesis.Hash);
                 forked.Append(block);
@@ -585,7 +585,7 @@ namespace Libplanet.Tests.Blockchain
                 var genesis = TestUtils.MineGenesis(
                     _policy.GetHashAlgorithm,
                     transactions: new[] { _fx.MakeTransaction(new[] { action }) }
-                ).AttachStateRootHash(_policy.GetHashAlgorithm, stateStore, _policy.BlockAction);
+                ).AttachStateRootHash(stateStore, _policy);
                 store.PutBlock(genesis);
                 var renderer = new RecordingActionRenderer<DumbAction>();
                 var blockChain = new BlockChain<DumbAction>(
@@ -636,7 +636,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10))
-            .AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            .AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(b1);
 
             Block<DumbAction> b2 = TestUtils.MineNext(
@@ -646,7 +646,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             Assert.Throws<InvalidTxNonceException>(() =>
                 _blockChain.Append(b2));
 
@@ -664,7 +664,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(b2);
         }
 
@@ -700,7 +700,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
 
             _blockChain.Append(b1);
 
@@ -720,7 +720,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10))
-            .AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            .AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(b2);
 
             Assert.Equal(2, _blockChain.GetNextTxNonce(address));
@@ -774,7 +774,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: minerAddress,
                 difficulty: _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(block1);
 
             PrivateKey privateKey = new PrivateKey(new byte[]
@@ -839,11 +839,7 @@ namespace Libplanet.Tests.Blockchain
                     null,
                     _policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(
-                    _policy.GetHashAlgorithm,
-                    _fx.StateStore,
-                    _policy.BlockAction
-                );
+                ).AttachStateRootHash(_fx.StateStore, _policy);
                 _blockChain.Append(b);
             }
 
@@ -875,7 +871,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             fork.Append(
                 forkTip,
                 DateTimeOffset.UtcNow,
@@ -1016,11 +1012,7 @@ namespace Libplanet.Tests.Blockchain
                 Block<DumbAction> genesis2 = TestUtils.MineGenesis<DumbAction>(
                     _policy.GetHashAlgorithm,
                     timestamp: DateTimeOffset.UtcNow
-                ).AttachStateRootHash(
-                    _policy.GetHashAlgorithm,
-                    fx2.StateStore,
-                    _policy.BlockAction
-                );
+                ).AttachStateRootHash(fx2.StateStore, _policy);
                 var chain2 = new BlockChain<DumbAction>(
                     _policy,
                     _stagePolicy,
@@ -1083,7 +1075,7 @@ namespace Libplanet.Tests.Blockchain
                     b,
                     policy.GetHashAlgorithm,
                     txs
-                ).AttachStateRootHash(policy.GetHashAlgorithm, _fx.StateStore, policy.BlockAction);
+                ).AttachStateRootHash(_fx.StateStore, policy);
                 chain.Append(b);
             }
 
@@ -1125,11 +1117,7 @@ namespace Libplanet.Tests.Blockchain
                     b,
                     blockPolicy.GetHashAlgorithm,
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(
-                    blockPolicy.GetHashAlgorithm,
-                    _fx.StateStore,
-                    blockPolicy.BlockAction
-                );
+                ).AttachStateRootHash(_fx.StateStore, blockPolicy);
                 chain.Append(b);
             }
 
@@ -1305,7 +1293,7 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
-            ).AttachStateRootHash(_policy.GetHashAlgorithm, _fx.StateStore, _policy.BlockAction);
+            ).AttachStateRootHash(_fx.StateStore, _policy);
             _blockChain.Append(b1);
 
             Assert.Equal(1, _blockChain.GetNextTxNonce(address));
@@ -1398,18 +1386,17 @@ namespace Libplanet.Tests.Blockchain
 
             var genesis = _blockChain.Genesis;
 
-            Block<T> MineNext<T>(Block<T> block, IReadOnlyList<Transaction<T>> txs)
-                where T : IAction, new() => TestUtils.MineNext(
+            Block<DumbAction> MineNext(
+                Block<DumbAction> block,
+                IReadOnlyList<Transaction<DumbAction>> txs
+            ) =>
+                TestUtils.MineNext(
                     block,
                     _policy.GetHashAlgorithm,
                     txs,
                     difficulty: 1024,
                     blockInterval: TimeSpan.FromSeconds(10)
-                ).AttachStateRootHash(
-                    _policy.GetHashAlgorithm,
-                    _fx.StateStore,
-                    _policy.BlockAction
-                );
+                ).AttachStateRootHash(_fx.StateStore, _policy);
 
             Transaction<DumbAction>[] txsA =
             {
@@ -1567,11 +1554,7 @@ namespace Libplanet.Tests.Blockchain
             Guid chainId = Guid.NewGuid();
             Block<DumbAction> genesisBlock = TestUtils.MineGenesis<DumbAction>(
                 blockPolicy.GetHashAlgorithm
-            ).AttachStateRootHash(
-                blockPolicy.GetHashAlgorithm,
-                stateStore,
-                blockPolicy.BlockAction
-            );
+            ).AttachStateRootHash(stateStore, blockPolicy);
             var chain = new BlockChain<DumbAction>(
                 blockPolicy,
                 new VolatileStagePolicy<DumbAction>(),
@@ -1635,11 +1618,7 @@ namespace Libplanet.Tests.Blockchain
                         blockPolicy.GetHashAlgorithm,
                         new[] { tx },
                         blockInterval: TimeSpan.FromSeconds(10)
-                    ).AttachStateRootHash(
-                        blockPolicy.GetHashAlgorithm,
-                        stateStore,
-                        blockPolicy.BlockAction
-                    );
+                    ).AttachStateRootHash(stateStore, blockPolicy);
                     previousStates = b.ProtocolVersion > 0
                         ? new AccountStateDeltaImpl(
                             dirty.GetValueOrDefault,

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -8,7 +9,7 @@ using Libplanet.Tx;
 
 namespace Libplanet.Tests.Blockchain
 {
-    public sealed class NullPolicy<T> : IBlockPolicy<T>
+    public class NullPolicy<T> : IBlockPolicy<T>
         where T : IAction, new()
     {
         private readonly InvalidBlockException _exceptionToThrow;
@@ -39,5 +40,8 @@ namespace Libplanet.Tests.Blockchain
             _exceptionToThrow;
 
         public int GetMaxBlockBytes(long index) => 1024 * 1024;
+
+        public virtual HashAlgorithmType GetHashAlgorithm(long index) =>
+            HashAlgorithmType.Of<SHA256>();
     }
 }

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -184,6 +185,25 @@ namespace Libplanet.Tests.Blockchain.Policies
                 1048,
                 _policy.GetNextBlockDifficulty(chain)
             );
+        }
+
+        [Fact]
+        public void GetHashAlgorithm()
+        {
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), _policy.GetHashAlgorithm(0));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), _policy.GetHashAlgorithm(1));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), _policy.GetHashAlgorithm(2));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), _policy.GetHashAlgorithm(10));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), _policy.GetHashAlgorithm(15));
+
+            var p = new BlockPolicy<DumbAction>(hashAlgorithmGetter: i =>
+                i % 2 == 0 ? HashAlgorithmType.Of<MD5>() : HashAlgorithmType.Of<SHA1>()
+            );
+            Assert.Equal(HashAlgorithmType.Of<MD5>(), p.GetHashAlgorithm(0));
+            Assert.Equal(HashAlgorithmType.Of<SHA1>(), p.GetHashAlgorithm(1));
+            Assert.Equal(HashAlgorithmType.Of<MD5>(), p.GetHashAlgorithm(2));
+            Assert.Equal(HashAlgorithmType.Of<MD5>(), p.GetHashAlgorithm(10));
+            Assert.Equal(HashAlgorithmType.Of<SHA1>(), p.GetHashAlgorithm(15));
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
@@ -19,12 +20,14 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private static Exception _exception = new Exception();
 
+        private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
         private static Block<DumbAction> _genesis =
             TestUtils.MineGenesis<DumbAction>(default(Address));
 
-        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis);
+        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
-        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis);
+        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
         [Fact]
         public void ActionRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesis<DumbAction>(default(Address));
+            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
 
         private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -23,11 +23,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithm, default(Address));
 
-        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static Block<DumbAction> _blockA =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
-        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static Block<DumbAction> _blockB =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
         [Fact]
         public void ActionRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
@@ -7,12 +8,14 @@ namespace Libplanet.Tests.Blockchain.Renderers
 {
     public class AnonymousRendererTest
     {
+        private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
         private static Block<DumbAction> _genesis =
             TestUtils.MineGenesis<DumbAction>(default(Address));
 
-        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis);
+        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
-        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis);
+        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
         [Fact]
         public void BlockRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -11,11 +11,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithm, default(Address));
 
-        private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static Block<DumbAction> _blockA =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
-        private static Block<DumbAction> _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static Block<DumbAction> _blockB =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
         [Fact]
         public void BlockRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesis<DumbAction>(default(Address));
+            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
 
         private static Block<DumbAction> _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var chainA = new Block<DumbAction>[10];
             var chainB = new Block<DumbAction>[chainA.Length];
-            chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>();
+            chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>(hashAlgorithm);
             for (int i = 1; i < chainA.Length / 2; i++)
             {
                 _branchpoint = chainA[i] = chainB[i] =

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
@@ -25,20 +26,25 @@ namespace Libplanet.Tests.Blockchain.Renderers
 #pragma warning disable S3963
         static DelayedRendererTest()
         {
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var chainA = new Block<DumbAction>[10];
             var chainB = new Block<DumbAction>[chainA.Length];
             chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>();
             for (int i = 1; i < chainA.Length / 2; i++)
             {
                 _branchpoint = chainA[i] = chainB[i] =
-                    TestUtils.MineNext(chainA[i - 1]);
+                    TestUtils.MineNext(chainA[i - 1], hashAlgorithm);
             }
 
             int extraDifficulty = 1;
             for (int i = chainA.Length / 2; i < chainA.Length; i++)
             {
-                chainA[i] = TestUtils.MineNext(chainA[i - 1], difficulty: 2);
-                chainB[i] = TestUtils.MineNext(chainB[i - 1], difficulty: 2 + extraDifficulty);
+                chainA[i] = TestUtils.MineNext(chainA[i - 1], hashAlgorithm, difficulty: 2);
+                chainB[i] = TestUtils.MineNext(
+                    chainB[i - 1],
+                    hashAlgorithm,
+                    difficulty: 2 + extraDifficulty
+                );
 
                 // The block right next the branchpoint in the chainB has 1 more difficulty than
                 // the block with the same index in the chainA, and then rest blocks have the

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -27,22 +27,23 @@ namespace Libplanet.Tests.Blockchain.Renderers
         static DelayedRendererTest()
         {
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            HashAlgorithmGetter hashAlgorithmGetter = _ => hashAlgorithm;
             var chainA = new Block<DumbAction>[10];
             var chainB = new Block<DumbAction>[chainA.Length];
-            chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>(hashAlgorithm);
+            chainA[0] = chainB[0] = TestUtils.MineGenesis<DumbAction>(hashAlgorithmGetter);
             for (int i = 1; i < chainA.Length / 2; i++)
             {
                 _branchpoint = chainA[i] = chainB[i] =
-                    TestUtils.MineNext(chainA[i - 1], hashAlgorithm);
+                    TestUtils.MineNext(chainA[i - 1], hashAlgorithmGetter);
             }
 
             int extraDifficulty = 1;
             for (int i = chainA.Length / 2; i < chainA.Length; i++)
             {
-                chainA[i] = TestUtils.MineNext(chainA[i - 1], hashAlgorithm, difficulty: 2);
+                chainA[i] = TestUtils.MineNext(chainA[i - 1], hashAlgorithmGetter, difficulty: 2);
                 chainB[i] = TestUtils.MineNext(
                     chainB[i - 1],
-                    hashAlgorithm,
+                    hashAlgorithmGetter,
                     difficulty: 2 + extraDifficulty
                 );
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -27,11 +27,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
         private static DumbBlock _genesis =
-            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithm, default(Address));
 
-        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
-        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
+        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Tests.Common.Action;
@@ -23,11 +24,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private static Exception _exception = new Exception();
 
+        private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
         private static DumbBlock _genesis = TestUtils.MineGenesis<DumbAction>(default(Address));
 
-        private static DumbBlock _blockA = TestUtils.MineNext(_genesis);
+        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
-        private static DumbBlock _blockB = TestUtils.MineNext(_genesis);
+        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _hashAlgorithm);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -26,7 +26,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
 
-        private static DumbBlock _genesis = TestUtils.MineGenesis<DumbAction>(default(Address));
+        private static DumbBlock _genesis =
+            TestUtils.MineGenesis<DumbAction>(_hashAlgorithm, default(Address));
 
         private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithm);
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -18,7 +18,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
     {
         private static HashAlgorithmType _hashAlgorithmType = HashAlgorithmType.Of<SHA256>();
 
-        private static DumbBlock _genesis = TestUtils.MineGenesis<DumbAction>(default(Address));
+        private static DumbBlock _genesis =
+            TestUtils.MineGenesis<DumbAction>(_hashAlgorithmType, default(Address));
 
         private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithmType);
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -19,11 +19,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static HashAlgorithmType _hashAlgorithmType = HashAlgorithmType.Of<SHA256>();
 
         private static DumbBlock _genesis =
-            TestUtils.MineGenesis<DumbAction>(_hashAlgorithmType, default(Address));
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithmType, default(Address));
 
-        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithmType);
+        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _ => _hashAlgorithmType);
 
-        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _hashAlgorithmType);
+        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _ => _hashAlgorithmType);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Tests.Common.Action;
 using Serilog;
@@ -15,11 +16,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
 {
     public class LoggedRendererTest : IDisposable
     {
+        private static HashAlgorithmType _hashAlgorithmType = HashAlgorithmType.Of<SHA256>();
+
         private static DumbBlock _genesis = TestUtils.MineGenesis<DumbAction>(default(Address));
 
-        private static DumbBlock _blockA = TestUtils.MineNext(_genesis);
+        private static DumbBlock _blockA = TestUtils.MineNext(_genesis, _hashAlgorithmType);
 
-        private static DumbBlock _blockB = TestUtils.MineNext(_genesis);
+        private static DumbBlock _blockB = TestUtils.MineNext(_genesis, _hashAlgorithmType);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -17,6 +17,7 @@ namespace Libplanet.Tests.Blocks
         {
             HashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Genesis = TestUtils.MineGenesis<PolymorphicAction<BaseAction>>(
+                hashAlgorithm: HashAlgorithm,
                 protocolVersion: ProtocolVersion
             );
             TxFixture = new TxFixture(Genesis.Hash);

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -15,15 +15,14 @@ namespace Libplanet.Tests.Blocks
 
         public BlockFixture()
         {
-            HashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Genesis = TestUtils.MineGenesis<PolymorphicAction<BaseAction>>(
-                hashAlgorithm: HashAlgorithm,
+                hashAlgorithmGetter: GetHashAlgorithm,
                 protocolVersion: ProtocolVersion
             );
             TxFixture = new TxFixture(Genesis.Hash);
             Next = TestUtils.MineNext(
                 Genesis,
-                HashAlgorithm,
+                hashAlgorithmGetter: GetHashAlgorithm,
                 nonce: new byte[] { 0x02, 0x00, 0x00, 0x00 },
                 protocolVersion: ProtocolVersion
             );
@@ -33,17 +32,15 @@ namespace Libplanet.Tests.Blocks
             };
             HasTx = TestUtils.MineNext(
                 Next,
-                HashAlgorithm,
-                new List<Transaction<PolymorphicAction<BaseAction>>>
+                hashAlgorithmGetter: GetHashAlgorithm,
+                txs: new List<Transaction<PolymorphicAction<BaseAction>>>
                 {
                     TxFixture.TxWithActions,
                 },
-                hasTxNonce,
+                nonce: hasTxNonce,
                 protocolVersion: ProtocolVersion
             );
         }
-
-        internal HashAlgorithmType HashAlgorithm { get; }
 
         internal TxFixture TxFixture { get; }
 
@@ -52,5 +49,7 @@ namespace Libplanet.Tests.Blocks
         internal Block<PolymorphicAction<BaseAction>> Next { get; }
 
         internal Block<PolymorphicAction<BaseAction>> HasTx { get; }
+
+        internal HashAlgorithmType GetHashAlgorithm(long index) => HashAlgorithmType.Of<SHA256>();
     }
 }

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
@@ -14,6 +15,7 @@ namespace Libplanet.Tests.Blocks
 
         public BlockFixture()
         {
+            HashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Genesis = TestUtils.MineGenesis<PolymorphicAction<BaseAction>>(
                 protocolVersion: ProtocolVersion
             );
@@ -37,6 +39,8 @@ namespace Libplanet.Tests.Blocks
                 protocolVersion: ProtocolVersion
             );
         }
+
+        internal HashAlgorithmType HashAlgorithm { get; }
 
         internal TxFixture TxFixture { get; }
 

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -22,6 +22,7 @@ namespace Libplanet.Tests.Blocks
             TxFixture = new TxFixture(Genesis.Hash);
             Next = TestUtils.MineNext(
                 Genesis,
+                HashAlgorithm,
                 nonce: new byte[] { 0x02, 0x00, 0x00, 0x00 },
                 protocolVersion: ProtocolVersion
             );
@@ -31,6 +32,7 @@ namespace Libplanet.Tests.Blocks
             };
             HasTx = TestUtils.MineNext(
                 Next,
+                HashAlgorithm,
                 new List<Transaction<PolymorphicAction<BaseAction>>>
                 {
                     TxFixture.TxWithActions,

--- a/Libplanet.Tests/Blocks/BlockHashTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHashTest.cs
@@ -85,6 +85,22 @@ namespace Libplanet.Tests.Blocks
         }
 
         [Fact]
+        public void DeriveFrom()
+        {
+            byte[] foo = { 0x66, 0x6f, 0x6f }, bar = { 0x62, 0x61, 0x72 };
+            TestUtils.AssertBytesEqual(
+                BlockHash.FromString(
+                    "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"),
+                BlockHash.DeriveFrom(foo)
+            );
+            TestUtils.AssertBytesEqual(
+                BlockHash.FromString(
+                    "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"),
+                BlockHash.DeriveFrom(bar)
+            );
+        }
+
+        [Fact]
         public void FromImmutableArrayConstructor()
         {
             byte[] b =

--- a/Libplanet.Tests/Blocks/BlockHashTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHashTest.cs
@@ -94,53 +94,6 @@ namespace Libplanet.Tests.Blocks
         }
 
         [Fact]
-        public void Satisfies()
-        {
-            Func<string, BlockHash> hash = BlockHash.FromString;
-            var def = default(BlockHash);
-            var emp = new BlockHash(new byte[0]);
-            var dl1 = hash("8ec2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8f00");
-            var dl2 = hash("e94a399c4fd6d508f022bbee8781a9c44754408bb92ca5b509fa824b00000000");
-            var dl4 = hash("a85f4662e531e44d161346dcaa256af7923c87291b5408b109fa820000000000");
-
-            Assert.True(def.Satisfies(0));
-            Assert.True(emp.Satisfies(0));
-            Assert.True(dl1.Satisfies(0));
-            Assert.True(dl2.Satisfies(0));
-            Assert.True(dl4.Satisfies(0));
-
-            Assert.False(def.Satisfies(1));
-            Assert.False(emp.Satisfies(1));
-            Assert.True(dl1.Satisfies(1));
-            Assert.True(dl2.Satisfies(1));
-            Assert.True(dl4.Satisfies(1));
-
-            Assert.False(def.Satisfies(457));
-            Assert.False(emp.Satisfies(457));
-            Assert.True(dl1.Satisfies(457));
-            Assert.True(dl2.Satisfies(457));
-            Assert.True(dl4.Satisfies(457));
-
-            Assert.False(def.Satisfies(458));
-            Assert.False(emp.Satisfies(458));
-            Assert.False(dl1.Satisfies(458));
-            Assert.True(dl2.Satisfies(458));
-            Assert.True(dl4.Satisfies(458));
-
-            Assert.False(def.Satisfies(14560825400));
-            Assert.False(emp.Satisfies(14560825400));
-            Assert.False(dl1.Satisfies(14560825400));
-            Assert.True(dl2.Satisfies(14560825400));
-            Assert.True(dl4.Satisfies(14560825400));
-
-            Assert.False(def.Satisfies(14560825401));
-            Assert.False(emp.Satisfies(14560825401));
-            Assert.False(dl1.Satisfies(14560825401));
-            Assert.False(dl2.Satisfies(14560825401));
-            Assert.True(dl4.Satisfies(14560825401));
-        }
-
-        [Fact]
         public void SerializeAndDeserialize()
         {
             byte[] b =

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
@@ -371,9 +372,7 @@ namespace Libplanet.Tests.Blocks
             ImmutableArray<byte> stateRootHash
         )
         {
-#pragma warning disable CS0612
-            ImmutableArray<byte> hash = Hashcash.Hash(
-#pragma warning restore CS0612
+            ImmutableArray<byte> hash = HashAlgorithmType.Of<SHA256>().Digest(
                 BlockHeader.SerializeForHash(
                     protocolVersion,
                     index,
@@ -385,7 +384,7 @@ namespace Libplanet.Tests.Blocks
                     txHash,
                     stateRootHash
                 )
-            ).ByteArray;
+            ).ToImmutableArray();
             return new BlockHeader(
                 protocolVersion,
                 index,

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -104,8 +104,8 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void ValidateValidHeader()
         {
-            _fx.Genesis.Header.Validate(DateTimeOffset.UtcNow);
-            _fx.Next.Header.Validate(DateTimeOffset.UtcNow);
+            _fx.Genesis.Header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow);
+            _fx.Next.Header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockHashException>(
-                () => { header.Validate(DateTime.UtcNow); });
+                () => { header.Validate(_fx.HashAlgorithm, DateTime.UtcNow); });
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                header.Validate(DateTimeOffset.UtcNow)
+                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
 
             header = new BlockHeader(
@@ -177,7 +177,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                header.Validate(DateTimeOffset.UtcNow)
+                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
         }
 
@@ -187,7 +187,9 @@ namespace Libplanet.Tests.Blocks
             DateTimeOffset now = DateTimeOffset.UtcNow;
             string future = (now + TimeSpan.FromSeconds(16))
                 .ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture);
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             BlockHeader header = MakeBlockHeader(
+                hashAlgorithm: hashAlgorithm,
                 protocolVersion: 0,
                 index: 0,
                 difficulty: 0,
@@ -202,10 +204,10 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockTimestampException>(
-                () => { header.Validate(now); });
+                () => { header.Validate(hashAlgorithm, now); });
 
             // it's okay because 2 seconds later.
-            header.Validate(now + TimeSpan.FromSeconds(2));
+            header.Validate(hashAlgorithm, now + TimeSpan.FromSeconds(2));
         }
 
         [Fact]
@@ -230,7 +232,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockNonceException>(() =>
-                header.Validate(DateTimeOffset.UtcNow));
+                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -255,7 +257,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockIndexException>(() =>
-                header.Validate(DateTimeOffset.UtcNow));
+                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -278,7 +280,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                genesisHeader.Validate(DateTimeOffset.UtcNow));
+                genesisHeader.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
 
             var header1 = new BlockHeader(
                 protocolVersion: 0,
@@ -296,7 +298,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                header1.Validate(DateTimeOffset.UtcNow));
+                header1.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
 
             var header2 = new BlockHeader(
                 protocolVersion: 0,
@@ -314,7 +316,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
-                header2.Validate(DateTimeOffset.UtcNow));
+                header2.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -337,7 +339,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                genesisHeader.Validate(DateTimeOffset.UtcNow));
+                genesisHeader.Validate(HashAlgorithmType.Of<SHA256>(), DateTimeOffset.UtcNow));
 
             var header = new BlockHeader(
                 protocolVersion: 0,
@@ -355,10 +357,11 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                genesisHeader.Validate(DateTimeOffset.UtcNow));
+                genesisHeader.Validate(HashAlgorithmType.Of<SHA256>(), DateTimeOffset.UtcNow));
         }
 
         private BlockHeader MakeBlockHeader(
+            HashAlgorithmType hashAlgorithm,
             int protocolVersion,
             long index,
             long difficulty,
@@ -372,7 +375,7 @@ namespace Libplanet.Tests.Blocks
             ImmutableArray<byte> stateRootHash
         )
         {
-            ImmutableArray<byte> hash = HashAlgorithmType.Of<SHA256>().Digest(
+            ImmutableArray<byte> hash = hashAlgorithm.Digest(
                 BlockHeader.SerializeForHash(
                     protocolVersion,
                     index,

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Tests.Blocks
                     BlockHeader.TimestampFormat,
                     CultureInfo.InvariantCulture
                 ),
-                preEvaluationHash: _fx.Genesis.PreEvaluationHash.ByteArray,
+                preEvaluationHash: _fx.Genesis.PreEvaluationHash,
                 stateRootHash: _fx.Genesis.StateRootHash?.ByteArray ?? ImmutableArray<byte>.Empty
             );
             Bencodex.Types.Dictionary expected = Bencodex.Types.Dictionary.Empty
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Blocks
                 .Add(BlockHeader.NonceKey, _fx.Genesis.Nonce.ToByteArray())
                 .Add(BlockHeader.HashKey, _fx.Genesis.Hash.ToByteArray())
                 .Add(BlockHeader.MinerKey, _fx.Genesis.Miner?.ToByteArray() ?? new byte[0])
-                .Add(BlockHeader.PreEvaluationHashKey, _fx.Genesis.PreEvaluationHash.ToByteArray());
+                .Add(BlockHeader.PreEvaluationHashKey, _fx.Genesis.PreEvaluationHash.ToArray());
             Assert.Equal(expected, header.ToBencodex());
             Assert.Equal(expected, new BlockHeader(expected).ToBencodex());
 
@@ -125,7 +125,7 @@ namespace Libplanet.Tests.Blocks
                     BlockHeader.TimestampFormat,
                     CultureInfo.InvariantCulture
                 ),
-                preEvaluationHash: _fx.Genesis.PreEvaluationHash.ByteArray,
+                preEvaluationHash: _fx.Genesis.PreEvaluationHash,
                 stateRootHash: _fx.Genesis.StateRootHash?.ByteArray ?? ImmutableArray<byte>.Empty
             );
 

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -371,7 +371,9 @@ namespace Libplanet.Tests.Blocks
             ImmutableArray<byte> stateRootHash
         )
         {
+#pragma warning disable CS0612
             ImmutableArray<byte> hash = Hashcash.Hash(
+#pragma warning restore CS0612
                 BlockHeader.SerializeForHash(
                     protocolVersion,
                     index,

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -104,8 +104,8 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void ValidateValidHeader()
         {
-            _fx.Genesis.Header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow);
-            _fx.Next.Header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow);
+            _fx.Genesis.Header.Validate(_fx.GetHashAlgorithm(0), DateTimeOffset.UtcNow);
+            _fx.Next.Header.Validate(_fx.GetHashAlgorithm(1), DateTimeOffset.UtcNow);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockHashException>(
-                () => { header.Validate(_fx.HashAlgorithm, DateTime.UtcNow); });
+                () => { header.Validate(_fx.GetHashAlgorithm(0), DateTime.UtcNow); });
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
+                header.Validate(_fx.GetHashAlgorithm(_fx.Next.Index), DateTimeOffset.UtcNow)
             );
 
             header = new BlockHeader(
@@ -177,7 +177,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
+                header.Validate(_fx.GetHashAlgorithm(_fx.Next.Index), DateTimeOffset.UtcNow)
             );
         }
 
@@ -232,7 +232,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockNonceException>(() =>
-                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
+                header.Validate(_fx.GetHashAlgorithm(_fx.Next.Index), DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockIndexException>(() =>
-                header.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
+                header.Validate(_fx.GetHashAlgorithm(-1), DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -280,7 +280,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                genesisHeader.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
+                genesisHeader.Validate(_fx.GetHashAlgorithm(0), DateTimeOffset.UtcNow));
 
             var header1 = new BlockHeader(
                 protocolVersion: 0,
@@ -298,7 +298,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                header1.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
+                header1.Validate(_fx.GetHashAlgorithm(10), DateTimeOffset.UtcNow));
 
             var header2 = new BlockHeader(
                 protocolVersion: 0,
@@ -316,7 +316,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
-                header2.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
+                header2.Validate(_fx.GetHashAlgorithm(10), DateTimeOffset.UtcNow));
         }
 
         [Fact]

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Blocks
                 _fx.Genesis.Hash
             );
 
-            Block<PolymorphicAction<BaseAction>> next = MineNext(_fx.Genesis);
+            Block<PolymorphicAction<BaseAction>> next = MineNext(_fx.Genesis, _fx.HashAlgorithm);
 
             Assert.Equal(1, _fx.Next.Index);
             Assert.Equal(1, _fx.Next.Difficulty);
@@ -618,6 +618,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Throws<InvalidTxSignatureException>(() =>
                 MineNext(
                     MineGenesis<DumbAction>(),
+                    HashAlgorithmType.Of<SHA256>(),
                     new List<Transaction<DumbAction>>
                     {
                         invalidTx,
@@ -660,6 +661,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Throws<InvalidTxPublicKeyException>(() =>
                 MineNext(
                     MineGenesis<DumbAction>(),
+                    HashAlgorithmType.Of<SHA256>(),
                     new List<Transaction<DumbAction>>
                     {
                         invalidTx,

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -203,6 +204,7 @@ namespace Libplanet.Tests.Blocks
             DateTimeOffset now = DateTimeOffset.UtcNow;
             Block<DumbAction> block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
+                HashAlgorithmType.Of<SHA256>(),
                 _fx.Next.Difficulty,
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,
@@ -215,6 +217,7 @@ namespace Libplanet.Tests.Blocks
 
             block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
+                HashAlgorithmType.Of<SHA256>(),
                 _fx.Next.Difficulty,
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,
@@ -232,6 +235,7 @@ namespace Libplanet.Tests.Blocks
             DateTimeOffset now = DateTimeOffset.UtcNow;
             var block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
+                HashAlgorithmType.Of<SHA256>(),
                 _fx.Next.Difficulty,
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -213,7 +213,9 @@ namespace Libplanet.Tests.Blocks
                 new Transaction<DumbAction>[] { },
                 protocolVersion: -1
             );
-            Assert.Throws<InvalidBlockProtocolVersionException>(() => block.Validate(now));
+            Assert.Throws<InvalidBlockProtocolVersionException>(
+                () => block.Validate(_fx.HashAlgorithm, now)
+            );
 
             block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
@@ -226,11 +228,13 @@ namespace Libplanet.Tests.Blocks
                 new Transaction<DumbAction>[] { },
                 protocolVersion: Block<DumbAction>.CurrentProtocolVersion + 1
             );
-            Assert.Throws<InvalidBlockProtocolVersionException>(() => block.Validate(now));
+            Assert.Throws<InvalidBlockProtocolVersionException>(
+                () => block.Validate(_fx.HashAlgorithm, now)
+            );
         }
 
         [Fact]
-        public void CanDetectInvalidTimestamp()
+        public void DetectInvalidTimestamp()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
             var block = Block<DumbAction>.Mine(
@@ -245,10 +249,10 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockTimestampException>(
-                () => { block.Validate(now); });
+                () => { block.Validate(_fx.HashAlgorithm, now); });
 
             // it's okay because 2 seconds later.
-            block.Validate(now + TimeSpan.FromSeconds(2));
+            block.Validate(_fx.HashAlgorithm, now + TimeSpan.FromSeconds(2));
         }
 
         [Fact]
@@ -269,7 +273,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockNonceException>(() =>
-                invalidBlock.Validate(DateTimeOffset.UtcNow));
+                invalidBlock.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
         }
 
         [Fact]
@@ -286,7 +290,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: MineGenesis<DumbAction>().Transactions
             );
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                invalidDifficultyGenesis.Validate(DateTimeOffset.UtcNow)
+                invalidDifficultyGenesis.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
 
             var invalidTotalDifficultyGenesis = new Block<DumbAction>(
@@ -300,7 +304,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: MineGenesis<DumbAction>().Transactions
             );
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
-                invalidTotalDifficultyGenesis.Validate(DateTimeOffset.UtcNow)
+                invalidTotalDifficultyGenesis.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
 
             var invalidDifficultyNext = new Block<PolymorphicAction<BaseAction>>(
@@ -314,7 +318,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: _fx.Next.Transactions
             );
             Assert.Throws<InvalidBlockDifficultyException>(() =>
-                invalidDifficultyNext.Validate(DateTimeOffset.UtcNow)
+                invalidDifficultyNext.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
 
             var invalidTotalDifficultyNext = new Block<PolymorphicAction<BaseAction>>(
@@ -328,7 +332,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: _fx.Next.Transactions
             );
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
-                invalidTotalDifficultyNext.Validate(DateTimeOffset.UtcNow)
+                invalidTotalDifficultyNext.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
         }
 
@@ -347,7 +351,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                invalidGenesis.Validate(DateTimeOffset.UtcNow)
+                invalidGenesis.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
 
             var invalidNext = new Block<PolymorphicAction<BaseAction>>(
@@ -362,7 +366,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                invalidNext.Validate(DateTimeOffset.UtcNow)
+                invalidNext.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
             );
         }
 
@@ -536,6 +540,7 @@ namespace Libplanet.Tests.Blocks
                 Transaction<DumbAction>.Create(0, new PrivateKey(), null, new DumbAction[0]),
                 Transaction<DumbAction>.Create(0, new PrivateKey(), null, new DumbAction[0]),
             };
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var block = new Block<DumbAction>(
                 index: 0,
                 difficulty: 0,
@@ -547,7 +552,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: txs
             );
 
-            block.Validate(DateTimeOffset.UtcNow);
+            block.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
 
             Dictionary blockDict = block.ToBencodex();
             var txList = (List)blockDict[RawBlock.TransactionsKey];
@@ -560,7 +565,7 @@ namespace Libplanet.Tests.Blocks
             );
 
             var exc = Assert.Throws<InvalidBlockTxHashException>(
-                () => abnormalTxs.Validate(DateTimeOffset.UtcNow)
+                () => abnormalTxs.Validate(hashAlgorithm, DateTimeOffset.UtcNow)
             );
             Assert.Equal(abnormalTxs.TxHash, exc.BlockTxHash);
 
@@ -571,7 +576,7 @@ namespace Libplanet.Tests.Blocks
                 )
             );
             Assert.Throws<InvalidBlockTxHashException>(
-                 () => emptyTxs.Validate(DateTimeOffset.UtcNow)
+                 () => emptyTxs.Validate(hashAlgorithm, DateTimeOffset.UtcNow)
             );
         }
 
@@ -590,7 +595,7 @@ namespace Libplanet.Tests.Blocks
                 transactions: _fx.Next.Transactions);
 
             Assert.Throws<InvalidBlockPreEvaluationHashException>(() =>
-                invalidBlock.Validate(DateTimeOffset.UtcNow));
+                invalidBlock.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow));
         }
 
         [Fact]

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -55,7 +55,8 @@ namespace Libplanet.Tests.Blocks
                 miner: null,
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
-                transactions: txs
+                transactions: txs,
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>()
             );
 
             // For transactions signed by the same signer, these should be ordered by its tx nonce.
@@ -204,7 +205,7 @@ namespace Libplanet.Tests.Blocks
             DateTimeOffset now = DateTimeOffset.UtcNow;
             Block<DumbAction> block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.HashAlgorithm,
                 _fx.Next.Difficulty,
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,
@@ -219,7 +220,7 @@ namespace Libplanet.Tests.Blocks
 
             block = Block<DumbAction>.Mine(
                 _fx.Next.Index,
-                HashAlgorithmType.Of<SHA256>(),
+                _fx.HashAlgorithm,
                 _fx.Next.Difficulty,
                 _fx.Genesis.TotalDifficulty,
                 _fx.Next.Miner.Value,
@@ -287,7 +288,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Genesis.Miner,
                 previousHash: _fx.Genesis.PreviousHash,
                 timestamp: _fx.Genesis.Timestamp,
-                transactions: MineGenesis<DumbAction>().Transactions
+                transactions: MineGenesis<DumbAction>(_fx.HashAlgorithm).Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
             Assert.Throws<InvalidBlockDifficultyException>(() =>
                 invalidDifficultyGenesis.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
@@ -301,7 +303,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Genesis.Miner,
                 previousHash: _fx.Genesis.PreviousHash,
                 timestamp: _fx.Genesis.Timestamp,
-                transactions: MineGenesis<DumbAction>().Transactions
+                transactions: MineGenesis<DumbAction>(_fx.HashAlgorithm).Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
                 invalidTotalDifficultyGenesis.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
@@ -315,7 +318,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Next.Miner,
                 previousHash: _fx.Next.PreviousHash,
                 timestamp: _fx.Next.Timestamp,
-                transactions: _fx.Next.Transactions
+                transactions: _fx.Next.Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
             Assert.Throws<InvalidBlockDifficultyException>(() =>
                 invalidDifficultyNext.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
@@ -329,7 +333,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Next.Miner,
                 previousHash: _fx.Next.PreviousHash,
                 timestamp: _fx.Next.Timestamp,
-                transactions: _fx.Next.Transactions
+                transactions: _fx.Next.Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
                 invalidTotalDifficultyNext.Validate(_fx.HashAlgorithm, DateTimeOffset.UtcNow)
@@ -347,7 +352,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Genesis.Miner,
                 previousHash: new BlockHash(GetRandomBytes(32)), // invalid
                 timestamp: _fx.Genesis.Timestamp,
-                transactions: MineGenesis<DumbAction>().Transactions
+                transactions: MineGenesis<DumbAction>(_fx.HashAlgorithm).Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
@@ -362,7 +368,8 @@ namespace Libplanet.Tests.Blocks
                 miner: _fx.Next.Miner,
                 previousHash: null,
                 timestamp: _fx.Next.Timestamp,
-                transactions: _fx.Next.Transactions
+                transactions: _fx.Next.Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
@@ -463,7 +470,8 @@ namespace Libplanet.Tests.Blocks
                 miner: sameBlock1.Miner,
                 previousHash: null,
                 timestamp: sameBlock1.Timestamp,
-                transactions: sameBlock1.Transactions
+                transactions: sameBlock1.Transactions,
+                hashAlgorithm: _fx.HashAlgorithm
             );
             Block<PolymorphicAction<BaseAction>> differentBlock = _fx.Next;
 
@@ -509,8 +517,9 @@ namespace Libplanet.Tests.Blocks
                     new PrivateKey(),
                     null,
                     new[] { new RandomAction(signer.ToAddress()) })).ToImmutableArray();
-            var blockA = MineGenesis(timestamp: timestamp, transactions: txs);
-            var blockB = MineGenesis(timestamp: timestamp,  transactions: txs);
+            HashAlgorithmType algo = HashAlgorithmType.Of<SHA256>();
+            var blockA = MineGenesis(algo, timestamp: timestamp, transactions: txs);
+            var blockB = MineGenesis(algo, timestamp: timestamp,  transactions: txs);
 
             Assert.True(blockA.Transactions.SequenceEqual(blockB.Transactions));
         }
@@ -526,7 +535,8 @@ namespace Libplanet.Tests.Blocks
                 miner: null,
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
-                transactions: new Transaction<DumbAction>[0]
+                transactions: new Transaction<DumbAction>[0],
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>()
             );
             Assert.Equal(146, block.BytesLength);
         }
@@ -549,7 +559,8 @@ namespace Libplanet.Tests.Blocks
                 miner: null,
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
-                transactions: txs
+                transactions: txs,
+                hashAlgorithm: HashAlgorithmType.Of<SHA256>()
             );
 
             block.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
@@ -617,7 +628,7 @@ namespace Libplanet.Tests.Blocks
             var invalidTx = new Transaction<DumbAction>(rawTx);
             Assert.Throws<InvalidTxSignatureException>(() =>
                 MineNext(
-                    MineGenesis<DumbAction>(),
+                    MineGenesis<DumbAction>(_fx.HashAlgorithm),
                     HashAlgorithmType.Of<SHA256>(),
                     new List<Transaction<DumbAction>>
                     {
@@ -660,7 +671,7 @@ namespace Libplanet.Tests.Blocks
             );
             Assert.Throws<InvalidTxPublicKeyException>(() =>
                 MineNext(
-                    MineGenesis<DumbAction>(),
+                    MineGenesis<DumbAction>(_fx.HashAlgorithm),
                     HashAlgorithmType.Of<SHA256>(),
                     new List<Transaction<DumbAction>>
                     {

--- a/Libplanet.Tests/Blocks/HashAlgorithmTableTest.cs
+++ b/Libplanet.Tests/Blocks/HashAlgorithmTableTest.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+using Xunit;
+
+namespace Libplanet.Tests.Blocks
+{
+    public class HashAlgorithmTableTest
+    {
+        [Fact]
+        public void ToHashAlgorithmGetter()
+        {
+            Dictionary<long, HashAlgorithmType> table = new Dictionary<long, HashAlgorithmType>
+            {
+                [0] = HashAlgorithmType.Of<SHA1>(),
+                [10] = HashAlgorithmType.Of<SHA256>(),
+                [100] = HashAlgorithmType.Of<SHA512>(),
+            };
+            HashAlgorithmGetter hashAlgorithmGetter = table.ToHashAlgorithmGetter();
+
+            Assert.Equal(HashAlgorithmType.Of<SHA1>(), hashAlgorithmGetter(0));
+            Assert.Equal(HashAlgorithmType.Of<SHA1>(), hashAlgorithmGetter(1));
+            Assert.Equal(HashAlgorithmType.Of<SHA1>(), hashAlgorithmGetter(9));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), hashAlgorithmGetter(10));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), hashAlgorithmGetter(11));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), hashAlgorithmGetter(50));
+            Assert.Equal(HashAlgorithmType.Of<SHA256>(), hashAlgorithmGetter(99));
+            Assert.Equal(HashAlgorithmType.Of<SHA512>(), hashAlgorithmGetter(100));
+            Assert.Equal(HashAlgorithmType.Of<SHA512>(), hashAlgorithmGetter(101));
+            Assert.Equal(HashAlgorithmType.Of<SHA512>(), hashAlgorithmGetter(200));
+            Assert.Equal(HashAlgorithmType.Of<SHA512>(), hashAlgorithmGetter(500));
+            Assert.Equal(HashAlgorithmType.Of<SHA512>(), hashAlgorithmGetter(long.MaxValue));
+
+            Assert.Throws<ArgumentException>(
+                () => new KeyValuePair<long, HashAlgorithmType>[0].ToHashAlgorithmGetter()
+            );
+            Assert.Throws<ArgumentException>(() =>
+                table.Append(
+                    new KeyValuePair<long, HashAlgorithmType>(10, HashAlgorithmType.Of<MD5>())
+                ).ToHashAlgorithmGetter()
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Blocks/InvalidBlockPreEvaluationHashExceptionTest.cs
+++ b/Libplanet.Tests/Blocks/InvalidBlockPreEvaluationHashExceptionTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Blocks;
@@ -10,8 +11,8 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void Serialize()
         {
-            var actual = new BlockHash(TestUtils.GetRandomBytes(32));
-            var expected = new BlockHash(TestUtils.GetRandomBytes(32));
+            var actual = TestUtils.GetRandomBytes(32).ToImmutableArray();
+            var expected = TestUtils.GetRandomBytes(32).ToImmutableArray();
             var exc = new InvalidBlockPreEvaluationHashException(
                 actual,
                 expected,

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -77,5 +77,45 @@ namespace Libplanet.Tests
                 ByteUtil.TimingSafelyCompare(new byte[] { 1, 2, 3, 4 }, new byte[] { 1, 2, 3 })
             );
         }
+
+        [Fact]
+        public void Satisfies()
+        {
+            Func<string, byte[]> hash = ByteUtil.ParseHex;
+            var emp = new byte[0];
+            var dl1 = hash("8ec2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8fc2f5285c8f00");
+            var dl2 = hash("e94a399c4fd6d508f022bbee8781a9c44754408bb92ca5b509fa824b00000000");
+            var dl4 = hash("a85f4662e531e44d161346dcaa256af7923c87291b5408b109fa820000000000");
+
+            Assert.True(ByteUtil.Satisfies(emp, 0));
+            Assert.True(ByteUtil.Satisfies(dl1, 0));
+            Assert.True(ByteUtil.Satisfies(dl2, 0));
+            Assert.True(ByteUtil.Satisfies(dl4, 0));
+
+            Assert.False(ByteUtil.Satisfies(emp, 1));
+            Assert.True(ByteUtil.Satisfies(dl1, 1));
+            Assert.True(ByteUtil.Satisfies(dl2, 1));
+            Assert.True(ByteUtil.Satisfies(dl4, 1));
+
+            Assert.False(ByteUtil.Satisfies(emp, 457));
+            Assert.True(ByteUtil.Satisfies(dl1, 457));
+            Assert.True(ByteUtil.Satisfies(dl2, 457));
+            Assert.True(ByteUtil.Satisfies(dl4, 457));
+
+            Assert.False(ByteUtil.Satisfies(emp, 458));
+            Assert.False(ByteUtil.Satisfies(dl1, 458));
+            Assert.True(ByteUtil.Satisfies(dl2, 458));
+            Assert.True(ByteUtil.Satisfies(dl4, 458));
+
+            Assert.False(ByteUtil.Satisfies(emp, 14560825400));
+            Assert.False(ByteUtil.Satisfies(dl1, 14560825400));
+            Assert.True(ByteUtil.Satisfies(dl2, 14560825400));
+            Assert.True(ByteUtil.Satisfies(dl4, 14560825400));
+
+            Assert.False(ByteUtil.Satisfies(emp, 14560825401));
+            Assert.False(ByteUtil.Satisfies(dl1, 14560825401));
+            Assert.False(ByteUtil.Satisfies(dl2, 14560825401));
+            Assert.True(ByteUtil.Satisfies(dl4, 14560825401));
+        }
     }
 }

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -60,5 +60,22 @@ namespace Libplanet.Tests
                 ByteUtil.CalculateHashCode(otherBytes)
             );
         }
+
+        [Fact]
+        public void TimingSafelyCompare()
+        {
+            Assert.True(ByteUtil.TimingSafelyCompare(new byte[0], new byte[0]));
+            Assert.False(ByteUtil.TimingSafelyCompare(new byte[] { 0 }, new byte[] { 1 }));
+            Assert.True(ByteUtil.TimingSafelyCompare(new byte[] { 1 }, new byte[] { 1 }));
+            Assert.True(
+                ByteUtil.TimingSafelyCompare(new byte[] { 1, 2, 3, 4 }, new byte[] { 1, 2, 3, 4 })
+            );
+            Assert.False(
+                ByteUtil.TimingSafelyCompare(new byte[] { 1, 2, 3, 4 }, new byte[] { 1, 2, 3, 5 })
+            );
+            Assert.False(
+                ByteUtil.TimingSafelyCompare(new byte[] { 1, 2, 3, 4 }, new byte[] { 1, 2, 3 })
+            );
+        }
     }
 }

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Tests.Fixtures
             StateStore = new TrieStateStore(KVStore, KVStore);
             HashAlgorithmType algo = HashAlgorithmType.Of<SHA256>();
             Genesis = Block<Arithmetic>.Mine(0, algo, 0, 0, Miner, null, DateTimeOffset.UtcNow, Txs)
-                .AttachStateRootHash(StateStore, policy.BlockAction);
+                .AttachStateRootHash(algo, StateStore, policy.BlockAction);
             Chain = new BlockChain<Arithmetic>(
                 policy,
                 new VolatileStagePolicy<Arithmetic>(),
@@ -142,12 +142,13 @@ namespace Libplanet.Tests.Fixtures
 
         public async Task<Block<Arithmetic>> Mine(CancellationToken cancellationToken = default)
         {
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<Arithmetic> draft = await Chain.MineBlock(
                 Miner,
                 DateTimeOffset.UtcNow,
                 cancellationToken: cancellationToken
             );
-            return draft.AttachStateRootHash(StateStore, Policy.BlockAction);
+            return draft.AttachStateRootHash(hashAlgorithm, StateStore, Policy.BlockAction);
         }
 
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -66,7 +66,8 @@ namespace Libplanet.Tests.Fixtures
             Store = new DefaultStore(null);
             KVStore = new MemoryKeyValueStore();
             StateStore = new TrieStateStore(KVStore, KVStore);
-            Genesis = Block<Arithmetic>.Mine(0, 0, 0, Miner, null, DateTimeOffset.UtcNow, Txs)
+            HashAlgorithmType algo = HashAlgorithmType.Of<SHA256>();
+            Genesis = Block<Arithmetic>.Mine(0, algo, 0, 0, Miner, null, DateTimeOffset.UtcNow, Txs)
                 .AttachStateRootHash(StateStore, policy.BlockAction);
             Chain = new BlockChain<Arithmetic>(
                 policy,

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -75,7 +75,7 @@ namespace Libplanet.Tests.Fixtures
                 previousHash: null,
                 timestamp: DateTimeOffset.UtcNow,
                 transactions: Txs
-            ).AttachStateRootHash(policy.GetHashAlgorithm, StateStore, policy.BlockAction);
+            ).AttachStateRootHash(StateStore, policy);
             Chain = new BlockChain<Arithmetic>(
                 policy,
                 new VolatileStagePolicy<Arithmetic>(),
@@ -154,11 +154,7 @@ namespace Libplanet.Tests.Fixtures
                 DateTimeOffset.UtcNow,
                 cancellationToken: cancellationToken
             );
-            return draft.AttachStateRootHash(
-                Chain.Policy.GetHashAlgorithm,
-                StateStore,
-                Policy.BlockAction
-            );
+            return draft.AttachStateRootHash(StateStore, Policy);
         }
 
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)

--- a/Libplanet.Tests/HashAlgorithmTypeTest.cs
+++ b/Libplanet.Tests/HashAlgorithmTypeTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+
+namespace Libplanet.Tests
+{
+    public class HashAlgorithmTypeTest
+    {
+        [Fact]
+        public void Of()
+        {
+            HashAlgorithmType md5 = HashAlgorithmType.Of<MD5>();
+            Assert.Same(typeof(MD5), md5.Type);
+            Assert.Equal(16, md5.DigestSize);
+
+            HashAlgorithmType sha1 = HashAlgorithmType.Of<SHA1>();
+            Assert.Same(typeof(SHA1), sha1.Type);
+            Assert.Equal(20, sha1.DigestSize);
+
+            HashAlgorithmType sha256 = HashAlgorithmType.Of(SHA256.Create());
+            Assert.Same(typeof(SHA256), sha256.Type);
+            Assert.Equal(32, sha256.DigestSize);
+        }
+
+        [Fact]
+        public void Digest()
+        {
+            HashAlgorithmType md5 = HashAlgorithmType.Of<MD5>();
+            byte[] digest = md5.Digest(Encoding.ASCII.GetBytes("hello"));
+            byte[] expected =
+            {
+                0x5d, 0x41, 0x40, 0x2a, 0xbc, 0x4b, 0x2a, 0x76,
+                0xb9, 0x71, 0x9d, 0x91, 0x10, 0x17, 0xc5, 0x92,
+            };
+            AssertBytesEqual(expected, digest);
+
+            ImmutableArray<byte> immutableDigest =
+                md5.Digest(Encoding.ASCII.GetBytes("hello").ToImmutableArray());
+            AssertBytesEqual(expected.ToImmutableArray(), immutableDigest);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            HashAlgorithmType md5 = HashAlgorithmType.Of<MD5>();
+            HashAlgorithmType md5a = HashAlgorithmType.Of(MD5.Create());
+            HashAlgorithmType sha1 = HashAlgorithmType.Of<SHA1>();
+
+            Assert.Equal(md5, md5a);
+            Assert.True(((IEquatable<HashAlgorithmType>)md5).Equals(md5a));
+            Assert.True(md5.Equals((object)md5a));
+            Assert.Equal(md5.GetHashCode(), md5a.GetHashCode());
+            Assert.True(md5 == md5a);
+            Assert.False(md5 != md5a);
+
+            Assert.NotEqual(md5, sha1);
+            Assert.True(!((IEquatable<HashAlgorithmType>)md5).Equals(sha1));
+            Assert.True(!md5.Equals((object)sha1));
+            Assert.NotEqual(md5.GetHashCode(), sha1.GetHashCode());
+            Assert.False(md5 == sha1);
+            Assert.True(md5 != sha1);
+        }
+
+        [Fact]
+        public void String()
+        {
+            HashAlgorithmType md5 = HashAlgorithmType.Of<MD5>();
+            HashAlgorithmType sha1 = HashAlgorithmType.Of<SHA1>();
+            Assert.Equal("System.Security.Cryptography.MD5", md5.ToString());
+            Assert.Equal("System.Security.Cryptography.SHA1", sha1.ToString());
+        }
+    }
+}

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -25,9 +25,9 @@ namespace Libplanet.Tests
             );
 #pragma warning disable CS0612
             Nonce answer2 = Hashcash.Answer(Stamp, difficulty);
-            BlockHash digest2 = Hashcash.Hash(Stamp(answer2));
 #pragma warning restore CS0612
-            Assert.True(digest2.Satisfies(difficulty));
+            byte[] digest2 = SHA256.Create().ComputeHash(Stamp(answer2));
+            Assert.True(Satisfies(digest2, difficulty));
         }
 
         [Fact]

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -23,11 +23,6 @@ namespace Libplanet.Tests
                 digest.ToArray(),
                 SHA256.Create().ComputeHash(Stamp(answer))
             );
-#pragma warning disable CS0612
-            Nonce answer2 = Hashcash.Answer(Stamp, difficulty);
-#pragma warning restore CS0612
-            byte[] digest2 = SHA256.Create().ComputeHash(Stamp(answer2));
-            Assert.True(Satisfies(digest2, difficulty));
         }
 
         [Fact]

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
-using Libplanet.Blocks;
 using Xunit;
 
 namespace Libplanet.Tests
@@ -60,7 +59,7 @@ namespace Libplanet.Tests
                 digest = bytes;
             }
 
-            return new BlockHash(digest).Satisfies(difficulty);
+            return ByteUtil.Satisfies(digest, difficulty);
         }
     }
 

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -290,7 +290,7 @@ namespace Libplanet.Tests.Net
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(),
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(hashAlgorithm),
                 demand = TestUtils.MineNext(genesis, hashAlgorithm),
                 wrong = TestUtils.MineNext(genesis, hashAlgorithm);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
@@ -398,7 +398,7 @@ namespace Libplanet.Tests.Net
             if (count >= 1)
             {
                 HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-                Block<T> block = TestUtils.MineGenesis<T>();
+                Block<T> block = TestUtils.MineGenesis<T>(hashAlgorithm);
                 yield return block;
 
                 for (int i = 1; i < count; i++)

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -289,10 +289,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(hashAlgorithm),
-                demand = TestUtils.MineNext(genesis, hashAlgorithm),
-                wrong = TestUtils.MineNext(genesis, hashAlgorithm);
+            HashAlgorithmGetter hashAlgoGetter = _ => HashAlgorithmType.Of<SHA256>();
+            Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(hashAlgoGetter),
+                demand = TestUtils.MineNext(genesis, hashAlgoGetter),
+                wrong = TestUtils.MineNext(genesis, hashAlgoGetter);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
             _logger.Debug("Demand:  #{Index} {Hash}", demand.Index, demand.Hash);
             _logger.Debug("Wrong:   #{Index} {Hash}", wrong.Index, wrong.Hash);
@@ -392,18 +392,21 @@ namespace Libplanet.Tests.Net
             );
         }
 
-        private IEnumerable<Block<T>> GenerateBlocks<T>(int count)
+        private IEnumerable<Block<T>> GenerateBlocks<T>(
+            int count,
+            HashAlgorithmGetter hashAlgorithmGetter = null
+        )
             where T : IAction, new()
         {
+            hashAlgorithmGetter = hashAlgorithmGetter ?? (_ => HashAlgorithmType.Of<SHA256>());
             if (count >= 1)
             {
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
-                Block<T> block = TestUtils.MineGenesis<T>(hashAlgorithm);
+                Block<T> block = TestUtils.MineGenesis<T>(hashAlgorithmGetter);
                 yield return block;
 
                 for (int i = 1; i < count; i++)
                 {
-                    block = TestUtils.MineNext(block, hashAlgorithm);
+                    block = TestUtils.MineNext(block, hashAlgorithmGetter);
                     yield return block;
                 }
             }

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dasync.Collections;
@@ -288,9 +289,10 @@ namespace Libplanet.Tests.Net
         [Fact(Timeout = Timeout)]
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<DumbAction> genesis = TestUtils.MineGenesis<DumbAction>(),
-                demand = TestUtils.MineNext(genesis),
-                wrong = TestUtils.MineNext(genesis);
+                demand = TestUtils.MineNext(genesis, hashAlgorithm),
+                wrong = TestUtils.MineNext(genesis, hashAlgorithm);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
             _logger.Debug("Demand:  #{Index} {Hash}", demand.Index, demand.Hash);
             _logger.Debug("Wrong:   #{Index} {Hash}", wrong.Index, wrong.Hash);
@@ -395,12 +397,13 @@ namespace Libplanet.Tests.Net
         {
             if (count >= 1)
             {
+                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<T> block = TestUtils.MineGenesis<T>();
                 yield return block;
 
                 for (int i = 1; i < count; i++)
                 {
-                    block = TestUtils.MineNext(block);
+                    block = TestUtils.MineNext(block, hashAlgorithm);
                     yield return block;
                 }
             }

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -141,7 +141,7 @@ namespace Libplanet.Tests.Net.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var dateTimeOffset = DateTimeOffset.UtcNow;
-            var genesis = TestUtils.MineGenesis<DumbAction>(HashAlgorithmType.Of<SHA256>());
+            var genesis = TestUtils.MineGenesis<DumbAction>(_ => HashAlgorithmType.Of<SHA256>());
             var message = new BlockHeaderMessage(genesis.Hash, genesis.Header);
             NetMQMessage raw =
                 message.ToNetMQMessage(privateKey, peer, dateTimeOffset, appProtocolVersion);

--- a/Libplanet.Tests/Net/Messages/MessageTest.cs
+++ b/Libplanet.Tests/Net/Messages/MessageTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Net.Messages;
@@ -140,7 +141,7 @@ namespace Libplanet.Tests.Net.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var dateTimeOffset = DateTimeOffset.UtcNow;
-            var genesis = TestUtils.MineGenesis<DumbAction>();
+            var genesis = TestUtils.MineGenesis<DumbAction>(HashAlgorithmType.Of<SHA256>());
             var message = new BlockHeaderMessage(genesis.Hash, genesis.Header);
             NetMQMessage raw =
                 message.ToNetMQMessage(privateKey, peer, dateTimeOffset, appProtocolVersion);

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
@@ -631,19 +632,23 @@ namespace Libplanet.Tests.Net
 
                 await BootstrapAsync(receiverSwarm, minerSwarm.AsPeer);
 
+                HashAlgorithmType hashAlgo1 = HashAlgorithmType.Of<SHA256>();
                 var block1 = TestUtils.MineNext(
                         blockChain.Genesis,
+                        hashAlgo1,
                         new[] { transactions[0] },
                         null,
                         policy.GetNextBlockDifficulty(blockChain))
-                    .AttachStateRootHash(blockChain.StateStore, policy.BlockAction);
+                    .AttachStateRootHash(hashAlgo1, blockChain.StateStore, policy.BlockAction);
                 blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
+                HashAlgorithmType hashAlgo2 = HashAlgorithmType.Of<SHA256>();
                 var block2 = TestUtils.MineNext(
                         block1,
+                        hashAlgo2,
                         new[] { transactions[1] },
                         null,
                         policy.GetNextBlockDifficulty(blockChain))
-                    .AttachStateRootHash(blockChain.StateStore, policy.BlockAction);
+                    .AttachStateRootHash(hashAlgo2, blockChain.StateStore, policy.BlockAction);
                 blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -634,23 +634,29 @@ namespace Libplanet.Tests.Net
 
                 await BootstrapAsync(receiverSwarm, minerSwarm.AsPeer);
 
-                HashAlgorithmType hashAlgo1 = HashAlgorithmType.Of<SHA256>();
                 var block1 = TestUtils.MineNext(
                         blockChain.Genesis,
-                        hashAlgo1,
+                        policy.GetHashAlgorithm,
                         new[] { transactions[0] },
                         null,
                         policy.GetNextBlockDifficulty(blockChain))
-                    .AttachStateRootHash(hashAlgo1, blockChain.StateStore, policy.BlockAction);
+                    .AttachStateRootHash(
+                        policy.GetHashAlgorithm,
+                        blockChain.StateStore,
+                        policy.BlockAction
+                    );
                 blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
-                HashAlgorithmType hashAlgo2 = HashAlgorithmType.Of<SHA256>();
                 var block2 = TestUtils.MineNext(
-                        block1,
-                        hashAlgo2,
-                        new[] { transactions[1] },
-                        null,
-                        policy.GetNextBlockDifficulty(blockChain))
-                    .AttachStateRootHash(hashAlgo2, blockChain.StateStore, policy.BlockAction);
+                    block1,
+                    policy.GetHashAlgorithm,
+                    new[] { transactions[1] },
+                    null,
+                    policy.GetNextBlockDifficulty(blockChain)
+                ).AttachStateRootHash(
+                    policy.GetHashAlgorithm,
+                    blockChain.StateStore,
+                    policy.BlockAction
+                );
                 blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -640,11 +640,7 @@ namespace Libplanet.Tests.Net
                         new[] { transactions[0] },
                         null,
                         policy.GetNextBlockDifficulty(blockChain))
-                    .AttachStateRootHash(
-                        policy.GetHashAlgorithm,
-                        blockChain.StateStore,
-                        policy.BlockAction
-                    );
+                    .AttachStateRootHash(blockChain.StateStore, policy);
                 blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
                 var block2 = TestUtils.MineNext(
                     block1,
@@ -652,11 +648,7 @@ namespace Libplanet.Tests.Net
                     new[] { transactions[1] },
                     null,
                     policy.GetNextBlockDifficulty(blockChain)
-                ).AttachStateRootHash(
-                    policy.GetHashAlgorithm,
-                    blockChain.StateStore,
-                    policy.BlockAction
-                );
+                ).AttachStateRootHash(blockChain.StateStore, policy);
                 blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -99,7 +99,9 @@ namespace Libplanet.Tests.Net
                 receiverSwarm.Address,
                 null,
                 DateTimeOffset.MinValue,
-                ImmutableArray<Transaction<DumbAction>>.Empty);
+                ImmutableArray<Transaction<DumbAction>>.Empty,
+                HashAlgorithmType.Of<SHA256>()
+            );
             BlockChain<DumbAction> seedChain = TestUtils.MakeBlockChain(
                 receiverChain.Policy,
                 new DefaultStore(path: null),

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -69,10 +69,14 @@ namespace Libplanet.Tests.Net
                     hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                     bestBlock = TestUtils.MineNext(
                         chain2.Tip,
-                        hashAlgorithm,
+                        policy.GetHashAlgorithm,
                         difficulty: nextDifficulty,
                         blockInterval: TimeSpan.FromMilliseconds(1)
-                    ).AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
+                    ).AttachStateRootHash(
+                        policy.GetHashAlgorithm,
+                        chain2.StateStore,
+                        policy.BlockAction
+                    );
                     _output.WriteLine("chain1's total difficulty: {0}", chain1.Tip.TotalDifficulty);
                     _output.WriteLine("chain2's total difficulty: {0}", bestBlock.TotalDifficulty);
                     break;
@@ -85,10 +89,14 @@ namespace Libplanet.Tests.Net
                         hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                         bestBlock = TestUtils.MineNext(
                             chain2.Tip,
-                            hashAlgorithm,
+                            policy.GetHashAlgorithm,
                             difficulty: policy.GetNextBlockDifficulty(chain2),
                             blockInterval: TimeSpan.FromMilliseconds(1)
-                        ).AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
+                        ).AttachStateRootHash(
+                            policy.GetHashAlgorithm,
+                            chain2.StateStore,
+                            policy.BlockAction
+                        );
                         hashStr = bestBlock.Hash.ToString();
                         _output.WriteLine("chain1's tip hash: {0}", chain1.Tip.Hash);
                         _output.WriteLine("chain2's tip hash: {0}", bestBlock.Hash);

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -59,24 +58,18 @@ namespace Libplanet.Tests.Net
             await chain1.MineBlock(miner1.Address);
             await chain1.MineBlock(miner2.Address);
 
-            HashAlgorithmType hashAlgorithm;
             Block<DumbAction> bestBlock;
             switch (canonComparerType)
             {
                 default:
                     long nextDifficulty =
                         (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
-                    hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                     bestBlock = TestUtils.MineNext(
                         chain2.Tip,
                         policy.GetHashAlgorithm,
                         difficulty: nextDifficulty,
                         blockInterval: TimeSpan.FromMilliseconds(1)
-                    ).AttachStateRootHash(
-                        policy.GetHashAlgorithm,
-                        chain2.StateStore,
-                        policy.BlockAction
-                    );
+                    ).AttachStateRootHash(chain2.StateStore, policy);
                     _output.WriteLine("chain1's total difficulty: {0}", chain1.Tip.TotalDifficulty);
                     _output.WriteLine("chain2's total difficulty: {0}", bestBlock.TotalDifficulty);
                     break;
@@ -86,17 +79,12 @@ namespace Libplanet.Tests.Net
                     string hashStr;
                     do
                     {
-                        hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                         bestBlock = TestUtils.MineNext(
                             chain2.Tip,
                             policy.GetHashAlgorithm,
                             difficulty: policy.GetNextBlockDifficulty(chain2),
                             blockInterval: TimeSpan.FromMilliseconds(1)
-                        ).AttachStateRootHash(
-                            policy.GetHashAlgorithm,
-                            chain2.StateStore,
-                            policy.BlockAction
-                        );
+                        ).AttachStateRootHash(chain2.StateStore, policy);
                         hashStr = bestBlock.Hash.ToString();
                         _output.WriteLine("chain1's tip hash: {0}", chain1.Tip.Hash);
                         _output.WriteLine("chain2's tip hash: {0}", bestBlock.Hash);

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -58,17 +59,20 @@ namespace Libplanet.Tests.Net
             await chain1.MineBlock(miner1.Address);
             await chain1.MineBlock(miner2.Address);
 
+            HashAlgorithmType hashAlgorithm;
             Block<DumbAction> bestBlock;
             switch (canonComparerType)
             {
                 default:
                     long nextDifficulty =
                         (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
+                    hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                     bestBlock = TestUtils.MineNext(
                         chain2.Tip,
+                        hashAlgorithm,
                         difficulty: nextDifficulty,
                         blockInterval: TimeSpan.FromMilliseconds(1)
-                    ).AttachStateRootHash(chain2.StateStore, policy.BlockAction);
+                    ).AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
                     _output.WriteLine("chain1's total difficulty: {0}", chain1.Tip.TotalDifficulty);
                     _output.WriteLine("chain2's total difficulty: {0}", bestBlock.TotalDifficulty);
                     break;
@@ -78,11 +82,13 @@ namespace Libplanet.Tests.Net
                     string hashStr;
                     do
                     {
+                        hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                         bestBlock = TestUtils.MineNext(
                             chain2.Tip,
+                            hashAlgorithm,
                             difficulty: policy.GetNextBlockDifficulty(chain2),
                             blockInterval: TimeSpan.FromMilliseconds(1)
-                        ).AttachStateRootHash(chain2.StateStore, policy.BlockAction);
+                        ).AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
                         hashStr = bestBlock.Hash.ToString();
                         _output.WriteLine("chain1's tip hash: {0}", chain1.Tip.Hash);
                         _output.WriteLine("chain2's tip hash: {0}", bestBlock.Hash);

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -112,13 +112,12 @@ namespace Libplanet.Tests.Net
             var blocks = new List<Block<DumbAction>>();
             foreach (int i in Enumerable.Range(0, 11))
             {
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<DumbAction> block = TestUtils.MineNext(
                         previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
-                        hashAlgorithm: hashAlgorithm,
+                        hashAlgorithmGetter: minerChain.Policy.GetHashAlgorithm,
                         difficulty: 1024)
                     .AttachStateRootHash(
-                        hashAlgorithm,
+                        minerChain.Policy.GetHashAlgorithm,
                         minerChain.StateStore,
                         minerChain.Policy.BlockAction);
                 blocks.Add(block);
@@ -327,15 +326,14 @@ namespace Libplanet.Tests.Net
                     DateTimeOffset.UtcNow
                 );
 
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 var block = TestUtils.MineNext(
                         minerChain.Tip,
-                        hashAlgorithm,
+                        minerChain.Policy.GetHashAlgorithm,
                         new[] { tx },
                         difficulty: policy.GetNextBlockDifficulty(minerChain),
                         blockInterval: TimeSpan.FromSeconds(1)
                 ).AttachStateRootHash(
-                    hashAlgorithm,
+                    minerChain.Policy.GetHashAlgorithm,
                     minerChain.StateStore,
                     minerChain.Policy.BlockAction
                 );
@@ -800,15 +798,14 @@ namespace Libplanet.Tests.Net
             await minerChain1.MineBlock(minerSwarm1.Address);
             await minerChain1.MineBlock(minerSwarm1.Address);
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             long nextDifficulty = (long)minerChain1.Tip.TotalDifficulty +
                                   minerChain2.Policy.GetNextBlockDifficulty(minerChain2);
             var block = TestUtils.MineNext(
                 minerChain2.Tip,
-                hashAlgorithm,
+                minerChain2.Policy.GetHashAlgorithm,
                 difficulty: nextDifficulty
             ).AttachStateRootHash(
-                hashAlgorithm,
+                minerChain2.Policy.GetHashAlgorithm,
                 minerChain2.StateStore,
                 minerChain2.Policy.BlockAction
             );

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -116,10 +116,7 @@ namespace Libplanet.Tests.Net
                         previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
                         hashAlgorithmGetter: minerChain.Policy.GetHashAlgorithm,
                         difficulty: 1024)
-                    .AttachStateRootHash(
-                        minerChain.Policy.GetHashAlgorithm,
-                        minerChain.StateStore,
-                        minerChain.Policy.BlockAction);
+                    .AttachStateRootHash(minerChain.StateStore, minerChain.Policy);
                 blocks.Add(block);
                 if (i != 10)
                 {
@@ -332,11 +329,7 @@ namespace Libplanet.Tests.Net
                         new[] { tx },
                         difficulty: policy.GetNextBlockDifficulty(minerChain),
                         blockInterval: TimeSpan.FromSeconds(1)
-                ).AttachStateRootHash(
-                    minerChain.Policy.GetHashAlgorithm,
-                    minerChain.StateStore,
-                    minerChain.Policy.BlockAction
-                );
+                ).AttachStateRootHash(minerChain.StateStore, minerChain.Policy);
                 minerSwarm.BlockChain.Append(block, DateTimeOffset.UtcNow, false, true, false);
 
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
@@ -804,11 +797,7 @@ namespace Libplanet.Tests.Net
                 minerChain2.Tip,
                 minerChain2.Policy.GetHashAlgorithm,
                 difficulty: nextDifficulty
-            ).AttachStateRootHash(
-                minerChain2.Policy.GetHashAlgorithm,
-                minerChain2.StateStore,
-                minerChain2.Policy.BlockAction
-            );
+            ).AttachStateRootHash(minerChain2.StateStore, minerChain2.Policy);
             minerChain2.Append(block);
 
             Assert.True(minerChain1.Count > minerChain2.Count);

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -842,6 +842,7 @@ namespace Libplanet.Tests.Net
         {
             var minerAddress = new PrivateKey().ToAddress();
             var policy = new BlockPolicy<DumbAction>();
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var genesisBlock1 = new Block<DumbAction>(
                 0,
                 0,
@@ -850,7 +851,9 @@ namespace Libplanet.Tests.Net
                 minerAddress,
                 null,
                 DateTimeOffset.MinValue,
-                ImmutableArray<Transaction<DumbAction>>.Empty);
+                ImmutableArray<Transaction<DumbAction>>.Empty,
+                hashAlgorithm
+            );
             var genesisBlock2 = new Block<DumbAction>(
                 0,
                 0,
@@ -859,7 +862,9 @@ namespace Libplanet.Tests.Net
                 minerAddress,
                 null,
                 DateTimeOffset.MinValue,
-                ImmutableArray<Transaction<DumbAction>>.Empty);
+                ImmutableArray<Transaction<DumbAction>>.Empty,
+                hashAlgorithm
+            );
 
             BlockChain<DumbAction> MakeBlockChain(Block<DumbAction> genesisBlock) =>
                 TestUtils.MakeBlockChain(

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1216,8 +1216,9 @@ namespace Libplanet.Tests.Net
             var actionsA = new[] { new DumbAction(signerAddress, "1") };
             var actionsB = new[] { new DumbAction(signerAddress, "2") };
 
-            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock(actionsA, privateKeyA);
-            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock(actionsB, privateKeyB);
+            HashAlgorithmType alg = HashAlgorithmType.Of<SHA256>();
+            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock(alg, actionsA, privateKeyA);
+            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock(alg, actionsB, privateKeyB);
 
             BlockChain<DumbAction> MakeGenesisChain(
                 IStore store, IStateStore stateStore, Block<DumbAction> genesisBlock) =>

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -714,13 +714,16 @@ namespace Libplanet.Tests.Net
             await chain2.MineBlock(swarm2.Address);
 
             // Creates a block that will make chain 2's total difficulty is higher than chain 1's.
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var block3 = TestUtils.MineNext(
-                    chain2.Tip,
-                    hashAlgorithm,
-                    difficulty: (long)chain1.Tip.TotalDifficulty + 1,
-                    blockInterval: TimeSpan.FromMilliseconds(1))
-                .AttachStateRootHash(hashAlgorithm, chain2.StateStore, chain2.Policy.BlockAction);
+                chain2.Tip,
+                policy2.GetHashAlgorithm,
+                difficulty: (long)chain1.Tip.TotalDifficulty + 1,
+                blockInterval: TimeSpan.FromMilliseconds(1)
+            ).AttachStateRootHash(
+                policy2.GetHashAlgorithm,
+                chain2.StateStore,
+                chain2.Policy.BlockAction
+            );
             chain2.Append(block3);
             try
             {
@@ -816,13 +819,12 @@ namespace Libplanet.Tests.Net
             await chain1.MineBlock(miner2.Address);
             long nextDifficulty =
                 (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var block = TestUtils.MineNext(
-                    chain2.Tip,
-                    hashAlgorithm,
-                    difficulty: nextDifficulty,
-                    blockInterval: TimeSpan.FromMilliseconds(1))
-                .AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
+                chain2.Tip,
+                policy.GetHashAlgorithm,
+                difficulty: nextDifficulty,
+                blockInterval: TimeSpan.FromMilliseconds(1)
+            ).AttachStateRootHash(policy.GetHashAlgorithm, chain2.StateStore, policy.BlockAction);
             chain2.Append(block);
 
             Assert.True(chain1.Tip.Index > chain2.Tip.Index);
@@ -1422,17 +1424,17 @@ namespace Libplanet.Tests.Net
 
             receiver.FindNextHashesChunkSize = 8;
             sender.FindNextHashesChunkSize = 8;
+            BlockChain<DumbAction> chain = sender.BlockChain;
 
             for (int i = 0; i < 6; i++)
             {
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<DumbAction> block =
-                    TestUtils.MineNext(sender.BlockChain.Tip, hashAlgorithm, difficulty: 1024)
+                    TestUtils.MineNext(chain.Tip, chain.Policy.GetHashAlgorithm, difficulty: 1024)
                         .AttachStateRootHash(
-                            hashAlgorithm,
-                            sender.BlockChain.StateStore,
-                            sender.BlockChain.Policy.BlockAction);
-                sender.BlockChain.Append(block);
+                            chain.Policy.GetHashAlgorithm,
+                            chain.StateStore,
+                            chain.Policy.BlockAction);
+                chain.Append(block);
             }
 
             Log.Debug("Sender's BlockChain Tip index: #{index}", sender.BlockChain.Tip.Index);
@@ -1465,17 +1467,17 @@ namespace Libplanet.Tests.Net
 
             receiver.FindNextHashesChunkSize = 2;
             sender.FindNextHashesChunkSize = 2;
+            BlockChain<DumbAction> chain = sender.BlockChain;
 
             for (int i = 0; i < 6; i++)
             {
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<DumbAction> block =
-                    TestUtils.MineNext(sender.BlockChain.Tip, hashAlgorithm, difficulty: 1024)
+                    TestUtils.MineNext(chain.Tip, chain.Policy.GetHashAlgorithm, difficulty: 1024)
                         .AttachStateRootHash(
-                            hashAlgorithm,
-                            sender.BlockChain.StateStore,
-                            sender.BlockChain.Policy.BlockAction);
-                sender.BlockChain.Append(block);
+                            chain.Policy.GetHashAlgorithm,
+                            chain.StateStore,
+                            chain.Policy.BlockAction);
+                chain.Append(block);
             }
 
             Log.Debug("Sender's BlockChain Tip index: #{index}", sender.BlockChain.Tip.Index);
@@ -1509,11 +1511,11 @@ namespace Libplanet.Tests.Net
             await StartAsync(sender1);
             await StartAsync(sender2);
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            BlockChain<DumbAction> chain = receiver.BlockChain;
             Block<DumbAction> b1 =
-                TestUtils.MineNext(receiver.BlockChain.Genesis, hashAlgorithm, difficulty: 1024)
+                TestUtils.MineNext(chain.Genesis, chain.Policy.GetHashAlgorithm, difficulty: 1024)
                     .AttachStateRootHash(
-                        hashAlgorithm,
+                        chain.Policy.GetHashAlgorithm,
                         sender1.BlockChain.StateStore,
                         sender1.BlockChain.Policy.BlockAction);
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -719,11 +719,7 @@ namespace Libplanet.Tests.Net
                 policy2.GetHashAlgorithm,
                 difficulty: (long)chain1.Tip.TotalDifficulty + 1,
                 blockInterval: TimeSpan.FromMilliseconds(1)
-            ).AttachStateRootHash(
-                policy2.GetHashAlgorithm,
-                chain2.StateStore,
-                chain2.Policy.BlockAction
-            );
+            ).AttachStateRootHash(chain2.StateStore, policy2);
             chain2.Append(block3);
             try
             {
@@ -824,7 +820,7 @@ namespace Libplanet.Tests.Net
                 policy.GetHashAlgorithm,
                 difficulty: nextDifficulty,
                 blockInterval: TimeSpan.FromMilliseconds(1)
-            ).AttachStateRootHash(policy.GetHashAlgorithm, chain2.StateStore, policy.BlockAction);
+            ).AttachStateRootHash(chain2.StateStore, policy);
             chain2.Append(block);
 
             Assert.True(chain1.Tip.Index > chain2.Tip.Index);
@@ -1430,10 +1426,7 @@ namespace Libplanet.Tests.Net
             {
                 Block<DumbAction> block =
                     TestUtils.MineNext(chain.Tip, chain.Policy.GetHashAlgorithm, difficulty: 1024)
-                        .AttachStateRootHash(
-                            chain.Policy.GetHashAlgorithm,
-                            chain.StateStore,
-                            chain.Policy.BlockAction);
+                        .AttachStateRootHash(chain.StateStore, chain.Policy);
                 chain.Append(block);
             }
 
@@ -1473,10 +1466,7 @@ namespace Libplanet.Tests.Net
             {
                 Block<DumbAction> block =
                     TestUtils.MineNext(chain.Tip, chain.Policy.GetHashAlgorithm, difficulty: 1024)
-                        .AttachStateRootHash(
-                            chain.Policy.GetHashAlgorithm,
-                            chain.StateStore,
-                            chain.Policy.BlockAction);
+                        .AttachStateRootHash(chain.StateStore, chain.Policy);
                 chain.Append(block);
             }
 
@@ -1514,10 +1504,7 @@ namespace Libplanet.Tests.Net
             BlockChain<DumbAction> chain = receiver.BlockChain;
             Block<DumbAction> b1 =
                 TestUtils.MineNext(chain.Genesis, chain.Policy.GetHashAlgorithm, difficulty: 1024)
-                    .AttachStateRootHash(
-                        chain.Policy.GetHashAlgorithm,
-                        sender1.BlockChain.StateStore,
-                        sender1.BlockChain.Policy.BlockAction);
+                    .AttachStateRootHash(sender1.BlockChain.StateStore, chain.Policy);
 
             try
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
@@ -713,11 +714,13 @@ namespace Libplanet.Tests.Net
             await chain2.MineBlock(swarm2.Address);
 
             // Creates a block that will make chain 2's total difficulty is higher than chain 1's.
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var block3 = TestUtils.MineNext(
                     chain2.Tip,
+                    hashAlgorithm,
                     difficulty: (long)chain1.Tip.TotalDifficulty + 1,
                     blockInterval: TimeSpan.FromMilliseconds(1))
-                .AttachStateRootHash(chain2.StateStore, chain2.Policy.BlockAction);
+                .AttachStateRootHash(hashAlgorithm, chain2.StateStore, chain2.Policy.BlockAction);
             chain2.Append(block3);
             try
             {
@@ -813,11 +816,13 @@ namespace Libplanet.Tests.Net
             await chain1.MineBlock(miner2.Address);
             long nextDifficulty =
                 (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             var block = TestUtils.MineNext(
                     chain2.Tip,
+                    hashAlgorithm,
                     difficulty: nextDifficulty,
                     blockInterval: TimeSpan.FromMilliseconds(1))
-                .AttachStateRootHash(chain2.StateStore, policy.BlockAction);
+                .AttachStateRootHash(hashAlgorithm, chain2.StateStore, policy.BlockAction);
             chain2.Append(block);
 
             Assert.True(chain1.Tip.Index > chain2.Tip.Index);
@@ -1419,9 +1424,11 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 6; i++)
             {
+                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<DumbAction> block =
-                    TestUtils.MineNext(sender.BlockChain.Tip, difficulty: 1024)
+                    TestUtils.MineNext(sender.BlockChain.Tip, hashAlgorithm, difficulty: 1024)
                         .AttachStateRootHash(
+                            hashAlgorithm,
                             sender.BlockChain.StateStore,
                             sender.BlockChain.Policy.BlockAction);
                 sender.BlockChain.Append(block);
@@ -1460,9 +1467,11 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 6; i++)
             {
+                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 Block<DumbAction> block =
-                    TestUtils.MineNext(sender.BlockChain.Tip, difficulty: 1024)
+                    TestUtils.MineNext(sender.BlockChain.Tip, hashAlgorithm, difficulty: 1024)
                         .AttachStateRootHash(
+                            hashAlgorithm,
                             sender.BlockChain.StateStore,
                             sender.BlockChain.Policy.BlockAction);
                 sender.BlockChain.Append(block);
@@ -1499,9 +1508,11 @@ namespace Libplanet.Tests.Net
             await StartAsync(sender1);
             await StartAsync(sender2);
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<DumbAction> b1 =
-                TestUtils.MineNext(receiver.BlockChain.Genesis, difficulty: 1024)
+                TestUtils.MineNext(receiver.BlockChain.Genesis, hashAlgorithm, difficulty: 1024)
                     .AttachStateRootHash(
+                        hashAlgorithm,
                         sender1.BlockChain.StateStore,
                         sender1.BlockChain.Policy.BlockAction);
 

--- a/Libplanet.Tests/Store/BlockSetTest.cs
+++ b/Libplanet.Tests/Store/BlockSetTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Store
         public BlockSetTest()
         {
             _fx = new DefaultStoreFixture();
-            _set = new BlockSet<DumbAction>(_fx.Store);
+            _set = new BlockSet<DumbAction>(_ => _fx.HashAlgorithm, _fx.Store);
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/BlockSetTest.cs
+++ b/Libplanet.Tests/Store/BlockSetTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Store
         public BlockSetTest()
         {
             _fx = new DefaultStoreFixture();
-            _set = new BlockSet<DumbAction>(_ => _fx.HashAlgorithm, _fx.Store);
+            _set = new BlockSet<DumbAction>(_fx.GetHashAlgorithm, _fx.Store);
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Store
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
             HashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            GenesisBlock = TestUtils.MineGenesis<DumbAction>()
+            GenesisBlock = TestUtils.MineGenesis<DumbAction>(HashAlgorithm)
                 .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
             Block1 = TestUtils.MineNext(GenesisBlock, HashAlgorithm)
                 .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -93,15 +93,14 @@ namespace Libplanet.Tests.Store
 
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
-            HashAlgorithm = HashAlgorithmType.Of<SHA256>();
-            GenesisBlock = TestUtils.MineGenesis<DumbAction>(HashAlgorithm)
-                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
-            Block1 = TestUtils.MineNext(GenesisBlock, HashAlgorithm)
-                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
-            Block2 = TestUtils.MineNext(Block1, HashAlgorithm)
-                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
-            Block3 = TestUtils.MineNext(Block2, HashAlgorithm)
-                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
+            GenesisBlock = TestUtils.MineGenesis<DumbAction>(GetHashAlgorithm)
+                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+            Block1 = TestUtils.MineNext(GenesisBlock, GetHashAlgorithm)
+                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+            Block2 = TestUtils.MineNext(Block1, GetHashAlgorithm)
+                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+            Block3 = TestUtils.MineNext(Block2, GetHashAlgorithm)
+                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
             Transaction2 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
@@ -135,8 +134,6 @@ namespace Libplanet.Tests.Store
         public BlockHash Hash2 { get; }
 
         public BlockHash Hash3 { get; }
-
-        public HashAlgorithmType HashAlgorithm { get; set; }
 
         public Block<DumbAction> GenesisBlock { get; }
 
@@ -182,5 +179,7 @@ namespace Libplanet.Tests.Store
                 timestamp
             );
         }
+
+        public HashAlgorithmType GetHashAlgorithm(long index) => HashAlgorithmType.Of<SHA256>();
     }
 }

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
@@ -92,11 +93,15 @@ namespace Libplanet.Tests.Store
 
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
+            HashAlgorithm = HashAlgorithmType.Of<SHA256>();
             GenesisBlock = TestUtils.MineGenesis<DumbAction>()
-                .AttachStateRootHash(stateStore, blockAction);
-            Block1 = TestUtils.MineNext(GenesisBlock).AttachStateRootHash(stateStore, blockAction);
-            Block2 = TestUtils.MineNext(Block1).AttachStateRootHash(stateStore, blockAction);
-            Block3 = TestUtils.MineNext(Block2).AttachStateRootHash(stateStore, blockAction);
+                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
+            Block1 = TestUtils.MineNext(GenesisBlock, HashAlgorithm)
+                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
+            Block2 = TestUtils.MineNext(Block1, HashAlgorithm)
+                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
+            Block3 = TestUtils.MineNext(Block2, HashAlgorithm)
+                .AttachStateRootHash(HashAlgorithm, stateStore, blockAction);
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
             Transaction2 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
@@ -130,6 +135,8 @@ namespace Libplanet.Tests.Store
         public BlockHash Hash2 { get; }
 
         public BlockHash Hash3 { get; }
+
+        public HashAlgorithmType HashAlgorithm { get; set; }
 
         public Block<DumbAction> GenesisBlock { get; }
 

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -94,13 +94,13 @@ namespace Libplanet.Tests.Store
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore(), new MemoryKeyValueStore());
             GenesisBlock = TestUtils.MineGenesis<DumbAction>(GetHashAlgorithm)
-                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+                .AttachStateRootHash(GetHashAlgorithm(0), stateStore, blockAction);
             Block1 = TestUtils.MineNext(GenesisBlock, GetHashAlgorithm)
-                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+                .AttachStateRootHash(GetHashAlgorithm(1), stateStore, blockAction);
             Block2 = TestUtils.MineNext(Block1, GetHashAlgorithm)
-                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+                .AttachStateRootHash(GetHashAlgorithm(2), stateStore, blockAction);
             Block3 = TestUtils.MineNext(Block2, GetHashAlgorithm)
-                .AttachStateRootHash(GetHashAlgorithm, stateStore, blockAction);
+                .AttachStateRootHash(GetHashAlgorithm(3), stateStore, blockAction);
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
             Transaction2 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -87,6 +87,7 @@ namespace Libplanet.Tests.Store
         {
             Block<DumbAction> block1 = TestUtils.MineNext(
                 TestUtils.MineGenesis<DumbAction>(),
+                Fx.HashAlgorithm,
                 new[] { Fx.Transaction1 });
             Fx.Store.AppendIndex(Fx.StoreChainId, block1.Hash);
             Guid arbitraryChainId = Guid.NewGuid();
@@ -995,7 +996,7 @@ namespace Libplanet.Tests.Store
 
             // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
             // actual block...
-            Block<DumbAction> anotherBlock3 = TestUtils.MineNext(Fx.Block2);
+            Block<DumbAction> anotherBlock3 = TestUtils.MineNext(Fx.Block2, Fx.HashAlgorithm);
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
             store.PutBlock(Fx.Block2);
@@ -1095,6 +1096,7 @@ namespace Libplanet.Tests.Store
                 // NOTE: it depends on that Block<T>.CurrentProtocolVersion is not 0.
                 Block<DumbAction> block = TestUtils.MineNext(
                     genesisBlock,
+                    fx.HashAlgorithm,
                     protocolVersion: 0);
 
                 fx.Store.PutBlock(block);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Tests.Store
         public void DeleteChainId()
         {
             Block<DumbAction> block1 = TestUtils.MineNext(
-                TestUtils.MineGenesis<DumbAction>(),
+                TestUtils.MineGenesis<DumbAction>(Fx.HashAlgorithm),
                 Fx.HashAlgorithm,
                 new[] { Fx.Transaction1 });
             Fx.Store.AppendIndex(Fx.StoreChainId, block1.Hash);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -86,8 +86,8 @@ namespace Libplanet.Tests.Store
         public void DeleteChainId()
         {
             Block<DumbAction> block1 = TestUtils.MineNext(
-                TestUtils.MineGenesis<DumbAction>(Fx.HashAlgorithm),
-                Fx.HashAlgorithm,
+                TestUtils.MineGenesis<DumbAction>(Fx.GetHashAlgorithm),
+                Fx.GetHashAlgorithm,
                 new[] { Fx.Transaction1 });
             Fx.Store.AppendIndex(Fx.StoreChainId, block1.Hash);
             Guid arbitraryChainId = Guid.NewGuid();
@@ -996,7 +996,7 @@ namespace Libplanet.Tests.Store
 
             // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
             // actual block...
-            Block<DumbAction> anotherBlock3 = TestUtils.MineNext(Fx.Block2, Fx.HashAlgorithm);
+            Block<DumbAction> anotherBlock3 = TestUtils.MineNext(Fx.Block2, Fx.GetHashAlgorithm);
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
             store.PutBlock(Fx.Block2);
@@ -1096,7 +1096,7 @@ namespace Libplanet.Tests.Store
                 // NOTE: it depends on that Block<T>.CurrentProtocolVersion is not 0.
                 Block<DumbAction> block = TestUtils.MineNext(
                     genesisBlock,
-                    fx.HashAlgorithm,
+                    fx.GetHashAlgorithm,
                     protocolVersion: 0);
 
                 fx.Store.PutBlock(block);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -293,7 +293,12 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             }
 
             var actionEvaluator = new ActionEvaluator<T>(
-                blockAction, StateGetter, FungibleAssetValueGetter, null);
+                hashAlgorithmGetter: _ => HashAlgorithmType.Of<SHA256>(),
+                policyBlockAction: blockAction,
+                stateGetter: StateGetter,
+                balanceGetter: FungibleAssetValueGetter,
+                trieGetter: null
+            );
             var actionEvaluationResult = actionEvaluator
                 .Evaluate(block, StateCompleterSet<T>.Reject)
                 .GetTotalDelta(ToStateKey, ToFungibleAssetKey);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -180,6 +180,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         }
 
         public static Block<T> MineGenesis<T>(
+            HashAlgorithmType hashAlgorithm,
             Address? miner = null,
             IReadOnlyList<Transaction<T>> transactions = null,
             DateTimeOffset? timestamp = null,
@@ -201,6 +202,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 previousHash: null,
                 timestamp: timestamp ?? new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero),
                 transactions: transactions,
+                hashAlgorithm: hashAlgorithm,
                 protocolVersion: protocolVersion
             );
 
@@ -255,6 +257,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                     previousHash: previousHash,
                     timestamp: timestamp,
                     transactions: txs,
+                    hashAlgorithm: hashAlgorithm,
                     protocolVersion: protocolVersion
                 );
             }
@@ -364,6 +367,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 null,
                 timestamp ?? DateTimeOffset.MinValue,
                 new[] { tx },
+                hashAlgorithm: hashAlgorithm,
                 protocolVersion: protocolVersion
             );
             genesisBlock = genesisBlock.AttachStateRootHash(

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -228,11 +228,13 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             DateTimeOffset timestamp =
                 previousBlock.Timestamp.Add(blockInterval ?? TimeSpan.FromSeconds(15));
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<T> block;
             if (nonce == null)
             {
                 block = Block<T>.Mine(
                     index: index,
+                    hashAlgorithm: hashAlgorithm,
                     difficulty: difficulty,
                     previousTotalDifficulty: previousBlock.TotalDifficulty,
                     miner: miner ?? previousBlock.Miner.Value,

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -259,7 +259,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 );
             }
 
-            block.Validate(DateTimeOffset.Now);
+            block.Validate(hashAlgorithm, DateTimeOffset.Now);
 
             return block;
         }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -373,31 +372,6 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             }
 
             return chain;
-        }
-
-        public static HashDigest<SHA256>? ActionEvaluationsToHash(
-            IEnumerable<ActionEvaluation> actionEvaluations)
-        {
-            ActionEvaluation actionEvaluation;
-            var evaluations = actionEvaluations.ToList();
-            if (evaluations.Any())
-            {
-                actionEvaluation = evaluations.Last();
-            }
-            else
-            {
-                return (HashDigest<SHA256>?)null;
-            }
-
-            IImmutableSet<Address> updatedAddresses =
-                actionEvaluation.OutputStates.UpdatedAddresses;
-            var dict = Bencodex.Types.Dictionary.Empty;
-            foreach (Address address in updatedAddresses)
-            {
-                dict.Add(address.ToHex(), actionEvaluation.OutputStates.GetState(address));
-            }
-
-            return HashDigest<SHA256>.DeriveFrom(new Codec().Encode(dict));
         }
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -381,8 +381,10 @@ namespace Libplanet.Action
             IAccountStateDelta previousStates,
             ITrie? previousBlockStatesTrie = null)
         {
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
             // FIXME: Probably not the best place to have Validate().
-            block.Validate(currentTime);
+            block.Validate(hashAlgorithm, currentTime);
 
             return EvaluateTxs(
                 block: block,

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -212,7 +212,7 @@ namespace Libplanet.Action
         /// </remarks>
         [Pure]
         internal static IEnumerable<ActionEvaluation> EvaluateActions(
-            BlockHash preEvaluationHash,
+            ImmutableArray<byte> preEvaluationHash,
             long blockIndex,
             TxId? txid,
             IAccountStateDelta previousStates,
@@ -244,7 +244,7 @@ namespace Libplanet.Action
                 hashedSignature = hasher.ComputeHash(signature);
             }
 
-            byte[] preEvaluationHashBytes = preEvaluationHash.ToByteArray();
+            byte[] preEvaluationHashBytes = preEvaluationHash.ToBuilder().ToArray();
             int seed =
                 (preEvaluationHashBytes.Length > 0
                     ? BitConverter.ToInt32(preEvaluationHashBytes, 0) : 0)

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -46,6 +46,7 @@ namespace Libplanet.Action
             transactions: ImmutableArray<Transaction<T>>.Empty);
 
         private static readonly ILogger _logger = Log.ForContext<ActionEvaluator<T>>();
+        private readonly Func<long, HashAlgorithmType> _hashAlgorithmGetter;
         private readonly IAction? _policyBlockAction;
         private readonly StateGetter<T> _stateGetter;
         private readonly BalanceGetter<T> _balanceGetter;
@@ -54,6 +55,8 @@ namespace Libplanet.Action
         /// <summary>
         /// Creates a new <see cref="ActionEvaluator{T}"/>.
         /// </summary>
+        /// <param name="hashAlgorithmGetter">The function to determine a hash algorithm to use
+        /// for a block index.</param>
         /// <param name="policyBlockAction">The <see cref="IAction"/> provided by
         /// <see cref="IBlockPolicy{T}.BlockAction"/> to evaluate at the end for each
         /// <see cref="Block{T}"/> that gets evaluated.</param>
@@ -64,11 +67,13 @@ namespace Libplanet.Action
         /// <param name="trieGetter">The function to retrieve a trie for
         /// a provided <see cref="BlockHash"/>.</param>
         public ActionEvaluator(
+            Func<long, HashAlgorithmType> hashAlgorithmGetter,
             IAction? policyBlockAction,
             StateGetter<T> stateGetter,
             BalanceGetter<T> balanceGetter,
             Func<BlockHash, ITrie>? trieGetter)
         {
+            _hashAlgorithmGetter = hashAlgorithmGetter;
             _policyBlockAction = policyBlockAction;
             _stateGetter = stateGetter;
             _balanceGetter = balanceGetter;
@@ -381,7 +386,7 @@ namespace Libplanet.Action
             IAccountStateDelta previousStates,
             ITrie? previousBlockStatesTrie = null)
         {
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            HashAlgorithmType hashAlgorithm = _hashAlgorithmGetter(block.Index);
 
             // FIXME: Probably not the best place to have Validate().
             block.Validate(hashAlgorithm, currentTime);

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -43,7 +43,9 @@ namespace Libplanet.Action
             miner: null,
             previousHash: null,
             timestamp: DateTimeOffset.UtcNow,
-            transactions: ImmutableArray<Transaction<T>>.Empty);
+            transactions: ImmutableArray<Transaction<T>>.Empty,
+            hashAlgorithm: HashAlgorithmType.Of<SHA256>()
+        );
 
         private static readonly ILogger _logger = Log.ForContext<ActionEvaluator<T>>();
         private readonly HashAlgorithmGetter _hashAlgorithmGetter;

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Action
             transactions: ImmutableArray<Transaction<T>>.Empty);
 
         private static readonly ILogger _logger = Log.ForContext<ActionEvaluator<T>>();
-        private readonly Func<long, HashAlgorithmType> _hashAlgorithmGetter;
+        private readonly HashAlgorithmGetter _hashAlgorithmGetter;
         private readonly IAction? _policyBlockAction;
         private readonly StateGetter<T> _stateGetter;
         private readonly BalanceGetter<T> _balanceGetter;
@@ -67,7 +67,7 @@ namespace Libplanet.Action
         /// <param name="trieGetter">The function to retrieve a trie for
         /// a provided <see cref="BlockHash"/>.</param>
         public ActionEvaluator(
-            Func<long, HashAlgorithmType> hashAlgorithmGetter,
+            HashAlgorithmGetter hashAlgorithmGetter,
             IAction? policyBlockAction,
             StateGetter<T> stateGetter,
             BalanceGetter<T> balanceGetter,

--- a/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
+++ b/Libplanet/Action/UnexpectedlyTerminatedActionException.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Immutable;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Bencodex;
@@ -24,9 +25,9 @@ namespace Libplanet.Action
         /// <summary>
         /// Creates a new <see cref="UnexpectedlyTerminatedActionException"/> object.
         /// </summary>
-        /// <param name="blockHash">The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/>
-        /// that <paramref name="action"/> belongs to.  This can be <c>null</c> on rehearsal mode.
-        /// </param>
+        /// <param name="preEvaluationHash">The <see cref="Block{T}.PreEvaluationHash"/> of the
+        /// <see cref="Block{T}"/> that <paramref name="action"/> belongs to.
+        /// This can be <c>null</c> on rehearsal mode.</param>
         /// <param name="blockIndex">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
         /// that <paramref name="action"/> belongs to.  This can be <c>null</c> on rehearsal mode.
         /// </param>
@@ -43,7 +44,7 @@ namespace Libplanet.Action
         /// <param name="innerException">The actual exception that the <see cref="Action"/> threw.
         /// </param>
         public UnexpectedlyTerminatedActionException(
-            BlockHash? blockHash,
+            ImmutableArray<byte>? preEvaluationHash,
             long? blockIndex,
             TxId? txid,
             HashDigest<SHA256>? previousStateRootHash,
@@ -53,7 +54,7 @@ namespace Libplanet.Action
         )
             : base(message, innerException)
         {
-            BlockHash = blockHash;
+            PreEvaluationHash = preEvaluationHash;
             BlockIndex = blockIndex;
             TxId = txid;
             PreviousStateRootHash = previousStateRootHash;
@@ -66,9 +67,9 @@ namespace Libplanet.Action
         )
             : base(info, context)
         {
-            if (info.TryGetValue(nameof(BlockHash), out byte[] blockHash))
+            if (info.TryGetValue(nameof(PreEvaluationHash), out byte[] blockHash))
             {
-                BlockHash = new BlockHash(blockHash);
+                PreEvaluationHash = blockHash.ToImmutableArray();
             }
 
             if (info.TryGetValue(nameof(BlockIndex), out long blockIndex))
@@ -123,10 +124,10 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// The <see cref="Block{T}.Hash"/> of the <see cref="Block{T}"/> that <see cref="Action"/>
-        /// belongs to.  This can be <c>null</c> on rehearsal mode.
+        /// The <see cref="Block{T}.PreEvaluationHash"/> of the <see cref="Block{T}"/> that
+        /// <see cref="Action"/> belongs to.  This can be <c>null</c> on rehearsal mode.
         /// </summary>
-        public BlockHash? BlockHash { get; }
+        public ImmutableArray<byte>? PreEvaluationHash { get; }
 
         /// <summary>
         /// The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/> that <see cref="Action"/>
@@ -152,9 +153,9 @@ namespace Libplanet.Action
         {
             base.GetObjectData(info, context);
 
-            if (BlockHash is { } blockHash)
+            if (PreEvaluationHash is { } preEvaluationHash)
             {
-                info.AddValue(nameof(BlockHash), blockHash.ToByteArray());
+                info.AddValue(nameof(PreEvaluationHash), preEvaluationHash.ToBuilder().ToArray());
             }
 
             if (BlockIndex is long blockIndex)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -147,7 +147,7 @@ namespace Libplanet.Blockchain
                 throw new ArgumentNullException(nameof(stateStore));
             }
 
-            _blocks = new BlockSet<T>(store);
+            _blocks = new BlockSet<T>(_ => HashAlgorithmType.Of<SHA256>(), store);
             Renderers = renderers is IEnumerable<IRenderer<T>> r
                 ? r.ToImmutableArray()
                 : ImmutableArray<IRenderer<T>>.Empty;
@@ -1865,7 +1865,7 @@ namespace Libplanet.Blockchain
                     Guid obsoleteId = Id;
                     Id = other.Id;
                     Store.SetCanonicalChainId(Id);
-                    _blocks = new BlockSet<T>(Store);
+                    _blocks = new BlockSet<T>(_ => HashAlgorithmType.Of<SHA256>(), Store);
                     TipChanged?.Invoke(this, (oldTip, newTip));
 
                     if (render)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -2003,7 +2003,9 @@ namespace Libplanet.Blockchain
                 dict.Add(address.ToHex(), actionEvaluation.OutputStates.GetState(address));
             }
 
+#pragma warning disable CS0612
             return Hashcash.Hash(new Codec().Encode(dict));
+#pragma warning restore CS0612
         }
 
         /// <summary>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -384,6 +384,7 @@ namespace Libplanet.Blockchain
 
             Block<T> block = Block<T>.Mine(
                 0,
+                HashAlgorithmType.Of<SHA256>(),
                 0,
                 0,
                 privateKey.ToAddress(),
@@ -949,12 +950,14 @@ namespace Libplanet.Blockchain
                 stagedTransactions.Length
             );
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<T> block;
             try
             {
                 block = await Task.Run(
                     () => Block<T>.Mine(
                         index: index,
+                        hashAlgorithm: hashAlgorithm,
                         difficulty: difficulty,
                         previousTotalDifficulty: Tip.TotalDifficulty,
                         miner: miner,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1982,32 +1982,6 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal BlockHash? ActionEvaluationsToHash(IEnumerable<ActionEvaluation> actionEvaluations)
-        {
-            ActionEvaluation actionEvaluation;
-            var evaluations = actionEvaluations.ToList();
-            if (evaluations.Any())
-            {
-                actionEvaluation = evaluations.Last();
-            }
-            else
-            {
-                return null;
-            }
-
-            IImmutableSet<Address> updatedAddresses =
-                actionEvaluation.OutputStates.UpdatedAddresses;
-            var dict = Bencodex.Types.Dictionary.Empty;
-            foreach (Address address in updatedAddresses)
-            {
-                dict.Add(address.ToHex(), actionEvaluation.OutputStates.GetState(address));
-            }
-
-#pragma warning disable CS0612
-            return Hashcash.Hash(new Codec().Encode(dict));
-#pragma warning restore CS0612
-        }
-
         /// <summary>
         /// Calculates and complements a block's incomplete states on the fly.
         /// </summary>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -147,7 +147,7 @@ namespace Libplanet.Blockchain
                 throw new ArgumentNullException(nameof(stateStore));
             }
 
-            _blocks = new BlockSet<T>(_ => HashAlgorithmType.Of<SHA256>(), store);
+            _blocks = new BlockSet<T>(Policy.GetHashAlgorithm, store);
             Renderers = renderers is IEnumerable<IRenderer<T>> r
                 ? r.ToImmutableArray()
                 : ImmutableArray<IRenderer<T>>.Empty;
@@ -166,8 +166,8 @@ namespace Libplanet.Blockchain
                 ? h => trieStateStore.GetTrie(h)
                 : (Func<BlockHash, ITrie>)null;
             ActionEvaluator = new ActionEvaluator<T>(
-                _ => HashAlgorithmType.Of<SHA256>(),
-                policy.BlockAction,
+                Policy.GetHashAlgorithm,
+                Policy.BlockAction,
                 GetState,
                 GetBalance,
                 trieGetter);
@@ -805,7 +805,7 @@ namespace Libplanet.Blockchain
                 procId
             );
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            HashAlgorithmType hashAlgorithm = Policy.GetHashAlgorithm(index);
 
             ImmutableArray<Transaction<T>> stagedTransactions = ListStagedTransactions();
             _logger.Debug(
@@ -1869,7 +1869,7 @@ namespace Libplanet.Blockchain
                     Guid obsoleteId = Id;
                     Id = other.Id;
                     Store.SetCanonicalChainId(Id);
-                    _blocks = new BlockSet<T>(_ => HashAlgorithmType.Of<SHA256>(), Store);
+                    _blocks = new BlockSet<T>(Policy.GetHashAlgorithm, Store);
                     TipChanged?.Invoke(this, (oldTip, newTip));
 
                     if (render)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -166,6 +166,7 @@ namespace Libplanet.Blockchain
                 ? h => trieStateStore.GetTrie(h)
                 : (Func<BlockHash, ITrie>)null;
             ActionEvaluator = new ActionEvaluator<T>(
+                _ => HashAlgorithmType.Of<SHA256>(),
                 policy.BlockAction,
                 GetState,
                 GetBalance,
@@ -393,6 +394,7 @@ namespace Libplanet.Blockchain
                 transactions);
 
             var actionEvaluator = new ActionEvaluator<T>(
+                _ => HashAlgorithmType.Of<SHA256>(),
                 blockAction,
                 (address, digest, stateCompleter) => null,
                 (address, currency, hash, fungibleAssetStateCompleter)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -803,6 +803,8 @@ namespace Libplanet.Blockchain
                 procId
             );
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
             ImmutableArray<Transaction<T>> stagedTransactions = ListStagedTransactions();
             _logger.Debug(
                 "There are {Transactions} staged transactions.",
@@ -824,7 +826,8 @@ namespace Libplanet.Blockchain
                 miner: miner,
                 previousHash: prevHash,
                 timestamp: currentTime,
-                transactions: new Transaction<T>[0]
+                transactions: new Transaction<T>[0],
+                hashAlgorithm: hashAlgorithm
             ).BytesLength;
             int maxBlockBytes = Math.Max(Policy.GetMaxBlockBytes(index), 1);
             var skippedSigners = new HashSet<Address>();
@@ -952,7 +955,6 @@ namespace Libplanet.Blockchain
                 stagedTransactions.Length
             );
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Block<T> block;
             try
             {

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -220,5 +221,9 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc />
         public int GetMaxBlockBytes(long index) => index > 0 ? _maxBlockBytes : _maxGenesisBytes;
+
+        /// <inheritdoc cref="IBlockPolicy{T}.GetHashAlgorithm(long)"/>
+        public HashAlgorithmType GetHashAlgorithm(long index) =>
+            HashAlgorithmType.Of<SHA256>();
     }
 }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -89,5 +89,13 @@ namespace Libplanet.Blockchain.Policies
         /// <remarks>If it returns less then 1, it is treated as 1, because there is no block
         /// taking 0 bytes or negative length of bytes.</remarks>
         int GetMaxBlockBytes(long index);
+
+        /// <summary>
+        /// Gets the <see cref="HashAlgorithmType"/> to use for block's proof-of-work.
+        /// </summary>
+        /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/> to
+        /// do proof-of-work.</param>
+        /// <returns>The <see cref="HashAlgorithmType"/> to use.</returns>
+        HashAlgorithmType GetHashAlgorithm(long index);
     }
 }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -346,6 +346,8 @@ namespace Libplanet.Blocks
         /// Generate a block with given <paramref name="transactions"/>.
         /// </summary>
         /// <param name="index">Index of the block.</param>
+        /// <param name="hashAlgorithm">The hash algorithm to use for calculating
+        /// <see cref="Block{T}.PreEvaluationHash"/>.</param>
         /// <param name="difficulty">Difficulty to find the <see cref="Block{T}"/>
         /// <see cref="Nonce"/>.</param>
         /// <param name="previousTotalDifficulty">The total difficulty until the previous
@@ -364,6 +366,7 @@ namespace Libplanet.Blocks
         /// <returns>A <see cref="Block{T}"/> that mined.</returns>
         public static Block<T> Mine(
             long index,
+            HashAlgorithmType hashAlgorithm,
             long difficulty,
             BigInteger previousTotalDifficulty,
             Address miner,
@@ -401,7 +404,6 @@ namespace Libplanet.Blocks
             byte[] stampSuffix = new byte[emptyNonce.Length - offset - nonceLength];
             Array.Copy(emptyNonce, offset + nonceLength, stampSuffix, 0, stampSuffix.Length);
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             (Nonce nonce, _) = Hashcash.Answer(
                 n =>
                 {

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -563,8 +563,8 @@ namespace Libplanet.Blocks
                 {
                     string message =
                         $"The expected pre evaluation hash of block {Hash} is " +
-                        $"{expectedPreEvaluationHash}, but its pre evaluation hash is " +
-                        $"{PreEvaluationHash}.";
+                        $"{ByteUtil.Hex(expectedPreEvaluationHash)}, but its pre evaluation hash " +
+                        $"is {ByteUtil.Hex(PreEvaluationHash)}.";
                     throw new InvalidBlockPreEvaluationHashException(
                         PreEvaluationHash,
                         expectedPreEvaluationHash.ToImmutableArray(),

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -82,11 +82,15 @@ namespace Libplanet.Blocks
             Transactions = transactions.OrderBy(tx => tx.Id).ToArray();
             TxHash = CalculateTxHashes(Transactions);
 
+#pragma warning disable CS0612
             PreEvaluationHash = preEvaluationHash ?? Hashcash.Hash(Header.SerializeForHash());
+#pragma warning restore CS0612
             StateRootHash = stateRootHash;
 
             // FIXME: This does not need to be computed every time?
+#pragma warning disable CS0612
             Hash = Hashcash.Hash(Header.SerializeForHash());
+#pragma warning restore CS0612
 
             // As the order of transactions should be unpredictable until a block is mined,
             // the sorter key should be derived from both a block hash and a txid.
@@ -399,7 +403,9 @@ namespace Libplanet.Blocks
             byte[] stampSuffix = new byte[emptyNonce.Length - offset - nonceLength];
             Array.Copy(emptyNonce, offset + nonceLength, stampSuffix, 0, stampSuffix.Length);
 
+#pragma warning disable CS0612
             Nonce nonce = Hashcash.Answer(
+#pragma warning restore CS0612
                 n =>
                 {
                     int nLen = n.ByteArray.Length;
@@ -514,7 +520,9 @@ namespace Libplanet.Blocks
             if (ProtocolVersion > 0)
             {
                 BlockHash expectedPreEvaluationHash =
+#pragma warning disable CS0612
                     Hashcash.Hash(Header.SerializeForHash(includeStateRootHash: false));
+#pragma warning restore CS0612
                 if (!expectedPreEvaluationHash.Equals(PreEvaluationHash))
                 {
                     string message =

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -401,9 +401,8 @@ namespace Libplanet.Blocks
             byte[] stampSuffix = new byte[emptyNonce.Length - offset - nonceLength];
             Array.Copy(emptyNonce, offset + nonceLength, stampSuffix, 0, stampSuffix.Length);
 
-#pragma warning disable CS0612
-            Nonce nonce = Hashcash.Answer(
-#pragma warning restore CS0612
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            (Nonce nonce, _) = Hashcash.Answer(
                 n =>
                 {
                     int nLen = n.ByteArray.Length;
@@ -423,6 +422,7 @@ namespace Libplanet.Blocks
                     Array.Copy(stampSuffix, 0, stamp, pos, stampSuffix.Length);
                     return stamp;
                 },
+                hashAlgorithm,
                 difficulty,
                 cancellationToken
             );

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -87,8 +87,7 @@ namespace Libplanet.Blocks
                 hashAlgorithm.Digest(Header.SerializeForHash()).ToImmutableArray();
             StateRootHash = stateRootHash;
 
-            // FIXME: This does not need to be computed every time?
-            Hash = new BlockHash(hashAlgorithm.Digest(Header.SerializeForHash()));
+            Hash = BlockHash.DeriveFrom(Header.SerializeForHash());
 
             // As the order of transactions should be unpredictable until a block is mined,
             // the sorter key should be derived from both a block hash and a txid.

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -489,6 +489,8 @@ namespace Libplanet.Blocks
         /// Validates this <see cref="Block{T}"/> and throws an appropriate exception
         /// if not valid.
         /// </summary>
+        /// <param name="hashAlgorithm">The hash algorithm used to calculate
+        /// the <see cref="PreEvaluationHash"/>.</param>
         /// <param name="currentTime">The current time to validate time-wise conditions.</param>
         /// <exception cref="InvalidBlockHashException">Thrown when <see cref="Hash"/>
         /// is invalid.</exception>
@@ -508,9 +510,9 @@ namespace Libplanet.Blocks
         /// <exception cref="InvalidBlockTxHashException">Thrown when the value of
         /// <see cref="TxHash"/> is not consistent with <see cref="Transactions"/>.
         /// </exception>
-        internal void Validate(DateTimeOffset currentTime)
+        internal void Validate(HashAlgorithmType hashAlgorithm, DateTimeOffset currentTime)
         {
-            Header.Validate(currentTime);
+            Header.Validate(hashAlgorithm, currentTime);
 
             foreach (Transaction<T> tx in Transactions)
             {
@@ -519,7 +521,6 @@ namespace Libplanet.Blocks
 
             if (ProtocolVersion > 0)
             {
-                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
                 byte[] expectedPreEvaluationHash =
                     hashAlgorithm.Digest(Header.SerializeForHash(includeStateRootHash: false));
                 if (!ByteUtil.TimingSafelyCompare(expectedPreEvaluationHash, PreEvaluationHash))

--- a/Libplanet/Blocks/BlockHash.cs
+++ b/Libplanet/Blocks/BlockHash.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Numerics;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Libplanet.Serialization;
@@ -109,15 +108,7 @@ namespace Libplanet.Blocks
                 return false;
             }
 
-            var maxTargetBytes = new byte[_byteArray.Length + 1];
-            maxTargetBytes[_byteArray.Length] = 0x01;
-            var maxTarget = new BigInteger(maxTargetBytes);
-            BigInteger target = maxTarget / difficulty;
-
-            // Add zero to convert unsigned BigInteger
-            var result = new BigInteger(_byteArray.Add(0).ToBuilder().ToArray());
-
-            return result < target;
+            return ByteUtil.Satisfies(this._byteArray, difficulty);
         }
 
         /// <summary>

--- a/Libplanet/Blocks/BlockHash.cs
+++ b/Libplanet/Blocks/BlockHash.cs
@@ -1,7 +1,9 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Libplanet.Serialization;
@@ -103,6 +105,19 @@ namespace Libplanet.Blocks
         [Pure]
         public static BlockHash FromHashDigest(HashDigest<SHA256> hashDigest)
             => new BlockHash(hashDigest.ByteArray);
+
+        /// <summary>
+        /// Computes a SHA-256 digest from the given <paramref name="blockBytes"/>.
+        /// </summary>
+        /// <param name="blockBytes">The bytes serializing a block to compute its hash.</param>
+        /// <returns>The SHA-256 hash digest derived from <paramref name="blockBytes"/>.</returns>
+        [Pure]
+        public static BlockHash DeriveFrom(IReadOnlyList<byte> blockBytes)
+        {
+            SHA256 sha256 = SHA256.Create();
+            byte[] digest = sha256.ComputeHash(blockBytes is byte[] b ? b : blockBytes.ToArray());
+            return new BlockHash(digest);
+        }
 
         /// <summary>
         /// Gets a bare mutable <see cref="byte"/> array of the block hash.

--- a/Libplanet/Blocks/BlockHash.cs
+++ b/Libplanet/Blocks/BlockHash.cs
@@ -89,29 +89,6 @@ namespace Libplanet.Blocks
             => new BlockHash(hashDigest.ByteArray);
 
         /// <summary>
-        /// Tests if a block hash is less than the target computed for the given
-        /// <paramref name="difficulty"/>).
-        /// </summary>
-        /// <param name="difficulty">The difficulty to compute target number.</param>
-        /// <returns><c>true</c> only if a digest is less than the target computed for the given
-        /// <paramref name="difficulty"/>).  If <paramref name="difficulty"/> is <c>0</c> it always
-        /// returns <c>true</c>.</returns>
-        [Pure]
-        public bool Satisfies(long difficulty)
-        {
-            if (difficulty == 0)
-            {
-                return true;
-            }
-            else if (_byteArray.IsDefaultOrEmpty)
-            {
-                return false;
-            }
-
-            return ByteUtil.Satisfies(this._byteArray, difficulty);
-        }
-
-        /// <summary>
         /// Gets a bare mutable <see cref="byte"/> array of the block hash.
         /// </summary>
         /// <returns>A new mutable <see cref="byte"/> array of the block hash.

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Store.Trie;
@@ -295,7 +294,7 @@ namespace Libplanet.Blocks
             return new Codec().Encode(dict);
         }
 
-        internal void Validate(DateTimeOffset currentTime)
+        internal void Validate(HashAlgorithmType hashAlgorithm, DateTimeOffset currentTime)
         {
             if (ProtocolVersion < 0)
             {
@@ -404,7 +403,6 @@ namespace Libplanet.Blocks
                 );
             }
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             BlockHash calculatedHash = new BlockHash(hashAlgorithm.Digest(SerializeForHash()));
             if (!hash.Equals(calculatedHash))
             {

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Store.Trie;
@@ -403,9 +404,8 @@ namespace Libplanet.Blocks
                 );
             }
 
-#pragma warning disable CS0612
-            BlockHash calculatedHash = Hashcash.Hash(SerializeForHash());
-#pragma warning restore CS0612
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            BlockHash calculatedHash = new BlockHash(hashAlgorithm.Digest(SerializeForHash()));
             if (!hash.Equals(calculatedHash))
             {
                 throw new InvalidBlockHashException(

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -403,7 +403,7 @@ namespace Libplanet.Blocks
                 );
             }
 
-            BlockHash calculatedHash = new BlockHash(hashAlgorithm.Digest(SerializeForHash()));
+            BlockHash calculatedHash = BlockHash.DeriveFrom(SerializeForHash());
             if (!hash.Equals(calculatedHash))
             {
                 throw new InvalidBlockHashException(

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -395,7 +395,7 @@ namespace Libplanet.Blocks
                 }
             }
 
-            if (!new BlockHash(PreEvaluationHash.ToArray()).Satisfies(Difficulty))
+            if (!ByteUtil.Satisfies(PreEvaluationHash, Difficulty))
             {
                 throw new InvalidBlockNonceException(
                     $"Block #{Index} {hash}'s pre-evaluation hash " +

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -403,7 +403,9 @@ namespace Libplanet.Blocks
                 );
             }
 
+#pragma warning disable CS0612
             BlockHash calculatedHash = Hashcash.Hash(SerializeForHash());
+#pragma warning restore CS0612
             if (!hash.Equals(calculatedHash))
             {
                 throw new InvalidBlockHashException(

--- a/Libplanet/Blocks/HashAlgorithmGetter.cs
+++ b/Libplanet/Blocks/HashAlgorithmGetter.cs
@@ -1,0 +1,11 @@
+#nullable enable
+namespace Libplanet.Blocks
+{
+    /// <summary>
+    /// The delegate to determine a hash algorithm to use for a <paramref name="blockIndex"/>.
+    /// </summary>
+    /// <param name="blockIndex">The <see cref="Block{T}.Index"/> of a block to determine its
+    /// hash algorithm.</param>
+    /// <returns>The hash algorithm to be used for proof-of-work on the block.</returns>
+    public delegate HashAlgorithmType HashAlgorithmGetter(long blockIndex);
+}

--- a/Libplanet/Blocks/HashAlgorithmTable.cs
+++ b/Libplanet/Blocks/HashAlgorithmTable.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Libplanet.Blocks
+{
+    public static class HashAlgorithmTable
+    {
+        /// <summary>
+        /// Creates a <see cref="HashAlgorithmGetter"/> delegate from a <paramref name="table"/>.
+        /// </summary>
+        /// <param name="table">A table with block index offsets and their corresponding
+        /// <see cref="HashAlgorithmType"/>.  For example, <c>0: SHA1, 10: SHA256, 100: SHA512</c>
+        /// means <c>i =&gt; i >= 100 ? HashAlgorithmType.Of&lt;SHA512&gt;() : i >= 10 ?
+        /// HashAlgorithmType.Of&lt;SHA256&gt;() : HashAlgorithmType.Of&lt;SHA1&gt;()</c>.
+        /// (Note that 0 means <em>otherwise</em>.)  It must contain at least one entry with
+        /// index 0, because it is the last fallback.</param>
+        /// <returns>A corresponding <see cref="HashAlgorithmGetter"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="table"/> has no
+        /// the last fallback entry with index 0, or there are entries with duplicate indices.
+        /// </exception>
+        public static HashAlgorithmGetter ToHashAlgorithmGetter(
+            this IEnumerable<KeyValuePair<long, HashAlgorithmType>> table
+        )
+        {
+            KeyValuePair<long, HashAlgorithmType>[] indices =
+                table.OrderByDescending(kv => kv.Key).ToArray();
+
+            if (!indices.Any() || indices[indices.Length - 1].Key > 0)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(table)} must contain at least one entry with index 0.",
+                    nameof(table)
+                );
+            }
+            else if (indices.Select(kv => kv.Key).ToImmutableHashSet().Count < indices.Length)
+            {
+                throw new ArgumentException(
+                    $"Entries with duplicate indices are disallowed.",
+                    nameof(table)
+                );
+            }
+
+            return index =>
+            {
+                foreach (KeyValuePair<long, HashAlgorithmType> pair in indices)
+                {
+                    if (index >= pair.Key)
+                    {
+                        return pair.Value;
+                    }
+                }
+
+                return indices[0].Value;
+            };
+        }
+    }
+}

--- a/Libplanet/Blocks/InvalidBlockPreEvaluationHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockPreEvaluationHashException.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.Serialization;
 using Libplanet.Serialization;
 
@@ -24,8 +26,8 @@ namespace Libplanet.Blocks
         /// <see cref="Block{T}.StateRootHash"/>.</param>
         /// <param name="message">The message that describes the error.</param>
         public InvalidBlockPreEvaluationHashException(
-            BlockHash actualPreEvaluationHash,
-            BlockHash expectedPreEvaluationHash,
+            ImmutableArray<byte> actualPreEvaluationHash,
+            ImmutableArray<byte> expectedPreEvaluationHash,
             string message)
             : base(message)
         {
@@ -37,21 +39,23 @@ namespace Libplanet.Blocks
             SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            ActualPreEvaluationHash = info.GetValue<BlockHash>(nameof(ActualPreEvaluationHash));
-            ExpectedPreEvaluationHash = info.GetValue<BlockHash>(nameof(ExpectedPreEvaluationHash));
+            ActualPreEvaluationHash =
+                info.GetValue<byte[]>(nameof(ActualPreEvaluationHash)).ToImmutableArray();
+            ExpectedPreEvaluationHash =
+                info.GetValue<byte[]>(nameof(ExpectedPreEvaluationHash)).ToImmutableArray();
         }
 
         /// <summary>
         /// The hash calculated from the block except <see cref="Block{T}.StateRootHash"/>.
         /// </summary>
         [Pure]
-        public BlockHash ActualPreEvaluationHash { get; }
+        public ImmutableArray<byte> ActualPreEvaluationHash { get; }
 
         /// <summary>
         /// The hash recorded as <see cref="Block{T}.PreEvaluationHash"/>.
         /// </summary>
         [Pure]
-        public BlockHash ExpectedPreEvaluationHash { get; }
+        public ImmutableArray<byte> ExpectedPreEvaluationHash { get; }
 
         public static bool operator ==(
             InvalidBlockPreEvaluationHashException left,
@@ -67,8 +71,8 @@ namespace Libplanet.Blocks
         {
             base.GetObjectData(info, context);
 
-            info.AddValue(nameof(ActualPreEvaluationHash), ActualPreEvaluationHash);
-            info.AddValue(nameof(ExpectedPreEvaluationHash), ExpectedPreEvaluationHash);
+            info.AddValue(nameof(ActualPreEvaluationHash), ActualPreEvaluationHash.ToArray());
+            info.AddValue(nameof(ExpectedPreEvaluationHash), ExpectedPreEvaluationHash.ToArray());
         }
     }
 }

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -117,6 +118,26 @@ namespace Libplanet
                 0,
                 (current, t) => unchecked(current * (bytes.Length + 1) + t)
             );
+        }
+
+        /// <summary>
+        /// Timing safe comparision of two byte arrays.
+        /// </summary>
+        /// <remarks>In case of two byte arrays do not have the same length, it tries to keep
+        /// the timing dependent on the length of the shorter one.</remarks>
+        /// <param name="left">A byte array.</param>
+        /// <param name="right">Another byte array.</param>
+        /// <returns><c>true</c> iff two byte arrays have the exactly same contents.</returns>
+        [Pure]
+        public static bool TimingSafelyCompare(IReadOnlyList<byte> left, IReadOnlyList<byte> right)
+        {
+            bool differ = left.Count != right.Count;
+            for (int i = 0, len = Math.Min(left.Count, right.Count); i < len; i++)
+            {
+                differ = differ || (left[i] ^ right[i]) != 0;
+            }
+
+            return !differ;
         }
     }
 }

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 
 namespace Libplanet
 {
@@ -138,6 +139,47 @@ namespace Libplanet
             }
 
             return !differ;
+        }
+
+        /// <summary>
+        /// Tests if a hash digest is less than the target computed for the given
+        /// <paramref name="difficulty"/>).
+        /// </summary>
+        /// <param name="hashDigest">A hash digest to test.</param>
+        /// <param name="difficulty">The difficulty to compute target number.</param>
+        /// <returns><c>true</c> only if a digest is less than the target computed for the given
+        /// <paramref name="difficulty"/>).  If <paramref name="difficulty"/> is <c>0</c> it always
+        /// returns <c>true</c>.</returns>
+        [Pure]
+        public static bool Satisfies(IReadOnlyList<byte> hashDigest, long difficulty)
+        {
+            if (difficulty == 0)
+            {
+                return true;
+            }
+            else if (!hashDigest.Any())
+            {
+                return false;
+            }
+
+            var maxTargetBytes = new byte[hashDigest.Count + 1];
+            maxTargetBytes[hashDigest.Count] = 0x01;
+            var maxTarget = new BigInteger(maxTargetBytes);
+            BigInteger target = maxTarget / difficulty;
+
+            var digestArray = new byte[hashDigest.Count + 1];
+            int i = 0;
+            foreach (byte b in hashDigest)
+            {
+                digestArray[i++] = b;
+            }
+
+            // Append zero to convert unsigned BigInteger.  Note that BigInteger(byte[]) assumes
+            // the input bytes are in little-endian order.
+            digestArray[i] = 0;
+
+            var result = new BigInteger(digestArray);
+            return result < target;
         }
     }
 }

--- a/Libplanet/HashAlgorithmType.cs
+++ b/Libplanet/HashAlgorithmType.cs
@@ -71,7 +71,8 @@ namespace Libplanet
         /// Creates a <see cref="HashAlgorithmType"/> which refers to <typeparamref name="T"/>.
         /// </summary>
         /// <param name="objectToInferType">An optional object to make the compiler infers the
-        /// type parameter <typeparamref name="T"/> from this.</param>
+        /// type parameter <typeparamref name="T"/> from this.  Note that the value in itself is
+        /// never used at runtime.</param>
         /// <typeparam name="T">A subclass of <see cref="HashAlgorithm"/>.</typeparam>
         /// <returns>A <see cref="HashAlgorithmType"/> which refers to <typeparamref name="T"/>.
         /// </returns>

--- a/Libplanet/HashAlgorithmType.cs
+++ b/Libplanet/HashAlgorithmType.cs
@@ -1,0 +1,133 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace Libplanet
+{
+    /// <summary>
+    /// Represents the type of <see cref="HashAlgorithm"/>.
+    /// <para>It is guaranteed that only one instance is created for the same subclass of
+    /// <see cref="HashAlgorithm"/>.</para>
+    /// </summary>
+    [Pure]
+    public sealed class HashAlgorithmType : IEquatable<HashAlgorithmType>
+    {
+        private static readonly ConcurrentDictionary<Type, HashAlgorithmType> _internedObjects
+            = new ConcurrentDictionary<Type, HashAlgorithmType>();
+
+        private readonly HashAlgorithm _instance;
+
+        private HashAlgorithmType(Type type)
+        {
+            Type = type;
+            MethodInfo method = type.GetMethod(nameof(HashAlgorithm.Create), new Type[0])!;
+            string excMsg =
+                $"Failed to invoke {type.FullName}.{nameof(HashAlgorithm.Create)}() static method.";
+            _instance = method?.Invoke(null, new object[0]) as HashAlgorithm
+                ?? throw new InvalidCastException(excMsg);
+        }
+
+        /// <summary>
+        /// The <see cref="Type"/> object which refers to a subclass of
+        /// <see cref="HashAlgorithm"/>.
+        /// </summary>
+        [Pure]
+        public Type Type { get; }
+
+        /// <summary>
+        /// The length of bytes of every digest that the <see cref="HashAlgorithmType"/> makes.
+        /// </summary>
+        [Pure]
+        public int DigestSize => _instance.HashSize / 8;
+
+        /// <summary>
+        /// Checks if two <see cref="HashAlgorithmType"/>s refers to the same
+        /// <see cref="HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="left">An instance.</param>
+        /// <param name="right">Another instance.</param>
+        /// <returns><c>true</c> iff two operands refers to the same <see cref="HashAlgorithm"/>
+        /// class.</returns>
+        [Pure]
+        public static bool operator ==(HashAlgorithmType left, HashAlgorithmType right) =>
+            left is IEquatable<HashAlgorithmType> l && l.Equals(right);
+
+        /// <summary>
+        /// Checks if two <see cref="HashAlgorithmType"/>s do not refer to the different
+        /// <see cref="HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="left">An instance.</param>
+        /// <param name="right">Another instance.</param>
+        /// <returns><c>false</c> iff two operands refers to the same <see cref="HashAlgorithm"/>
+        /// class.</returns>
+        public static bool operator !=(HashAlgorithmType left, HashAlgorithmType right) =>
+            !(left == right);
+
+        /// <summary>
+        /// Creates a <see cref="HashAlgorithmType"/> which refers to <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="objectToInferType">An optional object to make the compiler infers the
+        /// type parameter <typeparamref name="T"/> from this.</param>
+        /// <typeparam name="T">A subclass of <see cref="HashAlgorithm"/>.</typeparam>
+        /// <returns>A <see cref="HashAlgorithmType"/> which refers to <typeparamref name="T"/>.
+        /// </returns>
+        [Pure]
+        public static HashAlgorithmType Of<T>(T? objectToInferType = null)
+            where T : HashAlgorithm =>
+            Of(typeof(T));
+
+        /// <summary>
+        /// Computes a hash digest of the hash algorithm from the given
+        /// <paramref name="input"/> bytes.
+        /// </summary>
+        /// <param name="input">The bytes to compute its hash.</param>
+        /// <returns>The hash digest derived from <paramref name="input"/>.</returns>
+        [Pure]
+        public byte[] Digest(byte[] input) =>
+            _instance.ComputeHash(input);
+
+        /// <summary>
+        /// Computes a hash digest of the hash algorithm from the given
+        /// <paramref name="input"/> bytes.
+        /// </summary>
+        /// <param name="input">The bytes to compute its hash.</param>
+        /// <returns>The hash digest derived from <paramref name="input"/>.</returns>
+        [Pure]
+        public ImmutableArray<byte> Digest(ImmutableArray<byte> input) =>
+            Digest(input.ToBuilder().ToArray()).ToImmutableArray();
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        [Pure]
+        public bool Equals(HashAlgorithmType? other) =>
+            other is { } o && Type == o.Type;
+
+        /// <inheritdoc cref="object.Equals(object)"/>
+        [Pure]
+        public override bool Equals(object? obj) =>
+            obj is IEquatable<HashAlgorithmType> e && e.Equals(this);
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        [Pure]
+        public override int GetHashCode() =>
+            Type.GetHashCode();
+
+        /// <inheritdoc cref="object.ToString()"/>
+        [Pure]
+        public override string ToString() =>
+            Type.FullName ?? "(Unknown)";
+
+        private static HashAlgorithmType Of(Type type)
+        {
+            if (!_internedObjects.TryGetValue(type, out HashAlgorithmType? v))
+            {
+                v = new HashAlgorithmType(type);
+            }
+
+            return v;
+        }
+    }
+}

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.Collections.Immutable;
-using System.Security.Cryptography;
 using System.Threading;
 using Libplanet.Blocks;
 
@@ -80,32 +79,5 @@ namespace Libplanet
 
             throw new OperationCanceledException(cancellationToken);
         }
-
-        /// <summary>
-        /// Finds a <see cref="Nonce"/> that satisfies the given
-        /// <paramref name="difficulty"/>.  This process is so-called
-        /// &#x0201c;<a
-        /// href="https://en.wikipedia.org/wiki/Cryptocurrency#Mining"
-        /// >mining</a>&#x0201d;.
-        /// </summary>
-        /// <param name="stamp">A callback to get a &#x0201c;stamp&#x0201d;
-        /// which is a <see cref="byte"/> array determined from a given
-        /// <see cref="Nonce"/> value.</param>
-        /// <param name="difficulty">A number to calculate the target number
-        /// for which the returned answer should be less than.</param>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.
-        /// </param>
-        /// <returns>A <see cref="Nonce"/> value which satisfies the given
-        /// <paramref name="difficulty"/>.</returns>
-        /// <seealso cref="Stamp"/>
-        [Obsolete]
-        public static Nonce Answer(
-            Stamp stamp,
-            long difficulty,
-            CancellationToken cancellationToken = default
-        ) =>
-            Answer(stamp, HashAlgorithmType.Of<SHA256>(), difficulty, cancellationToken).Nonce;
     }
 }

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
-using Libplanet.Blocks;
 
 namespace Libplanet
 {
@@ -69,11 +68,10 @@ namespace Libplanet
                 random.NextBytes(nonceBytes);
                 var nonce = new Nonce(nonceBytes);
 
-                // FIXME: .Satisfies() method should be moved to other class.
-                var digest = new BlockHash(hashAlgorithmType.Digest(stamp(nonce)));
-                if (digest.Satisfies(difficulty))
+                var digest = hashAlgorithmType.Digest(stamp(nonce));
+                if (ByteUtil.Satisfies(digest, difficulty))
                 {
-                    return (nonce, digest.ByteArray);
+                    return (nonce, ImmutableArray.Create(digest));
                 }
             }
 

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -107,16 +107,5 @@ namespace Libplanet
             CancellationToken cancellationToken = default
         ) =>
             Answer(stamp, HashAlgorithmType.Of<SHA256>(), difficulty, cancellationToken).Nonce;
-
-        /// <summary>
-        /// Calculates a SHA-256 digest from the given <paramref name="bytes"/>.
-        /// </summary>
-        /// <param name="bytes">A <see cref="byte"/> array to calculate
-        /// its hash digest.</param>
-        /// <returns>A deterministic digest of the given
-        /// <paramref name="bytes"/>.</returns>
-        [Obsolete]
-        public static BlockHash Hash(byte[] bytes) =>
-            BlockHash.FromHashDigest(HashDigest<SHA256>.DeriveFrom(bytes));
     }
 }

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Threading;
 using Libplanet.Blocks;
@@ -23,15 +24,62 @@ namespace Libplanet
         /// >proof-of-work system</a>, the total time an implementation elapses
         /// should not vary for different <paramref name="nonce"/>s.</para>
         /// </summary>
-        /// <param name="nonce">An arbitrary nonce for an attempt, provided
-        /// by <see cref="Hashcash.Answer(Stamp, long, CancellationToken)"/> method.</param>
+        /// <param name="nonce">An arbitrary nonce for an attempt, provided by
+        /// <see cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, CancellationToken)"/> method.
+        /// </param>
         /// <returns>A <see cref="byte"/> array determined from the given
         /// <paramref name="nonce"/>.  It should return consistently
         /// an equivalent array for equivalent <paramref name="nonce"/>
         /// values.</returns>
-        /// <seealso cref="Hashcash.Answer(Stamp, long, CancellationToken)"/>
+        /// <seealso cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, CancellationToken)"/>
         /// <seealso cref="Nonce"/>
         public delegate byte[] Stamp(Nonce nonce);
+
+        /// <summary>
+        /// Finds a <see cref="Nonce"/> that satisfies the given
+        /// <paramref name="difficulty"/>.  This process is so-called
+        /// &#x0201c;<a
+        /// href="https://en.wikipedia.org/wiki/Cryptocurrency#Mining"
+        /// >mining</a>&#x0201d;.
+        /// </summary>
+        /// <param name="stamp">A callback to get a &#x0201c;stamp&#x0201d;
+        /// which is a <see cref="byte"/> array determined from a given
+        /// <see cref="Nonce"/> value.</param>
+        /// <param name="hashAlgorithmType">The hash algorithm to use.</param>
+        /// <param name="difficulty">A number to calculate the target number
+        /// for which the returned answer should be less than.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.
+        /// </param>
+        /// <returns>A pair of <see cref="Nonce"/> value which satisfies the
+        /// given <paramref name="difficulty"/>, and the succeeded hash
+        /// digest.</returns>
+        /// <seealso cref="Stamp"/>
+        public static (Nonce Nonce, ImmutableArray<byte> Digest) Answer(
+            Stamp stamp,
+            HashAlgorithmType hashAlgorithmType,
+            long difficulty,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var nonceBytes = new byte[10];
+            var random = new Random();
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                random.NextBytes(nonceBytes);
+                var nonce = new Nonce(nonceBytes);
+
+                // FIXME: .Satisfies() method should be moved to other class.
+                var digest = new BlockHash(hashAlgorithmType.Digest(stamp(nonce)));
+                if (digest.Satisfies(difficulty))
+                {
+                    return (nonce, digest.ByteArray);
+                }
+            }
+
+            throw new OperationCanceledException(cancellationToken);
+        }
 
         /// <summary>
         /// Finds a <see cref="Nonce"/> that satisfies the given
@@ -52,27 +100,13 @@ namespace Libplanet
         /// <returns>A <see cref="Nonce"/> value which satisfies the given
         /// <paramref name="difficulty"/>.</returns>
         /// <seealso cref="Stamp"/>
+        [Obsolete]
         public static Nonce Answer(
             Stamp stamp,
             long difficulty,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var nonceBytes = new byte[10];
-            var random = new Random();
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                random.NextBytes(nonceBytes);
-                var nonce = new Nonce(nonceBytes);
-                var digest = Hash(stamp(nonce));
-
-                if (digest.Satisfies(difficulty))
-                {
-                    return nonce;
-                }
-            }
-
-            throw new OperationCanceledException(cancellationToken);
-        }
+            CancellationToken cancellationToken = default
+        ) =>
+            Answer(stamp, HashAlgorithmType.Of<SHA256>(), difficulty, cancellationToken).Nonce;
 
         /// <summary>
         /// Calculates a SHA-256 digest from the given <paramref name="bytes"/>.
@@ -81,6 +115,7 @@ namespace Libplanet
         /// its hash digest.</param>
         /// <returns>A deterministic digest of the given
         /// <paramref name="bytes"/>.</returns>
+        [Obsolete]
         public static BlockHash Hash(byte[] bytes) =>
             BlockHash.FromHashDigest(HashDigest<SHA256>.DeriveFrom(bytes));
     }

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain.Policies;
@@ -134,9 +135,10 @@ namespace Libplanet.Net
                 ByteUtil.Hex(header.Hash)
             );
 
+            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             try
             {
-                header.Validate(DateTimeOffset.UtcNow);
+                header.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
             }
             catch (InvalidBlockException ibe)
             {

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain.Policies;
@@ -135,7 +134,7 @@ namespace Libplanet.Net
                 ByteUtil.Hex(header.Hash)
             );
 
-            HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+            HashAlgorithmType hashAlgorithm = BlockChain.Policy.GetHashAlgorithm(header.Index);
             try
             {
                 header.Validate(hashAlgorithm, DateTimeOffset.UtcNow);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
@@ -692,7 +693,8 @@ namespace Libplanet.Net
                         block.Index,
                         block.Hash
                     );
-                    block.Validate(DateTimeOffset.UtcNow);
+                    HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+                    block.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
                     wStore.PutBlock(block);
                     if (tempTip is null || block.Index > tempTip.Index)
                     {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
@@ -693,7 +692,8 @@ namespace Libplanet.Net
                         block.Index,
                         block.Hash
                     );
-                    HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+                    HashAlgorithmType hashAlgorithm =
+                        workspace.Policy.GetHashAlgorithm(block.Index);
                     block.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
                     wStore.PutBlock(block);
                     if (tempTip is null || block.Index > tempTip.Index)

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -79,9 +79,9 @@ namespace Libplanet.Store
                 BlockHash? prevHash = blockDigest.Header.PreviousHash.Any()
                     ? new BlockHash(blockDigest.Header.PreviousHash)
                     : (BlockHash?)null;
-                BlockHash? preEvaluationHash = blockDigest.Header.PreEvaluationHash.Any()
-                    ? new BlockHash(blockDigest.Header.PreEvaluationHash)
-                    : (BlockHash?)null;
+                ImmutableArray<byte>? preEvaluationHash = blockDigest.Header.PreEvaluationHash.Any()
+                    ? blockDigest.Header.PreEvaluationHash
+                    : (ImmutableArray<byte>?)null;
                 HashDigest<SHA256>? stateRootHash = blockDigest.Header.StateRootHash.Any()
                     ? new HashDigest<SHA256>(blockDigest.Header.StateRootHash)
                     : (HashDigest<SHA256>?)null;

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using LruCacheNet;
@@ -62,7 +63,8 @@ namespace Libplanet.Store
                         $"{value}.hash does not match to {key}");
                 }
 
-                value.Validate(DateTimeOffset.UtcNow);
+                HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+                value.Validate(hashAlgorithm, DateTimeOffset.UtcNow);
                 Store.PutBlock(value);
                 _cache.AddOrUpdate(value.Hash, value);
             }

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -448,7 +448,9 @@ namespace Libplanet.Store.Trie
         {
             if (_secure)
             {
+#pragma warning disable CS0612
                 key = Hashcash.Hash(key).ToByteArray();
+#pragma warning restore CS0612
             }
 
             var res = new byte[key.Length * 2];

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Store.Trie
         /// <see cref="MerkleTrie"/>.</param>
         /// <param name="secure">Whether to use <see cref="MerkleTrie"/> in
         /// secure mode.  If it is turned on, <see cref="MerkleTrie"/> internally stores hashed keys
-        /// instead of bare keys.  <see cref="Hashcash.Hash" /> is used to hash them.</param>
+        /// instead of bare keys.  Keys will be hashed with SHA-256.</param>
         public MerkleTrie(
             IKeyValueStore keyValueStore,
             HashDigest<SHA256> rootHash,
@@ -58,8 +58,7 @@ namespace Libplanet.Store.Trie
         /// it will be treated like empty trie.</param>
         /// <param name="secure">Whether to use <see cref="MerkleTrie"/> in secure
         /// mode. If it is true, <see cref="MerkleTrie"/> will stores the value with the hashed
-        /// result from the given key as the key. It will hash with
-        /// <see cref="Hashcash.Hash"/>.</param>
+        /// result from the given key as the key. Keys will be hashed with SHA-256.</param>
         internal MerkleTrie(IKeyValueStore keyValueStore, INode? root = null, bool secure = false)
         {
             KeyValueStore = keyValueStore;
@@ -448,9 +447,8 @@ namespace Libplanet.Store.Trie
         {
             if (_secure)
             {
-#pragma warning disable CS0612
-                key = Hashcash.Hash(key).ToByteArray();
-#pragma warning restore CS0612
+                SHA256 hasher = SHA256.Create();
+                key = hasher.ComputeHash(key);
             }
 
             var res = new byte[key.Length * 2];


### PR DESCRIPTION
This patch enables blockchain to consist of blocks with heterogeneous hash algorithms.  Few points:

- `IBlockPolicy<T>.GetHashAlgorithm(long blockIndex)` determines a hash algorithm for a block at `blockIndex`.
    - Blocks are not aware of which algorithm is used for hashing themselves.
- `BlockPolicy<T>()` constructor takes an optional `hashAlgorithmGetter` which configures the above method.  If omitted SHA-256 is used for every block in the chain.
    - `HashAlgorithmTable.ToHashAlgoirthmGetter()` extension method can be useful to describe a simple rule to determine hash algorithms by block indices.  E.g., `new Dictionary<long, HashAlgorithmType> { [0] = HashAlgorithmType.Of<SHA256>(), [1000] = HashAlgorithmType.Of<SHA512>() }.ToHashAlgorithmGetter()` is equivalent to `(idx) => idx >= 1000 ? HashAlgorithmType.Of<SHA512>() : HashAlgorithmType.Of<SHA256>()`.
- `HashAlgorithmType` is a type for comparing hash algorithms.
    - It can be instantiated using `Of<T>()` method, like `HashAlgorithmType.Of<SHA256>()`.
    - It implements equality methods and operators.  E.g., `HashAlgorithmType.Of<SHA256>() != HashAlgorithmType.Of<SHA1>()`, `HashAlgorithmType.Of<SHA256>().Equals(HashAlgorithmType.Of<SHA256>())`.  Also can be elements of `ISet<T>`/`IImmutableSet<T>` or keys of `IDictionary<TKey, TValue>`/`IImmutableDictionary<TKey, TValue>`.
- As proof-of-work does not directly determine `Block<T>.Hash`, but `Block<T>.PreEvaluationHash`, `BlockHash` became fixed-size (32 bytes).
- As various hash algorithms can be used for proof-of-work, `Block<T>.PreEvaluationHash` became represented as variable-length `ImmutableArray<byte>` (instead of `BlockHash`, which was misleading).