### PR TITLE
Fix bug of streamed hash calculation & release 0.18.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.18.5
 --------------
 
-To be released.
+Released on November 3, 2021.
 
  -  Fixed a bug where `HashAlgorithmType.Digest(byte[])` and
    `HashAlgorithmType.Digest(ImmutableArray<byte>)` methods had returned

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 0.18.5
 
 To be released.
 
+ -  Fixed a bug where `HashAlgorithmType.Digest(byte[])` and
+   `HashAlgorithmType.Digest(ImmutableArray<byte>)` methods had returned
+   a wrong hash digest after `HashAlgorithmType.Digest(IEnumerable<byte[]>)`
+   or `HashAlgorithmType.Digest(IEnumerable<ImmutableArray<byte>>)` methods
+   had been once called.  [[#1575]]
+
+[#1575]: https://github.com/planetarium/libplanet/pull/1575
+
 
 Version 0.18.4
 --------------
@@ -16,6 +24,8 @@ Released on November 2, 2021.
     a list shorter or longer than 32 bytes.  [[#1571]]
  -  `PrivateKey.FromString()` method no more accept a hexadecimal digits
     shorter or longer than 64 characters.  [[#1571]]
+
+[#1571]: https://github.com/planetarium/libplanet/pull/1571
 
 
 Version 0.18.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Libplanet changelog
 ===================
 
+Version 0.18.5
+--------------
+
+To be released.
+
+
 Version 0.18.4
 --------------
 

--- a/Libplanet.Tests/Blocks/HashAlgorithmTableTest.cs
+++ b/Libplanet.Tests/Blocks/HashAlgorithmTableTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if !NETFRAMEWORK
 using System.Linq;
+#endif
 using System.Security.Cryptography;
 using Libplanet.Blocks;
 using Xunit;

--- a/Libplanet.Tests/HashAlgorithmTypeTest.cs
+++ b/Libplanet.Tests/HashAlgorithmTypeTest.cs
@@ -4,12 +4,20 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests
 {
     public class HashAlgorithmTypeTest
     {
+        private readonly ITestOutputHelper _output;
+
+        public HashAlgorithmTypeTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void Of()
         {
@@ -87,16 +95,20 @@ namespace Libplanet.Tests
                 Encoding.ASCII.GetBytes("Bar"),
             };
             byte[] digest;
-            for (int i = 0; i < 20; i++)
+            const int trial = 20;
+            for (int i = 0; i < trial; i++)
             {
+                _output.WriteLine("[{0}] The trial {1}/{2}...", i, i + 1, trial);
                 for (int j = 0; j < 2; j++)
                 {
+                    _output.WriteLine("[{0}-{1}] Hash an input as a whole...", i, j);
                     digest = sha256.Digest(input);
                     AssertBytesEqual(expected, digest);
                 }
 
                 for (int j = 0; j < 2; j++)
                 {
+                    _output.WriteLine("[{0}-{1}] Hash an input as multiple chunks...", i, j);
                     digest = sha256.Digest(chunkedInput);
                     AssertBytesEqual(expected, digest);
                 }

--- a/Libplanet/HashAlgorithmType.cs
+++ b/Libplanet/HashAlgorithmType.cs
@@ -99,8 +99,12 @@ namespace Libplanet
         /// <param name="input">The bytes to compute its hash.</param>
         /// <returns>The hash digest derived from <paramref name="input"/>.</returns>
         [Pure]
-        public byte[] Digest(byte[] input) =>
-            _instance.Value!.ComputeHash(input);
+        public byte[] Digest(byte[] input)
+        {
+            HashAlgorithm algo = _instance.Value!;
+            algo.Initialize();
+            return algo.ComputeHash(input);
+        }
 
         /// <summary>
         /// Computes a hash digest of the hash algorithm from the given

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
-    <VersionPrefix>0.18.4</VersionPrefix>
+    <VersionPrefix>0.18.5</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:
       Version: 1.2.3-dev.456


### PR DESCRIPTION
This fixes the following error on Mono (including Unity) and .NET Framework:

```
Two byte arrays do not equal
Expected (C# array lit): new byte[32] { 0x78, 0x71, 0xe9, 0xcf, 0xd3, 0xf8, 0x22, 0x41, 0xd1, 0xd1, 0x70, 0x77, 0x27, 0x42, 0x12, 0xe5, 0xae, 0x20, 0xaa, 0xcd, 0x9c, 0xad, 0x04, 0xa4, 0x9d, 0x33, 0x69, 0x3b, 0xeb, 0xed, 0x0d, 0x8b }
Actual (C# array lit):   new byte[32] { 0x25, 0x81, 0xce, 0xcf, 0xeb, 0xf3, 0x95, 0x2f, 0xa9, 0xfc, 0x25, 0xfc, 0x38, 0x92, 0x9c, 0xa7, 0x5c, 0x7f, 0xd7, 0x83, 0x32, 0x84, 0x8b, 0x9f, 0x98, 0x7b, 0x38, 0x03, 0xa9, 0xbb, 0x4d, 0x8a }
Expected (hex): 7871e9cfd3f82241d1d17077274212e5ae20aacd9cad04a49d33693bebed0d8b
Actual (hex):   2581cecfebf3952fa9fc25fc38929ca75c7fd78332848b9f987b3803a9bb4d8a
  at Libplanet.Tests.TestUtils.AssertBytesEqual (System.Byte[] expected, System.Byte[] actual) [0x00128] in /root/project/Libplanet.Tests/TestUtils.cs:170 
  at Libplanet.Tests.HashAlgorithmTypeTest.DigestMultipleTimes () [0x0008c] in /root/project/Libplanet.Tests/HashAlgorithmTypeTest.cs:95 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <a1e9f114a6e64f4eacb529fc802ec93d>:0 
```