### PR TITLE
Represent `BlockHeader`'s fields as richer types

### DIFF
--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -47,9 +47,11 @@ for project in "${executables[@]}"; do
 done
 
 for project in "${projects[@]}"; do
-  dotnet_args="-p:Version=$version"
   if [ -f obj/version_suffix.txt ]; then
-    dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
+    version_suffix="$(cat obj/version_suffix.txt)"
+    dotnet_args="--version-suffix=$version_suffix -p:NoPackageAnalysis=true"
+  else
+    dotnet_args="-p:Version=$version"
   fi
   # shellcheck disable=SC2086
   dotnet build -c "$configuration" $dotnet_args

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ To be released.
     method instead.  [[#1464]]
  -  `PublicKey()` constructor's parameter type became `IReadOnlyList<byte>`
     (was `byte[]`).  [[#1464]]
- -  `PublicKey.Verify()` method's both parameters types became
+ -  `PublicKey.Verify()` method's both parameter types became
     `IReadOnlyList<byte>` (were both `byte[]`).  [[#1464]]
  -  `HashDigest<T>.DeriveFrom()` method's parameter type became
     `IReadOnlyList<byte>` (was `byte[]`).  [[#1464]]
@@ -33,6 +33,29 @@ To be released.
         by `BlockChain<T>`.
  -  Unused parameter `currentTime` removed from `BlockChain<T>.Append()`
     [[#1462], [#1465]]
+ -  `BlockHeader`'s properties are now represented as richer types than before.
+    [[#1470]]
+     -  `BlockHeader.Timestamp` property's type became `DateTimeOffset`
+        (was `string`).
+     -  `BlockHeader.Nonce` property's type became `Nonce` (was
+        `ImmutableArray<byte>`).
+     -  `BlockHeader.Miner` property's type became `Address` (was
+        `ImmutableArray<byte>`).
+     -  `BlockHeader.PreviousHash` property's type became `BlockHash?` (was
+        `ImmutableArray<byte>`).
+     -  `BlockHeader.TxHash` property's type became `HashDigest<SHA256>?` (was
+        `ImmutableArray<byte>`).
+     -  `BlockHeader.Hash` property's type became `BlockHash` (was
+        `ImmutableArray<byte>`).
+     -  `BlockHeader.StateRootHash` property's type became `HashDigest<SHA256>?`
+        (was `ImmutableArray<byte>`).
+     -  Removed `BlockHeader(int, long, string, ImmutableArray<byte>,
+        ImmutableArray<byte>, long, BigInteger, ImmutableArray<byte>,
+        ImmutableArray<byte>, ImmutableArray<byte>, ImmutableArray<byte>,
+        ImmutableArray<byte>)` constructor.  Use `BlockHeader(int, long,
+        DateTimeOffset, Nonce, Address, long, BigInteger, BlockHash?,
+        HashDigest<SHA256>?, BlockHash, ImmutableArray<byte>,
+        HashDigest<SHA256>?)` constructor instead.
 
 ### Backward-incompatible network protocol changes
 
@@ -56,6 +79,9 @@ To be released.
     [[#1449], [#1463]]
  -  `BlockChain<T>.MineBlock()` now takes `maxTransactionsPerSigner`
     as an optional parameter.  [[#1449], [#1463]]
+ -  Added `BlockHeader(int, long, DateTimeOffset, Nonce, Address, long,
+    BigInteger, BlockHash?, HashDigest<SHA256>?, BlockHash,
+    ImmutableArray<byte>, HashDigest<SHA256>?)` constructor.  [[#1470]]
 
 ### Behavioral changes
 
@@ -96,6 +122,7 @@ To be released.
 [#1463]: https://github.com/planetarium/libplanet/pull/1463
 [#1464]: https://github.com/planetarium/libplanet/pull/1464
 [#1465]: https://github.com/planetarium/libplanet/pull/1465
+[#1470]: https://github.com/planetarium/libplanet/pull/1470
 
 
 Version 0.16.0

--- a/Libplanet.Tests/Blocks/BlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHeaderTest.cs
@@ -13,6 +13,8 @@ namespace Libplanet.Tests.Blocks
 {
     public class BlockHeaderTest : IClassFixture<BlockFixture>
     {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+
         private BlockFixture _fx;
 
         public BlockHeaderTest(BlockFixture fixture) => _fx = fixture;
@@ -25,55 +27,47 @@ namespace Libplanet.Tests.Blocks
                 index: 0,
                 difficulty: _fx.Genesis.Difficulty,
                 totalDifficulty: _fx.Genesis.TotalDifficulty,
-                nonce: _fx.Genesis.Nonce.ByteArray,
-                miner: _fx.Genesis.Miner.ByteArray,
-                hash: _fx.Genesis.Hash.ByteArray,
-                txHash: _fx.Genesis.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Genesis.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Genesis.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Genesis.Nonce,
+                miner: _fx.Genesis.Miner,
+                hash: _fx.Genesis.Hash,
+                txHash: _fx.Genesis.TxHash,
+                previousHash: _fx.Genesis.PreviousHash,
+                timestamp: _fx.Genesis.Timestamp,
                 preEvaluationHash: _fx.Genesis.PreEvaluationHash,
-                stateRootHash: _fx.Genesis.StateRootHash?.ByteArray ?? ImmutableArray<byte>.Empty
+                stateRootHash: _fx.Genesis.StateRootHash
             );
             Bencodex.Types.Dictionary expected = Bencodex.Types.Dictionary.Empty
                 .Add(BlockHeader.IndexKey, 0)
                 .Add(
                     BlockHeader.TimestampKey,
-                    _fx.Genesis.Timestamp.ToString(
-                        BlockHeader.TimestampFormat,
-                        CultureInfo.InvariantCulture
-                    )
+                    _fx.Genesis.Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)
                 )
                 .Add(BlockHeader.DifficultyKey, _fx.Genesis.Difficulty)
                 .Add(
                     BlockHeader.TotalDifficultyKey,
                     (IValue)new Bencodex.Types.Integer(_fx.Genesis.TotalDifficulty)
                 )
-                .Add(BlockHeader.NonceKey, _fx.Genesis.Nonce.ToByteArray())
-                .Add(BlockHeader.HashKey, _fx.Genesis.Hash.ToByteArray())
-                .Add(BlockHeader.MinerKey, _fx.Genesis.Miner.ToByteArray())
+                .Add(BlockHeader.NonceKey, _fx.Genesis.Nonce.ByteArray)
+                .Add(BlockHeader.HashKey, _fx.Genesis.Hash.ByteArray)
+                .Add(BlockHeader.MinerKey, _fx.Genesis.Miner.ByteArray)
                 .Add(BlockHeader.PreEvaluationHashKey, _fx.Genesis.PreEvaluationHash.ToArray());
             Assert.Equal(expected, header.ToBencodex());
             Assert.Equal(expected, new BlockHeader(expected).ToBencodex());
 
-            ImmutableArray<byte> randomHash = TestUtils.GetRandomBytes(32).ToImmutableArray();
-            ImmutableArray<byte> randomHash2 = TestUtils.GetRandomBytes(32).ToImmutableArray();
+            var random = new Random();
+            HashDigest<SHA256> randomHash = random.NextHashDigest<SHA256>();
+            HashDigest<SHA256> randomHash2 = random.NextHashDigest<SHA256>();
             header = new BlockHeader(
                 protocolVersion: 1,
                 index: 1,
                 difficulty: _fx.Next.Difficulty,
                 totalDifficulty: _fx.Next.TotalDifficulty,
-                nonce: _fx.Next.Nonce.ByteArray,
-                miner: _fx.Next.Miner.ByteArray,
-                hash: _fx.Next.Hash.ByteArray,
+                nonce: _fx.Next.Nonce,
+                miner: _fx.Next.Miner,
+                hash: _fx.Next.Hash,
                 txHash: randomHash,
-                previousHash: _fx.Genesis.Hash.ByteArray,
-                timestamp: _fx.Next.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                previousHash: _fx.Genesis.Hash,
+                timestamp: _fx.Next.Timestamp,
                 preEvaluationHash: ImmutableArray<byte>.Empty,
                 stateRootHash: randomHash2
             );
@@ -83,7 +77,7 @@ namespace Libplanet.Tests.Blocks
                 .Add(
                     BlockHeader.TimestampKey,
                     _fx.Next.Timestamp.ToString(
-                        BlockHeader.TimestampFormat,
+                        TimestampFormat,
                         CultureInfo.InvariantCulture
                     )
                 )
@@ -92,12 +86,12 @@ namespace Libplanet.Tests.Blocks
                     BlockHeader.TotalDifficultyKey,
                     (IValue)new Bencodex.Types.Integer(_fx.Next.TotalDifficulty)
                 )
-                .Add(BlockHeader.NonceKey, _fx.Next.Nonce.ToByteArray())
-                .Add(BlockHeader.MinerKey, _fx.Next.Miner.ToByteArray())
-                .Add(BlockHeader.HashKey, _fx.Next.Hash.ToByteArray())
-                .Add(BlockHeader.PreviousHashKey, _fx.Genesis.Hash.ToByteArray())
-                .Add(BlockHeader.TxHashKey, randomHash.ToArray())
-                .Add(BlockHeader.StateRootHashKey, randomHash2.ToArray());
+                .Add(BlockHeader.NonceKey, _fx.Next.Nonce.ByteArray)
+                .Add(BlockHeader.MinerKey, _fx.Next.Miner.ByteArray)
+                .Add(BlockHeader.HashKey, _fx.Next.Hash.ByteArray)
+                .Add(BlockHeader.PreviousHashKey, _fx.Genesis.Hash.ByteArray)
+                .Add(BlockHeader.TxHashKey, randomHash.ByteArray)
+                .Add(BlockHeader.StateRootHashKey, randomHash2.ByteArray);
             Assert.Equal(expected, header.ToBencodex());
             Assert.Equal(expected, new BlockHeader(expected).ToBencodex());
         }
@@ -117,17 +111,14 @@ namespace Libplanet.Tests.Blocks
                 index: 0,
                 difficulty: _fx.Genesis.Difficulty,
                 totalDifficulty: _fx.Genesis.TotalDifficulty,
-                nonce: _fx.Genesis.Nonce.ByteArray,
-                miner: _fx.Genesis.Miner.ByteArray,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                txHash: _fx.Genesis.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Genesis.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Genesis.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Genesis.Nonce,
+                miner: _fx.Genesis.Miner,
+                hash: new Random().NextBlockHash(),
+                txHash: _fx.Genesis.TxHash,
+                previousHash: _fx.Genesis.PreviousHash,
+                timestamp: _fx.Genesis.Timestamp,
                 preEvaluationHash: _fx.Genesis.PreEvaluationHash,
-                stateRootHash: _fx.Genesis.StateRootHash?.ByteArray ?? ImmutableArray<byte>.Empty
+                stateRootHash: _fx.Genesis.StateRootHash
             );
 
             Assert.Throws<InvalidBlockHashException>(
@@ -142,17 +133,14 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: _fx.Next.Difficulty,
                 totalDifficulty: _fx.Next.TotalDifficulty,
-                nonce: _fx.Next.Nonce.ByteArray,
-                miner: _fx.Next.Miner.ByteArray,
-                hash: _fx.Next.Hash.ByteArray,
-                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Next.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Next.Nonce,
+                miner: _fx.Next.Miner,
+                hash: _fx.Next.Hash,
+                txHash: _fx.Next.TxHash,
+                previousHash: _fx.Next.PreviousHash,
+                timestamp: _fx.Next.Timestamp,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
@@ -164,17 +152,14 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: _fx.Next.Difficulty,
                 totalDifficulty: _fx.Next.TotalDifficulty,
-                nonce: _fx.Next.Nonce.ByteArray,
-                miner: _fx.Next.Miner.ByteArray,
-                hash: _fx.Next.Hash.ByteArray,
-                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Next.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Next.Nonce,
+                miner: _fx.Next.Miner,
+                hash: _fx.Next.Hash,
+                txHash: _fx.Next.TxHash,
+                previousHash: _fx.Next.PreviousHash,
+                timestamp: _fx.Next.Timestamp,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
@@ -186,8 +171,7 @@ namespace Libplanet.Tests.Blocks
         public void ValidateTimestamp()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            string future = (now + TimeSpan.FromSeconds(16))
-                .ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture);
+            DateTimeOffset future = now + TimeSpan.FromSeconds(16);
             HashAlgorithmType hashAlgorithm = HashAlgorithmType.Of<SHA256>();
             BlockHeader header = MakeBlockHeader(
                 hashAlgorithm: hashAlgorithm,
@@ -195,13 +179,14 @@ namespace Libplanet.Tests.Blocks
                 index: 0,
                 difficulty: 0,
                 totalDifficulty: 0,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: ImmutableArray<byte>.Empty,
-                txHash: ImmutableArray<byte>.Empty,
-                miner: ImmutableArray<byte>.Empty,
+                nonce: default,
+                previousHash: null,
+                txHash: default,
+                miner: default,
                 timestamp: future,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: TestUtils.GetRandomBytes(32).ToImmutableArray());
+                stateRootHash: new Random().NextHashDigest<SHA256>()
+            );
 
             Assert.Throws<InvalidBlockTimestampException>(
                 () => { header.Validate(hashAlgorithm, now); });
@@ -218,17 +203,14 @@ namespace Libplanet.Tests.Blocks
                 index: _fx.Next.Index,
                 difficulty: long.MaxValue,
                 totalDifficulty: _fx.Genesis.TotalDifficulty + long.MaxValue,
-                nonce: _fx.Next.Nonce.ByteArray,
-                miner: _fx.Next.Miner.ByteArray,
-                hash: _fx.Next.Hash.ByteArray,
-                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Next.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Next.Nonce,
+                miner: _fx.Next.Miner,
+                hash: _fx.Next.Hash,
+                txHash: _fx.Next.TxHash,
+                previousHash: _fx.Next.PreviousHash,
+                timestamp: _fx.Next.Timestamp,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockNonceException>(() =>
@@ -243,17 +225,14 @@ namespace Libplanet.Tests.Blocks
                 index: -1,
                 difficulty: _fx.Next.Difficulty,
                 totalDifficulty: _fx.Next.TotalDifficulty,
-                nonce: _fx.Next.Nonce.ByteArray,
-                miner: _fx.Next.Miner.ByteArray,
-                hash: _fx.Next.Hash.ByteArray,
-                txHash: _fx.Next.TxHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                previousHash: _fx.Next.PreviousHash?.ByteArray ?? ImmutableArray<byte>.Empty,
-                timestamp: _fx.Next.Timestamp.ToString(
-                    BlockHeader.TimestampFormat,
-                    CultureInfo.InvariantCulture
-                ),
+                nonce: _fx.Next.Nonce,
+                miner: _fx.Next.Miner,
+                hash: _fx.Next.Hash,
+                txHash: _fx.Next.TxHash,
+                previousHash: _fx.Next.PreviousHash,
+                timestamp: _fx.Next.Timestamp,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockIndexException>(() =>
@@ -264,19 +243,20 @@ namespace Libplanet.Tests.Blocks
         public void ValidateDifficulty()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
+            var random = new Random();
             var genesisHeader = new BlockHeader(
                 protocolVersion: 0,
                 index: 0,
                 difficulty: 1000,
                 totalDifficulty: 1000,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: ImmutableArray<byte>.Empty,
-                txHash: ImmutableArray<byte>.Empty,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                miner: ImmutableArray<byte>.Empty,
-                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
+                nonce: default,
+                previousHash: null,
+                txHash: default,
+                hash: random.NextBlockHash(),
+                miner: default,
+                timestamp: now,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
@@ -287,14 +267,14 @@ namespace Libplanet.Tests.Blocks
                 index: 10,
                 difficulty: 0,
                 totalDifficulty: 1000,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: ImmutableArray<byte>.Empty,
-                txHash: ImmutableArray<byte>.Empty,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                miner: ImmutableArray<byte>.Empty,
-                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
+                nonce: default,
+                previousHash: null,
+                txHash: default,
+                hash: random.NextBlockHash(),
+                miner: default,
+                timestamp: now,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockDifficultyException>(() =>
@@ -305,14 +285,14 @@ namespace Libplanet.Tests.Blocks
                 index: 10,
                 difficulty: 1000,
                 totalDifficulty: 10,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: ImmutableArray<byte>.Empty,
-                txHash: ImmutableArray<byte>.Empty,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                miner: ImmutableArray<byte>.Empty,
-                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
+                nonce: default,
+                previousHash: null,
+                txHash: default(HashDigest<SHA256>),
+                hash: random.NextBlockHash(),
+                miner: default,
+                timestamp: now,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockTotalDifficultyException>(() =>
@@ -323,19 +303,20 @@ namespace Libplanet.Tests.Blocks
         public void ValidatePreviousHash()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
+            var random = new Random();
             var genesisHeader = new BlockHeader(
                 protocolVersion: 0,
                 index: 0,
                 difficulty: 0,
                 totalDifficulty: 0,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                txHash: ImmutableArray<byte>.Empty,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                miner: ImmutableArray<byte>.Empty,
-                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
+                nonce: default,
+                previousHash: random.NextBlockHash(),
+                txHash: default(HashDigest<SHA256>),
+                hash: random.NextBlockHash(),
+                miner: default,
+                timestamp: now,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
@@ -346,14 +327,14 @@ namespace Libplanet.Tests.Blocks
                 index: 10,
                 difficulty: 1000,
                 totalDifficulty: 1500,
-                nonce: ImmutableArray<byte>.Empty,
-                previousHash: ImmutableArray<byte>.Empty,
-                txHash: ImmutableArray<byte>.Empty,
-                hash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                miner: ImmutableArray<byte>.Empty,
-                timestamp: now.ToString(BlockHeader.TimestampFormat, CultureInfo.InvariantCulture),
+                nonce: default,
+                previousHash: null,
+                txHash: default(HashDigest<SHA256>),
+                hash: random.NextBlockHash(),
+                miner: default,
+                timestamp: now,
                 preEvaluationHash: TestUtils.GetRandomBytes(32).ToImmutableArray(),
-                stateRootHash: ImmutableArray<byte>.Empty
+                stateRootHash: null
             );
 
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
@@ -366,13 +347,13 @@ namespace Libplanet.Tests.Blocks
             long index,
             long difficulty,
             BigInteger totalDifficulty,
-            ImmutableArray<byte> nonce,
-            ImmutableArray<byte> previousHash,
-            ImmutableArray<byte> txHash,
-            ImmutableArray<byte> miner,
-            string timestamp,
+            Nonce nonce,
+            BlockHash? previousHash,
+            HashDigest<SHA256> txHash,
+            Address miner,
+            DateTimeOffset timestamp,
             ImmutableArray<byte> preEvaluationHash,
-            ImmutableArray<byte> stateRootHash
+            HashDigest<SHA256>? stateRootHash
         )
         {
             return new BlockHeader(

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -388,78 +388,87 @@ namespace Libplanet.Tests.Blocks
             RawBlock rawGenesis = _fx.Genesis.ToRawBlock();
             Assert.Equal(0, rawGenesis.Header.Index);
             Assert.Equal(0, rawGenesis.Header.Difficulty);
-            Assert.Empty(rawGenesis.Header.PreviousHash);
-            Assert.Equal("2018-11-29T00:00:00.000000Z", rawGenesis.Header.Timestamp);
+            Assert.Null(rawGenesis.Header.PreviousHash);
             Assert.Equal(
-                ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644"),
+                new DateTimeOffset(2018, 11, 29, 0, 0, 0, default),
+                rawGenesis.Header.Timestamp
+            );
+            AssertBytesEqual(
+                new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
                 rawGenesis.Header.Miner
             );
             Assert.Empty(rawGenesis.Transactions);
-            Assert.Empty(rawGenesis.Header.TxHash);
-            Assert.Equal(
-                new byte[] { 0x01, 0x00, 0x00, 0x00 },
+            Assert.Null(rawGenesis.Header.TxHash);
+            AssertBytesEqual(
+                new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 }),
                 rawGenesis.Header.Nonce
             );
             AssertBytesEqual(
-                new byte[32]
+                new BlockHash(new byte[32]
                 {
                     0xd6, 0x93, 0xda, 0x38, 0x66, 0xa3, 0x4d, 0x65, 0x9e, 0x01, 0x4f, 0x97,
                     0xc8, 0xfe, 0xb0, 0x8a, 0xfe, 0x2e, 0x97, 0xc9, 0x9e, 0x3f, 0x33, 0x89,
                     0xda, 0x02, 0x5f, 0xd0, 0x66, 0x5c, 0x62, 0x1c,
-                },
-                rawGenesis.Header.Hash.ToArray()
+                }),
+                rawGenesis.Header.Hash
             );
 
             RawBlock rawNext = _fx.Next.ToRawBlock();
 
             Assert.Equal(1, rawNext.Header.Index);
             Assert.Equal(1, rawNext.Header.Difficulty);
-            Assert.Equal(rawGenesis.Header.Hash.ToArray(), rawNext.Header.PreviousHash.ToArray());
-            Assert.Equal("2018-11-29T00:00:15.000000Z", rawNext.Header.Timestamp);
+            AssertBytesEqual(rawGenesis.Header.Hash, rawNext.Header.PreviousHash ?? default);
             Assert.Equal(
-                ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644"),
+                new DateTimeOffset(2018, 11, 29, 0, 0, 15, default),
+                rawNext.Header.Timestamp
+            );
+            AssertBytesEqual(
+                new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
                 rawNext.Header.Miner
             );
             Assert.Empty(rawNext.Transactions);
-            Assert.Empty(rawNext.Header.TxHash);
+            Assert.Null(rawNext.Header.TxHash);
             AssertBytesEqual(
-                new byte[]
+                new BlockHash(new byte[]
                 {
                     0x1b, 0xba, 0x9f, 0xcf, 0x4c, 0x81, 0x52, 0xc8, 0x99, 0xed, 0x16, 0x74, 0xec,
                     0xbf, 0x4a, 0x65, 0x71, 0xc2, 0x71, 0x92, 0x2c, 0x08, 0x84, 0xae, 0x80, 0x9f,
                     0x91, 0xf0, 0x37, 0xbe, 0xd8, 0xfc,
-                },
-                rawNext.Header.Hash.ToArray()
+                }),
+                rawNext.Header.Hash
             );
 
             RawBlock rawHasText = _fx.HasTx.ToRawBlock();
 
             Assert.Equal(2, rawHasText.Header.Index);
             Assert.Equal(1, rawHasText.Header.Difficulty);
-            Assert.Equal(rawNext.Header.Hash.ToArray(), rawHasText.Header.PreviousHash.ToArray());
-            Assert.Equal("2018-11-29T00:00:30.000000Z", rawHasText.Header.Timestamp);
+            AssertBytesEqual(rawNext.Header.Hash, rawHasText.Header.PreviousHash ?? default);
             Assert.Equal(
-                ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644"),
+                new DateTimeOffset(2018, 11, 29, 0, 0, 30, default),
+                rawHasText.Header.Timestamp
+            );
+            AssertBytesEqual(
+                new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
                 rawHasText.Header.Miner
             );
             Assert.Single(rawHasText.Transactions);
             AssertBytesEqual(
-                new byte[]
+                new HashDigest<SHA256>(new byte[]
                 {
                     0x75, 0xa9, 0x2b, 0xf5, 0xcf, 0xf3, 0x5d, 0x5b, 0x4d, 0x0c, 0xb8, 0x40, 0xab,
                     0x61, 0x11, 0x3d, 0xee, 0xab, 0x6f, 0x78, 0x0f, 0x9b, 0x69, 0xfc, 0x48, 0x68,
                     0xe6, 0xba, 0xac, 0xdc, 0xcb, 0x54,
-                },
-                rawHasText.Header.TxHash.ToArray()
+                }),
+                rawHasText.Header.TxHash ?? default
             );
             AssertBytesEqual(
-                new byte[32]
+                new BlockHash(new byte[]
                 {
                     0x28, 0x40, 0xe8, 0x6a, 0x27, 0xda, 0x6e, 0x0d, 0xe6, 0x2e, 0xab, 0xab, 0x32,
                     0x95, 0x3e, 0x3b, 0x33, 0xf2, 0xa6, 0x51, 0x18, 0x35, 0xf1, 0x85, 0x1a, 0x1a,
                     0xcc, 0x51, 0xd7, 0x71, 0xcb, 0x99,
-                },
-                rawHasText.Header.Hash.ToArray()
+                }),
+                rawHasText.Header.Hash
             );
         }
 

--- a/Libplanet.Tests/RandomExtensions.cs
+++ b/Libplanet.Tests/RandomExtensions.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests
         =>
             new HashDigest<T>(random.NextBytes(HashDigest<T>.Size));
 
-        public static BlockHash NextBlockHash(this Random random, int size) =>
-            new BlockHash(random.NextBytes(size));
+        public static BlockHash NextBlockHash(this Random random) =>
+            new BlockHash(random.NextBytes(BlockHash.Size));
     }
 }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -171,6 +171,12 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             AssertBytesEqual(expected.ToByteArray(), actual.ToByteArray());
         }
 
+        public static void AssertBytesEqual(Nonce expected, Nonce actual) =>
+            AssertBytesEqual(expected.ToByteArray(), actual.ToByteArray());
+
+        public static void AssertBytesEqual(Address expected, Address actual) =>
+            AssertBytesEqual(expected.ToByteArray(), actual.ToByteArray());
+
         public static byte[] GetRandomBytes(int size)
         {
             var bytes = new byte[size];

--- a/Libplanet.Tests/Tx/TxFailureTest.cs
+++ b/Libplanet.Tests/Tx/TxFailureTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -24,7 +23,7 @@ namespace Libplanet.Tests.Tx
         public TxFailureTest()
         {
             var random = new Random();
-            _blockHash = random.NextBlockHash(HashDigest<SHA256>.Size);
+            _blockHash = random.NextBlockHash();
             _txid = random.NextTxId();
             _fx = new TxFailure(_blockHash, _txid, new ArgumentNullException("foo"));
         }

--- a/Libplanet.Tests/Tx/TxSuccessTest.cs
+++ b/Libplanet.Tests/Tx/TxSuccessTest.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Blocks;
@@ -35,7 +33,7 @@ namespace Libplanet.Tests.Tx
         public TxSuccessTest()
         {
             var random = new Random();
-            _blockHash = random.NextBlockHash(HashDigest<SHA256>.Size);
+            _blockHash = random.NextBlockHash();
             _txid = random.NextTxId();
             _updatedStates = Enumerable.Repeat(random, 5).ToImmutableDictionary(
                 RandomExtensions.NextAddress,

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -592,7 +592,7 @@ namespace Libplanet.Net
                     return;
                 }
 
-                var hash = new BlockHash(demand.Header.Hash);
+                BlockHash hash = demand.Header.Hash;
                 const string startLogMsg =
                     "{SessionId}: Got a new " + nameof(BlockDemand) + " from {Peer}; started " +
                     "to fetch the block #{BlockIndex} {BlockHash}...";

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -125,7 +125,7 @@ namespace Libplanet.Net
             _logger.Information(
                 $"Received {nameof(BlockHeader)} #{{BlockIndex}} {{BlockHash}}.",
                 header.Index,
-                ByteUtil.Hex(header.Hash)
+                header.Hash
             );
 
             HashAlgorithmType hashAlgorithm = BlockChain.Policy.GetHashAlgorithm(header.Index);
@@ -139,7 +139,7 @@ namespace Libplanet.Net
                     ibe,
                     "Received header #{BlockIndex} {BlockHash} seems invalid; ignored.",
                     header.Index,
-                    ByteUtil.Hex(header.Hash)
+                    header.Hash
                 );
                 return;
             }
@@ -150,7 +150,7 @@ namespace Libplanet.Net
                     "Received header #{BlockIndex} {BlockHash} from peer {Peer} is not needed " +
                     "for the current chain with tip #{TipIndex} {TipHash}.",
                     header.Index,
-                    ByteUtil.Hex(header.Hash),
+                    header.Hash,
                     peer,
                     BlockChain.Tip,
                     BlockChain.Tip.Hash);
@@ -161,7 +161,7 @@ namespace Libplanet.Net
                 "Adding received header #{BlockIndex} {BlockHash} from peer {Peer} to " +
                 $"{nameof(BlockDemandTable)}...",
                 header.Index,
-                ByteUtil.Hex(header.Hash),
+                header.Hash,
                 peer);
             BlockDemandTable.Add(
                 BlockChain,

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -76,34 +74,25 @@ namespace Libplanet.Store
         {
             if (GetBlockDigest(blockHash) is BlockDigest blockDigest)
             {
-                BlockHash? prevHash = blockDigest.Header.PreviousHash.Any()
-                    ? new BlockHash(blockDigest.Header.PreviousHash)
-                    : (BlockHash?)null;
-                ImmutableArray<byte>? preEvaluationHash = blockDigest.Header.PreEvaluationHash.Any()
-                    ? blockDigest.Header.PreEvaluationHash
+                BlockHeader header = blockDigest.Header;
+                ImmutableArray<byte>? preEvaluationHash = header.PreEvaluationHash.Any()
+                    ? header.PreEvaluationHash
                     : (ImmutableArray<byte>?)null;
-                HashDigest<SHA256>? stateRootHash = blockDigest.Header.StateRootHash.Any()
-                    ? new HashDigest<SHA256>(blockDigest.Header.StateRootHash)
-                    : (HashDigest<SHA256>?)null;
 
                 return new Block<T>(
-                    index: blockDigest.Header.Index,
-                    difficulty: blockDigest.Header.Difficulty,
-                    totalDifficulty: blockDigest.Header.TotalDifficulty,
-                    nonce: new Nonce(blockDigest.Header.Nonce),
-                    miner: new Address(blockDigest.Header.Miner),
-                    previousHash: prevHash,
-                    timestamp: DateTimeOffset.ParseExact(
-                        blockDigest.Header.Timestamp,
-                        BlockHeader.TimestampFormat,
-                        CultureInfo.InvariantCulture
-                    ).ToUniversalTime(),
+                    index: header.Index,
+                    difficulty: header.Difficulty,
+                    totalDifficulty: header.TotalDifficulty,
+                    nonce: header.Nonce,
+                    miner: header.Miner,
+                    previousHash: header.PreviousHash,
+                    timestamp: header.Timestamp,
                     transactions: blockDigest.TxIds
                         .Select(bytes => GetTransaction<T>(new TxId(bytes.ToArray())))
                         .ToImmutableArray(),
                     preEvaluationHash: preEvaluationHash,
-                    stateRootHash: stateRootHash,
-                    protocolVersion: blockDigest.Header.ProtocolVersion
+                    stateRootHash: header.StateRootHash,
+                    protocolVersion: header.ProtocolVersion
                 );
             }
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ In addition to stable releases, we also provide pre-release packages.
 For every day and every merge commit, it is packed into a *.nupkg*
 and uploaded to [NuGet] with a hyphen-suffixed version name.
 
-For a merge commit build, a version name is like `0.1.0-dev.20181231235959`
-where `20181231235959` is a UTC timestamp of the build.
-For a daily build, a version name is like `0.1.0-nightly.20181231`.
+For a merge commit build, a version name looks like
+`0.1.0-dev.20181231235959+a0b1c2d` where `20181231235959` is a UTC timestamp of
+the build and `a0b1c2d` is the first 7 hexadecimals of the Git commit hash.
+For a daily build, a version name is like `0.1.0-nightly.20181231+a0b1c2d`.
 
 Unfortunately, Unity currently does not support NuGet.  There are some Unity
 plug-ins to deal with NuGet package system, and these seem immature at present.


### PR DESCRIPTION
Instead of `string`s and `ImmutableArray<byte>`s, this patch gives `BlockHeader`'s fields richer types like `DateTimeOffset`, `BlockHash`, `Nonce`, and `HashDigest<SHA256>`.