### PR TITLE
`IStore` is now `IDisposable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,7 @@ To be released.
 [#1440]: https://github.com/planetarium/libplanet/pull/1440
 [#1442]: https://github.com/planetarium/libplanet/pull/1442
 [#1443]: https://github.com/planetarium/libplanet/pull/1443
+[#1448]: https://github.com/planetarium/libplanet/issues/1448
 [#1449]: https://github.com/planetarium/libplanet/issues/1449
 [#1455]: https://github.com/planetarium/libplanet/pull/1455
 [#1457]: https://github.com/planetarium/libplanet/pull/1457
@@ -123,6 +124,7 @@ To be released.
 [#1464]: https://github.com/planetarium/libplanet/pull/1464
 [#1465]: https://github.com/planetarium/libplanet/pull/1465
 [#1470]: https://github.com/planetarium/libplanet/pull/1470
+[#1474]: https://github.com/planetarium/libplanet/pull/1474
 
 
 Version 0.16.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@ To be released.
         DateTimeOffset, Nonce, Address, long, BigInteger, BlockHash?,
         HashDigest<SHA256>?, BlockHash, ImmutableArray<byte>,
         HashDigest<SHA256>?)` constructor instead.
+ -  `IStore`, `IStateStore`, and `IKeyValueStore` interfaces now inherit
+    `IDisposable`.  [[#1448], [#1474]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -472,6 +472,10 @@ If omitted (default) explorer only the local blockchain store.")]
                 where T : IAction, new()
             {
             }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -27,6 +27,7 @@ namespace Libplanet.Explorer.Store
 
         // FIXME we should separate it.
         private readonly IStore _store;
+        private bool _disposed = false;
 
         public LiteDBRichStore(
             IStore store,
@@ -413,6 +414,17 @@ namespace Libplanet.Explorer.Store
                 Query.EQ(nameof(AddressRefDoc.AddressString), addressString)
             );
             return collection.Find(query, offset, limit).Select(doc => doc.TxId);
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _db?.Dispose();
+                _memoryStream?.Dispose();
+                _store.Dispose();
+                _disposed = true;
+            }
         }
 
         private LiteCollection<TxRefDoc> TxRefCollection() =>

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -422,7 +422,7 @@ namespace Libplanet.Explorer.Store
             {
                 _db?.Dispose();
                 _memoryStream?.Dispose();
-                _store.Dispose();
+                _store?.Dispose();
                 _disposed = true;
             }
         }

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -26,9 +26,9 @@ namespace Libplanet.Explorer.Store
 
         // FIXME we should separate it.
         private readonly IStore _store;
-
         private readonly MySqlCompiler _compiler;
         private readonly string _connectionString;
+        private bool _disposed = false;
 
         public MySQLRichStore(IStore store, MySQLRichStoreOptions options)
         {
@@ -377,6 +377,15 @@ namespace Libplanet.Explorer.Store
             return query.OrderBy("tx_nonce")
                 .Get<byte[]>()
                 .Select(bytes => new TxId(bytes));
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _store.Dispose();
+                _disposed = true;
+            }
         }
 
         private QueryFactory OpenDB() =>

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -383,7 +383,7 @@ namespace Libplanet.Explorer.Store
         {
             if (!_disposed)
             {
-                _store.Dispose();
+                _store?.Dispose();
                 _disposed = true;
             }
         }

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StatsCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StatsCommandTest.cs
@@ -88,8 +88,8 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
         {
             foreach (var storeFixture in _storeFixtures)
             {
-                (storeFixture.Store as IDisposable)?.Dispose();
-                (storeFixture.StateStore as IDisposable)?.Dispose();
+                storeFixture.Store?.Dispose();
+                storeFixture.StateStore?.Dispose();
             }
 
             Console.SetOut(_originalWriter);

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -80,8 +80,8 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 v.Store.PutBlock(_block4);
                 v.Store.AppendIndex(guid, _block4.Hash);
 
-                (v.Store as IDisposable)?.Dispose();
-                (v.StateStore as IDisposable)?.Dispose();
+                v.Store?.Dispose();
+                v.StateStore?.Dispose();
             }
         }
 

--- a/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             }
 
             Console.WriteLine($"It taken {DateTimeOffset.UtcNow - prev}");
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         [Command(Description = "Query block hashes by transaction id.")]
@@ -60,7 +60,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             var blockHashes = store.IterateTxIdBlockHashIndex(new TxId(ByteUtil.ParseHex(strTxId)))
                 .ToImmutableArray();
             Console.WriteLine(Utils.SerializeHumanReadable(blockHashes));
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         [Command(Description = "Query a list of blocks by transaction id.")]
@@ -82,7 +82,7 @@ namespace Libplanet.Extensions.Cocona.Commands
 
             Console.WriteLine(Utils.SerializeHumanReadable(blocks));
 
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         [Command(Description = "Query a block by index.")]
@@ -97,7 +97,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             var blockHash = GetBlockHash(store, blockIndex);
             var block = GetBlock<Utils.DummyAction>(store, blockHash);
             Console.WriteLine(Utils.SerializeHumanReadable(block));
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         [Command(Description = "Query a block by hash.")]
@@ -111,7 +111,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             IStore store = LoadStoreFromUri(home);
             var block = GetBlock<Utils.DummyAction>(store, BlockHash.FromString(blockHash));
             Console.WriteLine(Utils.SerializeHumanReadable(block));
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         [Command(Description = "Query a transaction by tx id.")]
@@ -125,7 +125,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             IStore store = LoadStoreFromUri(home);
             var tx = GetTransaction<Utils.DummyAction>(store, new TxId(ByteUtil.ParseHex(strTxId)));
             Console.WriteLine(Utils.SerializeHumanReadable(tx));
-            (store as IDisposable)?.Dispose();
+            store?.Dispose();
         }
 
         private static Block<T> GetBlock<T>(IStore store, BlockHash blockHash)

--- a/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreFixture.cs
+++ b/Libplanet.RocksDBStore.Tests/MonoRocksDBStoreFixture.cs
@@ -33,8 +33,8 @@ namespace Libplanet.RocksDBStore.Tests
 
         public override void Dispose()
         {
-            (Store as IDisposable)?.Dispose();
-            (StateStore as IDisposable)?.Dispose();
+            Store?.Dispose();
+            StateStore?.Dispose();
 
             if (!(Path is null))
             {

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
@@ -33,8 +33,8 @@ namespace Libplanet.RocksDBStore.Tests
 
         public override void Dispose()
         {
-            (Store as IDisposable)?.Dispose();
-            (StateStore as IDisposable)?.Dispose();
+            Store?.Dispose();
+            StateStore?.Dispose();
 
             if (!(Path is null))
             {

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using Libplanet.Store.Trie;
 using RocksDbSharp;
@@ -10,7 +9,7 @@ namespace Libplanet.RocksDBStore
     /// The <a href="https://rocksdb.org/">RocksDB</a> <see cref="IKeyValueStore"/> implementation.
     /// This stores data in the RocksDB.
     /// </summary>
-    public class RocksDBKeyValueStore : IKeyValueStore, IDisposable
+    public class RocksDBKeyValueStore : IKeyValueStore
     {
         private readonly RocksDb _keyValueDb;
         private bool _disposed = false;

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -45,8 +45,8 @@ namespace Libplanet.Tests.Store
 
         public override void Dispose()
         {
-            (Store as IDisposable)?.Dispose();
-            (StateStore as IDisposable)?.Dispose();
+            Store?.Dispose();
+            StateStore?.Dispose();
 
             if (!(Path is null))
             {

--- a/Libplanet.Tests/Store/StateStoreTracker.cs
+++ b/Libplanet.Tests/Store/StateStoreTracker.cs
@@ -10,6 +10,7 @@ namespace Libplanet.Tests.Store
     public sealed class StateStoreTracker : BaseTracker, IStateStore
     {
         private readonly IStateStore _stateStore;
+        private bool _disposed = false;
 
         public StateStoreTracker(IStateStore stateStore)
         {
@@ -42,6 +43,15 @@ namespace Libplanet.Tests.Store
         {
             Log(nameof(ForkStates), sourceChainId, destinationChainId, branchPoint);
             _stateStore.ForkStates(sourceChainId, destinationChainId, branchPoint);
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _stateStore?.Dispose();
+                _disposed = true;
+            }
         }
     }
 }

--- a/Libplanet.Tests/Store/StateStoreTrackerTest.cs
+++ b/Libplanet.Tests/Store/StateStoreTrackerTest.cs
@@ -73,6 +73,10 @@ namespace Libplanet.Tests.Store
                 where T : IAction, new()
             {
             }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1126,13 +1126,10 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void IdempotentDispose()
         {
-            if (Fx.Store is IDisposable disposableStore)
-            {
 #pragma warning disable S3966 // Objects should not be disposed more than once
-                disposableStore.Dispose();
-                disposableStore.Dispose();
+            Fx.Store.Dispose();
+            Fx.Store.Dispose();
 #pragma warning restore S3966 // Objects should not be disposed more than once
-            }
         }
 
         private class AtomicityTestAction : IAction

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1127,8 +1127,8 @@ namespace Libplanet.Tests.Store
         public void IdempotentDispose()
         {
 #pragma warning disable S3966 // Objects should not be disposed more than once
-            Fx.Store.Dispose();
-            Fx.Store.Dispose();
+            Fx.Store?.Dispose();
+            Fx.Store?.Dispose();
 #pragma warning restore S3966 // Objects should not be disposed more than once
         }
 

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -11,6 +11,7 @@ namespace Libplanet.Tests.Store
     public sealed class StoreTracker : BaseTracker, IStore
     {
         private readonly IStore _store;
+        private bool _disposed = false;
 
         public StoreTracker(IStore store)
         {
@@ -256,6 +257,15 @@ namespace Libplanet.Tests.Store
         {
             Log(nameof(SetCanonicalChainId), chainId);
             _store.SetCanonicalChainId(chainId);
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _store.Dispose();
+                _disposed = true;
+            }
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -263,7 +263,7 @@ namespace Libplanet.Tests.Store
         {
             if (!_disposed)
             {
-                _store.Dispose();
+                _store?.Dispose();
                 _disposed = true;
             }
         }

--- a/Libplanet.Tests/Store/Trie/MemoryKeyValueStore.cs
+++ b/Libplanet.Tests/Store/Trie/MemoryKeyValueStore.cs
@@ -37,6 +37,10 @@ namespace Libplanet.Tests.Store.Trie
             return Dictionary.ContainsKey(key);
         }
 
+        public void Dispose()
+        {
+        }
+
         public IEnumerable<byte[]> ListKeys() => Dictionary.Keys;
     }
 }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Store
     /// <summary>
     /// Common code for several <see cref="IStore"/> implementations.
     /// </summary>
-    public abstract class BaseStore : IStore, IDisposable
+    public abstract class BaseStore : IStore
     {
         /// <inheritdoc />
         public abstract IEnumerable<Guid> ListChainIds();

--- a/Libplanet/Store/IStateStore.cs
+++ b/Libplanet/Store/IStateStore.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Store
     /// <summary>
     /// An interface to store states.
     /// </summary>
-    public interface IStateStore
+    public interface IStateStore : IDisposable
     {
         /// <summary>
         /// Sets states mapped as relation <see cref="Block{T}.Hash"/> → states.

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -8,7 +8,7 @@ using Libplanet.Tx;
 
 namespace Libplanet.Store
 {
-    public interface IStore
+    public interface IStore : IDisposable
     {
         /// <summary>
         /// Lists existing chain IDs.

--- a/Libplanet/Store/Trie/CacheableKeyValueStore.cs
+++ b/Libplanet/Store/Trie/CacheableKeyValueStore.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Store.Trie
     /// <summary>
     /// The proxy class to cache <see cref="IKeyValueStore"/> operations.
     /// </summary>
-    public class CacheableKeyValueStore : IKeyValueStore, IDisposable
+    public class CacheableKeyValueStore : IKeyValueStore
     {
         private readonly IKeyValueStore _keyValueStore;
         private readonly LruCache<byte[], byte[]> _cache;
@@ -68,7 +68,7 @@ namespace Libplanet.Store.Trie
 
         public void Dispose()
         {
-            (_keyValueStore as IDisposable)?.Dispose();
+            _keyValueStore?.Dispose();
         }
     }
 }

--- a/Libplanet/Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet/Store/Trie/DefaultKeyValueStore.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,7 +11,7 @@ namespace Libplanet.Store.Trie
     /// The default built-in <see cref="IKeyValueStore"/> implementation. This stores data in
     /// the file system or in memory.
     /// </summary>
-    public class DefaultKeyValueStore : IKeyValueStore, IDisposable
+    public class DefaultKeyValueStore : IKeyValueStore
     {
         private readonly IFileSystem _root;
 

--- a/Libplanet/Store/Trie/IKeyValueStore.cs
+++ b/Libplanet/Store/Trie/IKeyValueStore.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 
 namespace Libplanet.Store.Trie
@@ -6,7 +7,7 @@ namespace Libplanet.Store.Trie
     /// <summary>
     /// An interface to access key-value store.
     /// </summary>
-    public interface IKeyValueStore
+    public interface IKeyValueStore : IDisposable
     {
         public byte[] Get(byte[] key);
 

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -163,8 +163,8 @@ namespace Libplanet.Store
         {
             if (!_disposed)
             {
-                (_stateKeyValueStore as IDisposable)?.Dispose();
-                (_stateHashKeyValueStore as IDisposable)?.Dispose();
+                _stateKeyValueStore?.Dispose();
+                _stateHashKeyValueStore?.Dispose();
                 _disposed = true;
             }
         }

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Store
     /// <summary>
     /// An <see cref="IStateStore"/> implementation. It stores states with <see cref="MerkleTrie"/>.
     /// </summary>
-    public class TrieStateStore : IStateStore, IDisposable
+    public class TrieStateStore : IStateStore
     {
         private readonly IKeyValueStore _stateKeyValueStore;
         private readonly IKeyValueStore _stateHashKeyValueStore;


### PR DESCRIPTION
Closes #1448.

I don't think it is too far fetched to think `IStore`s (together with `IStateStore`s and `IKeyValueStore`s) in general might have unmanaged resources to be cleaned up from a user's perspective. I think it would be better to forgo type checking specific implementation whether a store is disposable or not and simply disposing an `IStore` as a general rule is better.

P.S. On a side note, I thought about also implementing finalizers, but there seem to be a general consensus to *avoid* using finalizers if possible. Any thoughts?