### PR TITLE
Funnel sending `Message`s to `SendMessageAsync()` when broadcasting for `NetMQTransport`

### DIFF
--- a/Libplanet/Net/DifferentAppProtocolVersionException.cs
+++ b/Libplanet/Net/DifferentAppProtocolVersionException.cs
@@ -7,7 +7,7 @@ namespace Libplanet.Net
 {
     /// <summary>
     /// The exception that is thrown when the version of the
-    /// <see cref="Message" /> that <see cref="Swarm{T}" /> received
+    /// <see cref="Message"/> that <see cref="Swarm{T}"/> received
     /// is different.
     /// </summary>
     [Serializable]
@@ -17,15 +17,13 @@ namespace Libplanet.Net
         /// Initializes a new instance of the
         /// <see cref="DifferentAppProtocolVersionException"/> class.
         /// </summary>
-        /// <param name="identity">The identity of the message received. Will have empty
-        /// string if the message is a reply.</param>
+        /// <param name="identity">The <see cref="Message.Identity"/> of the <see cref="Message"/>
+        /// received.</param>
         /// <param name="expectedVersion">The protocol version of the current
         /// <see cref="Swarm{T}"/>.</param>
-        /// <param name="actualVersion">The protocol version of the
-        /// <see cref="Peer"/> that <see cref="Swarm{T}" /> is trying to connect
-        /// to.</param>
-        /// <param name="message">Specifies an <see cref="Exception.Message"/>.
-        /// </param>
+        /// <param name="actualVersion">The protocol version of the <see cref="Peer"/> that
+        /// <see cref="Swarm{T}"/> is trying to connect to.</param>
+        /// <param name="message">Specifies an <see cref="Exception.Message"/>.</param>
         public DifferentAppProtocolVersionException(
             string message,
             byte[] identity,
@@ -44,7 +42,6 @@ namespace Libplanet.Net
 
         /// <summary>
         /// The identity of the message received.
-        /// Will have <c>null</c> if the message is a reply.
         /// </summary>
         public byte[] Identity { get; }
 

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -132,6 +132,10 @@ namespace Libplanet.Net.Messages
         /// If message B is a reply to message A,
         /// B's identity must be set to A's identity.
         /// </summary>
+        /// <remarks>
+        /// The handling of the identity of a message is implementation specific to
+        /// <see cref="ITransport"/>.
+        /// </remarks>
         public byte[]? Identity { get; set; }
 
         /// <summary>

--- a/Libplanet/Net/Transports/ITransport.cs
+++ b/Libplanet/Net/Transports/ITransport.cs
@@ -73,7 +73,7 @@ namespace Libplanet.Net.Transports
         Task WaitForRunningAsync();
 
         /// <summary>
-        /// Sends the <paramref name="message"/> to given <paramref name="peer"/>.
+        /// Sends a <see cref="Message"/> to a given <see cref="BoundPeer"/>.
         /// </summary>
         /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
         /// <param name="message">A <see cref="Message"/> to send.</param>
@@ -86,11 +86,11 @@ namespace Libplanet.Net.Transports
         Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sends the <paramref name="message"/>
-        /// to given <paramref name="peer"/> and waits for its single reply.
+        /// Sends a <see cref="Message"/> to a given <see cref="BoundPeer"/>
+        /// and waits for its single reply.
         /// </summary>
-        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
-        /// <param name="message">A <see cref="Message"/> to send.</param>
+        /// <param name="peer">The <see cref="BoundPeer"/> to send message to.</param>
+        /// <param name="message">The <see cref="Message"/> to send.</param>
         /// <param name="timeout">A timeout of waiting for the reply of the message.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
@@ -106,11 +106,11 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sends the <paramref name="message"/>
-        /// to given <paramref name="peer"/> and waits for its multiple replies.
+        /// Sends a <see cref="Message"/> to a given <see cref="BoundPeer"/>
+        /// and waits for its multiple replies.
         /// </summary>
-        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
-        /// <param name="message">A <see cref="Message"/> to send.</param>
+        /// <param name="peer">The <see cref="BoundPeer"/> to send message to.</param>
+        /// <param name="message">The <see cref="Message"/> to send.</param>
         /// <param name="timeout">A timeout of waiting for the reply of the message.</param>
         /// <param name="expectedResponses">The number of expected replies for the message.</param>
         /// <param name="returnWhenTimeout">Determines the behavior when failed to receive
@@ -120,8 +120,8 @@ namespace Libplanet.Net.Transports
         /// operation should be canceled.</param>
         /// <returns>The replies of the <paramref name="message"/>
         /// sent by <paramref name="peer"/>.</returns>
-        /// <exception cref="ObjectDisposedException">
-        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when <see cref="ITransport"/> instance
+        /// is already disposed.</exception>
         Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -131,24 +131,24 @@ namespace Libplanet.Net.Transports
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Broadcasts the <paramref name="message"/> to peers selected from the routing table.
+        /// Broadcasts a <see cref="Message"/> to peers selected from the routing table.
         /// </summary>
-        /// <param name="except">An <see cref="Address"/> to exclude from broadcasting.
-        /// If <c>null</c> is given, no peers will be excluded.</param>
-        /// <param name="message">A <see cref="Message"/> to broadcast.</param>
-        /// <exception cref="ObjectDisposedException">
-        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
+        /// <param name="except">The <see cref="Address"/> to exclude when broadcasting.
+        /// If <c>null</c>, no peers will be excluded.</param>
+        /// <param name="message">The <see cref="Message"/> to broadcast.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when <see cref="ITransport"/> instance
+        /// is already disposed.</exception>
         void BroadcastMessage(Address? except, Message message);
 
         /// <summary>
-        /// Replies message.
+        /// Sends a <see cref="Message"/> as a reply.
         /// </summary>
         /// <remarks>
-        /// The <see cref="Message.Identity"/> of the given <paramref name="message"/> must be
-        /// matched to <see cref="Message.Identity"/> of a message corresponding to the given
-        /// <paramref name="message"/>.
+        /// The <see cref="Message.Identity"/> of given <paramref name="message"/> must
+        /// match the <see cref="Message.Identity"/> of the request <see cref="Message"/>
+        /// corresponding to <paramref name="message"/>.
         /// </remarks>
-        /// <param name="message">A <see cref="Message"/> to reply.</param>
+        /// <param name="message">The <see cref="Message"/> to send as a reply.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.</param>

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -689,19 +689,25 @@ namespace Libplanet.Net.Transports
                     .Select(peer =>
                         SendMessageAsync(peer, message, _runtimeCancellationTokenSource.Token))
                     .ToList();
-                Task aggregateTask = Task.WhenAll(tasks);
-                try
-                {
-                    aggregateTask.GetAwaiter().GetResult();
-                }
-                catch (Exception)
-                {
-                    AggregateException aggregateException = aggregateTask.Exception!;
-                    _logger.Warning(
-                        aggregateException,
-                        "Failed to send {MessageType} to some peers while broadcasting.",
-                        message.Type);
-                }
+                Task aggregateTask = Task
+                    .WhenAll(tasks)
+                    .ContinueWith(task =>
+                        {
+                            if (task.IsFaulted)
+                            {
+                                AggregateException aggregateException = task.Exception;
+                                _logger.Warning(
+                                    aggregateException,
+                                    "Failed to send {Message} to some peers while broadcasting.",
+                                    message);
+                            }
+                            else if (task.IsCanceled)
+                            {
+                                _logger.Debug(
+                                    "{FName}() was canceled during its operation.",
+                                    nameof(DoBroadcast));
+                            }
+                        });
             }
             catch (Exception exc)
             {
@@ -709,7 +715,6 @@ namespace Libplanet.Net.Transports
                     exc,
                     "Unexpected error occurred during {FName}().",
                     nameof(DoBroadcast));
-                throw;
             }
         }
 

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -52,14 +52,13 @@ namespace Libplanet.Net.Transports
         private Task _runtimeProcessor;
 
         private TaskCompletionSource<object> _runningEvent;
-        private ConcurrentDictionary<Address, DealerSocket> _dealers;
         private ConcurrentDictionary<string, TaskCompletionSource<object>> _replyCompletionSources;
 
         private RoutingTable _table;
 
         /// <summary>
         /// The <see cref="EventHandler" /> triggered when the different version of
-        /// <see cref="Peer" /> is discovered.
+        /// <see cref="Peer"/> is discovered.
         /// </summary>
         private DifferentAppProtocolVersionEncountered _differentAppProtocolVersionEncountered;
 
@@ -158,7 +157,7 @@ namespace Libplanet.Net.Transports
                     try
                     {
                         using var runtime = new NetMQRuntime();
-                        var workerTasks = new Task[workers];
+                        Task[] workerTasks = new Task[workers];
 
                         for (int i = 0; i < workers; i++)
                         {
@@ -169,17 +168,17 @@ namespace Libplanet.Net.Transports
 
                         runtime.Run(workerTasks);
                     }
-                    catch (NetMQException e)
+                    catch (NetMQException nme)
                     {
                         _logger.Error(
-                            e,
+                            nme,
                             $"NetMQException occurred in {nameof(_runtimeProcessor)}."
                         );
                     }
-                    catch (ObjectDisposedException e)
+                    catch (ObjectDisposedException ode)
                     {
                         _logger.Error(
-                            e,
+                            ode,
                             $"ObjectDisposedException occurred in {nameof(_runtimeProcessor)}."
                         );
                     }
@@ -190,12 +189,11 @@ namespace Libplanet.Net.Transports
             );
 
             ProcessMessageHandler = new AsyncDelegate<Message>();
-            _dealers = new ConcurrentDictionary<Address, DealerSocket>();
             _replyCompletionSources =
                 new ConcurrentDictionary<string, TaskCompletionSource<object>>();
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <inheritdoc cref="ITransport.AsPeer"/>
@@ -228,7 +226,7 @@ namespace Libplanet.Net.Transports
 
         internal DnsEndPoint EndPoint => _turnClient?.EndPoint ?? _hostEndPoint;
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
             if (_disposed)
@@ -259,9 +257,6 @@ namespace Libplanet.Net.Transports
 
             List<Task> tasks = new List<Task>();
 
-            tasks.Add(DisposeUnusedDealerSockets(
-                TimeSpan.FromSeconds(10),
-                _runtimeCancellationTokenSource.Token));
             tasks.Add(RunPoller(_routerPoller));
             tasks.Add(RunPoller(_broadcastPoller));
 
@@ -270,7 +265,7 @@ namespace Libplanet.Net.Transports
             await await Task.WhenAny(tasks);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task StopAsync(
             TimeSpan waitFor,
             CancellationToken cancellationToken = default
@@ -305,18 +300,12 @@ namespace Libplanet.Net.Transports
                 _router.Dispose();
                 _turnClient?.Dispose();
 
-                foreach (DealerSocket dealer in _dealers.Values)
-                {
-                    dealer.Dispose();
-                }
-
-                _dealers.Clear();
                 _runtimeCancellationTokenSource.Cancel();
                 Running = false;
             }
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (!_disposed)
@@ -337,7 +326,7 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc cref="ITransport.WaitForRunningAsync"/>
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public Task SendMessageAsync(
             BoundPeer peer,
             Message message,
@@ -350,7 +339,7 @@ namespace Libplanet.Net.Transports
                 false,
                 cancellationToken);
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task<Message> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -370,7 +359,7 @@ namespace Libplanet.Net.Transports
             return reply;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task<IEnumerable<Message>> SendMessageWithReplyAsync(
             BoundPeer peer,
             Message message,
@@ -429,26 +418,25 @@ namespace Libplanet.Net.Transports
 
                 if (expectedResponses > 0)
                 {
-                    var reply = (await tcs.Task).ToList();
+                    List<Message> replies = (await tcs.Task).ToList();
                     const string logMsg =
-                        "Received {ReplyMessageCount} reply messages to {RequestId} " +
+                        "Received {ReplyCount} reply messages to {RequestId} " +
                         "from the {Peer}: {@ReplyMessages}.";
-                    _logger.Debug(logMsg, reply.Count, reqId, peer, reply);
+                    _logger.Debug(logMsg, replies.Count, reqId, peer, replies);
 
-                    return reply;
+                    return replies;
                 }
                 else
                 {
                     return new Message[0];
                 }
             }
-            catch (DifferentAppProtocolVersionException e)
+            catch (DifferentAppProtocolVersionException dapve)
             {
                 const string logMsg =
                     "{PeerAddress} sent a reply to {RequestId} with " +
-                    "a different app protocol version; " +
-                    "expected: {ExpectedVersion}; actual: {ActualVersion}.";
-                _logger.Error(e, logMsg, peer.Address, reqId, e.ExpectedVersion, e.ActualVersion);
+                    "a different app protocol version.";
+                _logger.Error(dapve, logMsg, peer.Address, reqId);
                 throw;
             }
             catch (InvalidTimestampException ite)
@@ -469,31 +457,31 @@ namespace Libplanet.Net.Transports
             {
                 var msg =
                     $"{nameof(NetMQTransport)}.{nameof(SendMessageWithReplyAsync)}() timed out " +
-                    "after {Timeout} of waiting a reply to {MessageType} ({RequestId}) from " +
+                    "after {Timeout} of waiting a reply to {MessageType} {RequestId} from " +
                     "{PeerAddress}.";
-                _logger.Debug(msg, timeout, message.GetType().Name, reqId, peer.Address);
+                _logger.Debug(msg, timeout, message.Type, reqId, peer.Address);
                 throw;
             }
             catch (TaskCanceledException)
             {
                 var msg =
                     $"{nameof(NetMQTransport)}.{nameof(SendMessageWithReplyAsync)}() was " +
-                    "cancelled to wait a reply to {MessageType} ({RequestId}) from {PeerAddress}.";
-                _logger.Debug(msg, message.GetType().Name, reqId, peer.Address);
+                    "cancelled to wait a reply to {MessageType} {RequestId} from {PeerAddress}.";
+                _logger.Debug(msg, message.Type, reqId, peer.Address);
                 throw;
             }
             catch (Exception e)
             {
                 var msg =
                     $"{nameof(NetMQTransport)}.{nameof(SendMessageWithReplyAsync)}() encountered " +
-                    "an unexpected exception during sending a request {MessageType} " +
-                    "({RequestId}) to {PeerAddress} and waiting a reply to it.";
-                _logger.Error(e, msg, message.GetType().Name, reqId, peer.Address);
+                    "an unexpected exception during sending a request {MessageType} {RequestId} " +
+                    "to {PeerAddress} and waiting a reply to it.";
+                _logger.Error(e, msg, message.Type, reqId, peer.Address);
                 throw;
             }
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void BroadcastMessage(Address? except, Message message)
         {
             if (_disposed)
@@ -504,7 +492,7 @@ namespace Libplanet.Net.Transports
             _broadcastQueue.Enqueue((except, message));
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
             if (_disposed)
@@ -513,7 +501,7 @@ namespace Libplanet.Net.Transports
             }
 
             string identityHex = ByteUtil.Hex(message.Identity);
-            var tcs = new TaskCompletionSource<object>();
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
             using CancellationTokenRegistration ctr =
                 cancellationToken.Register(() => tcs.TrySetCanceled());
             _replyCompletionSources.TryAdd(identityHex, tcs);
@@ -639,7 +627,7 @@ namespace Libplanet.Net.Transports
             }
             catch (DifferentAppProtocolVersionException dapve)
             {
-                var differentVersion = new DifferentVersion()
+                DifferentVersion differentVersion = new DifferentVersion()
                 {
                     Identity = dapve.Identity,
                 };
@@ -669,59 +657,34 @@ namespace Libplanet.Net.Transports
         {
             try
             {
-                (Address? except, Message msg) = e.Queue.Dequeue();
+                (Address? except, Message message) = e.Queue.Dequeue();
 
                 // FIXME Should replace with PUB/SUB model.
                 IReadOnlyList<BoundPeer> peers =
                     _table.PeersToBroadcast(except, _minimumBroadcastTarget);
-                _logger.Debug("Broadcasting message: {Message} as {AsPeer}", msg, AsPeer);
-                _logger.Debug("Peers to broadcast: {PeersCount}", peers.Count);
+                _logger.Debug(
+                    "Broadcasting {MessageType} to {PeerCount} peers as {AsPeer}...",
+                    message,
+                    peers.Count,
+                    AsPeer);
 
-                NetMQMessage message = _messageCodec.Encode(
-                    msg,
-                    _privateKey,
-                    AsPeer,
-                    DateTimeOffset.UtcNow,
-                    _appProtocolVersion);
-
-                peers.AsParallel().ForAll(peer =>
+                List<Task> tasks = peers
+                    .Select(peer =>
+                        SendMessageAsync(peer, message, _runtimeCancellationTokenSource.Token))
+                    .ToList();
+                Task aggregateTask = Task.WhenAll(tasks);
+                try
                 {
-                    try
-                    {
-                        string endpoint = peer.ToNetMQAddress();
-                        if (!_dealers.TryGetValue(peer.Address, out DealerSocket dealer) ||
-                            dealer.IsDisposed)
-                        {
-                            dealer = new DealerSocket(endpoint);
-                            _dealers[peer.Address] = dealer;
-                        }
-                        else if (dealer.Options.LastEndpoint != endpoint)
-                        {
-                            dealer.Dispose();
-                            dealer = new DealerSocket(endpoint);
-                            _dealers[peer.Address] = dealer;
-                        }
-
-                        if (!dealer.TrySendMultipartMessage(TimeSpan.FromSeconds(3), message))
-                        {
-                            _logger.Warning(
-                                "Broadcasting timed out. [Peer: {Peer}, Message: {Message}]",
-                                peer,
-                                msg
-                            );
-
-                            dealer.Dispose();
-                            _dealers.TryRemove(peer.Address, out _);
-                        }
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // NOTE: ObjectDisposedException can occur even the check exists. So just
-                        // ignore the case and remove dealer socket.
-                        _logger.Verbose("DealerSocket has been disposed.");
-                        _dealers.TryRemove(peer.Address, out _);
-                    }
-                });
+                    aggregateTask.GetAwaiter().GetResult();
+                }
+                catch (Exception)
+                {
+                    AggregateException aggregateException = aggregateTask.Exception!;
+                    _logger.Warning(
+                        aggregateException,
+                        "Failed to send {MessageType} to some peers while broadcasting.",
+                        message.Type);
+                }
             }
             catch (Exception exc)
             {
@@ -733,14 +696,14 @@ namespace Libplanet.Net.Transports
 
         private void DoReply(object sender, NetMQQueueEventArgs<NetMQMessage> e)
         {
-            NetMQMessage msg = e.Queue.Dequeue();
-            string identityHex = ByteUtil.Hex(msg[0].Buffer);
+            NetMQMessage message = e.Queue.Dequeue();
+            string identityHex = ByteUtil.Hex(message[0].Buffer);
 
             _logger.Verbose("Dequeued message. ({identity})", identityHex);
 
             // FIXME The current timeout value(1 sec) is arbitrary.
             // We should make this configurable or fix it to an unneeded structure.
-            if (_router.TrySendMultipartMessage(TimeSpan.FromSeconds(1), msg))
+            if (_router.TrySendMultipartMessage(TimeSpan.FromSeconds(1), message))
             {
                 _logger.Debug("A reply sent to {Identity}", identityHex);
             }
@@ -812,17 +775,17 @@ namespace Libplanet.Net.Transports
         private async Task ProcessRequest(MessageRequest req, CancellationToken cancellationToken)
         {
             _logger.Verbose(
-                "A request {RequestId} is ready to be processed in {TimeSpan}: {@Message}.",
+                "Request {RequestId} is ready to be processed in {TimeSpan}: {@Message}.",
                 req.Id,
                 DateTimeOffset.UtcNow - req.RequestedTime,
                 req.Message
             );
             DateTimeOffset startedTime = DateTimeOffset.UtcNow;
 
-            using var dealer = new DealerSocket(req.Peer.ToNetMQAddress());
+            using DealerSocket dealer = new DealerSocket(req.Peer.ToNetMQAddress());
 
             _logger.Debug(
-                "Trying to send a request {RequestId} to {Peer}...: {Message}.",
+                "Trying to send request {RequestId} to {Peer}...: {Message}.",
                 req.Id,
                 req.Peer,
                 req.Message
@@ -833,7 +796,7 @@ namespace Libplanet.Net.Transports
                 AsPeer,
                 DateTimeOffset.UtcNow,
                 _appProtocolVersion);
-            var result = new List<Message>();
+            List<Message> result = new List<Message>();
             TaskCompletionSource<IEnumerable<Message>> tcs = req.TaskCompletionSource;
             try
             {
@@ -850,7 +813,7 @@ namespace Libplanet.Net.Transports
                     req.Message
                 );
 
-                foreach (var i in Enumerable.Range(0, req.ExpectedResponses))
+                foreach (int i in Enumerable.Range(0, req.ExpectedResponses))
                 {
                     try
                     {
@@ -859,8 +822,8 @@ namespace Libplanet.Net.Transports
                             cancellationToken: cancellationToken
                         );
                         const string rcvMsg =
-                            "Received a raw message ({FrameCount} frames), which replies to " +
-                            "the request {RequestId}, from {Peer}.";
+                            "Received a raw message with {FrameCount} frames as a reply to " +
+                            "request {RequestId} from {Peer}.";
                         _logger.Verbose(
                             rcvMsg,
                             raw.FrameCount,
@@ -911,40 +874,6 @@ namespace Libplanet.Net.Transports
                 req.Message,
                 req.Id,
                 DateTimeOffset.UtcNow - startedTime);
-        }
-
-        private async Task DisposeUnusedDealerSockets(
-            TimeSpan period,
-            CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(period, cancellationToken);
-                    ImmutableHashSet<Address> peerAddresses =
-                        _table.Peers.Select(p => p.Address).ToImmutableHashSet();
-                    foreach (Address address in _dealers.Keys)
-                    {
-                        if (!peerAddresses.Contains(address) &&
-                            _dealers.TryGetValue(address, out DealerSocket removed))
-                        {
-                            removed.Dispose();
-                        }
-                    }
-                }
-                catch (OperationCanceledException e)
-                {
-                    _logger.Warning(e, $"{nameof(DisposeUnusedDealerSockets)}() is cancelled.");
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    var msg = "Unexpected exception occurred during " +
-                              $"{nameof(DisposeUnusedDealerSockets)}(): {{0}}";
-                    _logger.Warning(e, msg, e);
-                }
-            }
         }
 
         private Task RunPoller(NetMQPoller poller) =>
@@ -1000,8 +929,7 @@ namespace Libplanet.Net.Transports
                       expectedResponses,
                       returnWhenTimeout,
                       taskCompletionSource,
-                      0
-                    )
+                      0)
             {
             }
 


### PR DESCRIPTION
Internal behavior for broadcasting while using `NetMQTransport` changed to use `SendMessageAsync()`.