### PR TITLE
Prevent broadcasting invalid transactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,11 +40,15 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `TxCompletion` had broadcasted invalid transactions.
+    [[#1661]]
+
 ### Dependencies
 
 ### CLI tools
 
 [#1648]: https://github.com/planetarium/libplanet/pull/1648
+[#1661]: https://github.com/planetarium/libplanet/pull/1661
 [#1669]: https://github.com/planetarium/libplanet/pull/1669
 
 


### PR DESCRIPTION
Previously `TxCompletion` used to re-broadcast received all transactions even it is invalid so is not staged. It had lead to some unnecessary messages as follows:
```
           TxIds            GetTxs
         ┌-------> SwarmB ---------┐
SwarmA ----------> SwarmC ------------> SwarmA (no request since the invalid transaction does not exists)
         └-------> ...    ---------┘
```

Adding a regression test is skipped because there are no event handler such as `TxReceived` for the `TxId`s. But I've checked when receiving invalid transaction it broadcasts `TxId` and work as the diagram above.