### PR TITLE
Fix memory leakage in relayed clients

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,12 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed memory leak due to undisposed TCP relay clients.  [[#1236]]
+
 ### CLI tools
+
+[#1236]: https://github.com/planetarium/libplanet/pull/1236
+
 
 Version 0.12.0
 --------------

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -126,7 +126,7 @@ namespace Libplanet.Stun
 
         public async Task<IPEndPoint> AllocateRequestAsync(
             TimeSpan lifetime,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             StunMessage response;
@@ -159,7 +159,7 @@ namespace Libplanet.Stun
 
         public async Task CreatePermissionAsync(
             IPEndPoint peerAddress,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new CreatePermissionRequest(peerAddress);
@@ -176,8 +176,8 @@ namespace Libplanet.Stun
             }
         }
 
-        public async Task<NetworkStream> AcceptRelayedStreamAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<(TcpClient, NetworkStream)> AcceptRelayedStreamAsync(
+            CancellationToken cancellationToken = default)
         {
             while (true)
             {
@@ -214,7 +214,7 @@ namespace Libplanet.Stun
         }
 
         public async Task<IPEndPoint> GetMappedAddressAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new BindingRequest();
@@ -236,7 +236,7 @@ namespace Libplanet.Stun
 
         public async Task<TimeSpan> RefreshAllocationAsync(
             TimeSpan lifetime,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             NetworkStream stream = _control.GetStream();
             var request = new RefreshRequest((int)lifetime.TotalSeconds);
@@ -261,15 +261,13 @@ namespace Libplanet.Stun
             throw new TurnClientException("RefreshRequest failed.", response);
         }
 
-        public async Task<bool> IsBehindNAT(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<bool> IsBehindNAT(CancellationToken cancellationToken = default)
         {
             IPEndPoint mapped = await GetMappedAddressAsync(cancellationToken);
             return !_control.Client.LocalEndPoint.Equals(mapped);
         }
 
-        public async Task<bool> IsConnectable(
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<bool> IsConnectable(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -299,9 +297,7 @@ namespace Libplanet.Stun
             _logger.Debug($"{nameof(TurnClient)} is disposed.");
         }
 
-        public async Task BindProxies(
-            int listenPort,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task BindProxies(int listenPort, CancellationToken cancellationToken = default)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -333,7 +329,7 @@ namespace Libplanet.Stun
         private List<Task> BindMultipleProxies(
             int listenPort,
             int count,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return Enumerable.Range(1, count)
                 .Select(x => BindProxies(listenPort, cancellationToken))


### PR DESCRIPTION
This patch fixes memory leakage caused by not freeing disposed TCP clients in TurnClient.