### PR TITLE
Bugfix to remove unnecessary tx requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ To be released.  The solution now can be built on Apple Silicon
 
  -  `KBucket.Head` and `KBucket.Tail` now properly return `null` if
     the bucket is empty instead of faulting.  [[#1631]]
+ -  `TxCompletion.Demand()` no longer requests `Transaction<T>`s already in
+    storage.  [[#1649]]
 
 ### Dependencies
 
@@ -62,6 +64,7 @@ To be released.  The solution now can be built on Apple Silicon
 [#1631]: https://github.com/planetarium/libplanet/pull/1631
 [#1635]: https://github.com/planetarium/libplanet/pull/1635
 [#1636]: https://github.com/planetarium/libplanet/pull/1636
+[#1649]: https://github.com/planetarium/libplanet/pull/1649
 [Bencodex 0.4.0-dev.20211116020419]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211116020419
 [Bencodex 0.4.0-dev.20211205152306]: https://www.nuget.org/packages/Bencodex/0.4.0-dev.20211205152306
 [Planetarium.RocksDbSharp 6.2.4-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.4-planetarium

--- a/Libplanet/Net/TxCompletion.cs
+++ b/Libplanet/Net/TxCompletion.cs
@@ -101,10 +101,12 @@ namespace Libplanet.Net
 
         private HashSet<TxId> GetRequiredTxIds(IEnumerable<TxId> ids)
         {
-            return new HashSet<TxId>(ids.Where(IsTxIdRequired));
+            return new HashSet<TxId>(ids
+                .Where(txId =>
+                    !_blockChain.StagePolicy.Ignores(_blockChain, txId)
+                        && _blockChain.StagePolicy.Get(_blockChain, txId, true) is null
+                        && _blockChain.Store.GetTransaction<TAction>(txId) is null));
         }
-
-        private bool IsTxIdRequired(TxId id) => !_blockChain.StagePolicy.Ignores(_blockChain, id);
 
         private async Task RequestTxsFromPeerAsync(
             TPeer peer,


### PR DESCRIPTION
When demanding `Transaction<T>`s from a peer, `TxCompletion` also searches inside the storage and the staged pool to see if it needs to be downloaded.