### PR TITLE
Added metric log for transaction evaluation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ To be released.
     a certain amount of time.  [[#1741], [#1744]]
  -  `NetMQTransport` no longer attempts to retry failed communications.
     [[#1751], [#1752]]
+ -  New log output tagged with `Metric` added to measure evaluation time for
+    individual `Transaction<T>`s.  [[#1755], [#1758]]
 
 ### Bug fixes
 
@@ -67,7 +69,9 @@ To be released.
 [#1751]: https://github.com/planetarium/libplanet/issues/1751
 [#1752]: https://github.com/planetarium/libplanet/pull/1752
 [#1754]: https://github.com/planetarium/libplanet/issues/1754
+[#1755]: https://github.com/planetarium/libplanet/issues/1755
 [#1756]: https://github.com/planetarium/libplanet/pull/1756
+[#1758]: https://github.com/planetarium/libplanet/pull/1758
 [CVE-2022-0235]: https://github.com/advisories/GHSA-r683-j2x4-v87g
 
 

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -424,6 +424,7 @@ namespace Libplanet.Action
                 delta = block.ProtocolVersion > 0
                     ? new AccountStateDeltaImpl(delta.GetStates, delta.GetBalance, tx.Signer)
                     : new AccountStateDeltaImplV0(delta.GetStates, delta.GetBalance, tx.Signer);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 IEnumerable<ActionEvaluation> evaluations = EvaluateTx(
                     block: block,
                     tx: tx,
@@ -435,6 +436,15 @@ namespace Libplanet.Action
                     yield return evaluation;
                     delta = evaluation.OutputStates;
                 }
+
+                // FIXME: This is dependant on when the returned value is enumerated.
+                TimeSpan evalDuration = DateTimeOffset.Now - startTime;
+                _logger
+                    .ForContext("Tag", "Metric")
+                    .Debug(
+                        "Actions in transaction {TxId} evaluated in {DurationMs:F0}ms.",
+                        tx.Id,
+                        evalDuration.TotalMilliseconds);
             }
         }
 


### PR DESCRIPTION
Closes #1755.

Very minimal implementation to address #1755. There are two issues with this:

- There is no way to identify which `Block<T>` the target `Transaction<T>` belongs to. This is partially due to `ActionEvaluator<T>` not assuming, albeit rightly so, that `Block<T>` is "complete" since `IPreEvaluationBlock<T>` is passed on for evaluation not a mined `Block<T>`. It is possible to associate with `IPreEvaluationBlock<T>`'s `PreEvaluationHash`, but that is a whole another issue.
- As mentioned in `FIXME`, due to lazy evaluation, the measurement depends on how `EvaluateTx()` is called.

It might be possible to resolve the issues above, but I didn't actually want to change the behavior too much just for the sake of better logging. 😶