### PR TITLE
Release 0.23.1 & Fix `TrieStateStore.PruneStates()` throwing `ArgumentOutOfRangeException`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.23.1
 --------------
 
-To be released.
+Released on December 10, 2021.
 
  -  Fixed `TrieStateStore.PruneStates()` method's bug that it had thrown
     `ArgumentOutOfRangeException`.  [[#1653], [#1654]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.23.1
 
 To be released.
 
+ -  Fixed `TrieStateStore.PruneStates()` method's bug that it had thrown
+    `ArgumentOutOfRangeException`.  [[#1653], [#1654]]
+
+[#1653]: https://github.com/planetarium/libplanet/issues/1653
+[#1654]: https://github.com/planetarium/libplanet/pull/1654
+
 
 Version 0.23.0
 --------------

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Store
         {
             // TODO: As MerkleTrie now have two levels of Merkle trees (one for accounts and one for
             // Bencodex values), it needs to be fixed so that it can prune offloaded Bencodex
-            // values too.
+            // values too.  https://github.com/planetarium/libplanet/issues/1653
             var stopwatch = new Stopwatch();
             _logger.Verbose($"Started {nameof(PruneStates)}()");
             var survivalNodes = new HashSet<HashDigest<SHA256>>();
@@ -72,7 +72,10 @@ namespace Libplanet.Store
             stopwatch.Restart();
             foreach (var stateKey in _stateKeyValueStore.ListKeys())
             {
-                if (survivalNodes.Contains(new HashDigest<SHA256>(stateKey)))
+                // FIXME: Bencodex fingerprints also should be tracked.
+                //        https://github.com/planetarium/libplanet/issues/1653
+                if (stateKey.Length != HashDigest<SHA256>.Size ||
+                    survivalNodes.Contains(new HashDigest<SHA256>(stateKey)))
                 {
                     continue;
                 }


### PR DESCRIPTION
It's just a hotfix which is half-baked, but fixes <https://github.com/planetarium/NineChronicles.Snapshot/issues/78>.

The problem should be completely fixed through changing APIs.  See also <https://github.com/planetarium/libplanet/issues/1653> for my plan.