### PR TITLE
Bad tip expiration for pulling blocks fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,18 @@ Version 0.21.1
 
 To be released.
 
+### Behavioral changes
+
+ -  The default lifespan for a tip going stale is now `60` seconds instead of
+    `30` seconds for the purpose of polling blocks.  [[#1614]]
+
+### Bug fixes
+
+ -  Internal logic for determining when the tip becomes stale is now fixed.
+    [[#1614]]
+
+[#1614]: https://github.com/planetarium/libplanet/pull/1614
+
 
 Version 0.21.0
 --------------

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
-using Libplanet.Store;
 using Libplanet.Tx;
 using Nito.AsyncEx;
 
@@ -155,11 +154,11 @@ namespace Libplanet.Net
                     lastUpdated = DateTimeOffset.UtcNow;
                     lastTip = BlockChain.Tip;
                 }
-                else if (lastUpdated + tipLifespan > DateTimeOffset.UtcNow)
+                else if (lastUpdated + tipLifespan < DateTimeOffset.UtcNow)
                 {
                     _logger.Debug(
-                        "The tip #{TipIndex} {TipHash} is expired (last updated: {LastUpdated}); " +
-                        "pull blocks from neighbor peers...",
+                        "Tip #{TipIndex} {TipHash} has expired (last updated: {LastUpdated}); " +
+                        "pulling blocks from neighbor peers...",
                         lastTip.Index,
                         lastTip.Hash,
                         lastUpdated

--- a/Libplanet/Net/SwarmOptions.cs
+++ b/Libplanet/Net/SwarmOptions.cs
@@ -128,7 +128,7 @@ namespace Libplanet.Net
         /// for the configured lifespan, <see cref="Swarm{T}"/> pulls new blocks from neighbor
         /// peers.
         /// </summary>
-        public TimeSpan TipLifespan { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan TipLifespan { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// The type of <see cref="ITransport"/> used in <see cref="Swarm{T}"/>.


### PR DESCRIPTION
Inequality inside `Swarm<T>.PollBlocksAsync()` determining whether tip has become stale was set up to act oppositely to what was intended. This would've resulted in not polling properly once tip has actually gone stale unless tip is changed by a push from another node.

Also, changed the polling interval to `60` seconds.