### PR TITLE
Fragmented states on Merkle tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,13 @@ To be released.  The solution now can be built on Apple Silicon
 
 ### Behavioral changes
 
+ -  States became to take up much less space than before by reducing unnecessary
+    duplicate data.  Although this guarantees the backward compatibility with
+    the existing state store, in order to take complete effect of this
+    optimization, please replay your existing blockchain from the genesis block
+    with the empty store.  [[#1636]]
+
+
 ### Bug fixes
 
  -  `KBucket.Head` and `KBucket.Tail` now properly return `null` if
@@ -30,6 +37,9 @@ To be released.  The solution now can be built on Apple Silicon
 
 ### Dependencies
 
+ -  Upgraded *Bencodex* from 0.4.0-dev.20211123080042+d7f6c810 to
+    [0.4.0-dev.20211202015312+d837934e][Bencodex 0.4.0-dev.20211202015312].
+    [[#1636]]
  -  Upgraded *Planetarium.RocksDbSharp* from 6.2.3 to
     [6.2.4-planetarium][Planetarium.RocksDbSharp 6.2.4-planetarium].
     [[#1635]]
@@ -39,6 +49,7 @@ To be released.  The solution now can be built on Apple Silicon
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
 [#1635]: https://github.com/planetarium/libplanet/pull/1635
 [#1636]: https://github.com/planetarium/libplanet/pull/1636
+[Bencodex 0.4.0-dev.20211202015312]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211202015312
 [Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,6 @@ To be released.  The solution now can be built on Apple Silicon
     optimization, please replay your existing blockchain from the genesis block
     with the empty store.  [[#1636]]
 
-
 ### Bug fixes
 
  -  `KBucket.Head` and `KBucket.Tail` now properly return `null` if
@@ -38,7 +37,7 @@ To be released.  The solution now can be built on Apple Silicon
 ### Dependencies
 
  -  Upgraded *Bencodex* from 0.4.0-dev.20211123080042+d7f6c810 to
-    [0.4.0-dev.20211202015312+d837934e][Bencodex 0.4.0-dev.20211202015312].
+    [0.4.0-dev.20211205152306+db8d4e1b][Bencodex 0.4.0-dev.20211205152306].
     [[#1636]]
  -  Upgraded *Planetarium.RocksDbSharp* from 6.2.3 to
     [6.2.4-planetarium][Planetarium.RocksDbSharp 6.2.4-planetarium].
@@ -49,7 +48,7 @@ To be released.  The solution now can be built on Apple Silicon
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
 [#1635]: https://github.com/planetarium/libplanet/pull/1635
 [#1636]: https://github.com/planetarium/libplanet/pull/1636
-[Bencodex 0.4.0-dev.20211202015312]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211202015312
+[Bencodex 0.4.0-dev.20211205152306]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211205152306
 [Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,15 @@ To be released.  The solution now can be built on Apple Silicon
     the existing state store, in order to take complete effect of this
     optimization, please replay your existing blockchain from the genesis block
     with the empty store.  [[#1636]]
+ -  (Libplanet.Analyzers) Rule LAA1002 no more warns about enumerating sorted
+    sets/dictionaries:
+     -  `System.Collections.Generic.SortedDictionary<TKey, TValue>`
+     -  `System.Collections.Generic.SortedSet<T>`
+     -  `System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>`
+     -  `System.Collections.Immutable.ImmutableSortedSet<T>`
+     -  `Bencodex.Types.Dictionary` (which became to guarantee enumeration order
+        since [Bencodex 0.4.0-dev.20211116020419+abea0858][Bencodex
+        0.4.0-dev.20211116020419])
 
 ### Bug fixes
 
@@ -53,6 +62,7 @@ To be released.  The solution now can be built on Apple Silicon
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
 [#1635]: https://github.com/planetarium/libplanet/pull/1635
 [#1636]: https://github.com/planetarium/libplanet/pull/1636
+[Bencodex 0.4.0-dev.20211116020419]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211116020419
 [Bencodex 0.4.0-dev.20211205152306]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211205152306
 [Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@ To be released.  The solution now can be built on Apple Silicon
 
 ### Added APIs
 
+ -  Added `PreEvaluationBlock<T>.DetermineStateRootHash(BlockChain<T>,
+    StateCompleterSet<T>, out IImmutableDictionary<string, IValue>)` overloaded
+    method.  [[#1636]]
+ -  Added `PreEvaluationBlock<T>.DetermineStateRootHash(IAction?, IStateStore,
+    out IImmutableDictionary<string, IValue>)` overloaded method.  [[#1636]]
  -  Parameter `except` for `KBucket.GetRandomPeer()` now defaults to `null`.
     [[#1631]]
  -  Added `ArrayEqualityComparer<T>` class.  [[#1636]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ To be released.  The solution now can be built on Apple Silicon
 
  -  Parameter `except` for `KBucket.GetRandomPeer()` now defaults to `null`.
     [[#1631]]
+ -  Added `ArrayEqualityComparer<T>` class.  [[#1636]]
 
 ### Behavioral changes
 
@@ -37,6 +38,7 @@ To be released.  The solution now can be built on Apple Silicon
 
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
 [#1635]: https://github.com/planetarium/libplanet/pull/1635
+[#1636]: https://github.com/planetarium/libplanet/pull/1636
 [Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium
 
 

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -74,11 +74,25 @@ namespace Libplanet.Analyzers.Tests
         )]
         [InlineData(true, null, "char", "char[]", "new char[] { 'a', 'b', 'c' }")]
         [InlineData(
-            false,
+            true,
+            null,
+            "int",
+            "System.Collections.Generic.SortedSet<int>",
+            "new SortedSet<int> { 1, 2, 3 }"
+        )]
+        [InlineData(
+            true,
+            "string, int",
+            "System.Collections.Generic.KeyValuePair<string, int>",
+            "System.Collections.Generic.SortedDictionary<string, int>",
+            "new SortedDictionary<string, int> { [\"foo\"] = 1, [\"bar\"] = 2 }"
+        )]
+        [InlineData(
+            true,
             "Bencodex.Types.IKey, Bencodex.Types.IValue",
             "System.Collections.Generic.KeyValuePair<Bencodex.Types.IKey, Bencodex.Types.IValue>",
             "Bencodex.Types.Dictionary",
-            "new Bencodex.Types.Dictionary(new Dictionary<IKey, IValue> { })"
+            "Bencodex.Types.Dictionary.Empty.Add(\"foo\", 1).Add(\"bar\", 2)"
         )]
         public void LAA1002_DictionariesOrSetsShouldBeOrderedToEnumerate(
             bool pass,

--- a/Libplanet.Analyzers/rules/LAA1002.md
+++ b/Libplanet.Analyzers/rules/LAA1002.md
@@ -13,6 +13,18 @@ Applied interfaces are:
  -  `System.Collections.Immutable.IImmutableSet<V>`
  -  `System.Collections.IDictionary`
 
+However, the following containers are excepted as they are already sorted:
+
+ -  `System.Collections.Generic.SortedDictionary<K, V>`
+ -  `System.Collections.Generic.SortedSet<T>`
+ -  `System.Collections.Immutable.ImmutableSortedDictionary<K, V>`
+ -  `System.Collections.Immutable.ImmutableSortedSet<T>`
+ -  `Bencodex.Types.Dictionary` (which became to guarantee enumeration order
+    since [Bencodex 0.4.0-dev.20211116020419+abea0858][Bencodex
+    0.4.0-dev.20211116020419])
+
+[Bencodex 0.4.0-dev.20211116020419]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211116020419
+
 
 Examples
 --------

--- a/Libplanet.Tests/Misc/ArrayEqualityComparerTest.cs
+++ b/Libplanet.Tests/Misc/ArrayEqualityComparerTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Misc;
+using Xunit;
+
+namespace Libplanet.Tests.Misc
+{
+    public class ArrayEqualityComparerTest
+    {
+        private static readonly int[] ThreeInts = { 1, 2, 3 };
+        private static readonly int[] ThreeInts2 = { 1, 2, 3 };
+        private static readonly int[] DifferentInts = { 1, 2, 4 };
+        private static readonly int[] FourInts = { 1, 2, 3, 4 };
+        private static readonly int[] SignedInts = { -1, 2, -3 };
+        private readonly ArrayEqualityComparer<int> _comparer = new ArrayEqualityComparer<int>();
+        private readonly ArrayEqualityComparer<int> _absComparer =
+            new ArrayEqualityComparer<int>(new AbsIntComparer());
+
+        [Fact]
+        public void Nulls()
+        {
+            Assert.True(_comparer.Equals(null, null));
+            Assert.False(_comparer.Equals(null, ThreeInts));
+            Assert.False(_comparer.Equals(ThreeInts, null));
+            Assert.True(_absComparer.Equals(null, null));
+            Assert.False(_absComparer.Equals(null, ThreeInts));
+            Assert.False(_absComparer.Equals(ThreeInts, null));
+
+            Assert.Equal(0, _comparer.GetHashCode(null));
+            Assert.Equal(0, _absComparer.GetHashCode(null));
+        }
+
+        [Fact]
+        public void Equal()
+        {
+            Assert.True(_comparer.Equals(ThreeInts, ThreeInts2));
+            Assert.Equal(_comparer.GetHashCode(ThreeInts), _comparer.GetHashCode(ThreeInts2));
+            Assert.True(_absComparer.Equals(ThreeInts, ThreeInts2));
+            Assert.True(_absComparer.Equals(ThreeInts, SignedInts));
+            Assert.Equal(
+                _absComparer.GetHashCode(ThreeInts),
+                _absComparer.GetHashCode(ThreeInts2));
+            Assert.Equal(
+                _absComparer.GetHashCode(ThreeInts),
+                _absComparer.GetHashCode(SignedInts)
+            );
+        }
+
+        [Fact]
+        public void DifferentElements()
+        {
+            Assert.False(_comparer.Equals(ThreeInts, DifferentInts));
+            Assert.False(_comparer.Equals(ThreeInts, SignedInts));
+            Assert.False(_absComparer.Equals(ThreeInts, DifferentInts));
+
+            Assert.NotEqual(
+                _comparer.GetHashCode(ThreeInts),
+                _comparer.GetHashCode(DifferentInts)
+            );
+            Assert.NotEqual(
+                _comparer.GetHashCode(ThreeInts),
+                _comparer.GetHashCode(SignedInts)
+            );
+            Assert.NotEqual(
+                _absComparer.GetHashCode(ThreeInts),
+                _absComparer.GetHashCode(DifferentInts)
+            );
+        }
+
+        [Fact]
+        public void DifferentLengths()
+        {
+            Assert.False(_comparer.Equals(ThreeInts, FourInts));
+            Assert.NotEqual(_comparer.GetHashCode(ThreeInts), _comparer.GetHashCode(FourInts));
+
+            Assert.False(_absComparer.Equals(ThreeInts, FourInts));
+            Assert.NotEqual(
+                _absComparer.GetHashCode(ThreeInts),
+                _absComparer.GetHashCode(FourInts)
+            );
+        }
+
+        private class AbsIntComparer : EqualityComparer<int>
+        {
+            public override bool Equals(int x, int y) => Math.Abs(x) == Math.Abs(y);
+
+            public override int GetHashCode(int obj) => Math.Abs(obj);
+        }
+    }
+}

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -1,9 +1,13 @@
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using Bencodex.Types;
 using Libplanet.Store.Trie;
 using Libplanet.Store.Trie.Nodes;
 using Xunit;
+using static System.Linq.Enumerable;
+using static Libplanet.HashDigest<System.Security.Cryptography.SHA256>;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Store.Trie
 {
@@ -12,8 +16,7 @@ namespace Libplanet.Tests.Store.Trie
         [Fact]
         public void ConstructWithHashDigest()
         {
-            var hashDigest
-                = new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size));
+            var hashDigest = new HashDigest<SHA256>(GetRandomBytes(Size));
             var merkleTrie = new MerkleTrie(new MemoryKeyValueStore(), hashDigest);
             Assert.Equal(hashDigest, merkleTrie.Hash);
 
@@ -25,8 +28,7 @@ namespace Libplanet.Tests.Store.Trie
         [Fact]
         public void ConstructWithRootNode()
         {
-            var hashDigest
-                = new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size));
+            var hashDigest = new HashDigest<SHA256>(GetRandomBytes(Size));
             INode rootNode = new HashNode(hashDigest);
             var merkleTrie = new MerkleTrie(new MemoryKeyValueStore(), rootNode);
             Assert.Equal(hashDigest, merkleTrie.Hash);
@@ -41,13 +43,171 @@ namespace Libplanet.Tests.Store.Trie
 
             merkleTrie = (MerkleTrie)merkleTrie.Set(
                 new byte[] { 0xbe, 0xef, },
-                Dictionary.Empty.Add(TestUtils.GetRandomBytes(32), Null.Value));
+                Dictionary.Empty.Add(GetRandomBytes(32), Null.Value));
             // There are (ShortNode, ValueNode)
             Assert.Equal(2, merkleTrie.IterateNodes().Count());
 
             merkleTrie = (MerkleTrie)merkleTrie.Commit();
             // There are (HashNode, ShortNode, HashNode, ValueNode)
             Assert.Equal(4, merkleTrie.IterateNodes().Count());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Set(bool commit)
+        {
+            ITrie trie = new MerkleTrie(new MemoryKeyValueStore());
+            AssertBytesEqual(
+                FromString("1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"),
+                trie.Hash
+            );
+            Assert.False(trie.TryGet(new byte[] { 0xbe, 0xef }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            trie = trie.Set(new byte[] { 0xbe, 0xef, }, Null.Value);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString("16fc25f43edd0c2d2cb6e3cc3827576e57f4b9e04f8dc3a062c7fe59041f77bd"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out IValue got));
+            AssertBencodexEqual(Null.Value, got);
+            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            trie = trie.Set(new byte[] { 0xbe, 0xef }, new Boolean(true));
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString("4458796f4092b5ebfc1ffb3989e72edee228501e438080a12dea45591dc66d58"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            trie = trie.Set(new byte[] { 0x11, 0x22 }, List.Empty);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString("ab1359a2497453110a9c658dd3db45f282404fe68d8c8aca30856f395572284c"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(List.Empty, got);
+            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            trie = trie.Set(new byte[] { 0xaa, 0xbb }, new Text("hello world"));
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString("abb5759141f7af1c40f1b0993ba60073cf4227900617be9641373e5a097eaa3c"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(List.Empty, got);
+            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            AssertBencodexEqual(new Text("hello world"), got);
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            var longText = new Text(string.Join("\n", Range(0, 1000).Select(i => $"long str {i}")));
+            trie = trie.Set(new byte[] { 0xaa, 0xbb }, longText);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString(commit
+                    ? "56e5a39a726acba1f7631a6520ae92e20bb93ca3992a7b7d3542c6daee68e56d"
+                    : "ad9fb53a8f643bd308d7afea57a5d1796d6031b1df95bdd415fa69b44177d155"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(List.Empty, got);
+            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            AssertBencodexEqual(longText, got);
+            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+
+            trie = trie.Set(new byte[] { 0x12, 0x34 }, Dictionary.Empty);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString(commit
+                    ? "88d6375097fd03e6c30a129eb0030d938caeaa796643971ca938fbd27ff5e057"
+                    : "77d13e9d97033400ad31fcb0441819285b9165f6ea6ae599d85e7d7e24428feb"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(List.Empty, got);
+            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            AssertBencodexEqual(longText, got);
+            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            AssertBencodexEqual(Dictionary.Empty, got);
+
+            List complexList = List.Empty
+                .Add("Hello world")
+                .Add(Dictionary.Empty
+                    .Add("foo", 1)
+                    .Add("bar", 2)
+                    .Add(
+                        "lst",
+                        Range(0, 1000).Select(i => (IValue)new Text($"long str {i}"))))
+                .Add(new List(Range(0, 1000).Select(i => (IValue)new Text($"long str {i}"))));
+            trie = trie.Set(new byte[] { 0x11, 0x22 }, complexList);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString(commit
+                    ? "f29820df65c1d1a66b69a59b9fe3e21911bbd2d97a9f298853c529804bf84a26"
+                    : "586ba0ba5dfe07433b01fbf7611f95832bde07b8dc5669540ef8866f465bbb85"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(complexList, got);
+            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            AssertBencodexEqual(longText, got);
+            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            AssertBencodexEqual(Dictionary.Empty, got);
+
+            Dictionary complexDict = Dictionary.Empty
+                .Add("foo", 123)
+                .Add("bar", 456)
+                .Add("lst", Range(0, 1000).Select(i => (IValue)new Text($"long str {i}")))
+                .Add("cls", (IValue)complexList)
+                .Add(
+                    "dct",
+                    Dictionary.Empty
+                        .Add("abcd", Null.Value)
+                        .Add("efgh", false)
+                        .Add("ijkl", true)
+                        .Add("mnop", (IValue)new Binary("hello world", Encoding.ASCII))
+                        .Add("qrst", (IValue)complexList)
+                        .Add("uvwx", Dictionary.Empty));
+            trie = trie.Set(new byte[] { 0x12, 0x34 }, complexDict);
+            trie = commit ? trie.Commit() : trie;
+            AssertBytesEqual(
+                FromString(commit
+                    ? "1dabec2c0fea02af0182e9fee6c7ce7ad1a9d9bcfaa2cd80c2971bbce5272655"
+                    : "4783d18dfc8a2d4d98f722a935e45bd7fc1d0197fb4d33e62f734bfde968af39"),
+                trie.Hash
+            );
+            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            AssertBencodexEqual(new Boolean(true), got);
+            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            AssertBencodexEqual(complexList, got);
+            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            AssertBencodexEqual(longText, got);
+            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            AssertBencodexEqual(complexDict, got);
         }
     }
 }

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -62,7 +62,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.4.0-dev.20211123080042+d7f6c810" />
+    <PackageReference Include="Bencodex" Version="0.4.0-dev.20211202015312+d837934e" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -62,7 +62,7 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.4.0-dev.20211202015312+d837934e" />
+    <PackageReference Include="Bencodex" Version="0.4.0-dev.20211205152306+db8d4e1b" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />

--- a/Libplanet/Misc/ArrayEqualityComparer.cs
+++ b/Libplanet/Misc/ArrayEqualityComparer.cs
@@ -1,0 +1,99 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Libplanet.Misc
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> implementation to compare two arrays of the same
+    /// element type.  This compares the elements in the order of the array.
+    /// <para>The way to compare each element can be customized by specifying
+    /// the <see cref="ElementComparer"/>.</para>
+    /// </summary>
+    /// <typeparam name="T">The element type of the array.</typeparam>
+    public class ArrayEqualityComparer<T> : IEqualityComparer<T[]>
+        where T : IEquatable<T>
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ArrayEqualityComparer{T}"/>.
+        /// </summary>
+        /// <param name="elementComparer">Optionally customize the way to compare each element.
+        /// </param>
+        public ArrayEqualityComparer(IEqualityComparer<T>? elementComparer = null)
+        {
+            ElementComparer = elementComparer;
+        }
+
+        /// <summary>
+        /// Optionally customizes the way to compare each element.
+        /// </summary>
+        public IEqualityComparer<T>? ElementComparer { get; }
+
+        /// <inheritdoc cref="IEqualityComparer{T}.Equals(T, T)"/>
+        public bool Equals(T[]? x, T[]? y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+            else if (x is null || y is null)
+            {
+                return false;
+            }
+            else if (x.Length != y.Length)
+            {
+                return false;
+            }
+
+            if (ElementComparer is { } comparer)
+            {
+                for (long i = 0L; i < x.LongLength; i++)
+                {
+                    if (!comparer.Equals(x[i], y[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                for (long i = 0L; i < x.LongLength; i++)
+                {
+                    if (!x[i].Equals(y[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc cref="IEqualityComparer{T}.GetHashCode(T)"/>
+        public int GetHashCode(T[]? obj)
+        {
+            if (obj is null)
+            {
+                return 0;
+            }
+
+            int hash = 17;
+            if (ElementComparer is { } comparer)
+            {
+                foreach (T el in obj)
+                {
+                    hash = unchecked(hash * 31 + comparer.GetHashCode(el));
+                }
+            }
+            else
+            {
+                foreach (T el in obj)
+                {
+                    hash = unchecked(hash * 31 + el.GetHashCode());
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/Libplanet/Store/Trie/ITrieExtensions.cs
+++ b/Libplanet/Store/Trie/ITrieExtensions.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 
 namespace Libplanet.Store.Trie
 {
+    // FIXME: As it's not an interface, it should be renamed to TrieExtensions.
     internal static class ITrieExtensions
     {
         public static ITrie Set(this ITrie trie, IImmutableDictionary<byte[], IValue> values)

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -234,11 +234,8 @@ namespace Libplanet.Store.Trie
                 return fullNode;
             }
 
-            var serialized = _codec.Encode(fullNode.ToBencodex());
-            var nodeHash = HashDigest<SHA256>.DeriveFrom(serialized);
-            values[nodeHash.ToByteArray()] = serialized;
-
-            return new HashNode(nodeHash);
+            byte[] nodeHash = Encode(fullNode.ToBencodex(), values);
+            return new HashNode(new HashDigest<SHA256>(nodeHash));
         }
 
         private INode CommitShortNode(ShortNode shortNode, IDictionary<byte[], byte[]> values)
@@ -251,11 +248,8 @@ namespace Libplanet.Store.Trie
                 return shortNode;
             }
 
-            byte[] serialized = _codec.Encode(encoded);
-            HashDigest<SHA256> nodeHash = HashDigest<SHA256>.DeriveFrom(serialized);
-            values[nodeHash.ToByteArray()] = serialized;
-
-            return new HashNode(nodeHash);
+            byte[] nodeHash = Encode(encoded, values);
+            return new HashNode(new HashDigest<SHA256>(nodeHash));
         }
 
         private INode CommitValueNode(ValueNode valueNode, IDictionary<byte[], byte[]> values)
@@ -267,11 +261,16 @@ namespace Libplanet.Store.Trie
                 return valueNode;
             }
 
-            byte[] serialized = _codec.Encode(encoded);
-            var nodeHash = HashDigest<SHA256>.DeriveFrom(serialized);
-            values[nodeHash.ToByteArray()] = serialized;
+            byte[] nodeHash = Encode(encoded, values);
+            return new HashNode(new HashDigest<SHA256>(nodeHash));
+        }
 
-            return new HashNode(nodeHash);
+        private byte[] Encode(IValue value, IDictionary<byte[], byte[]> values)
+        {
+            byte[] serialized = _codec.Encode(value);
+            byte[] nodeHash = SHA256.Create().ComputeHash(serialized);
+            values[nodeHash] = serialized;
+            return nodeHash;
         }
 
         private INode Insert(

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
+using Libplanet.Misc;
 using Libplanet.Store.Trie.Nodes;
 
 namespace Libplanet.Store.Trie
@@ -120,7 +121,8 @@ namespace Libplanet.Store.Trie
                 return new MerkleTrie(KeyValueStore, new HashNode(EmptyRootHash));
             }
 
-            var values = new ConcurrentDictionary<byte[], byte[]>();
+            var values = new ConcurrentDictionary<byte[], byte[]>(
+                new ArrayEqualityComparer<byte>());
             var newRoot = Commit(Root, values);
 
             // It assumes embedded node if it's not HashNode.

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -23,9 +23,12 @@ namespace Libplanet.Store.Trie
     {
         public static readonly HashDigest<SHA256> EmptyRootHash;
 
-        private const long OffloadThresholdBytes = 512L;
+        private const long OffloadThresholdBytes = 256L;
 
-        private static Codec _codec;
+        private static readonly ConcurrentDictionary<Fingerprint, WeakReference<IValue>> _valueCache
+            = new ConcurrentDictionary<Fingerprint, WeakReference<IValue>>();
+
+        private static readonly Codec _codec;
 
         private readonly bool _secure;
 
@@ -132,10 +135,7 @@ namespace Libplanet.Store.Trie
             if (!(newRoot is HashNode))
             {
                 byte[] serialized = _codec.Encode(newRoot.ToBencodex());
-                KeyValueStore.Set(
-                    HashDigest<SHA256>.DeriveFrom(serialized).ToByteArray(),
-                    serialized
-                );
+                values[SHA256.Create().ComputeHash(serialized)] = serialized;
             }
 
             KeyValueStore.Set(values);
@@ -200,6 +200,17 @@ namespace Libplanet.Store.Trie
                         }
 
                         break;
+                }
+            }
+        }
+
+        private static void FreeValueCache()
+        {
+            foreach (KeyValuePair<Fingerprint, WeakReference<IValue>> kv in _valueCache)
+            {
+                if (!kv.Value.TryGetTarget(out _))
+                {
+                    _valueCache.TryRemove(kv.Key, out _);
                 }
             }
         }
@@ -269,7 +280,7 @@ namespace Libplanet.Store.Trie
 
         private HashNode Encode(IValue intermediateEncoding, IDictionary<byte[], byte[]> values)
         {
-            var offloadOptions = new OffloadOptions(values, KeyValueStore);
+            var offloadOptions = new OffloadOptions(OffloadThresholdBytes, values, KeyValueStore);
             byte[] serialized = _codec.Encode(intermediateEncoding, offloadOptions);
             byte[] fullEncoding = offloadOptions.Offloaded
                 ? _codec.Encode(intermediateEncoding)
@@ -446,8 +457,81 @@ namespace Libplanet.Store.Trie
             return NodeDecoder.Decode(intermediateEncoding);
         }
 
-        private IValue LoadIndirectValue(Fingerprint fp) =>
-            _codec.Decode(KeyValueStore.Get(fp.Serialize()), LoadIndirectValue);
+        private IValue LoadIndirectValue(Fingerprint fp)
+        {
+            if (fp.EncodingLength >= OffloadThresholdBytes &&
+                _valueCache.TryGetValue(fp, out WeakReference<IValue>? weakRef) &&
+                weakRef is { } w)
+            {
+                if (w.TryGetTarget(out IValue? cached) && cached is { } cachedValue)
+                {
+                    return cachedValue;
+                }
+
+                _valueCache.TryRemove(fp, out _);
+            }
+
+            if (fp.Kind != ValueKind.Dictionary)
+            {
+                FreeValueCache();
+                IValue v = _codec.Decode(KeyValueStore.Get(fp.Serialize()), LoadIndirectValue);
+                if (fp != v.Fingerprint)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to load an offloaded value." +
+                        $"\nExpected: {fp}\nActual:   {v.Fingerprint}\nLoaded:   {v}"
+                    );
+                }
+                else if (fp.EncodingLength >= OffloadThresholdBytes)
+                {
+                    _valueCache[fp] = new WeakReference<IValue>(v);
+                }
+
+                return v;
+            }
+
+            var pair = (List)_codec.Decode(KeyValueStore.Get(fp.Serialize()), LoadIndirectValue);
+            IEnumerable<IndirectValue> reprs =
+                pair.EnumerateIndirectValues(out IndirectValue.Loader? reprLoader);
+            Dictionary value;
+            if (reprLoader is { } l)
+            {
+                IndirectValue keysIv = reprs.First();
+                var keys = keysIv.LoadedValue is List lst ? lst : (List)keysIv.GetValue(l);
+                IEnumerable<KeyValuePair<IKey, IndirectValue>> indirectPairs = keys.Zip(
+                    reprs.Skip(1).Select(group => (List)group.GetValue(l)).SelectMany(vs =>
+                        vs.EnumerateIndirectValues(out _)
+                    ),
+                    (k, v) => new KeyValuePair<IKey, IndirectValue>((IKey)k, v)
+                );
+                value = new Dictionary(indirectPairs, l);
+            }
+            else
+            {
+                var keys = (List)pair[0];
+                IEnumerable<KeyValuePair<IKey, IValue>> pairs = keys.Zip(
+                    pair.Skip(1).SelectMany(group => (List)group),
+                    (k, v) => new KeyValuePair<IKey, IValue>((IKey)k, v)
+                );
+                value = new Dictionary(pairs);
+            }
+
+            if (fp != value.Fingerprint)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to load an offloaded value." +
+                    $"\nExpected: {fp}\nActual:   {value.Fingerprint}\nLoaded:   {value}"
+                );
+            }
+
+            FreeValueCache();
+            if (fp.EncodingLength >= OffloadThresholdBytes)
+            {
+                _valueCache[fp] = new WeakReference<IValue>(value);
+            }
+
+            return value;
+        }
 
         private byte[] ToKey(byte[] key)
         {
@@ -475,18 +559,25 @@ namespace Libplanet.Store.Trie
                 "SA1401:FieldsMustBePrivate",
                 Justification = "It's a private class and we want to get rid of runtime overhead.")]
             public bool Offloaded;
+
+            private readonly long _thresholdBytes;
             private readonly IDictionary<byte[], byte[]> _dirty;
             private readonly IKeyValueStore _store;
 
-            public OffloadOptions(IDictionary<byte[], byte[]> dirty, IKeyValueStore store)
+            public OffloadOptions(
+                long thresholdBytes,
+                IDictionary<byte[], byte[]> dirty,
+                IKeyValueStore store
+            )
             {
+                _thresholdBytes = thresholdBytes;
                 _dirty = dirty;
                 _store = store;
                 Offloaded = false;
             }
 
             public bool Embeds(in IndirectValue indirectValue) =>
-                indirectValue.EncodingLength < OffloadThresholdBytes;
+                indirectValue.EncodingLength < _thresholdBytes;
 
             public void Offload(in IndirectValue indirectValue, IndirectValue.Loader? loader)
             {
@@ -494,7 +585,65 @@ namespace Libplanet.Store.Trie
                 byte[] fp = indirectValue.Fingerprint.Serialize();
                 if (!_dirty.ContainsKey(fp) && !_store.Exists(fp))
                 {
-                    _dirty[fp] = _codec.Encode(indirectValue.GetValue(loader), this);
+                    IValue value = indirectValue.GetValue(loader);
+                    IValue repr = value;
+                    if (repr is Dictionary dict)
+                    {
+                        // For dictionaries, in order to reduce duplicate common keys (= schema),
+                        // they are encoded in [keys, [v, v', ...], [v'', v''', ...], ...] where
+                        // keys = [k, k', ...]  instead of [k, v, k', v', ...].
+                        // Keys and value groups can be offloaded too.
+                        const int groupSize = 5;
+                        var keys = new List<IKey>(dict.Count);
+                        var valueGroups =
+                            new IValue[1 + (int)Math.Ceiling((double)dict.Count / groupSize)];
+                        IEnumerable<KeyValuePair<IKey, IndirectValue>> pairs =
+                            dict.EnumerableIndirectPairs(out loader);
+                        if (loader is { } l)
+                        {
+                            var group = new List<IndirectValue>(groupSize);
+                            int g = 1;
+                            foreach (KeyValuePair<IKey, IndirectValue> pair in pairs)
+                            {
+                                keys.Add(pair.Key);
+                                group.Add(pair.Value);
+                                if (group.Count >= groupSize || keys.Count >= dict.Count)
+                                {
+                                    List valueGroup = new List(group, l);
+                                    group.Clear();
+                                    valueGroups[g] = valueGroup;
+                                    g++;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            var group = new List<IValue>(groupSize);
+                            int g = 1;
+                            foreach (KeyValuePair<IKey, IValue> pair in dict)
+                            {
+                                keys.Add(pair.Key);
+                                group.Add(pair.Value);
+                                if (group.Count >= groupSize || keys.Count >= dict.Count)
+                                {
+                                    List valueGroup = new List(group);
+                                    group.Clear();
+                                    valueGroups[g] = valueGroup;
+                                    g++;
+                                }
+                            }
+                        }
+
+                        valueGroups[0] = new List(keys);
+                        repr = new List(valueGroups);
+                    }
+
+                    _dirty[fp] = _codec.Encode(repr, this);
+                    if (!_valueCache.ContainsKey(indirectValue.Fingerprint))
+                    {
+                        FreeValueCache();
+                        _valueCache[indirectValue.Fingerprint] = new WeakReference<IValue>(value);
+                    }
                 }
             }
         }

--- a/Libplanet/Store/Trie/Nodes/BaseNode.cs
+++ b/Libplanet/Store/Trie/Nodes/BaseNode.cs
@@ -1,18 +1,10 @@
 #nullable enable
-using Bencodex;
 using Bencodex.Types;
 
 namespace Libplanet.Store.Trie.Nodes
 {
     internal abstract class BaseNode : INode
     {
-        private static Codec _codec;
-
-        static BaseNode()
-        {
-            _codec = new Codec();
-        }
-
         protected BaseNode(INode? value)
         {
             Value = value;
@@ -20,8 +12,6 @@ namespace Libplanet.Store.Trie.Nodes
 
         // It will not support embedded node.
         public INode? Value { get; }
-
-        public byte[] Serialize() => _codec.Encode(ToBencodex());
 
         /// <inheritdoc cref="INode.ToBencodex()"/>
         public abstract IValue ToBencodex();

--- a/Libplanet/Store/Trie/Nodes/INodeExtensions.cs
+++ b/Libplanet/Store/Trie/Nodes/INodeExtensions.cs
@@ -4,6 +4,7 @@ using Bencodex;
 
 namespace Libplanet.Store.Trie.Nodes
 {
+    // FIXME: As it's not an interface, it should be renamed to NodeExtensions.
     internal static class INodeExtensions
     {
         private static readonly Codec Codec = new Codec();
@@ -12,12 +13,7 @@ namespace Libplanet.Store.Trie.Nodes
         {
             return node is HashNode hashNode
                 ? hashNode.HashDigest
-                : HashDigest<SHA256>.DeriveFrom(node.Serialize());
-        }
-
-        internal static byte[] Serialize(this INode node)
-        {
-            return Codec.Encode(node.ToBencodex());
+                : HashDigest<SHA256>.DeriveFrom(Codec.Encode(node.ToBencodex()));
         }
     }
 }

--- a/Libplanet/Store/Trie/Nodes/ValueNode.cs
+++ b/Libplanet/Store/Trie/Nodes/ValueNode.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using Bencodex;
 using Bencodex.Types;
 
 namespace Libplanet.Store.Trie.Nodes
@@ -22,12 +21,6 @@ namespace Libplanet.Store.Trie.Nodes
 
         public static bool operator !=(ValueNode left, ValueNode right) =>
             Operator.Weave(left, right);
-
-        public byte[] Serialize()
-        {
-            var codec = new Codec();
-            return codec.Encode(ToBencodex());
-        }
 
         /// <inheritdoc cref="INode.ToBencodex()"/>
         public IValue ToBencodex() =>

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -38,6 +38,9 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IStateStore.PruneStates(IImmutableSet{HashDigest{SHA256}})"/>
         public void PruneStates(IImmutableSet<HashDigest<SHA256>> survivingStateRootHashes)
         {
+            // TODO: As MerkleTrie now have two levels of Merkle trees (one for accounts and one for
+            // Bencodex values), it needs to be fixed so that it can prune offloaded Bencodex
+            // values too.
             var stopwatch = new Stopwatch();
             _logger.Verbose($"Started {nameof(PruneStates)}()");
             var survivalNodes = new HashSet<HashDigest<SHA256>>();


### PR DESCRIPTION
This patches tries further fragmentation on states.  It addresses the following problems:

- States has been already fragmented on Merkle tree, but their atomic unit was an account.  Therefore, if an action changed only a tiny leaf in a tree, a new copy of the entire tree needed to be added.
- If an action needs only a tiny leaf in an account state tree, the entire tree had to be loaded including unused leafs.

By utilizing Bencodex offloading,[^1] states are now further fragmented into multiple subtrees, which can be offloaded and loaded when needed.  Such fragmentation is recursively applied to nested lists/dictionaries.  However, light values, encoded to 256 bytes[^2] or shorter, are embedded to their parent tree as offloading them is rather overkill.

To optimize shallow but broad dictionaries (for instance, a dictionary with 20+ keys with short strings), dictionary values are chunked into several groups so that each group can be loaded independently.  Each group contains up to 5 values.[^3]

To optimize similar-looking dictionaries (i.e., semi-schemed dictionaries), keys are independently stored from their associated values.  Therefore, `foo`/`bar`/`baz` in `{ foo: 1, bar: 2, baz: 3 }` and `{ foo: 4, bar: 5, baz: 6 }` are stored once.

[^1]: Related pull requests:
      - <https://github.com/planetarium/bencodex.net/pull/50>
      - <https://github.com/planetarium/bencodex.net/pull/52>
      - <https://github.com/planetarium/bencodex.net/pull/53>
      - <https://github.com/planetarium/bencodex.net/pull/55>
      - <https://github.com/planetarium/bencodex.net/pull/56>
[^2]: Hard-coded in `MerkleTrie.OffloadThresholdBytes`.  This can be adjusted in the future without breaking backward compatibility.
[^3]: Hard-coded in `MerkleTrie.OffloadOptions.Offload()`.  This also can be adjusted in the future without breaking backward compatibility.