### PR TITLE
Unnecessary parameter removed from Append()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ To be released.
     and negative values.  [[#1449], [#1463]]
      -  Returned values from these will now be taken literally
         by `BlockChain<T>`.
+ -  Unused parameter `currentTime` removed from `BlockChain<T>.Append()`
+    [[#1462], [#1465]]
 
 ### Backward-incompatible network protocol changes
 
@@ -83,8 +85,10 @@ To be released.
 [#1449]: https://github.com/planetarium/libplanet/issues/1449
 [#1455]: https://github.com/planetarium/libplanet/pull/1455
 [#1457]: https://github.com/planetarium/libplanet/pull/1457
+[#1462]: https://github.com/planetarium/libplanet/issues/1462
 [#1463]: https://github.com/planetarium/libplanet/pull/1463
 [#1464]: https://github.com/planetarium/libplanet/pull/1464
+[#1465]: https://github.com/planetarium/libplanet/pull/1465
 
 
 Version 0.16.0

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -924,7 +924,6 @@ namespace Libplanet.Tests.Action
             chain.ExecuteActions(block);
             chain.Append(
                 block,
-                DateTimeOffset.UtcNow,
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -385,7 +385,6 @@ namespace Libplanet.Tests.Blockchain
             Assert.Throws<ArgumentException>(() =>
                 _blockChain.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: false,
                     renderBlocks: true,
                     renderActions: true
@@ -396,7 +395,6 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.Append(
                 block,
-                DateTimeOffset.UtcNow,
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -132,7 +132,6 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.Append(
                 block1,
-                DateTimeOffset.UtcNow,
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -874,7 +874,6 @@ namespace Libplanet.Tests.Blockchain
             ).AttachStateRootHash(_fx.StateStore, _policy);
             fork.Append(
                 forkTip,
-                DateTimeOffset.UtcNow,
                 evaluateActions: true,
                 renderBlocks: true,
                 renderActions: false

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -586,7 +586,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
@@ -595,7 +594,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
@@ -604,7 +602,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
@@ -613,7 +610,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
@@ -709,7 +705,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
@@ -717,7 +712,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
             block = await forked.MineBlock(fx.Address1, append: false);
             forked.Append(
                     block,
-                    DateTimeOffset.UtcNow,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -641,7 +641,7 @@ namespace Libplanet.Tests.Net
                         null,
                         policy.GetNextBlockDifficulty(blockChain))
                     .AttachStateRootHash(blockChain.StateStore, policy);
-                blockChain.Append(block1, DateTimeOffset.MinValue.AddSeconds(3), true, true, false);
+                blockChain.Append(block1, true, true, false);
                 var block2 = TestUtils.MineNext(
                     block1,
                     policy.GetHashAlgorithm,
@@ -649,7 +649,7 @@ namespace Libplanet.Tests.Net
                     null,
                     policy.GetNextBlockDifficulty(blockChain)
                 ).AttachStateRootHash(blockChain.StateStore, policy);
-                blockChain.Append(block2, DateTimeOffset.MinValue.AddSeconds(8), true, true, false);
+                blockChain.Append(block2, true, true, false);
                 Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);
                 await receiverSwarm.BlockAppended.WaitAsync();

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -390,7 +390,7 @@ namespace Libplanet.Tests.Net
                         difficulty: policy.GetNextBlockDifficulty(minerChain),
                         blockInterval: TimeSpan.FromSeconds(1)
                 ).AttachStateRootHash(minerChain.StateStore, minerChain.Policy);
-                minerSwarm.BlockChain.Append(block, DateTimeOffset.UtcNow, false, true, false);
+                minerSwarm.BlockChain.Append(block, false, true, false);
 
                 await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1));
 

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -187,7 +187,6 @@ namespace Libplanet.Blockchain
             {
                 Append(
                     block,
-                    timestamp,
                     evaluateActions: true,
                     renderBlocks: true,
                     renderActions: true,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -181,7 +181,6 @@ namespace Libplanet.Blockchain
                 {
                     Append(
                         genesisBlock,
-                        currentTime: genesisBlock.Timestamp,
                         renderBlocks: !inFork,
                         renderActions: !inFork,
                         evaluateActions: !inFork
@@ -571,45 +570,12 @@ namespace Libplanet.Blockchain
         /// <see cref="Transaction{T}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
         /// <see cref="Transaction{T}.Signer"/>.</exception>
-        public void Append(Block<T> block, StateCompleterSet<T>? stateCompleters = null) =>
-            Append(block, DateTimeOffset.UtcNow, stateCompleters);
-
-        /// <summary>
-        /// Adds a <paramref name="block"/> to the end of this chain.
-        /// <para><see cref="Block{T}.Transactions"/> in the <paramref name="block"/> updates
-        /// states and balances in the blockchain, and <see cref="TxExecution"/>s for
-        /// transactions are recorded.</para>
-        /// <para>Note that <see cref="Renderers"/> receive events right after the <paramref
-        /// name="block"/> is confirmed (and thus all states reflect changes in the <paramref
-        /// name="block"/>).</para>
-        /// </summary>
-        /// <param name="block">A next <see cref="Block{T}"/>, which is mined,
-        /// to add.</param>
-        /// <param name="currentTime">The current time.</param>
-        /// <param name="stateCompleters">The strategy to complement incomplete block states which
-        /// are required for action execution and rendering.
-        /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.
-        /// </param>
-        /// <exception cref="InvalidBlockBytesLengthException">Thrown when the given <paramref
-        /// name="block"/> is too long in bytes (according to <see
-        /// cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>).</exception>
-        /// <exception cref="BlockExceedingTransactionsException">Thrown when the given <paramref
-        /// name="block"/> has too many transactions (according to <see
-        /// cref="IBlockPolicy{T}.MaxTransactionsPerBlock"/>).</exception>
-        /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
-        /// is invalid, in itself or according to the <see cref="Policy"/>.</exception>
-        /// <exception cref="InvalidTxNonceException">Thrown when the
-        /// <see cref="Transaction{T}.Nonce"/> is different from
-        /// <see cref="GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{T}.Signer"/>.</exception>
         public void Append(
             Block<T> block,
-            DateTimeOffset currentTime,
             StateCompleterSet<T>? stateCompleters = null
         ) =>
             Append(
                 block,
-                currentTime,
                 evaluateActions: true,
                 renderBlocks: true,
                 renderActions: true,
@@ -866,7 +832,6 @@ namespace Libplanet.Blockchain
 #pragma warning disable MEN003
         internal void Append(
             Block<T> block,
-            DateTimeOffset currentTime,
             bool evaluateActions,
             bool renderBlocks,
             bool renderActions,

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -411,7 +411,6 @@ namespace Libplanet.Net
                                     deltaBlock.Hash);
                                 workspace.Append(
                                     deltaBlock,
-                                    DateTimeOffset.UtcNow,
                                     evaluateActions: !preload,
                                     renderBlocks: renderBlocks,
                                     renderActions: renderActions
@@ -896,7 +895,6 @@ namespace Libplanet.Net
 
                         workspace.Append(
                             block,
-                            DateTimeOffset.UtcNow,
                             evaluateActions: evaluateActions,
                             renderBlocks: renderBlocks,
                             renderActions: renderActions


### PR DESCRIPTION
Closes #1462.

Should be fine as a standalone PR as lib9c does not seem to make any `Append()` call with a timestamp.