### PR TITLE
Experiments with CircleCI as a replacement of Azure Pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
   linux:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
-    resource_class: xlarge
+    resource_class: large
+    parallelism: 4
     steps:
     - checkout
     - concat_files:
@@ -31,11 +32,39 @@ jobs:
         - v1-deps-{{ arch }}
         - v1-deps
     - run: dotnet restore
-    - run: dotnet build -c Release -p:SkipSonar=true
+    - run: dotnet build --no-restore -c Release -p:SkipSonar=true
+    - run:
+        shell: bash
+        command: |
+          set -evx
+          dotnet test --no-restore --no-build -c Release --list-tests \
+          > .dotnet-list-tests.txt
+          grep -E '^    ' .dotnet-list-tests.txt \
+          | sed -E 's/^    |\(.*?\)$//g' \
+          | uniq \
+          | /usr/bin/sort -R --random-source=CHANGES.md \
+          > .tests.txt
+          total="$(wc -l .tests.txt | awk '{ print $1 }')"
+          part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
+          tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
+          | head -n $part \
+          > .current_tests.txt
+          first=1
+          while read test; do
+            if [[ "$first" = "1" ]]; then
+              echo "FullyQualifiedName=$test"
+              first=0
+            else
+              echo "| FullyQualifiedName=$test"
+            fi
+          done < .current_tests.txt > .test-filter.txt
     - run: >-
         dotnet test
+        --no-restore
+        --no-build
         -c Release
-        -l "junit;MethodFormat=Full;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+        --filter "$(cat .test-filter.txt)"
     - store_test_results:
         path: /tmp/junit
     - save_cache:
@@ -47,6 +76,7 @@ jobs:
     executor:
       name: win/default
       size: large
+    parallelism: 4
     steps:
     - checkout
     - concat_files:
@@ -58,11 +88,39 @@ jobs:
         - v1-deps-{{ arch }}
         - v1-deps
     - run: dotnet restore
-    - run: dotnet build -c Release -p:SkipSonar=true
+    - run: dotnet build --no-restore -c Release -p:SkipSonar=true
+    - run:
+        shell: bash
+        command: |
+          set -evx
+          dotnet test --no-restore --no-build -c Release --list-tests \
+          > .dotnet-list-tests.txt
+          grep -E '^    ' .dotnet-list-tests.txt \
+          | sed -E 's/^    |\(.*?\)$//g' \
+          | uniq \
+          | /usr/bin/sort -R --random-source=CHANGES.md \
+          > .tests.txt
+          total="$(wc -l .tests.txt | awk '{ print $1 }')"
+          part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
+          tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
+          | head -n $part \
+          > .current_tests.txt
+          first=1
+          while read test; do
+            if [[ "$first" = "1" ]]; then
+              echo "FullyQualifiedName=$test"
+              first=0
+            else
+              echo "| FullyQualifiedName=$test"
+            fi
+          done < .current_tests.txt > .test-filter.txt
     - run: >-
         dotnet test
+        --no-restore
+        --no-build
         -c Release
-        -l "junit;MethodFormat=Full;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+        --filter "$(cat .test-filter.txt)"
     - store_test_results:
         path: /tmp/junit
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,10 +151,6 @@ commands:
         shell: bash
         command: |
           set -evx
-          if ! command -v dotnet > /dev/null && \
-             [[ -d /usr/local/share/dotnet ]]; then
-            export PATH="/usr/local/share/dotnet:$PATH"
-          fi
           tests_collection="<<parameters.collect_tests_from>>"
           total="$(wc -l "$tests_collection" | awk '{ print $1 }')"
           part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
@@ -282,19 +278,27 @@ jobs:
     steps:
     - restore_cache:
         keys:
-        - v1-brew-cask-isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+        - v1-macos-dotnet-sdk-5.0
     - run: |
-        if ! command -v dotnet; then
-          if brew list --cask | grep dotnet-sdk3-1-400; then
-            brew reinstall --cask isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
-          else
-            brew install --cask isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
-          fi
+        {
+          echo export PATH="$HOME/.dotnet:$PATH"
+          echo export DOTNET_ROOT="$HOME/.dotnet"
+        } >> $BASH_ENV
+    - run: |
+        set -evx
+        echo $PATH > /dev/stderr
+        if ! command -v dotnet && [[ ! -f "$HOME/.dotnet/dotnet" ]]; then
+          curl -L -o /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
+          chmod +x /tmp/dotnet-install.sh
+          /tmp/dotnet-install.sh \
+            --verbose \
+            --channel 5.0
         fi
+        command -v dotnet
     - save_cache:
-        key: v1-brew-cask-isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+        key: v1-macos-dotnet-sdk-5.0
         paths:
-        - /usr/local/Caskroom/isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400/
+        - ~/.dotnet/
     - netcore_test_base
 
   windows-netcore-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
   macos-netcore-test:
     macos:
       xcode: 11.3.0
-    parallelism: 8
+    parallelism: 6
     steps:
     - brew_cask_install:
         package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ commands:
         - "v1-codecov"
         when: always
     - run:
+        name: Upload a code coverage report file to Codecov.io
         shell: bash
         command: |
           set -evx
@@ -73,7 +74,7 @@ commands:
         - ~/.nuget/packages
     - run: dotnet build --no-restore -c Release -p:SkipSonar=true
     - run:
-        description: Collect tests
+        name: Collect tests
         shell: bash
         command: |
           set -evx
@@ -137,11 +138,13 @@ commands:
     - restore_cache:
         keys:
         - v1-dotcover-{{ arch }}
-    - run: >-
-        dotnet tool install
-        --global
-        JetBrains.dotCover.GlobalTool
-        --version 2021.2.2
+    - run:
+        name: Install JetBrains dotCover
+        command: >-
+          dotnet tool install
+          --global
+          JetBrains.dotCover.GlobalTool
+          --version 2021.2.2
     - save_cache:
         key: v1-dotcover-{{ arch }}
         paths:
@@ -150,7 +153,7 @@ commands:
     - attach_workspace:
         at: .
     - run:
-        description: Distribute tests
+        name: Distribute tests
         shell: bash
         command: |
           set -evx
@@ -175,6 +178,7 @@ commands:
             fi
           done < .current_tests.txt > .test-filter.txt
     - run:
+        name: Run tests (using dotCover)
         command: >-
           ~/.dotnet/tools/dotnet-dotcover test
           --no-restore
@@ -207,22 +211,31 @@ commands:
     - restore_cache:
         keys:
         - v1-macos-dotnet-sdk-3.1
-    - run: |
-        {
-          echo export PATH="$HOME/.dotnet:$PATH"
-          echo export DOTNET_ROOT="$HOME/.dotnet"
-        } >> $BASH_ENV
-    - run: |
-        set -evx
-        echo $PATH > /dev/stderr
-        if ! command -v dotnet && [[ ! -f "$HOME/.dotnet/dotnet" ]]; then
-          curl -L -o /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
-          chmod +x /tmp/dotnet-install.sh
-          /tmp/dotnet-install.sh \
-            --verbose \
-            --channel 3.1
-        fi
-        command -v dotnet
+    - run:
+        name: Export PATH & DOTNET_ROOT
+        shell: bash
+        command: |
+          {
+            echo export PATH="$HOME/.dotnet:$PATH"
+            echo export DOTNET_ROOT="$HOME/.dotnet"
+          } >> $BASH_ENV
+    - run:
+        name: Install .NET Core 3.1 SDK
+        shell: bash
+        command: |
+          set -evx
+          echo $PATH > /dev/stderr
+          if ! command -v dotnet && [[ ! -f "$HOME/.dotnet/dotnet" ]]; then
+            curl \
+              -L \
+              -o /tmp/dotnet-install.sh \
+              https://dot.net/v1/dotnet-install.sh
+            chmod +x /tmp/dotnet-install.sh
+            /tmp/dotnet-install.sh \
+              --verbose \
+              --channel 3.1
+          fi
+          command -v dotnet
     - save_cache:
         key: v1-macos-dotnet-sdk-3.1
         paths:
@@ -244,6 +257,7 @@ commands:
     - attach_workspace:
         at: .
     - run:
+        name: Run tests (using xunit-unity-runner <<parameters.runner_version>>)
         shell: bash
         command: |
           set -evx
@@ -284,6 +298,7 @@ commands:
           "$xur_path" "${args[@]}"
         no_output_timeout: 65s
     - run:
+        name: Transform xUnit.net report XML to JUnit report XML
         shell: bash
         command: |
           set -evx
@@ -357,7 +372,9 @@ jobs:
     working_directory: /mnt/ramdisk
     parallelism: 2
     steps:
-    - run: apt update -y && apt install -y xsltproc
+    - run:
+        name: Install xsltproc
+        command: apt update -y && apt install -y xsltproc
     - unity_test_base
 
   macos-unity-test:
@@ -374,7 +391,9 @@ jobs:
       size: large
     parallelism: 4
     steps:
-    - run: choco install bzip2 xsltproc
+    - run:
+        name: Install bzip2 & xsltproc
+        command: choco install bzip2 xsltproc
     - unity_test_base:
         runner_target: StandaloneWindows64
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,13 @@ orbs:
   win: circleci/windows@2.2.0
 
 commands:
+  ulimit:
+    parameters:
+      n: { type: integer }
+    steps:
+    - run:
+        command: "echo 'ulimit -n <<parameters.n>>' >> $BASH_ENV"
+
   concat_files:
     description: Concatenate file contents
     parameters:
@@ -208,6 +215,7 @@ commands:
         type: string
         default: en_US.UTF-8
     steps:
+    - ulimit: { n: 10240 }
     - restore_cache:
         keys:
         - v1-macos-dotnet-sdk-3.1
@@ -382,6 +390,7 @@ jobs:
       xcode: 11.3.0
     parallelism: 3
     steps:
+    - ulimit: { n: 10240 }
     - unity_test_base:
         runner_target: StandaloneOSX
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,32 @@ commands:
         command: "cat -s <<parameters.glob>> > <<parameters.to>>"
         shell: bash
 
+  brew_cask_install:
+    description: "brew install --cask <<parameters.package>>"
+    parameters:
+      package: { type: string }
+      tap: { type: string, default: "" }
+    steps:
+    - restore_cache:
+        keys:
+        - "v1-brew-cask-<<parameters.tap>>/<<parameters.package>>"
+    - run: |
+        if brew list --cask | grep <<parameters.package>>; then
+          if [[ "<<parameters.tap>>" != "" ]]; then
+            brew tap "<<parameters.tap>>"
+          fi
+          brew reinstall --cask <<parameters.package>>
+        else
+          if [[ "<<parameters.tap>>" != "" ]]; then
+            brew tap "<<parameters.tap>>"
+          fi
+          brew install --cask <<parameters.package>>
+        fi
+    - save_cache:
+        key: "v1-brew-cask-<<parameters.tap>>/<<parameters.package>>"
+        paths:
+        - "/usr/local/Caskroom/<<parameters.package>>/"
+
   build_base:
     parameters:
       collect_tests_to:
@@ -25,11 +51,14 @@ commands:
     - concat_files:
         glob: "*/*.csproj"
         to: .combined-package-files.txt
+    - run:
+        shell: bash
+        # On macOS executor, "$HOME" directory does not exist:
+        command: 'if [[ ! -d "$HOME" ]]; then mkdir -p "$HOME"; fi; echo $HOME'
     - restore_cache:
         keys:
         - v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
         - v1-deps-{{ arch }}
-        - v1-deps
     - run: dotnet restore
     - save_cache:
         key: v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
@@ -41,6 +70,10 @@ commands:
         shell: bash
         command: |
           set -evx
+          if ! command -v dotnet > /dev/null && \
+             [[ -d /usr/local/share/dotnet ]]; then
+            export PATH="/usr/local/share/dotnet:$PATH"
+          fi
           dotnet test --no-restore --no-build -c Release --list-tests \
           > .dotnet-list-tests.txt
           grep -E '^    ' .dotnet-list-tests.txt \
@@ -68,12 +101,22 @@ commands:
         description: Distribute tests
         shell: bash
         command: |
+          set -evx
+          if ! command -v dotnet > /dev/null && \
+             [[ -d /usr/local/share/dotnet ]]; then
+            export PATH="/usr/local/share/dotnet:$PATH"
+          fi
           tests_collection="<<parameters.collect_tests_from>>"
           total="$(wc -l "$tests_collection" | awk '{ print $1 }')"
           part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
           tail -n +$((CIRCLE_NODE_INDEX * part + 1)) "$tests_collection" \
-          | head -n $part \
-          > .current_tests.txt
+          > .head_tests.txt
+          if [[ "$part" = "0" ]]; then
+            cp .head_tests.txt .current_tests.txt
+          else
+            head -n $part .head_tests.txt > .current_tests.txt
+          fi
+          cat .current_tests.txt
           first=1
           while read test; do
             if [[ "$first" = "1" ]]; then
@@ -107,6 +150,23 @@ jobs:
     parallelism: 4
     steps: [test_base]
 
+  macos-build:
+    macos:
+      xcode: 11.3.0
+    steps:
+    - brew_cask_install:
+        package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+    - build_base
+
+  macos-test:
+    macos:
+      xcode: 11.3.0
+    parallelism: 8
+    steps:
+    - brew_cask_install:
+        package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+    - test_base
+
   windows-build:
     executor:
       name: win/default
@@ -126,6 +186,7 @@ workflows:
     - linux-build
     - linux-test:
         requires: [linux-build]
-    - windows-build
+    - macos-test:
+        requires: [linux-build]
     - windows-test:
-        requires: [windows-build]
+        requires: [linux-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,18 @@ commands:
         type: string
         default: .tests.txt
     steps:
+    - restore_cache:
+        keys:
+        - v1-dotcover-{{ arch }}
+    - run: >-
+        dotnet tool install
+        --global
+        JetBrains.dotCover.GlobalTool
+        --version 2021.2.2
+    - save_cache:
+        key: v1-dotcover-{{ arch }}
+        paths:
+        - ~/.nuget/packages
     - checkout
     - attach_workspace:
         at: .
@@ -154,15 +166,27 @@ commands:
           done < .current_tests.txt > .test-filter.txt
     - run:
         command: >-
-          dotnet test
+          ~/.dotnet/tools/dotnet-dotcover test
           --no-restore
           --no-build
           -c Release
           -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
           --filter "$(cat .test-filter.txt)"
+          --dcDisableDefaultFilters
+          --dcReportType=DetailedXML
+          --dcFilters="+:Libplanet;+:Libplanet.*;-:Libplanet.Tests;-:Libplanet.*.Tests;-:Libplanet.*.UnitTests;-:Libplanet.Benchmarks;-:Libplanet.Explorer"
         no_output_timeout: 65s
     - store_test_results:
         path: /tmp/junit
+    - run:
+        shell: bash
+        command: |
+          curl -s https://codecov.io/bash | bash -s -- \
+            -f dotCover.Output.xml \
+            -t "$CODECOV_TOKEN" \
+            -n "$CIRCLE_BUILD_NUM" \
+            -Z
+        when: always
 
   unity_test_base:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
+jobs:
+  build-and-test:
+    executor:
+      name: win/default
+      size: large
+    steps:
+    - checkout
+    - run: dotnet build -c Release -p:SkipSonar=true
+    - run: dotnet test -c Release
+
+workflows:
+  main:
+    jobs:
+    - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,18 @@ version: 2.1
 orbs:
   win: circleci/windows@2.2.0
 
+commands:
+  concat_files:
+    description: Concatenate file contents
+    parameters:
+      glob: { type: string }
+      to: { type: string }
+    steps:
+    - run:
+        name: Concatenate file contents
+        command: "cat -s <<parameters.glob>> > <<parameters.to>>"
+        shell: bash
+
 jobs:
   build-and-test:
     executor:
@@ -10,6 +22,15 @@ jobs:
       size: large
     steps:
     - checkout
+    - concat_files:
+        glob: "*/*.csproj"
+        to: combined-package-files.txt
+    - restore_cache:
+        keys:
+        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        - v1-deps-{{ arch }}
+        - v1-deps
+    - run: dotnet restore
     - run: dotnet build -c Release -p:SkipSonar=true
     - run: >-
         dotnet test
@@ -17,6 +38,10 @@ jobs:
         -l "junit;MethodFormat=Full;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
     - store_test_results:
         path: /tmp/junit
+    - save_cache:
+        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        paths:
+        - C:\Users\circleci\.nuget\packages
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,12 @@ jobs:
     steps:
     - checkout
     - run: dotnet build -c Release -p:SkipSonar=true
-    - run: dotnet test -c Release
+    - run: >-
+        dotnet test
+        -c Release
+        -l "junit;MethodFormat=Full;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+    - store_test_results:
+        path: /tmp/junit
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,11 @@ commands:
           else
             xur_path=/tmp/xur/<<parameters.runner_target>>
           fi
+          excluded_classes=(
+            "Libplanet.Tests.Net.Protocols.ProtocolTest"
+            "Libplanet.Tests.Net.SwarmTest"
+            "Libplanet.Tests.Net.Transports.NetMQTransportTest"
+          )
           args=(
             "--hang-seconds=60"
             "--parallel=1"
@@ -227,6 +232,9 @@ commands:
               "--distributed-seed=$CIRCLE_BUILD_NUM"
             )
           fi
+          for c in "${exluced_classes[@]}"; do
+            args+=("--exclude-class=$c")
+          done
           for project in *.Tests; do
             args+=("$PWD/$project/bin/Release/net47/$project.dll")
           done
@@ -283,7 +291,7 @@ jobs:
     docker:
     - image: mono:6.12
     resource_class: large
-    parallelism: 8
+    parallelism: 4
     steps:
     - run: apt update -y && apt install -y xsltproc
     - unity_test_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,16 @@ jobs:
     parallelism: 2
     steps: [netcore_test_base]
 
+  linux-netcore-test-ar-SA:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    resource_class: large
+    working_directory: /mnt/ramdisk
+    parallelism: 2
+    steps:
+    - netcore_test_base:
+        locale: ar_SA.UTF-8
+
   linux-netcore-test-fr-FR:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
@@ -330,16 +340,8 @@ jobs:
   macos-netcore-test:
     macos:
       xcode: 11.3.0
-    parallelism: 3
+    parallelism: 4
     steps: [macos_netcore_test_base]
-
-  macos-netcore-test-ar-SA:
-    macos:
-      xcode: 11.3.0
-    parallelism: 3
-    steps:
-    - macos_netcore_test_base:
-        locale: ar_SA.UTF-8
 
   windows-netcore-test:
     executor:
@@ -370,7 +372,7 @@ jobs:
     executor:
       name: win/default
       size: large
-    parallelism: 3
+    parallelism: 4
     steps:
     - run: choco install bzip2 xsltproc
     - unity_test_base:
@@ -383,11 +385,11 @@ workflows:
     - linux-mono-build
     - linux-netcore-test:
         requires: [linux-netcore-build]
+    - linux-netcore-test-ar-SA:
+        requires: [linux-netcore-build]
     - linux-netcore-test-fr-FR:
         requires: [linux-netcore-build]
     - macos-netcore-test:
-        requires: [linux-netcore-build]
-    - macos-netcore-test-ar-SA:
         requires: [linux-netcore-build]
     - windows-netcore-test:
         requires: [linux-netcore-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,9 @@ commands:
       collect_tests_from:
         type: string
         default: .tests.txt
+      locale:
+        type: string
+        default: en_US.UTF-8
     steps:
     - restore_cache:
         keys:
@@ -182,11 +185,51 @@ commands:
           --dcDisableDefaultFilters
           --dcReportType=DetailedXML
           --dcFilters="+:Libplanet;+:Libplanet.*;-:Libplanet.Tests;-:Libplanet.*.Tests;-:Libplanet.*.UnitTests;-:Libplanet.Benchmarks;-:Libplanet.Explorer"
-        no_output_timeout: 65s
+        no_output_timeout: 180s
+        environment:
+          LC_ALL: "<<parameters.locale>>"
+          LANG: "<<parameters.locale>>"
+          LANGUAGE: "<<parameters.locale>>"
     - store_test_results:
         path: /tmp/junit
     - codecov:
         file: dotCover.Output.xml
+
+  macos_netcore_test_base:
+    parameters:
+      collect_tests_from:
+        type: string
+        default: .tests.txt
+      locale:
+        type: string
+        default: en_US.UTF-8
+    steps:
+    - restore_cache:
+        keys:
+        - v1-macos-dotnet-sdk-3.1
+    - run: |
+        {
+          echo export PATH="$HOME/.dotnet:$PATH"
+          echo export DOTNET_ROOT="$HOME/.dotnet"
+        } >> $BASH_ENV
+    - run: |
+        set -evx
+        echo $PATH > /dev/stderr
+        if ! command -v dotnet && [[ ! -f "$HOME/.dotnet/dotnet" ]]; then
+          curl -L -o /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
+          chmod +x /tmp/dotnet-install.sh
+          /tmp/dotnet-install.sh \
+            --verbose \
+            --channel 3.1
+        fi
+        command -v dotnet
+    - save_cache:
+        key: v1-macos-dotnet-sdk-3.1
+        paths:
+        - ~/.dotnet/
+    - netcore_test_base:
+        collect_tests_from: <<parameters.collect_tests_from>>
+        locale: <<parameters.locale>>
 
   unity_test_base:
     parameters:
@@ -268,51 +311,44 @@ jobs:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
-    parallelism: 3
+    parallelism: 2
     steps: [netcore_test_base]
+
+  linux-netcore-test-fr-FR:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    resource_class: large
+    parallelism: 2
+    steps:
+    - netcore_test_base:
+        locale: fr_FR.UTF-8
 
   macos-netcore-test:
     macos:
       xcode: 11.3.0
-    parallelism: 4
+    parallelism: 3
+    steps: [macos_netcore_test_base]
+
+  macos-netcore-test-ar-SA:
+    macos:
+      xcode: 11.3.0
+    parallelism: 3
     steps:
-    - restore_cache:
-        keys:
-        - v1-macos-dotnet-sdk-5.0
-    - run: |
-        {
-          echo export PATH="$HOME/.dotnet:$PATH"
-          echo export DOTNET_ROOT="$HOME/.dotnet"
-        } >> $BASH_ENV
-    - run: |
-        set -evx
-        echo $PATH > /dev/stderr
-        if ! command -v dotnet && [[ ! -f "$HOME/.dotnet/dotnet" ]]; then
-          curl -L -o /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
-          chmod +x /tmp/dotnet-install.sh
-          /tmp/dotnet-install.sh \
-            --verbose \
-            --channel 5.0
-        fi
-        command -v dotnet
-    - save_cache:
-        key: v1-macos-dotnet-sdk-5.0
-        paths:
-        - ~/.dotnet/
-    - netcore_test_base
+    - macos_netcore_test_base:
+        locale: ar_SA.UTF-8
 
   windows-netcore-test:
     executor:
       name: win/default
       size: large
-    parallelism: 4
+    parallelism: 3
     steps: [netcore_test_base]
 
   linux-unity-test:
     docker:
     - image: mono:6.12
     resource_class: large
-    parallelism: 3
+    parallelism: 2
     steps:
     - run: apt update -y && apt install -y xsltproc
     - unity_test_base
@@ -320,7 +356,7 @@ jobs:
   macos-unity-test:
     macos:
       xcode: 11.3.0
-    parallelism: 4
+    parallelism: 3
     steps:
     - unity_test_base:
         runner_target: StandaloneOSX
@@ -329,7 +365,7 @@ jobs:
     executor:
       name: win/default
       size: large
-    parallelism: 4
+    parallelism: 3
     steps:
     - run: choco install bzip2 xsltproc
     - unity_test_base:
@@ -342,7 +378,11 @@ workflows:
     - linux-mono-build
     - linux-netcore-test:
         requires: [linux-netcore-build]
+    - linux-netcore-test-fr-FR:
+        requires: [linux-netcore-build]
     - macos-netcore-test:
+        requires: [linux-netcore-build]
+    - macos-netcore-test-ar-SA:
         requires: [linux-netcore-build]
     - windows-netcore-test:
         requires: [linux-netcore-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,24 +15,24 @@ commands:
         command: "cat -s <<parameters.glob>> > <<parameters.to>>"
         shell: bash
 
-jobs:
-  linux-build:
-    docker:
-    - image: mcr.microsoft.com/dotnet/sdk:3.1
-    resource_class: xlarge
+  build_base:
+    parameters:
+      collect_tests_to:
+        type: string
+        default: .tests.txt
     steps:
     - checkout
     - concat_files:
         glob: "*/*.csproj"
-        to: combined-package-files.txt
+        to: .combined-package-files.txt
     - restore_cache:
         keys:
-        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        - v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
         - v1-deps-{{ arch }}
         - v1-deps
     - run: dotnet restore
     - save_cache:
-        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        key: v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
         paths:
         - ~/.nuget/packages
     - run: dotnet build --no-restore -c Release -p:SkipSonar=true
@@ -47,126 +47,78 @@ jobs:
           | sed -E 's/^    |\(.*?\)$//g' \
           | uniq \
           | /usr/bin/sort -R --random-source=CHANGES.md \
-          > .tests.txt
+          > "<<parameters.collect_tests_to>>"
     - persist_to_workspace:
         root: .
         paths:
-        - .tests.txt
+        - <<parameters.collect_tests_to>>
         - "*/bin/"
         - "*/obj/"
+
+  test_base:
+    parameters:
+      collect_tests_from:
+        type: string
+        default: .tests.txt
+    steps:
+    - checkout
+    - attach_workspace:
+        at: .
+    - run:
+        description: Distribute tests
+        shell: bash
+        command: |
+          tests_collection="<<parameters.collect_tests_from>>"
+          total="$(wc -l "$tests_collection" | awk '{ print $1 }')"
+          part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
+          tail -n +$((CIRCLE_NODE_INDEX * part + 1)) "$tests_collection" \
+          | head -n $part \
+          > .current_tests.txt
+          first=1
+          while read test; do
+            if [[ "$first" = "1" ]]; then
+              echo "FullyQualifiedName=$test"
+              first=0
+            else
+              echo "| FullyQualifiedName=$test"
+            fi
+          done < .current_tests.txt > .test-filter.txt
+    - run: >-
+        dotnet test
+        --no-restore
+        --no-build
+        -c Release
+        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+        --filter "$(cat .test-filter.txt)"
+    - store_test_results:
+        path: /tmp/junit
+
+jobs:
+  linux-build:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    resource_class: xlarge
+    steps: [build_base]
 
   linux-test:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
     parallelism: 4
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - run:
-        description: Distribute tests
-        shell: bash
-        command: |
-          total="$(wc -l .tests.txt | awk '{ print $1 }')"
-          part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
-          tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
-          | head -n $part \
-          > .current_tests.txt
-          first=1
-          while read test; do
-            if [[ "$first" = "1" ]]; then
-              echo "FullyQualifiedName=$test"
-              first=0
-            else
-              echo "| FullyQualifiedName=$test"
-            fi
-          done < .current_tests.txt > .test-filter.txt
-    - run: >-
-        dotnet test
-        --no-restore
-        --no-build
-        -c Release
-        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
-        --filter "$(cat .test-filter.txt)"
-    - store_test_results:
-        path: /tmp/junit
+    steps: [test_base]
 
   windows-build:
     executor:
       name: win/default
       size: xlarge
-    steps:
-    - checkout
-    - concat_files:
-        glob: "*/*.csproj"
-        to: combined-package-files.txt
-    - restore_cache:
-        keys:
-        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
-        - v1-deps-{{ arch }}
-        - v1-deps
-    - run: dotnet restore
-    - save_cache:
-        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
-        paths:
-        - ~/.nuget/packages
-    - run: dotnet build --no-restore -c Release -p:SkipSonar=true
-    - run:
-        description: Collect tests
-        shell: bash
-        command: |
-          set -evx
-          dotnet test --no-restore --no-build -c Release --list-tests \
-          > .dotnet-list-tests.txt
-          grep -E '^    ' .dotnet-list-tests.txt \
-          | sed -E 's/^    |\(.*?\)$//g' \
-          | uniq \
-          | /usr/bin/sort -R --random-source=CHANGES.md \
-          > .tests.txt
-    - persist_to_workspace:
-        root: .
-        paths:
-        - .tests.txt
-        - "*/bin/"
-        - "*/obj/"
+    steps: [build_base]
 
   windows-test:
     executor:
       name: win/default
       size: large
     parallelism: 4
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - run:
-        description: Distribute tests
-        shell: bash
-        command: |
-          total="$(wc -l .tests.txt | awk '{ print $1 }')"
-          part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
-          tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
-          | head -n $part \
-          > .current_tests.txt
-          first=1
-          while read test; do
-            if [[ "$first" = "1" ]]; then
-              echo "FullyQualifiedName=$test"
-              first=0
-            else
-              echo "| FullyQualifiedName=$test"
-            fi
-          done < .current_tests.txt > .test-filter.txt
-    - run: >-
-        dotnet test
-        --no-restore
-        --no-build
-        -c Release
-        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
-        --filter "$(cat .test-filter.txt)"
-    - store_test_results:
-        path: /tmp/junit
+    steps: [test_base]
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,18 +299,21 @@ jobs:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: xlarge
+    working_directory: /mnt/ramdisk
     steps: [netcore_build_base]
 
   linux-mono-build:
     docker:
     - image: mono:6.12
     resource_class: xlarge
+    working_directory: /mnt/ramdisk
     steps: [mono_build_base]
 
   linux-netcore-test:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
+    working_directory: /mnt/ramdisk
     parallelism: 2
     steps: [netcore_test_base]
 
@@ -318,6 +321,7 @@ jobs:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
+    working_directory: /mnt/ramdisk
     parallelism: 2
     steps:
     - netcore_test_base:
@@ -348,6 +352,7 @@ jobs:
     docker:
     - image: mono:6.12
     resource_class: large
+    working_directory: /mnt/ramdisk
     parallelism: 2
     steps:
     - run: apt update -y && apt install -y xsltproc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
         paths:
         - "/usr/local/Caskroom/<<parameters.package>>/"
 
-  build_base:
+  netcore_build_base:
     parameters:
       collect_tests_to:
         type: string
@@ -51,10 +51,6 @@ commands:
     - concat_files:
         glob: "*/*.csproj"
         to: .combined-package-files.txt
-    - run:
-        shell: bash
-        # On macOS executor, "$HOME" directory does not exist:
-        command: 'if [[ ! -d "$HOME" ]]; then mkdir -p "$HOME"; fi; echo $HOME'
     - restore_cache:
         keys:
         - v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
@@ -88,7 +84,37 @@ commands:
         - "*/bin/"
         - "*/obj/"
 
-  test_base:
+  mono_build_base:
+    steps:
+    - checkout
+    - concat_files:
+        glob: "*/*.csproj"
+        to: .combined-package-files.txt
+    - restore_cache:
+        keys:
+        - v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
+        - v1-deps-{{ arch }}
+    - run: |
+        msbuild \
+          -t:Restore \
+          -p:Configuration=Release \
+          -p:TestsTargetFramework=net47
+    - save_cache:
+        key: v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
+        paths:
+        - ~/.nuget/packages
+    - run: |
+        msbuild \
+          -p:Configuration=Release \
+          -p:TestsTargetFramework=net47 \
+          -p:SkipSonar=true
+    - persist_to_workspace:
+        root: .
+        paths:
+        - "*/bin/"
+        - "*/obj/"
+
+  netcore_test_base:
     parameters:
       collect_tests_from:
         type: string
@@ -126,67 +152,120 @@ commands:
               echo "| FullyQualifiedName=$test"
             fi
           done < .current_tests.txt > .test-filter.txt
-    - run: >-
-        dotnet test
-        --no-restore
-        --no-build
-        -c Release
-        -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
-        --filter "$(cat .test-filter.txt)"
+    - run:
+        command: >-
+          dotnet test
+          --no-restore
+          --no-build
+          -c Release
+          -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+          --filter "$(cat .test-filter.txt)"
+        no_output_timeout: 65s
+    - store_test_results:
+        path: /tmp/junit
+
+  unity_test_base:
+    parameters:
+      runner_target:
+        type: string
+        default: StandaloneLinux64
+      runner_version:
+        type: string
+        default: 0.4.0
+    steps:
+    - checkout
+    - attach_workspace:
+        at: .
+    - run:
+        shell: bash
+        command: |
+          set -evx
+          url="https://github.com/planetarium/xunit-unity-runner/releases/download/<<parameters.runner_version>>/xunit-unity-runner-<<parameters.runner_version>>-<<parameters.runner_target>>.tar.bz2"
+          mkdir -p /tmp/xur/
+          curl -o "/tmp/xur.tar.bz2" -L "$url"
+          pushd /tmp/xur/
+          tar xvfj ../xur.tar.bz2
+          popd
+          if [[ "<<parameters.runner_target>>" = "StandaloneOSX" ]]; then
+            xur_path=/tmp/xur/StandaloneOSX.app/Contents/MacOS/StandardOSX
+          else
+            xur_path=/tmp/xur/<<parameters.runner_target>>
+          fi
+          if [[ "$CIRCLE_NODE_TOTAL" != "" ]]; then
+            "$xur_path" \
+              --distributed=$CIRCLE_NODE_INDEX/$CIRCLE_NODE_TOTAL \
+              --distributed-seed=$CIRCLE_BUILD_NUM \
+              --report-xml-path=/tmp/xur.xml \
+              "$PWD"/*.Tests/bin/Release/net47/*.Tests.dll
+          else
+            "$xur_path" \
+              --report-xml-path=/tmp/xur.xml \
+              "$PWD"/*.Tests/bin/Release/net47/*.Tests.dll
+          fi
+        no_output_timeout: 65s
+    - run:
+        shell: bash
+        command: |
+          xsltproc -o /tmp/junit/xur.xml .circleci/xunit-junit.xslt /tmp/xur.xml
+        when: always
     - store_test_results:
         path: /tmp/junit
 
 jobs:
-  linux-build:
+  linux-netcore-build:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: xlarge
-    steps: [build_base]
+    steps: [netcore_build_base]
 
-  linux-test:
+  linux-mono-build:
+    docker:
+    - image: mono:6.12
+    resource_class: xlarge
+    steps: [mono_build_base]
+
+  linux-netcore-test:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
     parallelism: 4
-    steps: [test_base]
+    steps: [netcore_test_base]
 
-  macos-build:
-    macos:
-      xcode: 11.3.0
-    steps:
-    - brew_cask_install:
-        package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
-    - build_base
-
-  macos-test:
+  macos-netcore-test:
     macos:
       xcode: 11.3.0
     parallelism: 8
     steps:
     - brew_cask_install:
         package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
-    - test_base
+    - netcore_test_base
 
-  windows-build:
-    executor:
-      name: win/default
-      size: xlarge
-    steps: [build_base]
-
-  windows-test:
+  windows-netcore-test:
     executor:
       name: win/default
       size: large
     parallelism: 4
-    steps: [test_base]
+    steps: [netcore_test_base]
+
+  linux-unity-test:
+    docker:
+    - image: mono:6.12
+    resource_class: large
+    parallelism: 8
+    steps:
+    - run: apt update -y && apt install -y xsltproc
+    - unity_test_base
 
 workflows:
   main:
     jobs:
-    - linux-build
-    - linux-test:
-        requires: [linux-build]
-    - macos-test:
-        requires: [linux-build]
-    - windows-test:
-        requires: [linux-build]
+    - linux-netcore-build
+    - linux-mono-build
+    - linux-netcore-test:
+        requires: [linux-netcore-build]
+    - macos-netcore-test:
+        requires: [linux-netcore-build]
+    - windows-netcore-test:
+        requires: [linux-netcore-build]
+    - linux-unity-test:
+        requires: [linux-mono-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,34 +16,58 @@ commands:
         shell: bash
 
 jobs:
-  linux:
+  linux-build:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    resource_class: xlarge
+    steps:
+    - checkout
+    - concat_files:
+        glob: "*/*.csproj"
+        to: combined-package-files.txt
+    - restore_cache:
+        keys:
+        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        - v1-deps-{{ arch }}
+        - v1-deps
+    - run: dotnet restore
+    - save_cache:
+        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        paths:
+        - ~/.nuget/packages
+    - run: dotnet build --no-restore -c Release -p:SkipSonar=true
+    - run:
+        description: Collect tests
+        shell: bash
+        command: |
+          set -evx
+          dotnet test --no-restore --no-build -c Release --list-tests \
+          > .dotnet-list-tests.txt
+          grep -E '^    ' .dotnet-list-tests.txt \
+          | sed -E 's/^    |\(.*?\)$//g' \
+          | uniq \
+          | /usr/bin/sort -R --random-source=CHANGES.md \
+          > .tests.txt
+    - persist_to_workspace:
+        root: .
+        paths:
+        - .tests.txt
+        - "*/bin/"
+        - "*/obj/"
+
+  linux-test:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
     parallelism: 4
     steps:
     - checkout
-    - concat_files:
-        glob: "*/*.csproj"
-        to: combined-package-files.txt
-    - restore_cache:
-        keys:
-        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
-        - v1-deps-{{ arch }}
-        - v1-deps
-    - run: dotnet restore
-    - run: dotnet build --no-restore -c Release -p:SkipSonar=true
+    - attach_workspace:
+        at: .
     - run:
+        description: Distribute tests
         shell: bash
         command: |
-          set -evx
-          dotnet test --no-restore --no-build -c Release --list-tests \
-          > .dotnet-list-tests.txt
-          grep -E '^    ' .dotnet-list-tests.txt \
-          | sed -E 's/^    |\(.*?\)$//g' \
-          | uniq \
-          | /usr/bin/sort -R --random-source=CHANGES.md \
-          > .tests.txt
           total="$(wc -l .tests.txt | awk '{ print $1 }')"
           part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
           tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
@@ -67,16 +91,11 @@ jobs:
         --filter "$(cat .test-filter.txt)"
     - store_test_results:
         path: /tmp/junit
-    - save_cache:
-        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
-        paths:
-        - ~/.nuget/packages
 
-  windows:
+  windows-build:
     executor:
       name: win/default
-      size: large
-    parallelism: 4
+      size: xlarge
     steps:
     - checkout
     - concat_files:
@@ -88,8 +107,13 @@ jobs:
         - v1-deps-{{ arch }}
         - v1-deps
     - run: dotnet restore
+    - save_cache:
+        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        paths:
+        - ~/.nuget/packages
     - run: dotnet build --no-restore -c Release -p:SkipSonar=true
     - run:
+        description: Collect tests
         shell: bash
         command: |
           set -evx
@@ -100,6 +124,26 @@ jobs:
           | uniq \
           | /usr/bin/sort -R --random-source=CHANGES.md \
           > .tests.txt
+    - persist_to_workspace:
+        root: .
+        paths:
+        - .tests.txt
+        - "*/bin/"
+        - "*/obj/"
+
+  windows-test:
+    executor:
+      name: win/default
+      size: large
+    parallelism: 4
+    steps:
+    - checkout
+    - attach_workspace:
+        at: .
+    - run:
+        description: Distribute tests
+        shell: bash
+        command: |
           total="$(wc -l .tests.txt | awk '{ print $1 }')"
           part="$(( (total + CIRCLE_NODE_TOTAL - 1) / CIRCLE_NODE_TOTAL ))"
           tail -n +$((CIRCLE_NODE_INDEX * part + 1)) .tests.txt \
@@ -123,13 +167,13 @@ jobs:
         --filter "$(cat .test-filter.txt)"
     - store_test_results:
         path: /tmp/junit
-    - save_cache:
-        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
-        paths:
-        - ~/.nuget/packages
 
 workflows:
   main:
     jobs:
-    - linux
-    - windows
+    - linux-build
+    - linux-test:
+        requires: [linux-build]
+    - windows-build
+    - windows-test:
+        requires: [windows-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
     - image: mono:6.12
     resource_class: large
     working_directory: /mnt/ramdisk
-    parallelism: 2
+    parallelism: 4
     steps:
     - run:
         name: Install xsltproc
@@ -423,7 +423,9 @@ workflows:
         requires: [linux-netcore-build]
     - linux-unity-test:
         requires: [linux-mono-build]
-    - macos-unity-test:
-        requires: [linux-mono-build]
-    - windows-unity-test:
-        requires: [linux-mono-build]
+    # Temporarily turned off due to CircleCI's slow worker node assignments of
+    # macOS and Windows VMs:
+    #- macos-unity-test:
+    #    requires: [linux-mono-build]
+    #- windows-unity-test:
+    #    requires: [linux-mono-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,43 @@ commands:
         paths:
         - "/usr/local/Caskroom/<<parameters.package>>/"
 
+  codecov:
+    description: Upload a code coverage report file to Codecov.io
+    parameters:
+      file: { type: string }
+    steps:
+    - restore_cache:
+        keys:
+        - "v1-codecov"
+        when: always
+    - run:
+        shell: bash
+        command: |
+          set -evx
+          case "$OSTYPE" in
+            darwin*) plat=macos;;
+            msys*)   plat=windows; suffix=.exe;;
+            cygwin*) plat=windows; suffix=.exe;;
+            *)       plat=linux;;
+          esac
+          mkdir -p _codecov_uploader/$plat/
+          pushd _codecov_uploader/$plat/
+          if [[ ! -f "codecov$suffix" ]]; then
+            curl -OL "https://uploader.codecov.io/latest/$plat/codecov$suffix"
+          fi
+          chmod +x "codecov$suffix"
+          popd
+          "_codecov_uploader/$plat/codecov$suffix" \
+            -K \
+            -f '<<parameters.file>>' \
+            -n "$CIRCLE_BUILD_NUM"
+        when: always
+    - save_cache:
+        key: "v1-codecov"
+        paths:
+        - _codecov_uploader/
+        when: always
+
   netcore_build_base:
     parameters:
       collect_tests_to:
@@ -178,15 +215,8 @@ commands:
         no_output_timeout: 65s
     - store_test_results:
         path: /tmp/junit
-    - run:
-        shell: bash
-        command: |
-          curl -s https://codecov.io/bash | bash -s -- \
-            -f dotCover.Output.xml \
-            -t "$CODECOV_TOKEN" \
-            -n "$CIRCLE_BUILD_NUM" \
-            -Z
-        when: always
+    - codecov:
+        file: dotCover.Output.xml
 
   unity_test_base:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ commands:
         default: StandaloneLinux64
       runner_version:
         type: string
-        default: 0.4.0
+        default: 0.5.0
     steps:
     - checkout
     - attach_workspace:
@@ -184,32 +184,40 @@ commands:
           mkdir -p /tmp/xur/
           curl -o "/tmp/xur.tar.bz2" -L "$url"
           pushd /tmp/xur/
-          tar xvfj ../xur.tar.bz2
+          bzip2 -d ../xur.tar.bz2
+          tar xvf ../xur.tar
           popd
           if [[ "<<parameters.runner_target>>" = "StandaloneOSX" ]]; then
-            xur_path=/tmp/xur/StandaloneOSX.app/Contents/MacOS/StandardOSX
+            xur_path=/tmp/xur/StandaloneOSX.app/Contents/MacOS/unity-xunit
           else
             xur_path=/tmp/xur/<<parameters.runner_target>>
           fi
+          args=(
+            "--hang-seconds=60"
+            "--parallel=1"
+            "--report-xml-path=$PWD/.xur.xml"
+          )
           if [[ "$CIRCLE_NODE_TOTAL" != "" ]]; then
-            "$xur_path" \
-              --distributed=$CIRCLE_NODE_INDEX/$CIRCLE_NODE_TOTAL \
-              --distributed-seed=$CIRCLE_BUILD_NUM \
-              --report-xml-path=/tmp/xur.xml \
-              "$PWD"/*.Tests/bin/Release/net47/*.Tests.dll
-          else
-            "$xur_path" \
-              --report-xml-path=/tmp/xur.xml \
-              "$PWD"/*.Tests/bin/Release/net47/*.Tests.dll
+            args+=(
+              "--distributed=$CIRCLE_NODE_INDEX/$CIRCLE_NODE_TOTAL"
+              "--distributed-seed=$CIRCLE_BUILD_NUM"
+            )
           fi
+          for project in *.Tests; do
+            args+=("$PWD/$project/bin/Release/net47/$project.dll")
+          done
+          "$xur_path" "${args[@]}"
         no_output_timeout: 65s
     - run:
         shell: bash
         command: |
-          xsltproc -o /tmp/junit/xur.xml .circleci/xunit-junit.xslt /tmp/xur.xml
+          set -evx
+          mkdir -p _junit
+          xsltproc -o _junit/xur.xml .circleci/xunit-junit.xslt .xur.xml
+          cat _junit/xur.xml
         when: always
     - store_test_results:
-        path: /tmp/junit
+        path: _junit
 
 jobs:
   linux-netcore-build:
@@ -256,6 +264,24 @@ jobs:
     - run: apt update -y && apt install -y xsltproc
     - unity_test_base
 
+  macos-unity-test:
+    macos:
+      xcode: 11.3.0
+    parallelism: 4
+    steps:
+    - unity_test_base:
+        runner_target: StandaloneOSX
+
+  windows-unity-test:
+    executor:
+      name: win/default
+      size: large
+    parallelism: 4
+    steps:
+    - run: choco install bzip2 xsltproc
+    - unity_test_base:
+        runner_target: StandaloneWindows64
+
 workflows:
   main:
     jobs:
@@ -268,4 +294,8 @@ workflows:
     - windows-netcore-test:
         requires: [linux-netcore-build]
     - linux-unity-test:
+        requires: [linux-mono-build]
+    - macos-unity-test:
+        requires: [linux-mono-build]
+    - windows-unity-test:
         requires: [linux-mono-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,21 +141,27 @@ commands:
       locale:
         type: string
         default: en_US.UTF-8
+      code_coverage:
+        type: boolean
+        default: true
     steps:
-    - restore_cache:
-        keys:
-        - v1-dotcover-{{ arch }}
-    - run:
-        name: Install JetBrains dotCover
-        command: >-
-          dotnet tool install
-          --global
-          JetBrains.dotCover.GlobalTool
-          --version 2021.2.2
-    - save_cache:
-        key: v1-dotcover-{{ arch }}
-        paths:
-        - ~/.nuget/packages
+    - when:
+        condition: "<<parameters.code_coverage>>"
+        steps:
+        - restore_cache:
+            keys:
+            - v1-dotcover-{{ arch }}
+        - run:
+            name: Install JetBrains dotCover
+            command: >-
+              dotnet tool install
+              --global
+              JetBrains.dotCover.GlobalTool
+              --version 2021.2.2
+        - save_cache:
+            key: v1-dotcover-{{ arch }}
+            paths:
+            - ~/.nuget/packages
     - checkout
     - attach_workspace:
         at: .
@@ -184,27 +190,47 @@ commands:
               echo "| FullyQualifiedName=$test"
             fi
           done < .current_tests.txt > .test-filter.txt
-    - run:
-        name: Run tests (using dotCover)
-        command: >-
-          ~/.dotnet/tools/dotnet-dotcover test
-          --no-restore
-          --no-build
-          -c Release
-          -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
-          --filter "$(cat .test-filter.txt)"
-          --dcDisableDefaultFilters
-          --dcReportType=DetailedXML
-          --dcFilters="+:Libplanet;+:Libplanet.*;-:Libplanet.Tests;-:Libplanet.*.Tests;-:Libplanet.*.UnitTests;-:Libplanet.Benchmarks;-:Libplanet.Explorer"
-        no_output_timeout: 180s
-        environment:
-          LC_ALL: "<<parameters.locale>>"
-          LANG: "<<parameters.locale>>"
-          LANGUAGE: "<<parameters.locale>>"
-    - store_test_results:
-        path: /tmp/junit
-    - codecov:
-        file: dotCover.Output.xml
+    - when:
+        condition: "<<parameters.code_coverage>>"
+        steps:
+        - run:
+            name: Run tests (using dotCover)
+            command: >-
+              ~/.dotnet/tools/dotnet-dotcover test
+              --no-restore
+              --no-build
+              -c Release
+              -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+              --filter "$(cat .test-filter.txt)"
+              --dcDisableDefaultFilters
+              --dcReportType=DetailedXML
+              --dcFilters="+:Libplanet;+:Libplanet.*;-:Libplanet.Tests;-:Libplanet.*.Tests;-:Libplanet.*.UnitTests;-:Libplanet.Benchmarks;-:Libplanet.Explorer"
+            no_output_timeout: 180s
+            environment:
+              LC_ALL: "<<parameters.locale>>"
+              LANG: "<<parameters.locale>>"
+              LANGUAGE: "<<parameters.locale>>"
+        - store_test_results:
+            path: /tmp/junit
+        - codecov:
+            file: dotCover.Output.xml
+    - unless:
+        condition: "<<parameters.code_coverage>>"
+        steps:
+        - run:
+            name: Run tests
+            command: >-
+              dotnet test
+              --no-restore
+              --no-build
+              -c Release
+              -l "junit;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+              --filter "$(cat .test-filter.txt)"
+            no_output_timeout: 120s
+            environment:
+              LC_ALL: "<<parameters.locale>>"
+              LANG: "<<parameters.locale>>"
+              LANGUAGE: "<<parameters.locale>>"
 
   macos_netcore_test_base:
     parameters:
@@ -214,6 +240,9 @@ commands:
       locale:
         type: string
         default: en_US.UTF-8
+      code_coverage:
+        type: boolean
+        default: true
     steps:
     - ulimit: { n: 10240 }
     - restore_cache:
@@ -249,8 +278,9 @@ commands:
         paths:
         - ~/.dotnet/
     - netcore_test_base:
-        collect_tests_from: <<parameters.collect_tests_from>>
-        locale: <<parameters.locale>>
+        collect_tests_from: "<<parameters.collect_tests_from>>"
+        locale: "<<parameters.locale>>"
+        code_coverage: "<<parameters.code_coverage>>"
 
   unity_test_base:
     parameters:
@@ -364,7 +394,8 @@ jobs:
     macos:
       xcode: 11.3.0
     parallelism: 4
-    steps: [macos_netcore_test_base]
+    steps:
+    - macos_netcore_test_base: { code_coverage: false }
 
   windows-netcore-test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,32 +15,6 @@ commands:
         command: "cat -s <<parameters.glob>> > <<parameters.to>>"
         shell: bash
 
-  brew_cask_install:
-    description: "brew install --cask <<parameters.package>>"
-    parameters:
-      package: { type: string }
-      tap: { type: string, default: "" }
-    steps:
-    - restore_cache:
-        keys:
-        - "v1-brew-cask-<<parameters.tap>>/<<parameters.package>>"
-    - run: |
-        if brew list --cask | grep <<parameters.package>>; then
-          if [[ "<<parameters.tap>>" != "" ]]; then
-            brew tap "<<parameters.tap>>"
-          fi
-          brew reinstall --cask <<parameters.package>>
-        else
-          if [[ "<<parameters.tap>>" != "" ]]; then
-            brew tap "<<parameters.tap>>"
-          fi
-          brew install --cask <<parameters.package>>
-        fi
-    - save_cache:
-        key: "v1-brew-cask-<<parameters.tap>>/<<parameters.package>>"
-        paths:
-        - "/usr/local/Caskroom/<<parameters.package>>/"
-
   codecov:
     description: Upload a code coverage report file to Codecov.io
     parameters:
@@ -306,8 +280,21 @@ jobs:
       xcode: 11.3.0
     parallelism: 6
     steps:
-    - brew_cask_install:
-        package: isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+    - restore_cache:
+        keys:
+        - v1-brew-cask-isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+    - run: |
+        if ! command -v dotnet; then
+          if brew list --cask | grep dotnet-sdk3-1-400; then
+            brew reinstall --cask isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+          else
+            brew install --cask isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+          fi
+        fi
+    - save_cache:
+        key: v1-brew-cask-isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400
+        paths:
+        - /usr/local/Caskroom/isen-ng/dotnet-sdk-versions/dotnet-sdk3-1-400/
     - netcore_test_base
 
   windows-netcore-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,34 @@ commands:
         shell: bash
 
 jobs:
-  build-and-test:
+  linux:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    resource_class: xlarge
+    steps:
+    - checkout
+    - concat_files:
+        glob: "*/*.csproj"
+        to: combined-package-files.txt
+    - restore_cache:
+        keys:
+        - v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        - v1-deps-{{ arch }}
+        - v1-deps
+    - run: dotnet restore
+    - run: dotnet build -c Release -p:SkipSonar=true
+    - run: >-
+        dotnet test
+        -c Release
+        -l "junit;MethodFormat=Full;FailureBodyFormat=Verbose;LogFilePath=/tmp/junit/{assembly}.xml"
+    - store_test_results:
+        path: /tmp/junit
+    - save_cache:
+        key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
+        paths:
+        - ~/.nuget/packages
+
+  windows:
     executor:
       name: win/default
       size: large
@@ -41,9 +68,10 @@ jobs:
     - save_cache:
         key: v1-deps-{{ arch }}-{{ checksum "combined-package-files.txt" }}
         paths:
-        - C:\Users\circleci\.nuget\packages
+        - ~/.nuget/packages
 
 workflows:
   main:
     jobs:
-    - build-and-test
+    - linux
+    - windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,13 +268,13 @@ jobs:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
     resource_class: large
-    parallelism: 4
+    parallelism: 3
     steps: [netcore_test_base]
 
   macos-netcore-test:
     macos:
       xcode: 11.3.0
-    parallelism: 6
+    parallelism: 4
     steps:
     - restore_cache:
         keys:
@@ -312,7 +312,7 @@ jobs:
     docker:
     - image: mono:6.12
     resource_class: large
-    parallelism: 4
+    parallelism: 3
     steps:
     - run: apt update -y && apt install -y xsltproc
     - unity_test_base

--- a/.circleci/xunit-junit.xslt
+++ b/.circleci/xunit-junit.xslt
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Original: https://github.com/gabrielweyer/xunit-to-junit -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output
+    method="xml"
+    encoding="UTF-8"
+    byte-order-mark="no"
+    indent="yes"
+    omit-xml-declaration="no"
+    cdata-section-elements="skipped failure "/>
+  <xsl:template match="/">
+    <testsuites>
+      <xsl:for-each select="//assembly">
+        <testsuite>
+          <xsl:attribute name="name">
+            <xsl:value-of select="@name"/>
+          </xsl:attribute>
+          <xsl:attribute name="tests">
+            <xsl:value-of select="@total"/>
+          </xsl:attribute>
+          <xsl:attribute name="failures">
+            <xsl:value-of select="@failed"/>
+          </xsl:attribute>
+          <xsl:attribute name="skipped">
+            <xsl:value-of select="@skipped"/>
+          </xsl:attribute>
+          <xsl:attribute name="errors">
+            <xsl:value-of select="@errors"/>
+          </xsl:attribute>
+          <xsl:attribute name="time">
+            <xsl:value-of select="@time"/>
+          </xsl:attribute>
+          <xsl:attribute name="timestamp">
+            <xsl:value-of
+              select="@run-date"
+            />T<xsl:value-of select="@run-time"/>
+          </xsl:attribute>
+          <xsl:for-each select="collection/test">
+            <testcase>
+              <xsl:attribute name="name">
+                <xsl:value-of select="@name"/>
+              </xsl:attribute>
+              <xsl:attribute name="classname">
+                <xsl:value-of select="@type"/>
+              </xsl:attribute>
+              <xsl:attribute name="time">
+                <xsl:value-of select="@time"/>
+              </xsl:attribute>
+              <xsl:if test="@result='Skip'">
+                <skipped><xsl:value-of select="reason"/></skipped>
+              </xsl:if>
+              <xsl:if test="@result='Fail'">
+                <failure>
+                  <xsl:attribute name="type">
+                    <xsl:value-of select="failure/@exception-type"/>
+                  </xsl:attribute>
+                  <xsl:attribute name="message">
+                    <xsl:value-of select="failure/message"/>
+                  </xsl:attribute>
+                  <xsl:value-of select="failure/stack-trace"/>
+                </failure>
+              </xsl:if>
+            </testcase>
+          </xsl:for-each>
+        </testsuite>
+      </xsl:for-each>
+    </testsuites>
+  </xsl:template>
+</xsl:stylesheet>

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,6 +1,6 @@
 # This workflow checks if the build (compilation) succeeds without any errors.
-# Although the build is done in Azure Pipelines as well, to speed up the build time
-# some checks are turned off in Azure Pipelines.  To conduct the complete checks
+# Although the build is done in CircleCI/AzP as well, to speed up the build time
+# some checks are turned off in CircleCI/AzP.  To conduct the complete checks
 # there should be this separated workflow.
 # See also the below issues:
 # - https://github.com/planetarium/libplanet/pull/979

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 **/.idea/**/modules.xml
 **/.idea/**/projectSettingsUpdater.xml
 
+# dotCover
+dotCover.Output.*
+dotCover.Output/
+
 *.suo
 *.user
 .vs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ You can build these assemblies using `msbuild -r` Mono or .NET Framework
 provide.
 *You can't build them using `dotnet build` command or `dotnet msbuild`,*
 because the Unity runtime is not based on .NET Core but Mono,
-which is compatible with .NET Framework 4.6.
+which is compatible with .NET Framework 4.7.
 Please be sure that Mono's *bin* directory is prior to .NET Core's one
 (or it's okay too if .NET Core is not installed at all).  Mono or .NET
 Framework's `msbuild` could try to use .NET Core's version of several
@@ -239,9 +239,9 @@ option as well.
 
 To sum up, the instruction is like below (the example is assuming Linux):
 
-    msbuild -r
+    msbuild -r -p:TestsTargetFramework=net47
     xunit-unity-runner/StandaloneLinux64 \
-      "`pwd`"/*.Tests/bin/Debug/net47/*.Tests.dll
+      "$PWD"/*.Tests/bin/Debug/net47/*.Tests.dll
 
 [xunit-unity-runner]: https://github.com/planetarium/xunit-unity-runner
 [4]: https://github.com/planetarium/xunit-unity-runner/releases/latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ on GitHub consists of several projects:
 [libplanet-explorer-frontend]: https://github.com/planetarium/libplanet-explorer-frontend
 
 
-Tests [![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][2]
+Tests [![Build Status (CircleCI)](https://circleci.com/gh/planetarium/libplanet/tree/main.svg?style=shield)][CircleCI] [![Build Status (Azure Pipelines)](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines] [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][2]
 -----
 
 We write as complete tests as possible to the corresponding implementation code.
@@ -182,6 +182,7 @@ mono xunit.runner.console.*/tools/net47/xunit.console.exe \
     *.Tests/bin/Debug/net47/*.Tests.dll
 ~~~~
 
+[CircleCI]: https://app.circleci.com/pipelines/github/planetarium/libplanet
 [Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622
 [3]: https://codecov.io/gh/planetarium/libplanet
 [Xunit]: https://xunit.github.io/
@@ -209,7 +210,7 @@ or cloud offers like [Xirsys].
 
 Unity is one of our platforms we primarily target to support, so we've been
 testing Libplanet on the actual Unity runtime, and you could see whether it's
-passed on [Azure Pipelines].
+passed on [CircleCI] & [Azure Pipelines].
 
 However, if it fails and it does not fail on other platforms but only Unity,
 you need to run Unity tests on your own machine so that you rapidily and
@@ -217,7 +218,7 @@ repeatedly tinker things, make a try, and immediately get feedback from them.
 
 Here's how to run Unity tests on your machine.  We've made and used
 [xunit-unity-runner] to run [Xunit] tests on the actual Unity runtime,
-and our build jobs on Azure Pipelines also use this.  This test runner
+and our build jobs on CircleCI/Azure Pipelines also use this.  This test runner
 is actually a Unity app, though it's not a game app.  As of June 2019,
 there are [executable binaries][4] for Linux, macOS, and Windows.
 Its usage is simple.  It's a CLI app that takes *absolute* paths to

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Analyzers.Tests
 {
     public class ActionAnalyzerTest : DiagnosticVerifier
     {
-        [Fact]
+        [CSharpAnalysisFact]
         public void EmptyCode()
         {
             VerifyDiagnostic(@"
@@ -18,7 +18,7 @@ namespace Libplanet.Analyzers.Tests
             ");
         }
 
-        [Fact]
+        [CSharpAnalysisFact]
         public void LA1001_SystemRandomBreaksActionDeterminism()
         {
             var test = @"
@@ -50,7 +50,7 @@ namespace Libplanet.Analyzers.Tests
             VerifyDiagnostic(test, expected);
         }
 
-        [Theory]
+        [CSharpAnalysisTheory]
         [InlineData(
             false,
             null,

--- a/Libplanet.Analyzers.Tests/CSharpAnalysisFactAttribute.cs
+++ b/Libplanet.Analyzers.Tests/CSharpAnalysisFactAttribute.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Libplanet.Analyzers.Tests
+{
+    public sealed class CSharpAnalysisFactAttribute : FactAttribute
+    {
+        public static readonly bool CSharpSupported = IsCsharpSupported();
+
+        public CSharpAnalysisFactAttribute()
+        {
+            if (!CSharpSupported)
+            {
+                Skip = $"Code analysis on {LanguageNames.CSharp} is unsupported on this runtime.";
+            }
+        }
+
+        private static bool IsCsharpSupported()
+        {
+            try
+            {
+                _ = new AdhocWorkspace().CurrentSolution.AddProject(
+                    ProjectId.CreateNewId("TestProject"),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp
+                );
+            }
+            catch (NotSupportedException e)
+            {
+                if (e.Message.Contains(LanguageNames.CSharp))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -22,6 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference
       Include="Menees.Analyzers.2017"
       Version="2.0.3"

--- a/Libplanet.Analyzers.Tests/Verifiers/CSharpAnalysisTheoryAttribute.cs
+++ b/Libplanet.Analyzers.Tests/Verifiers/CSharpAnalysisTheoryAttribute.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Libplanet.Analyzers.Tests.Verifiers
+{
+    public sealed class CSharpAnalysisTheoryAttribute : TheoryAttribute
+    {
+        public CSharpAnalysisTheoryAttribute()
+        {
+            if (!CSharpAnalysisFactAttribute.CSharpSupported)
+            {
+                Skip = $"Code analysis on {LanguageNames.CSharp} is unsupported on this runtime.";
+            }
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
+++ b/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -18,7 +18,7 @@
     <LangVersion>8.0</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
-    <AssemblyName>Libplanet.Explorere</AssemblyName>
+    <AssemblyName>Libplanet.Explorer</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -29,6 +29,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
       <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -15,6 +15,7 @@ using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
+using xRetry;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 using Random = System.Random;
@@ -546,7 +547,7 @@ namespace Libplanet.Tests.Blockchain
             );
         }
 
-        [Fact]
+        [RetryFact]
         public async Task AbortMining()
         {
             // Pre-mined genesis 7ae04b6fc0a3410eef40341129b19030ea2e6a0b922e5ae7cc96ab19109495c4:

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tests/Net/BlockCompletionTest.cs
+++ b/Libplanet.Tests/Net/BlockCompletionTest.cs
@@ -13,6 +13,7 @@ using Libplanet.Net;
 using Libplanet.Tests.Common.Action;
 using Nito.AsyncEx;
 using Serilog;
+using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 using AsyncEnumerable = System.Linq.AsyncEnumerable;
@@ -103,7 +104,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact(Timeout = Timeout)]
+        [RetryFact(Timeout = Timeout)]
         public async void EnumerateChunks()
         {
             // 0, 1: Already existed blocks

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -390,7 +390,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact(Timeout = Timeout)]
+        [RetryFact(Timeout = Timeout)]
         public async Task BroadcastTxAsyncMany()
         {
             int size = 5;

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -245,7 +245,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact(Timeout = Timeout)]
+        [RetryFact(Timeout = Timeout)]
         public async Task RenderInPreload()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1132,7 +1132,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        [Fact(Timeout = Timeout)]
+        [RetryFact(Timeout = Timeout)]
         public async Task IgnoreTransactionFromDifferentGenesis()
         {
             var validKey = new PrivateKey();

--- a/Libplanet/KeyStore/Web3KeyStore.cs
+++ b/Libplanet/KeyStore/Web3KeyStore.cs
@@ -20,7 +20,11 @@ namespace Libplanet.KeyStore
     public class Web3KeyStore : IKeyStore
     {
         private static readonly string DefaultPath = System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) is { } p && p.Any()
+                ? p
+                : System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".config"),
             "planetarium",
             "keystore"
         );

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ Libplanet
 =========
 
 [![Discord](https://img.shields.io/discord/539405872346955788.svg?color=7289da&logo=discord&logoColor=white)][Discord]
-[![Build Status](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines]
+[![Build Status (CircleCI)](https://circleci.com/gh/planetarium/libplanet/tree/main.svg?style=shield)][CircleCI]
+[![Build Status (Azure Pipelines)](https://dev.azure.com/planetarium/libplanet/_apis/build/status/planetarium.libplanet?branchName=main)][Azure Pipelines]
 [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][Codecov]
 [![NuGet](https://img.shields.io/nuget/v/Libplanet.svg?style=flat)][NuGet]
 [![NuGet (prerelease)](https://img.shields.io/nuget/vpre/Libplanet.svg?style=flat)][NuGet]
@@ -31,6 +32,7 @@ To learn more about why Planetarium is creating technology for fully
 decentralized games, please refer to our [blog post].
 
 [Discord]: https://discord.gg/planetarium
+[CircleCI]: https://app.circleci.com/pipelines/github/planetarium/libplanet
 [Azure Pipelines]: https://dev.azure.com/planetarium/libplanet/_build?definitionId=3&_a=summary&repositoryFilter=3&branchFilter=622%2C622%2C622%2C622
 [Codecov]: https://codecov.io/gh/planetarium/libplanet
 [NuGet]: https://www.nuget.org/packages/Libplanet/


### PR DESCRIPTION
I've experimented with [CircleCI] for more than a week to evaluate it as a candidate for Azure Pipeline replacement.

The motivation was the deep-seated flakiness of our test suite and slow build time on CI (see also #1547), but an article on *Google Testing Blog* made me to try an alternative CI service: [*Where do our flaky tests come from?*][1] (by Jeff Listfield).  According to the article, memory consumption has the strong effect of flakiness on tests.  Although it's unsure which is the problem, a shortage of RAM or consuming memory in itself, I've supposed the former would be a cause of flakiness, at least in our test suite.

The problem with Azure Pipelines is the fact that [they give us only (?) 7 GB of RAM except for macOS runners which have 14 GB of RAM.][2][^1]  Unfortunately, they apparently offer no option to scale memory of worker nodes, at least for Microsoft-hosted runners.  Even though they also offer a way to use self-hosted runners, self-hosted things are what I (and probably we) try to avoid at all cost.

So I surveyed several alternative hosted CI services that offer scalable RAM options, and I found CircleCI the most suitable for our needs as it offers:

- [vertical scale options for a single node][3]
- [diverse platforms including macOS and Windows][4]
- [horizontal scale options through parallel nodes][5]
- [comprehensive documentation in general][6]

One key difference in a brief workflow from Azure Pipelines is that the build jobs are separated from the test jobs in CircleCI:

- As .NET Core and Mono compilers do not offer a way to build a single project/solution in distributed nodes,[^2] I had to utilize the fastest (and the most expensive) single runner to make compiling the Libplanet solution fast.  We need two target frameworks to run tests, so two parallel build jobs run at first.  .NET Core SDK is used for `netcoreapp3.1`, and Mono is used for `net47`.

- On the other hand, running tests are easier to parallelize in the distributed nodes than compiling the code.  By reusing the assemblies built by the previous build job with an expensive runner, we don't need to compile them again in the test jobs.  Thanks to CircleCI's job-level parallelism, I managed to split the tests cases into few chunks and assign them to different parallel nodes.  As a result, tests run by relatively smaller but cheaper nodes.[^3]

The above change is for cost efficiency.  So I choose different sizes of runners for each job:

- Each build process is run on a single `xlarge`-sized Docker/Linux node.  Note that Docker/Linux is the executor that CircleCI spins up the fastest, and the cheapest for the equivalent performance among executors.
- Docker/Linux nodes seem always fast.  I assigned only 2 parallel `large`-sized Docker/Linux nodes to run tests with .NET Core on Linux.
- macOS nodes are not only slow, but CircleCI takes long time to spin them up[^4].  So I assigned 4 parallel `large`-sized nodes to run tests with .NET Core on macOS.
- Windows nodes are in the middle of above two types.  However, they also take long time to be ready.[^4]  I assigned 3 parallel nodes to run tests with .NET Core on Windows.
- Running tests with [Unity] is unstable yet, so I commented out them on macOS and Windows.  4 parallel Docker/Linux nodes are assigned to run tests with Unity.

The above size and the number of parallel nodes can be easily changed, and still need to be adjusted for the next few weeks.  Deactivated tests with Unity on macOS and Windows also need to be turned on soon.

Even though there are still failed jobs due to some flaky tests, I found it more fast and less fragile than before:

![](https://user-images.githubusercontent.com/12431/140461121-64882d67-4c83-46a4-993b-0f3ac7d45506.png)

All settings for Azure Pipelines still remain.  For few weeks, we need to adjust the detailed configuration of CircleCI and the evaluate how suitable for the project, and decide if we should completely turn it into CircleCI or look for other alternatives. (Or remain in Azure Pipelines?)

[^1]: Actually, the reason why I got a gut feeling that a shortage of RAM causes a lot of flaky tests was the same test suite seemed less flaky on their macOS runners, which have double of their Linux & Windows runners.

[^2]: In the same manner to [distcc] for C/C++.

[^3]: It's still faster than Microsoft-hosted runners that Azure Pipelines & GitHub Actions provide.

[^4]: It takes only 5 seconds when it's good.  However, it usually takes more than 30 seconds and even can be up to 3 minutes.  We need to file a support ticket, or might need to pay more.

[CircleCI]: https://circleci.com/
[1]: https://testing.googleblog.com/2017/04/where-do-our-flaky-tests-come-from.html
[2]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted#hardware
[3]: https://circleci.com/docs/2.0/configuration-reference/#resourceclass
[4]: https://circleci.com/docs/2.0/executor-intro/
[5]: https://circleci.com/docs/2.0/parallelism-faster-jobs/
[6]: https://circleci.com/docs/2.0/
[Unity]: https://unity.com/
[distcc]: https://distcc.github.io/