### PR TITLE
Dealing the timeout of the request of multiple replies & Release 0.15.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Version 0.15.2
 
 To be released.
 
+ -  Removed `ITransport.SendMessageWithReplyAsync(BoundPeer,
+    Message, TimeSpan?, int, CancellationToken)` method.
+    Instead, added `ITransport.SendMessageWithReplyAsync(BoundPeer,
+    Message, TimeSpan?, int, bool, CancellationToken)` method.
+    [[#1458], [#1460]]
+ -  Fixed a bug where `GetTxs` request failed to receive transactions
+    if any messages are missing.  [[#1458], [#1460]]
+
+[#1458]: https://github.com/planetarium/libplanet/issues/1458
+[#1460]: https://github.com/planetarium/libplanet/pull/1460
+
 
 Version 0.15.1
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.15.2
 --------------
 
-To be released.
+Released on September 3, 2021.
 
  -  Removed `ITransport.SendMessageWithReplyAsync(BoundPeer,
     Message, TimeSpan?, int, CancellationToken)` method.

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -371,6 +371,7 @@ namespace Libplanet.Tests.Net.Protocols
             Message message,
             TimeSpan? timeout,
             int expectedResponses,
+            bool returnWhenTimeout,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return new[]

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -787,6 +787,7 @@ namespace Libplanet.Tests.Net
                     msg,
                     TimeSpan.FromSeconds(1),
                     4,
+                    true,
                     default)).ToList();
 
                 Assert.Equal(3, replies.Count);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1029,6 +1029,7 @@ namespace Libplanet.Net
                 request,
                 blockRecvTimeout,
                 ((hashCount - 1) / request.ChunkSize) + 1,
+                false,
                 cancellationToken
             );
 
@@ -1090,6 +1091,7 @@ namespace Libplanet.Net
                 request,
                 txRecvTimeout,
                 txCount,
+                true,
                 cancellationToken
             );
 

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -108,6 +108,8 @@ namespace Libplanet.Net.Transports
         /// <param name="message">A <see cref="Message"/> to send.</param>
         /// <param name="timeout">A timeout of waiting for the reply of the message.</param>
         /// <param name="expectedResponses">The number of expected replies for the message.</param>
+        /// <param name="returnWhenTimeout">Determines the behavior when failed to receive
+        /// <paramref name="expectedResponses"/> messages and timeout occurred.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
@@ -118,7 +120,8 @@ namespace Libplanet.Net.Transports
             Message message,
             TimeSpan? timeout,
             int expectedResponses,
-            CancellationToken cancellationToken = default);
+            bool returnWhenTimeout,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Broadcasts the <paramref name="message"/> to peers selected from the routing table.


### PR DESCRIPTION
Previously, the failure of receiving any messages leads to the failure of the whole process. This patch adds `ITransport.SendMessageWithReplyAsync(BoundPeer peer, Message message, TimeSpan? timeout, int expectedResponses, bool returnWhenTimeout, CancellationToken cancellationToken)` method to handle the case by hand over `returnWhenTimeout` argument to true.