### PR TITLE
Remove redundant memcpy/malloc from `HashDigest<T>.DeriveFrom()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  Replaced `HashDigest<T>(ImmutableArray<byte>)` constructor with
     `HashDigest<T>(in ImmutableArray<byte>)` constructor.  [[#1678]]
+ -  Replaced `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` overloaded static
+    method with ohter new overloads.  [[#1680]]
  -  `IKeyValueStore`'s key type became `KeyBytes` (was `byte[]`).  [[#1678]]
      -  Replaced `IKeyValueStore.Get(byte[])` method with `Get(in KeyBytes)`
         method.
@@ -36,6 +38,11 @@ To be released.
 
  -  Added `KeyBytes` readonly struct.  [[#1678]]
  -  Added `HashDigest<T>(in ImmutableArray<byte>)` constructor.  [[#1678]]
+ -  Added `HashDigest<T>.DeriveFrom(byte[])` overloaded static method. [[#1680]]
+ -  Added `HashDigest<T>.DeriveFrom(ImmutableArray<byte>)` overloaded static
+    method. [[#1680]]
+ -  Added `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` overloaded static
+    method. [[#1680]]
 
 ### Behavioral changes
 
@@ -49,10 +56,9 @@ To be released.
 
 ### CLI tools
 
-[#1678]: https://github.com/planetarium/libplanet/pull/1678
-
-
 [#1676]: https://github.com/planetarium/libplanet/pull/1676
+[#1678]: https://github.com/planetarium/libplanet/pull/1678
+[#1680]: https://github.com/planetarium/libplanet/pull/1680
 
 
 Version 0.24.1

--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -75,6 +75,14 @@ namespace Libplanet.Tests
                 HashDigest<SHA1>.DeriveFrom(foo)
             );
             Assert.Equal(
+                HashDigest<SHA1>.DeriveFrom(foo),
+                HashDigest<SHA1>.DeriveFrom(ImmutableArray.Create(foo))
+            );
+            Assert.Equal(
+                HashDigest<SHA1>.DeriveFrom(foo),
+                HashDigest<SHA1>.DeriveFrom(foo.AsSpan())
+            );
+            Assert.Equal(
                 HashDigest<SHA1>.FromString("62cdb7020ff920e5aa642c3d4066950dd1f01f4d"),
                 HashDigest<SHA1>.DeriveFrom(bar)
             );

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using Org.BouncyCastle.Asn1.Sec;
 using Org.BouncyCastle.Asn1.X9;
@@ -232,7 +233,8 @@ namespace Libplanet.Crypto
         public ImmutableArray<byte> Sign(ImmutableArray<byte> message)
         {
             HashDigest<SHA256> hashed = HashDigest<SHA256>.DeriveFrom(message);
-            return CryptoConfig.CryptoBackend.Sign(hashed, this).ToImmutableArray();
+            byte[] sig = CryptoConfig.CryptoBackend.Sign(hashed, this);
+            return Unsafe.As<byte[], ImmutableArray<byte>>(ref sig);
         }
 
         /// <summary>

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -169,8 +169,14 @@ namespace Libplanet.Crypto
 
             try
             {
+                HashDigest<SHA256> hashed = message switch
+                {
+                    byte[] ma => HashDigest<SHA256>.DeriveFrom(ma),
+                    ImmutableArray<byte> im => HashDigest<SHA256>.DeriveFrom(im),
+                    _ => HashDigest<SHA256>.DeriveFrom(message.ToArray()),
+                };
                 return CryptoConfig.CryptoBackend.Verify(
-                    HashDigest<SHA256>.DeriveFrom(message),
+                    hashed,
                     signature is byte[] ba ? ba : signature.ToArray(),
                     publicKey: this
                 );

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -105,6 +105,10 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This patch adds `HashDigest<T>.DeriveFrom()` overloads to remove redundant memcpy/malloc.

In order to move the pointer to the buffer (which is never changed) to `ImmutableArray<byte>` without memcpy, I used [`Unsafe.As<TFrom, TTo>()` method][1][^1] several times.[^2]  I would be able to implement it better if [there were `ImmutableArray.UnsafeFreeze<T>(T[])` method.][4]

[^1]: It parallels C++'s `std::reinterpret_cast<T>()`.
[^2]: Note that [`T[]` and `ImmutableArray<T>` share the same memory layout.][2]  See also [this article][3].

[1]: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafe.as?view=net-6.0#System_Runtime_CompilerServices_Unsafe_As__2___0__
[2]: https://github.com/dotnet/runtime/blob/v6.0.1/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/ImmutableArray.cs#L32
[3]: https://devblogs.microsoft.com/dotnet/please-welcome-immutablearrayt/
[4]: https://github.com/dotnet/runtime/issues/25461