### PR TITLE
Add IRandom.Seed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Added `IRandom.Seed` property.  [[#1431]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -19,6 +21,8 @@ To be released.
 ### Bug fixes
 
 ### CLI tools
+
+[#1431]: https://github.com/planetarium/libplanet/pull/1431
 
 
 Version 0.14.0

--- a/Libplanet/Action/IRandom.cs
+++ b/Libplanet/Action/IRandom.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Libplanet.Action
 {
@@ -10,6 +11,13 @@ namespace Libplanet.Action
     /// </summary>
     public interface IRandom
     {
+        /// <summary>
+        /// A number used to calculate a starting value for the pseudo-random
+        /// number sequence.
+        /// </summary>
+        [Pure]
+        int Seed { get; }
+
         /// <summary>
         /// Gets a non-negative random integer.
         /// </summary>

--- a/Libplanet/Action/Random.cs
+++ b/Libplanet/Action/Random.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Libplanet.Action
 {
     internal class Random : System.Random, IRandom
@@ -5,6 +7,9 @@ namespace Libplanet.Action
         public Random(int seed)
             : base(seed)
         {
+            Seed = seed;
         }
+
+        public int Seed { get; private set; }
     }
 }


### PR DESCRIPTION
This PR introduces `IRandom.Seed` to enable store and send replayable random seed to other nodes. 

Basically, `System.Random` is `[Serializable]` but we're using an inheritanced version(`Libplanet.Actions.Random`) and it can't be serialized natively.

---
Lib9c: https://github.com/planetarium/lib9c/pull/556
NineChronicles: https://github.com/planetarium/NineChronicles/pull/627
NineChronicles.Headless: https://github.com/planetarium/NineChronicles.Headless/pull/625