### PR TITLE
Remove ITransport.MessageHistory & Release 0.21.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.21.3
 --------------
 
-To be released.
+Released on December 5, 2021.
 
 - Removed `ITransport.MessageHistory` property due to memory leak.  [[#1638]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.21.3
 
 To be released.
 
+- Removed `ITransport.MessageHistory` property due to memory leak.  [[#1638]]
+
+[#1638]: https://github.com/planetarium/libplanet/pull/1638
+
 
 Version 0.21.2
 --------------

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -120,10 +120,10 @@ namespace Libplanet.Tests.Net
             var seedStateStore = new TrieStateStore(new MemoryKeyValueStore());
             IBlockPolicy<DumbAction> policy = receiverChain.Policy;
             Block<DumbAction> mismatchedGenesis = new BlockContent<DumbAction>
-                {
-                    PublicKey = receiverKey.PublicKey,
-                    Timestamp = DateTimeOffset.MinValue,
-                }
+            {
+                PublicKey = receiverKey.PublicKey,
+                Timestamp = DateTimeOffset.MinValue,
+            }
                 .Mine(policy.GetHashAlgorithm(0))
                 .Evaluate(receiverKey, policy.BlockAction, seedStateStore);
             BlockChain<DumbAction> seedChain = TestUtils.MakeBlockChain(
@@ -141,13 +141,6 @@ namespace Libplanet.Tests.Net
                 await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
                 Block<DumbAction> block = await seedChain.MineBlock(seedMiner);
                 seedSwarm.BroadcastBlock(block);
-                while (receiverSwarm.Transport.MessageHistory
-                    .Any(msg => msg is BlockHeaderMessage))
-                {
-                    await Task.Delay(100);
-                }
-
-                await Task.Delay(100);
                 Assert.NotEqual(seedChain.Tip, receiverChain.Tip);
             }
             finally

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading;
@@ -39,13 +38,6 @@ namespace Libplanet.Net.Transports
         /// <value>Gets the value indicates whether the instance is running.</value>
         [Pure]
         bool Running { get; }
-
-        /// <summary>
-        /// A fixed sized queue that keeps history of <see cref="Message"/> received.
-        /// It saves at most 30 recent <see cref="Message"/>s.
-        /// </summary>
-        [Pure]
-        ConcurrentQueue<Message> MessageHistory { get; }
 
         /// <summary>
         /// Initiates and runs transport layer.

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -199,7 +199,6 @@ namespace Libplanet.Net.Transports
                 TaskScheduler.Default
             );
 
-            MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
             ProcessMessageHandler = new AsyncDelegate<Message>();
             _dealers = new ConcurrentDictionary<Address, DealerSocket>();
             _replyCompletionSources =
@@ -234,9 +233,6 @@ namespace Libplanet.Net.Transports
                 }
             }
         }
-
-        /// <inheritdoc cref="ITransport.MessageHistory"/>
-        public ConcurrentQueue<Message> MessageHistory { get; }
 
         internal IPAddress PublicIPAddress => _turnClient?.PublicAddress;
 
@@ -467,11 +463,6 @@ namespace Libplanet.Net.Transports
                 if (expectedResponses > 0)
                 {
                     var reply = (await tcs.Task).ToList();
-                    foreach (var msg in reply)
-                    {
-                        MessageHistory.Enqueue(msg);
-                    }
-
                     const string logMsg =
                         "Received {ReplyMessageCount} reply messages to {RequestId} " +
                         "from the {Peer}: {@ReplyMessages}.";
@@ -631,7 +622,6 @@ namespace Libplanet.Net.Transports
                 _logger.Debug("A message has parsed: {0}, from {1}", message, message.Remote);
                 _logger.Debug("Received peer is boundpeer? {0}", message.Remote is BoundPeer);
 
-                MessageHistory.Enqueue(message);
                 LastMessageTimestamp = DateTimeOffset.UtcNow;
 
                 Task.Run(() =>

--- a/Libplanet/Net/Transports/TcpTransport.cs
+++ b/Libplanet/Net/Transports/TcpTransport.cs
@@ -22,7 +22,6 @@ namespace Libplanet.Net.Transports
     {
         public static readonly byte[] MagicCookie = { 0x4c, 0x50 }; // 'L', 'P'
 
-        private const int MessageHistoryCapacity = 30;
         private const int ListenerBacklog = 100;
         private const int MaxReplyStreams = 3000;
 
@@ -105,7 +104,6 @@ namespace Libplanet.Net.Transports
             _turnCancellationTokenSource = new CancellationTokenSource();
             _listener = new TcpListener(new IPEndPoint(IPAddress.Any, listenPort ?? 0));
             ProcessMessageHandler = new AsyncDelegate<Message>();
-            MessageHistory = new FixedSizedQueue<Message>(MessageHistoryCapacity);
         }
 
         /// <inheritdoc cref="ITransport.ProcessMessageHandler"/>
@@ -135,8 +133,6 @@ namespace Libplanet.Net.Transports
                 }
             }
         }
-
-        public ConcurrentQueue<Message> MessageHistory { get; }
 
         internal IPAddress? PublicIPAddress => _turnClient?.PublicAddress;
 
@@ -340,7 +336,6 @@ namespace Libplanet.Net.Transports
                             "Received message was {Message}. Total: {Count}",
                             received,
                             replies.Count);
-                        MessageHistory.Enqueue(received);
                         replies.Add(received);
                         expectedResponses--;
                     }
@@ -714,7 +709,6 @@ namespace Libplanet.Net.Transports
             {
                 _logger.Verbose("Trying to receive message");
                 Message message = await ReadMessageAsync(client, cancellationToken);
-                MessageHistory.Enqueue(message);
                 LastMessageTimestamp = DateTimeOffset.UtcNow;
                 _logger.Debug(
                     "A message has parsed: {Message}, from {Remove}",


### PR DESCRIPTION
We've found memory leak from `ITransport.MessageHistory`, so I removed as emergency measure.