### PR TITLE
Fix `ArgumentOutOfRangeException` caused by uninitialized `BlockChain<T>`'s `GetStates()`

### DIFF
--- a/Libplanet.Tests/Blockchain/NullPolicy.cs
+++ b/Libplanet.Tests/Blockchain/NullPolicy.cs
@@ -32,13 +32,13 @@ namespace Libplanet.Tests.Blockchain
 
         public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;
 
-        public long GetNextBlockDifficulty(BlockChain<T> blocks) =>
+        public virtual long GetNextBlockDifficulty(BlockChain<T> blocks) =>
             blocks.Count == 0 ? 0 : _difficulty;
 
-        public TxPolicyViolationException ValidateNextBlockTx(
+        public virtual TxPolicyViolationException ValidateNextBlockTx(
             BlockChain<T> blockChain, Transaction<T> transaction) => null;
 
-        public BlockPolicyViolationException ValidateNextBlock(
+        public virtual BlockPolicyViolationException ValidateNextBlock(
             BlockChain<T> blocks,
             Block<T> nextBlock
         )

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -469,11 +469,13 @@ namespace Libplanet.Blockchain
             BlockHash? offset = null,
             StateCompleter<T> stateCompleter = null
         ) =>
-            GetStates(
-                new[] { address },
-                offset ?? Tip.Hash,
-                stateCompleter ?? StateCompleters<T>.Reject
-            )[0];
+            Count > 0
+            ? GetStates(
+                    new[] { address },
+                    offset ?? Tip.Hash,
+                    stateCompleter ?? StateCompleters<T>.Reject
+                )[0]
+            : null;
 
         /// <summary>
         /// Gets multiple states associated to the specified <paramref name="addresses"/>.
@@ -498,11 +500,13 @@ namespace Libplanet.Blockchain
             BlockHash? offset = null,
             StateCompleter<T> stateCompleter = null
         ) =>
-            GetStates(
-                addresses,
-                offset ?? Tip.Hash,
-                stateCompleter ?? StateCompleters<T>.Reject
-            );
+            Count > 0
+                ? GetStates(
+                    addresses,
+                    offset ?? Tip.Hash,
+                    stateCompleter ?? StateCompleters<T>.Reject
+                )
+                : new IValue[addresses.Count];
 
         public IReadOnlyList<IValue> GetStates(
             IReadOnlyList<Address> addresses,


### PR DESCRIPTION
This patch fixes the uncaught `ArgumentOutOfRangeException` thrown by `BlockChain<T>.GetStates()` or `GetState()` where the chain is uninitialized yet (i.e., has no genesis block yet).  This can be caused when `IBlockPolicy<T>` tries to use `GetStates()`/`GetState()` inside any of its `GetNextBlockDifficulty()`/`ValidateNextBlockTx()`/`ValidateNextBlock()` methods.

The following stack trace is from the exception I saw:

    System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values.
    Stack Trace:
      at Libplanet.Blockchain.BlockChain`1.get_Item(Int64 index) in ~/libplanet/Libplanet/Blockchain/BlockChain.cs:line 304
      at Libplanet.Blockchain.BlockChain`1.get_Tip() in ~/libplanet/Libplanet/Blockchain/BlockChain.cs:line 246
      at Libplanet.Blockchain.BlockChain`1.GetState(Address address, Nullable`1 offset, StateCompleter`1 stateCompleter) in ~/libplanet/Libplanet/Blockchain/BlockChain.cs:line 472
      at Nekoyume.BlockChain.Policy.BlockPolicySource.GetAdminState(BlockChain`1 blockChain) in ~/lib9c/Lib9c/Policy/BlockPolicySource.Utils.cs:line 51
      at Nekoyume.BlockChain.Policy.BlockPolicySource.IsAdminTransaction(BlockChain`1 blockChain, Transaction`1 transaction) in ~/lib9c/Lib9c/Policy/BlockPolicySource.Utils.cs:line 35
      at Nekoyume.BlockChain.Policy.BlockPolicySource.ValidateNextBlockTxRaw(BlockChain`1 blockChain, Transaction`1 transaction, ImmutableHashSet`1 allAuthorizedMiners) in ~/lib9c/Lib9c/Policy/BlockPolicySource.cs:line 305
      at Nekoyume.BlockChain.Policy.BlockPolicySource.<>c__DisplayClass24_0.<GetPolicy>b__2(BlockChain`1 blockChain, Transaction`1 transaction) in ~/lib9c/Lib9c/Policy/BlockPolicySource.cs:line 200
      at Libplanet.Blockchain.Policies.BlockPolicy`1.ValidateNextBlockTx(BlockChain`1 blockChain, Transaction`1 transaction) in ~/libplanet/Libplanet/Blockchain/Policies/BlockPolicy.cs:line 223
      at Libplanet.Blockchain.BlockChain`1.Append(Block`1 block, Boolean evaluateActions, Boolean renderBlocks, Boolean renderActions, IReadOnlyList`1 actionEvaluations, Nullable`1 stateCompleters) in ~/libplanet/Libplanet/Blockchain/BlockChain.cs:line 901
      at Libplanet.Blockchain.BlockChain`1..ctor(IBlockPolicy`1 policy, IStagePolicy`1 stagePolicy, IStore store, IStateStore stateStore, Block`1 genesisBlock, IEnumerable`1 renderers) in ~/libplanet/Libplanet/Blockchain/BlockChain.cs:line 91
      at Lib9c.Tests.MinerTest.Proof() in ~/lib9c/.Lib9c.Tests/MinerTest.cs:line 30

I skipped the changelog as this bug has occurred from the previous patch #1703, which is not released yet.