### PR TITLE
Comparers genericized to use `IComparer<IBlockExcerpt>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ To be released.
 
  -  `BlockPerception` now implements `IBlockExcerpt` interface.  [[#1440]]
     -  `BlockPerception.Excerpt` property removed.
+ -  `TotalDifficultyComparer` now Implements `IComparer<IBlockExcerpt>`
+    interface.  [[#1442]]
 
 ### Backward-incompatible network protocol changes
 
@@ -24,6 +26,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  `TotalDifficultyComparer` no longer considers perceived time when comparing
+    `IBlockExcerpt`s.  [[#1442]]
  -  Block sync using `BlockDemand` became not to fill blocks
     from multiple peers.  [[#1457]]
 
@@ -32,6 +36,7 @@ To be released.
 ### CLI tools
 
 [#1440]: https://github.com/planetarium/libplanet/pull/1440
+[#1442]: https://github.com/planetarium/libplanet/pull/1442
 [#1455]: https://github.com/planetarium/libplanet/pull/1455
 [#1457]: https://github.com/planetarium/libplanet/pull/1457
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -407,7 +407,7 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public int MaxTransactionsPerBlock => _impl.MaxTransactionsPerBlock;
 
-            public IComparer<BlockPerception> CanonicalChainComparer =>
+            public IComparer<IBlockExcerpt> CanonicalChainComparer =>
                 _impl.CanonicalChainComparer;
 
             public bool DoesTransactionFollowsPolicy(

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -21,8 +21,8 @@ namespace Libplanet.Tests.Blockchain
             _difficulty = difficulty;
         }
 
-        public IComparer<BlockPerception> CanonicalChainComparer =>
-            new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
+        public IComparer<IBlockExcerpt> CanonicalChainComparer =>
+            new TotalDifficultyComparer();
 
         public IAction BlockAction => null;
 

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         protected static readonly IReadOnlyList<Block<DumbAction>> _chainA;
         protected static readonly IReadOnlyList<Block<DumbAction>> _chainB;
         protected static readonly Block<DumbAction> _branchpoint;
-        protected IComparer<BlockPerception> _canonicalChainComparer;
+        protected IComparer<IBlockExcerpt> _canonicalChainComparer;
         protected IStore _store;
         protected ILogger _logger;
 
@@ -76,7 +76,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _chainB
             );
 
-            _canonicalChainComparer = new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
+            _canonicalChainComparer = new TotalDifficultyComparer();
 
             _store = new DefaultStore(null);
             foreach (Block<DumbAction> b in _chainA.Concat(_chainB))

--- a/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
+++ b/Libplanet.Tests/Blockchain/TotalDifficultyComparerTest.cs
@@ -84,14 +84,14 @@ namespace Libplanet.Tests.Blockchain
 
             DateTimeOffset currentTime = DateTimeOffset.FromUnixTimeSeconds(1609426815);
             TimeSpan outdateAfter = TimeSpan.FromSeconds(15);
-            var comparer = new TotalDifficultyComparer(outdateAfter, () => currentTime);
+            var comparer = new TotalDifficultyComparer();
             BlockPerception[] sorted = BlockPerceptions.OrderBy(e => e, comparer).ToArray();
             PrintBlocks(sorted);
-            Assert.Equal(BlockPerceptions[0], sorted[0]);
-            Assert.Equal(BlockPerceptions[4], sorted[1]);
-            Assert.Equal(BlockPerceptions[3], sorted[2]);
-            Assert.Equal(BlockPerceptions[2], sorted[3]);
-            Assert.Equal(BlockPerceptions[1], sorted[4]);
+            Assert.True(BlockPerceptions[2].ExcerptEquals(sorted[0]));
+            Assert.True(BlockPerceptions[1].ExcerptEquals(sorted[1]));
+            Assert.True(BlockPerceptions[0].ExcerptEquals(sorted[2]));
+            Assert.True(BlockPerceptions[4].ExcerptEquals(sorted[3]));
+            Assert.True(BlockPerceptions[3].ExcerptEquals(sorted[4]));
 
             sorted = BlockPerceptions
                 .Select(p => new BlockPerception(p, currentTime))

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -19,15 +19,15 @@ namespace Libplanet.Tests.Net
         [InlineData(1)]
         public async Task DetermineCanonicalChain(short canonComparerType)
         {
-            IComparer<BlockPerception> canonComparer;
+            IComparer<IBlockExcerpt> canonComparer;
             switch (canonComparerType)
             {
                 default:
-                    canonComparer = new TotalDifficultyComparer(TimeSpan.FromSeconds(3));
+                    canonComparer = new TotalDifficultyComparer();
                     break;
 
                 case 1:
-                    canonComparer = new AnonymousComparer<BlockPerception>((a, b) =>
+                    canonComparer = new AnonymousComparer<IBlockExcerpt>((a, b) =>
                         string.Compare(
                             a.Hash.ToString(),
                             b.Hash.ToString(),

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -58,7 +58,7 @@ namespace Libplanet.Blockchain.Policies
             int maxBlockBytes = 100 * 1024,
             int maxGenesisBytes = 1024 * 1024,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
-            IComparer<BlockPerception> canonicalChainComparer = null,
+            IComparer<IBlockExcerpt> canonicalChainComparer = null,
             HashAlgorithmGetter hashAlgorithmGetter = null
         )
             : this(
@@ -98,9 +98,7 @@ namespace Libplanet.Blockchain.Policies
         /// A predicate that determines if the transaction follows the block policy.
         /// </param>
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
-        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> (having
-        /// <see cref="TotalDifficultyComparer.OutdateAfter"/> configured to triple of
-        /// <paramref name="blockInterval"/>) is used by default.</param>
+        /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
         /// <param name="hashAlgorithmGetter">Configures <see cref="GetHashAlgorithm(long)"/>.
         /// If omitted, SHA-256 is used for every block.</param>
         public BlockPolicy(
@@ -112,9 +110,8 @@ namespace Libplanet.Blockchain.Policies
             int maxBlockBytes,
             int maxGenesisBytes,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
-            IComparer<BlockPerception> canonicalChainComparer = null,
-            HashAlgorithmGetter hashAlgorithmGetter = null
-        )
+            IComparer<IBlockExcerpt> canonicalChainComparer = null,
+            HashAlgorithmGetter hashAlgorithmGetter = null)
         {
             if (blockInterval < TimeSpan.Zero)
             {
@@ -150,7 +147,7 @@ namespace Libplanet.Blockchain.Policies
             _maxGenesisBytes = maxGenesisBytes;
             _doesTransactionFollowPolicy = doesTransactionFollowPolicy ?? ((_, __) => true);
             CanonicalChainComparer = canonicalChainComparer
-                ?? new TotalDifficultyComparer(blockInterval + blockInterval + blockInterval);
+                ?? new TotalDifficultyComparer();
             _hashAlgorithmGetter = hashAlgorithmGetter ?? (_ => HashAlgorithmType.Of<SHA256>());
         }
 
@@ -171,7 +168,7 @@ namespace Libplanet.Blockchain.Policies
         public TimeSpan BlockInterval { get; }
 
         /// <inheritdoc />
-        public IComparer<BlockPerception> CanonicalChainComparer { get; }
+        public IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
 
         private long MinimumDifficulty { get; }
 

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Blockchain.Policies
         /// </summary>
         /// <seealso cref="IBlockExcerpt"/>
         /// <seealso cref="TotalDifficultyComparer"/>
-        IComparer<BlockPerception> CanonicalChainComparer { get; }
+        IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
 
         /// <summary>
         /// A block action to execute and be rendered for every block.

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -77,7 +77,7 @@ namespace Libplanet.Blockchain.Renderers
         /// If zero, which is a default value, is passed the buffer is not cleared.</param>
         public DelayedActionRenderer(
             IActionRenderer<T> renderer,
-            IComparer<BlockPerception> canonicalChainComparer,
+            IComparer<IBlockExcerpt> canonicalChainComparer,
             IStore store,
             int confirmations,
             long reorgResistantHeight = 0)

--- a/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedRenderer.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Blockchain.Renderers
     /// ]]></code>
     /// </example>
     /// <remarks>Since <see cref="IActionRenderer{T}"/> is a subtype of <see cref="IRenderer{T}"/>,
-    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IComparer{BlockPerception}, IStore, int)"/>
+    /// <see cref="DelayedRenderer{T}(IRenderer{T}, IComparer{IBlockExcerpt}, IStore, int)"/>
     /// constructor can take an <see cref="IActionRenderer{T}"/> instance as well.
     /// However, even it takes an action renderer, action-level fine-grained events won't hear.
     /// For action renderers, please use <see cref="DelayedActionRenderer{T}"/> instead.</remarks>
@@ -61,7 +61,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <paramref name="confirmations"/> is not greater than zero.</exception>
         public DelayedRenderer(
             IRenderer<T> renderer,
-            IComparer<BlockPerception> canonicalChainComparer,
+            IComparer<IBlockExcerpt> canonicalChainComparer,
             IStore store,
             int confirmations
         )
@@ -99,7 +99,7 @@ namespace Libplanet.Blockchain.Renderers
         /// The same canonical chain comparer to <see cref="BlockChain{T}.Policy"/>.
         /// </summary>
         /// <seealso cref="IBlockPolicy{T}.CanonicalChainComparer"/>
-        public IComparer<BlockPerception> CanonicalChainComparer { get; }
+        public IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
 
         /// <summary>
         /// The same store to what <see cref="BlockChain{T}"/> uses.

--- a/Libplanet/Blockchain/TotalDifficultyComparer.cs
+++ b/Libplanet/Blockchain/TotalDifficultyComparer.cs
@@ -16,57 +16,29 @@ namespace Libplanet.Blockchain
     /// protocol version, it always consider the higher version greater.</remarks>
     /// <seealso cref="IBlockPolicy{T}.CanonicalChainComparer"/>
     /// <seealso cref="IBlockExcerpt"/>
-    public class TotalDifficultyComparer : IComparer<BlockPerception>
+    public class TotalDifficultyComparer : IComparer<IBlockExcerpt>
     {
-        private readonly Func<DateTimeOffset> _currentTimeGetter;
-
         /// <summary>
         /// Creates a <see cref="TotalDifficultyComparer"/> instance.
         /// </summary>
-        /// <param name="outdateAfter">Blocks taken this time since they are perceived are
-        /// considered outdated, so that chains having these blocks as their tips become stale.
-        /// </param>
-        public TotalDifficultyComparer(TimeSpan outdateAfter)
-            : this(outdateAfter, () => DateTimeOffset.UtcNow)
+        public TotalDifficultyComparer()
         {
         }
-
-        /// <summary>
-        /// Creates a <see cref="TotalDifficultyComparer"/> instance.
-        /// </summary>
-        /// <param name="outdateAfter">Blocks taken this time since they are perceived are
-        /// considered outdated, so that chains having these blocks as their tips become stale.
-        /// </param>
-        /// <param name="currentTimeGetter">Configures the way to get the current time instead of
-        /// <see cref="DateTimeOffset.UtcNow"/> property.</param>
-        public TotalDifficultyComparer(
-            TimeSpan outdateAfter,
-            Func<DateTimeOffset> currentTimeGetter
-        )
-        {
-            _currentTimeGetter = currentTimeGetter;
-            OutdateAfter = outdateAfter;
-        }
-
-        /// <summary>
-        /// Blocks taken this time since they are perceived are considered outdated, so that
-        /// chains having these blocks as their tips become stale.
-        /// </summary>
-        public TimeSpan OutdateAfter { get; }
 
         /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
-        public int Compare(BlockPerception x, BlockPerception y)
+        public int Compare(IBlockExcerpt? x, IBlockExcerpt? y)
         {
-            DateTimeOffset outdateBefore = _currentTimeGetter() - OutdateAfter;
-            bool xOutdated = x.PerceivedTime <= outdateBefore,
-                 yOutdated = y.PerceivedTime <= outdateBefore;
-            if (xOutdated != yOutdated)
+            // FIXME: This deviates from the documented behavior of IComparer<T>.
+            if (x is null || y is null)
             {
-                return xOutdated ? -1 : 1;
+                throw new NullReferenceException(
+                    $"Neither {nameof(x)} nor {nameof(y)} should be null.");
             }
-
-            int vcmp = x.ProtocolVersion.CompareTo(y.ProtocolVersion);
-            return vcmp == 0 ? x.TotalDifficulty.CompareTo(y.TotalDifficulty) : vcmp;
+            else
+            {
+                int vcmp = x.ProtocolVersion.CompareTo(y.ProtocolVersion);
+                return vcmp == 0 ? x.TotalDifficulty.CompareTo(y.TotalDifficulty) : vcmp;
+            }
         }
     }
 }

--- a/Libplanet/Net/BlockDemandTable.cs
+++ b/Libplanet/Net/BlockDemandTable.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Net
             Func<IBlockExcerpt, bool> predicate,
             BlockDemand target)
         {
-            IComparer<BlockPerception> canonComparer = blockChain.Policy.CanonicalChainComparer;
+            IComparer<IBlockExcerpt> canonComparer = blockChain.Policy.CanonicalChainComparer;
             BoundPeer peer = target.Peer;
             var perception = blockChain.PerceiveBlock(target);
             bool needed =

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -577,7 +577,7 @@ namespace Libplanet.Net
         )
         {
             var sessionRandom = new Random();
-            IComparer<BlockPerception> canonComparer = BlockChain.Policy.CanonicalChainComparer;
+            IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
 
             int sessionId = sessionRandom.Next();
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -801,7 +801,7 @@ namespace Libplanet.Net
             int peersCount = peersWithExcerpts.Count;
             int i = 0;
             var exceptions = new List<Exception>();
-            IComparer<BlockPerception> canonComparer = BlockChain.Policy.CanonicalChainComparer;
+            IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
             foreach ((BoundPeer peer, IBlockExcerpt excerpt) in peersWithExcerpts)
             {
                 i++;
@@ -1065,7 +1065,7 @@ namespace Libplanet.Net
             CancellationToken cancellationToken)
         {
             BlockHash genesisHash = BlockChain.Genesis.Hash;
-            IComparer<BlockPerception> canonComparer = BlockChain.Policy.CanonicalChainComparer;
+            IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
             BlockPerception tipPerception = BlockChain.PerceiveBlock(initialTip);
             var peersWithChainStatusAndDiff =
                 (await DialToExistingPeers(dialTimeout, max, cancellationToken))
@@ -1170,7 +1170,7 @@ namespace Libplanet.Net
 
         private bool IsBlockNeeded(IBlockExcerpt target)
         {
-            IComparer<BlockPerception> canonComparer = BlockChain.Policy.CanonicalChainComparer;
+            IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
             var perception = BlockChain.PerceiveBlock(target);
             return canonComparer.Compare(perception, BlockChain.PerceiveBlock(BlockChain.Tip)) > 0;
         }


### PR DESCRIPTION
Preparatory refactoring for #1435.

This prepares for #1443. Although not strictly necessary, this allows to remove unnecessary parameters from `BlockDemandTable` class. 😛 

----

- <https://github.com/planetarium/libplanet/pull/1440>
- <https://github.com/planetarium/libplanet/pull/1442>
- <https://github.com/planetarium/libplanet/pull/1443>
- <https://github.com/planetarium/lib9c/pull/589>
- <https://github.com/planetarium/NineChronicles.Headless/pull/663>