### PR TITLE
Fixed a typo in transaction.cs on line 399

### DIFF
--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -396,7 +396,7 @@ namespace Libplanet.Tx
         /// the given <paramref name="privateKey"/>.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <c>null</c>
         /// is passed to <paramref name="privateKey"/> or
-        /// or <paramref name="actions"/>.
+        /// <paramref name="actions"/>.
         /// </exception>
         public static Transaction<T> Create(
             long nonce,


### PR DESCRIPTION
Fixed a  typo in line 399 of transaction.cs. 
Closes #1376

![image](https://user-images.githubusercontent.com/67814205/126039829-f5105d48-add0-4303-b372-bcd2ad9d60b5.png)
