### PR TITLE
Disallow shorter/longer private keys than 32 bytes & release 0.18.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Libplanet changelog
 ===================
 
+Version 0.18.4
+--------------
+
+To be released.
+
+
 Version 0.18.3
 --------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.18.4
 
 To be released.
 
+ -  `PrivateKey(IReadOnlyList<byte>)` overloaded constructor no more accepts
+    a list shorter or longer than 32 bytes.  [[#1571]]
+ -  `PrivateKey.FromString()` method no more accept a hexadecimal digits
+    shorter or longer than 64 characters.  [[#1571]]
+
 
 Version 0.18.3
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.18.4
 --------------
 
-To be released.
+Released on November 2, 2021.
 
  -  `PrivateKey(IReadOnlyList<byte>)` overloaded constructor no more accepts
     a list shorter or longer than 32 bytes.  [[#1571]]

--- a/Libplanet.Tests/Crypto/PrivateKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PrivateKeyTest.cs
@@ -15,6 +15,17 @@ namespace Libplanet.Tests.Crypto
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => PrivateKey.FromString(string.Empty));
             Assert.Throws<ArgumentOutOfRangeException>(() => PrivateKey.FromString("a"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => PrivateKey.FromString("870912"));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                PrivateKey.FromString(
+                    "00000000000000000000000000000000000000000000000000000000870912"
+                )
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                PrivateKey.FromString(
+                    "000000000000000000000000000000000000000000000000000000000000870912"
+                )
+            );
             Assert.Throws<FormatException>(() => PrivateKey.FromString("zz"));
             PrivateKey actual = PrivateKey.FromString(
                 "e07107ca4b0d19147fa1152a0f2c7884705d59cbb6318e2f901bd28dd9ff78e3"
@@ -49,7 +60,27 @@ namespace Libplanet.Tests.Crypto
         [Fact]
         public void BytesSanityCheckTest()
         {
-            var bs = new byte[]
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new PrivateKey(new byte[] { 0x87, 0x09, 0x12 })
+             );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new PrivateKey(new byte[31]
+                {
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0x87, 0x09, 0x12,
+                })
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new PrivateKey(new byte[33]
+                {
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0x87, 0x09, 0x12,
+                })
+            );
+
+            var bs = new byte[20]
             {
                 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,

--- a/Libplanet/KeyStore/ProtectedPrivateKey.cs
+++ b/Libplanet/KeyStore/ProtectedPrivateKey.cs
@@ -320,7 +320,10 @@ namespace Libplanet.KeyStore
             ImmutableArray<byte> encKey = MakeEncryptionKey(derivedKey);
             ImmutableArray<byte> plaintext = Cipher.Decrypt(encKey, Ciphertext);
 
-            var key = new PrivateKey(plaintext);
+            var key = new PrivateKey(
+                unverifiedKey: plaintext.ToBuilder().ToArray(),
+                informedConsent: true
+            );
             Address actualAddress = key.ToAddress();
             if (!Address.Equals(actualAddress))
             {

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
-    <VersionPrefix>0.18.3</VersionPrefix>
+    <VersionPrefix>0.18.4</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:
       Version: 1.2.3-dev.456


### PR DESCRIPTION
See also the changelog.