### PR TITLE
Update Discord links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We should expand it so that it covers reporting bugs, filing issues,
 and writing docs.
 
 
-Questions & online chat  [![Discord](https://img.shields.io/discord/539405872346955788.svg?color=7289da&logo=discord&logoColor=white)][Discord server]
+Questions & online chat  [![Discord](https://img.shields.io/discord/928926944937013338.svg?color=7289da&logo=discord&logoColor=white)][Discord server]
 -----------------------
 
 We have a [Discord server] to discuss Libplanet.  There are some channels
@@ -23,7 +23,7 @@ for purposes in the *Libplanet* category:
  -  *#development-ko*: The same purpose to *#development*,
     except you can speak Korean instead English here.
 
-[Discord server]: https://discord.gg/planetarium
+[Discord server]: https://planetarium.dev/discord
 
 
 Prerequisites

--- a/Libplanet.Explorer/README.md
+++ b/Libplanet.Explorer/README.md
@@ -28,7 +28,7 @@ store blockchain instead of storage.
 
 [.NET Core]: https://dotnet.microsoft.com/
 [PowerShell]: https://microsoft.com/PowerShell
-[1]: https://discord.gg/planetarium
+[1]: https://planetarium.dev/discord
 
 
 GraphQL

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Libplanet
 =========
 
-[![Discord](https://img.shields.io/discord/539405872346955788.svg?color=7289da&logo=discord&logoColor=white)][Discord]
+[![Discord](https://img.shields.io/discord/928926944937013338.svg?color=7289da&logo=discord&logoColor=white)][Discord]
 [![Build Status (CircleCI)](https://circleci.com/gh/planetarium/libplanet/tree/main.svg?style=shield)][CircleCI]
 [![Codecov](https://codecov.io/gh/planetarium/libplanet/branch/main/graph/badge.svg)][Codecov]
 [![NuGet](https://img.shields.io/nuget/v/Libplanet.svg?style=flat)][NuGet]
@@ -30,7 +30,7 @@ It has competitive advantages over other solutions for decentralized gaming:
 To learn more about why Planetarium is creating technology for fully
 decentralized games, please refer to our [blog post].
 
-[Discord]: https://discord.gg/planetarium
+[Discord]: https://planetarium.dev/discord
 [CircleCI]: https://app.circleci.com/pipelines/github/planetarium/libplanet
 [Codecov]: https://codecov.io/gh/planetarium/libplanet
 [NuGet]: https://www.nuget.org/packages/Libplanet/


### PR DESCRIPTION
We recently moved our Discord server which is separated from the existing one, as it's virtually dedicated to Nine Chronicles nowadays.