### PR TITLE
`PrivateKey.FromString()` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@ To be released.
 ### Added APIs
 
  -  `IBlockExcerpt.ExcerptEquals` extension method added.  [[#1440]]
+ -  Added `PrivateKey.FromString()` method.  [[#1475]]
  -  Added `PrivateKey.Sign(ImmutableArray<byte>)` overloaded method.  [[#1464]]
  -  Added `PrivateKey.Decrypt(ImmutableArray<byte>)` overloaded method.
     [[#1464]]
@@ -127,6 +128,7 @@ To be released.
 [#1465]: https://github.com/planetarium/libplanet/pull/1465
 [#1470]: https://github.com/planetarium/libplanet/pull/1470
 [#1474]: https://github.com/planetarium/libplanet/pull/1474
+[#1475]: https://github.com/planetarium/libplanet/pull/1475
 
 
 Version 0.16.0

--- a/Libplanet.Extensions.Cocona/Commands/Key/DerivationCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/Key/DerivationCommand.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Extensions.Cocona.Commands.Key
                  );
             }
 
-            var privateKey = new PrivateKey(ByteUtil.ParseHex(privateKeyHex));
+            PrivateKey privateKey = Crypto.PrivateKey.FromString(privateKeyHex);
             if (address)
             {
                 Console.Out.WriteLine(privateKey.ToAddress());

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -97,8 +97,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             PrivateKey key;
             try
             {
-                byte[] keyBytes = ByteUtil.ParseHex(rawKeyHex);
-                key = new PrivateKey(keyBytes);
+                key = PrivateKey.FromString(rawKeyHex);
             }
             catch (FormatException)
             {

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -12,6 +12,8 @@
     <Rule Id="SA1005" Action="None" />
     <!-- Closing parenthesis should be on line of opening parenthesis -->
     <Rule Id="SA1112" Action="None" />
+    <!-- The parameter spans multiple lines -->
+    <Rule Id="SA1118" Action="None" />
     <!-- Allow tuple types in signatures omit element names. -->
     <Rule Id="SA1414" Action="None" />
     <!-- Allow tuple fields to be referred by index (i.e. ItemN). -->

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
@@ -246,10 +245,6 @@ namespace Libplanet.Tests.Action
                     stateCompleterSet: StateCompleterSet<ThrowException>.Recalculate).ToList());
         }
 
-        [SuppressMessage(
-            "Microsoft.StyleCop.CSharp.ReadabilityRules",
-            "SA1118",
-            Justification = "Long array literals should be multiline.")]
         [Fact]
         public void EvaluateTxs()
         {

--- a/Libplanet.Tests/Crypto/PrivateKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PrivateKeyTest.cs
@@ -4,11 +4,32 @@ using System.Linq;
 using System.Text;
 using Libplanet.Crypto;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Crypto
 {
     public class PrivateKeyTest
     {
+        [Fact]
+        public void FromString()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => PrivateKey.FromString(string.Empty));
+            Assert.Throws<ArgumentOutOfRangeException>(() => PrivateKey.FromString("a"));
+            Assert.Throws<FormatException>(() => PrivateKey.FromString("zz"));
+            PrivateKey actual = PrivateKey.FromString(
+                "e07107ca4b0d19147fa1152a0f2c7884705d59cbb6318e2f901bd28dd9ff78e3"
+            );
+            AssertBytesEqual(
+                new byte[]
+                {
+                    0xe0, 0x71, 0x07, 0xca, 0x4b, 0x0d, 0x19, 0x14, 0x7f, 0xa1, 0x15,
+                    0x2a, 0x0f, 0x2c, 0x78, 0x84, 0x70, 0x5d, 0x59, 0xcb, 0xb6, 0x31,
+                    0x8e, 0x2f, 0x90, 0x1b, 0xd2, 0x8d, 0xd9, 0xff, 0x78, 0xe3,
+                },
+                actual.ToByteArray()
+            );
+        }
+
         [Fact]
         public void BytesTest()
         {
@@ -121,8 +142,9 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void ExchangeTest()
         {
-            var prvKey = new PrivateKey(ByteUtil.ParseHex(
-                "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465"));
+            PrivateKey prvKey = PrivateKey.FromString(
+                "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465"
+            );
             byte[] pubkeyBytes = ByteUtil.ParseHex(
                 "5f706787ac72c1080275c1f398640fb07e9da0b124ae9734b28b8d0f01eda586"
             );

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -433,17 +433,13 @@ namespace Libplanet.Tests.Net
         {
             // If the bucket stored peers are the same, the block may not propagate,
             // so specify private keys to make the buckets different.
-            var keyA = ByteUtil.ParseHex(
-                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20");
-            var keyB = ByteUtil.ParseHex(
+            PrivateKey minerKey = PrivateKey.FromString(
                 "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c");
-            var keyC = ByteUtil.ParseHex(
-                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
-
-            var minerKey = new PrivateKey(keyB);
-            var swarmA = CreateSwarm(new PrivateKey(keyA));
+            var swarmA = CreateSwarm(PrivateKey.FromString(
+                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20"));
             var swarmB = CreateSwarm(minerKey);
-            var swarmC = CreateSwarm(new PrivateKey(keyC));
+            var swarmC = CreateSwarm(PrivateKey.FromString(
+                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3"));
 
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
@@ -514,16 +510,12 @@ namespace Libplanet.Tests.Net
         {
             // If the bucket stored peers are the same, the block may not propagate,
             // so specify private keys to make the buckets different.
-            var keyA = ByteUtil.ParseHex(
-                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20");
-            var keyB = ByteUtil.ParseHex(
-                "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c");
-            var keyC = ByteUtil.ParseHex(
-                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
-
-            var swarmA = CreateSwarm(new PrivateKey(keyA));
-            var swarmB = CreateSwarm(new PrivateKey(keyB));
-            var swarmC = CreateSwarm(new PrivateKey(keyC));
+            var swarmA = CreateSwarm(PrivateKey.FromString(
+                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20"));
+            var swarmB = CreateSwarm(PrivateKey.FromString(
+                "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c"));
+            var swarmC = CreateSwarm(PrivateKey.FromString(
+                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3"));
 
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1160,16 +1160,12 @@ namespace Libplanet.Tests.Net
         {
             // If the bucket stored peers are the same, the block may not propagate,
             // so specify private keys to make the buckets different.
-            var keyA = ByteUtil.ParseHex(
-                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20");
-            var keyB = ByteUtil.ParseHex(
-                "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c");
-            var keyC = ByteUtil.ParseHex(
-                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
-
-            var minerSwarmA = CreateSwarm(new PrivateKey(keyA));
-            var minerSwarmB = CreateSwarm(new PrivateKey(keyB));
-            var receiverSwarm = CreateSwarm(new PrivateKey(keyC));
+            var minerSwarmA = CreateSwarm(PrivateKey.FromString(
+                "8568eb6f287afedece2c7b918471183db0451e1a61535bb0381cfdf95b85df20"));
+            var minerSwarmB = CreateSwarm(PrivateKey.FromString(
+                "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c"));
+            var receiverSwarm = CreateSwarm(PrivateKey.FromString(
+                "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3"));
 
             BlockChain<DumbAction> minerChainA = minerSwarmA.BlockChain;
             BlockChain<DumbAction> minerChainB = minerSwarmB.BlockChain;

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
@@ -721,10 +720,6 @@ namespace Libplanet.Tests.Tx
             Assert.Empty(t2.Actions);
         }
 
-        [SuppressMessage(
-            "Microsoft.StyleCop.CSharp.ReadabilityRules",
-            "SA1118",
-            Justification = "Long array literals should be multiline.")]
         internal RawTransaction GetExpectedRawTransaction(bool includeSingature)
         {
             var privateKey = new PrivateKey(new byte[]

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -123,6 +123,30 @@ namespace Libplanet.Crypto
             Operator.Weave(left, right);
 
         /// <summary>
+        /// Creates a <see cref="PrivateKey"/> instance from hexadecimal string of bytes.
+        /// </summary>
+        /// <param name="hex">A hexadecimal string of a private key's
+        /// <see cref="ByteArray"/>.</param>
+        /// <returns>A created <see cref="PrivateKey"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given <paramref name="hex"/>
+        /// string is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of the given
+        /// <paramref name="hex"/> string is an odd number, or it is empty.</exception>
+        /// <exception cref="FormatException">Thrown when the given <paramref name="hex"/> string is
+        /// not a valid hexadecimal string.</exception>
+        [Pure]
+        public static PrivateKey FromString(string hex)
+        {
+            if (!hex.Any())
+            {
+                throw new ArgumentOutOfRangeException(nameof(hex), "Argument must not be empty.");
+            }
+
+            byte[] bytes = ByteUtil.ParseHex(hex);
+            return new PrivateKey(bytes);
+        }
+
+        /// <summary>
         /// Creates a signature from the given <paramref name="message"/>.
         /// <para>
         /// A created signature can be verified by the corresponding


### PR DESCRIPTION
`new PrivateKey(ByteUtil.FromHex(hex))` now can be shortened as `PrivateKey.FromString(hex)`.