### PR TITLE
Add cache for action evaluations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,6 @@ Version 0.14.1
 
 To be released.
 
-### Behavioral changes
-
-
  -  Improved performance of `ActionEvaluator.Evaluate()` due to cache.
     [[#1429]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 0.14.1
 
 To be released.
 
+### Behavioral changes
+
+
+ -  Improved performance of `ActionEvaluator.Evaluate()` due to cache.
+    [[#1429]]
+
+[#1429]: https://github.com/planetarium/libplanet/pull/1429
+
 
 Version 0.14.0
 --------------


### PR DESCRIPTION
This PR adds a cache for action evaluations to prevent action re-executing frequently.