### PR TITLE
feat: introduce factory method to create unsigned tx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -191,6 +191,7 @@ To be released.
  -  Added `Address(Binary)` overloaded constructor.  [[#1289]]
  -  Added `Currency(IValue)` overloaded constructor.  [[#1289]]
  -  Added `Currency.Serialize()` method.  [[#1289]]
+ -  Added `Transaction<T>.CreateUnsigned()` method.  [[#1378]]
 
 ### Behavioral changes
 
@@ -214,6 +215,8 @@ To be released.
  -  (Libplanet.RocksDBStore) `RocksDBStore.ForkBlockIndexes()` became to share
     common ancestors between forks rather than duplicating them so that much
     less space is used.  [[#1280], [#1287]]
+ -  `Transaction<T>.Validate()` became to throw `InvalidTxSignatureException`
+    if the transaction was not signed.  [[#1378]]
 
 ### Bug fixes
 
@@ -297,6 +300,7 @@ To be released.
 [#1343]: https://github.com/planetarium/libplanet/pull/1343
 [#1348]: https://github.com/planetarium/libplanet/pull/1348
 [#1351]: https://github.com/planetarium/libplanet/pull/1351
+[#1378]: https://github.com/planetarium/libplanet/pull/1378
 
 
 Version 0.11.1

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -766,6 +766,18 @@ namespace Libplanet.Tests.Tx
         }
 
         [Fact]
+        public void DetectUnsignedTransaction()
+        {
+            Transaction<DumbAction> tx = Transaction<DumbAction>.CreateUnsigned(
+                0,
+                _fx.PublicKey1,
+                null,
+                new DumbAction[0]);
+
+            Assert.Throws<InvalidTxSignatureException>(() => tx.Validate());
+        }
+
+        [Fact]
         public void DetectBadSignature()
         {
             var rawTx = _fx.Tx.ToRawTransaction(true);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -98,6 +98,22 @@ namespace Libplanet.Tests.Tx
         }
 
         [Fact]
+        public void CreateUnsigned()
+        {
+            var tx =
+                Transaction<PolymorphicAction<BaseAction>>.CreateUnsigned(
+                    0,
+                    _fx.PublicKey1,
+                    null,
+                    _fx.TxWithActions.Actions);
+            Assert.Empty(tx.Signature);
+            Assert.Equal(
+                new[] { _fx.Address1 }.ToImmutableHashSet(),
+                tx.UpdatedAddresses
+            );
+        }
+
+        [Fact]
         public void CreateWithDefaultUpdatedAddresses()
         {
             Transaction<DumbAction> emptyTx = Transaction<DumbAction>.Create(

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -769,7 +769,7 @@ namespace Libplanet.Tx
         /// <see cref="Transaction{T}.PublicKey"/>.</exception>
         public void Validate()
         {
-            if (!PublicKey.Verify(Serialize(false), Signature))
+            if (Signature.Length == 0 || !PublicKey.Verify(Serialize(false), Signature))
             {
                 string message =
                     $"The signature ({ByteUtil.Hex(Signature)}) is failed " +


### PR DESCRIPTION
This pull request introduces `Transaction.CreateUnsigned()` factory method to create *unsigned transaction* easily.