### PR TITLE
Use forked chain while syncing blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,14 @@ To be released.
 
 ### Behavioral changes
 
+ -  `Swarm<T>` became to append blocks to forked chain to avoid locking
+    the canonical chain while syncing recent blocks. [[#1606]]
+
 ### Bug fixes
 
 ### CLI tools
+
+[#1606]: https://github.com/planetarium/libplanet/pull/1606
 
 
 Version 0.21.0

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -193,6 +193,8 @@ namespace Libplanet.Net
             {
                 workspace.Id,
             };
+            workspace = workspace.Fork(workspace.Tip.Hash);
+            chainIds.Add(workspace.Id);
             bool renderActions = render;
             bool renderBlocks = true;
 


### PR DESCRIPTION
## 💭  What this pull request does

This pull request makes `Swarm<T>` sync recent blocks after forking the canonical chain to improve synchronism.

## 🖇️ Background

I got a report that he saw the canonical chain was locked often and it disturbs its performance, while developing Nine Chronicles RPC mode from @ipdae.

When the `Swarm<T>` was syncing blocks among other nodes, it has locked the canonical chain (write-lock) and has blocked reading something from the canonical chain.

In code, when to see `ProcessBlockDemand` in `Swarm.BlockSync`, it passes `BlockChain`, the canonical chain, directly. Currently, Nine Chronicles is in single miner mode so there may be no reorg and it appends new blocks directly without a fork and take a write lock.

https://github.com/planetarium/libplanet/blob/c8c056acdc3f2e52cd4973be93e2fb993bfed81d/Libplanet/Net/Swarm.BlockSync.cs#L630-L639

### Q. Are there some test codes or ways to raise the situation?

I tried to write codes like below but it couldn't catch the moment well. But, in static analytics by code, I thought it seems right. Of course, I can be wrong then please leave a comment without feeling hard 🙏🏻 .

```csharp
bool chainHadLocked = false;
var cts = new CancellationTokenSource();
_ = Task.Run(() => {
  while (!cts.IsCancellationRequested!) {
    chainHadLocked |= chain._rwlock.IsWriteLockHeld;
  }
}, cts.Token);

// Other codes

Assert.False(chainHadLocked);
```

And it doesn't seem to be a good way to write test code depending on internal implementation. 🤔 