### PR TITLE
`txPriority` option for `BlockChain<T>.MineBlock()` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,8 +36,10 @@ To be released.
     [[#1447]]
  -  Added `IBlockPolicy<T>.GetMaxTransactionsPerBlock(long index)` method.
     [[#1447]]
- -  Unused parameter `currentTime` removed from `BlockChain<T>.Append()`
+ -  Unused parameter `currentTime` removed from `BlockChain<T>.Append()`.
     [[#1462], [#1465]]
+ -  Added an optional `maxTransactionsPerSigner` parameter to
+    `BlockChain<T>.MineBlock()` method.  [[#1449], [#1463]]
  -  `BlockHeader`'s properties are now represented as richer types than before.
     [[#1470]]
      -  `BlockHeader.Timestamp` property's type became `DateTimeOffset`
@@ -66,7 +68,7 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
- -  `Message` became to serialize peer with bencodex instead of
+ -  `Message` became to serialize peer with Bencodex instead of
     `BinaryFormatter`.  [[#1455]]
 
 ### Backward-incompatible storage format changes
@@ -85,8 +87,6 @@ To be released.
  -  Added `Nonce(ImmutableArray<byte>)` overloaded constructor.  [[#1464]]
  -  `IBlockPolicy.GetMaxTransactionsPerSignerPerBlock()` interface method added.
     [[#1449], [#1463]]
- -  `BlockChain<T>.MineBlock()` now takes `maxTransactionsPerSigner`
-    as an optional parameter.  [[#1449], [#1463]]
  -  Added `BlockHeader(int, long, DateTimeOffset, Nonce, Address, long,
     BigInteger, BlockHash?, HashDigest<SHA256>?, BlockHash,
     ImmutableArray<byte>, HashDigest<SHA256>?)` constructor.  [[#1470]]
@@ -136,6 +136,7 @@ To be released.
 [#1470]: https://github.com/planetarium/libplanet/pull/1470
 [#1474]: https://github.com/planetarium/libplanet/pull/1474
 [#1475]: https://github.com/planetarium/libplanet/pull/1475
+[#1477]: https://github.com/planetarium/libplanet/pull/1477
 
 
 Version 0.16.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ To be released.
     [[#1462], [#1465]]
  -  Added an optional `maxTransactionsPerSigner` parameter to
     `BlockChain<T>.MineBlock()` method.  [[#1449], [#1463]]
+ -  Added an optional `txPriority` parameter to `BlockChain<T>.MineBlock()`
+    method. [[#1477]]
  -  `BlockHeader`'s properties are now represented as richer types than before.
     [[#1470]]
      -  `BlockHeader.Timestamp` property's type became `DateTimeOffset`

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -70,6 +70,8 @@
     <Rule Id="S2933" Action="None" />
     <!-- Return 'Task' instead. -->
     <Rule Id="S3168" Action="None" />
+    <!-- Extract this nested ternary operation into an independent statement. -->
+    <Rule Id="S3358" Action="Info" />
     <!-- Make this test method non-'async' or return 'Task'. -->
     <Rule Id="S3433" Action="None" />
     <!-- Fix this implementation of 'IDisposable' to conform to the dispose

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Blockchain
     public partial class BlockChainTest
     {
         [Fact]
-        public async void MineBlock()
+        public async Task MineBlock()
         {
             // Tests if MineBlock() method will throw an exception if less than the minimum
             // transactions are present
@@ -113,7 +113,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithTxBatchSize()
+        public async Task MineBlockWithTxBatchSize()
         {
             List<PrivateKey> privateKeys = Enumerable.Range(0, 3)
                 .Select(_ => new PrivateKey()).ToList();
@@ -149,7 +149,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithPendingTxs()
+        public async Task MineBlockWithPendingTxs()
         {
             var keys = new[] { new PrivateKey(), new PrivateKey(), new PrivateKey() };
 
@@ -250,7 +250,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithPolicyViolationTx()
+        public async Task MineBlockWithPolicyViolationTx()
         {
             var validKey = new PrivateKey();
             var invalidKey = new PrivateKey();
@@ -290,7 +290,7 @@ namespace Libplanet.Tests.Blockchain
         [InlineData(3)]
         [InlineData(2)]
         [InlineData(1)]
-        public async void MineBlockWithReverseNonces(int maxTxs)
+        public async Task MineBlockWithReverseNonces(int maxTxs)
         {
             var key = new PrivateKey();
             var txs = new[]
@@ -358,7 +358,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithBlockAction()
+        public async Task MineBlockWithBlockAction()
         {
             var privateKey1 = new PrivateKey();
             var address1 = privateKey1.ToAddress();
@@ -400,7 +400,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithMaxTransactions()
+        public async Task MineBlockWithMaxTransactions()
         {
             Assert.Equal(1, _blockChain.Count);
 
@@ -439,7 +439,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void MineBlockWithMaxTransactionsPerSigner()
+        public async Task MineBlockWithMaxTransactionsPerSigner()
         {
             Assert.Equal(1, _blockChain.Count);
 
@@ -481,7 +481,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        private async void AbortMining()
+        public async Task AbortMining()
         {
             // This test makes 2 different policies even it's abnormal
             // because to make a mining task run forever just for testing.
@@ -532,7 +532,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        private async Task IgnoreLowerNonceTxsAndMine()
+        public async Task IgnoreLowerNonceTxsAndMine()
         {
             var privateKey = new PrivateKey();
             var address = privateKey.ToAddress();

--- a/Libplanet.Tests/RandomExtensions.cs
+++ b/Libplanet.Tests/RandomExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -27,5 +29,11 @@ namespace Libplanet.Tests
 
         public static BlockHash NextBlockHash(this Random random) =>
             new BlockHash(random.NextBytes(BlockHash.Size));
+
+        public static IOrderedEnumerable<T> Shuffle<T>(this Random random, IEnumerable<T> source) =>
+            source.OrderBy(_ => random.Next());
+
+        public static IOrderedEnumerable<T> Shuffle<T>(this IEnumerable<T> source, Random random) =>
+            random.Shuffle(source);
     }
 }

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -207,16 +207,20 @@ namespace Libplanet.Blockchain
         /// allowed.</param>
         /// <param name="maxTransactionsPerSigner">The maximum number of
         /// <see cref="Transaction{T}"/>s with the same signer allowed.</param>
+        /// <param name="txPriority">An optional comparer for give certain transactions to
+        /// priority to belong to the block.  No certain priority by default.</param>
         /// <returns>An <see cref="ImmutableList"/> of <see cref="Transaction{T}"/>s with its
         /// count not exceeding <paramref name="maxTransactions"/> and the number of
         /// <see cref="Transaction{T}"/>s in the list for each signer not exceeding
         /// <paramref name="maxTransactionsPerSigner"/>.</returns>
         internal ImmutableList<Transaction<T>> GatherTransactionsToMine(
             int maxTransactions,
-            int maxTransactionsPerSigner)
+            int maxTransactionsPerSigner,
+            IComparer<Transaction<T>> txPriority = null
+        )
         {
             long index = Count;
-            ImmutableList<Transaction<T>> stagedTransactions = ListStagedTransactions();
+            ImmutableList<Transaction<T>> stagedTransactions = ListStagedTransactions(txPriority);
             _logger.Information(
                 "Gathering transactions to mine for block #{Index} from {TransactionsCount} " +
                 "staged transactions...",

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -34,6 +34,8 @@ namespace Libplanet.Blockchain
         /// <param name="maxTransactionsPerSigner">The maximum number of transactions
         /// that a block can accept per signer.  See also
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
+        /// <param name="txPriority">An optional comparer for give certain transactions to
+        /// priority to belong to the block.  No certain priority by default.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is mined.</returns>
@@ -45,6 +47,7 @@ namespace Libplanet.Blockchain
             bool? append = null,
             int? maxTransactions = null,
             int? maxTransactionsPerSigner = null,
+            IComparer<Transaction<T>> txPriority = null,
             CancellationToken? cancellationToken = null) =>
 #pragma warning disable SA1118
                 await MineBlock(
@@ -55,6 +58,7 @@ namespace Libplanet.Blockchain
                         Policy.GetMaxTransactionsPerBlock(Count),
                     maxTransactionsPerSigner: maxTransactionsPerSigner
                         ?? Policy.GetMaxTransactionsPerSignerPerBlock(Count),
+                    txPriority: txPriority,
                     cancellationToken: cancellationToken ?? default(CancellationToken));
 #pragma warning restore SA1118
 
@@ -70,6 +74,8 @@ namespace Libplanet.Blockchain
         /// <param name="maxTransactionsPerSigner">The maximum number of transactions
         /// that a block can accept per signer.  See also
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
+        /// <param name="txPriority">An optional comparer for give certain transactions to
+        /// priority to belong to the block.  No certain priority by default.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is mined.</returns>
@@ -81,6 +87,7 @@ namespace Libplanet.Blockchain
             bool append,
             int maxTransactions,
             int maxTransactionsPerSigner,
+            IComparer<Transaction<T>> txPriority = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             using var cts = new CancellationTokenSource();
@@ -108,7 +115,9 @@ namespace Libplanet.Blockchain
 
             var transactionsToMine = GatherTransactionsToMine(
                 maxTransactions: maxTransactions,
-                maxTransactionsPerSigner: maxTransactionsPerSigner);
+                maxTransactionsPerSigner: maxTransactionsPerSigner,
+                txPriority: txPriority
+            );
 
             _logger.Verbose(
                 "{SessionId}/{ProcessId}: Mined block #{Index} will include " +


### PR DESCRIPTION
This patch adds a new option `txPriority` to `BlockChain<T>.MineBlock()` method (and its internal parts, `GatherTransactionsToMine()` & `ListStagedTransactions()`).  The parameter takes an [`IComparer<Transaction<T>>`][1] to determine the priority of staged transactions.  Here's a very simple example:

```csharp
// Prioritize a certain signer's transactions over others':
Address prioritySigner = new Address("…");
IComparer<Transaction<T>> txPriority = Comparer<Transaction<T>>.Create(
    (a, b) => a.Signer.Equal(prioritySigner) ? -1 : (b.Signer.Equal(prioritySigner) ? 1 : 0);
);
```

[1]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.icomparer-1?view=netstandard-2.0