### PR TITLE
Unused sender field removed from `Message.TxIds`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,8 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
- -  Removed `Sender` property from `Messages.TxIds`.  [[#1681]]
+ -  Removed `Sender` property from `Messages.TxIds` and `Messages.TxIds`'s
+    `MessageType` value bumped to `0x31`.  [[#1681]]
 
 ### Backward-incompatible storage format changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
+ -  Removed `Sender` property from `Messages.TxIds`.  [[#1681]]
+
 ### Backward-incompatible storage format changes
 
 ### Added APIs
@@ -64,6 +66,7 @@ To be released.
 [#1678]: https://github.com/planetarium/libplanet/pull/1678
 [#1679]: https://github.com/planetarium/libplanet/pull/1679
 [#1680]: https://github.com/planetarium/libplanet/pull/1680
+[#1681]: https://github.com/planetarium/libplanet/pull/1681
 
 
 Version 0.24.2

--- a/Libplanet.Tests/Net/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Tests/Net/Messages/NetMQMessageCodecTest.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Tests.Net.Messages
                 case Message.MessageType.GetBlockHashes:
                     return new GetBlockHashes(chain.GetBlockLocator(), genesis.Hash);
                 case Message.MessageType.TxIds:
-                    return new TxIds(privateKey.ToAddress(), new[] { transaction.Id });
+                    return new TxIds(new[] { transaction.Id });
                 case Message.MessageType.GetBlocks:
                     return new GetBlocks(new[] { genesis.Hash }, 10);
                 case Message.MessageType.GetTxs:

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Net.Messages
             /// <summary>
             /// Inventory to transfer transactions.
             /// </summary>
-            TxIds = 0x06,
+            TxIds = 0x31,
 
             /// <summary>
             /// Request to query blocks.

--- a/Libplanet/Net/Messages/TxIds.cs
+++ b/Libplanet/Net/Messages/TxIds.cs
@@ -8,25 +8,21 @@ namespace Libplanet.Net.Messages
 {
     internal class TxIds : Message
     {
-        public TxIds(Address sender, IEnumerable<TxId> txIds)
+        public TxIds(IEnumerable<TxId> txIds)
         {
-            Sender = sender;
             Ids = txIds;
         }
 
         public TxIds(byte[][] dataFrames)
         {
-            Sender = new Address(dataFrames[0]);
-            int txCount = BitConverter.ToInt32(dataFrames[1], 0);
+            int txCount = BitConverter.ToInt32(dataFrames[0], 0);
             Ids = dataFrames
-                .Skip(2).Take(txCount)
+                .Skip(1).Take(txCount)
                 .Select(ba => new TxId(ba))
                 .ToList();
         }
 
         public IEnumerable<TxId> Ids { get; }
-
-        public Address Sender { get; }
 
         public override MessageType Type => MessageType.TxIds;
 
@@ -35,7 +31,6 @@ namespace Libplanet.Net.Messages
             get
             {
                 var frames = new List<byte[]>();
-                frames.Add(Sender.ToByteArray());
                 frames.Add(BitConverter.GetBytes(Ids.Count()));
                 frames.AddRange(Ids.Select(id => id.ToByteArray()));
                 return frames;

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -1305,7 +1305,7 @@ namespace Libplanet.Net
 
         private void BroadcastTxIds(Address? except, IEnumerable<TxId> txIds)
         {
-            var message = new TxIds(Address, txIds);
+            var message = new TxIds(txIds);
             BroadcastMessage(except, message);
         }
 


### PR DESCRIPTION
Seems like `Sender` property isn't used anywhere? 😶 