### PR TITLE
Variable min txs per miner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,6 @@ To be released.
  -  `TotalDifficultyComparer` now implements `IComparer<IBlockExcerpt>`
     interface.  [[#1442]]
  -  Return type for `BlockDemandTable.Add()` is now `void`.  [[#1435], [#1443]]
- -  Added `IBlockPolicy<T>.MinTransactionsPerBlock` property.  [[#1445]]
  -  Added `BlockInsufficientTxsException`.  [[#1445]]
  -  `PrivateKey()` constructor's parameter type became `IReadOnlyList<byte>`
     (was `byte[]`).  [[#1464]]
@@ -87,11 +86,14 @@ To be released.
     [[#1464]]
  -  Added `PublicKey.ToImmutableArray()` method.  [[#1464]]
  -  Added `Nonce(ImmutableArray<byte>)` overloaded constructor.  [[#1464]]
- -  `IBlockPolicy.GetMaxTransactionsPerSignerPerBlock()` interface method added.
+ -  Added `IBlockPolicy.GetMaxTransactionsPerSignerPerBlock()` interface method.
     [[#1449], [#1463]]
  -  Added `BlockHeader(int, long, DateTimeOffset, Nonce, Address, long,
     BigInteger, BlockHash?, HashDigest<SHA256>?, BlockHash,
     ImmutableArray<byte>, HashDigest<SHA256>?)` constructor.  [[#1470]]
+ -  Added `IBlockPolicy<T>.GetMinTransactionsPerBlock()` interface method.
+    [[#1479]]
+
 
 ### Behavioral changes
 
@@ -139,6 +141,7 @@ To be released.
 [#1474]: https://github.com/planetarium/libplanet/pull/1474
 [#1475]: https://github.com/planetarium/libplanet/pull/1475
 [#1477]: https://github.com/planetarium/libplanet/pull/1477
+[#1479]: https://github.com/planetarium/libplanet/pull/1479
 
 
 Version 0.16.0

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -405,10 +405,11 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public IAction BlockAction => _impl.BlockAction;
 
-            public int MinTransactionsPerBlock => _impl.MinTransactionsPerBlock;
-
             public IComparer<IBlockExcerpt> CanonicalChainComparer =>
                 _impl.CanonicalChainComparer;
+
+            public int GetMinTransactionsPerBlock(long index) =>
+                _impl.GetMinTransactionsPerBlock(index);
 
             public int GetMaxTransactionsPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerBlock(index);

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Tests.Blockchain
 
         public IAction BlockAction => null;
 
-        public int MinTransactionsPerBlock => 0;
+        public int GetMinTransactionsPerBlock(long index) => 0;
 
         public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;
 

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -376,11 +376,11 @@ namespace Libplanet.Blockchain
                 }
             }
 
-            if (transactionsToMine.Count < Policy.MinTransactionsPerBlock)
+            if (transactionsToMine.Count < Policy.GetMinTransactionsPerBlock(index))
             {
                 throw new BlockInsufficientTxsException(
                     transactionsToMine.Count,
-                    Policy.MinTransactionsPerBlock,
+                    Policy.GetMinTransactionsPerBlock(index),
                     "Below Minimum Transactions");
             }
 

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -18,9 +18,10 @@ namespace Libplanet.Blockchain.Policies
     {
         private readonly int _maxBlockBytes;
         private readonly int _maxGenesisBytes;
-        private readonly int _maxTransactionsPerBlock;
         private readonly Func<Transaction<T>, BlockChain<T>, bool> _doesTransactionFollowPolicy;
         private readonly HashAlgorithmGetter _hashAlgorithmGetter;
+        private readonly int _minTransactionsPerBlock;
+        private readonly int _maxTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerSignerPerBlock;
 
         /// <summary>
@@ -41,8 +42,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
         /// <param name="maxTransactionsPerBlock">Configures the constant return value of
         /// <see cref="GetMaxTransactionsPerBlock(long)"/> method.  100 by default.</param>
-        /// <param name="minTransactionsPerBlock">Configures <see cref="MinTransactionsPerBlock"/>.
-        /// 0 by default.</param>
+        /// <param name="minTransactionsPerBlock">Configures the constant return value of
+        /// <see cref="GetMinTransactionsPerBlock"/> method.  0 by default.</param>
         /// <param name="maxBlockBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
         /// the block is not a genesis.  100 KiB by default.</param>
         /// <param name="maxGenesisBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
@@ -102,8 +103,8 @@ namespace Libplanet.Blockchain.Policies
         /// <see cref="DifficultyBoundDivisor"/>.</param>
         /// <param name="maxTransactionsPerBlock">Configures the constant return value of
         /// <see cref="GetMaxTransactionsPerBlock(long)"/> method.</param>
-        /// <param name="minTransactionsPerBlock">Configures <see cref="MinTransactionsPerBlock"/>.
-        /// </param>
+        /// <param name="minTransactionsPerBlock">Configures the constant return value of
+        /// <see cref="GetMinTransactionsPerBlock"/> method.  0 by default.</param>
         /// <param name="maxBlockBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
         /// the block is not a genesis.</param>
         /// <param name="maxGenesisBytes">Configures <see cref="GetMaxBlockBytes(long)"/> where
@@ -163,7 +164,7 @@ namespace Libplanet.Blockchain.Policies
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
             _maxTransactionsPerBlock = maxTransactionsPerBlock;
-            MinTransactionsPerBlock = minTransactionsPerBlock;
+            _minTransactionsPerBlock = minTransactionsPerBlock;
             _maxBlockBytes = maxBlockBytes;
             _maxGenesisBytes = maxGenesisBytes;
             _doesTransactionFollowPolicy = doesTransactionFollowPolicy ?? ((_, __) => true);
@@ -176,9 +177,6 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         public IAction BlockAction { get; }
-
-        /// <inheritdoc cref="IBlockPolicy{T}.MinTransactionsPerBlock"/>
-        public int MinTransactionsPerBlock { get; }
 
         /// <summary>
         /// An appropriate interval between consecutive <see cref="Block{T}"/>s.
@@ -251,15 +249,20 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc/>
         public int GetMaxBlockBytes(long index) => index > 0 ? _maxBlockBytes : _maxGenesisBytes;
 
-        /// <inheritdoc cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>
+        /// <inheritdoc/>
+        [Pure]
+        public int GetMinTransactionsPerBlock(long index) => _minTransactionsPerBlock;
+
+        /// <inheritdoc/>
         [Pure]
         public int GetMaxTransactionsPerBlock(long index) => _maxTransactionsPerBlock;
 
-        /// <inheritdoc cref="IBlockPolicy{T}.GetHashAlgorithm(long)"/>
+        /// <inheritdoc/>
         public HashAlgorithmType GetHashAlgorithm(long index) =>
             _hashAlgorithmGetter(index);
 
         /// <inheritdoc/>
+        [Pure]
         public int GetMaxTransactionsPerSignerPerBlock(long index)
             => _getMaxTransactionsPerSignerPerBlock(index);
     }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -31,13 +31,15 @@ namespace Libplanet.Blockchain.Policies
         IAction BlockAction { get; }
 
         /// <summary>
-        /// The minimum number of <see cref="Block{T}.Transactions"/> that a <see cref="Block{T}"/>
-        /// can accept.  This value must not be negative and must be deterministic (i.e., must not
-        /// change after an object is once instantiated).
+        /// Gets the minimum number of <see cref="Transaction{T}"/>s allowed for
+        /// a valid <see cref="Block{T}"/>.
         /// </summary>
-        /// <remarks>If the value is less then 0, it's treated as 0.</remarks>
+        /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
+        /// for which this constraint should apply.</param>
+        /// <returns>The minimum number of <see cref="Transaction{T}"/>s allowed for
+        /// a valid <see cref="Block{T}"/> can accept.</returns>
         [Pure]
-        int MinTransactionsPerBlock { get; }
+        int GetMinTransactionsPerBlock(long index);
 
         /// <summary>
         /// Gets the maximum number of <see cref="Block{T}.Transactions"/> that


### PR DESCRIPTION
Quick and dirty API change from `IBlockPolicy.MinTransactionsPerBlock` to `IBlockPolicy.GetMinTransactionsPerBlock()` for the surface level consistency. I'll do an internal cleanup after libplanet for [lib9c](https://github.com/planetarium/lib9c) and [headless](https://github.com/planetarium/NineChronicles.Headless) gets bumped.