### PR TITLE
Logging QoL improvements

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -157,7 +157,9 @@ namespace Libplanet.Blockchain
                 Store.SetCanonicalChainId(Id);
             }
 
-            _logger = Log.ForContext<BlockChain<T>>()
+            _logger = Log
+                .ForContext<BlockChain<T>>()
+                .ForContext("Source", $"[{nameof(BlockChain<T>)}] ")
                 .ForContext("CanonicalChainId", Id);
             ActionEvaluator = new ActionEvaluator<T>(
                 Policy.BlockAction,
@@ -998,7 +1000,8 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.EnterReadLock();
 
-                _logger.Debug("Finding branchpoint (locator: {Locator}).", locator);
+                _logger.Debug(
+                    "Finding a branchpoint with locator {LocatorHead}.", locator.FirstOrDefault());
                 foreach (BlockHash hash in locator)
                 {
                     if (_blocks.ContainsKey(hash)
@@ -1006,15 +1009,17 @@ namespace Libplanet.Blockchain
                         && hash.Equals(Store.IndexBlockHash(Id, block.Index)))
                     {
                         _logger.Debug(
-                            "Found the branchpoint (locator: {Locator}): {Hash}.",
-                            locator,
+                            "Found a branchpoint with locator {LocatorHead}: {Hash}.",
+                            locator.FirstOrDefault(),
                             hash
                         );
                         return hash;
                     }
                 }
 
-                _logger.Debug("Failed to find the branchpoint (locator: {Locator}).", locator);
+                _logger.Debug(
+                    "Failed to find a branchpoint locator {LocatorHead}.",
+                    locator.FirstOrDefault());
                 return null;
             }
             finally

--- a/Libplanet/Net/BlockCompletion.cs
+++ b/Libplanet/Net/BlockCompletion.cs
@@ -128,8 +128,8 @@ namespace Libplanet.Net
             if (block.PreviousHash is { } prevHash)
             {
                 _logger.Verbose(
-                    "The block #{BlockIndex} {BlockHash}'s previous block #{PreviousIndex} " +
-                    "{PreviousHash} is needed; add it to the queue...",
+                    "Block #{BlockIndex} {BlockHash}'s previous block " +
+                    "#{PreviousIndex} {PreviousHash} is needed; adding it to the queue...",
                     block.Index,
                     block.Hash,
                     block.Index - 1,
@@ -141,8 +141,8 @@ namespace Libplanet.Net
             if (_satisfiedBlocks.TryUpdate(block.Hash, true, false))
             {
                 _logger.Verbose(
-                    "Completed the block #{BlockIndex} {BlockHash}. " +
-                    "(Remained incomplete demands: {IncompleteDemands})",
+                    "Completed block #{BlockIndex} {BlockHash}. " +
+                    "(Remaining incomplete demands: {IncompleteDemands})",
                     block.Index,
                     block.Hash,
                     _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
@@ -153,8 +153,8 @@ namespace Libplanet.Net
             if (_satisfiedBlocks.ContainsKey(block.Hash))
             {
                 _logger.Verbose(
-                    "The block #{BlockIndex} {BlockHash} is already complete. " +
-                    "(Remained incomplete demands: {IncompleteDemands})",
+                    "Block #{BlockIndex} {BlockHash} is already complete. " +
+                    "(Remaining incomplete demands: {IncompleteDemands})",
                     block.Index,
                     block.Hash,
                     _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
@@ -163,8 +163,8 @@ namespace Libplanet.Net
             }
 
             _logger.Verbose(
-                "The block #{BlockIndex} {BlockHash} has never demanded. " +
-                "(Remained incomplete demands: {IncompleteDemands})",
+                "Block #{BlockIndex} {BlockHash} was never demanded. " +
+                "(Remaining incomplete demands: {IncompleteDemands})",
                 block.Index,
                 block.Hash,
                 _demands.Count + _satisfiedBlocks.Count(kv => !kv.Value)
@@ -246,7 +246,7 @@ namespace Libplanet.Net
 
                 yield return pair;
                 _logger.Verbose(
-                    "Completed a block {BlockIndex} {BlockHash} from {Peer}.",
+                    "Completed block #{BlockIndex} {BlockHash} from {Peer}.",
                     pair.Item1.Index,
                     pair.Item1.Hash,
                     pair.Item2
@@ -345,7 +345,7 @@ namespace Libplanet.Net
                         ct
                     );
                     using CancellationTokenRegistration ctr = timeoutToken.Register(() =>
-                        _logger.Debug("Timed out to wait a response from {Peer}.", peer)
+                        _logger.Debug("Timed out while waiting for a response from {Peer}.", peer)
                     );
                     CancellationToken linkedToken = linkedTokenSource.Token;
 
@@ -357,8 +357,7 @@ namespace Libplanet.Net
                         await foreach (Block<TAction> block in blocks)
                         {
                             _logger.Debug(
-                                "Downloaded a block #{BlockIndex} {BlockHash} " +
-                                "from {Peer}.",
+                                "Downloaded block #{BlockIndex} {BlockHash} from {Peer}.",
                                 block.Index,
                                 block.Hash,
                                 peer
@@ -389,13 +388,13 @@ namespace Libplanet.Net
 
                         _logger.Debug(
                             e,
-                            "Timed out to wait a response from {Peer}.",
+                            "Timed out while waiting for a response from {Peer}.",
                             peer
                         );
                     }
                     catch (Exception e)
                     {
-                        _logger.Error(e, "A blockFetcher job (peer: {Peer}) is failed.", peer);
+                        _logger.Error(e, "A blockFetcher job (peer: {Peer}) has failed.", peer);
                     }
                 }
                 finally

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -129,7 +129,7 @@ namespace Libplanet.Net.Messages
 
         /// <summary>
         /// <c>byte[]</c>-typed identity of the message.
-        /// If a message B is the reply of the message A,
+        /// If message B is a reply to message A,
         /// B's identity must be set to A's identity.
         /// </summary>
         public byte[]? Identity { get; set; }

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -42,7 +42,9 @@ namespace Libplanet.Net.Protocols
             _address = address;
             TableSize = tableSize;
             BucketSize = bucketSize;
-            _logger = Log.ForContext<RoutingTable>();
+            _logger = Log
+                .ForContext<RoutingTable>()
+                .ForContext("Source", $"[{nameof(RoutingTable)}] ");
 
             var random = new Random();
             _buckets = new KBucket[TableSize];
@@ -130,12 +132,12 @@ namespace Libplanet.Net.Protocols
             if (peer.Address.Equals(_address))
             {
                 throw new ArgumentException(
-                    "A peer is disallowed to remove itself to its routing table.",
+                    "A node is disallowed to remove itself from its routing table.",
                     nameof(peer)
                 );
             }
 
-            _logger.Debug("Removing peer {Peer} from routing table.", peer);
+            _logger.Debug("Removing peer {Peer} from the routing table.", peer);
             return BucketOf(peer).RemovePeer(peer);
         }
 
@@ -245,15 +247,12 @@ namespace Libplanet.Net.Protocols
             if (peer.Address.Equals(_address))
             {
                 throw new ArgumentException(
-                    "A peer is disallowed to add itself to its routing table.",
+                    "A node is disallowed to add itself to its routing table.",
                     nameof(peer)
                 );
             }
 
-            _logger.Debug(
-                "Adding a peer {Peer} to peer {Address}'s routing table...",
-                peer,
-                _address);
+            _logger.Debug("Adding peer {Peer} to the routing table...", peer);
             BucketOf(peer).AddPeer(peer, updated);
         }
 

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -350,7 +350,7 @@ namespace Libplanet.Net
                         SourcePeer = sourcePeer,
                     });
                     _logger.Debug(
-                        "Appended a block #{BlockIndex} {BlockHash} " +
+                        "Appended block #{BlockIndex} {BlockHash} " +
                         "to the workspace chain.",
                         block.Index,
                         block.Hash
@@ -359,7 +359,7 @@ namespace Libplanet.Net
 
                 tipCandidate = tempTip;
                 _logger.Debug(
-                    "TipCandidate: #{Index} {Block}",
+                    "TipCandidate: #{Index} {Hash}",
                     tipCandidate?.Index,
                     tipCandidate?.Hash);
 
@@ -557,7 +557,7 @@ namespace Libplanet.Net
             long actionsCount = 0, txsCount = 0, initHeight = branchpoint?.Index + 1 ?? 0;
             int count = 0, totalCount = (int)(workspace.Count - initHeight);
             DateTimeOffset executionStarted = DateTimeOffset.Now;
-            _logger.Debug("Starts to execute actions of {0} blocks.", totalCount);
+            _logger.Debug("Starting to execute actions of {BlockCount} blocks.", totalCount);
             var blockHashes = workspace.IterateBlockHashes((int)initHeight);
             foreach (BlockHash hash in blockHashes)
             {
@@ -576,7 +576,10 @@ namespace Libplanet.Net
                 actionsCount +=
                     transactions.Sum(tx => tx.Actions.Count);
 
-                _logger.Debug("Executed actions in the block {0}.", block.Hash);
+                _logger.Debug(
+                    "Executed actions in block #{Index} {Hash}.",
+                    block.Index,
+                    block.Hash);
                 progress?.Report(new ActionExecutionState()
                 {
                     TotalBlockCount = totalCount,
@@ -693,7 +696,7 @@ namespace Libplanet.Net
                 long receivedBlockCount = currentTipIndex - previousTipIndex;
 
                 const string startMsg =
-                    "{SessionId}: Starts " + nameof(SyncPreviousBlocksAsync) + "()...";
+                    "{SessionId}: Starting " + nameof(SyncPreviousBlocksAsync) + "()...";
                 _logger.Debug(startMsg, logSessionId);
                 FillBlocksAsyncStarted.Set();
                 synced = await SyncBlocksAsync(
@@ -729,7 +732,7 @@ namespace Libplanet.Net
                 )
                 {
                     _logger.Debug(
-                        "{SessionId}: Swap the chain {ChainIdA} for the chain {ChainIdB}...",
+                        "{SessionId}: Swapping chain {ChainIdA} with chain {ChainIdB}...",
                         logSessionId,
                         blockChain.Id,
                         synced.Id
@@ -739,10 +742,10 @@ namespace Libplanet.Net
                         render: true,
                         stateCompleters: null);
                     _logger.Debug(
-                        "{SessionId}: The chain {ChainIdB} replaced {ChainIdA}",
+                        "{SessionId}: Swapped chain {ChainIdA} with chain {ChainIdB}.",
                         logSessionId,
-                        synced.Id,
-                        blockChain.Id
+                        blockChain.Id,
+                        synced.Id
                     );
                 }
             }
@@ -803,10 +806,10 @@ namespace Libplanet.Net
                     if (!hashes.Any())
                     {
                         _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Peer {0} returned no hashes; ignored.",
+                            "{SessionId}/{SubSessionId}: Peer {Peer} returned no hashes; ignored.",
                             logSessionId,
                             subSessionId,
-                            peer.Address.ToHex()
+                            peer
                         );
                         return workspace;
                     }
@@ -827,7 +830,7 @@ namespace Libplanet.Net
                     if (tip is null || branchpoint.Equals(tip.Hash))
                     {
                         _logger.Debug(
-                            "{SessionId}/{SubSessionId}: It doesn't need to fork.",
+                            "{SessionId}/{SubSessionId}: No need to fork.",
                             logSessionId,
                             subSessionId
                         );
@@ -852,7 +855,7 @@ namespace Libplanet.Net
                     else
                     {
                         _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Needs to fork; trying to fork...",
+                            "{SessionId}/{SubSessionId}: Trying to fork...",
                             logSessionId,
                             subSessionId
                         );
@@ -908,7 +911,7 @@ namespace Libplanet.Net
                     await foreach (Block<T> block in blocks)
                     {
                         const string startMsg =
-                            "{SessionId}/{SubSessionId}: Try to append a block " +
+                            "{SessionId}/{SubSessionId}: Trying to append block " +
                             "#{BlockIndex} {BlockHash}...";
                         _logger.Debug(
                             startMsg,
@@ -935,8 +938,7 @@ namespace Libplanet.Net
                             SourcePeer = peer,
                         });
                         const string endMsg =
-                            "{SessionId}/{SubSessionId}: Block #{BlockIndex} {BlockHash} " +
-                            "was appended.";
+                            "{SessionId}/{SubSessionId}: Appended block #{BlockIndex} {BlockHash}.";
                         _logger.Debug(endMsg, logSessionId, subSessionId, block.Index, block.Hash);
                     }
 
@@ -947,7 +949,7 @@ namespace Libplanet.Net
                     if (receivedBlockCountCurrentLoop < FindNextHashesChunkSize && isEndedFirstTime)
                     {
                         _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Got {Blocks} blocks from Peer {Peer} " +
+                            "{SessionId}/{SubSessionId}: Got {Count} blocks from Peer {Peer} " +
                             "(tip: #{TipIndex} {TipHash})",
                             logSessionId,
                             subSessionId,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -157,7 +157,7 @@ namespace Libplanet.Net
             if (Running)
             {
                 _logger.Warning(
-                    "Swarm is scheduled to destruct, but NetMQTransport progress is still running."
+                    "Swarm is scheduled to destruct, but Transport progress is still running."
                 );
             }
         }
@@ -910,10 +910,10 @@ namespace Libplanet.Net
                         // FIXME: First value of totalBlocksToDownload is -1.
                         _logger.Verbose(
                             "Request block hashes to {Peer} (height: {PeerHeight}) using " +
-                            "locator {@Locator}... ({CurrentIndex}/{EstimatedTotalCount})",
+                            "locator {LocatorHead}... ({CurrentIndex}/{EstimatedTotalCount})",
                             peer,
                             peerIndex,
-                            locator.Select(h => h.ToString()),
+                            locator.FirstOrDefault(),
                             downloaded.Count,
                             totalBlockHashesToDownload
                         );

--- a/Libplanet/Net/TxCompletion.cs
+++ b/Libplanet/Net/TxCompletion.cs
@@ -82,8 +82,8 @@ namespace Libplanet.Net
             }
 
             _logger.Debug(
-                "Unaware transactions to receive: {@TxIds}.",
-                required.Select(txid => txid.ToString())
+                "Unaware transactions to receive: {TxIdCount}.",
+                required.Count
             );
 
             if (_txSyncTasks.ContainsKey(peer))
@@ -141,7 +141,7 @@ namespace Libplanet.Net
 
                                 _logger.Debug(
                                     "Received transaction {TxId} will not be staged " +
-                                    "since it does not follows policy.",
+                                    "since it does not follow policy.",
                                     tx.Id);
                                 _blockChain.StagePolicy.Ignore(_blockChain, tx.Id);
                                 return false;
@@ -157,7 +157,7 @@ namespace Libplanet.Net
                         {
                             _logger.Error(
                                 ite,
-                                "{TxId} will not be staged since it is invalid.",
+                                "Transaction {TxId} will not be staged since it is invalid.",
                                 tx.Id);
                         }
                     }
@@ -166,8 +166,8 @@ namespace Libplanet.Net
                     {
                         TxReceived.Set();
                         _logger.Debug(
-                            "Txs staged successfully: {@TxIds}",
-                            txs.Select(tx => tx.Id.ToString()));
+                            "{TxCount} txs staged successfully.",
+                            txs.Count);
 
                         // TODO: txs includes transaction which were ignored due to its nonce,
                         // which should not be re-broadcasted.
@@ -176,8 +176,8 @@ namespace Libplanet.Net
                     else
                     {
                         _logger.Information(
-                            "Failed to get transactions to stage: {@TxIds}",
-                            _requiredTxIds[peer].Select(txId => txId.ToString()));
+                            "Failed to get {TxIdCount} transactions to stage.",
+                            _requiredTxIds[peer].Count);
                     }
                 }
                 catch (Exception)


### PR DESCRIPTION
Aside from minor rephrasing here and there,
- `Source` property is added to `BlockChain<T>` and `RoutingTable` for easier `grep`ing.
  - Once again, this is not a proper solution, but only for practicality. In my opinion, unless we want to pour a significant amount of resource in making a proper usage of structured logging, this should help with surveying console output at a glance (for now).
- Tried to scrub listings of transaction `Id`s, block `Hash`s, and locator `Hash`s from `BlockChain<T>` and `Swarm<T>`.
  - Overly verbose logs related to `Message` seemed more detrimental than being helpful. If we really want to retain such information, level of logging for such messages should be lowered to `Verbose`, or handled at the `ITransport` layer.
