### PR TITLE
Make some message classes public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ To be released.
 
  -  Added `TrieStateStore.CopyStates()` method.  [[#1653], [#1691]]
  -  Added `NullBlockPolicy<T>` class.  [[#1531], [#1748]]
+ -  Added classes which implements `Message` abstract class.
+    [[#1754], [#1756]]
+     -  Added `Ping` class.
+     -  Added `Pong` class.
+     -  Added `FindNeighbors` class.
+     -  Added `Neighbors` class.
+     -  Added `DifferentVersion` class.
 
 ### Behavioral changes
 
@@ -39,7 +46,7 @@ To be released.
     from the routing table. Instead, it will be removed after
     a certain amount of time.  [[#1741], [#1744]]
  -  `NetMQTransport` no longer attempts to retry failed communications.
-    [[#1751] [#1752]]
+    [[#1751], [#1752]]
 
 ### Bug fixes
 
@@ -58,7 +65,9 @@ To be released.
 [#1747]: https://github.com/planetarium/libplanet/pull/1747
 [#1748]: https://github.com/planetarium/libplanet/pull/1748
 [#1751]: https://github.com/planetarium/libplanet/issues/1751
-[#1752]: https://github.com/planetarium/libplanet/issues/1752
+[#1752]: https://github.com/planetarium/libplanet/pull/1752
+[#1754]: https://github.com/planetarium/libplanet/issues/1754
+[#1756]: https://github.com/planetarium/libplanet/pull/1756
 [CVE-2022-0235]: https://github.com/advisories/GHSA-r683-j2x4-v87g
 
 

--- a/Libplanet/Net/Messages/DifferentVersion.cs
+++ b/Libplanet/Net/Messages/DifferentVersion.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
-    internal class DifferentVersion : Message
+    public class DifferentVersion : Message
     {
         public override MessageType Type => MessageType.DifferentVersion;
 

--- a/Libplanet/Net/Messages/DifferentVersion.cs
+++ b/Libplanet/Net/Messages/DifferentVersion.cs
@@ -2,6 +2,11 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// A reply to any messages with different <see cref="AppProtocolVersion"/>.
+    /// Contains the expected and actual <see cref="AppProtocolVersion"/>
+    /// value of the message.
+    /// </summary>
     public class DifferentVersion : Message
     {
         public override MessageType Type => MessageType.DifferentVersion;

--- a/Libplanet/Net/Messages/FindNeighbors.cs
+++ b/Libplanet/Net/Messages/FindNeighbors.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
-    internal class FindNeighbors : Message
+    public class FindNeighbors : Message
     {
         // TODO: This message may request exact peer instead of its neighbors.
         public FindNeighbors(Address target)

--- a/Libplanet/Net/Messages/FindNeighbors.cs
+++ b/Libplanet/Net/Messages/FindNeighbors.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// Message containing request for nearby peers.
+    /// </summary>
+    /// <seealso cref="Neighbors"/>
     public class FindNeighbors : Message
     {
         // TODO: This message may request exact peer instead of its neighbors.

--- a/Libplanet/Net/Messages/Neighbors.cs
+++ b/Libplanet/Net/Messages/Neighbors.cs
@@ -7,7 +7,7 @@ using Destructurama.Attributed;
 
 namespace Libplanet.Net.Messages
 {
-    internal class Neighbors : Message
+    public class Neighbors : Message
     {
         private static readonly Codec Codec = new Codec();
 

--- a/Libplanet/Net/Messages/Neighbors.cs
+++ b/Libplanet/Net/Messages/Neighbors.cs
@@ -7,6 +7,10 @@ using Destructurama.Attributed;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// Message containing nearby peers. A reply to <see cref="FindNeighbors"/>.
+    /// </summary>
+    /// <seealso cref="FindNeighbors"/>
     public class Neighbors : Message
     {
         private static readonly Codec Codec = new Codec();

--- a/Libplanet/Net/Messages/Ping.cs
+++ b/Libplanet/Net/Messages/Ping.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
-    internal class Ping : Message
+    public class Ping : Message
     {
         public override MessageType Type => MessageType.Ping;
 

--- a/Libplanet/Net/Messages/Ping.cs
+++ b/Libplanet/Net/Messages/Ping.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// Check message to determine peer is alive.
+    /// </summary>
+    /// <seealso cref="Pong"/>
     public class Ping : Message
     {
         public override MessageType Type => MessageType.Ping;

--- a/Libplanet/Net/Messages/Pong.cs
+++ b/Libplanet/Net/Messages/Pong.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
-    internal class Pong : Message
+    public class Pong : Message
     {
         public override MessageType Type => MessageType.Pong;
 

--- a/Libplanet/Net/Messages/Pong.cs
+++ b/Libplanet/Net/Messages/Pong.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace Libplanet.Net.Messages
 {
+    /// <summary>
+    /// A reply to <see cref="Ping"/>.
+    /// </summary>
+    /// <seealso cref="Ping"/>
     public class Pong : Message
     {
         public override MessageType Type => MessageType.Pong;


### PR DESCRIPTION
This implements #1754, but only protocol related messages were included because some of non-protocol messages use internal class (`BlockLocator`) as its constructor arguments. It would be great to make other messages as public in future.