### PR TITLE
Prevent tip regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,11 @@ To be released.
 
  -  `BlockPerception` now implements `IBlockExcerpt` interface.  [[#1440]]
     -  `BlockPerception.Excerpt` property removed.
+<<<<<<< HEAD
  -  `TotalDifficultyComparer` now Implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
+=======
+>>>>>>> 4582c75b4 (Changelog)
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ To be released.
     -  `BlockPerception.Excerpt` property removed.
  -  `TotalDifficultyComparer` now Implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
+ -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1443]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +29,12 @@ To be released.
 
  -  `TotalDifficultyComparer` no longer considers perceived time when comparing
     `IBlockExcerpt`s.  [[#1442]]
+ -  General logic for determining the canonical chain has been updated.
+    [[#1435], [#1443]]
+     -  Perceived time is only used for marking a received header in
+        `BlockDemandTable` in order to decide whether `BlockDemand` is stale
+        or not.  This should prevent a tip regression for a local node, as the
+        tip of a chain is never considered as stale.
  -  Block sync using `BlockDemand` became not to fill blocks
     from multiple peers.  [[#1457]]
 
@@ -35,8 +42,10 @@ To be released.
 
 ### CLI tools
 
+[#1435]: https://github.com/planetarium/libplanet/issues/1435
 [#1440]: https://github.com/planetarium/libplanet/pull/1440
 [#1442]: https://github.com/planetarium/libplanet/pull/1442
+[#1443]: https://github.com/planetarium/libplanet/pull/1443
 [#1455]: https://github.com/planetarium/libplanet/pull/1455
 [#1457]: https://github.com/planetarium/libplanet/pull/1457
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ To be released.
     -  `BlockPerception.Excerpt` property removed.
  -  `TotalDifficultyComparer` now implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
- -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1443]]
+ -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1435], [#1443]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,8 @@ To be released.
 
  -  `BlockPerception` now implements `IBlockExcerpt` interface.  [[#1440]]
     -  `BlockPerception.Excerpt` property removed.
-<<<<<<< HEAD
  -  `TotalDifficultyComparer` now Implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
-=======
->>>>>>> 4582c75b4 (Changelog)
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ To be released.
 
  -  `BlockPerception` now implements `IBlockExcerpt` interface.  [[#1440]]
     -  `BlockPerception.Excerpt` property removed.
- -  `TotalDifficultyComparer` now Implements `IComparer<IBlockExcerpt>`
+ -  `TotalDifficultyComparer` now implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
  -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1443]]
 

--- a/Libplanet/Blockchain/TotalDifficultyComparer.cs
+++ b/Libplanet/Blockchain/TotalDifficultyComparer.cs
@@ -31,7 +31,7 @@ namespace Libplanet.Blockchain
             // FIXME: This deviates from the documented behavior of IComparer<T>.
             if (x is null || y is null)
             {
-                throw new NullReferenceException(
+                throw new ArgumentNullException(
                     $"Neither {nameof(x)} nor {nameof(y)} should be null.");
             }
             else

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1168,11 +1168,18 @@ namespace Libplanet.Net
             BroadcastMessage(except, message);
         }
 
+        /// <summary>
+        /// Checks if the corresponding <see cref="Block{T}"/> to a given
+        /// <see cref="IBlockExcerpt"/> is needed for <see cref="BlockChain"/>.
+        /// </summary>
+        /// <param name="target">The <see cref="IBlockExcerpt"/> to compare to the current
+        /// <see cref="BlockChain{T}.Tip"/> of <see cref="BlockChain"/>.</param>
+        /// <returns><c>true</c> if the corresponding <see cref="Block{T}"/> to
+        /// <paramref name="target"/> is needed, otherwise, <c>false</c>.</returns>
         private bool IsBlockNeeded(IBlockExcerpt target)
         {
             IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
-            var perception = BlockChain.PerceiveBlock(target);
-            return canonComparer.Compare(perception, BlockChain.PerceiveBlock(BlockChain.Tip)) > 0;
+            return canonComparer.Compare(target, BlockChain.Tip) > 0;
         }
 
         private async Task ProcessFillTxs(CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #1435 and #1444.

`BlockDemand` handling inside `BlockDemandTable` class is overhauled. `BlockPerception` is no longer used for comparers. Removing "stale" `BlockDemand` is handled using internally stored `blockdemandLifespan`, which can be set on runtime.

----

- <https://github.com/planetarium/libplanet/pull/1440>
- <https://github.com/planetarium/libplanet/pull/1442>
- <https://github.com/planetarium/libplanet/pull/1443>
- <https://github.com/planetarium/lib9c/pull/589>
- <https://github.com/planetarium/NineChronicles.Headless/pull/663>