### PR TITLE
Fix `RocksDBStore`'s inaccurate lock handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,8 +114,8 @@ Released on January 5, 2022.
 ### Behavioral changes
 
   -  Improved performance of `Swarm<T>`'s block propagation.  [[#1676]]
-  -  Improved performance of `RocksDBStore<T>.IterateIndexes()` method.
-     [[#1676]]
+  -  (Libplanet.RocksDBStore) Improved performance of
+     `RocksDBStore<T>.IterateIndexes()` method. [[#1676]]
 
 [#1676]: https://github.com/planetarium/libplanet/pull/1676
 [#1678]: https://github.com/planetarium/libplanet/pull/1678
@@ -223,8 +223,8 @@ Released on December 13, 2021.
     improve parallelism.  [[#1657]]
  -  Improved performance of `Swarm<T>`'s block synchronization.  [[#1657]]
  -  Fixed a bug where `Swarm<T>` had swapped to improper chain.  [[#1657]]
- -  Fixed a bug where `RocksDBStore.ForkBlockIndexes()` had created temporary
-    chains unnecessarily.  [[#1657]]
+ -  (Libplanet.RocksDBStore) Fixed a bug where `RocksDBStore.ForkBlockIndexes()`
+    had created temporary chains unnecessarily.  [[#1657]]
 
 [#1657]: https://github.com/planetarium/libplanet/pull/1657
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,11 @@ To be released.
 
  -  Some additional logging to track down issues with staging `Transaction<T>`s.
     [[#1718]]
+ -  (Libplanet.RocksDBStore) Fixed `RocksDBStore`'s inaccurate lock handling.
+    [[#1719]]
 
 [#1718]: https://github.com/planetarium/libplanet/pull/1718
+[#1719]: https://github.com/planetarium/libplanet/pull/1719
 
 
 Version 0.25.3

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -630,7 +630,7 @@ namespace Libplanet.RocksDBStore
             {
                 string blockDbName = RocksDBStoreBitConverter.GetString(blockDbNameBytes);
                 RocksDb blockDb;
-                lock (_blockCache)
+                lock (_blockDbCache)
                 {
                     if (!_blockDbCache.TryGetValue(blockDbName, out blockDb))
                     {


### PR DESCRIPTION
I found this when testing for https://github.com/planetarium/NineChronicles.Headless/issues/1004.
I found similar code in `PutBlock, DeleteBlock` and these methods were locking `_blockDbCache`, so i think `GetBlockDigest` is holding the wrong lock.