### PR TITLE
Introduce: `ConsensusReactor` and `ConsensusBroadcaster` for PBFT

### DIFF
--- a/Libplanet.Tests/Net/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Tests/Net/Consensus/ConsensusReactorTest.cs
@@ -1,0 +1,42 @@
+using Libplanet.Net.Consensus;
+using Libplanet.Net.Messages;
+using Xunit;
+
+namespace Libplanet.Tests.Net.Consensus
+{
+    public class ConsensusReactorTest
+    {
+        [Fact]
+        public void ProcessPropose()
+        {
+            ConsensusReactor reactor = new ConsensusReactor(0, new MockedConsensusBroadCaster());
+            var data = new byte[] { 0x01 };
+            ConsensusPropose propose = new ConsensusPropose(0, 0, new byte[] { 0x01 });
+            reactor.ProcessMessage(propose);
+
+            ConsensusState state = reactor.GetState();
+            Assert.Equal(data, state.Data);
+            Assert.Equal(ConsensusState.RoundStep.RoundStepPrevoteWait, state.Step);
+        }
+
+        [Fact]
+        public void ProcessProposeWrongRound()
+        {
+             ConsensusReactor reactor = new ConsensusReactor(0, new MockedConsensusBroadCaster());
+             var data = new byte[] { 0x01 };
+             ConsensusPropose propose = new ConsensusPropose(0, 1, new byte[] { 0x01 });
+             reactor.ProcessMessage(propose);
+
+             ConsensusState state = reactor.GetState();
+             Assert.Equal(new byte[] { }, state.Data);
+             Assert.Equal(ConsensusState.RoundStep.RoundStepNewRound, state.Step);
+        }
+
+        public class MockedConsensusBroadCaster : IConsensusBroadcaster
+        {
+            public void BroadcastMessage(ConsensusMessage message)
+            {
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Fixtures.cs
@@ -74,7 +74,8 @@ namespace Libplanet.Tests.Net
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
-            SwarmOptions options = null)
+            SwarmOptions options = null,
+            long nodeId = 0)
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
             var fx = new DefaultStoreFixture(memory: true, blockAction: policy.BlockAction);
@@ -100,8 +101,8 @@ namespace Libplanet.Tests.Net
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
-            SwarmOptions options = null
-        )
+            SwarmOptions options = null,
+            long nodeId = 0)
             where T : IAction, new()
         {
             if (host is null && !(iceServers?.Any() ?? false))
@@ -119,7 +120,8 @@ namespace Libplanet.Tests.Net
                 iceServers,
                 differentAppProtocolVersionEncountered,
                 trustedAppProtocolVersionSigners,
-                options);
+                options,
+                nodeId: nodeId);
             _finalizers.Add(async () =>
             {
                 await StopAsync(swarm);

--- a/Libplanet/Net/Consensus/ConsensusBroadcaster.cs
+++ b/Libplanet/Net/Consensus/ConsensusBroadcaster.cs
@@ -1,0 +1,63 @@
+using System;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Transports;
+using Serilog;
+
+namespace Libplanet.Net.Consensus
+{
+    public class ConsensusBroadcaster : IConsensusBroadcaster
+    {
+        private readonly ILogger _logger;
+
+        private ITransport _transport;
+
+        public ConsensusBroadcaster(ITransport transport)
+        {
+            _transport = transport;
+            _logger = Log
+                .ForContext<ConsensusBroadcaster>()
+                .ForContext("Source", $"[{nameof(ConsensusBroadcaster)}] ");
+        }
+
+        public void BroadcastMessage(ConsensusMessage message)
+        {
+            switch (message)
+            {
+                case ConsensusPropose propose:
+                    BroadcastPropose(propose);
+                    break;
+                case ConsensusVote vote:
+                    BroadcastVote(vote);
+                    break;
+                case ConsensusVote23 vote23:
+                    BroadcastVote23(vote23);
+                    break;
+                default:
+                    throw new Exception($"Failed to handle message: {message}");
+            }
+        }
+
+        public void BroadcastPropose(ConsensusPropose propose)
+        {
+            _logger.Debug("Trying to broadcast propose...");
+            BroadcastMessage(null, propose);
+        }
+
+        public void BroadcastVote(ConsensusVote vote)
+        {
+            _logger.Debug("Broadcast voting... {NodeId}, {Round}", vote.NodeId, vote.Round);
+            BroadcastMessage(null, vote);
+        }
+
+        public void BroadcastVote23(ConsensusVote23 vote23)
+        {
+            _logger.Debug("Broadcast 2/3 voting... {NodeId}, {Round}", vote23.NodeId, vote23.Round);
+            BroadcastMessage(null, vote23);
+        }
+
+        private void BroadcastMessage(Address? address, ConsensusMessage message)
+        {
+            _transport.BroadcastMessage(address, message);
+        }
+    }
+}

--- a/Libplanet/Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet/Net/Consensus/ConsensusReactor.cs
@@ -49,12 +49,7 @@ namespace Libplanet.Net.Consensus
             }
         }
 
-        private void BroadcastMessage(ConsensusMessage message)
-        {
-            _broadcaster.BroadcastMessage(message);
-        }
-
-        private void ProcessMessage(ConsensusMessage message)
+        internal void ProcessMessage(ConsensusMessage message)
         {
             switch (message)
             {
@@ -72,6 +67,16 @@ namespace Libplanet.Net.Consensus
             }
         }
 
+        internal ConsensusState GetState()
+        {
+            return _state;
+        }
+
+        private void BroadcastMessage(ConsensusMessage message)
+        {
+            _broadcaster.BroadcastMessage(message);
+        }
+
         private void Propose(ConsensusPropose propose)
         {
             switch (propose)
@@ -85,7 +90,6 @@ namespace Libplanet.Net.Consensus
             }
 
             _lock.EnterWriteLock();
-            _lock.EnterReadLock();
             _state.Data = propose.Data;
             _state.Vote23Count = _state.VoteCount = 0;
             _state.Step = ConsensusState.RoundStep.RoundStepPrevote;
@@ -102,7 +106,6 @@ namespace Libplanet.Net.Consensus
             }
 
             _state.Step = ConsensusState.RoundStep.RoundStepPrevoteWait;
-            _lock.EnterReadLock();
             _lock.ExitWriteLock();
         }
 

--- a/Libplanet/Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet/Net/Consensus/ConsensusReactor.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public class ConsensusReactor : IConsensusReactor
+    {
+        private readonly IConsensusBroadcaster _broadcaster;
+        private readonly ConsensusState _state;
+        private readonly Channel<ConsensusMessage> _messageQueue;
+        private readonly ReaderWriterLockSlim _lock;
+        private readonly long _threshold;
+
+        public ConsensusReactor(long nodeId, IConsensusBroadcaster broadcaster)
+        {
+            _broadcaster = broadcaster;
+            _state = new ConsensusState(nodeId);
+            _messageQueue = Channel.CreateUnbounded<ConsensusMessage>(
+                new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+            _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+            _threshold = 3;
+        }
+
+        public bool AppendMessage(ConsensusMessage message)
+        {
+            return _messageQueue.Writer.TryWrite(message);
+        }
+
+        public void ProposeAsync(byte[] data)
+        {
+            if (_state.NodeId == LeaderElection())
+            {
+                var msg = new ConsensusPropose(_state.NodeId, _state.Round, data);
+                AppendMessage(msg);
+            }
+        }
+
+        public async Task ReactConsensusAsync(int tick, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(tick), token);
+                ConsensusMessage msg = await _messageQueue.Reader.ReadAsync(token);
+                BroadcastMessage(msg);
+                ProcessMessage(msg);
+            }
+        }
+
+        private void BroadcastMessage(ConsensusMessage message)
+        {
+            _broadcaster.BroadcastMessage(message);
+        }
+
+        private void ProcessMessage(ConsensusMessage message)
+        {
+            switch (message)
+            {
+                case ConsensusPropose propose:
+                    Propose(propose);
+                    break;
+                case ConsensusVote consensusVote:
+                    Vote(consensusVote);
+                    break;
+                case ConsensusVote23 consensusVote23:
+                    Vote23(consensusVote23);
+                    break;
+                default:
+                    throw new Exception($"Failed to handle message: {message}");
+            }
+        }
+
+        private void Propose(ConsensusPropose propose)
+        {
+            switch (propose)
+            {
+                case var msg when msg.Round != _state.Round:
+                    return;
+                case var msg when _state.Step != ConsensusState.RoundStep.RoundStepNewRound:
+                    return;
+                case var msg when msg.NodeId != LeaderElection():
+                    return;
+            }
+
+            _lock.EnterWriteLock();
+            _lock.EnterReadLock();
+            _state.Data = propose.Data;
+            _state.Vote23Count = _state.VoteCount = 0;
+            _state.Step = ConsensusState.RoundStep.RoundStepPrevote;
+
+            var voteMsg = new ConsensusVote(_state.NodeId, _state.Round, _state.Data);
+            try
+            {
+                AppendMessage(voteMsg);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return;
+            }
+
+            _state.Step = ConsensusState.RoundStep.RoundStepPrevoteWait;
+            _lock.EnterReadLock();
+            _lock.ExitWriteLock();
+        }
+
+        private void Vote(ConsensusVote vote)
+        {
+             switch (vote)
+             {
+                 case var msg when msg.Round != _state.Round:
+                     return;
+                 case var msg when _state.Step != ConsensusState.RoundStep.RoundStepPrevoteWait:
+                     return;
+             }
+
+             _lock.EnterWriteLock();
+             _state.VoteCount += 1;
+
+             if (_state.VoteCount >= _threshold)
+             {
+                 _state.VoteCount = 0;
+                 _state.Step = ConsensusState.RoundStep.RoundStepPreCommit;
+
+                 var voteMsg = new ConsensusVote23(_state.NodeId, _state.Round, _state.Data);
+                 AppendMessage(voteMsg);
+                 _state.Step = ConsensusState.RoundStep.RoundStepPreCommitWait;
+             }
+
+             _lock.EnterWriteLock();
+        }
+
+        private void Vote23(ConsensusVote23 vote23)
+        {
+              switch (vote23)
+              {
+                  case var msg when msg.Round != _state.Round:
+                      return;
+                  case var msg when _state.Step != ConsensusState.RoundStep.RoundStepPreCommitWait:
+                      return;
+              }
+
+              _lock.EnterWriteLock();
+              _state.Vote23Count += 1;
+              if (_state.Vote23Count >= _threshold)
+              {
+                  _state.Vote23Count = 0;
+                  _state.Step = ConsensusState.RoundStep.RoundStepCommit;
+
+                  _state.Round += 1;
+                  _state.Step = ConsensusState.RoundStep.RoundStepNewRound;
+              }
+        }
+
+        private long LeaderElection()
+        {
+            return _state.Round % 4;
+        }
+    }
+}

--- a/Libplanet/Net/Consensus/ConsensusState.cs
+++ b/Libplanet/Net/Consensus/ConsensusState.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Libplanet.Net.Consensus
+{
+    public class ConsensusState
+    {
+        public ConsensusState(long nodeId)
+        {
+            NodeId = nodeId;
+            Round = 0;
+            Step = RoundStep.RoundStepNewRound;
+            Data = Array.Empty<byte>();
+        }
+
+        /// <summary>
+        /// This is step of round for consensus.
+        /// </summary>
+        public enum RoundStep : byte
+        {
+            /// <summary>
+            /// New round.
+            /// </summary>
+            RoundStepNewRound = 0x00,
+
+            /// <summary>
+            /// Propose the new block.
+            /// </summary>
+            RoundStepPropose = 0x01,
+
+            /// <summary>
+            /// Voting for the new block.
+            /// </summary>
+            RoundStepPrevote = 0x02,
+
+            /// <summary>
+            /// Wait until reply about vote.
+            /// </summary>
+            RoundStepPrevoteWait = 0x03,
+
+            /// <summary>
+            /// Pre-committed message.
+            /// </summary>
+            RoundStepPreCommit = 0x04,
+
+            /// <summary>
+            /// Wait until reply about Pre-committed message.
+            /// </summary>
+            RoundStepPreCommitWait = 0x05,
+
+            /// <summary>
+            /// Commit.
+            /// </summary>
+            RoundStepCommit = 0x06,
+        }
+
+        internal long Round { get; set; }
+
+        internal RoundStep Step { get; set; }
+
+        internal byte[] Data { get; set; }
+
+        internal long VoteCount { get; set; }
+
+        internal long Vote23Count { get; set; }
+
+        internal long NodeId { get; }
+    }
+}

--- a/Libplanet/Net/Consensus/IConsensusBroadcaster.cs
+++ b/Libplanet/Net/Consensus/IConsensusBroadcaster.cs
@@ -1,0 +1,9 @@
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public interface IConsensusBroadcaster
+    {
+        public void BroadcastMessage(ConsensusMessage message);
+    }
+}

--- a/Libplanet/Net/Consensus/IConsensusReactor.cs
+++ b/Libplanet/Net/Consensus/IConsensusReactor.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public interface IConsensusReactor
+    {
+        public bool AppendMessage(ConsensusMessage message);
+
+        public Task ReactConsensusAsync(int tick, CancellationToken token);
+    }
+}

--- a/Libplanet/Net/Messages/ConsensusMessage.cs
+++ b/Libplanet/Net/Messages/ConsensusMessage.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    public abstract class ConsensusMessage : Message
+    {
+        protected ConsensusMessage(long nodeId, long round, byte[] data)
+        {
+            Round = round;
+            Data = data;
+            NodeId = nodeId;
+        }
+
+        protected ConsensusMessage(NetMQFrame[] frames)
+        {
+            NodeId = frames[0].ConvertToInt64();
+            Round = frames[1].ConvertToInt64();
+            Data = frames[2].ToByteArray();
+        }
+
+        public long Round { get; set; }
+
+        public long NodeId { get; set; }
+
+        public byte[] Data { get; set; }
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(NetworkOrderBitsConverter.GetBytes(NodeId));
+                yield return new NetMQFrame(NetworkOrderBitsConverter.GetBytes(Round));
+                yield return new NetMQFrame(Data);
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/ConsensusPropose.cs
+++ b/Libplanet/Net/Messages/ConsensusPropose.cs
@@ -1,0 +1,19 @@
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    public class ConsensusPropose : ConsensusMessage
+    {
+        public ConsensusPropose(long nodeId, long round, byte[] data)
+            : base(nodeId, round, data)
+        {
+        }
+
+        public ConsensusPropose(NetMQFrame[] frames)
+            : base(frames)
+        {
+        }
+
+        protected override MessageType Type => MessageType.ConsensusPropose;
+    }
+}

--- a/Libplanet/Net/Messages/ConsensusVote.cs
+++ b/Libplanet/Net/Messages/ConsensusVote.cs
@@ -1,0 +1,19 @@
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    public class ConsensusVote : ConsensusMessage
+    {
+        public ConsensusVote(long nodeId, long round, byte[] data)
+            : base(nodeId, round, data)
+        {
+        }
+
+        public ConsensusVote(NetMQFrame[] frames)
+            : base(frames)
+        {
+        }
+
+        protected override MessageType Type => MessageType.ConsensusVote;
+    }
+}

--- a/Libplanet/Net/Messages/ConsensusVote23.cs
+++ b/Libplanet/Net/Messages/ConsensusVote23.cs
@@ -1,0 +1,19 @@
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    public class ConsensusVote23 : ConsensusMessage
+    {
+        public ConsensusVote23(long nodeId, long round, byte[] data)
+            : base(nodeId, round, data)
+        {
+        }
+
+        public ConsensusVote23(NetMQFrame[] frames)
+            : base(frames)
+        {
+        }
+
+        protected override MessageType Type => MessageType.ConsensusVote23;
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -113,6 +113,21 @@ namespace Libplanet.Net.Messages
             /// value of the message.
             /// </summary>
             DifferentVersion = 0x30,
+
+            /// <summary>
+            /// Consensus New Round Message.
+            /// </summary>
+            ConsensusPropose = 0x40,
+
+            /// <summary>
+            /// Consensus New Round Message.
+            /// </summary>
+            ConsensusVote = 0x41,
+
+            /// <summary>
+            /// Consensus New Round Message.
+            /// </summary>
+            ConsensusVote23 = 0x42,
         }
 
         private enum MessageFrame
@@ -293,6 +308,9 @@ namespace Libplanet.Net.Messages
                 { MessageType.GetChainStatus, typeof(GetChainStatus) },
                 { MessageType.ChainStatus, typeof(ChainStatus) },
                 { MessageType.DifferentVersion, typeof(DifferentVersion) },
+                { MessageType.ConsensusPropose, typeof(ConsensusPropose) },
+                { MessageType.ConsensusVote, typeof(ConsensusVote) },
+                { MessageType.ConsensusVote23, typeof(ConsensusVote23) },
             };
 
             if (!types.TryGetValue(rawType, out Type type))

--- a/Libplanet/Net/Swarm.MessageHandlers.cs
+++ b/Libplanet/Net/Swarm.MessageHandlers.cs
@@ -86,6 +86,10 @@ namespace Libplanet.Net
                     ProcessBlockHeader(blockHeader);
                     break;
 
+                case ConsensusMessage consensusMessage:
+                    ConsensusReactor.AppendMessage(consensusMessage);
+                    break;
+
                 default:
                     throw new InvalidMessageException(
                         $"Failed to handle message: {message}",

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1009,6 +1009,27 @@ namespace Libplanet.Net
             BroadcastTxIds(except?.Address, txIds);
         }
 
+        private void BroadcastPropose(Address? except, long nodeId, long round, byte[] data)
+        {
+            _logger.Debug("Trying to broadcast propose...");
+            var message = new ConsensusPropose(nodeId, round, data);
+            BroadcastMessage(except, message);
+        }
+
+        private void BroadcastVote(Address? expect, long nodeId, long round, byte[] data)
+        {
+            _logger.Debug("Broadcast voting... {NodeId}, {Round}", nodeId, round);
+            var message = new ConsensusVote(nodeId, round, data);
+            BroadcastMessage(expect, message);
+        }
+
+        private void BroadcastVote23(Address? expect, long nodeId, long round, byte[] data)
+        {
+            _logger.Debug("Broadcast 2/3 voting... {NodeId}, {Round}", nodeId, round);
+            var message = new ConsensusVote23(nodeId, round, data);
+            BroadcastMessage(expect, message);
+        }
+
         private void BroadcastMessage(Address? except, Message message)
         {
             Transport.BroadcastMessage(except, message);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -70,6 +70,7 @@ namespace Libplanet.Net
         /// <c>null</c>, which is default.</param>
         /// <param name="options">Options for <see cref="Swarm{T}"/>.</param>
         /// <param name="consensusReactor">The reactor for consensus.</param>
+        /// <param name="nodeId">Node Id.</param>
         public Swarm(
             BlockChain<T> blockChain,
             PrivateKey privateKey,
@@ -81,7 +82,8 @@ namespace Libplanet.Net
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
             SwarmOptions options = null,
-            IConsensusReactor consensusReactor = null)
+            IConsensusReactor consensusReactor = null,
+            long nodeId = 0)
         {
             BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
             _store = BlockChain.Store;
@@ -122,7 +124,7 @@ namespace Libplanet.Net
             Transport.ProcessMessageHandler += ProcessMessageHandler;
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
             ConsensusReactor = consensusReactor ?? new ConsensusReactor(
-                0,
+                nodeId,
                 new ConsensusBroadcaster(Transport));
         }
 


### PR DESCRIPTION
This PR introduces the consensus reactor architecture for achieving consensus, which is the basis of the PBFT implementation. 

@dahlia I've to make the architecture you've mentioned but I re-design my own way. Please review carefully between `ConsensusReactor` and `ConsensusBroadcaster`

@kfangw Try to implement exactly what you're working stuff. Please review `ConsensusReactor`'s logic and test code. If don't mind. could you propose more test code like I working on this  PR?