### PR TITLE
Add multiget operation to `IKeyValueStore`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ To be released.
         `Exists(in KeyBytes)` method.
      -  `IKeyValueStore.ListKeys()` method's return type became
         `IEnumerable<KeyBytes>` (was `IEnumerable<byte[]>`).
+ -  Added `IKeyValueStore.Get(IEnumerable<KeyBytes>)` method.  [[#1678]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ To be released.
 
 ### Added APIs
 
+ -  Added `KeyBytes` readonly struct.  [[#1678]]
+
 ### Behavioral changes
 
   -  Improved performance of `Swarm<T>`'s block propagation.  [[#1676]]
@@ -27,6 +29,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#1678]: https://github.com/planetarium/libplanet/pull/1678
 
 
 [#1676]: https://github.com/planetarium/libplanet/pull/1676

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ To be released.
      -  `IKeyValueStore.ListKeys()` method's return type became
         `IEnumerable<KeyBytes>` (was `IEnumerable<byte[]>`).
  -  Added `IKeyValueStore.Get(IEnumerable<KeyBytes>)` method.  [[#1678]]
+ -  Added `IKeyValueStore.Delete(IEnumerable<KeyBytes>)` method.  [[#1678]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,22 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Replaced `HashDigest<T>(ImmutableArray<byte>)` constructor with
+    `HashDigest<T>(in ImmutableArray<byte>)` constructor.  [[#1678]]
+ -  `IKeyValueStore`'s key type became `KeyBytes` (was `byte[]`).  [[#1678]]
+     -  Replaced `IKeyValueStore.Get(byte[])` method with `Get(in KeyBytes)`
+        method.
+     -  Replaced `IKeyValueStore.Set(byte[], byte[])` method with
+        `Set(in KeyBytes, byte[])` method.
+     -  Replaced `IKeyValueStore.Set(IDictionary<byte[], byte[]>)` method with
+        `Set(IDictionary<KeyBytes, byte[]>)` method.
+     -  Replaced `IKeyValueStore.Delete(byte[])` method with
+        `Delete(in KeyBytes)` method.
+     -  Replaced `IKeyValueStore.Exists(byte[])` method with
+        `Exists(in KeyBytes)` method.
+     -  `IKeyValueStore.ListKeys()` method's return type became
+        `IEnumerable<KeyBytes>` (was `IEnumerable<byte[]>`).
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -17,6 +33,7 @@ To be released.
 ### Added APIs
 
  -  Added `KeyBytes` readonly struct.  [[#1678]]
+ -  Added `HashDigest<T>(in ImmutableArray<byte>)` constructor.  [[#1678]]
 
 ### Behavioral changes
 

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -27,34 +27,35 @@ namespace Libplanet.RocksDBStore
         }
 
         /// <inheritdoc/>
-        public byte[] Get(byte[] key) => _keyValueDb.Get(key) ?? throw new KeyNotFoundException(
-            $"There were no elements that correspond to the key (hex: {ByteUtil.Hex(key)}).");
+        public byte[] Get(in KeyBytes key) => _keyValueDb.Get(key.ToByteArray())
+            ?? throw new KeyNotFoundException($"No such key: ${key}.");
 
         /// <inheritdoc/>
-        public void Set(byte[] key, byte[] value)
+        public void Set(in KeyBytes key, byte[] value)
         {
-            _keyValueDb.Put(key, value);
+            _keyValueDb.Put(key.ToByteArray(), value);
         }
 
         /// <inheritdoc/>
-        public void Set(IDictionary<byte[], byte[]> values)
+        public void Set(IDictionary<KeyBytes, byte[]> values)
         {
             using var writeBatch = new WriteBatch();
 
-            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            foreach (KeyValuePair<KeyBytes, byte[]> kv in values)
             {
-                writeBatch.Put(kv.Key, kv.Value);
+                writeBatch.Put(kv.Key.ToByteArray(), kv.Value);
             }
 
             _keyValueDb.Write(writeBatch);
         }
 
         /// <inheritdoc/>
-        public void Delete(byte[] key)
+        public void Delete(in KeyBytes key)
         {
-            _keyValueDb.Remove(key);
+            _keyValueDb.Remove(key.ToByteArray());
         }
 
+        /// <inheritdoc cref="System.IDisposable.Dispose()"/>
         public void Dispose()
         {
             if (!_disposed)
@@ -65,15 +66,16 @@ namespace Libplanet.RocksDBStore
         }
 
         /// <inheritdoc/>
-        public bool Exists(byte[] key) => !(_keyValueDb.Get(key) is null);
+        public bool Exists(in KeyBytes key) =>
+            _keyValueDb.Get(key.ToByteArray()) is { };
 
         /// <inheritdoc/>
-        public IEnumerable<byte[]> ListKeys()
+        public IEnumerable<KeyBytes> ListKeys()
         {
             using Iterator it = _keyValueDb.NewIterator();
             for (it.SeekToFirst(); it.Valid(); it.Next())
             {
-                yield return it.Key();
+                yield return new KeyBytes(it.Key());
             }
         }
     }

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -74,6 +74,15 @@ namespace Libplanet.RocksDBStore
             _keyValueDb.Remove(key.ToByteArray());
         }
 
+        /// <inheritdoc cref="IKeyValueStore.Delete(IEnumerable{KeyBytes})"/>
+        public void Delete(IEnumerable<KeyBytes> keys)
+        {
+            foreach (KeyBytes key in keys)
+            {
+                _keyValueDb.Remove(key.ToByteArray());
+            }
+        }
+
         /// <inheritdoc cref="System.IDisposable.Dispose()"/>
         public void Dispose()
         {

--- a/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Immutable;
+using Libplanet.Store.Trie;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+
+namespace Libplanet.Tests.Store.Trie
+{
+    public class KeyBytesTest
+    {
+        [Fact]
+        public void Constructors()
+        {
+            AssertBytesEqual(ImmutableArray<byte>.Empty, default(KeyBytes).ByteArray);
+            AssertBytesEqual(
+                ImmutableArray<byte>.Empty.Add(1).Add(2).Add(3).Add(4),
+                new KeyBytes(ImmutableArray<byte>.Empty.Add(1).Add(2).Add(3).Add(4)).ByteArray
+            );
+            AssertBytesEqual(
+                new KeyBytes(ImmutableArray.Create<byte>(1, 2, 3, 4, 5)).ByteArray,
+                new KeyBytes(1, 2, 3, 4, 5).ByteArray
+            );
+        }
+
+        [Fact]
+        public void Length()
+        {
+            Assert.Equal(0, default(KeyBytes).Length);
+            Assert.Equal(2, new KeyBytes(0, 0).Length);
+            Assert.Equal(4, new KeyBytes(1, 2, 3, 4).Length);
+            Assert.Equal(5, new KeyBytes(1, 2, 3, 4, 5).Length);
+        }
+
+        [Fact]
+        public void ByteArray()
+        {
+            KeyBytes empty = default;
+            AssertBytesEqual(ImmutableArray<byte>.Empty, empty.ByteArray);
+            AssertBytesEqual(Array.Empty<byte>(), empty.ToByteArray());
+
+            var foo = new KeyBytes(0x66, 0x6f, 0x6f);
+            AssertBytesEqual(ImmutableArray.Create<byte>(0x66, 0x6f, 0x6f), foo.ByteArray);
+            AssertBytesEqual(new byte[] { 0x66, 0x6f, 0x6f }, foo.ToByteArray());
+        }
+
+        [Fact]
+        public void FromHex()
+        {
+            Assert.Equal(default, KeyBytes.FromHex(string.Empty));
+            Assert.Equal(new KeyBytes(1, 2, 3), KeyBytes.FromHex("010203"));
+            Assert.Equal(new KeyBytes(0xab, 0xcd, 0xef), KeyBytes.FromHex("AbcdeF"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => KeyBytes.FromHex("abc"));
+            Assert.Throws<FormatException>(() => KeyBytes.FromHex("zzzz"));
+            Assert.Throws<FormatException>(() => KeyBytes.FromHex("0xabcd"));
+        }
+
+        [Fact]
+        public void Hex()
+        {
+            KeyBytes empty = default;
+            var b123 = new KeyBytes(1, 2, 3);
+            var b122 = new KeyBytes(1, 2, 2);
+            var b1234 = new KeyBytes(1, 2, 3, 4);
+
+            Assert.Empty(empty.Hex);
+            Assert.Equal("010203", b123.Hex);
+            Assert.Equal("010202", b122.Hex);
+            Assert.Equal("01020304", b1234.Hex);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            KeyBytes empty = default;
+            var b123 = new KeyBytes(1, 2, 3);
+            var b122 = new KeyBytes(1, 2, 2);
+            var b1234 = new KeyBytes(1, 2, 3, 4);
+
+            Assert.True(empty.Equals(new KeyBytes(Array.Empty<byte>())));
+            Assert.False(empty.Equals(b123));
+            Assert.False(empty.Equals(b122));
+            Assert.False(empty.Equals(b1234));
+            Assert.True(empty == new KeyBytes(Array.Empty<byte>()));
+            Assert.False(empty == b123);
+            Assert.False(empty == b122);
+            Assert.False(empty == b1234);
+            Assert.False(empty != new KeyBytes(Array.Empty<byte>()));
+            Assert.True(empty != b123);
+            Assert.True(empty != b122);
+            Assert.True(empty != b1234);
+            Assert.True(empty.Equals(ImmutableArray<byte>.Empty));
+            Assert.False(empty.Equals(ImmutableArray.Create<byte>(1, 2, 3)));
+            Assert.False(empty.Equals(ImmutableArray.Create<byte>(1, 2, 2)));
+            Assert.False(empty.Equals(ImmutableArray.Create<byte>(1, 2, 3, 4)));
+            Assert.True(empty.Equals(Array.Empty<byte>()));
+            Assert.False(empty.Equals(new byte[] { 1, 2, 3 }));
+            Assert.False(empty.Equals(new byte[] { 1, 2, 2 }));
+            Assert.False(empty.Equals(new byte[] { 1, 2, 3, 4 }));
+            Assert.False(empty.Equals((byte[])null));
+            Assert.False(empty.Equals((object)Array.Empty<byte>()));
+            Assert.True(empty.Equals((object)new KeyBytes(Array.Empty<byte>())));
+            Assert.False(empty.Equals((object)b123));
+            Assert.False(empty.Equals((object)b122));
+            Assert.False(empty.Equals((object)b1234));
+            Assert.False(empty.Equals((object)null));
+            Assert.Equal(empty.GetHashCode(), new KeyBytes(Array.Empty<byte>()).GetHashCode());
+            Assert.NotEqual(empty.GetHashCode(), b123.GetHashCode());
+            Assert.NotEqual(empty.GetHashCode(), b122.GetHashCode());
+            Assert.NotEqual(empty.GetHashCode(), b1234.GetHashCode());
+
+            Assert.False(b123.Equals(empty));
+            Assert.True(b123.Equals(new KeyBytes(1, 2, 3)));
+            Assert.False(b123.Equals(b122));
+            Assert.False(b123.Equals(b1234));
+            Assert.False(b123 == new KeyBytes(Array.Empty<byte>()));
+            Assert.True(b123 == new KeyBytes(1, 2, 3));
+            Assert.False(b123 == b122);
+            Assert.False(b123 == b1234);
+            Assert.True(b123 != default);
+            Assert.False(b123 != new KeyBytes(1, 2, 3));
+            Assert.True(b123 != b122);
+            Assert.True(b123 != b1234);
+            Assert.False(b123.Equals(ImmutableArray<byte>.Empty));
+            Assert.True(b123.Equals(ImmutableArray.Create<byte>(1, 2, 3)));
+            Assert.False(b123.Equals(ImmutableArray.Create<byte>(1, 2, 2)));
+            Assert.False(b123.Equals(ImmutableArray.Create<byte>(1, 2, 3, 4)));
+            Assert.False(b123.Equals(Array.Empty<byte>()));
+            Assert.True(b123.Equals(new byte[] { 1, 2, 3 }));
+            Assert.False(b123.Equals(new byte[] { 1, 2, 2 }));
+            Assert.False(b123.Equals(new byte[] { 1, 2, 3, 4 }));
+            Assert.False(b123.Equals((byte[])null));
+            Assert.False(b123.Equals((object)Array.Empty<byte>()));
+            Assert.False(b123.Equals((object)default(KeyBytes)));
+            Assert.True(b123.Equals((object)b123));
+            Assert.False(b123.Equals((object)b122));
+            Assert.False(b123.Equals((object)b1234));
+            Assert.False(b123.Equals((object)null));
+            Assert.NotEqual(b123.GetHashCode(), default(KeyBytes).GetHashCode());
+            Assert.Equal(b123.GetHashCode(), new KeyBytes(1, 2, 3).GetHashCode());
+            Assert.NotEqual(b123.GetHashCode(), b122.GetHashCode());
+            Assert.NotEqual(b123.GetHashCode(), b1234.GetHashCode());
+        }
+
+        [Fact]
+        public void String()
+        {
+            KeyBytes empty = default;
+            var b123 = new KeyBytes(1, 2, 3);
+            var b122 = new KeyBytes(1, 2, 2);
+            var b1234 = new KeyBytes(1, 2, 3, 4);
+
+            Assert.Equal("KeyBytes (0 B)", empty.ToString());
+            Assert.Equal("KeyBytes (3 B) 010203", b123.ToString());
+            Assert.Equal("KeyBytes (3 B) 010202", b122.ToString());
+            Assert.Equal("KeyBytes (4 B) 01020304", b1234.ToString());
+        }
+    }
+}

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Tests.Store.Trie
 
         protected Random Random { get; } = new Random();
 
-        private byte[][] PreStoredDataKeys { get; set; }
+        private KeyBytes[] PreStoredDataKeys { get; set; }
 
         private byte[][] PreStoredDataValues { get; set; }
 
@@ -40,7 +40,7 @@ namespace Libplanet.Tests.Store.Trie
         [SkippableFact]
         public void Set()
         {
-            byte[] key = Random.NextBytes(PreStoredDataKeySize);
+            var key = new KeyBytes(Random.NextBytes(PreStoredDataKeySize));
             byte[] value = Random.NextBytes(PreStoredDataValueSize);
             KeyValueStore.Set(key, value);
 
@@ -50,16 +50,16 @@ namespace Libplanet.Tests.Store.Trie
         [SkippableFact]
         public void SetMany()
         {
-            var values = new Dictionary<byte[], byte[]>();
+            var values = new Dictionary<KeyBytes, byte[]>();
             foreach (int i in Enumerable.Range(0, 10))
             {
-                values[Random.NextBytes(PreStoredDataKeySize)] =
+                values[new KeyBytes(Random.NextBytes(PreStoredDataKeySize))] =
                     Random.NextBytes(PreStoredDataValueSize);
             }
 
             KeyValueStore.Set(values);
 
-            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            foreach (KeyValuePair<KeyBytes, byte[]> kv in values)
             {
                 Assert.Equal(kv.Value, KeyValueStore.Get(kv.Key));
             }
@@ -109,18 +109,17 @@ namespace Libplanet.Tests.Store.Trie
         [SkippableFact]
         public void ListKeys()
         {
-            ImmutableHashSet<byte[]> keys = KeyValueStore.ListKeys().ToImmutableHashSet();
+            ImmutableHashSet<KeyBytes> keys = KeyValueStore.ListKeys().ToImmutableHashSet();
             Assert.Equal(PreStoredDataCount, keys.Count);
-            var equalityComparer = new BytesEqualityComparer();
-            Assert.True(PreStoredDataKeys.ToImmutableHashSet(equalityComparer).SetEquals(keys));
+            Assert.True(PreStoredDataKeys.ToImmutableHashSet().SetEquals(keys));
         }
 
-        public byte[] NewRandomKey()
+        public KeyBytes NewRandomKey()
         {
-            byte[] randomKey;
+            KeyBytes randomKey;
             do
             {
-                randomKey = Random.NextBytes(PreStoredDataKeySize);
+                randomKey = new KeyBytes(Random.NextBytes(PreStoredDataKeySize));
             }
             while (KeyValueStore.Exists(randomKey));
 
@@ -129,12 +128,12 @@ namespace Libplanet.Tests.Store.Trie
 
         protected void InitializePreStoredData()
         {
-            PreStoredDataKeys = new byte[PreStoredDataCount][];
+            PreStoredDataKeys = new KeyBytes[PreStoredDataCount];
             PreStoredDataValues = new byte[PreStoredDataCount][];
 
             for (int i = 0; i < PreStoredDataCount; ++i)
             {
-                PreStoredDataKeys[i] = Random.NextBytes(PreStoredDataKeySize);
+                PreStoredDataKeys[i] = new KeyBytes(Random.NextBytes(PreStoredDataKeySize));
                 PreStoredDataValues[i] = Random.NextBytes(PreStoredDataValueSize);
                 KeyValueStore.Set(PreStoredDataKeys[i], PreStoredDataValues[i]);
             }

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -102,12 +102,29 @@ namespace Libplanet.Tests.Store.Trie
         [SkippableFact]
         public void Delete()
         {
-            foreach (var (key, expectedValue) in PreStoredDataKeys.Zip(
-                PreStoredDataValues, ValueTuple.Create))
+            foreach (KeyBytes key in PreStoredDataKeys)
             {
-                var actual = KeyValueStore.Get(key);
-                Assert.Equal(expectedValue, actual);
+                KeyValueStore.Delete(key);
+                Assert.False(KeyValueStore.Exists(key));
             }
+
+            KeyBytes nonExistent = NewRandomKey();
+            KeyValueStore.Delete(nonExistent);
+            Assert.False(KeyValueStore.Exists(nonExistent));
+        }
+
+        [SkippableFact]
+        public void DeleteMany()
+        {
+            KeyBytes[] nonExistentKeys = Enumerable.Range(0, 10)
+                .Select(_ => NewRandomKey())
+                .ToArray();
+            KeyBytes[] keys = PreStoredDataKeys
+                .Concat(PreStoredDataKeys.Take(PreStoredDataCount / 2))
+                .Concat(nonExistentKeys)
+                .ToArray();
+            KeyValueStore.Delete(keys);
+            Assert.All(keys, k => Assert.False(KeyValueStore.Exists(k)));
         }
 
         [SkippableFact]

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -38,6 +38,22 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [SkippableFact]
+        public void GetMany()
+        {
+            KeyBytes[] nonExistentKeys = Enumerable.Range(0, 10)
+                .Select(_ => NewRandomKey())
+                .ToArray();
+            KeyBytes[] keys = PreStoredDataKeys
+                .Concat(PreStoredDataKeys.Take(PreStoredDataCount / 2))
+                .Concat(nonExistentKeys)
+                .ToArray();
+            IReadOnlyDictionary<KeyBytes, byte[]> result = KeyValueStore.Get(keys);
+            Assert.Equal(PreStoredDataCount, result.Count);
+            Assert.All(PreStoredDataKeys, k => Assert.Contains(k, result));
+            Assert.All(nonExistentKeys, k => Assert.DoesNotContain(k, result));
+        }
+
+        [SkippableFact]
         public void Set()
         {
             var key = new KeyBytes(Random.NextBytes(PreStoredDataKeySize));

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -18,6 +18,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Protocols;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Xunit;
 using Xunit.Abstractions;
@@ -221,6 +222,12 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             AssertBytesEqual(expected.ToByteArray(), actual.ToByteArray());
 
         public static void AssertBytesEqual(Address? expected, Address? actual) =>
+            AssertBytesEqual(expected?.ToByteArray(), actual?.ToByteArray());
+
+        public static void AssertBytesEqual(KeyBytes expected, KeyBytes actual) =>
+            AssertBytesEqual(expected.ToByteArray(), actual.ToByteArray());
+
+        public static void AssertBytesEqual(KeyBytes? expected, KeyBytes? actual) =>
             AssertBytesEqual(expected?.ToByteArray(), actual?.ToByteArray());
 
         public static void AssertBencodexEqual(IValue expected, IValue actual)

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -85,7 +85,7 @@ namespace Libplanet
         /// <paramref name="hashDigest"/>'s <see cref="ImmutableArray{T}.Length"/> is not
         /// the same to the <see cref="Size"/> the hash algorithm
         /// (i.e., <typeparamref name="T"/>) requires.</exception>
-        public HashDigest(ImmutableArray<byte> hashDigest)
+        public HashDigest(in ImmutableArray<byte> hashDigest)
         {
             if (hashDigest.Length != Size)
             {

--- a/Libplanet/Store/Trie/CacheableKeyValueStore.cs
+++ b/Libplanet/Store/Trie/CacheableKeyValueStore.cs
@@ -83,6 +83,16 @@ namespace Libplanet.Store.Trie
             _cache.Remove(key);
         }
 
+        /// <inheritdoc cref="IKeyValueStore.Delete(IEnumerable{KeyBytes})"/>
+        public void Delete(IEnumerable<KeyBytes> keys)
+        {
+            _keyValueStore.Delete(keys);
+            foreach (KeyBytes key in keys)
+            {
+                _cache.Remove(key);
+            }
+        }
+
         /// <inheritdoc/>
         public bool Exists(in KeyBytes key)
         {

--- a/Libplanet/Store/Trie/CacheableKeyValueStore.cs
+++ b/Libplanet/Store/Trie/CacheableKeyValueStore.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Store.Trie
     public class CacheableKeyValueStore : IKeyValueStore
     {
         private readonly IKeyValueStore _keyValueStore;
-        private readonly LruCache<byte[], byte[]> _cache;
+        private readonly LruCache<KeyBytes, byte[]> _cache;
 
         /// <summary>
         /// Creates a new <see cref="CacheableKeyValueStore"/>.
@@ -22,55 +22,55 @@ namespace Libplanet.Store.Trie
         public CacheableKeyValueStore(IKeyValueStore keyValueStore, int cacheSize = 100)
         {
             _keyValueStore = keyValueStore;
-            _cache = new LruCache<byte[], byte[]>(cacheSize);
+            _cache = new LruCache<KeyBytes, byte[]>(cacheSize);
         }
 
         /// <inheritdoc/>
-        public byte[] Get(byte[] key)
+        public byte[] Get(in KeyBytes key)
         {
             if (_cache.ContainsKey(key))
             {
                 return _cache[key];
             }
 
-            if (_keyValueStore.Get(key) is byte[] bytes)
+            if (_keyValueStore.Get(key) is { } bytes)
             {
                 _cache[key] = bytes;
                 return bytes;
             }
 
-            throw new KeyNotFoundException("There were no elements that correspond to the key" +
-                                           $" (hex: {ByteUtil.Hex(key)}).");
+            throw new KeyNotFoundException($"No such key: ${key}.");
         }
 
         /// <inheritdoc/>
-        public void Set(byte[] key, byte[] value)
+        public void Set(in KeyBytes key, byte[] value)
         {
             _keyValueStore.Set(key, value);
             _cache[key] = value;
         }
 
-        public void Set(IDictionary<byte[], byte[]> values)
+        public void Set(IDictionary<KeyBytes, byte[]> values)
         {
             _keyValueStore.Set(values);
         }
 
         /// <inheritdoc/>
-        public void Delete(byte[] key)
+        public void Delete(in KeyBytes key)
         {
             _keyValueStore.Delete(key);
             _cache.Remove(key);
         }
 
         /// <inheritdoc/>
-        public bool Exists(byte[] key)
+        public bool Exists(in KeyBytes key)
         {
             return _cache.ContainsKey(key) || _keyValueStore.Exists(key);
         }
 
         /// <inheritdoc/>
-        public IEnumerable<byte[]> ListKeys() => _keyValueStore.ListKeys();
+        public IEnumerable<KeyBytes> ListKeys() => _keyValueStore.ListKeys();
 
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             _keyValueStore?.Dispose();

--- a/Libplanet/Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet/Store/Trie/DefaultKeyValueStore.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Zio;
@@ -50,6 +51,23 @@ namespace Libplanet.Store.Trie
             return _root.FileExists(path)
                 ? _root.ReadAllBytes(path)
                 : throw new KeyNotFoundException($"No such key: {key}.");
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Get(IEnumerable{KeyBytes})"/>
+        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
+        {
+            // We don't optimize this method because it is not used in production.
+            var dictBuilder = ImmutableDictionary.CreateBuilder<KeyBytes, byte[]>();
+            foreach (KeyBytes key in keys)
+            {
+                var path = DataPath(key);
+                if (_root.FileExists(path))
+                {
+                    dictBuilder[key] = _root.ReadAllBytes(path);
+                }
+            }
+
+            return dictBuilder.ToImmutable();
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet/Store/Trie/DefaultKeyValueStore.cs
@@ -44,32 +44,31 @@ namespace Libplanet.Store.Trie
         }
 
         /// <inheritdoc/>
-        public byte[] Get(byte[] key)
+        public byte[] Get(in KeyBytes key)
         {
             var path = DataPath(key);
             return _root.FileExists(path)
                 ? _root.ReadAllBytes(path)
-                : throw new KeyNotFoundException("There were no elements that correspond to the" +
-                                                 $" key (hex: {ByteUtil.Hex(key)}).");
+                : throw new KeyNotFoundException($"No such key: {key}.");
         }
 
         /// <inheritdoc/>
-        public void Set(byte[] key, byte[] value)
+        public void Set(in KeyBytes key, byte[] value)
         {
             var path = DataPath(key);
             _root.WriteAllBytes(path, value);
         }
 
-        public void Set(IDictionary<byte[], byte[]> values)
+        public void Set(IDictionary<KeyBytes, byte[]> values)
         {
-            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            foreach (KeyValuePair<KeyBytes, byte[]> kv in values)
             {
                 Set(kv.Key, kv.Value);
             }
         }
 
         /// <inheritdoc/>
-        public void Delete(byte[] key)
+        public void Delete(in KeyBytes key)
         {
             var path = DataPath(key);
             if (_root.FileExists(path))
@@ -84,17 +83,15 @@ namespace Libplanet.Store.Trie
         }
 
         /// <inheritdoc/>
-        public bool Exists(byte[] key)
+        public bool Exists(in KeyBytes key)
             => _root.FileExists(DataPath(key));
 
         /// <inheritdoc/>
-        public IEnumerable<byte[]> ListKeys() =>
+        public IEnumerable<KeyBytes> ListKeys() =>
             _root.EnumerateFiles(UPath.Root)
-                .Select(path => ByteUtil.ParseHex(path.GetName()));
+                .Select(path => KeyBytes.FromHex(path.GetName()));
 
-        private UPath DataPath(byte[] key)
-        {
-            return UPath.Root / ByteUtil.Hex(key);
-        }
+        private UPath DataPath(in KeyBytes key) =>
+            UPath.Root / key.Hex;
     }
 }

--- a/Libplanet/Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet/Store/Trie/DefaultKeyValueStore.cs
@@ -95,6 +95,15 @@ namespace Libplanet.Store.Trie
             }
         }
 
+        /// <inheritdoc cref="IKeyValueStore.Delete(IEnumerable{KeyBytes})"/>
+        public void Delete(IEnumerable<KeyBytes> keys)
+        {
+            foreach (KeyBytes key in keys)
+            {
+                Delete(key);
+            }
+        }
+
         public void Dispose()
         {
             _root.Dispose();

--- a/Libplanet/Store/Trie/IKeyValueStore.cs
+++ b/Libplanet/Store/Trie/IKeyValueStore.cs
@@ -18,6 +18,16 @@ namespace Libplanet.Store.Trie
         public byte[] Get(in KeyBytes key);
 
         /// <summary>
+        /// Gets multiple values associated with the specified keys at once.
+        /// </summary>
+        /// <param name="keys">Keys whose values to get.  The order of keys does not matter.
+        /// Duplicate keys after their first occurrence are ignored.</param>
+        /// <returns>Values associated the specified <paramref name="keys"/>.  Non-existent
+        /// <paramref name="keys"/> are omitted (rather than being filled with
+        /// <see langword="null"/>).</returns>
+        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys);
+
+        /// <summary>
         /// Sets the value to the key.  If the key already exists, the value is overwritten.
         /// </summary>
         /// <param name="key">The key of the value to set.</param>

--- a/Libplanet/Store/Trie/IKeyValueStore.cs
+++ b/Libplanet/Store/Trie/IKeyValueStore.cs
@@ -47,6 +47,13 @@ namespace Libplanet.Store.Trie
         public void Delete(in KeyBytes key);
 
         /// <summary>
+        /// Delete multiple <paramref name="keys"/> at once.
+        /// </summary>
+        /// <param name="keys">Keys to delete.  The order of keys does not matter.
+        /// Non-existent keys are ignored.</param>
+        public void Delete(IEnumerable<KeyBytes> keys);
+
+        /// <summary>
         /// Checks whether the given key exists in the store.
         /// </summary>
         /// <param name="key">A key to check.</param>

--- a/Libplanet/Store/Trie/IKeyValueStore.cs
+++ b/Libplanet/Store/Trie/IKeyValueStore.cs
@@ -9,25 +9,46 @@ namespace Libplanet.Store.Trie
     /// </summary>
     public interface IKeyValueStore : IDisposable
     {
-        public byte[] Get(byte[] key);
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <returns>The value associated with the specified key.</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when the key is not found.</exception>
+        public byte[] Get(in KeyBytes key);
 
-        public void Set(byte[] key, byte[] value);
+        /// <summary>
+        /// Sets the value to the key.  If the key already exists, the value is overwritten.
+        /// </summary>
+        /// <param name="key">The key of the value to set.</param>
+        /// <param name="value">The value to set.</param>
+        public void Set(in KeyBytes key, byte[] value);
 
         /// <summary>
         /// Sets all values in the given dictionary.
         /// </summary>
         /// <param name="values">A values to set.</param>
-        public void Set(IDictionary<byte[], byte[]> values);
+        public void Set(IDictionary<KeyBytes, byte[]> values);
 
-        public void Delete(byte[] key);
+        /// <summary>
+        /// Deletes the given key.  If the key does not exist, nothing happens.
+        /// </summary>
+        /// <param name="key">A key to delete.</param>
+        public void Delete(in KeyBytes key);
 
-        public bool Exists(byte[] key);
+        /// <summary>
+        /// Checks whether the given key exists in the store.
+        /// </summary>
+        /// <param name="key">A key to check.</param>
+        /// <returns><see langword="true"/> if the key exists; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Exists(in KeyBytes key);
 
         /// <summary>
         /// Lists all keys that have been stored in the storage.
         /// </summary>
         /// <returns>All keys in an arbitrary order.  The order might be vary for each call.
         /// </returns>
-        public IEnumerable<byte[]> ListKeys();
+        public IEnumerable<KeyBytes> ListKeys();
     }
 }

--- a/Libplanet/Store/Trie/KeyBytes.cs
+++ b/Libplanet/Store/Trie/KeyBytes.cs
@@ -1,0 +1,164 @@
+#nullable enable
+using System;
+using System.Collections.Immutable;
+
+namespace Libplanet.Store.Trie
+{
+    /// <summary>
+    /// Wraps a byte array and provides equality comparison and hash code calculation.  Designed
+    /// to be used as a key in dictionaries.
+    /// </summary>
+    public readonly struct KeyBytes
+        : IEquatable<KeyBytes>, IEquatable<ImmutableArray<byte>>, IEquatable<byte[]>
+    {
+        private readonly ImmutableArray<byte> _byteArray;
+
+        /// <summary>
+        /// Creates a new <see cref="KeyBytes"/> instance from the given byte array.
+        /// </summary>
+        /// <param name="bytes">A mutable byte array to wrap.</param>
+        public KeyBytes(params byte[] bytes)
+            : this(ImmutableArray.Create(bytes))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="KeyBytes"/> instance from the given byte array.
+        /// </summary>
+        /// <param name="bytes">An immutable byte array to wrap.</param>
+        public KeyBytes(in ImmutableArray<byte> bytes)
+        {
+            _byteArray = bytes;
+        }
+
+        /// <summary>
+        /// The length of the byte array.
+        /// </summary>
+        public int Length => _byteArray.IsDefault ? 0 : ByteArray.Length;
+
+        /// <summary>
+        /// The immutable array of bytes.
+        /// </summary>
+        public ImmutableArray<byte> ByteArray => _byteArray.IsDefault
+            ? ImmutableArray<byte>.Empty
+            : _byteArray;
+
+        /// <summary>
+        /// The hexadecimal string representation of the byte array.
+        /// </summary>
+        public string Hex => _byteArray.IsDefaultOrEmpty
+            ? string.Empty
+            : ByteUtil.Hex(_byteArray);
+
+        /// <summary>
+        /// Compares two <see cref="KeyBytes"/> values.
+        /// </summary>
+        /// <param name="left">An operand.</param>
+        /// <param name="right">Another operand.</param>
+        /// <returns><see langword="true"/> if two values equal; otherwise <see langword="false"/>.
+        /// </returns>
+        public static bool operator ==(KeyBytes left, KeyBytes right) => left.Equals(right);
+
+        /// <summary>
+        /// Compares two <see cref="KeyBytes"/> values.
+        /// </summary>
+        /// <param name="left">An operand.</param>
+        /// <param name="right">Another operand.</param>
+        /// <returns><see langword="false"/> if two values equal; otherwise <see langword="true"/>.
+        /// </returns>
+        public static bool operator !=(KeyBytes left, KeyBytes right) => !left.Equals(right);
+
+        /// <summary>
+        /// Parses the given hexadecimal string as bytes and returns a new <see cref="KeyBytes"/>
+        /// instance.
+        /// </summary>
+        /// <param name="hex">A hexadecimal string which encodes bytes.</param>
+        /// <returns>A new <see cref="KeyBytes"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given <paramref name="hex"/>
+        /// string is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of the given
+        /// <paramref name="hex"/> string is an odd number.</exception>
+        /// <exception cref="FormatException">Thrown when the given <paramref name="hex"/> string is
+        /// not a valid hexadecimal string.</exception>
+        public static KeyBytes FromHex(string hex) =>
+            new KeyBytes(ByteUtil.ParseHex(hex));
+
+        /// <summary>
+        /// Converts to a mutable byte array.
+        /// </summary>
+        /// <returns>A new copy of mutable byte array.</returns>
+        public byte[] ToByteArray() => ByteArray.IsDefault
+            ? Array.Empty<byte>()
+            : ByteArray.ToBuilder().ToArray();
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        public bool Equals(ImmutableArray<byte> other)
+        {
+            if (other.IsDefaultOrEmpty)
+            {
+                return _byteArray.IsDefaultOrEmpty;
+            }
+            else if (Length != other.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Length; i++)
+            {
+                if (_byteArray[i] != other[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        public bool Equals(KeyBytes other) => Equals(other._byteArray);
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        public bool Equals(byte[]? other)
+        {
+            if (other is { } o && o.Length == Length)
+            {
+                for (int i = 0; i < Length; i++)
+                {
+                    if (_byteArray[i] != o[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj) => obj is KeyBytes other && Equals(other);
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            if (!_byteArray.IsDefaultOrEmpty)
+            {
+                foreach (byte b in _byteArray)
+                {
+                    hash = unchecked(hash * (31 + b));
+                }
+            }
+
+            return hash;
+        }
+
+        /// <inheritdoc cref="object.ToString()"/>
+        public override string ToString()
+        {
+            string hex = Length > 0 ? $" {ByteUtil.Hex(_byteArray)}" : string.Empty;
+            return $"{nameof(KeyBytes)} ({Length} B){hex}";
+        }
+    }
+}

--- a/Libplanet/Store/Trie/MemoryKeyValueStore.cs
+++ b/Libplanet/Store/Trie/MemoryKeyValueStore.cs
@@ -12,27 +12,27 @@ namespace Libplanet.Store.Trie
     /// </summary>
     public sealed class MemoryKeyValueStore : IKeyValueStore
     {
-        private readonly ConcurrentDictionary<byte[], byte[]> _dictionary =
-            new ConcurrentDictionary<byte[], byte[]>(new BytesEqualityComparer());
+        private readonly ConcurrentDictionary<KeyBytes, byte[]> _dictionary =
+            new ConcurrentDictionary<KeyBytes, byte[]>();
 
-        byte[] IKeyValueStore.Get(byte[] key) =>
+        byte[] IKeyValueStore.Get(in KeyBytes key) =>
             _dictionary[key];
 
-        void IKeyValueStore.Set(byte[] key, byte[] value) =>
+        void IKeyValueStore.Set(in KeyBytes key, byte[] value) =>
             _dictionary[key] = value;
 
-        void IKeyValueStore.Set(IDictionary<byte[], byte[]> values)
+        void IKeyValueStore.Set(IDictionary<KeyBytes, byte[]> values)
         {
-            foreach (KeyValuePair<byte[], byte[]> kv in values)
+            foreach (KeyValuePair<KeyBytes, byte[]> kv in values)
             {
                 _dictionary[kv.Key] = kv.Value;
             }
         }
 
-        void IKeyValueStore.Delete(byte[] key) =>
+        void IKeyValueStore.Delete(in KeyBytes key) =>
             _dictionary.TryRemove(key, out _);
 
-        bool IKeyValueStore.Exists(byte[] key) =>
+        bool IKeyValueStore.Exists(in KeyBytes key) =>
             _dictionary.ContainsKey(key);
 
         void IDisposable.Dispose()
@@ -40,38 +40,7 @@ namespace Libplanet.Store.Trie
             // Method intentionally left empty.
         }
 
-        IEnumerable<byte[]> IKeyValueStore.ListKeys() =>
+        IEnumerable<KeyBytes> IKeyValueStore.ListKeys() =>
             _dictionary.Keys;
-
-        private class BytesEqualityComparer : EqualityComparer<byte[]>
-        {
-            public override bool Equals(byte[]? x, byte[]? y)
-            {
-                if (x is { } xa && y is { } ya)
-                {
-                    if (xa.Length != ya.Length)
-                    {
-                        return false;
-                    }
-
-                    for (int i = 0; i < xa.Length; i++)
-                    {
-                        if (xa[i] != ya[i])
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
-
-                return ReferenceEquals(x, y);
-            }
-
-            public override int GetHashCode(byte[] obj)
-            {
-                return 0;
-            }
-        }
     }
 }

--- a/Libplanet/Store/Trie/MemoryKeyValueStore.cs
+++ b/Libplanet/Store/Trie/MemoryKeyValueStore.cs
@@ -52,6 +52,15 @@ namespace Libplanet.Store.Trie
         void IKeyValueStore.Delete(in KeyBytes key) =>
             _dictionary.TryRemove(key, out _);
 
+        /// <inheritdoc cref="IKeyValueStore.Delete(IEnumerable{KeyBytes})"/>
+        public void Delete(IEnumerable<KeyBytes> keys)
+        {
+            foreach (KeyBytes key in keys)
+            {
+                _dictionary.TryRemove(key, out _);
+            }
+        }
+
         /// <inheritdoc/>
         bool IKeyValueStore.Exists(in KeyBytes key) =>
             _dictionary.ContainsKey(key);

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -75,7 +75,7 @@ namespace Libplanet.Store
                 // FIXME: Bencodex fingerprints also should be tracked.
                 //        https://github.com/planetarium/libplanet/issues/1653
                 if (stateKey.Length != HashDigest<SHA256>.Size ||
-                    survivalNodes.Contains(new HashDigest<SHA256>(stateKey)))
+                    survivalNodes.Contains(new HashDigest<SHA256>(stateKey.ByteArray)))
                 {
                     continue;
                 }


### PR DESCRIPTION
For later optimizations, this patch adds a new operation *multiget* to `IKeyValueStore`.  Further optimizations would be landed as separated patches later.

Plus, I addressed https://github.com/planetarium/libplanet/pull/1636#discussion_r764478088 that @greymistcube made in the previous pull request: now `IKeyValueStore` represents keys as `KeyBytes`, a thin wrapper around `ImmutableArray<byte>`, instead of `byte[]`.  `KeyBytes` is a readonly struct, and implements `IEquatable<KeyBytes>` & `GetHashCode()` method.  Human-readable `.ToString()` representation is a bonus.