### PR TITLE
Build on Apple Silicon (aarch64-apple-darwin)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Libplanet changelog
 Version 0.23.0
 --------------
 
-To be released.
+To be released.  The solution now can be built on Apple Silicon
+(aarch64-apple-darwin).
 
 ### Deprecated APIs
 
@@ -26,9 +27,17 @@ To be released.
  -  `KBucket.Head` and `KBucket.Tail` now properly return `null` if
     the bucket is empty instead of faulting.  [[#1631]]
 
+### Dependencies
+
+ -  Upgraded *Planetarium.RocksDbSharp* from 6.2.3 to
+    [6.2.4-planetarium][Planetarium.RocksDbSharp 6.2.4-planetarium].
+    [[#1635]]
+
 ### CLI tools
 
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
+[#1635]: https://github.com/planetarium/libplanet/pull/1635
+[Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium
 
 
 Version 0.22.0

--- a/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -17,6 +17,12 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>

--- a/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -17,6 +17,12 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
                              '$(BuildingByReSharper)'!='true'">
     <TargetFramework>net47</TargetFramework>

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -5,8 +5,14 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701,SA1118</NoWarn>
+    <NoWarn>NU1701,SA1118,SYSLIB0014</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
+++ b/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
@@ -7,6 +7,12 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
+    <PropertyGroup Condition="
+      '$([System.Runtime.InteropServices.RuntimeInformation]::
+        OSArchitecture.ToString())' == 'Arm64' ">
+      <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -9,6 +9,12 @@
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 
+    <PropertyGroup Condition="
+      '$([System.Runtime.InteropServices.RuntimeInformation]::
+        OSArchitecture.ToString())' == 'Arm64' ">
+      <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
         <TargetFramework>$(TestsTargetFramework)</TargetFramework>
     </PropertyGroup>

--- a/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -16,6 +16,12 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -23,6 +23,7 @@
   <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   <IsTestProject>false</IsTestProject>
   <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
 </PropertyGroup>
@@ -46,7 +47,7 @@
       runtime; build; native; contentfiles; analyzers; buildtransitive
     </IncludeAssets>
   </PackageReference>
-  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.3" />
+  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.4-planetarium" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>

--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -16,6 +16,12 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
-    <NoWarn>$(NoWarn);SA1401</NoWarn>
+    <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -16,6 +16,12 @@
     </AdditionalFiles>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
+
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -32,6 +32,12 @@
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
     <PackAsTool>true</PackAsTool>
     <AssemblyName>Libplanet.Tools</AssemblyName>


### PR DESCRIPTION
This fixes MSBuild files so that the entire project can be built and tested on Apple Silicon (aarch64-apple-darwin), commonly known as M1 series.

As Apple Silicon is supported since .NET 6, on these M1 Macs executable/test projects target `net6.0` instead of `netcoreapp3.1`.

It also bums the version of *Planetarium.RocksDbSharp* package from 6.2.3 to [6.2.4-planetarium](https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium) which contains prebuilt binaries for Apple Silicon (see also <https://github.com/planetarium/rocksdb-sharp/pull/6>).