### PR TITLE
Do not throw error in `NetMQTransport.DoBroadcast()` method & release 0.25.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,12 @@ Libplanet changelog
 Version 0.25.3
 --------------
 
-To be released.
+Released on January 14, 2022.
+
+ -  Fixed a bug when message broadcasting on `Swarm<T>`
+    had been stopped suddenly.  [[#1715]]
+
+[#1715]: https://github.com/planetarium/libplanet/pull/1715
 
 
 Version 0.25.2

--- a/Libplanet/Net/Transports/NetMQTransport.cs
+++ b/Libplanet/Net/Transports/NetMQTransport.cs
@@ -728,7 +728,6 @@ namespace Libplanet.Net.Transports
                 _logger.Error(
                     exc,
                     "Unexpected error occurred during " + nameof(DoBroadcast) + "().");
-                throw;
             }
         }
 


### PR DESCRIPTION
The subject says it all