### PR TITLE
Parallelize MPT path finding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  `MerkleTrie.Get()` method now finds multiple states in parallel.  [[#1743]]
+
 ### Bug fixes
 
 ### Dependencies
@@ -27,6 +29,7 @@ To be released.
 ### CLI tools
 
 [#1691]: https://github.com/planetarium/libplanet/pull/1691
+[#1743]: https://github.com/planetarium/libplanet/pull/1743
 
 
 Version 0.26.1

--- a/Libplanet.Tests/Store/Trie/MerkleTriePathCursorTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTriePathCursorTest.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Immutable;
+using Libplanet.Store.Trie;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+using PathCursor = Libplanet.Store.Trie.MerkleTrie.PathCursor;
+
+namespace Libplanet.Tests.Store.Trie
+{
+    public class MerkleTriePathCursorTest
+    {
+        [Fact]
+        public void Constructor()
+        {
+            KeyBytes keyBytes = KeyBytes.FromHex("cfed4460");
+            var cursor = new PathCursor(keyBytes, false);
+            AssertBytesEqual(keyBytes.ByteArray, cursor.Bytes);
+            Assert.Equal(8, cursor.NibbleLength);
+            Assert.Equal(0, cursor.NibbleOffset);
+
+            cursor = new PathCursor(keyBytes, true);
+            ImmutableArray<byte> hash =
+                FromHex("42b7a23ca82b1d195f73ac729f216074c7781af7bd808bea825e38556eca13a6");
+            AssertBytesEqual(hash, cursor.Bytes);
+            Assert.Equal(64, cursor.NibbleLength);
+            Assert.Equal(0, cursor.NibbleOffset);
+        }
+
+        [Fact]
+        public void FromNibbles()
+        {
+            ImmutableArray<byte> nibbles = FromHex("0c0f0e0d04040600");
+            PathCursor cursor = PathCursor.FromNibbles(nibbles);
+            AssertBytesEqual(FromHex("cfed4460"), cursor.Bytes);
+            Assert.Equal(8, cursor.NibbleLength);
+            Assert.Equal(0, cursor.NibbleOffset);
+
+            cursor = PathCursor.FromNibbles(nibbles, 1);
+            AssertBytesEqual(FromHex("cfed4460"), cursor.Bytes);
+            Assert.Equal(8, cursor.NibbleLength);
+            Assert.Equal(1, cursor.NibbleOffset);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = PathCursor.FromNibbles(nibbles, -1);
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = PathCursor.FromNibbles(nibbles, 9);
+            });
+        }
+
+        [Fact]
+        public void Next()
+        {
+            var cursor = new PathCursor(KeyBytes.FromHex("cfed4460"), false);
+            Assert.Equal(0, cursor.NibbleOffset);
+            Assert.Equal(8, cursor.RemainingNibbleLength);
+            Assert.Equal((byte)0xc, cursor.NextNibble);
+            AssertBytesEqual(FromHex("0c0f0e0d04040600"), cursor.GetRemainingNibbles());
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor = cursor.Next(-1); });
+            Assert.Equal(0, cursor.NibbleOffset);
+            Assert.Equal(8, cursor.RemainingNibbleLength);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor = cursor.Next(9); });
+            Assert.Equal(0, cursor.NibbleOffset);
+            Assert.Equal(8, cursor.RemainingNibbleLength);
+
+            var next = cursor.Next(1);
+            Assert.Equal(0, cursor.NibbleOffset);
+            Assert.Equal(8, cursor.RemainingNibbleLength);
+            Assert.Equal((byte)0xc, cursor.NextNibble);
+            AssertBytesEqual(FromHex("0c0f0e0d04040600"), cursor.GetRemainingNibbles());
+            Assert.Equal(1, next.NibbleOffset);
+            Assert.Equal((byte)0xf, next.NextNibble);
+            Assert.Equal(7, next.RemainingNibbleLength);
+            AssertBytesEqual(FromHex("0f0e0d04040600"), next.GetRemainingNibbles());
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { next = next.Next(-1); });
+            Assert.Equal(1, next.NibbleOffset);
+            Assert.Equal(7, next.RemainingNibbleLength);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { next = next.Next(8); });
+            Assert.Equal(1, next.NibbleOffset);
+            Assert.Equal(7, next.RemainingNibbleLength);
+
+            var next2 = next.Next(5);
+            Assert.Equal(0, cursor.NibbleOffset);
+            Assert.Equal(8, cursor.RemainingNibbleLength);
+            Assert.Equal((byte)0xc, cursor.NextNibble);
+            AssertBytesEqual(FromHex("0c0f0e0d04040600"), cursor.GetRemainingNibbles());
+            Assert.Equal(1, next.NibbleOffset);
+            Assert.Equal(7, next.RemainingNibbleLength);
+            Assert.Equal((byte)0xf, next.NextNibble);
+            AssertBytesEqual(FromHex("0f0e0d04040600"), next.GetRemainingNibbles());
+            Assert.Equal(6, next2.NibbleOffset);
+            Assert.Equal(2, next2.RemainingNibbleLength);
+            Assert.Equal((byte)0x6, next2.NextNibble);
+            AssertBytesEqual(FromHex("0600"), next2.GetRemainingNibbles());
+        }
+
+        [Fact]
+        public void NibbleAt()
+        {
+            var cursor = new PathCursor(KeyBytes.FromHex("cfed4460"), false);
+            Assert.Equal(0xc, cursor.NibbleAt(0));
+            Assert.Equal(0xf, cursor.NibbleAt(1));
+            Assert.Equal(0xe, cursor.NibbleAt(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(-1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(8); });
+
+            cursor = PathCursor.FromNibbles(FromHex("0c0f0e0d040406"), 3);
+            Assert.Equal(0xd, cursor.NibbleAt(0));
+            Assert.Equal(0x4, cursor.NibbleAt(1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(-1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(5); });
+        }
+
+        [Fact]
+        public void CountCommonStartingNibbles()
+        {
+            var cursor = new PathCursor(KeyBytes.FromHex("cfed4460"), false);
+            Assert.Equal(
+                0,
+                cursor.CountCommonStartingNibbles(ImmutableArray<byte>.Empty)
+            );
+            Assert.Equal(
+                0,
+                cursor.CountCommonStartingNibbles(FromHex("0a0b0c0d"))
+            );
+            Assert.Equal(
+                3,
+                cursor.CountCommonStartingNibbles(FromHex("0c0f0e0f0f0f0f"))
+            );
+            Assert.Equal(
+                8,
+                cursor.CountCommonStartingNibbles(FromHex("0c0f0e0d040406000a0b0c0d"))
+            );
+
+            PathCursor next = cursor.Next(3);
+            Assert.Equal(
+                0,
+                next.CountCommonStartingNibbles(ImmutableArray<byte>.Empty)
+            );
+            Assert.Equal(
+                0,
+                next.CountCommonStartingNibbles(FromHex("0c0f0e0f0f0f0f"))
+            );
+            Assert.Equal(
+                3,
+                next.CountCommonStartingNibbles(FromHex("0d04040a0b0c"))
+            );
+            Assert.Equal(
+                5,
+                next.CountCommonStartingNibbles(FromHex("0d040406000a0b0c0d"))
+            );
+        }
+
+        [Fact]
+        public void RemainingNibblesStartWith()
+        {
+            var cursor = new PathCursor(KeyBytes.FromHex("cfed4460"), false);
+            Assert.True(cursor.RemainingNibblesStartWith(FromHex("0c0f0e0d04")));
+            Assert.False(cursor.RemainingNibblesStartWith(FromHex("0c0f0e0d040406000a")));
+            Assert.False(cursor.RemainingNibblesStartWith(FromHex("0c0f0e0d0f0f0f")));
+
+            PathCursor next = cursor.Next(3);
+            Assert.True(next.RemainingNibblesStartWith(FromHex("0d0404")));
+            Assert.False(next.RemainingNibblesStartWith(FromHex("0d040406000a0b0c0d")));
+            Assert.False(next.RemainingNibblesStartWith(FromHex("0d040a0b0c")));
+        }
+
+        private static ImmutableArray<byte> FromHex(string hex) =>
+            ByteUtil.ParseHex(hex).ToImmutableArray();
+    }
+}

--- a/Libplanet.Tests/Store/Trie/Nodes/ShortNodeTest.cs
+++ b/Libplanet.Tests/Store/Trie/Nodes/ShortNodeTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Bencodex.Types;
 using Libplanet.Store.Trie.Nodes;
 using Xunit;
@@ -9,7 +10,10 @@ namespace Libplanet.Tests.Store.Trie.Nodes
         [Fact]
         public void ToBencodex()
         {
-            var shortNode = new ShortNode(ByteUtil.ParseHex("beef"), new ValueNode((Text)"foo"));
+            var shortNode = new ShortNode(
+                ByteUtil.ParseHex("beef").ToImmutableArray(),
+                new ValueNode((Text)"foo")
+            );
 
             var expected =
                 new List(new IValue[]

--- a/Libplanet/Store/Trie/MerkleTrie.Path.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.Path.cs
@@ -160,8 +160,8 @@ namespace Libplanet.Store.Trie
 
             // FIXME: We should declare a custom value type to represent nibbles...
             [Pure]
-            private static byte GetNibble(byte word, bool high) =>
-                high ? (byte)(word >> 4) : (byte)(word & 0b00001111);
+            private static byte GetNibble(byte octet, bool high) =>
+                high ? (byte)(octet >> 4) : (byte)(octet & 0b00001111);
         }
 
         private readonly struct PathResolution

--- a/Libplanet/Store/Trie/MerkleTrie.Path.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.Path.cs
@@ -1,0 +1,147 @@
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Security.Cryptography;
+
+namespace Libplanet.Store.Trie
+{
+    public partial class MerkleTrie
+    {
+        internal readonly struct PathCursor
+        {
+            public readonly ImmutableArray<byte> Bytes;
+            public readonly int NibbleLength;
+            public readonly int NibbleOffset;
+
+            public PathCursor(in KeyBytes keyBytes, bool secure)
+                : this(
+                    secure
+                        ? HashDigest<SHA256>.DeriveFrom(keyBytes.ByteArray).ByteArray
+                        : keyBytes.ByteArray,
+                    0,
+                    (secure ? HashDigest<SHA256>.Size : keyBytes.Length) * 2)
+            {
+            }
+
+            private PathCursor(in ImmutableArray<byte> bytes, int nibbleOffset, int nibbleLength)
+            {
+                if (nibbleOffset < 0 || nibbleOffset > nibbleLength)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(nibbleOffset));
+                }
+
+                Bytes = bytes;
+                NibbleOffset = nibbleOffset;
+                NibbleLength = nibbleLength;
+            }
+
+            [Pure]
+            public int RemainingNibbleLength => NibbleLength - NibbleOffset;
+
+            [Pure]
+            public bool RemainingAnyNibbles => NibbleLength > NibbleOffset;
+
+            [Pure]
+            public byte NextNibble => NibbleOffset < NibbleLength
+                ? GetNibble(Bytes[NibbleOffset / 2], NibbleOffset % 2 == 0)
+                : throw new IndexOutOfRangeException();
+
+            [Pure]
+            public static PathCursor FromNibbles(
+                in ImmutableArray<byte> nibbles,
+                int nibbleOffset = 0
+            )
+            {
+                if (nibbleOffset < 0 || nibbleOffset > nibbles.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(nibbleOffset));
+                }
+
+                int oddNibble = nibbles.Length % 2;
+                int byteLength = nibbles.Length / 2 + oddNibble;
+                var builder = ImmutableArray.CreateBuilder<byte>(byteLength);
+                for (int i = 0, evenNibbles = nibbles.Length - oddNibble; i < evenNibbles; i += 2)
+                {
+                    builder.Add((byte)(nibbles[i] << 4 | nibbles[i + 1]));
+                }
+
+                if (oddNibble > 0)
+                {
+                    builder.Add((byte)(nibbles[nibbles.Length - 1] << 4));
+                }
+
+                return new PathCursor(builder.MoveToImmutable(), nibbleOffset, nibbles.Length);
+            }
+
+            [Pure]
+            public byte NibbleAt(int index)
+            {
+                int nibbleOffset = NibbleOffset + index;
+                if (index < 0 || nibbleOffset >= NibbleLength)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return GetNibble(Bytes[nibbleOffset / 2], nibbleOffset % 2 == 0);
+            }
+
+            [Pure]
+            public ImmutableArray<byte> GetRemainingNibbles()
+            {
+                var builder = ImmutableArray.CreateBuilder<byte>(RemainingNibbleLength);
+                for (int i = NibbleOffset; i < NibbleLength; i++)
+                {
+                    builder.Add(GetNibble(Bytes[i / 2], i % 2 == 0));
+                }
+
+                return builder.MoveToImmutable();
+            }
+
+            [Pure]
+            public PathCursor Next(int nibbleOffset) => nibbleOffset < 0
+                ? throw new ArgumentOutOfRangeException(nameof(nibbleOffset))
+                : new PathCursor(Bytes, NibbleOffset + nibbleOffset, NibbleLength);
+
+            // FIXME: We should declare a custom value type to represent nibbles...
+            [Pure]
+            public bool RemainingNibblesStartWith(in ImmutableArray<byte> nibbles)
+            {
+                if (NibbleLength < nibbles.Length)
+                {
+                    return false;
+                }
+
+                return CountCommonStartingNibbles(nibbles) >= nibbles.Length;
+            }
+
+            // FIXME: We should declare a custom value type to represent nibbles...
+            [Pure]
+            public int CountCommonStartingNibbles(in ImmutableArray<byte> nibbles)
+            {
+                for (int i = 0; i < nibbles.Length; i++)
+                {
+                    int nibbleOffset = NibbleOffset + i;
+                    int byteOffset = nibbleOffset / 2;
+                    if (byteOffset >= Bytes.Length)
+                    {
+                        return i;
+                    }
+
+                    byte nibble = GetNibble(Bytes[byteOffset], nibbleOffset % 2 == 0);
+                    if (nibble != nibbles[i])
+                    {
+                        return i;
+                    }
+                }
+
+                return nibbles.Length;
+            }
+
+            // FIXME: We should declare a custom value type to represent nibbles...
+            [Pure]
+            private static byte GetNibble(byte word, bool high) =>
+                high ? (byte)(word >> 4) : (byte)(word & 0b00001111);
+        }
+    }
+}

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -660,6 +660,16 @@ namespace Libplanet.Store.Trie
             return value;
         }
 
+        /// <summary>
+        /// Encodes <paramref name="key"/> bytes into double-sized bytes where each byte of
+        /// the input <paramref name="key"/> is split into a high and a low nibble, e.g.,
+        /// AB CD (10101011 11001101) becomes 0A 0B 0C 0D (00001010 00001011 00001100 00001101).
+        /// While the original Patricia tree traverses a bit for each step, we followed Ethereum's
+        /// modified Patricia tree which traverses a nibble for each step.
+        /// </summary>
+        /// <param name="key">The input key bytes.</param>
+        /// <returns>Double-sized bytes where each two bytes correspond to high and low nibbles
+        /// of the input <paramref name="key"/> bytes.</returns>
         private ImmutableArray<byte> ToKey(in KeyBytes key)
         {
             var bytes = _secure

--- a/Libplanet/Store/Trie/Nodes/ShortNode.cs
+++ b/Libplanet/Store/Trie/Nodes/ShortNode.cs
@@ -7,17 +7,13 @@ namespace Libplanet.Store.Trie.Nodes
 {
     internal sealed class ShortNode : BaseNode, IEquatable<ShortNode>
     {
-        public ShortNode(byte[] key, INode? value)
-            : this(key.ToImmutableArray(), value)
-        {
-        }
-
-        public ShortNode(ImmutableArray<byte> key, INode? value)
+        public ShortNode(in ImmutableArray<byte> key, INode? value)
             : base(value)
         {
             Key = key;
         }
 
+        // FIXME: We should declare a custom value type to represent nibbles...
         public ImmutableArray<byte> Key { get; }
 
         bool IEquatable<ShortNode>.Equals(ShortNode? other)


### PR DESCRIPTION
This allows multiple states to be loaded at a time through `IKeyValueStore.Get(IReadOnlyList<KeyBytes>)` method.  In order to parallelize path finding, I replaced recursion-based path finder with explicit loops.  See also `MerkleTrie.ResolvePath()` method and `MerkleTrie.Get()` method.