### PR TITLE
Introduce TCP transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,12 @@
 **/.idea/**/dynamic.xml
 
 # Rider
-# Rider auto-generates .iml files, contentModel.xml, and projectSettingsUpdater.xml
+# Rider auto-generates .iml files, contentModel.xml, projectSettingsUpdater.xml, and indexLayout.xml
 **/.idea/**/*.iml
 **/.idea/**/contentModel.xml
 **/.idea/**/modules.xml
 **/.idea/**/projectSettingsUpdater.xml
+**/.idea/**/indexLayout.xml
 
 # dotCover
 dotCover.Output.*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,12 +16,34 @@ To be released.
     [[#1554], [#1570]]
  -  Removed `rehearsal` parameter from `StateStoreExtensions.Commit()`
     extension method.  [[#1554], [#1570]]
+ -  Removed `ITransport.RunAsync()` method.
+    `ITransport.StartAsync()` now conducts operation that
+    `ITransport.RunAsync()` used to conduct.  [[#1523]]
+ -  Removed `ITransport.ReplyMessage()` method which was non-blocking.
+    Instead, added `ITransport.ReplyMessageAsync()` asynchronous method
+    which is awaited until the reply message is sent.  [[#1523]]
+ -  The type of `ITransport.ProcessMessageHandler` became
+    `AsyncDelegate<T>` (which was `EventHandler`).  [[#1523]]
+ -  Removed unused `BlockChain<T>` type parameter from
+    `IStagePolicy<T>.Iterate()` method.  [[#1553], [#1556]]
 
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  Added `ITransport.MessageHistory` property.  [[#1523]]
+ -  Added `ITransport.WaitForRunning()` method.  [[#1523]]
+ -  Added `TcpTransport` class which implements `ITransport` interface.
+    [[#1523]]
+ -  Added `SwarmOptions.Type` property.  [[#1523]]
+ -  Added `SwarmOptions.TransportType` enum.  [[#1523]]
+ -  Added `AsyncDelegate<T>` class.  [[#1523]]
+ -  Added `InvalidMagicCookieException` class.  [[#1523]]
+ -  Added `MessageCodec` class which inherits `IMessageCodec<T>`.
+    [[#1523]]
+ -  Added `IStagePolicy<T>.GetNextTxNonce()` method.  [[#1553], [#1556]]
 
 ### Behavioral changes
 
@@ -38,6 +60,7 @@ To be released.
     `monorocksdb`.  [[#1513], [#1579]]
 
 [#1579]: https://github.com/planetarium/libplanet/pull/1579
+[#1523]: https://github.com/planetarium/libplanet/pull/1523
 
 
 Version 0.20.2

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
 using global::Cocona;
@@ -280,7 +281,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         }
 
         [Command(Description = "Query app protocol version (a.k.a. APV) of target node.")]
-        public void Query(
+        public async Task Query(
             [Argument(
                 Name = "TARGET",
 #pragma warning disable MEN002 // Line is too long
@@ -302,7 +303,7 @@ namespace Libplanet.Extensions.Cocona.Commands
 
             try
             {
-                apv = peer.QueryAppProtocolVersion();
+                apv = await peer.QueryAppProtocolVersionTcp();
             }
             catch
             {

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -389,7 +389,7 @@ namespace Libplanet.Tests.Net.Protocols
             };
         }
 
-        public void ReplyMessage(Message message)
+        public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
             if (!Running)
             {
@@ -398,12 +398,9 @@ namespace Libplanet.Tests.Net.Protocols
 
             _logger.Debug("Replying {Message}...", message);
             message.Remote = AsPeer;
-            Task.Run(async () =>
-            {
-                await Task.Delay(_networkDelay);
-                _transports[_peersToReply[message.Identity]].ReceiveReply(message);
-                _peersToReply.TryRemove(message.Identity, out Address addr);
-            });
+            await Task.Delay(_networkDelay, cancellationToken);
+            _transports[_peersToReply[message.Identity]].ReceiveReply(message);
+            _peersToReply.TryRemove(message.Identity, out Address addr);
         }
 
         public async Task WaitForTestMessageWithData(
@@ -468,11 +465,13 @@ namespace Libplanet.Tests.Net.Protocols
 
             if (message is Ping)
             {
-                ReplyMessage(new Pong
-                {
-                    Identity = message.Identity,
-                    Remote = AsPeer,
-                });
+                _ = ReplyMessageAsync(
+                    new Pong
+                    {
+                        Identity = message.Identity,
+                        Remote = AsPeer,
+                    },
+                    default);
             }
 
             LastMessageTimestamp = DateTimeOffset.UtcNow;

--- a/Libplanet.Tests/Net/Protocols/TestTransport.cs
+++ b/Libplanet.Tests/Net/Protocols/TestTransport.cs
@@ -32,8 +32,10 @@ namespace Libplanet.Tests.Net.Protocols
         private readonly Random _random;
         private readonly bool _blockBroadcast;
 
+        private TaskCompletionSource<object> _runningEvent;
         private CancellationTokenSource _swarmCancellationTokenSource;
         private TimeSpan _networkDelay;
+        private bool _disposed;
 
         public TestTransport(
             Dictionary<Address, TestTransport> transports,
@@ -43,6 +45,7 @@ namespace Libplanet.Tests.Net.Protocols
             int bucketSize,
             TimeSpan? networkDelay)
         {
+            _runningEvent = new TaskCompletionSource<object>();
             _privateKey = privateKey;
             _blockBroadcast = blockBroadcast;
             var loggerId = _privateKey.ToAddress().ToHex();
@@ -60,11 +63,12 @@ namespace Libplanet.Tests.Net.Protocols
             _ignoreTestMessageWithData = new List<string>();
             _random = new Random();
             Table = new RoutingTable(Address, tableSize, bucketSize);
+            ProcessMessageHandler = new AsyncDelegate<Message>();
             Protocol = new KademliaProtocol(Table, this, Address);
             MessageHistory = new FixedSizedQueue<Message>(30);
         }
 
-        public event EventHandler<Message> ProcessMessageHandler;
+        public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         public AsyncAutoResetEvent MessageReceived { get; }
 
@@ -78,7 +82,22 @@ namespace Libplanet.Tests.Net.Protocols
 
         public DateTimeOffset? LastMessageTimestamp { get; private set; }
 
-        public bool Running => !(_swarmCancellationTokenSource is null);
+        public bool Running
+        {
+            get => _runningEvent.Task.Status == TaskStatus.RanToCompletion;
+
+            private set
+            {
+                if (value)
+                {
+                    _runningEvent.TrySetResult(null);
+                }
+                else
+                {
+                    _runningEvent = new TaskCompletionSource<object>();
+                }
+            }
+        }
 
         public ConcurrentQueue<Message> MessageHistory { get; }
 
@@ -90,26 +109,31 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void Dispose()
         {
+            if (!_disposed)
+            {
+                _swarmCancellationTokenSource?.Cancel();
+                Running = false;
+                _disposed = true;
+            }
         }
 
-#pragma warning disable CS1998 // Method need to implement ITransport but it isn't be async
         public async Task StartAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             _logger.Debug("Starting transport of {Peer}.", AsPeer);
             _swarmCancellationTokenSource = new CancellationTokenSource();
-        }
-#pragma warning restore CS1998
-
-        public async Task RunAsync(
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
             CancellationToken token = cancellationToken.Equals(CancellationToken.None)
                 ? _swarmCancellationTokenSource.Token
                 : CancellationTokenSource
                     .CreateLinkedTokenSource(
                         _swarmCancellationTokenSource.Token, cancellationToken)
                     .Token;
+            Running = true;
             await ProcessRuntime(token);
         }
 
@@ -117,15 +141,23 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan waitFor,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            _logger.Debug("Stopping transport of {Peer}.", AsPeer);
-            _swarmCancellationTokenSource.Cancel();
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
+            if (Running)
+            {
+                _logger.Debug("Stopping transport of {Peer}.", AsPeer);
+                _swarmCancellationTokenSource.Cancel();
+                Running = false;
+            }
+
             await Task.Delay(waitFor, cancellationToken);
         }
 
-        public Task WaitForRunningAsync()
-        {
-            return Task.CompletedTask;
-        }
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
+        public Task WaitForRunningAsync() => _runningEvent.Task;
 
         public async Task BootstrapAsync(
             IEnumerable<Peer> bootstrapPeers,
@@ -134,6 +166,11 @@ namespace Libplanet.Tests.Net.Protocols
             int depth = 3,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             IEnumerable<BoundPeer> peers = bootstrapPeers.OfType<BoundPeer>();
 
             await BootstrapAsync(
@@ -152,9 +189,14 @@ namespace Libplanet.Tests.Net.Protocols
             int depth = 3,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (bootstrapPeers is null)
@@ -185,9 +227,14 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (peers is null)
@@ -247,9 +294,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void SendPing(Peer target, TimeSpan? timeSpan = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (!(target is BoundPeer boundPeer))
@@ -268,9 +320,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void BroadcastTestMessage(Address? except, string data)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             var message = new TestMessage(data) { Remote = AsPeer };
@@ -280,6 +337,11 @@ namespace Libplanet.Tests.Net.Protocols
 
         public void BroadcastMessage(Address? except, Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             var peers = Table.PeersToBroadcast(except);
             var peersString = string.Join(", ", peers.Select(peer => peer.Address));
             _logger.Debug(
@@ -305,9 +367,14 @@ namespace Libplanet.Tests.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             if (!(peer is BoundPeer boundPeer))
@@ -391,9 +458,14 @@ namespace Libplanet.Tests.Net.Protocols
 
         public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             _logger.Debug("Replying {Message}...", message);
@@ -407,9 +479,14 @@ namespace Libplanet.Tests.Net.Protocols
             string data,
             CancellationToken token = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TestTransport));
+            }
+
             if (!Running)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new TransportException("Start transport before use.");
             }
 
             while (!token.IsCancellationRequested && !ReceivedTestMessageOfData(data))
@@ -420,9 +497,9 @@ namespace Libplanet.Tests.Net.Protocols
 
         public bool ReceivedTestMessageOfData(string data)
         {
-            if (!Running)
+            if (_disposed)
             {
-                throw new SwarmException("Start swarm before use.");
+                throw new ObjectDisposedException(nameof(TestTransport));
             }
 
             return ReceivedMessages.OfType<TestMessage>().Any(msg => msg.Data == data);
@@ -463,20 +540,9 @@ namespace Libplanet.Tests.Net.Protocols
                 _peersToReply[message.Identity] = boundPeer.Address;
             }
 
-            if (message is Ping)
-            {
-                _ = ReplyMessageAsync(
-                    new Pong
-                    {
-                        Identity = message.Identity,
-                        Remote = AsPeer,
-                    },
-                    default);
-            }
-
             LastMessageTimestamp = DateTimeOffset.UtcNow;
             ReceivedMessages.Add(message);
-            ProcessMessageHandler?.Invoke(this, message);
+            _ = ProcessMessageHandler.InvokeAsync(message);
             MessageReceived.Set();
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -309,6 +309,8 @@ namespace Libplanet.Tests.Net
                 await StartAsync(swarmC);
 
                 await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
+                Assert.Contains(swarmC.AsPeer, swarmA.Peers);
+                Assert.Contains(swarmA.AsPeer, swarmC.Peers);
 
                 for (var i = 0; i < 100; i++)
                 {

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -141,7 +141,7 @@ namespace Libplanet.Tests.Net
                 await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
                 Block<DumbAction> block = await seedChain.MineBlock(seedMiner);
                 seedSwarm.BroadcastBlock(block);
-                while (!((NetMQTransport)receiverSwarm.Transport).MessageHistory
+                while (receiverSwarm.Transport.MessageHistory
                     .Any(msg => msg is BlockHeaderMessage))
                 {
                     await Task.Delay(100);

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -129,8 +129,15 @@ namespace Libplanet.Tests.Net
                 options);
             _finalizers.Add(async () =>
             {
-                await StopAsync(swarm);
-                swarm.Dispose();
+                try
+                {
+                    await StopAsync(swarm);
+                    swarm.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                    _logger.Debug("Swarm {Swarm} is already disposed.", swarm);
+                }
             });
             return swarm;
         }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1652,6 +1652,57 @@ namespace Libplanet.Tests.Net
             }
         }
 
+        [Fact(Timeout = Timeout)]
+        public async Task DoNotFillMultipleTimes()
+        {
+            Swarm<DumbAction> receiver = CreateSwarm();
+            Swarm<DumbAction> sender1 = CreateSwarm();
+            Swarm<DumbAction> sender2 = CreateSwarm();
+
+            await StartAsync(receiver);
+            await StartAsync(sender1);
+            await StartAsync(sender2);
+
+            BlockChain<DumbAction> chain = receiver.BlockChain;
+            var minerKey = new PrivateKey();
+            Block<DumbAction> b1 =
+                TestUtils.MineNext(
+                        chain.Genesis,
+                        chain.Policy.GetHashAlgorithm,
+                        difficulty: 1024,
+                        miner: minerKey.PublicKey)
+                    .Evaluate(minerKey, chain);
+
+            try
+            {
+                await BootstrapAsync(sender1, receiver.AsPeer);
+                await BootstrapAsync(sender2, receiver.AsPeer);
+
+                sender1.BlockChain.Append(b1);
+                sender2.BlockChain.Append(b1);
+
+                sender1.BroadcastBlock(b1);
+                sender2.BroadcastBlock(b1);
+
+                // Make sure that receiver swarm only filled once for same block
+                // that were broadcasted simultaneously.
+                await receiver.BlockReceived.WaitAsync();
+
+                // Awaits 1 second because receiver swarm may tried to fill again after filled.
+                await Task.Delay(1000);
+                var transport = receiver.Transport;
+                Log.Debug("Messages: {@Message}", transport.MessageHistory);
+                Assert.Single(
+                    transport.MessageHistory.Where(msg => msg is Libplanet.Net.Messages.Blocks));
+            }
+            finally
+            {
+                await StopAsync(receiver);
+                await StopAsync(sender1);
+                await StopAsync(sender2);
+            }
+        }
+
         [RetryFact(10, Timeout = Timeout)]
         public async Task GetPeerChainStateAsync()
         {

--- a/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
@@ -22,8 +22,10 @@ namespace Libplanet.Tests.Net.Transports
             NetMQConfig.Cleanup(false);
         }
 
-        [Fact(Timeout = 60 * 1000)]
-        public async Task QueryAppProtocolVersion()
+        [Theory(Timeout = 60 * 1000)]
+        [InlineData(SwarmOptions.TransportType.NetMQTransport)]
+        [InlineData(SwarmOptions.TransportType.TcpTransport)]
+        public async Task QueryAppProtocolVersion(SwarmOptions.TransportType transportType)
         {
             var fx = new MemoryStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
@@ -35,12 +37,18 @@ namespace Libplanet.Tests.Net.Transports
             string host = IPAddress.Loopback.ToString();
             int port = FreeTcpPort();
 
+            var option = new SwarmOptions
+            {
+                Type = transportType,
+            };
+
             using (var swarm = new Swarm<DumbAction>(
                 blockchain,
                 swarmKey,
                 apv,
                 host: host,
-                listenPort: port))
+                listenPort: port,
+                options: option))
             {
                 var peer = new BoundPeer(swarmKey.PublicKey, new DnsEndPoint(host, port));
                 // Before swarm starting...

--- a/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Tests/Net/Transports/BoundPeerExtensionsTest.cs
@@ -10,6 +10,7 @@ using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using NetMQ;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Libplanet.Tests.Net.Transports
 {
@@ -21,7 +22,7 @@ namespace Libplanet.Tests.Net.Transports
             NetMQConfig.Cleanup(false);
         }
 
-        [Fact]
+        [Fact(Timeout = 60 * 1000)]
         public async Task QueryAppProtocolVersion()
         {
             var fx = new MemoryStoreFixture();
@@ -50,7 +51,21 @@ namespace Libplanet.Tests.Net.Transports
                 _ = swarm.StartAsync();
                 try
                 {
-                    AppProtocolVersion receivedAPV = peer.QueryAppProtocolVersion();
+                    AppProtocolVersion receivedAPV = default;
+                    if (swarm.Transport is NetMQTransport)
+                    {
+                        receivedAPV = peer.QueryAppProtocolVersion();
+                    }
+                    else if (swarm.Transport is TcpTransport)
+                    {
+                        receivedAPV = await peer.QueryAppProtocolVersionTcp();
+                    }
+                    else
+                    {
+                        throw new XunitException(
+                            "Each type of transport must have corresponding test case.");
+                    }
+
                     Assert.Equal(apv, receivedAPV);
                 }
                 finally

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -9,6 +9,7 @@ using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
+using NetMQ;
 using Nito.AsyncEx;
 using Serilog;
 using Xunit;
@@ -55,6 +56,11 @@ namespace Libplanet.Tests.Net.Transports
                 .CreateLogger()
                 .ForContext<NetMQTransportTest>();
             Logger = Log.ForContext<NetMQTransportTest>();
+        }
+
+        public void Dispose()
+        {
+            NetMQConfig.Cleanup(false);
         }
 
         [SkippableFact(Timeout = Timeout, Skip = "Target method is broken.")]

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -9,7 +9,6 @@ using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
-using NetMQ;
 using Nito.AsyncEx;
 using Serilog;
 using Xunit;
@@ -56,11 +55,6 @@ namespace Libplanet.Tests.Net.Transports
                 .CreateLogger()
                 .ForContext<NetMQTransportTest>();
             Logger = Log.ForContext<NetMQTransportTest>();
-        }
-
-        public void Dispose()
-        {
-            NetMQConfig.Cleanup(false);
         }
 
         [SkippableFact(Timeout = Timeout, Skip = "Target method is broken.")]

--- a/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/NetMQTransportTest.cs
@@ -64,10 +64,11 @@ namespace Libplanet.Tests.Net.Transports
             var transportB = CreateNetMQTransport();
 
             var messageReceived = new AsyncAutoResetEvent();
-            transportB.ProcessMessageHandler += (sender, message) =>
+            transportB.ProcessMessageHandler.Register(async message =>
             {
                 messageReceived.Set();
-            };
+                await Task.Yield();
+            });
 
             try
             {

--- a/Libplanet.Tests/Net/Transports/TcpTransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TcpTransportTest.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Net.Transports
+{
+    public class TcpTransportTest : TransportTest
+    {
+        public TcpTransportTest(ITestOutputHelper testOutputHelper)
+        {
+            TransportConstructor = CreateTcpTransport;
+
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffff}[{ThreadId}] - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.WithThreadId()
+                .WriteTo.TestOutput(testOutputHelper, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<TcpTransportTest>();
+            Logger = Log.ForContext<TcpTransportTest>();
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task ReadWriteMessageAsync()
+        {
+            var listener = new TcpListener(IPAddress.Any, 0);
+            listener.Start();
+            var client = new TcpClient();
+            await client.ConnectAsync("127.0.0.1", ((IPEndPoint)listener.LocalEndpoint).Port);
+            TcpClient listenerSocket = await listener.AcceptTcpClientAsync();
+
+            TcpTransport transport = CreateTcpTransport(
+                appProtocolVersion: AppProtocolVersion.Sign(new PrivateKey(), 1));
+            try
+            {
+                var message1 = new Ping
+                {
+                    Identity = Guid.NewGuid().ToByteArray(),
+                };
+
+                var message2 = new Pong
+                {
+                    Identity = Guid.NewGuid().ToByteArray(),
+                };
+
+                await transport.WriteMessageAsync(message1, client, default);
+                await transport.WriteMessageAsync(message2, client, default);
+                Message[] messages = new Message[2];
+                messages[0] = await transport.ReadMessageAsync(listenerSocket, default);
+                messages[1] = await transport.ReadMessageAsync(listenerSocket, default);
+                Assert.Equal(2, messages.Length);
+                Assert.Contains(messages, message => message is Ping);
+                Assert.Contains(messages, message => message is Pong);
+            }
+            finally
+            {
+                listenerSocket.Dispose();
+                client.Dispose();
+            }
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task ReadMessageCancelAsync()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(3));
+            var listener = new TcpListener(IPAddress.Any, 0);
+            listener.Start();
+            var client = new TcpClient();
+            await client.ConnectAsync("127.0.0.1", ((IPEndPoint)listener.LocalEndpoint).Port);
+            TcpClient listenerSocket = await listener.AcceptTcpClientAsync();
+
+            TcpTransport transport = CreateTcpTransport(
+                appProtocolVersion: AppProtocolVersion.Sign(new PrivateKey(), 1));
+            try
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                    await transport.ReadMessageAsync(listenerSocket, cts.Token));
+            }
+            finally
+            {
+                listenerSocket.Dispose();
+                client.Dispose();
+            }
+        }
+
+        [SkippableFact(Timeout = Timeout)]
+        public async Task ReadWriteMessageWithInvalidMagicCookieAsync()
+        {
+            byte[] invalidCookie = { 0x01, 0x02 };
+            Assert.False(TcpTransport.MagicCookie.SequenceEqual(invalidCookie));
+
+            var listener = new TcpListener(IPAddress.Any, 0);
+            listener.Start();
+            var client = new TcpClient();
+            await client.ConnectAsync("127.0.0.1", ((IPEndPoint)listener.LocalEndpoint).Port);
+            TcpClient listenerSocket = await listener.AcceptTcpClientAsync();
+
+            AppProtocolVersion version = AppProtocolVersion.Sign(new PrivateKey(), 1);
+            TcpTransport transport = CreateTcpTransport(appProtocolVersion: version);
+            try
+            {
+                var message = new Ping
+                {
+                    Identity = Guid.NewGuid().ToByteArray(),
+                };
+
+                var codec = new MessageCodec();
+                byte[] serialized = codec.Encode(
+                    message,
+                    new PrivateKey(),
+                    transport.AsPeer,
+                    DateTimeOffset.UtcNow,
+                    version);
+                int length = serialized.Length;
+                var buffer = new byte[invalidCookie.Length + sizeof(int) + length];
+                invalidCookie.CopyTo(buffer, 0);
+                BitConverter.GetBytes(length).CopyTo(buffer, invalidCookie.Length);
+                serialized.CopyTo(buffer, invalidCookie.Length + sizeof(int));
+                NetworkStream stream = client.GetStream();
+                await stream.WriteAsync(buffer, 0, buffer.Length, default);
+                await Assert.ThrowsAsync<InvalidMagicCookieException>(
+                    async () => await transport.ReadMessageAsync(listenerSocket, default));
+
+                byte[] shortBuffer = { 0x00 };
+                await stream.WriteAsync(shortBuffer, 0, shortBuffer.Length, default);
+                await Assert.ThrowsAsync<InvalidMagicCookieException>(
+                    async () => await transport.ReadMessageAsync(listenerSocket, default));
+            }
+            finally
+            {
+                listenerSocket.Dispose();
+                client.Dispose();
+            }
+        }
+
+        private TcpTransport CreateTcpTransport(
+            PrivateKey privateKey = null,
+            int tableSize = 160,
+            int bucketSize = 16,
+            AppProtocolVersion appProtocolVersion = default,
+            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners = null,
+            string host = null,
+            int? listenPort = null,
+            IEnumerable<IceServer> iceServers = null,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
+            int minimumBroadcastTarget = 10,
+            TimeSpan? messageLifespan = null
+        )
+        {
+            privateKey = privateKey ?? new PrivateKey();
+            host = host ?? IPAddress.Loopback.ToString();
+            iceServers = iceServers ?? new IceServer[] { };
+            var table = new RoutingTable(privateKey.ToAddress(), tableSize, bucketSize);
+
+            return CreateTcpTransport(
+                table,
+                privateKey,
+                appProtocolVersion,
+                trustedAppProtocolVersionSigners,
+                host,
+                listenPort,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                minimumBroadcastTarget,
+                messageLifespan);
+        }
+
+        private TcpTransport CreateTcpTransport(
+            RoutingTable table,
+            PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
+            string host,
+            int? listenPort,
+            IEnumerable<IceServer> iceServers,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
+            int minimumBroadcastTarget,
+            TimeSpan? messageLifespan
+        )
+        {
+            return new TcpTransport(
+                table,
+                privateKey,
+                appProtocolVersion,
+                trustedAppProtocolVersionSigners,
+                host,
+                listenPort,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                minimumBroadcastTarget,
+                messageLifespan);
+        }
+    }
+}

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -99,8 +99,8 @@ namespace Libplanet.Tests.Net.Transports
                         default));
                 Assert.Throws<ObjectDisposedException>(
                     () => transport.BroadcastMessage(null, message));
-                Assert.Throws<ObjectDisposedException>(
-                    () => transport.ReplyMessage(message));
+                await Assert.ThrowsAsync<ObjectDisposedException>(
+                    async () => await transport.ReplyMessageAsync(message, default));
 
                 // To check multiple Dispose() throws error or not.
                 transport.Dispose();
@@ -188,7 +188,7 @@ namespace Libplanet.Tests.Net.Transports
             }
         }
 
-        // This also tests ITransport.ReplyMessage at the same time.
+        // This also tests ITransport.ReplyMessageAsync at the same time.
         [SkippableFact(Timeout = Timeout)]
         public async Task SendMessageWithReplyAsync()
         {
@@ -199,10 +199,12 @@ namespace Libplanet.Tests.Net.Transports
             {
                 if (message is Ping)
                 {
-                    transportB.ReplyMessage(new Pong
-                    {
-                        Identity = message.Identity,
-                    });
+                    _ = transportB.ReplyMessageAsync(
+                        new Pong
+                        {
+                            Identity = message.Identity,
+                        },
+                        CancellationToken.None);
                 }
             };
 

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -28,18 +28,13 @@ namespace Libplanet.Tests.Net.Transports
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
-        public async Task RunAsync()
+        public void StartAsync()
         {
             ITransport transport = CreateTransport();
 
             try
             {
-                // RunAsync() throws NRE if it is not started yet.
-                await Assert.ThrowsAsync<TransportException>(
-                    async () => await transport.RunAsync());
-                await transport.StartAsync();
-                Assert.False(transport.Running);
-                _ = transport.RunAsync();
+                _ = transport.StartAsync();
                 Assert.True(transport.Running);
             }
             finally
@@ -231,8 +226,7 @@ namespace Libplanet.Tests.Net.Transports
             ITransport transport,
             CancellationToken cts = default)
         {
-            await transport.StartAsync(cts);
-            Task task = transport.RunAsync(cts);
+            Task task = transport.StartAsync(cts);
 
             while (!transport.Running)
             {

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -30,13 +30,14 @@ namespace Libplanet.Tests.Net.Transports
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
-        public void StartAsync()
+        public async Task StartAsync()
         {
             ITransport transport = CreateTransport();
 
             try
             {
                 _ = transport.StartAsync();
+                await transport.WaitForRunningAsync();
                 Assert.True(transport.Running);
             }
             finally

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -166,10 +166,11 @@ namespace Libplanet.Tests.Net.Transports
 
             TaskCompletionSource<Message> tcs = new TaskCompletionSource<Message>();
 
-            transportB.ProcessMessageHandler += (sender, message) =>
+            transportB.ProcessMessageHandler.Register(async message =>
             {
                 tcs.SetResult(message);
-            };
+                await Task.Yield();
+            });
 
             try
             {
@@ -202,18 +203,18 @@ namespace Libplanet.Tests.Net.Transports
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
 
-            transportB.ProcessMessageHandler += (sender, message) =>
+            transportB.ProcessMessageHandler.Register(async message =>
             {
                 if (message is Ping)
                 {
-                    _ = transportB.ReplyMessageAsync(
+                    await transportB.ReplyMessageAsync(
                         new Pong
                         {
                             Identity = message.Identity,
                         },
                         CancellationToken.None);
                 }
-            };
+            });
 
             try
             {
@@ -269,24 +270,24 @@ namespace Libplanet.Tests.Net.Transports
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
 
-            transportB.ProcessMessageHandler += (sender, message) =>
+            transportB.ProcessMessageHandler.Register(async message =>
             {
                 if (message is Ping)
                 {
-                    _ = transportB.ReplyMessageAsync(
+                    await transportB.ReplyMessageAsync(
                         new Ping
                         {
                             Identity = message.Identity,
                         },
                         default);
-                    _ = transportB.ReplyMessageAsync(
+                    await transportB.ReplyMessageAsync(
                         new Pong
                         {
                             Identity = message.Identity,
                         },
                         default);
                 }
-            };
+            });
 
             try
             {
@@ -386,18 +387,20 @@ namespace Libplanet.Tests.Net.Transports
             var tcsC = new TaskCompletionSource<Message>();
             var tcsD = new TaskCompletionSource<Message>();
 
-            transportB.ProcessMessageHandler += MessageHandler(tcsB);
-            transportC.ProcessMessageHandler += MessageHandler(tcsC);
-            transportD.ProcessMessageHandler += MessageHandler(tcsD);
+            transportB.ProcessMessageHandler.Register(MessageHandler(tcsB));
+            transportC.ProcessMessageHandler.Register(MessageHandler(tcsC));
+            transportD.ProcessMessageHandler.Register(MessageHandler(tcsD));
 
-            EventHandler<Message> MessageHandler(TaskCompletionSource<Message> tcs)
+            Func<Message, Task> MessageHandler(TaskCompletionSource<Message> tcs)
             {
-                return (sender, message) =>
+                return async message =>
                 {
                     if (message is Ping)
                     {
                         tcs.SetResult(message);
                     }
+
+                    await Task.Yield();
                 };
             }
 

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -50,13 +50,11 @@ namespace Libplanet.Tests.Net.Transports
 
             try
             {
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
                 await transport.StopAsync(TimeSpan.Zero);
                 Assert.False(transport.Running);
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
             }
             finally
@@ -72,8 +70,7 @@ namespace Libplanet.Tests.Net.Transports
 
             try
             {
-                _ = transport.StartAsync();
-                await transport.WaitForRunningAsync();
+                await InitializeAsync(transport);
                 Assert.True(transport.Running);
                 transport.Dispose();
                 var boundPeer = new BoundPeer(
@@ -98,6 +95,7 @@ namespace Libplanet.Tests.Net.Transports
                         message,
                         null,
                         3,
+                        false,
                         default));
                 Assert.Throws<ObjectDisposedException>(
                     () => transport.BroadcastMessage(null, message));
@@ -292,18 +290,12 @@ namespace Libplanet.Tests.Net.Transports
             }
         }
 
-        protected async Task<Task> InitializeAsync(
+        protected async Task InitializeAsync(
             ITransport transport,
             CancellationToken cts = default)
         {
-            Task task = transport.StartAsync(cts);
-
-            while (!transport.Running)
-            {
-                await Task.Delay(100, cts);
-            }
-
-            return task;
+            _ = transport.StartAsync(cts);
+            await transport.WaitForRunningAsync();
         }
 
         private ITransport CreateTransport(

--- a/Libplanet/Net/AsyncDelegate.cs
+++ b/Libplanet/Net/AsyncDelegate.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Libplanet.Net
+{
+    public class AsyncDelegate<T>
+    {
+        private IEnumerable<Func<T, Task>> _functions;
+
+        public AsyncDelegate()
+        {
+            _functions = new List<Func<T, Task>>();
+        }
+
+        public void Register(Func<T, Task> func)
+        {
+#pragma warning disable PC002
+            // Usage of a .NET Standard API that isn’t available on the .NET Framework 4.6.1
+#if NETFRAMEWORK && !NET48 && !NET472 && !NET471
+            _functions = _functions.Concat(new[] { func });
+#else
+            _functions = _functions.Append(func);
+#endif
+#pragma warning restore PC002
+        }
+
+        public void Unregister(Func<T, Task> func)
+        {
+            _functions = _functions.Where(f => !f.Equals(func));
+        }
+
+        public async Task InvokeAsync(T arg)
+        {
+            IEnumerable<Task> tasks = _functions.Select(f => f(arg));
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/Libplanet/Net/Messages/MessageCodec.cs
+++ b/Libplanet/Net/Messages/MessageCodec.cs
@@ -1,0 +1,215 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bencodex;
+using Libplanet.Crypto;
+
+namespace Libplanet.Net.Messages
+{
+    public class MessageCodec : IMessageCodec<byte[]>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+
+        private readonly Codec _codec;
+
+        public MessageCodec()
+        {
+            _codec = new Codec();
+        }
+
+        /// <inheritdoc cref="IMessageCodec{T}.Encode"/>
+        public byte[] Encode(
+            Message message,
+            PrivateKey privateKey,
+            Peer peer,
+            DateTimeOffset timestamp,
+            AppProtocolVersion version)
+        {
+            if (peer is null)
+            {
+                throw new ArgumentNullException(nameof(peer));
+            }
+
+            var frames = new List<byte[]>();
+
+            // Write body (by concrete class)
+            foreach (byte[] frame in message.DataFrames)
+            {
+                frames.Add(frame);
+            }
+
+            // Write headers. (inverse order, version-type-peer-timestamp)
+            frames.Insert(0, BitConverter.GetBytes(timestamp.Ticks));
+            frames.Insert(0, _codec.Encode(peer.ToBencodex()));
+            frames.Insert(0, BitConverter.GetBytes((int)message.Type));
+            frames.Insert(0, Encoding.ASCII.GetBytes(version.Token));
+
+            // Make and insert signature
+            byte[] signature = privateKey.Sign(
+                frames.Aggregate(new byte[] { }, (arr, bytes) => arr.Concat(bytes).ToArray()));
+            frames.Insert((int)Message.MessageFrame.Sign, signature);
+
+            if (message.Identity is { } to)
+            {
+                frames.Insert(0, message.Identity);
+            }
+
+            using var stream = new MemoryStream();
+            stream.Write(BitConverter.GetBytes(frames.Count), 0, sizeof(int));
+            foreach (var frame in frames)
+            {
+                stream.Write(BitConverter.GetBytes(frame.Length), 0, sizeof(int));
+                stream.Write(frame, 0, frame.Length);
+            }
+
+            return stream.ToArray();
+        }
+
+        /// <inheritdoc cref="IMessageCodec{T}.Decode"/>
+        public Message Decode(
+            byte[] encoded,
+            bool reply,
+            Action<byte[], Peer, AppProtocolVersion> appProtocolVersionValidator,
+            TimeSpan? lifetime)
+        {
+            if (encoded.Length == 0)
+            {
+                throw new ArgumentException("Can't parse empty byte array.");
+            }
+
+            using var stream = new MemoryStream(encoded);
+            var buffer = new byte[sizeof(int)];
+            stream.Read(buffer, 0, sizeof(int));
+            int frameCount = BitConverter.ToInt32(buffer, 0);
+            var frames = new List<byte[]>();
+            for (var i = 0; i < frameCount; i++)
+            {
+                buffer = new byte[sizeof(int)];
+                stream.Read(buffer, 0, sizeof(int));
+                int frameSize = BitConverter.ToInt32(buffer, 0);
+                buffer = new byte[frameSize];
+                stream.Read(buffer, 0, frameSize);
+                frames.Add(buffer);
+            }
+
+            // (reply == true)            [version, type, peer, timestamp, sign, frames...]
+            // (reply == false) [identity, version, type, peer, timestamp, sign, frames...]
+            List<byte[]> remains = reply ? frames : frames.Skip(1).ToList();
+
+            var versionToken = Encoding.ASCII.GetString(remains[(int)Message.MessageFrame.Version]);
+
+            AppProtocolVersion remoteVersion = AppProtocolVersion.FromToken(versionToken);
+            Peer remotePeer;
+            var dictionary =
+                (Bencodex.Types.Dictionary)_codec.Decode(remains[(int)Message.MessageFrame.Peer]);
+            try
+            {
+                remotePeer = new BoundPeer(dictionary);
+            }
+            catch (KeyNotFoundException)
+            {
+                remotePeer = new Peer(dictionary);
+            }
+
+            appProtocolVersionValidator(
+                reply ? new byte[] { } : frames[0],
+                remotePeer,
+                remoteVersion);
+
+            var type =
+                (Message.MessageType)BitConverter.ToInt32(
+                    remains[(int)Message.MessageFrame.Type],
+                    0);
+            long ticks = BitConverter.ToInt64(remains[(int)Message.MessageFrame.Timestamp], 0);
+            var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
+
+            var currentTime = DateTimeOffset.UtcNow;
+            if (!(lifetime is null) &&
+                (currentTime < timestamp || timestamp + lifetime < currentTime))
+            {
+                var msg = $"Received message is invalid, created at " +
+                          $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +
+                          $"but designated lifetime is {lifetime} and the current datetime " +
+                          $"offset is " +
+                          $"{currentTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}.";
+                throw new InvalidTimestampException(msg, timestamp, lifetime.Value, currentTime);
+            }
+
+            byte[] signature = remains[(int)Message.MessageFrame.Sign];
+
+            byte[][] body = remains.Skip(Message.CommonFrames).ToArray();
+
+            Message message = CreateMessage(type, body);
+            message.Version = remoteVersion;
+            message.Remote = remotePeer;
+            message.Timestamp = timestamp;
+
+            var headerWithoutSign = new[]
+            {
+                remains[(int)Message.MessageFrame.Version],
+                remains[(int)Message.MessageFrame.Type],
+                remains[(int)Message.MessageFrame.Peer],
+                remains[(int)Message.MessageFrame.Timestamp],
+            };
+
+            var messageForVerify = headerWithoutSign.Concat(body).Aggregate(
+                new byte[] { },
+                (arr, bytes) => arr.Concat(bytes).ToArray());
+
+            if (!remotePeer.PublicKey.Verify(messageForVerify, signature))
+            {
+                throw new InvalidMessageException("The message signature is invalid", message);
+            }
+
+            if (!reply)
+            {
+                message.Identity = frames[0];
+            }
+
+            return message;
+        }
+
+        private Message CreateMessage(Message.MessageType type, byte[][] dataframes)
+        {
+            switch (type)
+            {
+                case Message.MessageType.Ping:
+                    return new Ping();
+                case Message.MessageType.Pong:
+                    return new Pong();
+                case Message.MessageType.GetBlockHashes:
+                    return new GetBlockHashes(dataframes);
+                case Message.MessageType.TxIds:
+                    return new TxIds(dataframes);
+                case Message.MessageType.GetBlocks:
+                    return new GetBlocks(dataframes);
+                case Message.MessageType.GetTxs:
+                    return new GetTxs(dataframes);
+                case Message.MessageType.Blocks:
+                    return new Blocks(dataframes);
+                case Message.MessageType.Tx:
+                    return new Tx(dataframes);
+                case Message.MessageType.FindNeighbors:
+                    return new FindNeighbors(dataframes);
+                case Message.MessageType.Neighbors:
+                    return new Neighbors(dataframes);
+                case Message.MessageType.BlockHeaderMessage:
+                    return new BlockHeaderMessage(dataframes);
+                case Message.MessageType.BlockHashes:
+                    return new BlockHashes(dataframes);
+                case Message.MessageType.GetChainStatus:
+                    return new GetChainStatus();
+                case Message.MessageType.ChainStatus:
+                    return new ChainStatus(dataframes);
+                case Message.MessageType.DifferentVersion:
+                    return new DifferentVersion();
+                default:
+                    throw new InvalidCastException($"Given type {type} is not a valid message.");
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -703,7 +703,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            _transport.ReplyMessage(pong);
+            _ = _transport.ReplyMessageAsync(pong, default);
         }
 
         /// <summary>
@@ -852,7 +852,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            _transport.ReplyMessage(neighbors);
+            _ = _transport.ReplyMessageAsync(neighbors, default);
         }
     }
 }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -57,7 +57,7 @@ namespace Libplanet.Net.Protocols
             _requestTimeout =
                 requestTimeout ??
                 TimeSpan.FromMilliseconds(5000);
-            _transport.ProcessMessageHandler += ProcessMessageHandler;
+            _transport.ProcessMessageHandler.Register(ProcessMessageHandler);
         }
 
         /// <inheritdoc />
@@ -488,20 +488,19 @@ namespace Libplanet.Net.Protocols
             }
         }
 
-        private void ProcessMessageHandler(object target, Message message)
+        private async Task ProcessMessageHandler(Message message)
         {
             switch (message)
             {
                 case Ping ping:
                 {
-                    _logger.Debug("Received message is Ping.");
-                    ReceivePing(ping);
+                    await ReceivePingAsync(ping);
                     break;
                 }
 
                 case FindNeighbors findNeighbors:
                 {
-                    ReceiveFindPeer(findNeighbors);
+                    await ReceiveFindPeerAsync(findNeighbors);
                     break;
                 }
             }
@@ -691,7 +690,7 @@ namespace Libplanet.Net.Protocols
         }
 
         // Send pong back to remote
-        private void ReceivePing(Ping ping)
+        private async Task ReceivePingAsync(Ping ping)
         {
             if (ping.Remote.Address.Equals(_address))
             {
@@ -703,7 +702,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            _ = _transport.ReplyMessageAsync(pong, default);
+            await _transport.ReplyMessageAsync(pong, default);
         }
 
         /// <summary>
@@ -842,7 +841,7 @@ namespace Libplanet.Net.Protocols
 
         // FIXME: this method is not safe from amplification attack
         // maybe ping/pong/ping/pong is required
-        private void ReceiveFindPeer(FindNeighbors findNeighbors)
+        private async Task ReceiveFindPeerAsync(FindNeighbors findNeighbors)
         {
             IEnumerable<BoundPeer> found =
                 _table.Neighbors(findNeighbors.Target, _table.BucketSize, true);
@@ -852,7 +851,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            _ = _transport.ReplyMessageAsync(neighbors, default);
+            await _transport.ReplyMessageAsync(neighbors, default);
         }
     }
 }

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 using Libplanet.Tx;
@@ -9,7 +10,7 @@ namespace Libplanet.Net
 {
     public partial class Swarm<T>
     {
-        private void ProcessMessageHandler(object target, Message message)
+        private async Task ProcessMessageHandlerAsync(Message message)
         {
             switch (message)
             {
@@ -34,7 +35,7 @@ namespace Libplanet.Net
                         Identity = getChainStatus.Identity,
                     };
 
-                    _ = Transport.ReplyMessageAsync(chainStatus, default);
+                    await Transport.ReplyMessageAsync(chainStatus, default);
                     break;
                 }
 
@@ -62,16 +63,16 @@ namespace Libplanet.Net
                         Identity = getBlockHashes.Identity,
                     };
 
-                    _ = Transport.ReplyMessageAsync(reply, default);
+                    await Transport.ReplyMessageAsync(reply, default);
                     break;
                 }
 
                 case GetBlocks getBlocks:
-                    TransferBlocks(getBlocks);
+                    await TransferBlocksAsync(getBlocks);
                     break;
 
                 case GetTxs getTxs:
-                    TransferTxs(getTxs);
+                    await TransferTxsAsync(getTxs);
                     break;
 
                 case TxIds txIds:
@@ -181,7 +182,7 @@ namespace Libplanet.Net
                 new BlockDemand(header, peer, DateTimeOffset.UtcNow));
         }
 
-        private void TransferTxs(GetTxs getTxs)
+        private async Task TransferTxsAsync(GetTxs getTxs)
         {
             foreach (TxId txid in getTxs.TxIds)
             {
@@ -198,7 +199,7 @@ namespace Libplanet.Net
                     {
                         Identity = getTxs.Identity,
                     };
-                    _ = Transport.ReplyMessageAsync(response, default);
+                    await Transport.ReplyMessageAsync(response, default);
                 }
                 catch (KeyNotFoundException)
                 {
@@ -227,7 +228,7 @@ namespace Libplanet.Net
             TxCompletion.Demand(peer, message.Ids);
         }
 
-        private void TransferBlocks(GetBlocks getData)
+        private async Task TransferBlocksAsync(GetBlocks getData)
         {
             string identityHex = ByteUtil.Hex(getData.Identity);
             _logger.Verbose(
@@ -263,7 +264,7 @@ namespace Libplanet.Net
                         i,
                         total
                     );
-                    _ = Transport.ReplyMessageAsync(response, default);
+                    await Transport.ReplyMessageAsync(response, default);
                     blocks.Clear();
                 }
 
@@ -282,7 +283,7 @@ namespace Libplanet.Net
                     total,
                     identityHex
                 );
-                _ = Transport.ReplyMessageAsync(response, default);
+                await Transport.ReplyMessageAsync(response, default);
             }
 
             _logger.Debug("Blocks were transferred to {Identity}.", identityHex);

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -164,7 +164,7 @@ namespace Libplanet.Net
                     header.Index,
                     header.Hash,
                     peer,
-                    BlockChain.Tip,
+                    BlockChain.Tip.Index,
                     BlockChain.Tip.Hash);
                 return;
             }

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net
                         Identity = getChainStatus.Identity,
                     };
 
-                    Transport.ReplyMessage(chainStatus);
+                    _ = Transport.ReplyMessageAsync(chainStatus, default);
                     break;
                 }
 
@@ -62,7 +62,7 @@ namespace Libplanet.Net
                         Identity = getBlockHashes.Identity,
                     };
 
-                    Transport.ReplyMessage(reply);
+                    _ = Transport.ReplyMessageAsync(reply, default);
                     break;
                 }
 
@@ -198,7 +198,7 @@ namespace Libplanet.Net
                     {
                         Identity = getTxs.Identity,
                     };
-                    Transport.ReplyMessage(response);
+                    _ = Transport.ReplyMessageAsync(response, default);
                 }
                 catch (KeyNotFoundException)
                 {
@@ -263,7 +263,7 @@ namespace Libplanet.Net
                         i,
                         total
                     );
-                    Transport.ReplyMessage(response);
+                    _ = Transport.ReplyMessageAsync(response, default);
                     blocks.Clear();
                 }
 
@@ -282,7 +282,7 @@ namespace Libplanet.Net
                     total,
                     identityHex
                 );
-                Transport.ReplyMessage(response);
+                _ = Transport.ReplyMessageAsync(response, default);
             }
 
             _logger.Debug("Blocks were transferred to {Identity}.", identityHex);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -131,13 +131,13 @@ namespace Libplanet.Net
             }
         }
 
-        public bool Running => Transport.Running;
+        public bool Running => Transport?.Running ?? false;
 
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
         public Address Address => _privateKey.ToAddress();
 
-        public Peer AsPeer => Transport.AsPeer;
+        public Peer AsPeer => Transport?.AsPeer;
 
         /// <summary>
         /// The last time when any message was arrived.
@@ -313,13 +313,9 @@ namespace Libplanet.Net
                     _workerCancellationTokenSource.Token, cancellationToken
                 ).Token;
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
-            try
+            if (Transport.Running)
             {
-                await Transport.StartAsync(_cancellationToken);
-            }
-            catch (TransportException te)
-            {
-                throw new SwarmException("Swarm is already running.", innerException: te);
+                throw new SwarmException("Swarm is already running.");
             }
 
             _logger.Debug("Starting swarm...");

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Net
                 differentAppProtocolVersionEncountered,
                 Options.MinimumBroadcastTarget,
                 Options.MessageLifespan);
-            Transport.ProcessMessageHandler += ProcessMessageHandler;
+            Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -336,7 +336,7 @@ namespace Libplanet.Net
                         Options.RefreshLifespan,
                         _cancellationToken));
                 tasks.Add(RebuildConnectionAsync(TimeSpan.FromMinutes(30), _cancellationToken));
-                tasks.Add(Transport.RunAsync(_cancellationToken));
+                tasks.Add(Transport.StartAsync(_cancellationToken));
                 tasks.Add(BroadcastBlockAsync(broadcastBlockInterval, _cancellationToken));
                 tasks.Add(BroadcastTxAsync(broadcastTxInterval, _cancellationToken));
                 tasks.Add(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -131,7 +131,7 @@ namespace Libplanet.Net
             }
         }
 
-        public bool Running => Transport is NetMQTransport p && p.Running;
+        public bool Running => Transport.Running;
 
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
@@ -191,10 +191,10 @@ namespace Libplanet.Net
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.
         /// </summary>
-        /// <seealso cref="NetMQTransport.WaitForRunningAsync()"/>
-        /// <returns>A <see cref="Task"/> completed when <see cref="NetMQTransport.Running"/>
+        /// <seealso cref="ITransport.WaitForRunningAsync()"/>
+        /// <returns>A <see cref="Task"/> completed when <see cref="ITransport.Running"/>
         /// property becomes <c>true</c>.</returns>
-        public Task WaitForRunningAsync() => (Transport as NetMQTransport)?.WaitForRunningAsync();
+        public Task WaitForRunningAsync() => Transport?.WaitForRunningAsync();
 
         public void Dispose()
         {

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -5,12 +5,29 @@ using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Libplanet.Tx;
 
 namespace Libplanet.Net
 {
     public class SwarmOptions
     {
+        /// <summary>
+        /// <c>Enum</c> represents the type of the <see cref="ITransport"/>.
+        /// </summary>
+        public enum TransportType : byte
+        {
+            /// <summary>
+            /// NetMQ based transport.
+            /// </summary>
+            NetMQTransport = 0x01,
+
+            /// <summary>
+            /// TCP based transport.
+            /// </summary>
+            TcpTransport = 0x02,
+        }
+
         /// <summary>
         /// The maximum timeout used in <see cref="Swarm{T}"/>.
         /// </summary>
@@ -112,5 +129,10 @@ namespace Libplanet.Net
         /// peers.
         /// </summary>
         public TimeSpan TipLifespan { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// The type of <see cref="ITransport"/> used in <see cref="Swarm{T}"/>.
+        /// </summary>
+        public TransportType Type { get; set; } = TransportType.TcpTransport;
     }
 }

--- a/Libplanet/Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet/Net/Transports/BoundPeerExtensions.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using NetMQ;
@@ -13,7 +16,8 @@ namespace Libplanet.Net.Transports
     public static class BoundPeerExtensions
     {
         /// <summary>
-        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>.
+        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>
+        /// specialized for NetMQ based transport.
         /// </summary>
         /// <param name="peer">The <see cref="BoundPeer"/> to query
         /// <see cref="AppProtocolVersion"/>.</param>
@@ -49,6 +53,77 @@ namespace Libplanet.Net.Transports
             throw new TimeoutException(
                 $"Peer[{peer}] didn't respond within the specified time[{timeout}]."
             );
+        }
+
+        /// <summary>
+        /// Queries <see cref="AppProtocolVersion"/> of given <see cref="BoundPeer"/>
+        /// specialized for TCP based transport.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to query
+        /// <see cref="AppProtocolVersion"/>.</param>
+        /// <param name="timeout">Timeout value for request.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns><see cref="AppProtocolVersion"/> of given peer. </returns>
+        public static async Task<AppProtocolVersion> QueryAppProtocolVersionTcp(
+            this BoundPeer peer,
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+            client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
+            using var stream = client.GetStream();
+            var key = new PrivateKey();
+            var ping = new Ping
+            {
+                Identity = Guid.NewGuid().ToByteArray(),
+            };
+            var messageCodec = new MessageCodec();
+
+            byte[] serialized = messageCodec.Encode(
+                ping,
+                key,
+                peer,
+                DateTimeOffset.UtcNow,
+                default);
+            int length = serialized.Length;
+            var buffer = new byte[TcpTransport.MagicCookie.Length + sizeof(int) + length];
+            TcpTransport.MagicCookie.CopyTo(buffer, 0);
+            BitConverter.GetBytes(length).CopyTo(buffer, TcpTransport.MagicCookie.Length);
+            serialized.CopyTo(buffer, TcpTransport.MagicCookie.Length + sizeof(int));
+            await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+
+            buffer = new byte[1000000];
+            int bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+            var magicCookieBuffer = new byte[TcpTransport.MagicCookie.Length];
+            Array.Copy(buffer, 0, magicCookieBuffer, 0, TcpTransport.MagicCookie.Length);
+            var sizeBuffer = new byte[sizeof(int)];
+            Array.Copy(buffer, TcpTransport.MagicCookie.Length, sizeBuffer, 0, sizeof(int));
+            length = BitConverter.ToInt32(sizeBuffer, 0);
+            var contentBuffer = new byte[length];
+            Array.Copy(
+                buffer,
+                TcpTransport.MagicCookie.Length + sizeof(int),
+                contentBuffer,
+                0,
+                length);
+
+            // length of identity
+            Array.Copy(contentBuffer, 4, sizeBuffer, 0, 4);
+            length = BitConverter.ToInt32(sizeBuffer, 0);
+
+            // length of apv token
+            Array.Copy(contentBuffer, 4 + 4 + length, sizeBuffer, 0, 4);
+            int apvLength = BitConverter.ToInt32(sizeBuffer, 0);
+            var apvBytes = new byte[apvLength];
+            Array.Copy(contentBuffer, 4 + 4 + length + 4, apvBytes, 0, apvLength);
+            var frame = new NetMQFrame(apvBytes);
+            string token = frame.ConvertToString();
+            AppProtocolVersion version = AppProtocolVersion.FromToken(token);
+            return version;
         }
 
         internal static string ToNetMQAddress(this BoundPeer peer)

--- a/Libplanet/Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet/Net/Transports/BoundPeerExtensions.cs
@@ -41,13 +41,20 @@ namespace Libplanet.Net.Transports
             );
 
             TimeSpan timeoutNotNull = timeout ?? TimeSpan.FromSeconds(5);
-            if (dealerSocket.TrySendMultipartMessage(timeoutNotNull, request))
+            try
             {
-                var response = new NetMQMessage();
-                if (dealerSocket.TryReceiveMultipartMessage(timeoutNotNull, ref response))
+                if (dealerSocket.TrySendMultipartMessage(timeoutNotNull, request))
                 {
-                    return AppProtocolVersion.FromToken(response.First.ConvertToString());
+                    var response = new NetMQMessage();
+                    if (dealerSocket.TryReceiveMultipartMessage(timeoutNotNull, ref response))
+                    {
+                        return AppProtocolVersion.FromToken(response.First.ConvertToString());
+                    }
                 }
+            }
+            catch (TerminatingException)
+            {
+                throw new TimeoutException($"Peer didn't respond.");
             }
 
             throw new TimeoutException(
@@ -73,7 +80,15 @@ namespace Libplanet.Net.Transports
         )
         {
             using var client = new TcpClient();
-            await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+            try
+            {
+                await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+            }
+            catch (SocketException)
+            {
+                throw new TimeoutException("Cannot find peer.");
+            }
+
             client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
             using var stream = client.GetStream();
             var key = new PrivateKey();

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -40,23 +40,13 @@ namespace Libplanet.Net.Transports
         bool Running { get; }
 
         /// <summary>
-        /// Initiates transport layer.
+        /// Initiates and runs transport layer.
         /// </summary>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
         Task StartAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Starts running transport layer. To <see cref="RunAsync"/>, you should call
-        /// <see cref="StartAsync"/> first.
-        /// </summary>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.</param>
-        /// <returns>An awaitable task without value.</returns>
-        Task RunAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stops running transport layer.

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -15,11 +15,11 @@ namespace Libplanet.Net.Transports
     public interface ITransport : IDisposable
     {
         /// <summary>
-        /// The <see cref="EventHandler"/> invoked when a message that is not
+        /// The list of tasks invoked when a message that is not
         /// a reply is received. To handle reply, please use <see cref=
         /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
         /// </summary>
-        event EventHandler<Message> ProcessMessageHandler;
+        AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <summary>
         /// <see cref="Peer"/> representation of <see cref="ITransport"/>.

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -54,6 +54,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task StartAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -65,6 +67,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default);
@@ -85,6 +89,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
 
         /// <summary>
@@ -99,6 +105,8 @@ namespace Libplanet.Net.Transports
         /// operation should be canceled.</param>
         /// <returns>The replies of the <paramref name="message"/>
         /// sent by <paramref name="peer"/>.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -120,6 +128,8 @@ namespace Libplanet.Net.Transports
         /// operation should be canceled.</param>
         /// <returns>The replies of the <paramref name="message"/>
         /// sent by <paramref name="peer"/>.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -134,6 +144,8 @@ namespace Libplanet.Net.Transports
         /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
         /// If <c>null</c> is given, no peers will be excluded.</param>
         /// <param name="message">A <see cref="Message"/> to broadcast.</param>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         void BroadcastMessage(Address? except, Message message);
 
         /// <summary>
@@ -149,6 +161,8 @@ namespace Libplanet.Net.Transports
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
         Task ReplyMessageAsync(Message message, CancellationToken cancellationToken);
     }
 }

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading;
@@ -40,6 +41,13 @@ namespace Libplanet.Net.Transports
         bool Running { get; }
 
         /// <summary>
+        /// A fixed sized queue that keeps history of <see cref="Message"/> received.
+        /// It saves at most 30 recent <see cref="Message"/>s.
+        /// </summary>
+        [Pure]
+        ConcurrentQueue<Message> MessageHistory { get; }
+
+        /// <summary>
         /// Initiates and runs transport layer.
         /// </summary>
         /// <param name="cancellationToken">
@@ -60,6 +68,13 @@ namespace Libplanet.Net.Transports
         Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Waits until this <see cref="ITransport"/> instance gets started to run.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> completed when <see cref="ITransport.Running"/>
+        /// property becomes <c>true</c>.</returns>
+        Task WaitForRunningAsync();
 
         /// <summary>
         /// Sends the <paramref name="message"/> to given <paramref name="peer"/>.

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -145,6 +145,10 @@ namespace Libplanet.Net.Transports
         /// <paramref name="message"/>.
         /// </remarks>
         /// <param name="message">A <see cref="Message"/> to reply.</param>
-        void ReplyMessage(Message message);
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this
+        /// operation should be canceled.</param>
+        /// <returns>An awaitable task without value.</returns>
+        Task ReplyMessageAsync(Message message, CancellationToken cancellationToken);
     }
 }

--- a/Libplanet/Net/Transports/InvalidMagicCookieException.cs
+++ b/Libplanet/Net/Transports/InvalidMagicCookieException.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Serialization;
+using Libplanet.Serialization;
+
+namespace Libplanet.Net.Transports
+{
+    [Serializable]
+    public class InvalidMagicCookieException : Exception
+    {
+        public InvalidMagicCookieException(IEnumerable<byte> expected, IEnumerable<byte> actual)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        public InvalidMagicCookieException(
+            IEnumerable<byte> expected,
+            IEnumerable<byte> actual,
+            string message)
+            : base(message)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        public InvalidMagicCookieException(
+            IEnumerable<byte> expected,
+            IEnumerable<byte> actual,
+            string message,
+            Exception innerException)
+            : base(message, innerException)
+        {
+            Expected = expected.ToImmutableArray();
+            Actual = actual.ToImmutableArray();
+        }
+
+        protected InvalidMagicCookieException(
+            SerializationInfo info,
+            StreamingContext context
+        )
+            : base(info, context)
+        {
+            Expected = info.GetValue<ImmutableArray<byte>>(nameof(Expected));
+            Actual = info.GetValue<ImmutableArray<byte>>(nameof(Actual));
+        }
+
+        public ImmutableArray<byte> Expected { get; private set; }
+
+        public ImmutableArray<byte> Actual { get; private set; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Expected), Expected);
+            info.AddValue(nameof(Actual), Actual);
+        }
+    }
+}

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -281,21 +281,6 @@ namespace Libplanet.Net.Transports
             _router.ReceiveReady += ReceiveMessage;
             _replyQueue.ReceiveReady += DoReply;
             _broadcastQueue.ReceiveReady += DoBroadcast;
-        }
-
-        /// <inheritdoc />
-        public async Task RunAsync(CancellationToken cancellationToken)
-        {
-            if (Running)
-            {
-                throw new TransportException("Transport is already running.");
-            }
-
-            if (_router is null)
-            {
-                throw new TransportException(
-                    $"Transport needs to be started before {nameof(RunAsync)}().");
-            }
 
             List<Task> tasks = new List<Task>();
 

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -239,6 +239,11 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             if (Running)
             {
                 throw new TransportException("Transport is already running.");
@@ -301,6 +306,11 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken = default
         )
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             if (Running)
             {
                 await Task.Delay(waitFor, cancellationToken);
@@ -403,6 +413,11 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken
         )
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             Guid reqId = Guid.NewGuid();
             try
             {
@@ -514,12 +529,22 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc />
         public void BroadcastMessage(Address? except, Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             _broadcastQueue.Enqueue((except, message));
         }
 
         /// <inheritdoc />
         public void ReplyMessage(Message message)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NetMQTransport));
+            }
+
             string identityHex = ByteUtil.Hex(message.Identity);
             _logger.Debug("Reply {Message} to {Identity}...", message, identityHex);
             _replyQueue.Enqueue(_messageCodec.Encode(

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -199,13 +199,14 @@ namespace Libplanet.Net.Transports
             );
 
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
+            ProcessMessageHandler = new AsyncDelegate<Message>();
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
             _replyCompletionSources =
                 new ConcurrentDictionary<string, TaskCompletionSource<object>>();
         }
 
         /// <inheritdoc />
-        public event EventHandler<Message> ProcessMessageHandler;
+        public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <inheritdoc cref="ITransport.AsPeer"/>
         public Peer AsPeer => EndPoint is null
@@ -628,7 +629,7 @@ namespace Libplanet.Net.Transports
                 {
                     try
                     {
-                        ProcessMessageHandler?.Invoke(this, message);
+                        _ = ProcessMessageHandler.InvokeAsync(message);
                     }
                     catch (Exception exc)
                     {

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -230,7 +230,8 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        internal FixedSizedQueue<Message> MessageHistory { get; }
+        /// <inheritdoc cref="ITransport.MessageHistory"/>
+        public ConcurrentQueue<Message> MessageHistory { get; }
 
         internal IPAddress PublicIPAddress => _turnClient?.PublicAddress;
 
@@ -362,12 +363,7 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        /// <summary>
-        /// Waits until this <see cref="NetMQTransport"/> instance gets started to run.
-        /// </summary>
-        /// <seealso cref="Swarm{T}.WaitForRunningAsync()"/>
-        /// <returns>A <see cref="Task"/> completed when <see cref="Running"/>
-        /// property becomes <c>true</c>.</returns>
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
         /// <inheritdoc />

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -1,0 +1,819 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Protocols;
+using Libplanet.Stun;
+using Nito.AsyncEx;
+using Serilog;
+
+namespace Libplanet.Net.Transports
+{
+    public class TcpTransport : ITransport
+    {
+        public static readonly byte[] MagicCookie = { 0x4c, 0x50 }; // 'L', 'P'
+
+        private const int MessageHistoryCapacity = 30;
+        private const int ListenerBacklog = 100;
+        private const int MaxReplyStreams = 3000;
+
+        // TODO: Should be configurable (ex. SwarmOptions.MaxTimeout)
+        private static readonly TimeSpan ListenerLifetime = TimeSpan.FromMinutes(2);
+
+        // TURN Permission lifetime was defined in RFC 5766
+        // see also https://tools.ietf.org/html/rfc5766#section-8
+        private static readonly TimeSpan TurnPermissionLifetime =
+            TimeSpan.FromMinutes(5);
+
+        private readonly RoutingTable _table;
+        private readonly PrivateKey _privateKey;
+        private readonly AppProtocolVersion _appProtocolVersion;
+        private readonly IImmutableSet<PublicKey>? _trustedAppProtocolVersionSigners;
+        private readonly string? _host;
+        private readonly DifferentAppProtocolVersionEncountered?
+            _differentAppProtocolVersionEncountered;
+
+        private readonly IList<IceServer>? _iceServers;
+        private readonly ILogger _logger;
+        private readonly int _minimumBroadcastTarget;
+        private readonly TimeSpan? _messageLifespan;
+        private readonly MessageCodec _messageCodec;
+
+        private readonly CancellationTokenSource _turnCancellationTokenSource;
+
+        private readonly ConcurrentDictionary<Guid, ReplyStream> _streams;
+
+        private TaskCompletionSource<object> _runningEvent;
+        private CancellationTokenSource _runtimeCancellationTokenSource;
+        private CancellationToken _cancellationToken;
+
+        private int _listenPort;
+        private DnsEndPoint? _hostEndPoint;
+        private TcpListener? _listener;
+        private TurnClient? _turnClient;
+
+        private bool _disposed;
+
+        public TcpTransport(
+            RoutingTable table,
+            PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
+            string? host,
+            int? listenPort,
+            IEnumerable<IceServer> iceServers,
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            int minimumBroadcastTarget,
+            TimeSpan? messageLifespan = null)
+        {
+            _runningEvent = null!;
+            Running = false;
+
+            _table = table;
+            _privateKey = privateKey;
+            _appProtocolVersion = appProtocolVersion;
+            _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
+            _host = host;
+            _listenPort = listenPort ?? 0;
+            _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
+            _iceServers = iceServers?.ToList();
+            _minimumBroadcastTarget = minimumBroadcastTarget;
+            _messageLifespan = messageLifespan;
+            _messageCodec = new MessageCodec();
+            _streams = new ConcurrentDictionary<Guid, ReplyStream>();
+
+            if (!(_host is null) && listenPort is { } listenPortAsInt)
+            {
+                _hostEndPoint = new DnsEndPoint(_host, listenPortAsInt);
+            }
+
+            if (_host == null && (_iceServers == null || !_iceServers.Any()))
+            {
+                throw new ArgumentException(
+                    $"Swarm requires either {nameof(host)} or " +
+                    $"{nameof(iceServers)}."
+                );
+            }
+
+            _logger = Log.ForContext<TcpTransport>();
+            _runtimeCancellationTokenSource = new CancellationTokenSource();
+            _turnCancellationTokenSource = new CancellationTokenSource();
+            MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
+        }
+
+        public event EventHandler<Message> ProcessMessageHandler = null!;
+
+        /// <inheritdoc cref="ITransport.AsPeer"/>
+        public Peer AsPeer => EndPoint is null
+            ? new Peer(_privateKey.PublicKey, PublicIPAddress)
+            : new BoundPeer(_privateKey.PublicKey, EndPoint, PublicIPAddress);
+
+        /// <inheritdoc cref="ITransport.Running"/>
+        public DateTimeOffset? LastMessageTimestamp { get; private set; }
+
+        public bool Running
+        {
+            get => _runningEvent?.Task.Status == TaskStatus.RanToCompletion;
+
+            private set
+            {
+                if (value)
+                {
+                    _runningEvent?.TrySetResult(null!);
+                }
+                else
+                {
+                    _runningEvent = new TaskCompletionSource<object>();
+                }
+            }
+        }
+
+        public ConcurrentQueue<Message> MessageHistory { get; }
+
+        internal IPAddress? PublicIPAddress => _turnClient?.PublicAddress;
+
+        internal DnsEndPoint? EndPoint => _turnClient?.EndPoint ?? _hostEndPoint;
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _listener?.Stop();
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+
+                _runtimeCancellationTokenSource.Dispose();
+                _turnCancellationTokenSource.Dispose();
+                StopAllStreamsAsync().Wait();
+                Running = false;
+                _disposed = true;
+            }
+        }
+
+        /// <inheritdoc cref="ITransport.StartAsync"/>
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (Running)
+            {
+                throw new TransportException("Transport is already running.");
+            }
+
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, _listenPort));
+            _listener.Start(ListenerBacklog);
+
+            // _listenPort might be 0, which is any, so it should be re-set.
+            _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            _logger.Information("Listen on {Port}", _listenPort);
+
+            if (_host is null && !(_iceServers is null))
+            {
+                _turnClient = await IceServer.CreateTurnClient(_iceServers);
+                await _turnClient.StartAsync(_listenPort, cancellationToken);
+            }
+
+            _runtimeCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _cancellationToken = _runtimeCancellationTokenSource.Token;
+
+            if (_turnClient is null || !_turnClient.BehindNAT)
+            {
+                string? host = _host ?? PublicIPAddress?.ToString();
+                if (host is null)
+                {
+                    throw new TransportException("Host is null.");
+                }
+
+                _hostEndPoint = new DnsEndPoint(host, _listenPort);
+            }
+
+            List<Task> tasks = new List<Task>();
+
+            tasks.Add(ReceiveMessageAsync(_cancellationToken));
+            tasks.Add(ProcessRuntime(_cancellationToken));
+
+            Running = true;
+            _logger.Debug("Start to run. TurnClient: {Client}", _turnClient);
+
+            await await Task.WhenAny(tasks);
+        }
+
+        public async Task StopAsync(TimeSpan waitFor, CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (Running)
+            {
+                await Task.Delay(waitFor, cancellationToken);
+                _listener?.Stop();
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+                await StopAllStreamsAsync();
+                Running = false;
+            }
+        }
+
+        /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
+        public Task WaitForRunningAsync() => _runningEvent.Task;
+
+        public Task SendMessageAsync(
+            BoundPeer peer,
+            Message message,
+            CancellationToken cancellationToken)
+            => SendMessageWithReplyAsync(
+                peer,
+                message,
+                TimeSpan.FromSeconds(3),
+                0,
+                false,
+                cancellationToken);
+
+        public async Task<Message> SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<Message> replies =
+                await SendMessageWithReplyAsync(
+                    peer,
+                    message,
+                    timeout,
+                    1,
+                    false,
+                    cancellationToken);
+            Message reply = replies.First();
+
+            return reply;
+        }
+
+        public async Task<IEnumerable<Message>> SendMessageWithReplyAsync(
+            BoundPeer peer,
+            Message message,
+            TimeSpan? timeout,
+            int expectedResponses,
+            bool returnWhenTimeout,
+            CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (expectedResponses < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(expectedResponses));
+            }
+
+            Guid reqId;
+            if (message.Identity is null)
+            {
+                reqId = Guid.NewGuid();
+                message.Identity = reqId.ToByteArray();
+            }
+            else
+            {
+                reqId = new Guid(message.Identity);
+            }
+
+            _logger.Verbose(
+                "Start to request {RequestId} to {Peer}: {Message}. (expected responses: {Count})",
+                reqId,
+                peer,
+                message,
+                expectedResponses
+            );
+
+            using var client = new TcpClient { LingerState = new LingerOption(true, 1) };
+            try
+            {
+                await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+                _logger.Verbose(
+                    "SendMessageAsync client: {EndPoint}",
+                    (IPEndPoint)client.Client.LocalEndPoint);
+                client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
+                await WriteMessageAsync(message, client, cancellationToken);
+                _logger.Verbose(
+                    "Successfully sent request {RequestId} to {Peer}: {Message}.",
+                    reqId,
+                    peer,
+                    message
+                );
+
+                var replies = new List<Message>();
+                using var timeoutCts = new CancellationTokenSource();
+                if (expectedResponses != 0 && !(timeout is null))
+                {
+                    timeoutCts.CancelAfter(
+                        (int)timeout.Value.TotalMilliseconds * expectedResponses);
+                }
+
+                using CancellationTokenSource linkedTcs =
+                    CancellationTokenSource.CreateLinkedTokenSource(
+                        timeoutCts.Token,
+                        cancellationToken);
+                while (expectedResponses > 0)
+                {
+                    try
+                    {
+                        // TODO: Should consider case where stream bytes exceeds buffer size.
+                        Message received = await ReadMessageAsync(
+                            client,
+                            linkedTcs.Token);
+                        _logger.Verbose(
+                            "Received message was {Message}. Total: {Count}",
+                            received,
+                            replies.Count);
+                        MessageHistory.Enqueue(received);
+                        replies.Add(received);
+                        expectedResponses--;
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        if (timeoutCts.IsCancellationRequested)
+                        {
+                            var msg =
+                                $"{nameof(SendMessageWithReplyAsync)}() timed out after " +
+                                "{Timeout} of waiting a reply to {MessageType} ({RequestId}) " +
+                                "from {PeerAddress}.";
+                            _logger.Debug(
+                                msg,
+                                timeout,
+                                message.GetType().Name,
+                                reqId,
+                                peer.Address);
+                            if (returnWhenTimeout)
+                            {
+                                break;
+                            }
+
+                            throw new TimeoutException();
+                        }
+
+                        throw;
+                    }
+                }
+
+                if (replies.Any())
+                {
+                    const string logMsg =
+                        "Received {ReplyMessageCount} reply messages to {RequestId} " +
+                        "from the {Peer}: {ReplyMessages}.";
+                    _logger.Debug(logMsg, replies.Count, reqId, peer, replies);
+                }
+
+                return replies;
+            }
+            catch (DifferentAppProtocolVersionException e)
+            {
+                const string logMsg =
+                    "{PeerAddress} sent a reply to {RequestId} with " +
+                    "a different app protocol version; " +
+                    "expected: {ExpectedVersion}; actual: {ActualVersion}.";
+                _logger.Error(e, logMsg, peer.Address, reqId, e.ExpectedVersion, e.ActualVersion);
+                throw;
+            }
+            catch (ArgumentException e)
+            {
+                // This exception is thrown on .NET framework when the given peer is invalid.
+                _logger.Error(
+                    e,
+                    "ArgumentException occurred during {FName} to {RequestId}. {E}",
+                    nameof(SendMessageWithReplyAsync),
+                    reqId,
+                    e);
+
+                // To match with previous implementation, throws TimeoutException when it failed to
+                // find peer to send message.
+                throw new TimeoutException($"Cannot find peer {peer}.", e);
+            }
+            catch (SocketException e)
+            {
+                // This exception is thrown on .NET core when the given peer is invalid.
+                _logger.Error(
+                    e,
+                    "SocketException occurred during {FName} to {Peer}. {E}",
+                    nameof(SendMessageWithReplyAsync),
+                    peer,
+                    e);
+
+                // To match with previous implementation, throws TimeoutException when it failed to
+                // find peer to send message.
+                throw new TimeoutException($"Cannot find peer {peer}.", e);
+            }
+            catch (InvalidMagicCookieException e)
+            {
+                _logger.Verbose(
+                    "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
+                    e.Expected,
+                    e.Actual);
+                throw;
+            }
+        }
+
+        public void BroadcastMessage(Address? except, Message message)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            foreach (var peer in _table.PeersToBroadcast(except, _minimumBroadcastTarget))
+            {
+                _ = SendMessageAsync(peer, message, _cancellationToken);
+            }
+        }
+
+        public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TcpTransport));
+            }
+
+            if (message.Identity is null)
+            {
+                throw new ArgumentException(
+                    "Message format is invalid. Reply must have identity.",
+                    nameof(message));
+            }
+
+            var id = new Guid(message.Identity);
+            _logger.Verbose("Trying to reply message. ID: {Id}", id);
+            if (_streams.TryGetValue(id, out ReplyStream stream))
+            {
+                _logger.Verbose("Send reply message {Message}", message);
+                try
+                {
+                    _logger.Verbose("Start to writing reply {Message}.", message);
+                    using var @lock = stream.Lock.Lock();
+                    await WriteMessageAsync(message, stream.Client, _cancellationToken);
+                }
+                catch (IOException)
+                {
+                    _logger.Error(
+                        "Failed to reply message {Message} with {Id}. Connection is lost",
+                        message,
+                        id);
+                    _ = TryRemoveStreamAsync(id, _runtimeCancellationTokenSource.Token);
+                }
+            }
+            else
+            {
+                _logger.Error(
+                    "Failed to reply message {Message} with {Id}. Corresponding stream is removed.",
+                    message,
+                    id);
+            }
+        }
+
+        internal async Task WriteMessageAsync(
+            Message message,
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new TaskCanceledException();
+            }
+
+            byte[] serialized = _messageCodec.Encode(
+                message,
+                _privateKey,
+                AsPeer,
+                DateTimeOffset.UtcNow,
+                _appProtocolVersion);
+            int length = serialized.Length;
+            var buffer = new byte[MagicCookie.Length + sizeof(int) + length];
+            MagicCookie.CopyTo(buffer, 0);
+            BitConverter.GetBytes(length).CopyTo(buffer, MagicCookie.Length);
+            serialized.CopyTo(buffer, MagicCookie.Length + sizeof(int));
+            NetworkStream stream = client.GetStream();
+
+            // NOTE: Stream is forced to be closed because NetStream.WriteAsync()'s
+            // cancellation token never works in .NET Framework.
+            using (cancellationToken.Register(() => stream.Close()))
+            {
+                try
+                {
+                    await stream.WriteAsync(buffer, 0, buffer.Length, default);
+                }
+                catch (Exception)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        internal async Task<Message> ReadMessageAsync(
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            var content = new List<byte>();
+            byte[] buffer = new byte[1000];
+            NetworkStream stream = client.GetStream();
+
+            // NOTE: Stream is forced to be closed because NetStream.ReadAsync()'s
+            // cancellation token never works in .NET Framework.
+            using (cancellationToken.Register(() => stream.Close()))
+            {
+                try
+                {
+                    // May read shorter than MagicCookie's length just by network condition
+                    int bytesRead = await stream.ReadAsync(buffer, 0, MagicCookie.Length, default);
+                    if (bytesRead < MagicCookie.Length ||
+                        !buffer.Take(MagicCookie.Length).SequenceEqual(MagicCookie))
+                    {
+                        throw new InvalidMagicCookieException(MagicCookie, buffer.Take(bytesRead));
+                    }
+
+                    await stream.ReadAsync(buffer, 0, sizeof(int), default);
+                    int bytesLeft = BitConverter.ToInt32(buffer.Take(sizeof(int)).ToArray(), 0);
+
+                    while (bytesLeft != 0)
+                    {
+                        bytesRead = await stream.ReadAsync(
+                            buffer,
+                            0,
+                            bytesLeft < buffer.Length ? bytesLeft : buffer.Length,
+                            default);
+                        content.AddRange(buffer.Take(bytesRead));
+                        bytesLeft -= bytesRead;
+                    }
+                }
+                catch (InvalidMagicCookieException)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TaskCanceledException();
+                    }
+
+                    _logger.Error(
+                        e,
+                        "Error occurred during {FName}() {E}",
+                        nameof(ReadMessageAsync),
+                        e);
+                    throw;
+                }
+            }
+
+            _logger.Verbose("Received {Bytes} bytes from network stream.", content.Count);
+
+            Message message = _messageCodec.Decode(
+                content.ToArray(),
+                false,
+                AppProtocolVersionValidator,
+                _messageLifespan);
+
+            _logger.Verbose(
+                "ReadMessageAsync success. Received message {Message} from network stream.",
+                message);
+            return message;
+        }
+
+        private void AppProtocolVersionValidator(
+            byte[] identity,
+            Peer remotePeer,
+            AppProtocolVersion remoteVersion)
+        {
+            bool valid;
+            if (remoteVersion.Equals(_appProtocolVersion))
+            {
+                valid = true;
+            }
+            else if (!(_trustedAppProtocolVersionSigners is null) &&
+                     !_trustedAppProtocolVersionSigners.Any(remoteVersion.Verify))
+            {
+                valid = false;
+            }
+            else if (_differentAppProtocolVersionEncountered is null)
+            {
+                valid = false;
+            }
+            else
+            {
+                valid = _differentAppProtocolVersionEncountered(
+                    remotePeer,
+                    remoteVersion,
+                    _appProtocolVersion);
+            }
+
+            if (!valid)
+            {
+                throw new DifferentAppProtocolVersionException(
+                    "The version of the received message is not valid.",
+                    identity,
+                    _appProtocolVersion,
+                    remoteVersion);
+            }
+        }
+
+        private async Task ReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            while (!(cancellationToken.IsCancellationRequested || _listener is null))
+            {
+                try
+                {
+                    TcpClient client = await _listener.AcceptTcpClientAsync();
+                    client.LingerState = new LingerOption(true, 1);
+                    _logger.Verbose("Connected to tcp client.");
+                    Guid guid = Guid.NewGuid();
+                    _logger.Verbose("Start to accept message of {Id}.", guid);
+
+                    // TODO: Maximum message processor should be limited.
+                    _ = AcceptAsync(client, cancellationToken)
+                        .ContinueWith<Task>(
+                            async t =>
+                            {
+                                _logger.Verbose("Ended to accept message of {Id}.", guid);
+                                try
+                                {
+                                    // Wait 15 seconds to close client to receive ACK from TURN.
+                                    await Task.Delay(
+                                        15 * 1000,
+                                        _runtimeCancellationTokenSource.Token);
+                                }
+                                finally
+                                {
+                                    client.Close();
+                                }
+                            },
+                            cancellationToken);
+                }
+                catch (ObjectDisposedException)
+                {
+                    _logger.Warning("TCPListener is disposed.");
+                    break;
+                }
+            }
+        }
+
+        private async Task AcceptAsync(
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.Verbose("Trying to receive message");
+                Message message = await ReadMessageAsync(client, cancellationToken);
+                MessageHistory.Enqueue(message);
+                LastMessageTimestamp = DateTimeOffset.UtcNow;
+                _logger.Debug(
+                    "A message has parsed: {Message}, from {Remove}",
+                    message,
+                    message.Remote);
+
+                if (message.Identity is null)
+                {
+                    throw new InvalidMessageException(
+                        "Identity of the message cannot be null.",
+                        message);
+                }
+
+                var id = new Guid(message.Identity);
+                await TryAddStreamAsync(id, client, cancellationToken);
+
+                ProcessMessageHandler?.Invoke(this, message);
+            }
+            catch (DifferentAppProtocolVersionException dapve)
+            {
+                _logger.Debug("Message from peer with different version received.");
+                var differentVersion = new DifferentVersion
+                {
+                    Identity = dapve.Identity,
+                };
+
+                await WriteMessageAsync(differentVersion, client, cancellationToken);
+            }
+            catch (IOException)
+            {
+                _logger.Verbose("Connection is lost.");
+            }
+            catch (InvalidMagicCookieException e)
+            {
+                _logger.Verbose(
+                    "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
+                    e.Expected,
+                    e.Actual);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    e,
+                    "Unexpected exception occurred during {FName}(). {E}",
+                    nameof(AcceptAsync),
+                    e);
+                throw;
+            }
+        }
+
+        private async Task ProcessRuntime(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                foreach (KeyValuePair<Guid, ReplyStream> pair in _streams)
+                {
+                    // FIXME: This lifetime related disposing logic can be tested?
+                    if (pair.Value.SpawnAt + ListenerLifetime < DateTimeOffset.UtcNow)
+                    {
+                        _ = TryRemoveStreamAsync(pair.Key, cancellationToken);
+                    }
+                }
+
+                await Task.Delay(100, cancellationToken);
+            }
+        }
+
+        private async Task TryAddStreamAsync(
+            Guid id,
+            TcpClient client,
+            CancellationToken cancellationToken)
+        {
+            while (_streams.Count > MaxReplyStreams && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(100, cancellationToken);
+            }
+
+            _streams.TryAdd(id, new ReplyStream(client, DateTimeOffset.UtcNow));
+            _logger.Verbose("Added stream to the collection. {Id}", id);
+        }
+
+        private async Task TryRemoveStreamAsync(Guid id, CancellationToken cancellationToken)
+        {
+            if (!_streams.TryRemove(id, out ReplyStream stream))
+            {
+                return;
+            }
+
+            using var @lock = await stream.Lock.LockAsync(cancellationToken);
+            try
+            {
+                stream.Client.Close();
+                stream.Client.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            _logger.Verbose("Removed stream from the collection. {Id}", id);
+        }
+
+        private async Task StopAllStreamsAsync()
+        {
+            var tasks = new List<Task>();
+            foreach (Guid id in _streams.Keys)
+            {
+                tasks.Add(TryRemoveStreamAsync(id, default));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private struct ReplyStream
+        {
+            public ReplyStream(TcpClient client, DateTimeOffset spawnAt)
+            {
+                Client = client;
+                SpawnAt = spawnAt;
+                Lock = new AsyncLock();
+            }
+
+            public DateTimeOffset SpawnAt { get; }
+
+            public TcpClient Client { get; }
+
+            public AsyncLock Lock { get; }
+        }
+    }
+}

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -48,13 +48,11 @@ namespace Libplanet.Net.Transports
         private readonly TimeSpan? _messageLifespan;
         private readonly MessageCodec _messageCodec;
 
-        private readonly CancellationTokenSource _turnCancellationTokenSource;
-
         private readonly ConcurrentDictionary<Guid, ReplyStream> _streams;
 
         private TaskCompletionSource<object> _runningEvent;
         private CancellationTokenSource _runtimeCancellationTokenSource;
-        private CancellationToken _cancellationToken;
+        private CancellationTokenSource _turnCancellationTokenSource;
 
         private int _listenPort;
         private DnsEndPoint? _hostEndPoint;
@@ -181,16 +179,16 @@ namespace Libplanet.Net.Transports
             _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
 
             _logger.Information("Listen on {Port}", _listenPort);
+            _runtimeCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _turnCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             if (_host is null && !(_iceServers is null))
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
                 await _turnClient.StartAsync(_listenPort, cancellationToken);
             }
-
-            _runtimeCancellationTokenSource =
-                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _cancellationToken = _runtimeCancellationTokenSource.Token;
 
             if (_turnClient is null || !_turnClient.BehindNAT)
             {
@@ -205,8 +203,8 @@ namespace Libplanet.Net.Transports
 
             List<Task> tasks = new List<Task>();
 
-            tasks.Add(ReceiveMessageAsync(_cancellationToken));
-            tasks.Add(ProcessRuntime(_cancellationToken));
+            tasks.Add(ReceiveMessageAsync(_runtimeCancellationTokenSource.Token));
+            tasks.Add(ProcessRuntime(_runtimeCancellationTokenSource.Token));
 
             Running = true;
             _logger.Debug("Start to run. TurnClient: {Client}", _turnClient);
@@ -303,7 +301,11 @@ namespace Libplanet.Net.Transports
                 expectedResponses
             );
 
-            using var client = new TcpClient { LingerState = new LingerOption(true, 1) };
+            using CancellationTokenSource linkedTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    _runtimeCancellationTokenSource.Token);
+            var client = new TcpClient { LingerState = new LingerOption(true, 1) };
             try
             {
                 await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
@@ -311,7 +313,7 @@ namespace Libplanet.Net.Transports
                     "SendMessageAsync client: {EndPoint}",
                     (IPEndPoint)client.Client.LocalEndPoint);
                 client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
-                await WriteMessageAsync(message, client, cancellationToken);
+                await WriteMessageAsync(message, client, linkedTokenSource.Token);
                 _logger.Verbose(
                     "Successfully sent request {RequestId} to {Peer}: {Message}.",
                     reqId,
@@ -327,18 +329,17 @@ namespace Libplanet.Net.Transports
                         (int)timeout.Value.TotalMilliseconds * expectedResponses);
                 }
 
-                using CancellationTokenSource linkedTcs =
+                using CancellationTokenSource timeoutTokenSource =
                     CancellationTokenSource.CreateLinkedTokenSource(
                         timeoutCts.Token,
-                        cancellationToken);
+                        linkedTokenSource.Token);
                 while (expectedResponses > 0)
                 {
                     try
                     {
-                        // TODO: Should consider case where stream bytes exceeds buffer size.
                         Message received = await ReadMessageAsync(
                             client,
-                            linkedTcs.Token);
+                            timeoutTokenSource.Token);
                         _logger.Verbose(
                             "Received message was {Message}. Total: {Count}",
                             received,
@@ -428,6 +429,23 @@ namespace Libplanet.Net.Transports
                     e.Actual);
                 throw;
             }
+            finally
+            {
+                _ = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            // Wait 15 seconds to close client to receive ACK from TURN.
+                            await Task.Delay(15 * 1000, _runtimeCancellationTokenSource.Token);
+                        }
+                        finally
+                        {
+                            client.Dispose();
+                        }
+                    },
+                    _runtimeCancellationTokenSource.Token);
+            }
         }
 
         public void BroadcastMessage(Address? except, Message message)
@@ -439,7 +457,7 @@ namespace Libplanet.Net.Transports
 
             foreach (var peer in _table.PeersToBroadcast(except, _minimumBroadcastTarget))
             {
-                _ = SendMessageAsync(peer, message, _cancellationToken);
+                _ = SendMessageAsync(peer, message, _runtimeCancellationTokenSource.Token);
             }
         }
 
@@ -458,6 +476,10 @@ namespace Libplanet.Net.Transports
             }
 
             var id = new Guid(message.Identity);
+            using CancellationTokenSource linkedTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    _runtimeCancellationTokenSource.Token);
             _logger.Verbose("Trying to reply message. ID: {Id}", id);
             if (_streams.TryGetValue(id, out ReplyStream stream))
             {
@@ -466,7 +488,7 @@ namespace Libplanet.Net.Transports
                 {
                     _logger.Verbose("Start to writing reply {Message}.", message);
                     using var @lock = stream.Lock.Lock();
-                    await WriteMessageAsync(message, stream.Client, _cancellationToken);
+                    await WriteMessageAsync(message, stream.Client, linkedTokenSource.Token);
                 }
                 catch (IOException)
                 {
@@ -533,6 +555,11 @@ namespace Libplanet.Net.Transports
             TcpClient client,
             CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new TaskCanceledException();
+            }
+
             var content = new List<byte>();
             byte[] buffer = new byte[1000];
             NetworkStream stream = client.GetStream();
@@ -649,7 +676,9 @@ namespace Libplanet.Net.Transports
                 {
                     TcpClient client = await _listener.AcceptTcpClientAsync();
                     client.LingerState = new LingerOption(true, 1);
-                    _logger.Verbose("Connected to tcp client.");
+                    _logger.Verbose(
+                        "Connected to tcp client {Address}.",
+                        (IPEndPoint)client.Client.RemoteEndPoint);
                     Guid guid = Guid.NewGuid();
                     _logger.Verbose("Start to accept message of {Id}.", guid);
 

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -54,9 +54,8 @@ namespace Libplanet.Net.Transports
         private CancellationTokenSource _runtimeCancellationTokenSource;
         private CancellationTokenSource _turnCancellationTokenSource;
 
-        private int _listenPort;
         private DnsEndPoint? _hostEndPoint;
-        private TcpListener? _listener;
+        private TcpListener _listener;
         private TurnClient? _turnClient;
 
         private bool _disposed;
@@ -81,7 +80,6 @@ namespace Libplanet.Net.Transports
             _appProtocolVersion = appProtocolVersion;
             _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
             _host = host;
-            _listenPort = listenPort ?? 0;
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
             _iceServers = iceServers?.ToList();
             _minimumBroadcastTarget = minimumBroadcastTarget;
@@ -105,6 +103,7 @@ namespace Libplanet.Net.Transports
             _logger = Log.ForContext<TcpTransport>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, listenPort ?? 0));
             ProcessMessageHandler = new AsyncDelegate<Message>();
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
         }
@@ -147,7 +146,7 @@ namespace Libplanet.Net.Transports
         {
             if (!_disposed)
             {
-                _listener?.Stop();
+                _listener.Stop();
                 _runtimeCancellationTokenSource.Cancel();
                 _turnCancellationTokenSource.Cancel();
 
@@ -172,13 +171,10 @@ namespace Libplanet.Net.Transports
                 throw new TransportException("Transport is already running.");
             }
 
-            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, _listenPort));
             _listener.Start(ListenerBacklog);
+            int listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
 
-            // _listenPort might be 0, which is any, so it should be re-set.
-            _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
-
-            _logger.Information("Listen on {Port}", _listenPort);
+            _logger.Information("Listen on {Port}", listenPort);
             _runtimeCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _turnCancellationTokenSource =
@@ -187,7 +183,7 @@ namespace Libplanet.Net.Transports
             if (_host is null && !(_iceServers is null))
             {
                 _turnClient = await IceServer.CreateTurnClient(_iceServers);
-                await _turnClient.StartAsync(_listenPort, cancellationToken);
+                await _turnClient.StartAsync(listenPort, cancellationToken);
             }
 
             if (_turnClient is null || !_turnClient.BehindNAT)
@@ -198,7 +194,7 @@ namespace Libplanet.Net.Transports
                     throw new TransportException("Host is null.");
                 }
 
-                _hostEndPoint = new DnsEndPoint(host, _listenPort);
+                _hostEndPoint = new DnsEndPoint(host, listenPort);
             }
 
             List<Task> tasks = new List<Task>();
@@ -222,7 +218,7 @@ namespace Libplanet.Net.Transports
             if (Running)
             {
                 await Task.Delay(waitFor, cancellationToken);
-                _listener?.Stop();
+                _listener.Stop();
                 _runtimeCancellationTokenSource.Cancel();
                 _turnCancellationTokenSource.Cancel();
                 await StopAllStreamsAsync();
@@ -670,7 +666,7 @@ namespace Libplanet.Net.Transports
 
         private async Task ReceiveMessageAsync(CancellationToken cancellationToken)
         {
-            while (!(cancellationToken.IsCancellationRequested || _listener is null))
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {


### PR DESCRIPTION
This PR adds TcpTransport which implements ITransport interface. NetMQTransport is still supported, but it is not a default option anymore. In order to use NetMQTransport, please set SwarmOptions.Type to SwarmOptions.TransportType.NetMQTransport.

Added `MessageCodec` class which inherits `IMessageCodec<T>` interface to encode a message into bytearray.