### PR TITLE
Logging ActionEvaluator<T>.Evaluate() directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Version 0.28.0
 
 To be released.
 
+
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
@@ -52,6 +53,8 @@ To be released.
     complete its process within given timeframe `timeout` argument instead
     of possibly taking longer on some edge cases when waiting for
     multiple replies.  [[#1734], [#1789]]
+ -  `ActionEvaluator<T>.Evaluate()` method became to log message directly
+    instead of other methods that use it.  [[#1773]]
 
 ### Bug fixes
 
@@ -79,6 +82,7 @@ To be released.
 [#1729]: https://github.com/planetarium/libplanet/pull/1729
 [#1734]: https://github.com/planetarium/libplanet/issues/1734
 [#1771]: https://github.com/planetarium/libplanet/pull/1771
+[#1773]: https://github.com/planetarium/libplanet/pull/1773
 [#1779]: https://github.com/planetarium/libplanet/pull/1779
 [#1781]: https://github.com/planetarium/libplanet/issues/1781
 [#1786]: https://github.com/planetarium/libplanet/pull/1786

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -783,28 +783,10 @@ namespace Libplanet.Blockchain
             StateCompleterSet<T>? stateCompleters = null
         )
         {
-            _logger.Debug(
-                "Evaluating actions in the block #{BlockIndex} {BlockHash}...",
-                block.Index,
-                block.Hash
-            );
-            IReadOnlyList<ActionEvaluation> evaluations = null;
-            DateTimeOffset evaluateActionStarted = DateTimeOffset.Now;
-            evaluations = ActionEvaluator.Evaluate(
+            IReadOnlyList<ActionEvaluation> evaluations = ActionEvaluator.Evaluate(
                 block,
                 stateCompleters ?? StateCompleterSet<T>.Recalculate
             );
-            TimeSpan evalDuration = DateTimeOffset.Now - evaluateActionStarted;
-            _logger
-                .ForContext("Tag", "Metric")
-                .Debug(
-                    "Actions in {TxCount} transactions for block #{BlockIndex} {BlockHash} " +
-                    "evaluated in {DurationMs:F0}ms.",
-                    block.Transactions.Count,
-                    block.Index,
-                    block.Hash,
-                    evalDuration.TotalMilliseconds);
-
             _rwlock.EnterWriteLock();
             try
             {


### PR DESCRIPTION
This PR moves logging from `BlockChain<T>.ExecuteActions()` to `ActionEvalutor<T>.Evaluate()` to enable logging of other methods that call it