### PR TITLE
Non-blocking renderers

### DIFF
--- a/.azure-pipelines/dotnet-core.yml
+++ b/.azure-pipelines/dotnet-core.yml
@@ -4,6 +4,7 @@ parameters:
   locale: "en_US.UTF8"
   testTimeoutInMinutes: 16
   useDotnetTest: false
+  continueOnTestError: false
 
 steps:
 
@@ -70,6 +71,7 @@ steps:
       LANGUAGE: ${{ parameters.locale }}
       LC_ALL: ${{ parameters.locale }}
     timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+    continueOnError: ${{ parameters.continueOnTestError }}
   - task: PublishTestResults@2
     inputs:
       testRunner: XUnit
@@ -91,6 +93,7 @@ steps:
       LANGUAGE: ${{ parameters.locale }}
       LC_ALL: ${{ parameters.locale }}
     timeoutInMinutes: ${{ parameters.testTimeoutInMinutes }}
+    continueOnError: ${{ parameters.continueOnTestError }}
   - task: PublishTestResults@2
     inputs:
       testRunner: VSTest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ To be released.
 ### Added APIs
 
  -  Added `NonblockRenderer<T>` class.  [[#1402], [#1422]]
+ -  Added `NonblockActionRenderer<T>` class.  [[#1402], [#1422]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,11 +14,16 @@ To be released.
 
 ### Added APIs
 
+ -  Added `NonblockRenderer<T>` class.  [[#1402], [#1422]]
+
 ### Behavioral changes
 
 ### Bug fixes
 
 ### CLI tools
+
+[#1402]: https://github.com/planetarium/libplanet/issues/1402
+[#1422]: https://github.com/planetarium/libplanet/pull/1422
 
 
 Version 0.13.1

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using Libplanet.Action;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using xRetry;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class NonblockActionRendererTest
+    {
+        private static IAction _action = new DumbAction();
+
+        private static IAccountStateDelta _stateDelta =
+            new AccountStateDeltaImpl(_ => null, (_, __) => default, default);
+
+        private static IActionContext _actionContext =
+            new ActionContext(default, default, default, 1, _stateDelta, default);
+
+        private static Exception _exception = new Exception("EXPECTED");
+        private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
+        private static Block<DumbAction> _genesis =
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithm, default(Address));
+
+        private static Block<DumbAction> _blockA =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
+
+        private static Block<DumbAction> _blockB =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
+
+        [RetryFact]
+        public void Test()
+        {
+            const int sleepSeconds = 1;
+            var log = new List<string>();
+            var innerRenderer = new AnonymousActionRenderer<DumbAction>()
+            {
+                BlockRenderer = (Block<DumbAction> oldTip, Block<DumbAction> newTip) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"Block({oldTip.Index}, {newTip.Index})");
+                },
+                BlockEndRenderer = (Block<DumbAction> oldTip, Block<DumbAction> newTip) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"BlockEnd({oldTip.Index}, {newTip.Index})");
+                },
+                ReorgRenderer = (
+                    Block<DumbAction> oldTip,
+                    Block<DumbAction> newTip,
+                    Block<DumbAction> branchpoint
+                ) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"Reorg({oldTip.Index}, {newTip.Index}, {branchpoint.Index})");
+                },
+                ReorgEndRenderer = (
+                    Block<DumbAction> oldTip,
+                    Block<DumbAction> newTip,
+                    Block<DumbAction> branchpoint
+                ) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"ReorgEnd({oldTip.Index}, {newTip.Index}, {branchpoint.Index})");
+                },
+                ActionRenderer = (IAction act, IActionContext ctx, IAccountStateDelta delta) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"Action({act.GetType().Name}, {ctx.BlockIndex})");
+                },
+                ActionErrorRenderer = (IAction act, IActionContext ctx, Exception e) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"ActionError({act.GetType().Name}, {ctx.BlockIndex}, {e.Message})");
+                },
+                ActionUnrenderer = (IAction act, IActionContext ctx, IAccountStateDelta delta) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"~Action({act.GetType().Name}, {ctx.BlockIndex})");
+                },
+                ActionErrorUnrenderer = (IAction act, IActionContext ctx, Exception e) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"~ActionError({act.GetType().Name}, {ctx.BlockIndex}, {e.Message})");
+                },
+            };
+            using (var renderer = new NonblockActionRenderer<DumbAction>(
+                innerRenderer, 8, NonblockActionRenderer<DumbAction>.FullMode.DropNewest))
+            {
+                DateTimeOffset start = DateTimeOffset.UtcNow;
+                renderer.RenderReorg(_blockA, _blockB, _genesis);
+                Assert.Empty(log);
+                renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+                Assert.Empty(log);
+                renderer.UnrenderActionError(_action, _actionContext, _exception);
+                Assert.Empty(log);
+                renderer.RenderBlock(_blockA, _blockB);
+                renderer.RenderActionError(_action, _actionContext, _exception);
+                renderer.RenderAction(_action, _actionContext, _stateDelta);
+                renderer.RenderBlockEnd(_blockA, _blockB);
+                renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
+                DateTimeOffset end = DateTimeOffset.UtcNow;
+                TimeSpan elapsed = end - start;
+                Assert.True(
+                    elapsed < TimeSpan.FromSeconds(3 * sleepSeconds),
+                    $"Elapsed more than {3 * sleepSeconds} seconds ({elapsed}); seems blocking."
+                );
+            }
+
+            Assert.Equal(
+                new[]
+                {
+                    "Reorg(1, 1, 0)",
+                    "~Action(DumbAction, 1)",
+                    "~ActionError(DumbAction, 1, EXPECTED)",
+                    "Block(1, 1)",
+                    "ActionError(DumbAction, 1, EXPECTED)",
+                    "Action(DumbAction, 1)",
+                    "BlockEnd(1, 1)",
+                    "ReorgEnd(1, 1, 0)",
+                },
+                log
+            );
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using xRetry;
+using Xunit;
+
+namespace Libplanet.Tests.Blockchain.Renderers
+{
+    public class NonblockRendererTest
+    {
+        private static HashAlgorithmType _hashAlgorithm = HashAlgorithmType.Of<SHA256>();
+
+        private static Block<DumbAction> _genesis =
+            TestUtils.MineGenesis<DumbAction>(_ => _hashAlgorithm, default(Address));
+
+        private static Block<DumbAction> _blockA =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
+
+        private static Block<DumbAction> _blockB =
+            TestUtils.MineNext(_genesis, _ => _hashAlgorithm);
+
+        [RetryFact]
+        public void Test()
+        {
+            const int sleepSeconds = 1;
+            var log = new List<string>();
+            var innerRenderer = new AnonymousRenderer<DumbAction>()
+            {
+                BlockRenderer = (Block<DumbAction> oldTip, Block<DumbAction> newTip) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"Block({oldTip.Index}, {newTip.Index})");
+                },
+                ReorgRenderer = (
+                    Block<DumbAction> oldTip,
+                    Block<DumbAction> newTip,
+                    Block<DumbAction> branchpoint
+                ) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"Reorg({oldTip.Index}, {newTip.Index}, {branchpoint.Index})");
+                },
+                ReorgEndRenderer = (
+                    Block<DumbAction> oldTip,
+                    Block<DumbAction> newTip,
+                    Block<DumbAction> branchpoint
+                ) =>
+                {
+                    Thread.Sleep(sleepSeconds * 1000);
+                    log.Add($"ReorgEnd({oldTip.Index}, {newTip.Index}, {branchpoint.Index})");
+                },
+            };
+            using (var renderer = new NonblockRenderer<DumbAction>(
+                innerRenderer, 3, NonblockRenderer<DumbAction>.FullMode.DropNewest))
+            {
+                DateTimeOffset start = DateTimeOffset.UtcNow;
+                renderer.RenderReorg(_blockA, _blockB, _genesis);
+                Assert.Empty(log);
+                renderer.RenderBlock(_blockA, _blockB);
+                Assert.Empty(log);
+                renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
+                Assert.Empty(log);
+                DateTimeOffset end = DateTimeOffset.UtcNow;
+                TimeSpan elapsed = end - start;
+                Assert.True(
+                    elapsed < TimeSpan.FromSeconds(3 * sleepSeconds),
+                    $"Elapsed more than {3 * sleepSeconds} seconds ({elapsed}); seems blocking."
+                );
+            }
+
+            Assert.Equal(
+                new[]
+                {
+                    "Reorg(1, 1, 0)",
+                    "Block(1, 1)",
+                    "ReorgEnd(1, 1, 0)",
+                },
+                log
+            );
+        }
+    }
+}

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Blockchain.Renderers
         private long _reorgResistantHeight;
 
         /// <summary>
-        /// Creates a new <see cref="DelayedRenderer{T}"/> instance decorating the given
+        /// Creates a new <see cref="DelayedActionRenderer{T}"/> instance decorating the given
         /// <paramref name="renderer"/>.
         /// </summary>
         /// <param name="renderer">The renderer to decorate which has the <em>actual</em>

--- a/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
@@ -1,0 +1,121 @@
+using System;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+#nullable enable
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// Decorates a <see cref="IActionRenderer{T}"/> instance and lets all rendering events be
+    /// non-blocking.
+    /// <para>Every method call on the renderer will immediately return and the rendering
+    /// will be performed in a background thread.  Note that the order of render events is
+    /// still guaranteed.  In other words, a later event never arrives before events earlier
+    /// than it.</para>
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <example>
+    /// <code><![CDATA[
+    /// IActionRenderer<ExampleAction> actionRenderer = new SomeActionRenderer();
+    /// // Wraps the actionRenderer with NonblockActionRenderer; the SomeActionRenderer instance
+    /// // becomes to receive event messages in NonblockActionRenderer's backround thread:
+    /// actionRenderer = new NonblockActionRenderer<ExampleAction>(
+    ///    actionRenderer,
+    ///    queue: 1024,
+    ///    fullFallback: droppedEvent => ShowError("Too many rendering events in a short time."));
+    /// /// ...
+    /// // Should be disposed when no longer needed:
+    /// actionRenderer.Dispose();
+    /// ]]></code>
+    /// </example>
+    /// <remarks>As rendering events become performed in a background thread instead of the main
+    /// thread, some graphics/UI drawings might be disallowed.  In such case, communicate with the
+    /// main thread through <a
+    /// href="https://devblogs.microsoft.com/dotnet/an-introduction-to-system-threading-channels/"
+    /// >producer/consumer channels</a>.</remarks>
+    public class NonblockActionRenderer<T> : NonblockRenderer<T>, IActionRenderer<T>
+        where T : IAction, new()
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="NonblockActionRenderer{T}"/> decorating the given
+        /// <paramref name="renderer"/> instance.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives events in a background thread.</param>
+        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="fullMode">Specifies the behavior when the internal event queue is full so
+        /// that no more event can be added.</param>
+        public NonblockActionRenderer(IActionRenderer<T> renderer, int queue, FullMode fullMode)
+            : base(renderer, queue, fullMode)
+        {
+            ActionRenderer = renderer;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NonblockActionRenderer{T}"/> decorating the given
+        /// <paramref name="renderer"/> instance.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives events in a background thread.</param>
+        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="fullFallback">Specifies the custom behavior when the internal event
+        /// queue is full so that no more event can be added.</param>
+        public NonblockActionRenderer(
+            IActionRenderer<T> renderer,
+            int queue,
+            FullFallback fullFallback
+        )
+            : base(renderer, queue, fullFallback)
+        {
+            ActionRenderer = renderer;
+        }
+
+        /// <summary>
+        /// The inner action renderer which has the <em>actual</em> implementations and receives
+        /// events.
+        /// </summary>
+        public IActionRenderer<T> ActionRenderer { get; }
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void RenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            Queue(() => ActionRenderer.RenderAction(action, context, nextStates));
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        public void UnrenderAction(
+            IAction action,
+            IActionContext context,
+            IAccountStateDelta nextStates
+        ) =>
+            Queue(() => ActionRenderer.UnrenderAction(action, context, nextStates));
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        public void RenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        ) =>
+            Queue(() => ActionRenderer.RenderActionError(action, context, exception));
+
+        /// <inheritdoc
+        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+        public void UnrenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception
+        ) =>
+            Queue(() => ActionRenderer.UnrenderActionError(action, context, exception));
+
+        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block{T}, Block{T})"/>
+        public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip) =>
+            Queue(() => ActionRenderer.RenderBlockEnd(oldTip, newTip));
+    }
+}

--- a/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
@@ -44,11 +44,11 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
         /// implementations and receives events in a background thread.</param>
-        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="queueSize">The size of the internal event queue.</param>
         /// <param name="fullMode">Specifies the behavior when the internal event queue is full so
         /// that no more event can be added.</param>
-        public NonblockActionRenderer(IActionRenderer<T> renderer, int queue, FullMode fullMode)
-            : base(renderer, queue, fullMode)
+        public NonblockActionRenderer(IActionRenderer<T> renderer, int queueSize, FullMode fullMode)
+            : base(renderer, queueSize, fullMode)
         {
             ActionRenderer = renderer;
         }
@@ -59,15 +59,15 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
         /// implementations and receives events in a background thread.</param>
-        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="queueSize">The size of the internal event queue.</param>
         /// <param name="fullFallback">Specifies the custom behavior when the internal event
         /// queue is full so that no more event can be added.</param>
         public NonblockActionRenderer(
             IActionRenderer<T> renderer,
-            int queue,
+            int queueSize,
             FullFallback fullFallback
         )
-            : base(renderer, queue, fullFallback)
+            : base(renderer, queueSize, fullFallback)
         {
             ActionRenderer = renderer;
         }

--- a/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
@@ -45,6 +45,7 @@ namespace Libplanet.Blockchain.Renderers
         private readonly ChannelReader<System.Action> _reader;
         private readonly FullFallback? _fullFallback;
         private readonly Thread _worker;
+        private readonly object _workerLock = new object();
 
         /// <summary>
         /// Creates a new instance of <see cref="NonblockRenderer{T}"/> decorating the given
@@ -188,7 +189,15 @@ namespace Libplanet.Blockchain.Renderers
 
             if (!_worker.IsAlive)
             {
-                _worker.Start();
+                // ↑ To avoid entering the below lock at all except of the first time,
+                // checks one more time if the worker is alive before we try to lock.
+                lock (_workerLock)
+                {
+                    if (!_worker.IsAlive)
+                    {
+                        _worker.Start();
+                    }
+                }
             }
         }
     }

--- a/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
@@ -52,17 +52,17 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
         /// implementations and receives events in a background thread.</param>
-        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="queueSize">The size of the internal event queue.</param>
         /// <param name="fullMode">Specifies the behavior when the internal event queue is full so
         /// that no more event can be added.</param>
         [SuppressMessage(
             "Microsoft.StyleCop.CSharp.ReadabilityRules",
             "SA1118",
             Justification = "A switch expression should be multiline.")]
-        public NonblockRenderer(IRenderer<T> renderer, int queue, FullMode fullMode)
+        public NonblockRenderer(IRenderer<T> renderer, int queueSize, FullMode fullMode)
             : this(
                 renderer,
-                queue,
+                queueSize,
                 fullMode switch
                 {
                     FullMode.DropOldest => BoundedChannelFullMode.DropOldest,
@@ -78,13 +78,13 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
         /// implementations and receives events in a background thread.</param>
-        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="queueSize">The size of the internal event queue.</param>
         /// <param name="fullFallback">Specifies the custom behavior when the internal event
         /// queue is full so that no more event can be added.</param>
-        public NonblockRenderer(IRenderer<T> renderer, int queue, FullFallback fullFallback)
+        public NonblockRenderer(IRenderer<T> renderer, int queueSize, FullFallback fullFallback)
             : this(
                 renderer,
-                queue,
+                queueSize,
                 BoundedChannelFullMode.DropWrite,
                 fullFallback
             )

--- a/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
@@ -1,0 +1,195 @@
+#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Channels;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain.Renderers
+{
+    /// <summary>
+    /// Decorates a <see cref="IRenderer{T}"/> instance and lets all rendering events be
+    /// non-blocking.
+    /// <para>Every method call on the renderer will immediately return and the rendering
+    /// will be performed in a background thread.  Note that the order of render events is
+    /// still guaranteed.  In other words, a later event never arrives before events earlier
+    /// than it.</para>
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
+    /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
+    /// <example>
+    /// <code><![CDATA[
+    /// IRenderer<ExampleAction> renderer = new SomeRenderer();
+    /// // Wraps the renderer with NonblockRenderer; the SomeRenderer instance becomes to receive
+    /// // event messages in NonblockRenderer's backround thread:
+    /// renderer = new NonblockRenderer<ExampleAction>(
+    ///    renderer,
+    ///    queue: 1024,
+    ///    fullFallback: droppedEvent => ShowError("Too many rendering events in a short time."));
+    /// /// ...
+    /// // Should be disposed when no longer needed:
+    /// renderer.Dispose();
+    /// ]]></code>
+    /// </example>
+    /// <remarks>As rendering events become performed in a background thread instead of the main
+    /// thread, some graphics/UI drawings might be disallowed.  In such case, communicate with the
+    /// main thread through <a
+    /// href="https://devblogs.microsoft.com/dotnet/an-introduction-to-system-threading-channels/"
+    /// >producer/consumer channels</a>.</remarks>
+    public class NonblockRenderer<T> : IRenderer<T>, IDisposable
+        where T : IAction, new()
+    {
+        private readonly Channel<System.Action> _channel;
+        private readonly ChannelWriter<System.Action> _writer;
+        private readonly ChannelReader<System.Action> _reader;
+        private readonly FullFallback? _fullFallback;
+        private readonly Thread _worker;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NonblockRenderer{T}"/> decorating the given
+        /// <paramref name="renderer"/> instance.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives events in a background thread.</param>
+        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="fullMode">Specifies the behavior when the internal event queue is full so
+        /// that no more event can be added.</param>
+        [SuppressMessage(
+            "Microsoft.StyleCop.CSharp.ReadabilityRules",
+            "SA1118",
+            Justification = "A switch expression should be multiline.")]
+        public NonblockRenderer(IRenderer<T> renderer, int queue, FullMode fullMode)
+            : this(
+                renderer,
+                queue,
+                fullMode switch
+                {
+                    FullMode.DropOldest => BoundedChannelFullMode.DropOldest,
+                    _ => BoundedChannelFullMode.DropNewest,
+                }
+            )
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NonblockRenderer{T}"/> decorating the given
+        /// <paramref name="renderer"/> instance.
+        /// </summary>
+        /// <param name="renderer">The renderer to decorate which has the <em>actual</em>
+        /// implementations and receives events in a background thread.</param>
+        /// <param name="queue">The size of the internal event queue.</param>
+        /// <param name="fullFallback">Specifies the custom behavior when the internal event
+        /// queue is full so that no more event can be added.</param>
+        public NonblockRenderer(IRenderer<T> renderer, int queue, FullFallback fullFallback)
+            : this(
+                renderer,
+                queue,
+                BoundedChannelFullMode.DropWrite,
+                fullFallback
+            )
+        {
+        }
+
+        private NonblockRenderer(
+            IRenderer<T> renderer,
+            int queue,
+            BoundedChannelFullMode boundedChannelFullMode,
+            FullFallback? fullFallback = null
+        )
+        {
+            Renderer = renderer;
+            _channel = Channel.CreateBounded<System.Action>(new BoundedChannelOptions(queue)
+            {
+                AllowSynchronousContinuations = true,
+                FullMode = boundedChannelFullMode,
+                SingleReader = true,
+                SingleWriter = true,
+            });
+            _writer = _channel.Writer;
+            _reader = _channel.Reader;
+            _fullFallback = fullFallback;
+            _worker = new Thread(async () =>
+            {
+                while (await _reader.WaitToReadAsync())
+                {
+                    while (_reader.TryRead(out System.Action? action))
+                    {
+                        action?.Invoke();
+                    }
+                }
+            })
+            {
+                IsBackground = true,
+            };
+        }
+
+        /// <summary>
+        /// Customizes behavior when the internal event queue is full so that no more event
+        /// can be added.
+        /// </summary>
+        /// <param name="droppedEvent">The render event failed to be queued.</param>
+        public delegate void FullFallback(System.Action droppedEvent);
+
+        /// <summary>
+        /// Specifies the behavior when the internal event queue is full so that no more event
+        /// can be added.
+        /// </summary>
+        public enum FullMode
+        {
+            /// <summary>
+            /// Drops the oldest event when the queue is full.
+            /// </summary>
+            DropOldest,
+
+            /// <summary>
+            /// Drops the newest event when the queue is full.
+            /// </summary>
+            DropNewest,
+        }
+
+        /// <summary>
+        /// The inner renderer which has the <em>actual</em> implementations and receives events.
+        /// </summary>
+        public IRenderer<T> Renderer { get; }
+
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
+        public void Dispose()
+        {
+            _channel.Writer.Complete();
+            if (_worker.IsAlive)
+            {
+                _worker.Join();
+            }
+        }
+
+        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/>
+        public void RenderBlock(Block<T> oldTip, Block<T> newTip) =>
+            Queue(() => Renderer.RenderBlock(oldTip, newTip));
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
+        public void RenderReorg(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint) =>
+            Queue(() => Renderer.RenderReorg(oldTip, newTip, branchpoint));
+
+        /// <inheritdoc cref="IRenderer{T}.RenderReorgEnd(Block{T}, Block{T}, Block{T})"/>
+        public void RenderReorgEnd(Block<T> oldTip, Block<T> newTip, Block<T> branchpoint) =>
+            Queue(() => Renderer.RenderReorgEnd(oldTip, newTip, branchpoint));
+
+        /// <summary>
+        /// Queues the callback to be executed in the worker thread.
+        /// </summary>
+        /// <param name="action">The callback to be executed in the worker thread.</param>
+        protected void Queue(System.Action action)
+        {
+            if (!_writer.TryWrite(action))
+            {
+                _fullFallback?.Invoke(action);
+            }
+
+            if (!_worker.IsAlive)
+            {
+                _worker.Start();
+            }
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
 - job: Windows_NETCore_coverage
   pool:
     vmImage: windows-2019
+  continueOnError: true
   steps:
   - task: CmdLine@2
     displayName: dotnet tool install Codecov.Tool
@@ -27,6 +28,7 @@ jobs:
         --logger trx
         --collect "Code coverage"
         --logger "console;verbosity=normal"
+      continueOnTestError: true
   - task: Bash@3
     displayName: codecov
     inputs:


### PR DESCRIPTION
This implements <https://github.com/planetarium/libplanet/issues/1402>.

> Currently `BlockChain<T>` and `Swarm<T>` wait for registered renderers to get their jobs done for every render event.  These render calls can be nonblocking if there is a renderer decorator which maintains its own background thread and a queue/channel to communicate between the main thread and the background thread.

----

Relevant pull requests on Nine Chronicles:

- <https://github.com/planetarium/lib9c/pull/532>
- <https://github.com/planetarium/NineChronicles.Headless/pull/599>