### PR TITLE
Introduce `Swarm<T>.BlockCandidateConsumer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,12 @@ To be released.
 
 ### Behavioral changes
 
+ -  Improved performance of `Swarm<T>.FillBlocksAsync()`'s block sync.  [[#1663], [#1699]]
+     -  `Swarm<T>.FillBlocksAsync()` now download block from the multiple peers
+         in parallel.
+     -  `Swarm<T>.BlockCandidateConsumer()` is consumed and append its candidate blocks
+         in parallel.
+
 ### Bug fixes
 
  -  Fixed a bug where unnecessary additional attempts were made to
@@ -60,7 +66,9 @@ To be released.
 
 ### CLI tools
 
+[#1663]: https://github.com/planetarium/libplanet/issues/1663
 [#1692]: https://github.com/planetarium/libplanet/pull/1692
+[#1699]: https://github.com/planetarium/libplanet/pull/1699
 [#1703]: https://github.com/planetarium/libplanet/pull/1703
 [#1710]: https://github.com/planetarium/libplanet/pull/1710
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,11 +50,12 @@ To be released.
 
 ### Behavioral changes
 
- -  Improved performance of `Swarm<T>.FillBlocksAsync()`'s block sync.  [[#1663], [#1699]]
-     -  `Swarm<T>.FillBlocksAsync()` now download block from the multiple peers
-         in parallel.
-     -  `Swarm<T>.BlockCandidateConsumer()` is consumed and append its candidate blocks
-         in parallel.
+ -  Improved performance of `Swarm<T>.FillBlocksAsync()`'s block sync.
+    [[#1663], [#1699]]
+     -  The way `Swarm<T>` synchronizes the attached `BlockChain<T>`
+        with peers became more performant by splitting downloading
+        and appending blocks
+        into two parallel tasks.
 
 ### Bug fixes
 

--- a/Libplanet.Tests/Net/SwarmTest.Consensus.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Consensus.cs
@@ -118,6 +118,7 @@ namespace Libplanet.Tests.Net
                 miner2.BroadcastBlock(bestBlock);
                 _output.WriteLine("miner1 is waiting for a new block...");
                 await miner1.BlockReceived.WaitAsync();
+                await miner1.BlockAppended.WaitAsync();
 
                 Assert.Equal(miner1.BlockChain.Tip, bestBlock);
                 Assert.Equal(miner2.BlockChain.Tip, bestBlock);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1558,7 +1558,7 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task FillWhenGetChunkBlocksFromSender()
+        public async Task FillWhenGetAChunkOfBlocksFromSender()
         {
             Swarm<DumbAction> receiver = CreateSwarm();
             Swarm<DumbAction> sender = CreateSwarm();

--- a/Libplanet/Net/BlockCandidateTable.cs
+++ b/Libplanet/Net/BlockCandidateTable.cs
@@ -4,13 +4,20 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Action;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Serilog;
 
 namespace Libplanet.Net
 {
+    /// <summary>
+    /// A class which table data structure that stores <see cref="Block{T}"/>s
+    /// received from <see cref="Peer"/>.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
     public class BlockCandidateTable<T>
-    where T : IAction, new()
+        where T : IAction, new()
     {
         private readonly ConcurrentDictionary<BlockHeader, SortedList<long, Block<T>>> _blocks;
 
@@ -26,6 +33,12 @@ namespace Libplanet.Net
 
         public bool Any() => !_blocks.IsEmpty;
 
+        /// <summary>
+        /// Adds a <see cref="Block{T}"/>s to the table.
+        /// </summary>
+        /// <param name="blockHeader">This is the header of the <see cref="BlockChain{T}"/>
+        /// tip at the time of downloading the blocks.</param>
+        /// <param name="blocks">List of downloaded <see cref="Block{T}"/>.</param>
         public void Add(BlockHeader blockHeader, IEnumerable<Block<T>> blocks)
         {
             if (_blocks.ContainsKey(blockHeader))
@@ -51,6 +64,12 @@ namespace Libplanet.Net
             }
         }
 
+        /// <summary>
+        /// Get the <see cref="Block{T}"/>s which are in the table.
+        /// </summary>
+        /// <param name="thisRoundTip">Canonical <see cref="BlockChain{T}"/>'s
+        /// tip of this round.</param>
+        /// <returns><see cref="Block{T}"/>s by <paramref name="thisRoundTip"/>.</returns>
         public SortedList<long, Block<T>>? GetCurrentRoundCandidate(
             BlockHeader thisRoundTip)
         {

--- a/Libplanet/Net/BlockCandidateTable.cs
+++ b/Libplanet/Net/BlockCandidateTable.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Serilog;
+
+namespace Libplanet.Net
+{
+    public class BlockCandidateTable<T>
+    where T : IAction, new()
+    {
+        private readonly ConcurrentDictionary<BlockHeader, SortedList<long, Block<T>>> _blocks;
+
+        public BlockCandidateTable()
+        {
+            _blocks = new ConcurrentDictionary<BlockHeader, SortedList<long, Block<T>>>();
+        }
+
+        public long Count
+        {
+            get => _blocks.Count;
+        }
+
+        public bool Any() => !_blocks.IsEmpty;
+
+        public void Add(BlockHeader blockHeader, IEnumerable<Block<T>> blocks)
+        {
+            if (_blocks.ContainsKey(blockHeader))
+            {
+                return;
+            }
+
+            try
+            {
+                var sortedBlocks =
+                    new SortedList<long, Block<T>>(blocks.ToDictionary(i => i.Index));
+                _blocks.TryAdd(blockHeader, sortedBlocks);
+            }
+            catch (ArgumentException e)
+            {
+                Log.Debug(
+                    "Among the previous blocks of BlockHeader " +
+                    "#{Index} {BlockHash}, there is a block with the wrong index. " +
+                    "InnerMessage: {InnerMessage}",
+                    blockHeader.Index,
+                    blockHeader.Hash,
+                    e.Message);
+            }
+        }
+
+        public SortedList<long, Block<T>> GetCurrentRoundCandidate(
+            BlockHeader thisRoundTip)
+        {
+            return _blocks.TryGetValue(thisRoundTip, out var blocks)
+                ? blocks
+                : null;
+        }
+
+        public bool TryRemove(BlockHeader header, out SortedList<long, Block<T>> blocks)
+        {
+            return _blocks.TryRemove(header, out blocks);
+        }
+
+        public void Cleanup(Func<IBlockExcerpt, bool> predicate)
+        {
+            foreach (var blockHeader in _blocks.Keys)
+            {
+                if (!predicate(blockHeader))
+                {
+                    _blocks.TryRemove(blockHeader, out _);
+                }
+            }
+        }
+    }
+}

--- a/Libplanet/Net/BlockCandidateTable.cs
+++ b/Libplanet/Net/BlockCandidateTable.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -50,7 +51,7 @@ namespace Libplanet.Net
             }
         }
 
-        public SortedList<long, Block<T>> GetCurrentRoundCandidate(
+        public SortedList<long, Block<T>>? GetCurrentRoundCandidate(
             BlockHeader thisRoundTip)
         {
             return _blocks.TryGetValue(thisRoundTip, out var blocks)
@@ -58,9 +59,9 @@ namespace Libplanet.Net
                 : null;
         }
 
-        public bool TryRemove(BlockHeader header, out SortedList<long, Block<T>> blocks)
+        public bool TryRemove(BlockHeader header)
         {
-            return _blocks.TryRemove(header, out blocks);
+            return _blocks.TryRemove(header, out _);
         }
 
         public void Cleanup(Func<IBlockExcerpt, bool> predicate)

--- a/Libplanet/Net/Swarm.BlockCandidate.cs
+++ b/Libplanet/Net/Swarm.BlockCandidate.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    public partial class Swarm<T>
+    {
+        private async Task BlockCandidateConsumer(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            var checkInterval = TimeSpan.FromMilliseconds(100);
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (BlockCandidateTable.Any())
+                {
+                    BlockHeader tipHeader = BlockChain.Tip.Header;
+                    SortedList<long, Block<T>> blocks =
+                        BlockCandidateTable.GetCurrentRoundCandidate(tipHeader);
+                    if (!(blocks is null))
+                    {
+                        var latest = blocks.Last();
+                        _logger.Debug(
+                            "{MethodName} has started. " +
+                            "expert : #{BlockIndex} {BlockHash} " +
+                            "Count of {BlockCandidateTable}: {Count}",
+                            nameof(BlockCandidateConsumer),
+                            latest.Value.Index,
+                            latest.Value.Header,
+                            nameof(BlockCandidateTable),
+                            BlockCandidateTable.Count);
+                        _ = BlockCandidateHandlerAsync(
+                            blocks,
+                            timeout,
+                            cancellationToken);
+                        BlockAppended.Set();
+                    }
+                }
+                else
+                {
+                    await Task.Delay(checkInterval, cancellationToken);
+                    continue;
+                }
+
+                BlockCandidateTable.Cleanup(IsBlockNeeded);
+            }
+        }
+
+        private bool BlockCandidateHandlerAsync(
+            SortedList<long, Block<T>> candidate,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            BlockChain<T> synced = null;
+            bool forked = false;
+            System.Action renderSwap = () => { };
+            try
+            {
+                FillBlocksAsyncStarted.Set();
+                _logger.Debug(
+                    "{MethodName} start append. Current tip: #{BlockIndex}",
+                    nameof(BlockCandidateHandlerAsync),
+                    BlockChain.Tip.Index);
+                (synced, forked) = AppendPreviousBlocks(
+                    blockChain: BlockChain,
+                    candidate: candidate,
+                    timeout: timeout,
+                    evaluateActions: true);
+                ProcessFillBlocksFinished.Set();
+                _logger.Debug(
+                    "{MethodName} finish append. Synced tip: #{BlockIndex}",
+                    nameof(BlockCandidateHandlerAsync),
+                    synced.Tip.Index);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    "Cannot append blocks at {MethodName}. " +
+                    "InnerException: {InnerException}",
+                    nameof(BlockCandidateTable),
+                    e.Message);
+                FillBlocksAsyncFailed.Set();
+                return false;
+            }
+
+            var canonComparer = BlockChain.Policy.CanonicalChainComparer;
+
+            if (synced is { } syncedB
+                && !syncedB.Id.Equals(BlockChain?.Id)
+                && (canonComparer.Compare(
+                        BlockChain.PerceiveBlock(BlockChain.Tip),
+                        BlockChain.PerceiveBlock(syncedB.Tip)) < 0
+                )
+            )
+            {
+                _logger.Debug(
+                    "Swapping chain {ChainIdA} with chain {ChainIdB}...",
+                    BlockChain.Id,
+                    synced.Id
+                );
+                renderSwap = BlockChain.Swap(
+                    synced,
+                    render: forked,
+                    stateCompleters: null);
+                _logger.Debug(
+                    "Swapped chain {ChainIdA} with chain {ChainIdB}.",
+                    BlockChain.Id,
+                    synced.Id
+                );
+            }
+
+            renderSwap();
+            BroadcastBlock(BlockChain.Tip);
+            return true;
+        }
+
+        private (BlockChain<T>, bool) AppendPreviousBlocks(
+            BlockChain<T> blockChain,
+            SortedList<long, Block<T>> candidate,
+            TimeSpan timeout,
+            bool evaluateActions)
+        {
+             bool forked = false;
+             BlockChain<T> workspace = blockChain.Fork(blockChain.Tip.Hash, inheritRenderers: true);
+             List<Guid> scope = new List<Guid> { workspace.Id };
+             bool renderActions = evaluateActions;
+             bool renderBlocks = true;
+
+             Block<T> oldTip = workspace.Tip;
+             Block<T> newTip = candidate.Last().Value;
+             List<Block<T>> blocks = candidate.Values.ToList();
+             Block<T> branchpoint = FindBranchpoint(oldTip, newTip, blocks);
+
+             if (oldTip is null || branchpoint.Equals(oldTip))
+             {
+                 _logger.Debug(
+                     "No need to fork. at {MethodName}",
+                     nameof(AppendPreviousBlocks)
+                 );
+             }
+             else if (!workspace.ContainsBlock(branchpoint.Hash))
+             {
+                 // FIXME: This behavior can unexpectedly terminate the swarm (and the game
+                 // app) if it encounters a peer having a different blockchain, and therefore
+                 // can be exploited to remotely shut down other nodes as well.
+                 // Since the intention of this behavior is to prevent mistakes to try to
+                 // connect incorrect seeds (by a user), this behavior should be limited for
+                 // only seed peers.
+                 var msg =
+                     $"Since the genesis block is fixed to {BlockChain.Genesis} " +
+                     "protocol-wise, the blockchain which does not share " +
+                     "any mutual block is not acceptable.";
+                 throw new InvalidGenesisBlockException(
+                     branchpoint.Hash,
+                     workspace.Genesis.Hash,
+                     msg);
+             }
+             else
+             {
+                 _logger.Debug(
+                     "Trying to fork... at {MethodName}",
+                     nameof(AppendPreviousBlocks)
+                 );
+                 workspace = workspace.Fork(branchpoint.Hash);
+                 renderActions = false;
+                 renderBlocks = false;
+                 forked = true;
+                 scope.Add(workspace.Id);
+                 _logger.Debug(
+                     "Fork finished. at {MethodName}",
+                     nameof(AppendPreviousBlocks)
+                 );
+             }
+
+             if (!(workspace.Tip is null))
+             {
+                 blocks = blocks.Skip(1).ToList();
+             }
+
+             try
+             {
+                 foreach (var block in blocks)
+                 {
+                     workspace.Append(
+                         block,
+                         evaluateActions: evaluateActions,
+                         renderBlocks: renderBlocks,
+                         renderActions: renderActions);
+                 }
+             }
+             catch (Exception)
+             {
+                 _logger.Debug(
+                     "Delete Chain Id: {ChainId}",
+                     workspace.Id
+                 );
+
+                 foreach (var chainId in scope)
+                 {
+                     _store.DeleteChainId(chainId);
+                 }
+
+                 workspace = null;
+
+                 throw;
+             }
+
+             foreach (var id in scope.Where(guid => guid != workspace?.Id))
+             {
+                 _store.DeleteChainId(id);
+             }
+
+             _logger.Debug(
+                 "Completed (chain ID: {ChainId}, tip: #{TipIndex} {TipHash}). at {MethodName}",
+                 workspace?.Id,
+                 workspace?.Tip?.Index,
+                 workspace?.Tip?.Hash,
+                 nameof(AppendPreviousBlocks)
+             );
+
+             return (workspace, forked);
+        }
+
+        private Block<T> FindBranchpoint(Block<T> oldTip, Block<T> newTip, List<Block<T>> newBlocks)
+        {
+            while (oldTip is Block<T> && oldTip.Index > newTip.Index &&
+                   oldTip.PreviousHash is { } aPrev)
+            {
+                oldTip = BlockChain[aPrev];
+            }
+
+            while (newTip is Block<T> && newTip.Index > oldTip.Index &&
+                   newTip.PreviousHash is { } bPrev)
+            {
+                try
+                {
+                    newTip = newBlocks.Single(x => x.Hash.Equals(bPrev));
+                }
+                catch (ArgumentNullException)
+                {
+                    newTip = BlockChain[bPrev];
+                }
+            }
+
+            if (oldTip is null || newTip is null || oldTip.Index != newTip.Index)
+            {
+                throw new ArgumentException(
+                    "Some previous blocks of two blocks are orphan.",
+                    nameof(oldTip)
+                );
+            }
+
+            while (oldTip.Index >= 0)
+            {
+                if (oldTip.Equals(newTip))
+                {
+                    return oldTip;
+                }
+
+                if (oldTip.PreviousHash is { } aPrev &&
+                    newTip.PreviousHash is { } bPrev)
+                {
+                    oldTip = BlockChain[aPrev];
+                    try
+                    {
+                        newTip = newBlocks.Single(x => x.Hash.Equals(bPrev));
+                    }
+                    catch (ArgumentNullException)
+                    {
+                        newTip = BlockChain[bPrev];
+                    }
+
+                    continue;
+                }
+
+                break;
+            }
+
+            throw new ArgumentException(
+                "Two blocks do not have any ancestors in common.",
+                nameof(oldTip)
+            );
+        }
+
+        private async Task<bool> ProcessBlockDemandAsync(
+            BlockDemand demand,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+             var sessionRandom = new Random();
+             IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
+
+             int sessionId = sessionRandom.Next();
+
+             BoundPeer peer = demand.Peer;
+
+             if (canonComparer.Compare(
+                 BlockChain.PerceiveBlock(demand),
+                 BlockChain.PerceiveBlock(BlockChain.Tip)
+             ) <= 0)
+             {
+                 return false;
+             }
+
+             const string downloadStartLogMsg =
+                 "{SessionId}: Downloading blocks from {Peer}; started " +
+                 "to fetch the block #{BlockIndex} {BlockHash} at {MethodName}.";
+             _logger.Debug(
+                 downloadStartLogMsg,
+                 sessionId,
+                 peer,
+                 demand.Header.Index,
+                 demand.Header.Hash,
+                 nameof(ProcessBlockDemandAsync));
+
+             try
+             {
+                var result = await BlockCandidateDownload(
+                     peer: peer,
+                     blockChain: BlockChain,
+                     stop: demand.Header,
+                     timeout: timeout,
+                     logSessionId: sessionId,
+                     cancellationToken: cancellationToken);
+
+                BlockReceived.Set();
+                return result;
+             }
+             catch (TimeoutException)
+             {
+                 const string msg =
+                     "{SessionId}: Timeout occurred during " + nameof(ProcessBlockDemandAsync) +
+                     "() from {Peer}.";
+                 _logger.Debug(msg, sessionId, peer);
+                 return false;
+             }
+             catch (InvalidBlockIndexException)
+             {
+                 const string msg =
+                     "{SessionId}: {Peer} sent an invalid block index.";
+                 _logger.Debug(msg, sessionId, peer);
+                 return false;
+             }
+             catch (InvalidBlockHashException)
+             {
+                 const string msg =
+                     "{SessionId}: {Peer} sent an invalid block hash.";
+                 _logger.Debug(msg, sessionId, peer);
+                 return false;
+             }
+             catch (InvalidBlockException)
+             {
+                 const string msg =
+                     "{SessionId}: {Peer} sent an invalid block.";
+                 _logger.Debug(msg, sessionId, peer);
+                 return false;
+             }
+             catch (Exception e)
+             {
+                const string msg =
+                    "{SessionId}: Unexpected exception occurred during " +
+                    nameof(ProcessBlockDemandAsync) + "() from {Peer}: {Exception}";
+                _logger.Error(e, msg, sessionId, peer, e);
+                return false;
+             }
+        }
+
+        private async Task<bool> BlockCandidateDownload(
+            BoundPeer peer,
+            BlockChain<T> blockChain,
+            BlockHeader stop,
+            TimeSpan timeout,
+            int logSessionId,
+            CancellationToken cancellationToken)
+        {
+            var sessionRandom = new Random();
+            int subSessionId = sessionRandom.Next();
+            BlockLocator locator = blockChain.GetBlockLocator(Options.BranchpointThreshold);
+            Block<T> tip = blockChain.Tip;
+
+            IAsyncEnumerable<Tuple<long, BlockHash>> hashesAsync = GetBlockHashes(
+                peer: peer,
+                locator: locator,
+                stop: stop.Hash,
+                timeout: timeout,
+                logSessionIds: (logSessionId, subSessionId),
+                cancellationToken: cancellationToken);
+            IEnumerable<Tuple<long, BlockHash>> hashes = await hashesAsync.ToArrayAsync();
+
+            if (!hashes.Any())
+            {
+                FillBlocksAsyncFailed.Set();
+                return false;
+            }
+
+            IAsyncEnumerable<Block<T>> blocksAsync = GetBlocksAsync(
+                peer,
+                hashes.Select(pair => pair.Item2),
+                cancellationToken);
+            var blocks = await blocksAsync.ToArrayAsync(cancellationToken);
+            BlockCandidateTable.Add(tip.Header, blocks);
+            return true;
+        }
+    }
+}

--- a/Libplanet/Net/Swarm.BlockCandidate.cs
+++ b/Libplanet/Net/Swarm.BlockCandidate.cs
@@ -14,7 +14,7 @@ namespace Libplanet.Net
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
-            var checkInterval = TimeSpan.FromMilliseconds(100);
+            var checkInterval = TimeSpan.FromMilliseconds(10);
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (BlockCandidateTable.Any())

--- a/Libplanet/Net/Swarm.BlockCandidate.cs
+++ b/Libplanet/Net/Swarm.BlockCandidate.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Net
 {
     public partial class Swarm<T>
     {
-        private async Task BlockCandidateConsumer(
+        private async Task BlockCandidateConsume(
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -28,12 +28,12 @@ namespace Libplanet.Net
                         _logger.Debug(
                             "{MethodName} has started. Excerpt: #{BlockIndex} {BlockHash} " +
                             "Count of {BlockCandidateTable}: {Count}",
-                            nameof(BlockCandidateConsumer),
+                            nameof(BlockCandidateConsume),
                             latest.Value.Index,
                             latest.Value.Header,
                             nameof(BlockCandidateTable),
                             BlockCandidateTable.Count);
-                        _ = BlockCandidateHandler(
+                        _ = BlockCandidateProcess(
                             blocks,
                             timeout,
                             cancellationToken);
@@ -50,7 +50,7 @@ namespace Libplanet.Net
             }
         }
 
-        private bool BlockCandidateHandler(
+        private bool BlockCandidateProcess(
             SortedList<long, Block<T>> candidate,
             TimeSpan timeout,
             CancellationToken cancellationToken)
@@ -62,7 +62,7 @@ namespace Libplanet.Net
                 FillBlocksAsyncStarted.Set();
                 _logger.Debug(
                     "{MethodName} start append. Current tip: #{BlockIndex}",
-                    nameof(BlockCandidateHandler),
+                    nameof(BlockCandidateProcess),
                     BlockChain.Tip.Index);
                 synced = AppendPreviousBlocks(
                     blockChain: BlockChain,
@@ -72,7 +72,7 @@ namespace Libplanet.Net
                 ProcessFillBlocksFinished.Set();
                 _logger.Debug(
                     "{MethodName} finish append. Synced tip: #{BlockIndex}",
-                    nameof(BlockCandidateHandler),
+                    nameof(BlockCandidateProcess),
                     synced.Tip.Index);
             }
             catch (Exception e)

--- a/Libplanet/Net/Swarm.BlockCandidate.cs
+++ b/Libplanet/Net/Swarm.BlockCandidate.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Net
 {
     public partial class Swarm<T>
     {
-        private async Task BlockCandidateConsume(
+        private async Task ConsumeBlockCandidates(
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -28,7 +28,7 @@ namespace Libplanet.Net
                         _logger.Debug(
                             "{MethodName} has started. Excerpt: #{BlockIndex} {BlockHash} " +
                             "Count of {BlockCandidateTable}: {Count}",
-                            nameof(BlockCandidateConsume),
+                            nameof(ConsumeBlockCandidates),
                             latest.Value.Index,
                             latest.Value.Header,
                             nameof(BlockCandidateTable),

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -20,6 +20,10 @@ namespace Libplanet.Net
         /// </summary>
         public BlockDemandTable<T> BlockDemandTable { get; private set; }
 
+        /// <summary>
+        /// This is a table of waiting <see cref="Block"/>s to enter the <see cref="BlockChain"/>.
+        /// <seealso cref="BlockCandidateTable{T}"/>
+        /// </summary>
         public BlockCandidateTable<T> BlockCandidateTable { get; private set; }
 
         internal AsyncAutoResetEvent FillBlocksAsyncStarted { get; } = new AsyncAutoResetEvent();

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -20,6 +20,8 @@ namespace Libplanet.Net
         /// </summary>
         public BlockDemandTable<T> BlockDemandTable { get; private set; }
 
+        public BlockCandidateTable<T> BlockCandidateTable { get; private set; }
+
         internal AsyncAutoResetEvent FillBlocksAsyncStarted { get; } = new AsyncAutoResetEvent();
 
         internal AsyncAutoResetEvent FillBlocksAsyncFailed { get; } = new AsyncAutoResetEvent();
@@ -92,8 +94,8 @@ namespace Libplanet.Net
             catch (Exception e)
             {
                 var msg =
-                    $"Unexpected exception occured during {nameof(PullBlocksAsync)}().";
-                _logger.Error(e, msg);
+                    $"Unexpected exception occured during {nameof(PullBlocksAsync)}(). {{e}}";
+                _logger.Error(e, msg, e);
                 FillBlocksAsyncFailed.Set();
             }
             finally
@@ -115,16 +117,18 @@ namespace Libplanet.Net
             {
                 if (BlockDemandTable.Any())
                 {
-                    BlockDemand largest =
-                        BlockDemandTable.Demands.Values.Aggregate(
-                            (acc, next) =>
-                                next.TotalDifficulty > acc.TotalDifficulty ? next : acc);
-
-                    await ProcessBlockDemand(
-                        largest,
-                        timeout,
-                        cancellationToken);
-                    BlockDemandTable.Remove(largest.Peer);
+                    _logger.Debug(
+                        "{MethodName} blockDemand count: {BlockDemandCount}",
+                        nameof(FillBlocksAsync),
+                        BlockDemandTable.Demands.Count);
+                    foreach (var blockDemand in BlockDemandTable.Demands.Values)
+                    {
+                        BlockDemandTable.Remove(blockDemand.Peer);
+                        _ = ProcessBlockDemandAsync(
+                            blockDemand,
+                            timeout,
+                            cancellationToken);
+                    }
                 }
                 else
                 {
@@ -454,7 +458,9 @@ namespace Libplanet.Net
                         {
                             _logger.Error(
                                 e,
-                                "An exception occurred during appending blocks: {Exception}");
+                                "An exception occurred during appending blocks: {Exception}",
+                                e
+                            );
                             throw;
                         }
 
@@ -613,403 +619,6 @@ namespace Libplanet.Net
                 txsCount,
                 spent);
         }
-
-        private async Task ProcessBlockDemand(
-            BlockDemand demand,
-            TimeSpan timeout,
-            CancellationToken cancellationToken
-        )
-        {
-            var sessionRandom = new Random();
-            IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
-
-            int sessionId = sessionRandom.Next();
-
-            BoundPeer peer = demand.Peer;
-
-            try
-            {
-                if (canonComparer.Compare(
-                    BlockChain.PerceiveBlock(demand),
-                    BlockChain.PerceiveBlock(BlockChain.Tip)
-                ) <= 0)
-                {
-                    return;
-                }
-
-                BlockHash hash = demand.Header.Hash;
-                const string startLogMsg =
-                    "{SessionId}: Got a new " + nameof(BlockDemand) + " from {Peer}; started " +
-                    "to fetch the block #{BlockIndex} {BlockHash}...";
-                _logger.Debug(startLogMsg, sessionId, peer, demand.Header.Index, hash);
-                System.Action renderSwap = await SyncPreviousBlocksAsync(
-                    blockChain: BlockChain,
-                    peer: peer,
-                    stop: hash,
-                    progress: null,
-                    timeout: timeout,
-                    totalBlockCount: 0,
-                    logSessionId: sessionId,
-                    cancellationToken: cancellationToken
-                );
-                _logger.Debug(
-                    "{SessionId}: Synced block(s) from {Peer}; broadcast them to neighbors...",
-                    sessionId,
-                    peer
-                );
-
-                BroadcastBlock(peer.Address, BlockChain.Tip);
-                renderSwap();
-
-                // FIXME: Clean up events
-                BlockReceived.Set();
-                BlockAppended.Set();
-
-                ProcessFillBlocksFinished.Set();
-            }
-            catch (TimeoutException)
-            {
-                const string msg =
-                    "{SessionId}: Timeout occurred during " + nameof(ProcessBlockDemand) +
-                    "() from {Peer}.";
-                _logger.Debug(msg, sessionId, peer);
-            }
-            catch (InvalidBlockIndexException ibie)
-            {
-                const string msg =
-                    "{SessionId}: " + nameof(InvalidBlockIndexException) + " occurred during " +
-                    nameof(ProcessBlockDemand) + "() from {Peer}: {Exception}";
-                _logger.Warning(ibie, msg, sessionId, peer, ibie);
-            }
-            catch (Exception e)
-            {
-                const string msg =
-                    "{SessionId}: Unexpected exception occurred during " +
-                    nameof(ProcessBlockDemand) + "() from {Peer}.";
-                _logger.Error(e, msg, sessionId, peer);
-            }
-        }
-
-        private async Task<System.Action> SyncPreviousBlocksAsync(
-            BlockChain<T> blockChain,
-            BoundPeer peer,
-            BlockHash? stop,
-            IProgress<BlockDownloadState> progress,
-            TimeSpan timeout,
-            long totalBlockCount,
-            int logSessionId,
-            CancellationToken cancellationToken
-        )
-        {
-            long previousTipIndex = blockChain.Tip?.Index ?? -1;
-            BlockChain<T> synced = null;
-            System.Action renderSwap = () => { };
-
-            try
-            {
-                long currentTipIndex = blockChain.Tip?.Index ?? -1;
-                long receivedBlockCount = currentTipIndex - previousTipIndex;
-
-                const string startMsg =
-                    "{SessionId}: Starting " + nameof(SyncPreviousBlocksAsync) + "()...";
-                _logger.Debug(startMsg, logSessionId);
-                FillBlocksAsyncStarted.Set();
-                synced = await SyncBlocksAsync(
-                    peer,
-                    blockChain,
-                    stop,
-                    progress,
-                    totalBlockCount,
-                    receivedBlockCount,
-                    true,
-                    timeout,
-                    logSessionId,
-                    cancellationToken
-                );
-                const string finishMsg =
-                    "{SessionId}: Finished " + nameof(SyncPreviousBlocksAsync) + "().";
-                _logger.Debug(finishMsg, logSessionId);
-            }
-            catch (Exception)
-            {
-                FillBlocksAsyncFailed.Set();
-                throw;
-            }
-            finally
-            {
-                var canonComparer = BlockChain.Policy.CanonicalChainComparer;
-                if (synced is { } syncedB
-                    && !syncedB.Id.Equals(blockChain?.Id)
-                    && (canonComparer.Compare(
-                        blockChain.PerceiveBlock(blockChain.Tip),
-                        blockChain.PerceiveBlock(syncedB.Tip)) < 0
-                    )
-                )
-                {
-                    _logger.Debug(
-                        "{SessionId}: Swapping chain {ChainIdA} with chain {ChainIdB}...",
-                        logSessionId,
-                        blockChain.Id,
-                        synced.Id
-                    );
-                    renderSwap = blockChain.Swap(
-                        synced,
-                        render: true,
-                        stateCompleters: null);
-                    _logger.Debug(
-                        "{SessionId}: Swapped chain {ChainIdA} with chain {ChainIdB}.",
-                        logSessionId,
-                        blockChain.Id,
-                        synced.Id
-                    );
-                }
-            }
-
-            return renderSwap;
-        }
-
-#pragma warning disable MEN003
-        private async Task<BlockChain<T>> SyncBlocksAsync(
-            BoundPeer peer,
-            BlockChain<T> blockChain,
-            BlockHash? stop,
-            IProgress<BlockDownloadState> progress,
-            long totalBlockCount,
-            long receivedBlockCount,
-            bool evaluateActions,
-            TimeSpan timeout,
-            int logSessionId,
-            CancellationToken cancellationToken
-        )
-        {
-            var sessionRandom = new Random();
-            const string fname = nameof(SyncBlocksAsync);
-            BlockChain<T> workspace = blockChain;
-            var scope = new List<Guid>();
-            bool renderActions = evaluateActions;
-            bool renderBlocks = true;
-
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    int subSessionId = sessionRandom.Next();
-                    Block<T> tip = workspace?.Tip;
-
-                    _logger.Debug(
-                        "{SessionId}/{SubSessionId}: Trying to find branchpoint...",
-                        logSessionId,
-                        subSessionId
-                    );
-                    BlockLocator locator = workspace.GetBlockLocator(Options.BranchpointThreshold);
-                    _logger.Debug(
-                        "{SessionId}/{SubSessionId}: Locator's length: {LocatorLength}",
-                        logSessionId,
-                        subSessionId,
-                        locator.Count()
-                    );
-                    IAsyncEnumerable<Tuple<long, BlockHash>> hashesAsync = GetBlockHashes(
-                        peer: peer,
-                        locator: locator,
-                        stop: stop,
-                        timeout: timeout,
-                        logSessionIds: (logSessionId, subSessionId),
-                        cancellationToken: cancellationToken
-                    );
-                    IEnumerable<Tuple<long, BlockHash>> hashes = await hashesAsync.ToArrayAsync();
-
-                    if (!hashes.Any())
-                    {
-                        _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Peer {Peer} returned no hashes; ignored.",
-                            logSessionId,
-                            subSessionId,
-                            peer
-                        );
-                        return workspace;
-                    }
-
-                    hashes.First().Deconstruct(
-                        out long branchIndex,
-                        out BlockHash branchpoint
-                    );
-
-                    _logger.Debug(
-                        "{SessionId}/{SubSessionId}: Branchpoint is #{BranchIndex} {BranchHash}.",
-                        logSessionId,
-                        subSessionId,
-                        branchIndex,
-                        branchpoint
-                    );
-
-                    if (tip is null || branchpoint.Equals(tip.Hash))
-                    {
-                        _logger.Debug(
-                            "{SessionId}/{SubSessionId}: No need to fork.",
-                            logSessionId,
-                            subSessionId
-                        );
-                    }
-                    else if (!workspace.ContainsBlock(branchpoint))
-                    {
-                        // FIXME: This behavior can unexpectedly terminate the swarm (and the game
-                        // app) if it encounters a peer having a different blockchain, and therefore
-                        // can be exploited to remotely shut down other nodes as well.
-                        // Since the intention of this behavior is to prevent mistakes to try to
-                        // connect incorrect seeds (by a user), this behavior should be limited for
-                        // only seed peers.
-                        var msg =
-                            $"Since the genesis block is fixed to {BlockChain.Genesis} " +
-                            "protocol-wise, the blockchain which does not share " +
-                            "any mutual block is not acceptable.";
-                        throw new InvalidGenesisBlockException(
-                            branchpoint,
-                            workspace.Genesis.Hash,
-                            msg);
-                    }
-                    else
-                    {
-                        _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Trying to fork...",
-                            logSessionId,
-                            subSessionId
-                        );
-                        workspace = workspace.Fork(branchpoint);
-                        Guid workChainId = workspace.Id;
-                        scope.Add(workChainId);
-                        renderActions = false;
-                        renderBlocks = false;
-                        _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Fork finished.",
-                            logSessionId,
-                            subSessionId
-                        );
-                    }
-
-                    if (!(workspace.Tip is null))
-                    {
-                        hashes = hashes.Skip(1);
-                    }
-
-                    _logger.Debug(
-                        "{SessionId}/{SubSessionId}: Trying to fill up previous blocks...",
-                        logSessionId,
-                        subSessionId
-                    );
-
-                    var hashesAsArray = hashes as Tuple<long, BlockHash>[] ?? hashes.ToArray();
-                    if (!hashesAsArray.Any())
-                    {
-                        break;
-                    }
-
-                    int hashCount = hashesAsArray.Count();
-                    _logger.Debug(
-                        "{SessionId}/{SubSessionId}: Required {Hashes} hashes " +
-                        "(tip: #{TipIndex} {TipHash}).",
-                        logSessionId,
-                        subSessionId,
-                        hashCount,
-                        workspace.Tip?.Index,
-                        workspace.Tip?.Hash
-                    );
-
-                    totalBlockCount = Math.Max(totalBlockCount, receivedBlockCount + hashCount);
-
-                    IAsyncEnumerable<Block<T>> blocks = GetBlocksAsync(
-                        peer,
-                        hashesAsArray.Select(pair => pair.Item2),
-                        cancellationToken
-                    );
-
-                    var receivedBlockCountCurrentLoop = 0;
-                    await foreach (Block<T> block in blocks)
-                    {
-                        const string startMsg =
-                            "{SessionId}/{SubSessionId}: Trying to append block " +
-                            "#{BlockIndex} {BlockHash}...";
-                        _logger.Debug(
-                            startMsg,
-                            logSessionId,
-                            subSessionId,
-                            block.Index,
-                            block.Hash
-                        );
-
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        workspace.Append(
-                            block,
-                            evaluateActions: evaluateActions,
-                            renderBlocks: renderBlocks,
-                            renderActions: renderActions
-                        );
-                        receivedBlockCountCurrentLoop++;
-                        progress?.Report(new BlockDownloadState
-                        {
-                            TotalBlockCount = totalBlockCount,
-                            ReceivedBlockCount = receivedBlockCount + receivedBlockCountCurrentLoop,
-                            ReceivedBlockHash = block.Hash,
-                            SourcePeer = peer,
-                        });
-                        const string endMsg =
-                            "{SessionId}/{SubSessionId}: Appended block #{BlockIndex} {BlockHash}.";
-                        _logger.Debug(endMsg, logSessionId, subSessionId, block.Index, block.Hash);
-                    }
-
-                    receivedBlockCount += receivedBlockCountCurrentLoop;
-                    var isEndedFirstTime = receivedBlockCount == receivedBlockCountCurrentLoop &&
-                                           receivedBlockCount < FindNextHashesChunkSize - 1;
-
-                    if (receivedBlockCountCurrentLoop < FindNextHashesChunkSize && isEndedFirstTime)
-                    {
-                        _logger.Debug(
-                            "{SessionId}/{SubSessionId}: Got {Count} blocks from Peer {Peer} " +
-                            "(tip: #{TipIndex} {TipHash})",
-                            logSessionId,
-                            subSessionId,
-                            receivedBlockCountCurrentLoop,
-                            peer.Address.ToHex(),
-                            workspace.Tip?.Index,
-                            workspace.Tip?.Hash
-                        );
-                        break;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                const string msg =
-                    "{SessionId}: Unexpected error occurred during " + fname + "().";
-                _logger.Error(e, msg, logSessionId);
-                if (workspace?.Id is Guid workspaceId && scope.Contains(workspaceId))
-                {
-                    _store.DeleteChainId(workspaceId);
-                }
-
-                throw;
-            }
-            finally
-            {
-                const string msg =
-                    "{SessionId}: " + fname +
-                    "() completed (chain ID: {ChainId}, tip: #{TipIndex} {TipHash}).";
-                _logger.Debug(
-                    msg,
-                    logSessionId,
-                    workspace?.Id,
-                    workspace?.Tip?.Index,
-                    workspace?.Tip?.Hash
-                );
-                foreach (var id in scope.Where(guid => guid != workspace?.Id))
-                {
-                    _store.DeleteChainId(id);
-                }
-            }
-
-            return workspace;
-        }
-#pragma warning restore MEN003
 
         private void OnBlockChainTipChanged(object sender, (Block<T> OldTip, Block<T> NewTip) e)
         {

--- a/Libplanet/Net/Swarm.BlockSync.cs
+++ b/Libplanet/Net/Swarm.BlockSync.cs
@@ -21,7 +21,8 @@ namespace Libplanet.Net
         public BlockDemandTable<T> BlockDemandTable { get; private set; }
 
         /// <summary>
-        /// This is a table of waiting <see cref="Block"/>s to enter the <see cref="BlockChain"/>.
+        /// This is a table of waiting <see cref="Block{T}"/>s
+        /// to enter the <see cref="BlockChain"/>.
         /// <seealso cref="BlockCandidateTable{T}"/>
         /// </summary>
         public BlockCandidateTable<T> BlockCandidateTable { get; private set; }
@@ -98,8 +99,8 @@ namespace Libplanet.Net
             catch (Exception e)
             {
                 var msg =
-                    $"Unexpected exception occured during {nameof(PullBlocksAsync)}(). {{e}}";
-                _logger.Error(e, msg, e);
+                    $"Unexpected exception occured during {nameof(PullBlocksAsync)}().";
+                _logger.Error(e, msg);
                 FillBlocksAsyncFailed.Set();
             }
             finally
@@ -462,9 +463,7 @@ namespace Libplanet.Net
                         {
                             _logger.Error(
                                 e,
-                                "An exception occurred during appending blocks: {Exception}",
-                                e
-                            );
+                                "An exception occurred during appending blocks.");
                             throw;
                         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -372,7 +372,7 @@ namespace Libplanet.Net
                         Options.PollInterval,
                         Options.MaximumPollPeers,
                         _cancellationToken));
-                tasks.Add(BlockCandidateConsume(
+                tasks.Add(ConsumeBlockCandidates(
                     dialTimeout,
                     _cancellationToken));
                 tasks.Add(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -372,7 +372,7 @@ namespace Libplanet.Net
                         Options.PollInterval,
                         Options.MaximumPollPeers,
                         _cancellationToken));
-                tasks.Add(BlockCandidateConsumer(
+                tasks.Add(BlockCandidateConsume(
                     dialTimeout,
                     _cancellationToken));
                 tasks.Add(

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -259,6 +259,7 @@ namespace Libplanet.Net
             }
 
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
+            BlockCandidateTable = new BlockCandidateTable<T>();
             _logger.Debug($"{nameof(Swarm<T>)} stopped.");
         }
 
@@ -342,6 +343,7 @@ namespace Libplanet.Net
                     _workerCancellationTokenSource.Token, cancellationToken
                 ).Token;
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
+            BlockCandidateTable = new BlockCandidateTable<T>();
             if (Transport.Running)
             {
                 throw new SwarmException("Swarm is already running.");
@@ -370,6 +372,9 @@ namespace Libplanet.Net
                         Options.PollInterval,
                         Options.MaximumPollPeers,
                         _cancellationToken));
+                tasks.Add(BlockCandidateConsumer(
+                    dialTimeout,
+                    _cancellationToken));
                 tasks.Add(
                     PollBlocksAsync(
                         dialTimeout,


### PR DESCRIPTION
![Flowchart for this PR](https://user-images.githubusercontent.com/16367497/148346600-12c2b9ac-51a2-460d-85a4-c8a642c0c60d.JPG)

In order to solve the problem that it takes a long time to timeout when a node is disconnected while downloading a block from a node, it is a PR that implements a method of attaching downloaded blocks after receiving blocks in parallel. 