### PR TITLE
Difficulty adjustment algorithm separated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@ To be released.
     `BlockPolicy<T>()` constructor with `Func<long, int>? getMaxBlockBytes`.
     [[#1485]]
  -  Removed `TxViolatingBlockPolicyException` class.  [[#1485]]
+ -  Optional parameter name `difficultyBoundDivisor` for `BlockPolicy<T>()`
+    constructor changed to `difficultyStability`.  [[#1495]]
 
 ### Backward-incompatible network protocol changes
 
@@ -115,6 +117,9 @@ To be released.
     ImmutableArray<byte>, HashDigest<SHA256>?)` constructor.  [[#1470]]
  -  Added `BlockPolicyViolationException` and `TxPolicyViolationException`
     classes.  [[#1485]]
+ -  Added `DifficultyAdjustment` static class.  [[#1495]]
+ -  Added `BlockPolicy<T>.DifficultyStability` and
+    `BlockPolicy<T>.MinimumDifficulty` properties.  [[#1495]]
 
 ### Behavioral changes
 
@@ -144,6 +149,14 @@ To be released.
 
 ### Bug fixes
 
+ -  Improper sanity checks for `minimumDifficulty` and `difficultyStability`
+    (changed from the old name `difficultyBoundDivisor`) arguments given to
+    `BlockPolicy<T>()` constructor fixed.  [[#1495]]
+     -  It was possible for `difficultyStability` not to be positive when this
+        makes no sense.
+     -  Wrongly threw an `ArgumentOutOfRangeException` for the case where
+        `minimumDifficulty` would equal `difficultyStability`.
+
 ### CLI tools
 
 [#1358]: https://github.com/planetarium/libplanet/issues/1358
@@ -170,6 +183,7 @@ To be released.
 [#1479]: https://github.com/planetarium/libplanet/pull/1479
 [#1480]: https://github.com/planetarium/libplanet/pull/1480
 [#1485]: https://github.com/planetarium/libplanet/pull/1485
+[#1495]: https://github.com/planetarium/libplanet/pull/1495
 
 
 Version 0.16.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@ To be released.
  -  Removed `TxViolatingBlockPolicyException` class.  [[#1485]]
  -  Optional parameter name `difficultyBoundDivisor` for `BlockPolicy<T>()`
     constructor changed to `difficultyStability`.  [[#1495]]
+ -  Type for optional parameter `difficultyStability` for `BlockPolicy<T>()`
+    constructor changed to `long?` from `int?`.  [[#1495]]
 
 ### Backward-incompatible network protocol changes
 
@@ -149,13 +151,19 @@ To be released.
 
 ### Bug fixes
 
- -  Improper sanity checks for `minimumDifficulty` and `difficultyStability`
-    (changed from the old name `difficultyBoundDivisor`) arguments given to
+ -  Improper sanity checks for `targetBlockInterval` (changed from the old name
+    `blockInterval`), `minimumDifficulty`, and `difficultyStability` (changed
+    from the old name `difficultyBoundDivisor`) arguments given to
     `BlockPolicy<T>()` constructor fixed.  [[#1495]]
+     -  It was possible for `targetBlockInterval` to be zero, which would result
+        in division by zero, when this makes no sense.
      -  It was possible for `difficultyStability` not to be positive when this
         makes no sense.
      -  Wrongly threw an `ArgumentOutOfRangeException` for the case where
         `minimumDifficulty` would equal `difficultyStability`.
+     -  It was possible for `minimumDifficulty` to be zero, which would allow
+        difficulty to be stuck at zero indefinitely, when this does not
+        make sense.
 
 ### CLI tools
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -350,8 +350,8 @@ If omitted (default) explorer only the local blockchain store.")]
             return new BlockPolicy<T>(
                 blockAction: null,
                 blockInterval: TimeSpan.FromMilliseconds(options.BlockIntervalMilliseconds),
+                difficultyStability: options.DifficultyBoundDivisor,
                 minimumDifficulty: options.MinimumDifficulty,
-                difficultyBoundDivisor: options.DifficultyBoundDivisor,
                 getMaxBlockBytes: i => i > 0 ? options.MaxBlockBytes : options.MaxGenesisBytes,
                 getMaxTransactionsPerBlock: _ => options.MaxTransactionsPerBlock);
         }

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -54,8 +54,8 @@ namespace Libplanet.Tests.Blockchain.Policies
             var a = new BlockPolicy<DumbAction>(
                 blockAction: null,
                 blockInterval: tenSec,
-                minimumDifficulty: 1024L,
-                difficultyBoundDivisor: 128);
+                difficultyStability: 128,
+                minimumDifficulty: 1024L);
             Assert.Equal(tenSec, a.BlockInterval);
 
             var b = new BlockPolicy<DumbAction>(
@@ -73,8 +73,8 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new BlockPolicy<DumbAction>(
                     blockAction: null,
                     blockInterval: tenSec.Negate(),
-                    minimumDifficulty: 1024,
-                    difficultyBoundDivisor: 128)
+                    difficultyStability: 128,
+                    minimumDifficulty: 1024)
             );
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new BlockPolicy<DumbAction>(
@@ -84,15 +84,15 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new BlockPolicy<DumbAction>(
                     blockAction: null,
                     blockInterval: tenSec,
-                    minimumDifficulty: 0,
-                    difficultyBoundDivisor: 128)
+                    difficultyStability: 128,
+                    minimumDifficulty: 0)
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new BlockPolicy<DumbAction>(
                     blockAction: null,
                     blockInterval: tenSec,
-                    minimumDifficulty: 1024,
-                    difficultyBoundDivisor: 1024)
+                    difficultyStability: 0,
+                    minimumDifficulty: 1024)
             );
         }
 

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -48,6 +48,64 @@ namespace Libplanet.Tests.Blockchain.Policies
         }
 
         [Fact]
+        public void DifficultyAdjustment()
+        {
+            TimeSpan defaultInterval =
+                DifficultyAdjustment<DumbAction>.DefaultTargetBlockInterval;
+            long defaultStability =
+                DifficultyAdjustment<DumbAction>.DefaultDifficultyStability;
+            long defaultMinimum =
+                DifficultyAdjustment<DumbAction>.DefaultMinimumDifficulty;
+
+            // Should work with defaults.
+            DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                defaultInterval,
+                defaultStability,
+                defaultMinimum);
+
+            // Negative block interval.
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                    TimeSpan.FromMilliseconds(-5),
+                    defaultStability,
+                    defaultMinimum));
+
+            // Zero block interval.
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                    TimeSpan.FromMilliseconds(0),
+                    defaultStability,
+                    defaultMinimum));
+
+            // Invalid stability due to being too low.
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                    defaultInterval,
+                    0,
+                    defaultMinimum));
+
+            // Stability being equal to minimum difficulty should be fine.
+            DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                defaultInterval,
+                defaultMinimum,
+                defaultMinimum);
+
+            // Invalid stability in relation to minimum difficulty for stability being too high.
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                    defaultInterval,
+                    defaultMinimum + 1,
+                    defaultMinimum));
+
+            // Invalid minimum difficulty for being too low.
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
+                    defaultInterval,
+                    defaultStability,
+                    0));
+        }
+
+        [Fact]
         public void Constructors()
         {
             var tenSec = new TimeSpan(0, 0, 10);
@@ -68,32 +126,6 @@ namespace Libplanet.Tests.Blockchain.Policies
             Assert.Equal(
                 new TimeSpan(0, 0, 5),
                 c.BlockInterval);
-
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(
-                    blockAction: null,
-                    blockInterval: tenSec.Negate(),
-                    difficultyStability: 128,
-                    minimumDifficulty: 1024)
-            );
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => new BlockPolicy<DumbAction>(
-                    blockInterval: TimeSpan.FromMilliseconds(-5)));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(
-                    blockAction: null,
-                    blockInterval: tenSec,
-                    difficultyStability: 128,
-                    minimumDifficulty: 0)
-            );
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new BlockPolicy<DumbAction>(
-                    blockAction: null,
-                    blockInterval: tenSec,
-                    difficultyStability: 0,
-                    minimumDifficulty: 1024)
-            );
         }
 
         [Fact]

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -83,7 +83,7 @@ namespace Libplanet.Blockchain.Policies
         public BlockPolicy(
             IAction? blockAction = null,
             TimeSpan? blockInterval = null,
-            int? difficultyStability = null,
+            long? difficultyStability = null,
             long? minimumDifficulty = null,
             Func<BlockChain<T>, Transaction<T>, TxPolicyViolationException?>?
                 validateNextBlockTx = null,
@@ -131,7 +131,7 @@ namespace Libplanet.Blockchain.Policies
         /// See the corresponding parameter description for
         /// <see cref="DifficultyAdjustment{T}.BaseAlgorithm"/> for full detail.
         /// </summary>
-        public int DifficultyStability { get; }
+        public long DifficultyStability { get; }
 
         /// <summary>
         /// Minimum difficulty for a <see cref="Block{T}"/>.  See the corresponding

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -28,6 +28,7 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerSignerPerBlock;
+        private readonly Func<BlockChain<T>, long> _getNextBlockDifficulty;
 
         /// <summary>
         /// <para>
@@ -42,13 +43,16 @@ namespace Libplanet.Blockchain.Policies
         /// every <see cref="Block{T}"/>.  Set to <c>null</c> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction{T}"/>s.
         /// </param>
-        /// <param name="blockInterval">Configures <see cref="BlockInterval"/>.
-        /// Set to <c>5</c> seconds by default.
+        /// <param name="blockInterval">Goes to <see cref="BlockInterval"/>.
+        /// Set to <see cref="DifficultyAdjustment{T}.DefaultTargetBlockInterval"/>
+        /// by default.
         /// </param>
-        /// <param name="minimumDifficulty">Configures
-        /// <see cref="MinimumDifficulty"/>. 1024 by default.</param>
-        /// <param name="difficultyBoundDivisor">Configures
-        /// <see cref="DifficultyBoundDivisor"/>. 128 by default.</param>
+        /// <param name="difficultyStability">Goes to <see cref="DifficultyStability"/>.
+        /// Set to <see cref="DifficultyAdjustment{T}.DefaultDifficultyStability"/>
+        /// by default.</param>
+        /// <param name="minimumDifficulty">Goes to <see cref="MinimumDifficulty"/>.
+        /// Set to <see cref="DifficultyAdjustment{T}.DefaultMinimumDifficulty"/>
+        /// by default.</param>
         /// <param name="validateNextBlockTx">The predicate that determines if
         /// a <see cref="Transaction{T}"/> follows the policy.  Set to a constant function of
         /// <c>null</c> by default.</param>
@@ -79,8 +83,8 @@ namespace Libplanet.Blockchain.Policies
         public BlockPolicy(
             IAction? blockAction = null,
             TimeSpan? blockInterval = null,
-            long minimumDifficulty = 1024,
-            int difficultyBoundDivisor = 128,
+            int? difficultyStability = null,
+            long? minimumDifficulty = null,
             Func<BlockChain<T>, Transaction<T>, TxPolicyViolationException?>?
                 validateNextBlockTx = null,
             Func<BlockChain<T>, Block<T>, BlockPolicyViolationException?>?
@@ -92,32 +96,13 @@ namespace Libplanet.Blockchain.Policies
             Func<long, int>? getMaxTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null)
         {
-            if (blockInterval < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(blockInterval),
-                    "Interval between blocks cannot be negative.");
-            }
-            else if (minimumDifficulty < 0)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(minimumDifficulty),
-                    "Minimum difficulty must be greater than 0.");
-            }
-            else if (minimumDifficulty <= difficultyBoundDivisor)
-            {
-                const string message =
-                    "Difficulty bound divisor must be less than " +
-                    "the minimum difficulty.";
-                throw new ArgumentOutOfRangeException(
-                    nameof(difficultyBoundDivisor),
-                    message);
-            }
-
             BlockAction = blockAction;
-            BlockInterval = blockInterval ?? TimeSpan.FromMilliseconds(5000);
-            MinimumDifficulty = minimumDifficulty;
-            DifficultyBoundDivisor = difficultyBoundDivisor;
+            BlockInterval = blockInterval
+                ?? DifficultyAdjustment<T>.DefaultTargetBlockInterval;
+            DifficultyStability = difficultyStability
+                ?? DifficultyAdjustment<T>.DefaultDifficultyStability;
+            MinimumDifficulty = minimumDifficulty
+                ?? DifficultyAdjustment<T>.DefaultMinimumDifficulty;
             _validateNextBlockTx = validateNextBlockTx ?? ((_, __) => null);
             _validateNextBlock = validateNextBlock ?? ((_, __) => null);
             CanonicalChainComparer = canonicalChainComparer ?? new TotalDifficultyComparer();
@@ -127,27 +112,36 @@ namespace Libplanet.Blockchain.Policies
             _getMaxTransactionsPerBlock = getMaxTransactionsPerBlock ?? (_ => 100);
             _getMaxTransactionsPerSignerPerBlock = getMaxTransactionsPerSignerPerBlock
                 ?? GetMaxTransactionsPerBlock;
+            _getNextBlockDifficulty = DifficultyAdjustment<T>.AlgorithmFactory(
+                BlockInterval, DifficultyStability, MinimumDifficulty);
         }
 
         /// <inheritdoc/>
         public IAction? BlockAction { get; }
 
         /// <summary>
-        /// An appropriate interval between consecutive <see cref="Block{T}"/>s.
-        /// It is usually from 20 to 30 seconds.
-        /// <para>If a previous interval took longer than this
-        /// <see cref="GetNextBlockDifficulty(BlockChain{T})"/> method
-        /// raises the <see cref="Block{T}.Difficulty"/>.  If it took shorter
-        /// than this <see cref="Block{T}.Difficulty"/> is dropped.</para>
+        /// Targeted time interval between two consecutive <see cref="Block{T}"/>s.
+        /// See the corresponding parameter description for
+        /// <see cref="DifficultyAdjustment{T}.BaseAlgorithm"/> for full detail.
         /// </summary>
         public TimeSpan BlockInterval { get; }
 
+        /// <summary>
+        /// Stability of a series of difficulties for a <see cref="BlockChain{T}"/>.
+        /// See the corresponding parameter description for
+        /// <see cref="DifficultyAdjustment{T}.BaseAlgorithm"/> for full detail.
+        /// </summary>
+        public int DifficultyStability { get; }
+
+        /// <summary>
+        /// Minimum difficulty for a <see cref="Block{T}"/>.  See the corresponding
+        /// parameter description for <see cref="DifficultyAdjustment{T}.BaseAlgorithm"/> for
+        /// full detail.
+        /// </summary>
+        public long MinimumDifficulty { get; }
+
         /// <inheritdoc/>
         public IComparer<IBlockExcerpt> CanonicalChainComparer { get; }
-
-        private long MinimumDifficulty { get; }
-
-        private int DifficultyBoundDivisor { get; }
 
         /// <inheritdoc/>
         public virtual TxPolicyViolationException? ValidateNextBlockTx(
@@ -165,38 +159,8 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc/>
-        public virtual long GetNextBlockDifficulty(BlockChain<T> blockChain)
-        {
-            long index = blockChain.Count;
-
-            if (index < 0)
-            {
-                throw new InvalidBlockIndexException(
-                    $"Count of blocks must be 0 or more, but its value is {index}.");
-            }
-
-            if (index <= 1)
-            {
-                return index == 0 ? 0 : MinimumDifficulty;
-            }
-
-            var prevBlock = blockChain[index - 1];
-
-            DateTimeOffset prevPrevTimestamp = blockChain[index - 2].Timestamp;
-            DateTimeOffset prevTimestamp = prevBlock.Timestamp;
-            TimeSpan timeDiff = prevTimestamp - prevPrevTimestamp;
-            long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
-            const long minimumMultiplier = -99;
-            long multiplier = 1 - (timeDiffMilliseconds /
-                                   (long)BlockInterval.TotalMilliseconds);
-            multiplier = Math.Max(multiplier, minimumMultiplier);
-
-            var prevDifficulty = prevBlock.Difficulty;
-            var offset = prevDifficulty / DifficultyBoundDivisor;
-            long nextDifficulty = prevDifficulty + (offset * multiplier);
-
-            return Math.Max(nextDifficulty, MinimumDifficulty);
-        }
+        public virtual long GetNextBlockDifficulty(BlockChain<T> blockChain) =>
+            _getNextBlockDifficulty(blockChain);
 
         /// <inheritdoc/>
         [Pure]

--- a/Libplanet/Blockchain/Policies/DifficultyAdjustment.cs
+++ b/Libplanet/Blockchain/Policies/DifficultyAdjustment.cs
@@ -10,9 +10,9 @@ namespace Libplanet.Blockchain.Policies
     {
         public static readonly TimeSpan DefaultTargetBlockInterval = TimeSpan.FromSeconds(5);
 
-        public static readonly int DefaultDifficultyStability = 128;
+        public static readonly long DefaultDifficultyStability = 128;
 
-        public static readonly int DefaultMinimumDifficulty = 1024;
+        public static readonly long DefaultMinimumDifficulty = 1024;
 
         /// <summary>
         /// An Ethereum based difficulty adjustment algorithm.
@@ -96,11 +96,11 @@ namespace Libplanet.Blockchain.Policies
             long difficultyStability,
             long minimumDifficulty)
         {
-            if (targetBlockInterval < TimeSpan.Zero)
+            if (targetBlockInterval <= TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(targetBlockInterval),
-                    "Target interval between blocks must be non-negative.");
+                    "Target interval between blocks must be positive.");
             }
             else if (difficultyStability <= 0)
             {
@@ -114,11 +114,11 @@ namespace Libplanet.Blockchain.Policies
                     nameof(difficultyStability),
                     "Minimum difficulty must be greater than or equal to difficulty stability.");
             }
-            else if (minimumDifficulty < 0)
+            else if (minimumDifficulty <= 0)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(minimumDifficulty),
-                    "Minimum difficulty must be non-negative.");
+                    "Minimum difficulty must be positive.");
             }
 
             return blockChain => BaseAlgorithm(

--- a/Libplanet/Blockchain/Policies/DifficultyAdjustment.cs
+++ b/Libplanet/Blockchain/Policies/DifficultyAdjustment.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using System;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain.Policies
+{
+    public static class DifficultyAdjustment<T>
+        where T : IAction, new()
+    {
+        public static readonly TimeSpan DefaultTargetBlockInterval = TimeSpan.FromSeconds(5);
+
+        public static readonly int DefaultDifficultyStability = 128;
+
+        public static readonly int DefaultMinimumDifficulty = 1024;
+
+        /// <summary>
+        /// An Ethereum based difficulty adjustment algorithm.
+        /// </summary>
+        /// <param name="blockChain">The <see cref="BlockChain{T}"/> instance
+        /// to calculate the next difficulty from.</param>
+        /// <param name="targetBlockInterval">The base block interval this difficulty adjustment
+        /// algorithm targets.  In reality, the algorithm does not actually target the given
+        /// <see cref="TimeSpan"/>.  Assuming stable hash rate, the actual average of
+        /// block intervals comes out to be about <c>targetBaseInterval * 1.4</c>.</param>
+        /// <param name="difficultystability">Determines how stable difficulty should be over time.
+        /// </param>
+        /// <param name="minimumDifficulty">The lower bound on the difficulty.  This is ignored
+        /// for genesis blocks.</param>
+        /// <returns>The next target difficulty of a <see cref="Block{T}"/> that gets
+        /// appended to <paramref name="blockChain"/>.</returns>
+        /// <exception cref="IndexOutOfRangeException">When the number of blocks
+        /// in <see cref="BlockChain{T}"/> is negative.</exception>
+        /// <remarks>
+        /// It is strongly recommended to use the factory version <see cref="AlgorithmFactory"/>
+        /// to get a working difficulty adjustment algorithm.
+        /// </remarks>
+        public static long BaseAlgorithm(
+            BlockChain<T> blockChain,
+            TimeSpan targetBlockInterval,
+            long difficultystability,
+            long minimumDifficulty)
+        {
+            long index = blockChain.Count;
+
+            if (index < 0)
+            {
+                throw new IndexOutOfRangeException(
+                    $"Count of blocks must be non-negative: {index}.");
+            }
+            else if (index <= 1)
+            {
+                return index == 0 ? 0 : minimumDifficulty;
+            }
+
+            Block<T> prevBlock = blockChain[index - 1];
+            Block<T> prevPrevBlock = blockChain[index - 2];
+            TimeSpan prevTimeDiff = prevBlock.Timestamp - prevPrevBlock.Timestamp;
+
+            const long minimumAdjustmentMultiplier = -99;
+            long adjustmentMultiplier = Math.Max(
+                1 - ((long)prevTimeDiff.TotalMilliseconds /
+                    (long)targetBlockInterval.TotalMilliseconds),
+                minimumAdjustmentMultiplier);
+            long difficultyAdjustment =
+                prevBlock.Difficulty / difficultystability * adjustmentMultiplier;
+
+            long nextDifficulty = Math.Max(
+                prevBlock.Difficulty + difficultyAdjustment, minimumDifficulty);
+
+            return nextDifficulty;
+        }
+
+        /// <summary>
+        /// Does sanity checks and binds arguments to the <see cref="BaseAlgorithm"/> based
+        /// difficulty adjustment algorithm.
+        /// </summary>
+        /// <param name="targetBlockInterval">The base block interval this difficulty adjustment
+        /// algorithm targets.  In reality, the algorithm does not actually target the given
+        /// <see cref="TimeSpan"/>.  Assuming stable hash rate, the actual average of
+        /// block intervals comes out to be about <c>targetBaseInterval * 1.4</c>.
+        /// If ommited, set to <see cref="DefaultTargetBlockInterval"/> by default.
+        /// </param>
+        /// <param name="difficultyStability">Determines how stable difficulty should be over time.
+        /// If ommited, set to <see cref="DefaultDifficultyStability"/> by default.
+        /// </param>
+        /// <param name="minimumDifficulty">The lower bound on the difficulty.</param>
+        /// <returns>The next target difficulty of a <see cref="Block{T}"/> that gets
+        /// appended to some <See cref="BlockChain{T}"/>.  If ommited, set to
+        /// <see cref="DefaultMinimumDifficulty"/> by default.</returns>
+        /// <returns>A difficulty adjustment algorithm with bound constants provided.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If any of the arguments fail to
+        /// satisfy the necessary constraints for the formula to work.</exception>
+        public static Func<BlockChain<T>, long> AlgorithmFactory(
+            TimeSpan targetBlockInterval,
+            long difficultyStability,
+            long minimumDifficulty)
+        {
+            if (targetBlockInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(targetBlockInterval),
+                    "Target interval between blocks must be non-negative.");
+            }
+            else if (difficultyStability <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(difficultyStability),
+                    "Difficulty stability must be positive");
+            }
+            else if (minimumDifficulty < difficultyStability)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(difficultyStability),
+                    "Minimum difficulty must be greater than or equal to difficulty stability.");
+            }
+            else if (minimumDifficulty < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(minimumDifficulty),
+                    "Minimum difficulty must be non-negative.");
+            }
+
+            return blockChain => BaseAlgorithm(
+                blockChain, targetBlockInterval, difficultyStability, minimumDifficulty);
+        }
+    }
+}


### PR DESCRIPTION
Just some preparatory work to make difficulty adjustment algorithm more pluggable.

Other than separating out the chunk of default implementation inside `BlockPolicy<T>`, minor changes can be found in the changelog.

Making `minimumDifficulty` and `difficultyStability` parameters nullable is partly due to my OCD, but with an additional reason that these shouldn't really be easily configurable unless the user *really* knows what they are doing. I suspect the current default values used are rather inappropriate. 😶 