### PR TITLE
Upgrade Bencodex to 0.4.0-dev.20211123080042+d7f6c810

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,19 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `Transaction<T>.BytesLength` property.  [[#1609]]
+ -  Removed `Block<T>.BytesLength` property.  [[#1609]]
+ -  The types of `BlockChain<T>.MineBlock()` overloaded methods' `maxBlockBytes`
+    parameters became `long?` (were `int?`).  [[#1609]]
+ -  The type of `IBlockPolicy<T>.GetMaxBlockBytes(long)` method became `long`
+    (was `int`).  [[#1609]]
+ -  The type of `BlockPolicy<T>()` constructor's `getMaxBlockBytes` parameter
+    became `Func<long, long>?` (was `Func<long, int>?`).  [[#1609]]
+ -  The type of `InvalidBlockBytesLengthException()` constructor's `bytesLength`
+    parameter became `long` (was `int`).  [[#1609]]
+ -  The type of `InvalidBlockBytesLengthException.BytesLength` property became
+    `long` (was `int`).  [[#1609]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,9 +36,17 @@ To be released.
 
 ### Bug fixes
 
+### Dependencies
+
+ -  Upgraded *Bencodex* from 0.3.0 to
+    [0.4.0-dev.20211123080042+d7f6c810][Bencodex 0.4.0-dev.20211123080042].
+    [[#1609]]
+
 ### CLI tools
 
 [#1606]: https://github.com/planetarium/libplanet/pull/1606
+[#1609]: https://github.com/planetarium/libplanet/pull/1609
+[Bencodex 0.4.0-dev.20211123080042]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211123080042
 
 
 Version 0.21.0

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Analyzers.Tests
                 namespace SampleGame {
                     public class SampleAction : IAction {
                         public SampleAction() {}
-                        public IValue PlainValue => default(Null);
+                        public IValue PlainValue => Null.Value;
                         public void LoadPlainValue(IValue plainValue) {}
                         public IAccountStateDelta Execute(IActionContext context) {
                             new Random().Next();
@@ -112,7 +112,7 @@ namespace Libplanet.Analyzers.Tests
                 namespace SampleGame {
                     public class SampleAction : IAction {
                         public SampleAction() {}
-                        public IValue PlainValue => default(Null);
+                        public IValue PlainValue => Null.Value;
                         public void LoadPlainValue(IValue plainValue) {}
                         public IAccountStateDelta Execute(IActionContext context) {
                             // Following code should all fail:

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -407,10 +407,8 @@ If omitted (default) explorer only the local blockchain store.")]
             public int GetMaxTransactionsPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerBlock(index);
 
-            public int GetMaxBlockBytes(long index)
-            {
-                return _impl.GetMaxBlockBytes(index);
-            }
+            public long GetMaxBlockBytes(long index) =>
+                _impl.GetMaxBlockBytes(index);
 
             public long GetNextBlockDifficulty(BlockChain<NullAction> blocks)
             {

--- a/Libplanet.Explorer/GraphTypes/ActionType.cs
+++ b/Libplanet.Explorer/GraphTypes/ActionType.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Explorer.GraphTypes
 
             Field<NonNullGraphType<StringGraphType>>(
                 name: "Inspection",
-                resolve: ctx => ctx.Source.PlainValue.Inspection
+                resolve: ctx => ctx.Source.PlainValue.Inspect(loadAll: true)
             );
 
             Name = "Action";

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -29,11 +29,11 @@ namespace Libplanet.Tools.Tests
             using var stateKeyValueStoreB = new DefaultKeyValueStore(_pathB);
             _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
                 ImmutableDictionary<string, IValue>.Empty
-                    .Add("deleted", default(Null))
+                    .Add("deleted", Null.Value)
                     .Add("common", (Text)"before")).Commit();
             _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
                 ImmutableDictionary<string, IValue>.Empty
-                    .Add("created", default(Null))
+                    .Add("created", Null.Value)
                     .Add("common", (Text)"after")).Commit();
         }
 

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -150,7 +150,7 @@ namespace Libplanet.Tests.Action
         {
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             ITrie previousBlockStatesTrie = new MerkleTrie(keyValueStore);
-            previousBlockStatesTrie = previousBlockStatesTrie.Set(new byte[0], default(Null));
+            previousBlockStatesTrie = previousBlockStatesTrie.Set(new byte[0], Null.Value);
             var actionContext = new ActionContext(
                 signer: _address,
                 txid: _txid,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1087,7 +1087,7 @@ namespace Libplanet.Tests.Action
             public readonly Address MinerKey = new PrivateKey().ToAddress();
             public readonly Address BlockIndexKey = new PrivateKey().ToAddress();
 
-            public IValue PlainValue => default(Dictionary);
+            public IValue PlainValue => Dictionary.Empty;
 
             public void LoadPlainValue(IValue plainValue)
             {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -330,8 +330,8 @@ namespace Libplanet.Tests.Blockchain
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
-            int maxBytes = _blockChain.Policy.GetMaxBlockBytes(block.Index);
-            Assert.True(block.BytesLength > maxBytes);
+            long maxBytes = _blockChain.Policy.GetMaxBlockBytes(block.Index);
+            Assert.True(block.MarshalBlock().EncodingLength > maxBytes);
 
             var e = Assert.Throws<InvalidBlockBytesLengthException>(() =>
                 _blockChain.Append(block)

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Tests.Blockchain
                     privateKey: signingKey);
             _blockChainMinTx.StageTransaction(lightTx);
 
-            Func<long, int> getMaxBlockBytes = _blockChain.Policy.GetMaxBlockBytes;
+            Func<long, long> getMaxBlockBytes = _blockChain.Policy.GetMaxBlockBytes;
             Assert.Equal(1, _blockChain.Count);
             AssertBencodexEqual((Text)$"{GenesisMiner.ToAddress()}", _blockChain.GetState(default));
 
@@ -45,7 +45,7 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block = await _blockChain.MineBlock(minerA);
             Assert.True(_blockChain.ContainsBlock(block.Hash));
             Assert.Equal(2, _blockChain.Count);
-            Assert.True(block.BytesLength <= getMaxBlockBytes(block.Index));
+            Assert.True(block.MarshalBlock().EncodingLength <= getMaxBlockBytes(block.Index));
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()}",
                 _blockChain.GetState(default)
@@ -55,7 +55,9 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> anotherBlock = await _blockChain.MineBlock(minerB);
             Assert.True(_blockChain.ContainsBlock(anotherBlock.Hash));
             Assert.Equal(3, _blockChain.Count);
-            Assert.True(anotherBlock.BytesLength <= getMaxBlockBytes(anotherBlock.Index));
+            Assert.True(
+                anotherBlock.MarshalBlock().EncodingLength <= getMaxBlockBytes(anotherBlock.Index)
+            );
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",
                 _blockChain.GetState(default)
@@ -65,7 +67,7 @@ namespace Libplanet.Tests.Blockchain
                 await _blockChain.MineBlock(new PrivateKey(), append: false);
             Assert.False(_blockChain.ContainsBlock(block3.Hash));
             Assert.Equal(3, _blockChain.Count);
-            Assert.True(block3.BytesLength <= getMaxBlockBytes(block3.Index));
+            Assert.True(block3.MarshalBlock().EncodingLength <= getMaxBlockBytes(block3.Index));
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",
                 _blockChain.GetState(default)
@@ -96,14 +98,14 @@ namespace Libplanet.Tests.Blockchain
                 await _blockChain.MineBlock(new PrivateKey(), append: false);
             Assert.False(_blockChain.ContainsBlock(block4.Hash));
             _logger.Debug(
-                $"{nameof(block4)}.{nameof(block4.BytesLength)} = {0}",
-                block4.BytesLength
+                $"{nameof(block4)}: {0} bytes",
+                block4.MarshalBlock().EncodingLength
             );
             _logger.Debug(
                 $"{nameof(getMaxBlockBytes)}({nameof(block4)}.{nameof(block4.Index)}) = {0}",
                 getMaxBlockBytes(block4.Index)
             );
-            Assert.True(block4.BytesLength <= getMaxBlockBytes(block4.Index));
+            Assert.True(block4.MarshalBlock().EncodingLength <= getMaxBlockBytes(block4.Index));
             Assert.Equal(3, block4.Transactions.Count());
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",

--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Blockchain
                 : null;
         }
 
-        public int GetMaxBlockBytes(long index) => 1024 * 1024;
+        public long GetMaxBlockBytes(long index) => 1024 * 1024;
 
         public virtual HashAlgorithmType GetHashAlgorithm(long index) =>
             HashAlgorithmType.Of<SHA256>();

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -77,15 +76,6 @@ namespace Libplanet.Tests.Blocks
             var blockB = MineGenesis(algoGetter, timestamp: timestamp, transactions: txs);
 
             Assert.True(blockA.Transactions.SequenceEqual(blockB.Transactions));
-        }
-
-        [Fact]
-        public void BytesLength()
-        {
-            Assert.Equal(
-                new Codec().Encode(_fx.Genesis.MarshalBlock()).Length,
-                _fx.Genesis.BytesLength
-            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Common/Action/RandomAction.cs
+++ b/Libplanet.Tests/Common/Action/RandomAction.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Common.Action
             IAccountStateDelta states = context.PreviousStates;
             if (context.Rehearsal)
             {
-                return states.SetState(Address, default(Null));
+                return states.SetState(Address, Null.Value);
             }
 
             return states.SetState(Address, (Integer)context.Random.Next());

--- a/Libplanet.Tests/Fixtures/Arithmetic.cs
+++ b/Libplanet.Tests/Fixtures/Arithmetic.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Fixtures
         public IValue PlainValue => Bencodex.Types.Dictionary.Empty
             .Add(
                 "op",
-                Operator is OperatorType op ? new Text(op.ToString()) : (IValue)default(Null)
+                Operator is OperatorType op ? new Text(op.ToString()) : (IValue)Null.Value
             )
             .Add("operand", (IValue)new Bencodex.Types.Integer(Operand));
 

--- a/Libplanet.Tests/Net/AppProtocolVersionTest.cs
+++ b/Libplanet.Tests/Net/AppProtocolVersionTest.cs
@@ -127,7 +127,7 @@ namespace Libplanet.Tests.Net
 
             var claim3 = new AppProtocolVersion(
                 claim.Version,
-                default(Bencodex.Types.Null),
+                Bencodex.Types.Null.Value,
                 claim.Signature,
                 claim.Signer
             );

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2002,7 +2002,7 @@ namespace Libplanet.Tests.Net
 
         private class Sleep : IAction
         {
-            public IValue PlainValue => default(Null);
+            public IValue PlainValue => Null.Value;
 
             public IAccountStateDelta Execute(IActionContext context)
             {

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -17,13 +17,13 @@ namespace Libplanet.Tests.Store.Trie
             MerkleTrie trieA = new MerkleTrie(keyValueStore),
                 trieB = new MerkleTrie(keyValueStore);
 
-            trieA = (MerkleTrie)trieA.Set(new byte[] { 0x01, }, default(Null))
-                .Set(new byte[] { 0x02, }, default(Null))
-                .Set(new byte[] { 0x03, }, default(Null))
+            trieA = (MerkleTrie)trieA.Set(new byte[] { 0x01, }, Null.Value)
+                .Set(new byte[] { 0x02, }, Null.Value)
+                .Set(new byte[] { 0x03, }, Null.Value)
                 .Commit();
             trieB = (MerkleTrie)trieB.Set(new byte[] { 0x01, }, Dictionary.Empty)
-                .Set(new byte[] { 0x02, }, default(Null))
-                .Set(new byte[] { 0x04, }, default(Null))
+                .Set(new byte[] { 0x02, }, Null.Value)
+                .Set(new byte[] { 0x04, }, Null.Value)
                 .Commit();
 
             Dictionary<string, (HashDigest<SHA256> Root, IValue Value)[]> differentNodes =
@@ -47,10 +47,10 @@ namespace Libplanet.Tests.Store.Trie
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             MerkleTrie trie = new MerkleTrie(keyValueStore);
 
-            trie = (MerkleTrie)trie.Set(new byte[] { 0x01, }, default(Null))
-                    .Set(new byte[] { 0x02, }, default(Null))
-                    .Set(new byte[] { 0x03, }, default(Null))
-                    .Set(new byte[] { 0x04, }, default(Null))
+            trie = (MerkleTrie)trie.Set(new byte[] { 0x01, }, Null.Value)
+                    .Set(new byte[] { 0x02, }, Null.Value)
+                    .Set(new byte[] { 0x03, }, Null.Value)
+                    .Set(new byte[] { 0x04, }, Null.Value)
                     .Set(new byte[] { 0xbe, 0xef }, Dictionary.Empty);
 
             Dictionary<ImmutableArray<byte>, IValue> states =
@@ -59,10 +59,10 @@ namespace Libplanet.Tests.Store.Trie
                     pair => pair.Value,
                     new ImmutableArrayEqualityComparer<byte>());
             Assert.Equal(5, states.Count);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x01)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x02)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x03)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x04)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x01)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x02)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x03)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x04)]);
             Assert.Equal(Dictionary.Empty, states[ImmutableArray<byte>.Empty.Add(0xbe).Add(0xef)]);
 
             trie = (MerkleTrie)trie.Commit();
@@ -71,10 +71,10 @@ namespace Libplanet.Tests.Store.Trie
                 pair => pair.Value,
                 new ImmutableArrayEqualityComparer<byte>());
             Assert.Equal(5, states.Count);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x01)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x02)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x03)]);
-            Assert.Equal(default(Null), states[ImmutableArray<byte>.Empty.Add(0x04)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x01)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x02)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x03)]);
+            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x04)]);
             Assert.Equal(Dictionary.Empty, states[ImmutableArray<byte>.Empty.Add(0xbe).Add(0xef)]);
         }
     }

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Tests.Store.Trie
 
             merkleTrie = (MerkleTrie)merkleTrie.Set(
                 new byte[] { 0xbe, 0xef, },
-                Dictionary.Empty.Add(TestUtils.GetRandomBytes(32), default(Null)));
+                Dictionary.Empty.Add(TestUtils.GetRandomBytes(32), Null.Value));
             // There are (ShortNode, ValueNode)
             Assert.Equal(2, merkleTrie.IterateNodes().Count());
 

--- a/Libplanet.Tests/Store/Trie/Nodes/FullNodeTest.cs
+++ b/Libplanet.Tests/Store/Trie/Nodes/FullNodeTest.cs
@@ -16,8 +16,8 @@ namespace Libplanet.Tests.Store.Trie.Nodes
                     .Add(new ValueNode(Dictionary.Empty)).ToImmutableArray());
 
             var expected =
-                new List(Enumerable.Repeat<IValue>(default(Null), 16).ToImmutableArray()
-                    .Add(new List(new IValue[] { default(Null), Dictionary.Empty })));
+                new List(Enumerable.Repeat<IValue>(Null.Value, 16).ToImmutableArray()
+                    .Add(new List(new IValue[] { Null.Value, Dictionary.Empty })));
             var encoded = fullNode.ToBencodex();
             Assert.IsType<List>(encoded);
             Assert.Equal(expected.Count, ((List)encoded).Count);

--- a/Libplanet.Tests/Store/Trie/Nodes/NodeDecoderTest.cs
+++ b/Libplanet.Tests/Store/Trie/Nodes/NodeDecoderTest.cs
@@ -17,21 +17,21 @@ namespace Libplanet.Tests.Store.Trie.Nodes
             var list = new List(new IValue[]
             {
                 (Binary)hashA.ToByteArray(),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
-                default(Null),
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
+                Null.Value,
                 (Binary)hashB.ToByteArray(),
             });
             Assert.Equal(17, list.Count);
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Store.Trie.Nodes
         [InlineData(18)]
         public void DecodeInvalidFullNodeThrowsException(int listCount)
         {
-            var list = new List(Enumerable.Repeat((IValue)default(Null), listCount));
+            var list = new List(Enumerable.Repeat((IValue)Null.Value, listCount));
             Assert.Throws<InvalidTrieNodeException>(() => NodeDecoder.Decode(list));
         }
 
@@ -62,7 +62,7 @@ namespace Libplanet.Tests.Store.Trie.Nodes
             var list = new List(new IValue[]
             {
                 (Binary)ByteUtil.ParseHex("beef").ToArray(),
-                new List(new IValue[] { default(Null), (Text)"beef", }),
+                new List(new IValue[] { Null.Value, (Text)"beef", }),
             });
 
             INode node = NodeDecoder.Decode(list);

--- a/Libplanet.Tests/Store/Trie/Nodes/ShortNodeTest.cs
+++ b/Libplanet.Tests/Store/Trie/Nodes/ShortNodeTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Store.Trie.Nodes
                 new List(new IValue[]
                 {
                     (Binary)ByteUtil.ParseHex("beef"),
-                    new List(new IValue[] { default(Null), (Text)"foo" }),
+                    new List(new IValue[] { Null.Value, (Text)"foo" }),
                 });
             var encoded = shortNode.ToBencodex();
             Assert.IsType<List>(encoded);

--- a/Libplanet.Tests/Store/Trie/Nodes/ValueNodeTest.cs
+++ b/Libplanet.Tests/Store/Trie/Nodes/ValueNodeTest.cs
@@ -11,11 +11,11 @@ namespace Libplanet.Tests.Store.Trie.Nodes
         {
             var values = new IValue[]
             {
-                default(Null),
+                Null.Value,
                 (Binary)ByteUtil.ParseHex("beef"),
                 (Integer)0xbeef,
                 Dictionary.Empty,
-                default(List),
+                List.Empty,
             };
 
             foreach (var value in values)
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Store.Trie.Nodes
                 var valueNode = new ValueNode(value);
                 var expected = new List(new[]
                 {
-                    default(Null), value,
+                    Null.Value, value,
                 });
                 Assert.Equal(expected, valueNode.ToBencodex());
             }

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -89,7 +89,6 @@ namespace Libplanet.Tests.Tx
                 (stateStore, "RecordRehearsal"),
                 DumbAction.RehearsalRecords.Value
             );
-            Assert.Equal(338, tx.BytesLength);
         }
 
         [Fact]
@@ -323,7 +322,6 @@ namespace Libplanet.Tests.Tx
             };
 
             AssertBytesEqual(expected, _fx.Tx.Serialize(true));
-            Assert.Equal(expected.Length, _fx.Tx.BytesLength);
         }
 
         [Fact]
@@ -363,7 +361,6 @@ namespace Libplanet.Tests.Tx
             };
 
             AssertBytesEqual(expected, _fx.TxWithActions.Serialize(true));
-            Assert.Equal(expected.Length, _fx.TxWithActions.BytesLength);
         }
 
         [Fact]
@@ -427,7 +424,6 @@ namespace Libplanet.Tests.Tx
                 ),
                 tx.Id
             );
-            Assert.Equal(tx.BytesLength, bytes.Length);
         }
 
         [Fact]
@@ -535,7 +531,6 @@ namespace Libplanet.Tests.Tx
                 }),
                 tx.Actions[1].InnerAction.PlainValue
             );
-            Assert.Equal(bytes.Length, tx.BytesLength);
         }
 
         [Fact]

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -100,7 +100,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
         /// for which this constraint should apply.</param>
         /// <returns>The maximum length of a <see cref="Block{T}"/> in bytes to accept.</returns>
-        int GetMaxBlockBytes(long index);
+        long GetMaxBlockBytes(long index);
 
         /// <summary>
         /// Gets the <see cref="HashAlgorithmType"/> to use for block's proof-of-work.

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -239,7 +239,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                     return "[N/A]";
                 }
 
-                return action.PlainValue.Inspection
+                return action.PlainValue.Inspect(loadAll: true)
                     .Replace(" \n ", " ")
                     .Replace(" \n", " ")
                     .Replace("\n ", " ")

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Numerics;
 using System.Security.Cryptography;
-using Bencodex;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Tx;
@@ -25,10 +24,7 @@ namespace Libplanet.Blocks
         /// </summary>
         public const int CurrentProtocolVersion = BlockMetadata.CurrentProtocolVersion;
 
-        private static readonly Codec Codec = new Codec();
-
         private readonly PreEvaluationBlock<T> _preEvaluationBlock;
-        private int? _bytesLength;
 
         /// <summary>
         /// Creates a <see cref="Block{T}"/> instance by combining a block <paramref name="header"/>
@@ -150,12 +146,6 @@ namespace Libplanet.Blocks
 
         /// <inheritdoc cref="IBlockContent{T}.Transactions"/>
         public IReadOnlyList<Transaction<T>> Transactions => _preEvaluationBlock.Transactions;
-
-        /// <summary>
-        /// The bytes length in its serialized format.
-        /// </summary>
-        public int BytesLength =>
-            _bytesLength ?? (int)(_bytesLength = Codec.Encode(this.MarshalBlock()).Length);
 
         /// <summary>
         /// The <see cref="BlockHeader"/> of the block.

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -151,6 +151,26 @@ namespace Libplanet.Blocks
                 MarshalTransactions(block.Transactions)
             );
 
+        public static Dictionary AppendTxToMarshaledBlock<T>(
+            Dictionary marshaledBlock,
+            Transaction<T> tx
+        )
+            where T : IAction, new()
+        {
+            List marshaledTxs;
+            try
+            {
+                marshaledTxs = (List)marshaledBlock[TransactionsKey];
+            }
+            catch (KeyNotFoundException)
+            {
+                marshaledTxs = List.Empty;
+            }
+
+            marshaledTxs = marshaledTxs.Add(tx.ToBencodex(true));
+            return marshaledBlock.SetItem(TransactionsKey, (IValue)marshaledTxs);
+        }
+
         public static long UnmarshalBlockMetadataIndex(Dictionary marshaledMetadata) =>
             marshaledMetadata.GetValue<Integer>(IndexKey);
 

--- a/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
+++ b/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
@@ -6,8 +6,8 @@ using Libplanet.Blockchain.Policies;
 namespace Libplanet.Blocks
 {
     /// <summary>
-    /// An exception thrown when <see cref="Block{T}.BytesLength"/>
-    /// does not follow the constraint provided by <see cref="IBlockPolicy{T}"/>.
+    /// An exception thrown when a <see cref="Block{T}"/>'s encoded bytes exceeds
+    /// <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>.
     /// </summary>
     [Serializable]
     public sealed class InvalidBlockBytesLengthException : BlockPolicyViolationException
@@ -16,9 +16,9 @@ namespace Libplanet.Blocks
         /// Initializes a new instance of <see cref="InvalidBlockBytesLengthException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        /// <param name="bytesLength">The invalid <see cref="Block{T}.BytesLength"/>
-        /// according to <see cref="IBlockPolicy{T}"/>.</param>
-        public InvalidBlockBytesLengthException(string message, int bytesLength)
+        /// <param name="bytesLength">The actual length of the <see cref="Block{T}"/>'s encoded
+        /// bytes.</param>
+        public InvalidBlockBytesLengthException(string message, long bytesLength)
             : base(message)
         {
             BytesLength = bytesLength;
@@ -27,11 +27,15 @@ namespace Libplanet.Blocks
         private InvalidBlockBytesLengthException(SerializationInfo info, StreamingContext context)
             : base(info.GetString(nameof(Message)) ?? string.Empty)
         {
-            BytesLength = info.GetInt32(nameof(BytesLength));
+            BytesLength = info.GetInt64(nameof(BytesLength));
         }
 
-        public int BytesLength { get; private set; }
+        /// <summary>
+        /// The actual length of the <see cref="Block{T}"/>'s encoded bytes.
+        /// </summary>
+        public long BytesLength { get; private set; }
 
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -62,7 +62,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.3.0" />
+    <PackageReference Include="Bencodex" Version="0.4.0-dev.20211123080042+d7f6c810" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="Equals.Fody" Version="4.0.1" />

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -216,7 +216,7 @@ namespace Libplanet.Store
             {
                 const string msg = nameof(TxExecution) +
                     " must be serialized as a Bencodex dictionary, not {ActualValue}.";
-                logger?.Error(msg, decoded.Inspection);
+                logger?.Error(msg, decoded.Inspect(false));
                 return null;
             }
 

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Store.Trie
         static MerkleTrie()
         {
             _codec = new Codec();
-            var bxNull = _codec.Encode(default(Null)!);
+            var bxNull = _codec.Encode(Null.Value!);
             EmptyRootHash = HashDigest<SHA256>.DeriveFrom(bxNull);
         }
 
@@ -310,8 +310,9 @@ namespace Libplanet.Store.Trie
                     return Insert(hn, prefix, key, value);
 
                 default:
-                    throw new InvalidTrieNodeException("Not supported node came." +
-                                                       $" raw: {node.ToBencodex().Inspection}");
+                    throw new InvalidTrieNodeException(
+                        $"Unsupported node value: {node.ToBencodex().Inspect(false)}"
+                    );
             }
         }
 
@@ -423,7 +424,8 @@ namespace Libplanet.Store.Trie
 
                 default:
                     throw new InvalidTrieNodeException(
-                        $"Invalid node: raw: {node.ToBencodex().Inspection}");
+                        $"Invalid node value: {node.ToBencodex().Inspect(false)}"
+                    );
             }
         }
 

--- a/Libplanet/Store/Trie/Nodes/BaseNode.cs
+++ b/Libplanet/Store/Trie/Nodes/BaseNode.cs
@@ -23,6 +23,7 @@ namespace Libplanet.Store.Trie.Nodes
 
         public byte[] Serialize() => _codec.Encode(ToBencodex());
 
+        /// <inheritdoc cref="INode.ToBencodex()"/>
         public abstract IValue ToBencodex();
     }
 }

--- a/Libplanet/Store/Trie/Nodes/FullNode.cs
+++ b/Libplanet/Store/Trie/Nodes/FullNode.cs
@@ -83,9 +83,8 @@ namespace Libplanet.Store.Trie.Nodes
             return Children.GetHashCode();
         }
 
-        public override IValue ToBencodex()
-        {
-            return new List(Children.Select(child => child?.ToBencodex() ?? default(Null)));
-        }
+        /// <inheritdoc cref="INode.ToBencodex()"/>
+        public override IValue ToBencodex() =>
+            new List(Children.Select(child => child?.ToBencodex() ?? Null.Value));
     }
 }

--- a/Libplanet/Store/Trie/Nodes/HashNode.cs
+++ b/Libplanet/Store/Trie/Nodes/HashNode.cs
@@ -28,10 +28,9 @@ namespace Libplanet.Store.Trie.Nodes
             return HashDigest.ToByteArray();
         }
 
-        public IValue ToBencodex()
-        {
-            return (Binary)HashDigest.ToByteArray();
-        }
+        /// <inheritdoc cref="INode.ToBencodex()"/>
+        public IValue ToBencodex() =>
+            new Binary(HashDigest.ToByteArray());
 
         public override int GetHashCode()
         {

--- a/Libplanet/Store/Trie/Nodes/NodeDecoder.cs
+++ b/Libplanet/Store/Trie/Nodes/NodeDecoder.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
@@ -35,7 +34,7 @@ namespace Libplanet.Store.Trie.Nodes
 
                     default:
                         throw new InvalidTrieNodeException(
-                            $"Can't decode a node from the bencodex value: {value.Inspection}");
+                            $"Can't decode a node from the bencodex value: {value.Inspect(false)}");
                 }
             }
 
@@ -73,7 +72,7 @@ namespace Libplanet.Store.Trie.Nodes
             switch (value)
             {
                 case List list:
-                    if (EstimateSize(list) > HashDigest<SHA256>.Size)
+                    if (list.EncodingLength > HashDigest<SHA256>.Size)
                     {
                         throw new InvalidTrieNodeException("Invalid embedded node exists.");
                     }
@@ -96,17 +95,6 @@ namespace Libplanet.Store.Trie.Nodes
             }
 
             throw new InvalidTrieNodeException("Failed to decode reference node or embedded node.");
-        }
-
-        private static long EstimateSize(IValue value)
-        {
-            long size = 0;
-            foreach (var chunk in value.EncodeIntoChunks())
-            {
-                size += chunk.Length;
-            }
-
-            return size;
         }
     }
 }

--- a/Libplanet/Store/Trie/Nodes/ShortNode.cs
+++ b/Libplanet/Store/Trie/Nodes/ShortNode.cs
@@ -1,8 +1,6 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Bencodex.Types;
 
 namespace Libplanet.Store.Trie.Nodes
@@ -50,15 +48,8 @@ namespace Libplanet.Store.Trie.Nodes
             }
         }
 
-        public override IValue ToBencodex()
-        {
-            var list = new List<IValue>
-            {
-                (Bencodex.Types.Binary)Key.ToArray(),
-                Value!.ToBencodex(),
-            };
-
-            return new Bencodex.Types.List(list);
-        }
+        /// <inheritdoc cref="INode.ToBencodex()"/>
+        public override IValue ToBencodex() =>
+            new Bencodex.Types.List(new Binary(Key), Value!.ToBencodex());
     }
 }

--- a/Libplanet/Store/Trie/Nodes/ValueNode.cs
+++ b/Libplanet/Store/Trie/Nodes/ValueNode.cs
@@ -29,10 +29,9 @@ namespace Libplanet.Store.Trie.Nodes
             return codec.Encode(ToBencodex());
         }
 
-        public IValue ToBencodex()
-        {
-            return new List(new IValue[] { default(Null)!, Value });
-        }
+        /// <inheritdoc cref="INode.ToBencodex()"/>
+        public IValue ToBencodex() =>
+            new List(Null.Value, Value);
 
         public override int GetHashCode() => Value?.GetHashCode() ?? 0;
     }


### PR DESCRIPTION
Upgrade Bencodex from 0.3.0 to 0.4.0-dev.20211123080042+d7f6c810, to take advantage of its recent performance improvement: <https://github.com/planetarium/bencodex.net/pull/54>.

It also get rid of `Block<T>.BytesLength` and `Transaction<T>.BytesLength`, as now we can find the number of bytes needed for encoding a Bencodex value before encoding it through `IValue.EncodingLength` property: <https://github.com/planetarium/bencodex.net/pull/49>.