### PR TITLE
Append Git commit hash to version suffix

### DIFF
--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -47,9 +47,11 @@ for project in "${executables[@]}"; do
 done
 
 for project in "${projects[@]}"; do
-  dotnet_args="-p:Version=$version"
   if [ -f obj/version_suffix.txt ]; then
-    dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
+    version_suffix="$(cat obj/version_suffix.txt)"
+    dotnet_args="--version-suffix=$version_suffix -p:NoPackageAnalysis=true"
+  else
+    dotnet_args="-p:Version=$version"
   fi
   # shellcheck disable=SC2086
   dotnet build -c "$configuration" $dotnet_args

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ In addition to stable releases, we also provide pre-release packages.
 For every day and every merge commit, it is packed into a *.nupkg*
 and uploaded to [NuGet] with a hyphen-suffixed version name.
 
-For a merge commit build, a version name is like `0.1.0-dev.20181231235959`
-where `20181231235959` is a UTC timestamp of the build.
-For a daily build, a version name is like `0.1.0-nightly.20181231`.
+For a merge commit build, a version name looks like
+`0.1.0-dev.20181231235959+a0b1c2d` where `20181231235959` is a UTC timestamp of
+the build and `a0b1c2d` is the first 7 hexadecimals of the Git commit hash.
+For a daily build, a version name is like `0.1.0-nightly.20181231+a0b1c2d`.
 
 Unfortunately, Unity currently does not support NuGet.  There are some Unity
 plug-ins to deal with NuGet package system, and these seem immature at present.


### PR DESCRIPTION
This adds Git commit hashes to version suffixes of prereleases.  See also the [diff of README.md](https://github.com/dahlia/libplanet/commit/648768c3ca1c984130cc912fe55f24bcb46e6cc3?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).