### PR TITLE
Represent `ITrie` keys using `KeyBytes`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,14 @@ To be released.
         `Exists(in KeyBytes)` method.
      -  `IKeyValueStore.ListKeys()` method's return type became
         `IEnumerable<KeyBytes>` (was `IEnumerable<byte[]>`).
+ -  `ITrie`'s key type became `KeyBytes` (was `byte[]`).  [[#1689]]
+     -  Replaced `ITrie.Set(byte[], IValue)` method with
+        `Set(in KeyBytes, IValue)` method.
+     -  Replaced `ITrie.TryGet(byte[], out IValue?)` method with
+        `TryGet(in KeyBytes, out IValue?)` method.
+     -  The return type of `MerkleTrieExtensions.ListAllStates()` static method
+        became `IEnumerable<KeyValuePair<KeyBytes, IValue>>` (was
+        `IEnumerable<KeyValuePair<ImmutableArray<byte>, IValue>>`).  [[#1653]]
  -  Added `IKeyValueStore.Get(IEnumerable<KeyBytes>)` method.  [[#1678]]
  -  Added `IKeyValueStore.Delete(IEnumerable<KeyBytes>)` method.  [[#1678]]
  -  `nullable` context enabled for `Peer` and `BoundPeer` classes.  All public
@@ -50,6 +58,8 @@ To be released.
     method. [[#1680]]
  -  Added `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` overloaded static
     method. [[#1680]]
+ -  Added `StateStoreExtensions.EncodeKey()` static method.  [[#1689]]
+ -  Added `StateStoreExtensions.DecodeKey()` static method.  [[#1689]]
 
 ### Behavioral changes
 
@@ -68,6 +78,7 @@ To be released.
 [#1679]: https://github.com/planetarium/libplanet/pull/1679
 [#1680]: https://github.com/planetarium/libplanet/pull/1680
 [#1681]: https://github.com/planetarium/libplanet/pull/1681
+[#1689]: https://github.com/planetarium/libplanet/pull/1689
 
 
 Version 0.24.2

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -150,7 +150,7 @@ namespace Libplanet.Tests.Action
         {
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             ITrie previousBlockStatesTrie = new MerkleTrie(keyValueStore);
-            previousBlockStatesTrie = previousBlockStatesTrie.Set(new byte[0], Null.Value);
+            previousBlockStatesTrie = previousBlockStatesTrie.Set(default, Null.Value);
             var actionContext = new ActionContext(
                 signer: _address,
                 txid: _txid,

--- a/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
+++ b/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
@@ -42,11 +42,11 @@ namespace Libplanet.Tests.Store
             .Add("foo", (Text)"ABC")
             .Add("baz", (Text)"ghi");
 
-        public static byte[] KeyFoo => StateStoreExtensions.KeyEncoding.GetBytes("foo");
+        public static KeyBytes KeyFoo => StateStoreExtensions.EncodeKey("foo");
 
-        public static byte[] KeyBar => StateStoreExtensions.KeyEncoding.GetBytes("bar");
+        public static KeyBytes KeyBar => StateStoreExtensions.EncodeKey("bar");
 
-        public static byte[] KeyBaz => StateStoreExtensions.KeyEncoding.GetBytes("baz");
+        public static KeyBytes KeyBaz => StateStoreExtensions.EncodeKey("baz");
 
         [Theory]
         [MemberData(nameof(StateStores))]

--- a/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Text;
 using Libplanet.Store.Trie;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
@@ -13,12 +14,20 @@ namespace Libplanet.Tests.Store.Trie
         {
             AssertBytesEqual(ImmutableArray<byte>.Empty, default(KeyBytes).ByteArray);
             AssertBytesEqual(
+                ImmutableArray<byte>.Empty,
+                new KeyBytes(string.Empty, Encoding.ASCII).ByteArray
+            );
+            AssertBytesEqual(
                 ImmutableArray<byte>.Empty.Add(1).Add(2).Add(3).Add(4),
                 new KeyBytes(ImmutableArray<byte>.Empty.Add(1).Add(2).Add(3).Add(4)).ByteArray
             );
             AssertBytesEqual(
                 new KeyBytes(ImmutableArray.Create<byte>(1, 2, 3, 4, 5)).ByteArray,
                 new KeyBytes(1, 2, 3, 4, 5).ByteArray
+            );
+            AssertBytesEqual(
+                new KeyBytes(ImmutableArray.Create<byte>(0x66, 0x6f, 0x6f)).ByteArray,
+                new KeyBytes("foo", Encoding.ASCII).ByteArray
             );
         }
 

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using Bencodex.Types;
@@ -17,13 +16,13 @@ namespace Libplanet.Tests.Store.Trie
             MerkleTrie trieA = new MerkleTrie(keyValueStore),
                 trieB = new MerkleTrie(keyValueStore);
 
-            trieA = (MerkleTrie)trieA.Set(new byte[] { 0x01, }, Null.Value)
-                .Set(new byte[] { 0x02, }, Null.Value)
-                .Set(new byte[] { 0x03, }, Null.Value)
+            trieA = (MerkleTrie)trieA.Set(new KeyBytes(0x01), Null.Value)
+                .Set(new KeyBytes(0x02), Null.Value)
+                .Set(new KeyBytes(0x03), Null.Value)
                 .Commit();
-            trieB = (MerkleTrie)trieB.Set(new byte[] { 0x01, }, Dictionary.Empty)
-                .Set(new byte[] { 0x02, }, Null.Value)
-                .Set(new byte[] { 0x04, }, Null.Value)
+            trieB = (MerkleTrie)trieB.Set(new KeyBytes(0x01), Dictionary.Empty)
+                .Set(new KeyBytes(0x02), Null.Value)
+                .Set(new KeyBytes(0x04), Null.Value)
                 .Commit();
 
             Dictionary<string, (HashDigest<SHA256> Root, IValue Value)[]> differentNodes =
@@ -47,35 +46,29 @@ namespace Libplanet.Tests.Store.Trie
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             MerkleTrie trie = new MerkleTrie(keyValueStore);
 
-            trie = (MerkleTrie)trie.Set(new byte[] { 0x01, }, Null.Value)
-                    .Set(new byte[] { 0x02, }, Null.Value)
-                    .Set(new byte[] { 0x03, }, Null.Value)
-                    .Set(new byte[] { 0x04, }, Null.Value)
-                    .Set(new byte[] { 0xbe, 0xef }, Dictionary.Empty);
+            trie = (MerkleTrie)trie.Set(new KeyBytes(0x01), Null.Value)
+                    .Set(new KeyBytes(0x02), Null.Value)
+                    .Set(new KeyBytes(0x03), Null.Value)
+                    .Set(new KeyBytes(0x04), Null.Value)
+                    .Set(new KeyBytes(0xbe, 0xef), Dictionary.Empty);
 
-            Dictionary<ImmutableArray<byte>, IValue> states =
-                trie.ListAllStates().ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value,
-                    new ImmutableArrayEqualityComparer<byte>());
+            Dictionary<KeyBytes, IValue> states =
+                trie.ListAllStates().ToDictionary(pair => pair.Key, pair => pair.Value);
             Assert.Equal(5, states.Count);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x01)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x02)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x03)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x04)]);
-            Assert.Equal(Dictionary.Empty, states[ImmutableArray<byte>.Empty.Add(0xbe).Add(0xef)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x01)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x02)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x03)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x04)]);
+            Assert.Equal(Dictionary.Empty, states[new KeyBytes(0xbe, 0xef)]);
 
             trie = (MerkleTrie)trie.Commit();
-            states = trie.ListAllStates().ToDictionary(
-                pair => pair.Key,
-                pair => pair.Value,
-                new ImmutableArrayEqualityComparer<byte>());
+            states = trie.ListAllStates().ToDictionary(pair => pair.Key, pair => pair.Value);
             Assert.Equal(5, states.Count);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x01)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x02)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x03)]);
-            Assert.Equal(Null.Value, states[ImmutableArray<byte>.Empty.Add(0x04)]);
-            Assert.Equal(Dictionary.Empty, states[ImmutableArray<byte>.Empty.Add(0xbe).Add(0xef)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x01)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x02)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x03)]);
+            Assert.Equal(Null.Value, states[new KeyBytes(0x04)]);
+            Assert.Equal(Dictionary.Empty, states[new KeyBytes(0xbe, 0xef)]);
         }
     }
 }

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Empty(merkleTrie.IterateNodes());
 
             merkleTrie = (MerkleTrie)merkleTrie.Set(
-                new byte[] { 0xbe, 0xef, },
+                new KeyBytes(0xbe, 0xef),
                 Dictionary.Empty.Add(GetRandomBytes(32), Null.Value));
             // There are (ShortNode, ValueNode)
             Assert.Equal(2, merkleTrie.IterateNodes().Count());
@@ -62,64 +62,64 @@ namespace Libplanet.Tests.Store.Trie
                 FromString("1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"),
                 trie.Hash
             );
-            Assert.False(trie.TryGet(new byte[] { 0xbe, 0xef }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0xbe, 0xef), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x11, 0x22), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0xaa, 0xbb), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
-            trie = trie.Set(new byte[] { 0xbe, 0xef, }, Null.Value);
+            trie = trie.Set(new KeyBytes(0xbe, 0xef), Null.Value);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString("16fc25f43edd0c2d2cb6e3cc3827576e57f4b9e04f8dc3a062c7fe59041f77bd"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out IValue got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out IValue got));
             AssertBencodexEqual(Null.Value, got);
-            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x11, 0x22), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0xaa, 0xbb), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
-            trie = trie.Set(new byte[] { 0xbe, 0xef }, new Boolean(true));
+            trie = trie.Set(new KeyBytes(0xbe, 0xef), new Boolean(true));
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString("4458796f4092b5ebfc1ffb3989e72edee228501e438080a12dea45591dc66d58"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.False(trie.TryGet(new byte[] { 0x11, 0x22 }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x11, 0x22), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0xaa, 0xbb), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
-            trie = trie.Set(new byte[] { 0x11, 0x22 }, List.Empty);
+            trie = trie.Set(new KeyBytes(0x11, 0x22), List.Empty);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString("ab1359a2497453110a9c658dd3db45f282404fe68d8c8aca30856f395572284c"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(List.Empty, got);
-            Assert.False(trie.TryGet(new byte[] { 0xaa, 0xbb }, out _));
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0xaa, 0xbb), out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
-            trie = trie.Set(new byte[] { 0xaa, 0xbb }, new Text("hello world"));
+            trie = trie.Set(new KeyBytes(0xaa, 0xbb), new Text("hello world"));
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString("abb5759141f7af1c40f1b0993ba60073cf4227900617be9641373e5a097eaa3c"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(List.Empty, got);
-            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xaa, 0xbb), out got));
             AssertBencodexEqual(new Text("hello world"), got);
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
             var longText = new Text(string.Join("\n", Range(0, 1000).Select(i => $"long str {i}")));
-            trie = trie.Set(new byte[] { 0xaa, 0xbb }, longText);
+            trie = trie.Set(new KeyBytes(0xaa, 0xbb), longText);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
@@ -127,15 +127,15 @@ namespace Libplanet.Tests.Store.Trie
                     : "ad9fb53a8f643bd308d7afea57a5d1796d6031b1df95bdd415fa69b44177d155"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(List.Empty, got);
-            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xaa, 0xbb), out got));
             AssertBencodexEqual(longText, got);
-            Assert.False(trie.TryGet(new byte[] { 0x12, 0x34 }, out _));
+            Assert.False(trie.TryGet(new KeyBytes(0x12, 0x34), out _));
 
-            trie = trie.Set(new byte[] { 0x12, 0x34 }, Dictionary.Empty);
+            trie = trie.Set(new KeyBytes(0x12, 0x34), Dictionary.Empty);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
@@ -143,13 +143,13 @@ namespace Libplanet.Tests.Store.Trie
                     : "77d13e9d97033400ad31fcb0441819285b9165f6ea6ae599d85e7d7e24428feb"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(List.Empty, got);
-            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xaa, 0xbb), out got));
             AssertBencodexEqual(longText, got);
-            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x12, 0x34), out got));
             AssertBencodexEqual(Dictionary.Empty, got);
 
             List complexList = List.Empty
@@ -161,7 +161,7 @@ namespace Libplanet.Tests.Store.Trie
                         "lst",
                         Range(0, 1000).Select(i => (IValue)new Text($"long str {i}"))))
                 .Add(new List(Range(0, 1000).Select(i => (IValue)new Text($"long str {i}"))));
-            trie = trie.Set(new byte[] { 0x11, 0x22 }, complexList);
+            trie = trie.Set(new KeyBytes(0x11, 0x22), complexList);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
@@ -169,13 +169,13 @@ namespace Libplanet.Tests.Store.Trie
                     : "586ba0ba5dfe07433b01fbf7611f95832bde07b8dc5669540ef8866f465bbb85"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(complexList, got);
-            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xaa, 0xbb), out got));
             AssertBencodexEqual(longText, got);
-            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x12, 0x34), out got));
             AssertBencodexEqual(Dictionary.Empty, got);
 
             Dictionary complexDict = Dictionary.Empty
@@ -192,7 +192,7 @@ namespace Libplanet.Tests.Store.Trie
                         .Add("mnop", (IValue)new Binary("hello world", Encoding.ASCII))
                         .Add("qrst", (IValue)complexList)
                         .Add("uvwx", Dictionary.Empty));
-            trie = trie.Set(new byte[] { 0x12, 0x34 }, complexDict);
+            trie = trie.Set(new KeyBytes(0x12, 0x34), complexDict);
             trie = commit ? trie.Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
@@ -200,13 +200,13 @@ namespace Libplanet.Tests.Store.Trie
                     : "4783d18dfc8a2d4d98f722a935e45bd7fc1d0197fb4d33e62f734bfde968af39"),
                 trie.Hash
             );
-            Assert.True(trie.TryGet(new byte[] { 0xbe, 0xef }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xbe, 0xef), out got));
             AssertBencodexEqual(new Boolean(true), got);
-            Assert.True(trie.TryGet(new byte[] { 0x11, 0x22 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x11, 0x22), out got));
             AssertBencodexEqual(complexList, got);
-            Assert.True(trie.TryGet(new byte[] { 0xaa, 0xbb }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0xaa, 0xbb), out got));
             AssertBencodexEqual(longText, got);
-            Assert.True(trie.TryGet(new byte[] { 0x12, 0x34 }, out got));
+            Assert.True(trie.TryGet(new KeyBytes(0x12, 0x34), out got));
             AssertBencodexEqual(complexDict, got);
         }
     }

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -18,15 +18,15 @@ namespace Libplanet.Tests.Store
             _stateKeyValueStore = new DefaultKeyValueStore(null);
         }
 
-        public static byte[] KeyFoo => StateStoreExtensions.KeyEncoding.GetBytes("foo");
+        public static KeyBytes KeyFoo => StateStoreExtensions.EncodeKey("foo");
 
-        public static byte[] KeyBar => StateStoreExtensions.KeyEncoding.GetBytes("bar");
+        public static KeyBytes KeyBar => StateStoreExtensions.EncodeKey("bar");
 
-        public static byte[] KeyBaz => StateStoreExtensions.KeyEncoding.GetBytes("baz");
+        public static KeyBytes KeyBaz => StateStoreExtensions.EncodeKey("baz");
 
-        public static byte[] KeyQux => StateStoreExtensions.KeyEncoding.GetBytes("qux");
+        public static KeyBytes KeyQux => StateStoreExtensions.EncodeKey("qux");
 
-        public static byte[] KeyQuux => StateStoreExtensions.KeyEncoding.GetBytes("quux");
+        public static KeyBytes KeyQuux => StateStoreExtensions.EncodeKey("quux");
 
         [Theory]
         [InlineData(true)]

--- a/Libplanet/Store/Trie/ITrie.cs
+++ b/Libplanet/Store/Trie/ITrie.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Store.Trie
         /// <exception cref="System.ArgumentNullException">Thrown when the given
         /// <paramref name="value"/> is <c>null</c>.</exception>
         /// <returns>Returns new updated <see cref="ITrie"/>.</returns>
-        ITrie Set(byte[] key, IValue value);
+        ITrie Set(in KeyBytes key, IValue value);
 
         /// <summary>
         /// Gets the value stored with <paramref name="key"/> in <see cref="Set"/>.
@@ -40,7 +40,7 @@ namespace Libplanet.Store.Trie
         /// <returns>If there is a value corresponded to <paramref name="key"/>,
         /// set <paramref name="value"/> to it and return true. If not, set <paramref name="value"/>
         /// to null and return false.</returns>
-        bool TryGet(byte[] key, out IValue? value);
+        bool TryGet(in KeyBytes key, out IValue? value);
 
         /// <summary>
         /// Cleans up and stores the <see cref="ITrie"/> in storage.

--- a/Libplanet/Store/Trie/KeyBytes.cs
+++ b/Libplanet/Store/Trie/KeyBytes.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Libplanet.Store.Trie
 {
@@ -29,6 +31,20 @@ namespace Libplanet.Store.Trie
         public KeyBytes(in ImmutableArray<byte> bytes)
         {
             _byteArray = bytes;
+        }
+
+        /// <summary>
+        /// Creates a new <seealso cref="KeyBytes"/> instance from the given <paramref
+        /// name="string"/>.
+        /// </summary>
+        /// <param name="string">A key string.  This is encoded to bytes.</param>
+        /// <param name="encoding">The text encoding used for the key string.</param>
+        public KeyBytes(string @string, Encoding encoding)
+        {
+            byte[] neverReusedBuffer = encoding.GetBytes(@string);
+            ImmutableArray<byte> movedImmutable =
+                Unsafe.As<byte[], ImmutableArray<byte>>(ref neverReusedBuffer);
+            _byteArray = movedImmutable;
         }
 
         /// <summary>


### PR DESCRIPTION
A small refactoring as a preparation for fixing #1653.  @moreal You should work on your job after this patch is merged.