### PR TITLE
Fix/explorer blocktype

### DIFF
--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,8 +1,6 @@
 using System.Security.Cryptography;
-using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
-using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Store;
@@ -33,10 +31,11 @@ namespace Libplanet.Explorer.GraphTypes
                         return null;
                     }
 
+                    // FIXME: (BlockChain<T>) casting does not work
+                    // REF COMMIT HASH: d50c90933c17a70381ad758719144e01bf9c21dc
+                    HashAlgorithmGetter hashAlgorithmGetter = _ => HashAlgorithmType.Of<SHA256>();
                     var store = (IStore)ctx.UserContext[nameof(IBlockChainContext<T>.Store)];
-                    var chain =
-                        (BlockChain<T>)ctx.UserContext[nameof(IBlockChainContext<T>.BlockChain)];
-                    return store.GetBlock<T>(chain.Policy.GetHashAlgorithm, h);
+                    return store.GetBlock<T>(hashAlgorithmGetter, h);
                 });
             Field(x => x.Timestamp);
             Field<NonNullGraphType<ByteStringType>>(


### PR DESCRIPTION
This PR resolve the following error when querying the data for `PreviousBlock`:

```
System.Collections.Generic.KeyNotFoundException: The given key 'BlockChain' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Libplanet.Explorer.GraphTypes.BlockType`1.<>c.<.ctor>b__0_7(IResolveFieldContext`1 ctx) in C:\Users\kidon\Desktop\planetarium_repo\NineChronicles.Headless\Lib9c\.Libplanet\Libplanet.Explorer\GraphTypes\BlockType.cs:line 37
   at GraphQL.Resolvers.FuncFieldResolver`2.Resolve(IResolveFieldContext context) in /_/src/GraphQL/Resolvers/FuncFieldResolver.cs:line 42
   at GraphQL.Resolvers.FuncFieldResolver`2.GraphQL.Resolvers.IFieldResolver.Resolve(IResolveFieldContext context) in /_/src/GraphQL/Resolvers/FuncFieldResolver.cs:line 44
   at GraphQL.Resolvers.FieldResolverExtensions.ResolveAsync(IFieldResolver resolver, IResolveFieldContext context) in /_/src/GraphQL/Resolvers/FieldResolverExtensions.cs:line 16
   at GraphQL.Instrumentation.InstrumentFieldsMiddleware.Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next) in /_/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs:line 21
   at GraphQL.Execution.ExecutionStrategy.ExecuteNodeAsync(ExecutionContext context, ExecutionNode node) in /_/src/GraphQL/Execution/ExecutionStrategy.cs:line 182
```