### PR TITLE
New metric for `BlockChain<T>.FindNextHashes()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ To be released.
      -  `VolatileStagePolicy<T>` now holds every previously known unconfirmed
         `Transaction<T>` regardless of its staging/unstaging history unless
         it is expired or ignored.
+ -  New log output tagged with `Metric` added to measure execution time for
+    `BlockChain<T>.FindNextHashes()`.  [[#1669]]
 
 ### Bug fixes
 
@@ -43,6 +45,7 @@ To be released.
 ### CLI tools
 
 [#1648]: https://github.com/planetarium/libplanet/pull/1648
+[#1669]: https://github.com/planetarium/libplanet/pull/1669
 
 
 Version 0.23.3

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -763,12 +763,12 @@ namespace Libplanet.Blockchain
                 _logger
                     .ForContext("Tag", "Metric")
                     .Debug(
-                    "Finished updating the states with {KeyCount} key changes affected by " +
-                    "block #{BlockIndex} {BlockHash} in {DurationMs:F0}ms.",
-                    totalDelta.Count,
-                    block.Index,
-                    block.Hash,
-                    setStatesDuration.TotalMilliseconds);
+                        "Finished updating the states with {KeyCount} key changes affected by " +
+                        "block #{BlockIndex} {BlockHash} in {DurationMs:F0}ms.",
+                        totalDelta.Count,
+                        block.Index,
+                        block.Hash,
+                        setStatesDuration.TotalMilliseconds);
 
                 IEnumerable<TxExecution> txExecutions = MakeTxExecutions(block, evaluations);
                 UpdateTxExecutions(txExecutions);
@@ -1025,6 +1025,7 @@ namespace Libplanet.Blockchain
         {
             try
             {
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 _rwlock.EnterReadLock();
 
                 BlockHash? tip = Store.IndexBlockHash(Id, -1);
@@ -1065,6 +1066,16 @@ namespace Libplanet.Blockchain
 
                     count--;
                 }
+
+                TimeSpan duration = DateTimeOffset.Now - startTime;
+                _logger
+                    .ForContext("Tag", "Metric")
+                    .Debug(
+                        "Found {HashCount} hashes from storage with {ChainIdCount} chain ids " +
+                        "in {DurationMs:F0}ms.",
+                        result.Count,
+                        Store.ListChainIds().Count(),
+                        duration.TotalMilliseconds);
 
                 return new Tuple<long?, IReadOnlyList<BlockHash>>(branchpointIndex, result);
             }


### PR DESCRIPTION
Adds a simple tagged metric to measure how long it takes to fetch stored hashes.

It might be a good idea to see how many chain ids there are but I'm not sure about the performance of `Store.ListChainIds()`. 😶 