### PR TITLE
Multi-threaded mining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ To be released.
     Use `IMessageCodec<T>.Decode()` method instead.  [[#1503]]
  -  Removed unused `HashAlgorithmGetter` type parameter from
     `ActionEvaluator<T>()` constructor.  [[#1537]]
+ -  `Hashcash.Answer()` method became to take random `seed` value explicitly.
+    [[#1546]]
 
 ### Backward-incompatible network protocol changes
 
@@ -35,11 +37,16 @@ To be released.
  -  Added `MemoryStore` class.  [[#1544]]
  -  Added `MemoryKeyValueStore` class.  [[#1544]]
  -  Added `BlockDemandTable.Remove()` method.  [[#1549]]
+ -  Added
+    `BlockMetadata.MineNonce(HashAlgorithmType, int, CancellationToken)`
+    overloaded method.  [[#1546]]
 
 ### Behavioral changes
 
  -  `IStore.ForkTxNonces()` method became to throw `ChainIdNotFoundException`
     when a given `sourceChainId` does not exist.  [[#1544]]
+ -  `BlockMetadata.MineNonce()` method became to use multithreading when
+    looking for the nonce.  [[#1546]]
 
 ### Bug fixes
 
@@ -68,6 +75,7 @@ To be released.
 [#1535]: https://github.com/planetarium/libplanet/pull/1535
 [#1537]: https://github.com/planetarium/libplanet/pull/1537
 [#1544]: https://github.com/planetarium/libplanet/pull/1544
+[#1546]: https://github.com/planetarium/libplanet/pull/1546
 [#1550]: https://github.com/planetarium/libplanet/issues/1550
 [#1549]: https://github.com/planetarium/libplanet/pull/1549
 [#1551]: https://github.com/planetarium/libplanet/pull/1551

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -45,7 +45,8 @@ namespace Libplanet.Tests.Blocks
                     Hashcash.Answer(
                         n => new[] { _codec.Encode(_contents.BlockMetadata1.MakeCandidateData(n)) },
                         _sha256,
-                        _contents.BlockMetadata1.Difficulty
+                        _contents.BlockMetadata1.Difficulty,
+                        0
                     );
                 string nonceLit = string.Join(
                     ", ",

--- a/Libplanet.Tests/HashcashTest.cs
+++ b/Libplanet.Tests/HashcashTest.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Tests
         {
             IEnumerable<byte[]> Stamp(Nonce nonce) => new[] { challenge, nonce.ToByteArray() };
             (Nonce answer, ImmutableArray<byte> digest) =
-                Hashcash.Answer(Stamp, HashAlgorithmType.Of<SHA256>(), difficulty);
+                Hashcash.Answer(Stamp, HashAlgorithmType.Of<SHA256>(), difficulty, 0);
             Assert.True(Satisfies(digest.ToArray(), difficulty));
             TestUtils.AssertBytesEqual(
                 digest.ToArray(),

--- a/Libplanet/Hashcash.cs
+++ b/Libplanet/Hashcash.cs
@@ -24,13 +24,15 @@ namespace Libplanet
         /// should not vary for different <paramref name="nonce"/>s.</para>
         /// </summary>
         /// <param name="nonce">An arbitrary nonce for an attempt, provided by
-        /// <see cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, CancellationToken)"/> method.
+        /// <see cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, int, CancellationToken)"/>
+        /// method.
         /// </param>
         /// <returns>Chunked <see cref="byte"/>s determined from the given <paramref name="nonce"/>.
         /// It should return consistently equivalent bytes for equivalent <paramref name="nonce"/>
         /// values.  The way how bytes are split into chunks can be flexible; regardless of the way,
         /// they are concatenated into a single byte array.</returns>
-        /// <seealso cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, CancellationToken)"/>
+        /// <seealso cref="Hashcash.Answer(Stamp, HashAlgorithmType, long, int, CancellationToken)"
+        /// />
         /// <seealso cref="Nonce"/>
         public delegate IEnumerable<byte[]> Stamp(Nonce nonce);
 
@@ -47,6 +49,7 @@ namespace Libplanet
         /// <param name="hashAlgorithmType">The hash algorithm to use.</param>
         /// <param name="difficulty">A number to calculate the target number
         /// for which the returned answer should be less than.</param>
+        /// <param name="seed">The seed number for random generator.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -61,11 +64,12 @@ namespace Libplanet
             Stamp stamp,
             HashAlgorithmType hashAlgorithmType,
             long difficulty,
+            int seed,
             CancellationToken cancellationToken = default
         )
         {
             var nonceBytes = new byte[10];
-            var random = new Random();
+            var random = new Random(seed);
             while (!cancellationToken.IsCancellationRequested)
             {
                 random.NextBytes(nonceBytes);


### PR DESCRIPTION
This PR enables multithreading for `BlockMetadata.MineNonce()`. 
it also adds an overloaded method to control parallelism.