### PR TITLE
Release 0.13.2 & Fix TURN reconnection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,14 @@ Version 0.13.2
 
 To be released.
 
- - When a reorg happens, `Swarm<T>` now broadcasts a reorged chain tip first
-   before rendering. [[#1385], [#1415]]
+ -  When a reorg happens, `Swarm<T>` now broadcasts a reorged chain tip first
+    before rendering. [[#1385], [#1415]]
+ -  Fixed a bug where `TurnClient` hadn't been recovered when TURN connection
+    had been disconnected.  [[#1424]]
 
 [#1385]: https://github.com/planetarium/libplanet/issues/1385
 [#1415]: https://github.com/planetarium/libplanet/pull/1415
+[#1424]: https://github.com/planetarium/libplanet/pull/1424
 
 
 Version 0.13.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.13.2
 --------------
 
-To be released.
+Released on Aug 5, 2021.
 
  -  When a reorg happens, `Swarm<T>` now broadcasts a reorged chain tip first
     before rendering. [[#1385], [#1415]]


### PR DESCRIPTION
This PR fixes reconnecting logic for TURN connections.

- Lib9c bump: https://github.com/planetarium/lib9c/pull/536
- 9c Headless bump: https://github.com/planetarium/NineChronicles.Headless/pull/602
- 9c Unity bump: https://github.com/planetarium/NineChronicles/pull/578