### PR TITLE
Broadcast new blocks immediately after they are appended

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.19.3
 
 To be released.
 
+ -  `Swarm<T>` became to broadcast a new block to peers immediately after
+    `Swarm<T>.BlockChain`'s `Tip` changes while it is `Running`.  [[#1582]]
+
+[#1582]: https://github.com/planetarium/libplanet/pull/1582
+
 
 Version 0.19.2
 --------------

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using Libplanet.Action;
@@ -22,6 +21,8 @@ namespace Libplanet.Tests.Blockchain
             _difficulty = difficulty;
         }
 
+        public ISet<Address> BlockedMiners { get; } = new HashSet<Address>();
+
         public IComparer<IBlockExcerpt> CanonicalChainComparer =>
             new TotalDifficultyComparer();
 
@@ -38,7 +39,20 @@ namespace Libplanet.Tests.Blockchain
             BlockChain<T> blockChain, Transaction<T> transaction) => null;
 
         public BlockPolicyViolationException ValidateNextBlock(
-            BlockChain<T> blocks, Block<T> nextBlock) => _exceptionToThrow;
+            BlockChain<T> blocks,
+            Block<T> nextBlock
+        )
+        {
+            if (_exceptionToThrow != null)
+            {
+                return _exceptionToThrow;
+            }
+
+            return BlockedMiners.Contains(nextBlock.Miner)
+                ? new BlockPolicyViolationException(
+                    $"Disallowed #{nextBlock.Index} {nextBlock.Hash} mined by {nextBlock.Miner}.")
+                : null;
+        }
 
         public int GetMaxBlockBytes(long index) => 1024 * 1024;
 

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -658,6 +658,25 @@ namespace Libplanet.Tests.Net
                     privateKey: privateKey),
             };
 
+            Block<DumbAction> block1 = TestUtils.MineNext(
+                blockChain.Genesis,
+                policy.GetHashAlgorithm,
+                new[] { transactions[0] },
+                null,
+                policy.GetNextBlockDifficulty(blockChain),
+                miner: TestUtils.GenesisMiner.PublicKey
+            ).Evaluate(TestUtils.GenesisMiner, blockChain);
+            blockChain.Append(block1, true, true, false);
+            Block<DumbAction> block2 = TestUtils.MineNext(
+                block1,
+                policy.GetHashAlgorithm,
+                new[] { transactions[1] },
+                null,
+                policy.GetNextBlockDifficulty(blockChain),
+                miner: TestUtils.GenesisMiner.PublicKey
+            ).Evaluate(TestUtils.GenesisMiner, blockChain);
+            blockChain.Append(block2, true, true, false);
+
             try
             {
                 await StartAsync(minerSwarm);
@@ -665,28 +684,12 @@ namespace Libplanet.Tests.Net
 
                 await BootstrapAsync(receiverSwarm, minerSwarm.AsPeer);
 
-                Block<DumbAction> block1 = TestUtils.MineNext(
-                    blockChain.Genesis,
-                    policy.GetHashAlgorithm,
-                    new[] { transactions[0] },
-                    null,
-                    policy.GetNextBlockDifficulty(blockChain),
-                    miner: TestUtils.GenesisMiner.PublicKey
-                ).Evaluate(TestUtils.GenesisMiner, blockChain);
-                blockChain.Append(block1, true, true, false);
-                Block<DumbAction> block2 = TestUtils.MineNext(
-                    block1,
-                    policy.GetHashAlgorithm,
-                    new[] { transactions[1] },
-                    null,
-                    policy.GetNextBlockDifficulty(blockChain),
-                    miner: TestUtils.GenesisMiner.PublicKey
-                ).Evaluate(TestUtils.GenesisMiner, blockChain);
-                blockChain.Append(block2, true, true, false);
-                Log.Debug("Ready to broadcast blocks.");
                 minerSwarm.BroadcastBlock(block2);
-                await receiverSwarm.BlockAppended.WaitAsync();
 
+                await TestUtils.AssertThatEventually(
+                    () => receiverChain.Tip.Equals(block2),
+                    5_000
+                );
                 Assert.Equal(3, receiverChain.Count);
                 Assert.Equal(4, renderCount);
             }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1204,9 +1204,51 @@ namespace Libplanet.Tests.Net
                 "c34f7498befcc39a14f03b37833f6c7bb78310f1243616524eda70e078b8313c");
             PrivateKey keyC = PrivateKey.FromString(
                 "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
-            var minerSwarmA = CreateSwarm(keyA);
-            var minerSwarmB = CreateSwarm(keyB);
-            var receiverSwarm = CreateSwarm(keyC);
+
+            var policy = new NullPolicy<DumbAction>();
+            var policyA = new NullPolicy<DumbAction>();
+            var policyB = new NullPolicy<DumbAction>();
+            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(
+                policy.GetHashAlgorithm,
+                keyC,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+            Block<DumbAction> aBlock1 = MineNextBlock(
+                genesis,
+                policyA.GetHashAlgorithm,
+                keyA,
+                difficulty: 10,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+            Block<DumbAction> aBlock2 = MineNextBlock(
+                aBlock1,
+                policyA.GetHashAlgorithm,
+                keyA,
+                difficulty: 9,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+            Block<DumbAction> aBlock3 = MineNextBlock(
+                aBlock2,
+                policyA.GetHashAlgorithm,
+                keyA,
+                difficulty: 11,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+            Block<DumbAction> bBlock1 = MineNextBlock(
+                genesis,
+                policyB.GetHashAlgorithm,
+                keyB,
+                difficulty: 9,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+            Block<DumbAction> bBlock2 = MineNextBlock(
+                bBlock1,
+                policyB.GetHashAlgorithm,
+                keyB,
+                difficulty: 11,
+                stateRootHash: MerkleTrie.EmptyRootHash);
+
+            policyA.BlockedMiners.Add(keyB.ToAddress());
+            policyB.BlockedMiners.Add(keyA.ToAddress());
+
+            var minerSwarmA = CreateSwarm(keyA, policy: policyA, genesis: genesis);
+            var minerSwarmB = CreateSwarm(keyB, policy: policyB, genesis: genesis);
+            var receiverSwarm = CreateSwarm(keyC, policy: policy, genesis: genesis);
 
             BlockChain<DumbAction> minerChainA = minerSwarmA.BlockChain;
             BlockChain<DumbAction> minerChainB = minerSwarmB.BlockChain;
@@ -1222,9 +1264,8 @@ namespace Libplanet.Tests.Net
                 await BootstrapAsync(minerSwarmB, receiverSwarm.AsPeer);
 
                 // Broadcast SwarmA's first block.
-                var b1 = await minerChainA.MineBlock(keyA);
-                await minerChainB.MineBlock(keyB);
-                minerSwarmA.BroadcastBlock(b1);
+                minerChainA.Append(aBlock1);
+                minerChainB.Append(bBlock1);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),
@@ -1234,9 +1275,8 @@ namespace Libplanet.Tests.Net
                 );
 
                 // Broadcast SwarmB's second block.
-                await minerChainA.MineBlock(keyA);
-                var b2 = await minerChainB.MineBlock(keyB);
-                minerSwarmB.BroadcastBlock(b2);
+                minerChainB.Append(bBlock2);
+                minerChainA.Append(aBlock2);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainB.Tip),
@@ -1246,9 +1286,7 @@ namespace Libplanet.Tests.Net
                 );
 
                 // Broadcast SwarmA's third block.
-                var b3 = await minerChainA.MineBlock(keyA);
-                await minerChainB.MineBlock(keyB);
-                minerSwarmA.BroadcastBlock(b3);
+                minerChainA.Append(aBlock3);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -206,7 +206,9 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// An event which is invoked when <see cref="Tip"/> is changed.
         /// </summary>
-        private event EventHandler<(Block<T> OldTip, Block<T> NewTip)> TipChanged;
+        // FIXME: This should be completely replaced by IRenderer<T>.RenderBlock() or any other
+        // alternatives.
+        internal event EventHandler<(Block<T> OldTip, Block<T> NewTip)> TipChanged;
 
         /// <summary>
         /// The list of registered renderers listening the state changes.

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -993,5 +993,13 @@ namespace Libplanet.Net
             return workspace;
         }
 #pragma warning restore MEN003
+
+        private void OnBlockChainTipChanged(object sender, (Block<T> OldTip, Block<T> NewTip) e)
+        {
+            if (Running)
+            {
+                BroadcastBlock(e.NewTip);
+            }
+        }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -220,6 +220,9 @@ namespace Libplanet.Net
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
+            _logger.Debug("Stopping watching " + nameof(BlockChain) + " for tip changes...");
+            BlockChain.TipChanged -= OnBlockChainTipChanged;
+
             _logger.Debug($"Stopping {nameof(Swarm<T>)}...");
             using (await _runningMutex.LockAsync())
             {
@@ -321,6 +324,9 @@ namespace Libplanet.Net
 
             _logger.Debug("Starting swarm...");
             _logger.Debug("Peer information : {Peer}", AsPeer);
+
+            _logger.Debug("Watching the " + nameof(BlockChain) + " for tip changes...");
+            BlockChain.TipChanged += OnBlockChainTipChanged;
 
             try
             {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -446,6 +446,15 @@ namespace Libplanet.Net
             }
         }
 
+        /// <summary>
+        /// Broadcasts the given block to peers.
+        /// <para>The message is immediately broadcasted, and it is done if the same block has
+        /// already been broadcasted before.</para>
+        /// </summary>
+        /// <param name="block">The block to broadcast to peers.</param>
+        /// <remarks>It does not have to be called manually, because <see cref="Swarm{T}"/> in
+        /// itself watches <see cref="BlockChain"/> for <see cref="BlockChain{T}.Tip"/> changes and
+        /// immediately broadcasts updates if anything changes.</remarks>
         public void BroadcastBlock(Block<T> block)
         {
             BroadcastBlock(null, block);


### PR DESCRIPTION
This patch apparently stabilizes several flaky tests.

See also the changelog.