### PR TITLE
Maintain static peers in `Swarm<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -216,9 +216,8 @@ To be released.
  -  Added `BoundPeer.Parse()` static method.  [[#1240]]
  -  Added `TransportException` class.  [[#1242]]
  -  Added `SwarmOptions.StaticPeers` property.  [[#1230], [#1271]]
+ -  Added `SwarmOptions.StaticPeersMaintainPeriod` property.  [[#1230], [#1367]]
  -  Added `SwarmOptions.BranchpointThreshold` property.  [[#1348]]
- -  Added `StaticPeers` as the last parameter to
-    `RoutingTable(Address, int, int)` constructor.  [[#1230], [#1271]]
  -  Added `AtomicActionRenderer<T>` class.  [[#1267], [#1275]]
  -  Added `TxExecution` abstract class.  [[#1156], [#1289]]
  -  Added `TxSuccess` class.  [[#1156], [#1289]]
@@ -241,9 +240,6 @@ To be released.
     for this case).  [[#1156], [#1289]]
  -  `ITransport.StartAsync()` and `ITransport.RunAsync()` became to throw
     `TransportException` instead of `SwarmException`.  [[#1242]]
- -  When selecting peers for `ITransport.BroadcastMessage()`,
-    peers are selected from static peers in addition to peers selected
-    according to existing selection methods.  [[#1230], [#1271]]
  -  `NetMQTransport` became to enforce NetMQ/[AsyncIO] to use its pure .NET
     implementation instead of Windows'
     <abbr title="input/output completion port">IOCP</abbr> when it is running
@@ -262,6 +258,8 @@ To be released.
     if `OutOfMemoryException` is caught from `IAction.Execute()`.
     [[#1320], [#1343]]
  -  Improved performance of broadcasting using `Swarm<T>`.  [[#1334]]
+ -  `Swarm<T>` now maintains static peers provided via
+    `SwarmOptions.StaticPeers` periodically.  [[#1230], [#1367]]
  -  `Block<T>.Header` is now cached instead of creating a new instance every
     call. [[#1347]]
  -  `BlockChain<T>.ExecuteActions()` became no longer throw
@@ -377,6 +375,7 @@ To be released.
 [#1352]: https://github.com/planetarium/libplanet/pull/1352
 [#1353]: https://github.com/planetarium/libplanet/pull/1353
 [#1360]: https://github.com/planetarium/libplanet/pull/1360
+[#1367]: https://github.com/planetarium/libplanet/pull/1367
 [#1368]: https://github.com/planetarium/libplanet/pull/1368
 [#1379]: https://github.com/planetarium/libplanet/pull/1379
 [#1389]: https://github.com/planetarium/libplanet/pull/1389

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -64,10 +64,17 @@ namespace Libplanet.Net
 
         /// <summary>
         /// The list of <see cref="Peer"/>s to keep in routing table permanently.
-        /// The <see cref="Peer"/>s in the list won't be removed in any cases.
+        /// The <see cref="Peer"/>s in the list will be maintained periodically within
+        /// <see cref="StaticPeersMaintainPeriod"/>.
         /// </summary>
         public IImmutableSet<BoundPeer> StaticPeers { get; set; } =
             ImmutableHashSet<BoundPeer>.Empty;
+
+        /// <summary>
+        /// The period of <c>Task</c> maintains static peer.
+        /// </summary>
+        /// <seealso cref="StaticPeers"/>
+        public TimeSpan StaticPeersMaintainPeriod { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The threshold for detecting branchpoint when block synchronization.


### PR DESCRIPTION
This patch addresses issue #1230 continue to #1271.

#1271 caused network overload to the single static peer because it selected at least one peer from the static peers when broadcasting messages. In this patch, revert changes in the routing table. Now static peers are dealt same with normal peers. Instead a task named `MaintainStaticPeersAsync()` in `Swarm<T>` checks whether the peer is existing in the table periodically, if not, send a message to add the peer to the table.