### PR TITLE
Hotfix on non-blocking renderers & release 0.23.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.23.4
 --------------
 
-To be released.
+Released on December 24, 2021.
 
  -  Fixed a bug of `NonblockRenderer<T>` and `NonblockActionRenderer<T>` where
     they had thrown `ThreadStateException` when any render events occured after

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.23.4
 
 To be released.
 
+ -  Fixed a bug of `NonblockRenderer<T>` and `NonblockActionRenderer<T>` where
+    they had thrown `ThreadStateException` when any render events occured after
+    disposed.  [[#1682]]
+
+[#1682]: https://github.com/planetarium/libplanet/pull/1682
+
 
 Version 0.23.3
 --------------


### PR DESCRIPTION
This patch fixes a bug that `NonblockRenderer<T>` & `NonblockActionRenderer<T>` are broken after they are once disposed.