### PR TITLE
Nullable context on `Protocols` namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `nullable` context enabled for `IProtocol` interface and `Kademlia`,
+    `KademliaProtocol`, and `RoutingTable` classes.  [[#1692]]
+ -  `RoutingTable.Neighbors(Peer, int, bool)` changed to
+    `RoutingTable.Neighbors(BoundPeer, int, bool)`.  As a result,
+    `RoutingTable` class now only explicitly deals with `BoundPeer`s.
+    [[#1692]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -20,9 +27,15 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where unnecessary additional attempts were made to
+    unresponsive `Peer`s when discovering a `Peer` through `KademliaProtocol`.
+    [[#1692]]
+
 ### Dependencies
 
 ### CLI tools
+
+[#1692]: https://github.com/planetarium/libplanet/pull/1692
 
 
 Version 0.25.0

--- a/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Tests/Net/Protocols/RoutingTableTest.cs
@@ -41,14 +41,6 @@ namespace Libplanet.Tests.Net.Protocols
         }
 
         [Fact]
-        public void AddNull()
-        {
-            var pubKey = new PrivateKey().PublicKey;
-            var table = new RoutingTable(pubKey.ToAddress());
-            Assert.Throws<ArgumentNullException>(() => table.AddPeer(null));
-        }
-
-        [Fact]
         public void AddPeer()
         {
             var pubKey0 = new PrivateKey().PublicKey;
@@ -80,7 +72,6 @@ namespace Libplanet.Tests.Net.Protocols
             var peer2 = new BoundPeer(pubKey2, new DnsEndPoint("0.0.0.0", 1234));
 
             Assert.Throws<ArgumentException>(() => table.RemovePeer(peer1));
-            Assert.Throws<ArgumentNullException>(() => table.RemovePeer(null));
 
             bool ret = table.RemovePeer(peer2);
             Assert.False(ret);

--- a/Libplanet/Net/Protocols/IProtocol.cs
+++ b/Libplanet/Net/Protocols/IProtocol.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/Libplanet/Net/Protocols/Kademlia.cs
+++ b/Libplanet/Net/Protocols/Kademlia.cs
@@ -38,15 +38,8 @@ namespace Libplanet.Net.Protocols
         /// <returns>The distance between two <see cref="Address"/>es.</returns>
         public static Address CalculateDistance(Address left, Address right)
         {
-            ImmutableArray<byte> lba = left.ByteArray;
-            ImmutableArray<byte> rba = right.ByteArray;
-            byte[] dba = new byte[Address.Size];
-
-            for (int i = 0; i < Address.Size; i++)
-            {
-                dba[i] = (byte)(lba[i] ^ rba[i]);
-            }
-
+            byte[] dba = Enumerable.Zip(
+                left.ByteArray, right.ByteArray, (l, r) => (byte)(l ^ r)).ToArray();
             return new Address(dba);
         }
 
@@ -83,21 +76,18 @@ namespace Libplanet.Net.Protocols
 
         /// <summary>
         /// Sorts the element of the sequence from in ascending order of
-        /// the distance with <paramref name="targetAddr"/>.
+        /// the distance with <paramref name="target"/>.
         /// </summary>
         /// <param name="peers">A sequence of values to order.</param>
-        /// <param name="targetAddr">
+        /// <param name="target">
         /// <see cref="Address"/> to calculate distance of element.</param>
         /// <returns>>An <see cref="IEnumerable{T}"/> whose elements are sorted
-        /// according to the distance with <paramref name="targetAddr"/>.</returns>
+        /// according to the distance with <paramref name="target"/>.</returns>
         public static IEnumerable<BoundPeer> SortByDistance(
             IEnumerable<BoundPeer> peers,
-            Address targetAddr)
+            Address target)
         {
-            return peers.OrderBy(peer =>
-                CalculateDistance(
-                    peer.Address,
-                    targetAddr).ToHex());
+            return peers.OrderBy(peer => CalculateDistance(peer.Address, target).ToHex());
         }
     }
 }

--- a/Libplanet/Net/Protocols/Kademlia.cs
+++ b/Libplanet/Net/Protocols/Kademlia.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Libplanet.Net.Protocols
@@ -17,7 +18,7 @@ namespace Libplanet.Net.Protocols
         /// <summary>
         /// The number of buckets in the table.
         /// </summary>
-        public const int TableSize = Address.Size * sizeof(byte) * 8;
+        public const int TableSize = Address.Size * 8;
 
         /// <summary>
         /// The number of concurrency in peer discovery.
@@ -30,43 +31,44 @@ namespace Libplanet.Net.Protocols
         public const int MaxDepth = 3;
 
         /// <summary>
-        /// Calculates xor distance between two address.
+        /// Calculates the xor distance between two <see cref="Address"/>es.
         /// </summary>
-        /// <param name="left">First element to calculate distance.</param>
-        /// <param name="right">Second element to calculate distance.</param>
-        /// <returns>Distance between two addresses in <see cref="Address"/>.</returns>
+        /// <param name="left">The first element to calculate the distance.</param>
+        /// <param name="right">The second element to calculate the distance.</param>
+        /// <returns>The distance between two <see cref="Address"/>es.</returns>
         public static Address CalculateDistance(Address left, Address right)
         {
-            var dba = new byte[Address.Size];
-            var aba = left.ToByteArray();
-            var bba = right.ToByteArray();
+            ImmutableArray<byte> lba = left.ByteArray;
+            ImmutableArray<byte> rba = right.ByteArray;
+            byte[] dba = new byte[Address.Size];
 
-            for (var i = 0; i < Address.Size; i++)
+            for (int i = 0; i < Address.Size; i++)
             {
-                dba[i] = (byte)(aba[i] ^ bba[i]);
+                dba[i] = (byte)(lba[i] ^ rba[i]);
             }
 
             return new Address(dba);
         }
 
         /// <summary>
-        /// Calculates length of common prefix length
-        /// by finding the index of first bit of xor value.
+        /// Calculates the length of the common prefix between two <see cref="Address"/>es
+        /// by finding the index of the first non-zero bit of the xor between the two.
         /// </summary>
-        /// <param name="left">First element to calculate common prefix length.</param>
-        /// <param name="right">Second element to calculate common prefix length.</param>
-        /// <returns>Length of the common prefix length.</returns>
+        /// <param name="left">The first element to calculate the common prefix length.</param>
+        /// <param name="right">The second element to calculate the common prefix length.</param>
+        /// <returns>The length of the common prefix between <paramref name="left"/> and
+        /// <paramref name="right"/>.</returns>
         public static int CommonPrefixLength(Address left, Address right)
         {
-            Address distance = CalculateDistance(left, right);
-            var length = 0;
+            ImmutableArray<byte> bytes = CalculateDistance(left, right).ByteArray;
+            int length = 0;
 
-            foreach (var x in distance.ToByteArray())
+            foreach (byte b in bytes)
             {
-                var mask = 1 << 7;
-                while (length < 160 && mask != 0)
+                int mask = 1 << 7;
+                while (mask != 0)
                 {
-                    if ((mask & x) != 0)
+                    if ((mask & b) != 0)
                     {
                         return length;
                     }

--- a/Libplanet/Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet/Net/Protocols/KademliaProtocol.cs
@@ -503,8 +503,12 @@ namespace Libplanet.Net.Protocols
                 }
             }
 
-            // Should we update peer status for non-protocol related messages? (i.e. BlockHashes)
-            Update(message.Remote);
+            if (message.Remote is BoundPeer peer)
+            {
+                // Should we update peer status for non-protocol related messages?
+                // (i.e. BlockHashes)
+                Update(peer);
+            }
         }
 
         /// <summary>
@@ -540,24 +544,19 @@ namespace Libplanet.Net.Protocols
         }
 
         /// <summary>
-        /// Updates routing table when receiving a message. If corresponding bucket
-        /// for remote peer is not full, just adds given <paramref name="rawPeer"/>.
-        /// Otherwise, checks aliveness of the least recently used (LRU) peer
-        /// and determine evict LRU peer or discard given <paramref name="rawPeer"/>.
+        /// Updates routing table when receiving a message.
         /// </summary>
-        /// <param name="rawPeer"><see cref="Peer"/> to update.</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when <paramref name="rawPeer"/> is <c>null</c>.
-        /// </exception>
-        private void Update(Peer rawPeer)
+        /// <param name="peer"><see cref="BoundPeer"/> to update.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="peer"/>
+        /// is <c>null</c>.</exception>
+        private void Update(BoundPeer peer)
         {
-            _logger.Verbose($"Try to {nameof(Update)}() {{Peer}}.", rawPeer);
-            if (rawPeer is null)
+            _logger.Verbose($"Try to {nameof(Update)}() {{Peer}}.", peer);
+            if (peer is null)
             {
-                throw new ArgumentNullException(nameof(rawPeer));
+                throw new ArgumentNullException(nameof(peer));
             }
-
-            if (rawPeer is BoundPeer peer)
+            else
             {
                 // Don't update peer without endpoint or with different appProtocolVersion.
                 _table.AddPeer(peer);

--- a/Libplanet/Net/Protocols/RoutingTable.cs
+++ b/Libplanet/Net/Protocols/RoutingTable.cs
@@ -177,12 +177,12 @@ namespace Libplanet.Net.Protocols
         /// Returns <paramref name="k"/> nearest peers to given parameter peer from routing table.
         /// Return value is already sorted with respect to target.
         /// </summary>
-        /// <param name="target"><see cref="Peer"/> to look up.</param>
+        /// <param name="target"><see cref="BoundPeer"/> to look up.</param>
         /// <param name="k">Number of peers to return.</param>
         /// <param name="includeTarget">A boolean value indicates to include a peer with
         /// <see cref="Address"/> of <paramref name="target"/> in return value or not.</param>
         /// <returns>An enumerable of <see cref="BoundPeer"/>.</returns>
-        public IReadOnlyList<BoundPeer> Neighbors(Peer target, int k, bool includeTarget)
+        public IReadOnlyList<BoundPeer> Neighbors(BoundPeer target, int k, bool includeTarget)
         {
             return Neighbors(target.Address, k, includeTarget);
         }


### PR DESCRIPTION
As a result of having new `nullable` contexts, nullability of arguments and properties have changed.

As a part of refactoring, although certain internal implementations have changed, other than a slight bugfix mentioned in the changelog, there should be no noticeable external behavior change. 😶 