### PR TITLE
Set session timeout of block completion into SwarmOptions.MaxTimeout

### DIFF
--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -244,6 +244,7 @@ namespace Libplanet.Net
                     blockCompletion.Complete(
                         peers: peersWithExcerpt.Select(pair => pair.Item1).ToList(),
                         blockFetcher: GetBlocksAsync,
+                        singleSessionTimeout: Options.MaxTimeout,
                         cancellationToken: cancellationToken
                     );
 


### PR DESCRIPTION
Which is 150 seconds by default. This addresses issue #1490.

This PR does not contains neither changes of CHANGES.md nor new test cases. Please feel free to comment if you think any of those is required.