### PR TITLE
Allow IValue for PolymorphicAction<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,9 @@ To be released.
 
  -  `InvalidMagicCookieException` and `InvalidTimestampException` can now
     be serialized and deserialized.  [[#1613]]
+ -  Fixed a bug where `PolymorphicAction<T>` had thrown `InvalidCastException`
+    when inner action's `.PlainValue` returns other value than
+    `Bencodex.Types.Dictionary`.  [[#1628]]
 
 ### Dependencies
 
@@ -69,6 +72,7 @@ To be released.
 [#1613]: https://github.com/planetarium/libplanet/pull/1613
 [#1625]: https://github.com/planetarium/libplanet/pull/1625
 [#1627]: https://github.com/planetarium/libplanet/pull/1627
+[#1628]: https://github.com/planetarium/libplanet/pull/1628
 [Libplanet.Stun]: https://www.nuget.org/packages/Libplanet.Stun/
 [Bencodex 0.4.0-dev.20211123080042]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211123080042
 [Caching.dll 1.4.0.1]: https://www.nuget.org/packages/Caching.dll/1.4.0.1

--- a/Libplanet.Tests/Action/PolymorphicActionTest.cs
+++ b/Libplanet.Tests/Action/PolymorphicActionTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -100,6 +101,47 @@ namespace Libplanet.Tests.Action
                 "Libplanet.Action.PolymorphicAction" +
                 "<Libplanet.Tests.Common.Action.DetectRehearsal>",
                 new PolymorphicAction<BaseAction>(new DetectRehearsal()).ToString());
+        }
+
+        [Fact]
+        public void TextPlainValue()
+        {
+            var a = new TextPlainValueAction("just string");
+            var pa = new PolymorphicAction<BaseAction>(a);
+
+            var plainValue = pa.PlainValue;
+#pragma warning disable 612
+            var newPa = new PolymorphicAction<BaseAction>();
+#pragma warning restore 612
+            newPa.LoadPlainValue(plainValue);
+            Assert.Equal("just string", (Text)newPa.InnerAction.PlainValue);
+        }
+
+        [ActionType("TextPlainValueAction")]
+        private class TextPlainValueAction : BaseAction
+        {
+            private string _value;
+
+            public TextPlainValueAction()
+            {
+            }
+
+            public TextPlainValueAction(string value)
+            {
+                _value = value;
+            }
+
+            public override IValue PlainValue => (Text)_value;
+
+            public override IAccountStateDelta Execute(IActionContext context)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void LoadPlainValue(IValue plainValue)
+            {
+                _value = (Text)plainValue;
+            }
         }
     }
 }

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -235,8 +235,7 @@ namespace Libplanet.Action
         {
             var typeStr = plainValue["type_id"];
             var innerAction = (T)Activator.CreateInstance(Types[(Text)typeStr]);
-            var values = (Dictionary)plainValue["values"];
-            innerAction.LoadPlainValue(values);
+            innerAction.LoadPlainValue(plainValue["values"]);
             InnerAction = innerAction;
         }
 


### PR DESCRIPTION
This PR lets allow `PolymorphicAction<T>.InnerAction.PlainValue` to `IValue` instead of concrete `Dictionary`.