### PR TITLE
Change the way how `TxCompletion<TPeer, TAction>` fetch transaction from other peers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ Version 0.25.2
 
 To be released.
 
+ -  Fixed a bug where `TxCompletion<TPeer, TAction>` failed to fetch
+    transactions from other peers.  [[#1704]]
+ -  In `TxCompletion<TPeer, TAction>`, instead of maintaining single
+    `RequestTxsFromPeerAsync()` task for each peer, a new
+    `RequestTxsFromPeerAsync()` task is spawned every time a new
+    demand is received.  [[#1704]]
+
+[#1704]: https://github.com/planetarium/libplanet/pull/1704
+
 
 Version 0.25.1
 --------------


### PR DESCRIPTION
Previously `TxCompletion<TPeer, TAction>.RequestTxsFromPeerAsync()` is maintained maximum 1 task for each peer to fetch transactions from. It caused a bug where fetching does not working even received a new `TxId`s from other peer.

This PR force to spawn `TxCompletion<TPeer, TAction>.RequestTxsFromPeerAsync()` task every time new `TxId`s are received.