### PR TITLE
Configurable bucket size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ To be released.
 ### Added APIs
 
  -  Added `Transaction<T>.CreateUnsigned()` method.  [[#1378]]
+ -  Added `SwarmOptions.TableSize` property.  [[#1401]]
+ -  Added `SwarmOptions.BucketSize` property.  [[#1401]]
 
 ### Behavioral changes
 
@@ -36,6 +38,7 @@ To be released.
 [#1365]: https://github.com/planetarium/libplanet/pull/1365
 [#1378]: https://github.com/planetarium/libplanet/pull/1378
 [#1391]: https://github.com/planetarium/libplanet/pull/1391
+[#1401]: https://github.com/planetarium/libplanet/pull/1401
 
 
 Version 0.12.0

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -9,7 +9,6 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
-using Libplanet.Net.Protocols;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
@@ -70,11 +69,8 @@ namespace Libplanet.Tests.Net
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
             AppProtocolVersion? appProtocolVersion = null,
-            int tableSize = Kademlia.TableSize,
-            int bucketSize = Kademlia.BucketSize,
             string host = null,
             int? listenPort = null,
-            DateTimeOffset? createdAt = null,
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
@@ -87,11 +83,8 @@ namespace Libplanet.Tests.Net
                 blockchain,
                 privateKey,
                 appProtocolVersion,
-                tableSize,
-                bucketSize,
                 host,
                 listenPort,
-                createdAt,
                 iceServers,
                 differentAppProtocolVersionEncountered,
                 trustedAppProtocolVersionSigners,
@@ -102,11 +95,8 @@ namespace Libplanet.Tests.Net
             BlockChain<T> blockChain,
             PrivateKey privateKey = null,
             AppProtocolVersion? appProtocolVersion = null,
-            int tableSize = Kademlia.TableSize,
-            int bucketSize = Kademlia.BucketSize,
             string host = null,
             int? listenPort = null,
-            DateTimeOffset? createdAt = null,
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
@@ -123,12 +113,9 @@ namespace Libplanet.Tests.Net
                 blockChain,
                 privateKey ?? new PrivateKey(),
                 appProtocolVersion ?? DefaultAppProtocolVersion,
-                tableSize,
-                bucketSize,
                 5,
                 host,
                 listenPort,
-                createdAt,
                 iceServers,
                 differentAppProtocolVersionEncountered,
                 trustedAppProtocolVersionSigners,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -79,37 +79,6 @@ namespace Libplanet.Net
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
             SwarmOptions options = null)
-            : this(
-                blockChain,
-                privateKey,
-                appProtocolVersion,
-                Kademlia.TableSize,
-                Kademlia.BucketSize,
-                workers,
-                host,
-                listenPort,
-                null,
-                iceServers,
-                differentAppProtocolVersionEncountered,
-                trustedAppProtocolVersionSigners,
-                options)
-        {
-        }
-
-        internal Swarm(
-            BlockChain<T> blockChain,
-            PrivateKey privateKey,
-            AppProtocolVersion appProtocolVersion,
-            int tableSize,
-            int bucketSize,
-            int workers = 5,
-            string host = null,
-            int? listenPort = null,
-            DateTimeOffset? createdAt = null,
-            IEnumerable<IceServer> iceServers = null,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
-            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
-            SwarmOptions options = null)
         {
             BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
             _store = BlockChain.Store;
@@ -117,8 +86,6 @@ namespace Libplanet.Net
             LastSeenTimestamps =
                 new ConcurrentDictionary<Peer, DateTimeOffset>();
 
-            DateTimeOffset now = createdAt.GetValueOrDefault(
-                DateTimeOffset.UtcNow);
             TxReceived = new AsyncAutoResetEvent();
             BlockHeaderReceived = new AsyncAutoResetEvent();
             BlockAppended = new AsyncAutoResetEvent();
@@ -136,7 +103,7 @@ namespace Libplanet.Net
                 .ForContext("SwarmId", loggerId);
 
             Options = options ?? new SwarmOptions();
-            RoutingTable = new RoutingTable(Address, tableSize, bucketSize);
+            RoutingTable = new RoutingTable(Address, Options.TableSize, Options.BucketSize);
             Transport = new NetMQTransport(
                 RoutingTable,
                 _privateKey,

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -88,5 +88,17 @@ namespace Libplanet.Net
         /// It is 10 by default.
         /// </summary>
         public int MinimumBroadcastTarget { get; set; } = 10;
+
+        /// <summary>
+        /// The number of buckets of the Kademlia based routing table.
+        /// </summary>
+        /// <seealso cref="RoutingTable"/>
+        public int TableSize { get; set; } = Kademlia.TableSize;
+
+        /// <summary>
+        /// The size of each bucket of the Kademlia based routing table.
+        /// </summary>
+        /// <seealso cref="RoutingTable"/>
+        public int BucketSize { get; set; } = Kademlia.BucketSize;
     }
 }


### PR DESCRIPTION
This PR allows `SwarmOptions` to control `TableSize` and `BucketSize` of the `RoutingTable`.