### PR TITLE
Introduce `TrieStateStore.CopyStates()` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ To be released.
 
 ### Added APIs
 
+ -  Added `TrieStateStore.CopyStates()` method.  [[#1653], [#1691]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -23,6 +25,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#1691]: https://github.com/planetarium/libplanet/pull/1691
 
 
 Version 0.26.1

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -104,6 +104,8 @@ namespace Libplanet.Store
             IKeyValueStore targetKeyValueStore = targetStateStore._stateKeyValueStore;
             var stopwatch = new Stopwatch();
             _logger.Verbose($"Started {nameof(CopyStates)}()");
+            stopwatch.Start();
+
             foreach (HashDigest<SHA256> stateRootHash in stateRootHashes)
             {
                 var stateTrie = new MerkleTrie(
@@ -111,20 +113,14 @@ namespace Libplanet.Store
                     new HashNode(stateRootHash),
                     _secure
                 );
-                _logger.Debug("Started to copy states.");
-                stopwatch.Start();
 
                 foreach (var (key, value) in stateTrie.IterateNodeKeyValuePairs())
                 {
                     targetKeyValueStore.Set(key, value);
                 }
-
-                _logger.Debug(
-                    "Finished to copy states (elapsed: {ElapsedMilliseconds} ms).",
-                    stopwatch.ElapsedMilliseconds);
-                stopwatch.Stop();
             }
 
+            stopwatch.Stop();
             _logger.Debug(
                 "Finished to copy all states {ElapsedMilliseconds} ms",
                 stopwatch.ElapsedMilliseconds);


### PR DESCRIPTION
Currently, `TrieStateStore.PruneStates` is too slow to use because its algorithm iterates all of the key-value pairs even if it was unnecessary. Its purpose was to make a state store consisting of only states of specific state root hashes. It tried to use another method which uses more disks but less CPU time and memory while maintaining the purpose. 
This pull request introduces the `TrieStateStore.CopyStates` method which copies only states of the given state root hashes. In the original plan, it planned to modify `TrieStateStore.PruneStates` but I became to think the `CopyStates` name seems to fit more during working. How do you think about it? 🤔  @dahlia 