### PR TITLE
Slight optimization of `ByteUtil.Satisfies()`

### DIFF
--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -162,23 +162,20 @@ namespace Libplanet
                 return false;
             }
 
-            var maxTargetBytes = new byte[hashDigest.Count + 1];
-            maxTargetBytes[hashDigest.Count] = 0x01;
-            var maxTarget = new BigInteger(maxTargetBytes);
+            BigInteger maxTarget = BigInteger.One << 8 * hashDigest.Count;
             BigInteger target = maxTarget / difficulty;
 
-            var digestArray = new byte[hashDigest.Count + 1];
+            // Ensures the last byte to be zero to prevent negative result when converted
+            // to BigInteger.  Note that BigInteger(byte[]) assumes the input bytes are in
+            // little-endian order.
+            byte[] digestArray = new byte[hashDigest.Count + 1];
             int i = 0;
             foreach (byte b in hashDigest)
             {
                 digestArray[i++] = b;
             }
 
-            // Append zero to convert unsigned BigInteger.  Note that BigInteger(byte[]) assumes
-            // the input bytes are in little-endian order.
-            digestArray[i] = 0;
-
-            var result = new BigInteger(digestArray);
+            BigInteger result = new BigInteger(digestArray);
             return result < target;
         }
     }


### PR DESCRIPTION
Removed unnecessary array allocation and uses bit shifting instead.

Note:
- As for `digestArray`, `CopyTo` or `CopyTo<T>` is slightly faster but `IReadOnlyList<T>` does not support direct copying.
  - Although from the method's perspective, changing the parameter type to `ImmutableArray<T>` may seem appropriate, it does not work since `HashAlgorithmType.Digest(byte[])` results in `byte[]` and there is no implicit conversion from `byte[]` to `ImmutableArray<byte>`. Furthermore, conversion to `ImmutableArray<byte>` from `byte[]` is rather slow, so this defeats the whole purpose. ☹️ 
  - `ReadOnlySpan<T>` is another possible option, but in this case, converting `ImmutableArray<T>` to `ReadOnlySpan<T>` causes an issue. Aside from whether this is the right choice, significant portion of the existing code needs to be updated if we are to go this route. ☹️ 