### PR TITLE
Improve performance of `BlockChain<T>.FindNextHashes()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,9 @@ To be released.
 
 ### Behavioral changes
 
- -  Improved performance of `Swarm<T>`'s block propagation.  [[#1676]]
+  -  Improved performance of `Swarm<T>`'s block propagation.  [[#1676]]
+  -  Improved performance of `RocksDBStore<T>.IterateIndexes()` method.
+     [[#1676]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,16 @@ To be released.
 
 ### Behavioral changes
 
+ -  Improved performance of `Swarm<T>`'s block propagation.  [[#1676]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
+
+
+[#1676]: https://github.com/planetarium/libplanet/pull/1676
 
 
 Version 0.24.1

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1042,7 +1042,7 @@ namespace Libplanet.Blockchain
         {
             DateTimeOffset startTime = DateTimeOffset.Now;
 
-            // FIXME Theatrically, we don't accept empty chain. so `tip` can't be null on this
+            // FIXME Theoretically, we don't accept empty chain. so `tip` can't be null on this
             // assumption. but during some test case(e.g. GetDemandBlockHashesDuringReorg),
             // it had been occurred.
             // We should find a reason for that and fix it before remote this early return.


### PR DESCRIPTION
This PR improves performance of `BlockChain<T>.FindNextHashes()` through two bellow adjustments.

1. Removed `_rwlock` from `BlockChain<T>.FindNextHashes()` because it has already protected by another lock on `BlockChain<T>.FindBranchpoint()`.
2. Added a memory cache for `RocksDBStore.IterateIndexes()` to speed up iterative lookups.