### PR TITLE
Refactor/transport initialization

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -563,11 +563,12 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public void CanResolveEndPoint()
+        public async Task CanResolveEndPoint()
         {
             var expected = new DnsEndPoint("1.2.3.4", 5678);
             using (Swarm<DumbAction> s = CreateSwarm(host: "1.2.3.4", listenPort: 5678))
             {
+                await ((TcpTransport)s.Transport).Initialize();
                 Assert.Equal(expected, s.EndPoint);
                 Assert.Equal(expected, (s.AsPeer as BoundPeer)?.EndPoint);
             }

--- a/Libplanet.Tests/Net/Transports/TransportTest.cs
+++ b/Libplanet.Tests/Net/Transports/TransportTest.cs
@@ -145,6 +145,7 @@ namespace Libplanet.Tests.Net.Transports
                 Assert.IsType<BoundPeer>(peer);
                 Assert.Equal(privateKey.ToAddress(), peer.Address);
 
+                await InitializeAsync(boundTransport);
                 peer = boundTransport.AsPeer;
                 Assert.IsType<BoundPeer>(peer);
                 var boundPeer = (BoundPeer)peer;

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Net.Transports
         /// <summary>
         /// The list of tasks invoked when a message that is not
         /// a reply is received. To handle reply, please use <see cref=
-        /// "SendMessageWithReplyAsync(BoundPeer,Message,TimeSpan?,CancellationToken)"/>.
+        /// "SendMessageWithReplyAsync(BoundPeer, Message, TimeSpan?, CancellationToken)"/>.
         /// </summary>
         AsyncDelegate<Message> ProcessMessageHandler { get; }
 

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -31,8 +31,7 @@ namespace Libplanet.Net.Transports
 
         // TURN Permission lifetime was defined in RFC 5766
         // see also https://tools.ietf.org/html/rfc5766#section-8
-        private static readonly TimeSpan TurnPermissionLifetime =
-            TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan TurnPermissionLifetime = TimeSpan.FromMinutes(5);
 
         private readonly RoutingTable _table;
         private readonly PrivateKey _privateKey;
@@ -53,9 +52,10 @@ namespace Libplanet.Net.Transports
         private CancellationTokenSource _runtimeCancellationTokenSource;
         private CancellationTokenSource _turnCancellationTokenSource;
 
-        private DnsEndPoint? _hostEndPoint;
         private TcpListener _listener;
+        private int _listenPort;
         private TurnClient? _turnClient;
+        private DnsEndPoint? _hostEndPoint;
 
         private bool _disposed;
 
@@ -75,6 +75,12 @@ namespace Libplanet.Net.Transports
                 .ForContext<TcpTransport>()
                 .ForContext("Source", nameof(TcpTransport));
 
+            if (host is null && !iceServers.Any())
+            {
+                throw new ArgumentException(
+                    $"Swarm requires either {nameof(host)} or {nameof(iceServers)}.");
+            }
+
             _runningEvent = null!;
             Running = false;
 
@@ -83,31 +89,16 @@ namespace Libplanet.Net.Transports
             _appProtocolVersion = appProtocolVersion;
             _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
             _host = host;
+            _iceServers = iceServers.ToList();
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
-            _iceServers = iceServers?.ToList();
             _minimumBroadcastTarget = minimumBroadcastTarget;
             _messageCodec = new TcpMessageCodec(messageLifespan);
             _streams = new ConcurrentDictionary<Guid, ReplyStream>();
-
-            if (!(_host is null) && listenPort is { } listenPortAsInt)
-            {
-                _hostEndPoint = new DnsEndPoint(_host, listenPortAsInt);
-            }
-
-            if (_host == null && (_iceServers == null || !_iceServers.Any()))
-            {
-                throw new ArgumentException(
-                    $"Swarm requires either {nameof(host)} or " +
-                    $"{nameof(iceServers)}."
-                );
-            }
-
-            _logger = Log
-                .ForContext<TcpTransport>()
-                .ForContext("Source", $"[{nameof(TcpTransport)}] ");
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
-            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, listenPort ?? 0));
+            _listenPort = listenPort ?? 0;
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, _listenPort));
+
             ProcessMessageHandler = new AsyncDelegate<Message>();
             MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
         }
@@ -159,31 +150,12 @@ namespace Libplanet.Net.Transports
                 throw new TransportException("Transport is already running.");
             }
 
-            _listener.Start(ListenerBacklog);
-            int listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            await Initialize(cancellationToken);
 
-            _logger.Information("Listen on {Port}", listenPort);
             _runtimeCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _turnCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-            if (_host is null && !(_iceServers is null))
-            {
-                _turnClient = await IceServer.CreateTurnClient(_iceServers);
-                await _turnClient.StartAsync(listenPort, cancellationToken);
-            }
-
-            if (_turnClient is null || !_turnClient.BehindNAT)
-            {
-                string? host = _host ?? PublicIPAddress?.ToString();
-                if (host is null)
-                {
-                    throw new TransportException("Host is null.");
-                }
-
-                _hostEndPoint = new DnsEndPoint(host, listenPort);
-            }
 
             List<Task> tasks = new List<Task>();
 
@@ -191,7 +163,7 @@ namespace Libplanet.Net.Transports
             tasks.Add(ProcessRuntime(_runtimeCancellationTokenSource.Token));
 
             Running = true;
-            _logger.Debug("Start to run. TurnClient: {Client}", _turnClient);
+            _logger.Debug("Started to run. TurnClient: {Client}", _turnClient);
 
             await await Task.WhenAny(tasks);
         }
@@ -505,6 +477,29 @@ namespace Libplanet.Net.Transports
                     "Failed to reply message {Message} with {Id}. Corresponding stream is removed.",
                     message,
                     id);
+            }
+        }
+
+        internal async Task Initialize(CancellationToken cancellationToken = default)
+        {
+            _listener.Start(ListenerBacklog);
+            _listenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            _logger.Information("Listening on {Port}...", _listenPort);
+
+            if (_host is { } host)
+            {
+                _hostEndPoint = new DnsEndPoint(host, _listenPort);
+            }
+            else if (_iceServers is { } iceServers)
+            {
+                _turnClient = await IceServer.CreateTurnClient(_iceServers);
+                await _turnClient.StartAsync(_listenPort, cancellationToken);
+                if (!_turnClient.BehindNAT)
+                {
+                    _hostEndPoint = new DnsEndPoint(
+                        _turnClient.PublicAddress.ToString(), _listenPort);
+                }
             }
         }
 

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -102,7 +102,9 @@ namespace Libplanet.Net.Transports
                 );
             }
 
-            _logger = Log.ForContext<TcpTransport>();
+            _logger = Log
+                .ForContext<TcpTransport>()
+                .ForContext("Source", $"[{nameof(TcpTransport)}] ");
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
             _listener = new TcpListener(new IPEndPoint(IPAddress.Any, listenPort ?? 0));
@@ -143,22 +145,6 @@ namespace Libplanet.Net.Transports
         internal IPAddress? PublicIPAddress => _turnClient?.PublicAddress;
 
         internal DnsEndPoint? EndPoint => _turnClient?.EndPoint ?? _hostEndPoint;
-
-        public void Dispose()
-        {
-            if (!_disposed)
-            {
-                _listener.Stop();
-                _runtimeCancellationTokenSource.Cancel();
-                _turnCancellationTokenSource.Cancel();
-
-                _runtimeCancellationTokenSource.Dispose();
-                _turnCancellationTokenSource.Dispose();
-                StopAllStreamsAsync().Wait();
-                Running = false;
-                _disposed = true;
-            }
-        }
 
         /// <inheritdoc cref="ITransport.StartAsync"/>
         public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -225,6 +211,22 @@ namespace Libplanet.Net.Transports
                 _turnCancellationTokenSource.Cancel();
                 await StopAllStreamsAsync();
                 Running = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _listener.Stop();
+                _runtimeCancellationTokenSource.Cancel();
+                _turnCancellationTokenSource.Cancel();
+
+                _runtimeCancellationTokenSource.Dispose();
+                _turnCancellationTokenSource.Dispose();
+                StopAllStreamsAsync().Wait();
+                Running = false;
+                _disposed = true;
             }
         }
 


### PR DESCRIPTION
Just some preparatory work for #1612.

Not sure if `host` overriding `iceServers`, if both are provided, is intended, although it looks a bit icky, but the logic is left intact. However, caching `null` values and juggling `DnsEndPoint` and `PublicIPAddress` with implicitly cached `null` is somewhat cleaned up.

In my opinion, it'd be better to offload `Initialize()` step to constructors, either via factory method or forcing synchronization through `Task.Run()`, but this happens to break too many tests. ☹️ 