### PR TITLE
Let maximum transactions vary depending on block index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,11 +26,15 @@ To be released.
     `IReadOnlyList<byte>` (were both `byte[]`).  [[#1464]]
  -  `HashDigest<T>.DeriveFrom()` method's parameter type became
     `IReadOnlyList<byte>` (was `byte[]`).  [[#1464]]
- -  `IBlockPolicy<T>.MaxTransactionsPerBlock` and
-    `IBlockPolicy<T>.GetMaxBlockBytes()` description changed for `0`
+ -  `IBlockPolicy<T>.GetMaxBlockBytes()` description changed for `0`
     and negative values.  [[#1449], [#1463]]
      -  Returned values from these will now be taken literally
         by `BlockChain<T>`.
+ -  Removed `IBlockPolicy<T>.MaxTransactionsPerBlock` property.  It is replaced
+    by `IBlockPolicy<T>.GetMaxTransactionsPerBlock(long index)` method.
+    [[#1447]]
+ -  Added `IBlockPolicy<T>.GetMaxTransactionsPerBlock(long index)` method.
+    [[#1447]]
  -  Unused parameter `currentTime` removed from `BlockChain<T>.Append()`
     [[#1462], [#1465]]
  -  `BlockHeader`'s properties are now represented as richer types than before.
@@ -118,6 +122,7 @@ To be released.
 [#1440]: https://github.com/planetarium/libplanet/pull/1440
 [#1442]: https://github.com/planetarium/libplanet/pull/1442
 [#1443]: https://github.com/planetarium/libplanet/pull/1443
+[#1447]: https://github.com/planetarium/libplanet/pull/1446
 [#1448]: https://github.com/planetarium/libplanet/issues/1448
 [#1449]: https://github.com/planetarium/libplanet/issues/1449
 [#1455]: https://github.com/planetarium/libplanet/pull/1455

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -405,10 +405,11 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public IAction BlockAction => _impl.BlockAction;
 
-            public int MaxTransactionsPerBlock => _impl.MaxTransactionsPerBlock;
-
             public IComparer<IBlockExcerpt> CanonicalChainComparer =>
                 _impl.CanonicalChainComparer;
+
+            public int GetMaxTransactionsPerBlock(long index) =>
+                _impl.GetMaxTransactionsPerBlock(index);
 
             public bool DoesTransactionFollowsPolicy(
                 Transaction<NullAction> transaction, BlockChain<NullAction> blockChain

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -341,7 +341,7 @@ namespace Libplanet.Tests.Blockchain
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             PrivateKey signer = null;
             int nonce = 0;
-            int maxTxs = _blockChain.Policy.MaxTransactionsPerBlock;
+            int maxTxs = _blockChain.Policy.GetMaxTransactionsPerBlock(1);
             var manyTxs = new List<Transaction<DumbAction>>();
             for (int i = 0; i <= maxTxs; i++)
             {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -408,7 +408,9 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.MakeTransaction(key, new DumbAction[0]);
             }
 
-            Assert.True(_blockChain.Policy.MaxTransactionsPerBlock > maxTransactions);
+            Assert.True(
+                _blockChain.Policy.GetMaxTransactionsPerBlock(_blockChain.Count) > maxTransactions
+            );
 
             // These assume there will be enough time to mine as many transactions as
             // possible.
@@ -446,7 +448,9 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.MakeTransaction(key, new DumbAction[0]);
             }
 
-            Assert.True(_blockChain.Policy.MaxTransactionsPerBlock > maxTransactions);
+            Assert.True(
+                _blockChain.Policy.GetMaxTransactionsPerBlock(_blockChain.Count) > maxTransactions
+            );
 
             // These assume there will be enough time to mine as many transactions as
             // possible.

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Tests.Blockchain
 
         public IAction BlockAction => null;
 
-        public int MaxTransactionsPerBlock => int.MaxValue;
+        public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;
 
         public bool DoesTransactionFollowsPolicy(
             Transaction<T> transaction,
@@ -44,6 +44,7 @@ namespace Libplanet.Tests.Blockchain
         public virtual HashAlgorithmType GetHashAlgorithm(long index) =>
             HashAlgorithmType.Of<SHA256>();
 
-        public int GetMaxTransactionsPerSignerPerBlock(long index) => MaxTransactionsPerBlock;
+        public int GetMaxTransactionsPerSignerPerBlock(long index) =>
+            GetMaxTransactionsPerBlock(index);
     }
 }

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -29,7 +29,8 @@ namespace Libplanet.Blockchain
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> when mining started.</param>
         /// <param name="append">Whether to append the mined block immediately after mining.</param>
         /// <param name="maxTransactions">The maximum number of transactions that a block can
-        /// accept.  See also <see cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>.</param>
+        /// accept.  See also <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>
+        /// method.</param>
         /// <param name="maxTransactionsPerSigner">The maximum number of transactions
         /// that a block can accept per signer.  See also
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
@@ -50,7 +51,8 @@ namespace Libplanet.Blockchain
                     miner: miner,
                     timestamp: timestamp ?? DateTimeOffset.UtcNow,
                     append: append ?? true,
-                    maxTransactions: maxTransactions ?? Policy.MaxTransactionsPerBlock,
+                    maxTransactions: maxTransactions ??
+                        Policy.GetMaxTransactionsPerBlock(Count),
                     maxTransactionsPerSigner: maxTransactionsPerSigner
                         ?? Policy.GetMaxTransactionsPerSignerPerBlock(Count),
                     cancellationToken: cancellationToken ?? default(CancellationToken));
@@ -63,7 +65,8 @@ namespace Libplanet.Blockchain
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> when mining started.</param>
         /// <param name="append">Whether to append the mined block immediately after mining.</param>
         /// <param name="maxTransactions">The maximum number of transactions that a block can
-        /// accept.  See also <see cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>.</param>
+        /// accept.  See also <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>
+        /// method.</param>
         /// <param name="maxTransactionsPerSigner">The maximum number of transactions
         /// that a block can accept per signer.  See also
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
@@ -86,7 +89,7 @@ namespace Libplanet.Blockchain
             void WatchTip(object target, (Block<T> OldTip, Block<T> NewTip) tip) => cts.Cancel();
             TipChanged += WatchTip;
 
-            long index = Store.CountIndex(Id);
+            long index = Count;
             long difficulty = Policy.GetNextBlockDifficulty(this);
             BlockHash? prevHash = Store.IndexBlockHash(Id, index - 1);
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -563,7 +563,7 @@ namespace Libplanet.Blockchain
         /// cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>).</exception>
         /// <exception cref="BlockExceedingTransactionsException">Thrown when the given <paramref
         /// name="block"/> has too many transactions (according to <see
-        /// cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).</exception>
+        /// cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>).</exception>
         /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
         /// is invalid, in itself or according to the <see cref="Policy"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
@@ -856,12 +856,12 @@ namespace Libplanet.Blockchain
 
             _logger.Debug("Trying to append block {blockIndex}: {block}", block?.Index, block);
 
-            if (block.Transactions.Count() is { } txCount &&
-                txCount > Policy.MaxTransactionsPerBlock)
+            int policyMaxTx = Policy.GetMaxTransactionsPerBlock(block.Index);
+            if (block.Transactions.Count() is { } txCount && txCount > policyMaxTx)
             {
                 throw new BlockExceedingTransactionsException(
                     txCount,
-                    Policy.MaxTransactionsPerBlock,
+                    policyMaxTx,
                     "The block to append has too many transactions."
                 );
             }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -31,11 +31,18 @@ namespace Libplanet.Blockchain.Policies
         IAction BlockAction { get; }
 
         /// <summary>
-        /// The maximum number of <see cref="Block{T}.Transactions"/> that a <see cref="Block{T}"/>
-        /// can accept.
+        /// Gets the maximum number of <see cref="Block{T}.Transactions"/> that
+        /// a <see cref="Block{T}"/> (of the given <paramref name="index"/>) can accept.
+        /// This value must not be negative and must be deterministic (i.e., must return
+        /// the same number for the same <paramref name="index"/>).
         /// </summary>
+        /// <param name="index">An <see cref="Block{T}.Index"/> of a block to mine or receive.
+        /// </param>
+        /// <returns>The maximum number of <see cref="Block{T}.Transactions"/> that
+        /// a <see cref="Block{T}"/> can accept.</returns>
+        /// <remarks>If the return value is less then 1, it's treated as 1.</remarks>
         [Pure]
-        int MaxTransactionsPerBlock { get; }
+        int GetMaxTransactionsPerBlock(long index);
 
         /// <summary>
         /// A predicate that determines if the transaction follows the block policy.

--- a/Libplanet/Blocks/BlockExceedingTransactionsException.cs
+++ b/Libplanet/Blocks/BlockExceedingTransactionsException.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Blocks
     /// <summary>
     /// The exception that is thrown when a <see cref="Block{T}"/> has too many
     /// <see cref="Block{T}.Transactions"/> (i.e., more than the number specified by
-    /// <see cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).
+    /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>).
     /// </summary>
     [Serializable]
     public class BlockExceedingTransactionsException : InvalidBlockException, ISerializable
@@ -42,7 +42,7 @@ namespace Libplanet.Blocks
         /// <summary>
         /// The maximum allowed number of transactions per block.
         /// </summary>
-        /// <seealso cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>
+        /// <seealso cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>
         public int MaxTransactionsPerBlock { get; set; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)


### PR DESCRIPTION
`IBlockPolicy<T>.MaxTransactionsPerBlock` property is replaced by `IBlockPolicy<T>.GetMaxTransactionsPerBlock(long index)` method.