### PR TITLE
Revert "Merge pull request #1606 from moreal/refactor/core/remove-lock"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,14 +18,9 @@ To be released.
 
 ### Behavioral changes
 
- -  `Swarm<T>` became to append blocks to forked chain to avoid locking
-    the canonical chain while syncing recent blocks. [[#1606]]
-
 ### Bug fixes
 
 ### CLI tools
-
-[#1606]: https://github.com/planetarium/libplanet/pull/1606
 
 
 Version 0.21.0


### PR DESCRIPTION
This reverts commit 2eb1e95b99e1ef94e955613ab9b40a750be8c8d0, reversing
changes made to c8c056acdc3f2e52cd4973be93e2fb993bfed81d.

----

Currently, the #1606 can break the node, unable to process preloading.