### PR TITLE
Catch `ArgumentOutOfRangeException` & return `null` instead during block sync

### DIFF
--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1222,6 +1222,7 @@ namespace Libplanet.Net
                         locator = new BlockLocator(
                             idx =>
                             {
+                                long arg = idx;
                                 if (idx < 0)
                                 {
                                     idx = currentTipIndex + downloaded.Count + 1 + idx;
@@ -1233,7 +1234,20 @@ namespace Libplanet.Net
                                 }
 
                                 int relIdx = (int)(idx - currentTipIndex - 1);
-                                return downloaded[relIdx];
+
+                                try
+                                {
+                                    return downloaded[relIdx];
+                                }
+                                catch (ArgumentOutOfRangeException e)
+                                {
+                                    const string msg =
+                                        "Failed to look up a block hash by its index {Index} " +
+                                        "(current tip index: {CurrentTipIndex}; " +
+                                        "downloaded: {Downloaded}).";
+                                    _logger.Error(e, msg, arg, currentTipIndex, downloaded.Count);
+                                    return null;
+                                }
                             },
                             hash => blockChain.Store.GetBlock<T>(hash) is Block<T> b
                                 ? b.Index


### PR DESCRIPTION
As `BlockLocator()` constructor already is ready for `indexBlockHash()` callback returning `null` (but is not ready for it throwing exceptions), make it to catch unexpected `ArgumentOutOfRangeException` and return `null` instead of throwing exceptions.

On the other hand, to investigate enough when such exception is thrown, I left a log with local variable values too.

Closes <https://github.com/planetarium/libplanet/issues/1346>.