### PR TITLE
Prevent premature unstaging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Version 0.24.1
 
 To be released.
 
+### Added APIs
+
+ -  Added `BlockChain<T>.IsCanonical` property.  [[#1672]]
+
+### Bug fixes
+
+ -  Fixed a bug where `Transaction<T>`s were unstaged when they were not
+    supposed to.  [[#1672]]
+
+[#1672]: https://github.com/planetarium/libplanet/pull/1672
+
 
 Version 0.24.0
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,6 @@ Version 0.24.1
 
 To be released.
 
-### Added APIs
-
- -  Added `BlockChain<T>.IsCanonical` property.  [[#1672]]
-
 ### Bug fixes
 
  -  Fixed a bug where `Transaction<T>`s were unstaged when they were not

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -537,6 +537,20 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void ForkAndSwapCanonicity()
+        {
+            // Fork is not canonical.
+            var workspace = _blockChain.Fork(_blockChain.Genesis.Hash);
+            Assert.True(_blockChain.IsCanonical);
+            Assert.False(workspace.IsCanonical);
+
+            // Both are canonical after swap.
+            _blockChain.Swap(workspace, false, null);
+            Assert.True(_blockChain.IsCanonical);
+            Assert.True(workspace.IsCanonical);
+        }
+
+        [Fact]
         public async Task ForkWithBlockNotExistInChain()
         {
             var key = new PrivateKey();

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -254,6 +254,11 @@ namespace Libplanet.Blockchain
         public Guid Id { get; private set; }
 
         /// <summary>
+        /// Whether the instance is canonical or not.
+        /// </summary>
+        public bool IsCanonical => Store.GetCanonicalChainId() is Guid guid && Id == guid;
+
+        /// <summary>
         /// All <see cref="Block{T}.Hash"/>es in the current index.  The genesis block's hash goes
         /// first, and the tip goes last.
         /// Returns a <see cref="long"/> integer that represents the number of elements in the

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -907,21 +907,33 @@ namespace Libplanet.Blockchain
                     _rwlock.ExitWriteLock();
                 }
 
-                _logger.Debug(
-                    "Unstaging {TxCount} transactions from block #{BlockIndex} {BlockHash}...",
-                    block.Transactions.Count(),
-                    block.Index,
-                    block.Hash);
-                foreach (Transaction<T> tx in block.Transactions)
+                if (IsCanonical)
                 {
-                    UnstageTransaction(tx);
-                }
+                    _logger.Debug(
+                        "Unstaging {TxCount} transactions from block #{BlockIndex} {BlockHash}...",
+                        block.Transactions.Count(),
+                        block.Index,
+                        block.Hash);
+                    foreach (Transaction<T> tx in block.Transactions)
+                    {
+                        UnstageTransaction(tx);
+                    }
 
-                _logger.Debug(
-                    "Unstaged {TxCount} transactions, from block #{BlockIndex} {BlockHash}...",
-                    block.Transactions.Count(),
-                    block.Index,
-                    block.Hash);
+                    _logger.Debug(
+                        "Unstaged {TxCount} transactions from block #{BlockIndex} {BlockHash}...",
+                        block.Transactions.Count(),
+                        block.Index,
+                        block.Hash);
+                }
+                else
+                {
+                    _logger.Debug(
+                        "Skipping unstaging transactions from block #{BlockIndex} {BlockHash} " +
+                        "for non-canonical chain {ChainID}.",
+                        block.Index,
+                        block.Hash,
+                        Id);
+                }
 
                 TipChanged?.Invoke(this, (prevTip, block));
                 _logger.Debug(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -254,11 +254,6 @@ namespace Libplanet.Blockchain
         public Guid Id { get; private set; }
 
         /// <summary>
-        /// Whether the instance is canonical or not.
-        /// </summary>
-        public bool IsCanonical => Store.GetCanonicalChainId() is Guid guid && Id == guid;
-
-        /// <summary>
         /// All <see cref="Block{T}.Hash"/>es in the current index.  The genesis block's hash goes
         /// first, and the tip goes last.
         /// Returns a <see cref="long"/> integer that represents the number of elements in the
@@ -279,6 +274,11 @@ namespace Libplanet.Blockchain
         internal IStateStore StateStore { get; }
 
         internal ActionEvaluator<T> ActionEvaluator { get; }
+
+        /// <summary>
+        /// Whether the instance is canonical or not.
+        /// </summary>
+        internal bool IsCanonical => Store.GetCanonicalChainId() is Guid guid && Id == guid;
 
         /// <summary>
         /// Gets the block corresponding to the <paramref name="index"/>.


### PR DESCRIPTION
When working with a forked chain, `Append()` on a forked chain prematurely unstages transactions in the block being appended. This results in invalid nonce calculation when trying to create a new transaction while a forked chain is being worked on. Note unstaging and restaging of relevant transactions is dealt with in `Swap()` when syncing the canonical chain to a forked chain anyway.

This PR prevents premature unstaging of transactions by checking whether its calling instance is the canonical chain or not.