### PR TITLE
Shortened source tagging

### DIFF
--- a/Libplanet/Blockchain/Renderers/LoggedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedRenderer.cs
@@ -52,7 +52,10 @@ namespace Libplanet.Blockchain.Renderers
         )
         {
             Renderer = renderer;
-            Logger = logger.ForContext(renderer.GetType());
+            Logger = logger
+                .ForContext<LoggedRenderer<T>>()
+                .ForContext("Source", $"[{nameof(LoggedRenderer<T>)}] ")
+                .ForContext(renderer.GetType());
             Level = level;
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -99,7 +99,9 @@ namespace Libplanet.Net
                 trustedAppProtocolVersionSigners?.ToImmutableHashSet();
 
             string loggerId = _privateKey.ToAddress().ToHex();
-            _logger = Log.ForContext<Swarm<T>>()
+            _logger = Log
+                .ForContext<Swarm<T>>()
+                .ForContext("Source", $"[{nameof(Swarm<T>)}] ")
                 .ForContext("SwarmId", loggerId);
 
             Options = options ?? new SwarmOptions();

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -154,7 +154,9 @@ namespace Libplanet.Net.Transports
                 );
             }
 
-            _logger = Log.ForContext<NetMQTransport>();
+            _logger = Log
+                .ForContext<NetMQTransport>()
+                .ForContext("Source", $"[{nameof(NetMQTransport)}] ");
 
             _requests = Channel.CreateUnbounded<MessageRequest>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
General QoL improvement for log parsing.

Although `SourceContext` is always provided, due to generic classes and usage of fully qualified name, directly using `SourceContext` results in something akin to:

```
[09:16:29 DBG] Libplanet.Net.BlockCompletion`2[[Libplanet.Net.BoundPeer, Libplanet, Version=0.12.0.0, Culture=neutral, PublicKeyToken=null],[Libplanet.Action.PolymorphicAction`1[[Nekoyume.Action.ActionBase, Lib9c, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]], Libplanet, Version=0.12.0.0, Culture=neutral, PublicKeyToken=null]] Downloaded a block #2122913 8af712404f75ec894b9c8474fa6f04f21933953f7bafaabaf5ddcbe0aa8a37c6 from 0xc1BF31cb992aCfb82EAe8f57Ee4fF455B18A679E.Unspecified/3.22.224.238:56104.73.111.87.115.
```

This is just an ad hoc improvement. Proper implementation would be to use regex parsed `SourceContext` values.

---

[Libplanet PR](https://github.com/planetarium/libplanet/pull/1433)
[Lib9c PR](https://github.com/planetarium/lib9c/pull/558)
[NineChronicles.Headless PR](https://github.com/planetarium/NineChronicles.Headless/pull/626)