### PR TITLE
Tune `MerkleTrie`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  (Libplanet.RocksDBStore) Removed `MonoRocksDBStore` class.
     [[#1513], [#1579]]
+ -  Removed `Rehearsal` parameter from `ITrie.Commit()` and
+    `StateStoreExtensions.Commit()`.  [[#1570]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,10 @@ To be released.
 
  -  (Libplanet.RocksDBStore) Removed `MonoRocksDBStore` class.
     [[#1513], [#1579]]
- -  Removed `Rehearsal` parameter from `ITrie.Commit()` and
-    `StateStoreExtensions.Commit()`.  [[#1570]]
+ -  Removed `rehearsal` parameter from `ITrie.Commit()` method.
+    [[#1554], [#1570]]
+ -  Removed `rehearsal` parameter from `StateStoreExtensions.Commit()`
+    extension method.  [[#1554], [#1570]]
 
 ### Backward-incompatible network protocol changes
 
@@ -24,7 +26,7 @@ To be released.
 ### Behavioral changes
 
  -  Improved performance of `MerkleTrie.Commit()` and
-    `BlockChain<T>.ExecuteActions()`.   [[#1570]]
+    `BlockChain<T>.ExecuteActions()` methods.   [[#1554], [#1570]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ To be released.
 
 ### Behavioral changes
 
+ -  Improved performance of `MerkleTrie.Commit()` and
+    `BlockChain<T>.ExecuteActions()`.   [[#1570]]
+
 ### Bug fixes
 
 ### CLI tools

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -37,6 +37,19 @@ namespace Libplanet.RocksDBStore
         }
 
         /// <inheritdoc/>
+        public void Set(IDictionary<byte[], byte[]> values)
+        {
+            using var writeBatch = new WriteBatch();
+
+            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            {
+                writeBatch.Put(kv.Key, kv.Value);
+            }
+
+            _keyValueDb.Write(writeBatch);
+        }
+
+        /// <inheritdoc/>
         public void Delete(byte[] key)
         {
             _keyValueDb.Remove(key);

--- a/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
+++ b/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
@@ -52,16 +52,9 @@ namespace Libplanet.Tests.Store
         [MemberData(nameof(StateStores))]
         public void Commit(string label, IStateStore stateStore)
         {
-            ITrie dryA = stateStore.Commit(null, DeltaA, rehearsal: true);
-            Assert.False(dryA.Recorded);
-            Assert.False(dryA.TryGet(KeyFoo, out _));
-            Assert.False(dryA.TryGet(KeyBar, out _));
-            Assert.False(dryA.TryGet(KeyBaz, out _));
-
             IValue value;
-            ITrie a = stateStore.Commit(null, DeltaA, rehearsal: false);
+            ITrie a = stateStore.Commit(null, DeltaA);
             Assert.True(a.Recorded);
-            AssertBytesEqual(dryA.Hash, a.Hash);
             Assert.True(a.TryGet(KeyFoo, out value));
             AssertBencodexEqual((Text)"abc", value);
             Assert.True(a.TryGet(KeyBar, out value));
@@ -106,19 +99,8 @@ namespace Libplanet.Tests.Store
         [MemberData(nameof(StateStores))]
         public void ContainsStateRoot(string label, IStateStore stateStore)
         {
-            ITrie dryA = stateStore.Commit(null, DeltaA, rehearsal: true);
-            Assert.False(stateStore.ContainsStateRoot(dryA.Hash));
-
-            ITrie a = stateStore.Commit(null, DeltaA, rehearsal: false);
-            Assert.True(stateStore.ContainsStateRoot(dryA.Hash));
+            ITrie a = stateStore.Commit(null, DeltaA);
             Assert.True(stateStore.ContainsStateRoot(a.Hash));
-
-            ITrie dryB = stateStore.Commit(dryA.Hash, DeltaB, rehearsal: true);
-            Assert.False(stateStore.ContainsStateRoot(dryB.Hash));
-
-            ITrie b = stateStore.Commit(a.Hash, DeltaB);
-            Assert.True(stateStore.ContainsStateRoot(dryB.Hash));
-            Assert.True(stateStore.ContainsStateRoot(b.Hash));
         }
     }
 }

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -37,6 +37,34 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Throws<KeyNotFoundException>(() => KeyValueStore.Get(randomKey));
         }
 
+        [SkippableFact]
+        public void Set()
+        {
+            byte[] key = Random.NextBytes(PreStoredDataKeySize);
+            byte[] value = Random.NextBytes(PreStoredDataValueSize);
+            KeyValueStore.Set(key, value);
+
+            Assert.Equal(value, KeyValueStore.Get(key));
+        }
+
+        [SkippableFact]
+        public void SetMany()
+        {
+            var values = new Dictionary<byte[], byte[]>();
+            foreach (int i in Enumerable.Range(0, 10))
+            {
+                values[Random.NextBytes(PreStoredDataKeySize)] =
+                    Random.NextBytes(PreStoredDataValueSize);
+            }
+
+            KeyValueStore.Set(values);
+
+            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            {
+                Assert.Equal(kv.Value, KeyValueStore.Get(kv.Key));
+            }
+        }
+
         // This test will cover DefaultKeyValueStore.Set
         [SkippableFact]
         public void Overwrite()

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -47,13 +47,8 @@ namespace Libplanet.Tests.Store
                 .Add("bar", (Text)ByteUtil.Hex(GetRandomBytes(32)))
                 .Add("baz", (Bencodex.Types.Boolean)false)
                 .Add("qux", Bencodex.Types.Dictionary.Empty);
-            HashDigest<SHA256> hash = stateStore.Commit(null, values, rehearsal: true).Hash;
-
-            ITrie notFound = stateStore.GetStateRoot(hash);
-            Assert.False(notFound.Recorded);
-
             IValue value;
-            stateStore.Commit(null, values, rehearsal: false);
+            HashDigest<SHA256> hash = stateStore.Commit(null, values).Hash;
             ITrie found = stateStore.GetStateRoot(hash);
             Assert.True(found.Recorded);
             Assert.True(found.TryGet(KeyFoo, out value));

--- a/Libplanet/Store/StateStoreExtensions.cs
+++ b/Libplanet/Store/StateStoreExtensions.cs
@@ -27,15 +27,11 @@ namespace Libplanet.Store
         /// <param name="previousStateRootHash">The state root hash on which
         /// the <paramref name="rawStatesDelta"/> is based.</param>
         /// <param name="rawStatesDelta">The raw states delta to be recorded.</param>
-        /// <param name="rehearsal">If turned on, the <paramref name="rawStatesDelta"/> is not
-        /// recorded to the <paramref name="stateStore"/>, but only shadow trie root is returned.
-        /// Turned off by default.</param>
         /// <returns>The new state root.</returns>
         public static ITrie Commit(
             this IStateStore stateStore,
             HashDigest<SHA256>? previousStateRootHash,
-            IImmutableDictionary<string, IValue> rawStatesDelta,
-            bool rehearsal = false
+            IImmutableDictionary<string, IValue> rawStatesDelta
         )
         {
             ITrie trie = stateStore.GetStateRoot(previousStateRootHash);
@@ -45,8 +41,8 @@ namespace Libplanet.Store
                 trie = trie.Set(keyBytes, pair.Value);
             }
 
-            ITrie stage = trie.Commit(rehearsal);
-            return rehearsal ? stage : stateStore.GetStateRoot(stage.Hash);
+            ITrie stage = trie.Commit();
+            return stateStore.GetStateRoot(stage.Hash);
         }
 
         /// <summary>

--- a/Libplanet/Store/Trie/CacheableKeyValueStore.cs
+++ b/Libplanet/Store/Trie/CacheableKeyValueStore.cs
@@ -50,6 +50,11 @@ namespace Libplanet.Store.Trie
             _cache[key] = value;
         }
 
+        public void Set(IDictionary<byte[], byte[]> values)
+        {
+            _keyValueStore.Set(values);
+        }
+
         /// <inheritdoc/>
         public void Delete(byte[] key)
         {

--- a/Libplanet/Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet/Store/Trie/DefaultKeyValueStore.cs
@@ -60,6 +60,14 @@ namespace Libplanet.Store.Trie
             _root.WriteAllBytes(path, value);
         }
 
+        public void Set(IDictionary<byte[], byte[]> values)
+        {
+            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            {
+                Set(kv.Key, kv.Value);
+            }
+        }
+
         /// <inheritdoc/>
         public void Delete(byte[] key)
         {

--- a/Libplanet/Store/Trie/IKeyValueStore.cs
+++ b/Libplanet/Store/Trie/IKeyValueStore.cs
@@ -13,6 +13,12 @@ namespace Libplanet.Store.Trie
 
         public void Set(byte[] key, byte[] value);
 
+        /// <summary>
+        /// Sets all values in the given dictionary.
+        /// </summary>
+        /// <param name="values">A values to set.</param>
+        public void Set(IDictionary<byte[], byte[]> values);
+
         public void Delete(byte[] key);
 
         public bool Exists(byte[] key);

--- a/Libplanet/Store/Trie/ITrie.cs
+++ b/Libplanet/Store/Trie/ITrie.cs
@@ -45,8 +45,7 @@ namespace Libplanet.Store.Trie
         /// <summary>
         /// Cleans up and stores the <see cref="ITrie"/> in storage.
         /// </summary>
-        /// <param name="rehearsal">Whether to store nodes.</param>
         /// <returns>Returns new committed <see cref="ITrie"/>.</returns>
-        ITrie Commit(bool rehearsal = false);
+        ITrie Commit();
     }
 }

--- a/Libplanet/Store/Trie/MemoryKeyValueStore.cs
+++ b/Libplanet/Store/Trie/MemoryKeyValueStore.cs
@@ -21,6 +21,14 @@ namespace Libplanet.Store.Trie
         void IKeyValueStore.Set(byte[] key, byte[] value) =>
             _dictionary[key] = value;
 
+        void IKeyValueStore.Set(IDictionary<byte[], byte[]> values)
+        {
+            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            {
+                _dictionary[kv.Key] = kv.Value;
+            }
+        }
+
         void IKeyValueStore.Delete(byte[] key) =>
             _dictionary.TryRemove(key, out _);
 


### PR DESCRIPTION
This PR introduces #1554 by using a new `RocksDBKeyValueStore.Set(IDictionary<byte[], byte[]>)` method to increase write performance.

Additionally, it removes `rehearsal ` argument and feature from `ITrie` since there is no usage internally.