### PR TITLE
fix(tool): handle redirected input

### DIFF
--- a/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
+++ b/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
@@ -10,6 +10,12 @@ namespace Libplanet.Extensions.Cocona
             var password = new StringBuilder();
 
             Console.Write(prompt);
+
+            if (Console.IsInputRedirected)
+            {
+                return Console.ReadLine();
+            }
+
             do
             {
                 var key = Console.ReadKey(true).KeyChar;


### PR DESCRIPTION
When you executed `planet apv sign` with password through input redirection (i.e. pipe),
it throws `System.InvalidOperationException` from `Console.ReadKey`.

So, this commit fixes it by catching the case.

For the test, you can run the below scenario in the main branch:

```
planet key create -p <PASSPHRASE>
echo <PASSPHRASE> | planet apv sign <KEY-ID> 1000
```

But it may seem to be useless because there is already `--passphrase` option. If you think like that, you can close this pull request.