### PR TITLE
Put in place an option for MinTransactionsPerBlock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Version 0.17.0
 To be released.
 
 ### Backward-incompatible API changes
+- Added MinTransactionsPerBlock to assist in block validation
 
  -  Added `StateCompleterSet<T>.ComplementAll` property.  [[#1358], [#1386]]
  -  Added `StateCompleterSet<T>.ComplementLatest` property.  [[#1358], [#1386]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ To be released.
     interface.  [[#1442]]
  -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1435], [#1443]]
  -  Added `IBlockPolicy<T>.MinTransactionsPerBlock` property.  [[#1445]]
+ -  Added `BlockInsufficientTxsException`.  [[#1445]]
  -  `PrivateKey()` constructor's parameter type became `IReadOnlyList<byte>`
     (was `byte[]`).  [[#1464]]
  -  `PrivateKey.ByteArray` property's type became `ImmutableArray<byte>`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,6 @@ Version 0.17.0
 To be released.
 
 ### Backward-incompatible API changes
-- Added MinTransactionsPerBlock to assist in block validation
-
  -  Added `StateCompleterSet<T>.ComplementAll` property.  [[#1358], [#1386]]
  -  Added `StateCompleterSet<T>.ComplementLatest` property.  [[#1358], [#1386]]
  -  `BlockPerception` now implements `IBlockExcerpt` interface.  [[#1440]]
@@ -16,6 +14,7 @@ To be released.
  -  `TotalDifficultyComparer` now implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
  -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1435], [#1443]]
+ -  Added `IBlockPolicy<T>.MinTransactionsPerBlock` property.  [[#1445]]
  -  `PrivateKey()` constructor's parameter type became `IReadOnlyList<byte>`
     (was `byte[]`).  [[#1464]]
  -  `PrivateKey.ByteArray` property's type became `ImmutableArray<byte>`
@@ -123,7 +122,8 @@ To be released.
 [#1440]: https://github.com/planetarium/libplanet/pull/1440
 [#1442]: https://github.com/planetarium/libplanet/pull/1442
 [#1443]: https://github.com/planetarium/libplanet/pull/1443
-[#1447]: https://github.com/planetarium/libplanet/pull/1446
+[#1445]: https://github.com/planetarium/libplanet/pull/1445
+[#1447]: https://github.com/planetarium/libplanet/pull/1447
 [#1448]: https://github.com/planetarium/libplanet/issues/1448
 [#1449]: https://github.com/planetarium/libplanet/issues/1449
 [#1455]: https://github.com/planetarium/libplanet/pull/1455

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -405,6 +405,8 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public IAction BlockAction => _impl.BlockAction;
 
+            public int MinTransactionsPerBlock => _impl.MinTransactionsPerBlock;
+
             public IComparer<IBlockExcerpt> CanonicalChainComparer =>
                 _impl.CanonicalChainComparer;
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Tests.Blockchain
         {
             // Tests if MineBlock() method will throw an exception if less than the minimum
             // transactions are present
-            await Assert.ThrowsAsync<InvalidBlockMinTxException>(async () =>
+            await Assert.ThrowsAsync<BlockInsufficientTxsException>(async () =>
             {
                 await _blockChainMinTx.MineBlock(_fx.Address3);
             });

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -37,13 +37,6 @@ namespace Libplanet.Tests.Blockchain
                     privateKey: new PrivateKey());
             _blockChainMinTx.StageTransaction(lightTx);
 
-            // Tests if MineBlock() method will throw an OperationCanceledException
-            // if there are staged transactions, but less than minimum can be included
-            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            {
-                await _blockChainMinTx.MineBlock(_fx.Address3);
-            });
-
             Func<long, int> getMaxBlockBytes = _blockChain.Policy.GetMaxBlockBytes;
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             Assert.Equal(1, _blockChain.Count);

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -26,6 +26,8 @@ namespace Libplanet.Tests.Blockchain
 
         public IAction BlockAction => null;
 
+        public int MinTransactionsPerBlock => 0;
+
         public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;
 
         public bool DoesTransactionFollowsPolicy(

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -58,6 +58,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 minimumDifficulty: 1024L,
                 difficultyBoundDivisor: 128,
                 maxTransactionsPerBlock: 100,
+                minTransactionsPerBlock: 0,
                 maxBlockBytes: 100 * 1024,
                 maxGenesisBytes: 1024 * 1024
             );
@@ -80,6 +81,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                     minimumDifficulty: 1024,
                     difficultyBoundDivisor: 128,
                     maxTransactionsPerBlock: 100,
+                    minTransactionsPerBlock: 0,
                     maxBlockBytes: 100 * 1024,
                     maxGenesisBytes: 1024 * 1024
                 )
@@ -94,6 +96,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                     minimumDifficulty: 0,
                     difficultyBoundDivisor: 128,
                     maxTransactionsPerBlock: 100,
+                    minTransactionsPerBlock: 0,
                     maxBlockBytes: 100 * 1024,
                     maxGenesisBytes: 1024 * 1024
                 )
@@ -105,6 +108,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                     minimumDifficulty: 1024,
                     difficultyBoundDivisor: 1024,
                     maxTransactionsPerBlock: 100,
+                    minTransactionsPerBlock: 0,
                     maxBlockBytes: 100 * 1024,
                     maxGenesisBytes: 1024 * 1024
                 )

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -363,6 +363,20 @@ namespace Libplanet.Blockchain
                 }
             }
 
+            if (transactionsToMine.Count < Policy.MinTransactionsPerBlock)
+            {
+                if (stagedTransactions.Count > transactionsToMine.Count)
+                {
+                    throw new OperationCanceledException(
+                        "stagedTransactions higher than transactionsToMine.");
+                }
+
+                throw new InvalidBlockMinTxException(
+                    transactionsToMine.Count,
+                    Policy.MinTransactionsPerBlock,
+                    "Below Minimum Transactions");
+            }
+
             _logger.Information(
                 "Gathered total of {TransactionsToMineCount} transactions to mine for " +
                 "block #{Index} from {StagedTransactionsCount} staged transactions.",

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -365,13 +365,7 @@ namespace Libplanet.Blockchain
 
             if (transactionsToMine.Count < Policy.MinTransactionsPerBlock)
             {
-                if (stagedTransactions.Count > transactionsToMine.Count)
-                {
-                    throw new OperationCanceledException(
-                        "stagedTransactions higher than transactionsToMine.");
-                }
-
-                throw new InvalidBlockMinTxException(
+                throw new BlockInsufficientTxsException(
                     transactionsToMine.Count,
                     Policy.MinTransactionsPerBlock,
                     "Below Minimum Transactions");

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1254,11 +1254,11 @@ namespace Libplanet.Blockchain
             IReadOnlyList<ActionEvaluation> actionEvaluations
         )
         {
-           if (!StateStore.ContainsBlockStates(block.Hash))
-           {
-               var totalDelta = actionEvaluations.GetTotalDelta(ToStateKey, ToFungibleAssetKey);
-               StateStore.SetStates(block, totalDelta);
-           }
+            if (!StateStore.ContainsBlockStates(block.Hash))
+            {
+                var totalDelta = actionEvaluations.GetTotalDelta(ToStateKey, ToFungibleAssetKey);
+                StateStore.SetStates(block, totalDelta);
+            }
         }
 
         internal IEnumerable<Block<T>> IterateBlocks(int offset = 0, int? limit = null)

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -41,6 +41,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         /// <param name="maxTransactionsPerBlock">Configures the constant return value of
         /// <see cref="GetMaxTransactionsPerBlock(long)"/> method.  100 by default.</param>
+        /// <param name="minTransactionsPerBlock">Configures <see cref="MinTransactionsPerBlock"/>.
+        /// 100 by default.</param>
         /// <param name="maxBlockBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
         /// the block is not a genesis.  100 KiB by default.</param>
         /// <param name="maxGenesisBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
@@ -62,6 +64,7 @@ namespace Libplanet.Blockchain.Policies
             long minimumDifficulty = 1024,
             int difficultyBoundDivisor = 128,
             int maxTransactionsPerBlock = 100,
+            int minTransactionsPerBlock = 0,
             int maxBlockBytes = 100 * 1024,
             int maxGenesisBytes = 1024 * 1024,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
@@ -74,6 +77,7 @@ namespace Libplanet.Blockchain.Policies
                 minimumDifficulty,
                 difficultyBoundDivisor,
                 maxTransactionsPerBlock,
+                minTransactionsPerBlock,
                 maxBlockBytes,
                 maxGenesisBytes,
                 doesTransactionFollowPolicy,
@@ -98,6 +102,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="DifficultyBoundDivisor"/>.</param>
         /// <param name="maxTransactionsPerBlock">Configures the constant return value of
         /// <see cref="GetMaxTransactionsPerBlock(long)"/> method.</param>
+        /// <param name="minTransactionsPerBlock">Configures <see cref="MinTransactionsPerBlock"/>.
+        /// </param>
         /// <param name="maxBlockBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
         /// the block is not a genesis.</param>
         /// <param name="maxGenesisBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
@@ -119,6 +125,7 @@ namespace Libplanet.Blockchain.Policies
             long minimumDifficulty,
             int difficultyBoundDivisor,
             int maxTransactionsPerBlock,
+            int minTransactionsPerBlock,
             int maxBlockBytes,
             int maxGenesisBytes,
             Func<Transaction<T>, BlockChain<T>, bool> doesTransactionFollowPolicy = null,
@@ -156,6 +163,7 @@ namespace Libplanet.Blockchain.Policies
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
             _maxTransactionsPerBlock = maxTransactionsPerBlock;
+            MinTransactionsPerBlock = minTransactionsPerBlock;
             _maxBlockBytes = maxBlockBytes;
             _maxGenesisBytes = maxGenesisBytes;
             _doesTransactionFollowPolicy = doesTransactionFollowPolicy ?? ((_, __) => true);
@@ -168,6 +176,9 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         public IAction BlockAction { get; }
+
+        /// <inheritdoc cref="IBlockPolicy{T}.MinTransactionsPerBlock"/>
+        public int MinTransactionsPerBlock { get; }
 
         /// <summary>
         /// An appropriate interval between consecutive <see cref="Block{T}"/>s.

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="maxTransactionsPerBlock">Configures the constant return value of
         /// <see cref="GetMaxTransactionsPerBlock(long)"/> method.  100 by default.</param>
         /// <param name="minTransactionsPerBlock">Configures <see cref="MinTransactionsPerBlock"/>.
-        /// 100 by default.</param>
+        /// 0 by default.</param>
         /// <param name="maxBlockBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
         /// the block is not a genesis.  100 KiB by default.</param>
         /// <param name="maxGenesisBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -31,6 +31,15 @@ namespace Libplanet.Blockchain.Policies
         IAction BlockAction { get; }
 
         /// <summary>
+        /// The minimum number of <see cref="Block{T}.Transactions"/> that a <see cref="Block{T}"/>
+        /// can accept.  This value must not be negative and must be deterministic (i.e., must not
+        /// change after an object is once instantiated).
+        /// </summary>
+        /// <remarks>If the value is less then 0, it's treated as 0.</remarks>
+        [Pure]
+        int MinTransactionsPerBlock { get; }
+
+        /// <summary>
         /// Gets the maximum number of <see cref="Block{T}.Transactions"/> that
         /// a <see cref="Block{T}"/> (of the given <paramref name="index"/>) can accept.
         /// This value must not be negative and must be deterministic (i.e., must return

--- a/Libplanet/Blocks/BlockInsufficientTxsException.cs
+++ b/Libplanet/Blocks/BlockInsufficientTxsException.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Blocks
     /// <see cref="Block{T}.Transactions"/> Count is too small.
     /// </summary>
     [Serializable]
-    public sealed class InvalidBlockMinTxException : InvalidBlockException, ISerializable
+    public sealed class BlockInsufficientTxsException : InvalidBlockException, ISerializable
     {
         /// <summary>
         /// Initializes a new instance of <see cref="InvalidBlockBytesLengthException"/> class.
@@ -21,7 +21,7 @@ namespace Libplanet.Blocks
         /// <param name="minTransactionsPerBlock">The minimum allowed transactions.  It is
         /// automatically included to the <see cref="Exception.Message"/> string.</param>
         /// <param name="message">The message that describes the error.</param>
-        public InvalidBlockMinTxException(
+        public BlockInsufficientTxsException(
             int transactionCount,
             int minTransactionsPerBlock,
             string message
@@ -35,7 +35,7 @@ namespace Libplanet.Blocks
             MinTransactionsPerBlock = minTransactionsPerBlock;
         }
 
-        private InvalidBlockMinTxException(SerializationInfo info, StreamingContext context)
+        private BlockInsufficientTxsException(SerializationInfo info, StreamingContext context)
             : base(info.GetString(nameof(Message)) ?? string.Empty)
         {
             TransactionCount = info.GetInt32(nameof(TransactionCount));

--- a/Libplanet/Blocks/InvalidBlockMinTxException.cs
+++ b/Libplanet/Blocks/InvalidBlockMinTxException.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Runtime.Serialization;
+using Libplanet.Blockchain.Policies;
+
+namespace Libplanet.Blocks
+{
+    /// <summary>
+    /// The exception that is thrown when a <see cref="Block{T}"/>'s
+    /// <see cref="Block{T}.Transactions"/> Count is too small.
+    /// </summary>
+    [Serializable]
+    public sealed class InvalidBlockMinTxException : InvalidBlockException, ISerializable
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="InvalidBlockBytesLengthException"/> class.
+        /// </summary>
+        /// <param name="transactionCount">The invalid <see cref="Block{T}"/>'s
+        /// <see cref="Block{T}.Transactions"/> Count.  It is automatically included to the
+        /// <see cref="Exception.Message"/> string.</param>
+        /// <param name="minTransactionsPerBlock">The minimum allowed transactions.  It is
+        /// automatically included to the <see cref="Exception.Message"/> string.</param>
+        /// <param name="message">The message that describes the error.</param>
+        public InvalidBlockMinTxException(
+            int transactionCount,
+            int minTransactionsPerBlock,
+            string message
+        )
+            : base(
+                $"{message}\n" +
+                $"Actual: {transactionCount} bytes\n" +
+                $"Allowed (min): {minTransactionsPerBlock} bytes")
+        {
+            TransactionCount = transactionCount;
+            MinTransactionsPerBlock = minTransactionsPerBlock;
+        }
+
+        private InvalidBlockMinTxException(SerializationInfo info, StreamingContext context)
+            : base(info.GetString(nameof(Message)) ?? string.Empty)
+        {
+            TransactionCount = info.GetInt32(nameof(TransactionCount));
+            MinTransactionsPerBlock = info.GetInt32(nameof(MinTransactionsPerBlock));
+        }
+
+        /// <summary>
+        /// The bytes length of the actual block.
+        /// </summary>
+        public int TransactionCount { get; set; }
+
+        /// <summary>
+        /// The maximum allowed length of a block in bytes.
+        /// </summary>
+        /// <seealso cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>
+        public int MinTransactionsPerBlock { get; set; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Message), Message);
+            info.AddValue(nameof(TransactionCount), TransactionCount);
+            info.AddValue(nameof(MinTransactionsPerBlock), MinTransactionsPerBlock);
+        }
+    }
+}


### PR DESCRIPTION
Put in place an option for MinTransactionsPerBlock to keep energy and cpu time to a minimum if a block policy (such as implemented by 9c) requires that blocks contain at least 1 or more transactions.  This code will stop the miner from trying to get the hash if there are less than the MinTrasactionsPerBlock as defined in the policy.

Currently the miner will continue mining an invalid block, and 9c has implemented a custom setting to force at least 1 transaction.  This will allow that to be configurable in the future.