### PR TITLE
Fix BlockChain<T>.MineBlock() for dupped nonce & Release 0.15.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,13 @@ Libplanet changelog
 Version 0.15.4
 --------------
 
-To be released.
+Released on September 14, 2021.
+
+ -  Fixed a bug where `BlockChain<T>.MineBlock()` had created a block that
+    includes both transactions when there are two or more transactions with
+    the same nonce on the stage.  [[#1491]]
+
+[#1491]: https://github.com/planetarium/libplanet/pull/1491
 
 
 Version 0.15.3

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -459,5 +459,24 @@ namespace Libplanet.Tests.Blockchain
             Assert.Single(b2.Transactions);
             Assert.Contains(txsB[3], b2.Transactions);
         }
+
+        [Fact]
+        private async Task IgnoreDuplicatedNonceTxs()
+        {
+            var privateKey = new PrivateKey();
+            var address = privateKey.ToAddress();
+            var txs = Enumerable.Range(0, 3)
+                .Select(_ => _fx.MakeTransaction(
+                    nonce: 0,
+                    privateKey: privateKey,
+                    timestamp: DateTimeOffset.Now))
+                .ToArray();
+            StageTransactions(txs);
+            Block<DumbAction> b = await _blockChain.MineBlock(address, append: false);
+            _blockChain.Append(b);
+
+            Assert.Single(b.Transactions);
+            Assert.Equal(txs[0], b.Transactions.Single());
+        }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -842,15 +842,7 @@ namespace Libplanet.Blockchain
                 if (!storedNonces.ContainsKey(tx.Signer))
                 {
                     storedNonces[tx.Signer] = Store.GetTxNonce(Id, tx.Signer);
-                }
-
-                if (nextNonces.TryGetValue(tx.Signer, out long prevNonce))
-                {
-                    nextNonces[tx.Signer] = prevNonce + 1;
-                }
-                else
-                {
-                    nextNonces[tx.Signer] = storedNonces[tx.Signer] + 1;
+                    nextNonces[tx.Signer] = storedNonces[tx.Signer];
                 }
 
                 _logger.Verbose(
@@ -887,7 +879,7 @@ namespace Libplanet.Blockchain
                     continue;
                 }
 
-                if (storedNonces[tx.Signer] <= tx.Nonce && tx.Nonce < nextNonces[tx.Signer])
+                if (storedNonces[tx.Signer] <= tx.Nonce && tx.Nonce == nextNonces[tx.Signer])
                 {
                     if (estimatedBytes + tx.BytesLength > maxBlockBytes)
                     {
@@ -907,6 +899,7 @@ namespace Libplanet.Blockchain
                     }
 
                     transactionsToMine.Add(tx);
+                    nextNonces[tx.Signer] += 1;
                     estimatedBytes += tx.BytesLength;
                 }
                 else if (tx.Nonce < storedNonces[tx.Signer])


### PR DESCRIPTION
This PR forces `BlockChain<T>.MineBlock<T>` contain only one for transactions with two or more same nonces.

This symptom does not appear to occur after Libplanet 0.17.