### PR TITLE
OrderTxsForEvaluationV3 added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
+ -  The `Block<T>.CurrentProtocolVersion` is bumped from 2 to 3.
+    [[#1322], [#1323], [#1518]]
+
 ### Backward-incompatible storage format changes
 
 ### Added APIs
@@ -43,6 +46,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  `Block<T>.Transactions` is ordered using a different scheme for
+    evaluation due to protocol version bump.  [[#1322], [#1323], [#1518]]
  -  (Libplanet.Net) `NetMQTransport.SendMessageWithReplyAsync()` should now
     complete its process within given timeframe `timeout` argument instead
     of possibly taking longer on some edge cases when waiting for
@@ -67,6 +72,9 @@ To be released.
     in one line as JSON whenever a different key is found,
     than it outputs all of the different nodes at once.  [[#1729]]
 
+[#1322]: https://github.com/planetarium/libplanet/issues/1322
+[#1323]: https://github.com/planetarium/libplanet/issues/1323
+[#1518]: https://github.com/planetarium/libplanet/pull/1518
 [#1593]: https://github.com/planetarium/libplanet/pull/1593
 [#1729]: https://github.com/planetarium/libplanet/pull/1729
 [#1734]: https://github.com/planetarium/libplanet/issues/1734

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2146,8 +2146,6 @@ Released on July 23, 2021.
 [#1315]: https://github.com/planetarium/libplanet/issues/1315
 [#1316]: https://github.com/planetarium/libplanet/issues/1316
 [#1320]: https://github.com/planetarium/libplanet/issues/1320
-[#1322]: https://github.com/planetarium/libplanet/issues/1322
-[#1323]: https://github.com/planetarium/libplanet/issues/1323
 [#1325]: https://github.com/planetarium/libplanet/pull/1325
 [#1326]: https://github.com/planetarium/libplanet/pull/1326
 [#1328]: https://github.com/planetarium/libplanet/pull/1328

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1025,7 +1025,7 @@ namespace Libplanet.Tests.Action
                 }
 
                 List<string> orderedAddresses;
-                if (protocolVersion > 1)
+                if (protocolVersion >= 3)
                 {
                     // Spec for protocol version >= 3.
                     orderedAddresses = new List<string>

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -30,6 +30,7 @@ namespace Libplanet.Tests.Action
     public class ActionEvaluatorTest
     {
         private readonly ILogger _logger;
+        private readonly ITestOutputHelper _output;
         private readonly BlockPolicy<DumbAction> _policy;
         private readonly StoreFixture _storeFx;
         private readonly TxFixture _txFx;
@@ -43,6 +44,7 @@ namespace Libplanet.Tests.Action
                 .CreateLogger()
                 .ForContext<ActionEvaluatorTest>();
 
+            _output = output;
             _policy = new BlockPolicy<DumbAction>(
                 blockAction: new MinerReward(1),
                 getMaxBlockBytes: _ => 50 * 1024);
@@ -943,8 +945,6 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void OrderTxsForEvaluation()
         {
-            // New test should be written once this breaks with a protocol version bump.
-            const int protocolVersion = BlockMetadata.CurrentProtocolVersion;
             const int numSigners = 5;
             const int numTxsPerSigner = 3;
             var epoch = DateTimeOffset.FromUnixTimeSeconds(0);
@@ -988,26 +988,6 @@ namespace Libplanet.Tests.Action
             };
             ImmutableArray<byte> preEvaluationHash = preEvaluationHashBytes.ToImmutableArray();
 
-            var orderedTxs = ActionEvaluator<RandomAction>.OrderTxsForEvaluation(
-                protocolVersion: protocolVersion,
-                txs: txs,
-                preEvaluationHash: preEvaluationHash
-            ).ToImmutableArray();
-
-            // Check signers are grouped together.
-            for (int i = 0; i < numSigners; i++)
-            {
-                var signerTxs = orderedTxs.Skip(i * numTxsPerSigner).Take(numTxsPerSigner);
-                Assert.True(signerTxs.Select(tx => tx.Signer).Distinct().Count() == 1);
-            }
-
-            // Check nonces are ordered.
-            foreach (var signer in signers)
-            {
-                var signerTxs = orderedTxs.Where(tx => tx.Signer == signer.ToAddress());
-                Assert.Equal(signerTxs.OrderBy(tx => tx.Nonce).ToArray(), signerTxs.ToArray());
-            }
-
             string[] originalAddresses =
             {
                 "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
@@ -1016,21 +996,66 @@ namespace Libplanet.Tests.Action
                 "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
                 "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
             };
-            string[] orderedAddresses =
-            {
-                "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
-                "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
-                "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
-                "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
-                "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
-            };
-
+            // Sanity check.
             Assert.True(originalAddresses.SequenceEqual(
                 signers.Select(signer => signer.ToAddress().ToString())));
-            Assert.True(orderedAddresses.SequenceEqual(
-                orderedTxs
-                    .Where((tx, i) => i % numTxsPerSigner == 0)
-                    .Select(tx => tx.Signer.ToString())));
+
+            // Make sure to cover every case *and* the currently running protocol does not break.
+            int[] protocolVersions = { 0, 3, BlockMetadata.CurrentProtocolVersion };
+            foreach (int protocolVersion in protocolVersions)
+            {
+                var orderedTxs = ActionEvaluator<RandomAction>.OrderTxsForEvaluation(
+                    protocolVersion: protocolVersion,
+                    txs: txs,
+                    preEvaluationHash: preEvaluationHash
+                ).ToImmutableArray();
+
+                // Check signers are grouped together.
+                for (int i = 0; i < numSigners; i++)
+                {
+                    var signerTxs = orderedTxs.Skip(i * numTxsPerSigner).Take(numTxsPerSigner);
+                    Assert.True(signerTxs.Select(tx => tx.Signer).Distinct().Count() == 1);
+                }
+
+                // Check nonces are ordered.
+                foreach (var signer in signers)
+                {
+                    var signerTxs = orderedTxs.Where(tx => tx.Signer == signer.ToAddress());
+                    Assert.Equal(signerTxs.OrderBy(tx => tx.Nonce).ToArray(), signerTxs.ToArray());
+                }
+
+                List<string> orderedAddresses;
+                if (protocolVersion > 1)
+                {
+                    // Spec for protocol version >= 3.
+                    orderedAddresses = new List<string>
+                    {
+                        "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
+                        "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
+                        "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
+                        "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
+                        "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
+                    };
+                }
+                else
+                {
+                    // Spec for protocol version < 3.
+                    orderedAddresses = new List<string>
+                    {
+                        "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
+                        "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
+                        "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",
+                        "0xfcbfa4977B2Fc7A608E4Bd2F6F0D6b27C0a4cd13",
+                        "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
+                    };
+                }
+
+                // Check according to spec.
+                Assert.True(orderedAddresses.SequenceEqual(
+                    orderedTxs
+                        .Where((tx, i) => i % numTxsPerSigner == 0)
+                        .Select(tx => tx.Signer.ToString())));
+            }
         }
 
         private (Address[], Transaction<DumbAction>[]) MakeFixturesForAppendTests(

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -948,8 +948,8 @@ namespace Libplanet.Tests.Action
         [ClassData(typeof(OrderTxsForEvaluationData))]
         public void OrderTxsForEvaluation(
             int protocolVersion,
-            string[] originalAddresses,
-            string[] orderedAddresses)
+            List<string> originalAddresses,
+            List<string> orderedAddresses)
         {
             const int numSigners = 5;
             const int numTxsPerSigner = 3;
@@ -1095,7 +1095,7 @@ namespace Libplanet.Tests.Action
     internal class OrderTxsForEvaluationData : IEnumerable<object[]>
     {
         // For fixture sanity.
-        public string[] OriginalAddresses =
+        public List<string> OriginalAddresses = new List<string>
         {
             "0xc2A86014073D662a4a9bFCF9CB54263dfa4F5cBc",
             "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
@@ -1105,7 +1105,7 @@ namespace Libplanet.Tests.Action
         };
 
         // Spec for protocol version < 3.
-        public string[] OrderedAddressesV0 =
+        public List<string> OrderedAddressesV0 = new List<string>
         {
             "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
             "0x1d2B31bF9A2CA71051f8c66E1C783Ae70EF32798",
@@ -1115,7 +1115,7 @@ namespace Libplanet.Tests.Action
         };
 
         // Spec for protocol version >= 3.
-        public string[] OrderedAddressesV3 =
+        public List<string> OrderedAddressesV3 = new List<string>
         {
             "0x921Ba81C0be280C8A2faed79E14aD2a098874759",
             "0xB0ea0018Ab647418FA81c384194C9167e6A3C925",

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -45,22 +45,19 @@ namespace Libplanet.Tests.Blockchain
             }.Mine(_fx.GetHashAlgorithm(1)).Evaluate(_fx.Miner, _blockChain);
             _blockChain.Append(block1);
 
-            PreEvaluationBlock<DumbAction> preEvalblock2 = new BlockContent<DumbAction>
+            Block<DumbAction> block2 = new BlockContent<DumbAction>
             {
                 Index = 2,
                 Difficulty = 1024,
                 TotalDifficulty = block1.TotalDifficulty + 1024,
-                Miner = _fx.GenesisBlock.Miner,
+                PublicKey = _fx.Miner.PublicKey,
+                Miner = _fx.Miner.ToAddress(),
                 PreviousHash = block1.Hash,
                 Timestamp = _fx.GenesisBlock.Timestamp.AddDays(1),
                 Transactions = _emptyTransaction,
                 ProtocolVersion = _blockChain.Tip.ProtocolVersion - 1,
-            }.Mine(_fx.GetHashAlgorithm(2));
-            Block<DumbAction> block2 = new Block<DumbAction>(
-                preEvalblock2,
-                preEvalblock2.DetermineStateRootHash(_blockChain),
-                null
-            );
+            }.Mine(_fx.GetHashAlgorithm(2)).Evaluate(_fx.Miner, _blockChain);
+
             Assert.Throws<InvalidBlockProtocolVersionException>(() => _blockChain.Append(block2));
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -135,7 +135,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 2);
+                .Add("protocol_version", 3);
             AssertBencodexEqual(expectedGenesis, GenesisMetadata.MakeCandidateData(default));
             AssertBencodexEqual(
                 expectedGenesis.SetItem("nonce", new byte[] { 0x00, 0x01, 0x02 }),
@@ -160,7 +160,7 @@ namespace Libplanet.Tests.Blocks
                     "transaction_fingerprint",
                     ParseHex("654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0")
                 )
-                .Add("protocol_version", 2);
+                .Add("protocol_version", 3);
             AssertBencodexEqual(
                 expectedBlock1,
                 BlockMetadata1.MakeCandidateData(new Nonce(new byte[] { 0xff, 0xef, 0x01, 0xcc }))
@@ -259,15 +259,15 @@ namespace Libplanet.Tests.Blocks
             HashAlgorithmType sha512 = HashAlgorithmType.Of<SHA512>();
             ImmutableArray<byte> hash = GenesisMetadata.DerivePreEvaluationHash(sha256, default);
             AssertBytesEqual(
-                FromHex("0bc1b1d6ff56e7e714d016e32e7a95417e51ee407717a65632cef29a1599e8c4"),
+                FromHex("98866bfa9622d47dda427a7d3eb2a44397e0eacedd01078acb5cc6de36bb6a90"),
                 hash
             );
 
             hash = GenesisMetadata.DerivePreEvaluationHash(sha512, default);
             AssertBytesEqual(
                 FromHex(
-                    "aa46f7b4a740ff144cd866505a1696461c004a4eaa6b032dafec194ae42c76d7" +
-                    "fadd4ca45bfbb802aa4b9af28d3150f5e1f67a94b32ddb399f5c455b3e118d03"
+                    "f68f16b3c41b46865930b61c17db21071f15dcd0c8411d846f2dff18ab66d189" +
+                    "0cf2a12349795ddb5032fbe31607ec2c0d1c67778ef5cafb5275055af6048fc5"
                 ),
                 hash
             );
@@ -277,7 +277,7 @@ namespace Libplanet.Tests.Blocks
                 new Nonce(FromHex("e7c1adf92c65d35aaae5"))
             );
             AssertBytesEqual(
-                FromHex("c9f3fc47ec5554dc1544fd1317760f16627366af728e2608348736673e2b7b3d"),
+                FromHex("9691d5845a0d0ef5bcc99b2bb22108abe0d0168ce240ade7c40452967feb33e6"),
                 hash
             );
 
@@ -287,8 +287,8 @@ namespace Libplanet.Tests.Blocks
             );
             AssertBytesEqual(
                 FromHex(
-                    "41d59e78eef7f1bb4b95a2f34973674afc7840eb1a4a468f5ea303eda3e3cdb1" +
-                    "0ee2fdf9d900a07447fb2208197ef7dd76b83ed2e463886e234fa6b5e29c1bff"
+                    "e693300ac4c55f4e5ad8fd54817d1763bfa8fe50342060f855ef84d04c4e7f93" +
+                    "c798b6b6c5bb517a1ad0b3a388e1de41d031389367ab295ebdee5ba4916f4232"
                 ),
                 hash
             );

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Tests.Blocks
 
             // Checks if the hard-coded proof of the fixture is up-to-date.  If it's outdated,
             // throws an exception that prints a regenerated up-to-date one:
-            const int lastCheckedProtocolVersion = 2;
+            const int lastCheckedProtocolVersion = 3;
             if (_contents.BlockMetadata1.ProtocolVersion > lastCheckedProtocolVersion)
             {
                 (Nonce Nonce, ImmutableArray<byte> Digest) regen =
@@ -62,7 +62,7 @@ namespace Libplanet.Tests.Blocks
             }
 
             var validBlock1Nonce = new Nonce(
-                new byte[] { 0x0f, 0xe0, 0xb5, 0x1e, 0xa0, 0x6c, 0x6f, 0xc9, 0x0b, 0x4f }
+                new byte[] { 0xf4, 0xbe, 0xc2, 0x4d, 0x1e, 0x04, 0xeb, 0x4b, 0xb5, 0x98 }
             );
             byte[] validBlock1Bytes =
                 _codec.Encode(_contents.BlockMetadata1.MakeCandidateData(validBlock1Nonce));
@@ -317,7 +317,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 2)
+                .Add("protocol_version", 3)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray);
             var genesis = new PreEvaluationBlockHeader(
                 _contents.GenesisMetadata,
@@ -354,7 +354,7 @@ namespace Libplanet.Tests.Blocks
                         "654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0"
                     )
                 )
-                .Add("protocol_version", 2)
+                .Add("protocol_version", 3)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray);
             var block1 = new PreEvaluationBlockHeader(
                 _contents.BlockMetadata1,
@@ -469,8 +469,8 @@ namespace Libplanet.Tests.Blocks
                 nonce: _validBlock1Proof.Nonce
             );
             ImmutableArray<byte> validSig = ByteUtil.ParseHex(
-                "3045022100ae733a8b3f54b8212710300f2cc2ca29de726be818880338aab39c5f0881d" +
-                "ccd022033eb32a9cfb1c39798efb4037caa0bab9c2f0c269101a6f471d0efaf1cce09a5"
+                "3045022100e0c6bc5ccbde4a6fc0bc255b663972904373543247e6c7ea082817ebe6ae6" +
+                "3f202201a4fa72853caddca4027be60b88652106d096a901521c59d22ec980ff6a8d184"
             ).ToImmutableArray();
             Assert.True(block1.VerifySignature(validSig, arbitraryHash));
             Assert.False(block1.VerifySignature(null, arbitraryHash));
@@ -506,22 +506,22 @@ namespace Libplanet.Tests.Blocks
                 preEvaluationHash: _validGenesisProof.PreEvaluationHash
             );
             AssertBytesEqual(
-                fromHex("d8524ca6cea91244564eb8e95e4b83704d997b34bee023849c51eedfc57ec1a4"),
+                fromHex("13993f54b6ea839ba4fefdfdf0485091e296b120c45e306b45354bce8fb81cd5"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("8006aab7a37d27c8eb64c2d90d0815ee2f80fab6a85b797e9052627ecfa69213"),
+                fromHex("6f6e3f2f3340de60a0cd0d0c83305edde6c0f30b15f98e59f528091fe8dd7e3c"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("100e07c7c447c539a1a15216f68ec7820c69a70c09aad6c4981ab30fba04503b"),
+                fromHex("1c7b98d3d33c3a03f0903a072b9914ed901a2f345f780647a2f26cb56d2859cc"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("38f0de2abd8641201b8ed50662e668dea09400c191c5e3898c29d8c685a7ccab"),
+                fromHex("0567da3ad52c1c3961bad5985edb27eaca1094520370d8cab57fb63323b86208"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash)
@@ -534,19 +534,19 @@ namespace Libplanet.Tests.Blocks
                 nonce: _validBlock1Proof.Nonce
             );
             AssertBytesEqual(
-                fromHex("60756799c3fda2f177cf0180b9f9b6bc6df1337a730d1b4d6ae8846f35906530"),
+                fromHex("feb41eb7e2123244d1df38c0750d0687a89efcbd8f6035d13a8ca80f73e69d91"),
                 block1.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("4f995659dabaa1768c97938769fa30f039d77810986a1dc8809ecd0a31881da4"),
+                fromHex("6a9ca0f7a25d27e1c4fcdcad7f163a60c6f051d877b146a8a796a3b6b6f82bd7"),
                 block1.DeriveBlockHash(default, block1.MakeSignature(_contents.Block1Key, default))
             );
             AssertBytesEqual(
-                fromHex("9c158442cb77066e3af85ff9bfc757728fb33648c75e238e906910fc628f3253"),
+                fromHex("7dfabe89be16f23496725dc7aa605462aa4a174e136e7520a86a47a6f21db183"),
                 block1.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("fc4a14bb2099bef4a301197602926e133a52d958e758e1d89d2d665e8f678f85"),
+                fromHex("e84077961ee7a06c10c03cf15f3936a352bde4510681099d595239629c2607bb"),
                 block1.DeriveBlockHash(
                     arbitraryHash,
                     block1.MakeSignature(_contents.Block1Key, arbitraryHash)

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -620,21 +620,28 @@ namespace Libplanet.Action
         {
             using SHA256 sha256 = SHA256.Create();
 
-            var groups = txs
-                .GroupBy(tx => tx.Signer)
-                .OrderBy(group => group.Key)
-                .ToList();
+            // Some deterministic preordering is necessary.
+            var groups = txs.GroupBy(tx => tx.Signer).OrderBy(group => group.Key).ToList();
 
-            // First hash assumes preEvaluationHash has enough entropy to make sampling of
-            // startIndex uniform enough.  Second hash is used to obfuscate parity.
-            byte[] firstHash = sha256.ComputeHash(preEvaluationHash.ToBuilder().ToArray());
-            byte[] secondHash = sha256.ComputeHash(firstHash);
+            // Although strictly not necessary, additional hash computation removes zero padding
+            // just in case.
+            byte[] reHash = sha256.ComputeHash(preEvaluationHash.ToBuilder().ToArray());
 
-            int startIndex = (int)(new BigInteger(firstHash) % groups.Count);
+            // As BigInteger uses little-endian, we take the last byte for parity to prevent
+            // the value of reverse directly tied to the parity of startIndex below.
+            bool reverse = reHash.Last() % 2 == 1;
+
+            // This assumes the entropy of preEvaluationHash, thus reHash, is large enough and
+            // its range with BigInteger conversion also is large enough that selection of
+            // startIndex is approximately uniform.
+            int startIndex = groups.Count <= 1
+                ? 0
+                : (int)(new BigInteger(reHash) % groups.Count);
             startIndex = startIndex >= 0 ? startIndex : -startIndex;
-            bool reverse = secondHash[0] % 2 == 1;
 
-            var result = groups.Skip(startIndex).Concat(groups.Take(startIndex));
+            var result = groups
+                .Skip(startIndex)
+                .Concat(groups.Take(startIndex));
             if (reverse)
             {
                 result = result.Reverse();

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -371,7 +371,9 @@ namespace Libplanet.Action
             IEnumerable<Transaction<T>> txs,
             ImmutableArray<byte> preEvaluationHash)
         {
-            return OrderTxsForEvaluationV0(txs, preEvaluationHash);
+            return protocolVersion >= 3
+                ? OrderTxsForEvaluationV3(txs, preEvaluationHash)
+                : OrderTxsForEvaluationV0(txs, preEvaluationHash);
         }
 
         /// <summary>
@@ -609,6 +611,36 @@ namespace Libplanet.Action
                         .Select(tx => new BigInteger(tx.Id.ToByteArray()))
                         .Aggregate((first, second) => first ^ second))
                 .SelectMany(group => group.OrderBy(tx => tx.Nonce));
+        }
+
+        [Pure]
+        private static IEnumerable<Transaction<T>> OrderTxsForEvaluationV3(
+            IEnumerable<Transaction<T>> txs,
+            ImmutableArray<byte> preEvaluationHash)
+        {
+            using SHA256 sha256 = SHA256.Create();
+
+            var groups = txs
+                .GroupBy(tx => tx.Signer)
+                .OrderBy(group => group.Key)
+                .ToList();
+
+            // First hash assumes preEvaluationHash has enough entropy to make sampling of
+            // startIndex uniform enough.  Second hash is used to obfuscate parity.
+            byte[] firstHash = sha256.ComputeHash(preEvaluationHash.ToBuilder().ToArray());
+            byte[] secondHash = sha256.ComputeHash(firstHash);
+
+            int startIndex = (int)(new BigInteger(firstHash) % groups.Count);
+            startIndex = startIndex >= 0 ? startIndex : -startIndex;
+            bool reverse = secondHash[0] % 2 == 1;
+
+            var result = groups.Skip(startIndex).Concat(groups.Take(startIndex));
+            if (reverse)
+            {
+                result = result.Reverse();
+            }
+
+            return result.SelectMany(group => group.OrderBy(tx => tx.Nonce));
         }
 
         /// <summary>

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Blocks
         /// <summary>
         /// The latest protocol version.
         /// </summary>
-        public const int CurrentProtocolVersion = 2;
+        public const int CurrentProtocolVersion = 3;
 
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();


### PR DESCRIPTION
Related to #1326.
Closes #1322.
Closes #1323.

This tries to readdress the issues mentioned in #1322 and #1323. While working on this PR, initial attempt was made to implement [Fisher-Yates] shuffling, but it turns out this is no trivial task.

First, some context on why [Fisher-Yates] is not used in this PR. The goal is to use `PreEvaluationHash` of a `Block<T>` to deterministically pseudo-randomly shuffle transactions by signer addresses. What [Fisher-Yates] algorithm provides is an unbiased sampling, but this requires higher entropy than that of `PreEvaluationHash` can provide by itself.<sup>[1](#footnote_01)</sup> Proper implementation would require increasing entropy by extending `PreEvaluationHash` with each transaction's signature, *not* signer address, on each step of selection required for [Fisher-Yates]. As my own implementation got more and more elaborate, I became concerned about possible performance degradation, so decided to take another route.

Implementation in this PR tries to achieve at least the following.

- Given `n` signers, the probability of any signer to be selected as first is `1/n`.
- Given any pair of signers `a` and `b`, the probability of `a` being selected before `b` is `1/2`.

Keep in mind, these conditions are *not* sufficient enough to give us unbiased permutation samplings of `n` signers, which is a potential security hole, however minor it may be. As two "consecutive" signers in the original ordering is highly likely to be executed consecutively, although not necessarily in order. This *can* be somewhat mitigated easily with some additional computation, but cannot be completely normalized while using *only* `PreEvaluationHash` as the random seed.

----

<a name="footenote_01">1</a>: For unbiased sampling of permutations of `n` elements, minimum required entropy is `log2(n!)`, meaning approximately `524` randomly generated `bit`s are required for shuffling `100` elements.

[Fisher-Yates]: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle