### PR TITLE
Add transport type selection for `SwarmTest`s by environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,9 +362,21 @@ jobs:
     working_directory: /mnt/ramdisk
     steps: [mono_build_base]
 
-  linux-netcore-test:
+  linux-netcore-test-tcp:
     docker:
     - image: mcr.microsoft.com/dotnet/sdk:3.1
+    environment:
+      TRANSPORT_TYPE: tcp
+    resource_class: large
+    working_directory: /mnt/ramdisk
+    parallelism: 2
+    steps: [netcore_test_base]
+
+  linux-netcore-test-netmq:
+    docker:
+    - image: mcr.microsoft.com/dotnet/sdk:3.1
+    environment:
+      TRANSPORT_TYPE: netmq
     resource_class: large
     working_directory: /mnt/ramdisk
     parallelism: 2
@@ -442,7 +454,9 @@ workflows:
     jobs:
     - linux-netcore-build
     - linux-mono-build
-    - linux-netcore-test:
+    - linux-netcore-test-tcp:
+        requires: [linux-netcore-build]
+    - linux-netcore-test-netmq:
         requires: [linux-netcore-build]
     - linux-netcore-test-ar-SA:
         requires: [linux-netcore-build]

--- a/Libplanet.Net.Tests/AppProtocolVersionTest.cs
+++ b/Libplanet.Net.Tests/AppProtocolVersionTest.cs
@@ -3,10 +3,9 @@ using System;
 using System.Collections.Immutable;
 using Bencodex;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class AppProtocolVersionTest
     {

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -16,6 +16,9 @@ using Serilog;
 using xRetry;
 using Xunit;
 using Xunit.Abstractions;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 using static Libplanet.Tests.TestUtils;
 using AsyncEnumerable = System.Linq.AsyncEnumerable;
 

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -10,16 +10,16 @@ using System.Threading.Tasks;
 using Dasync.Collections;
 using Libplanet.Action;
 using Libplanet.Blocks;
-using Libplanet.Net;
 using Libplanet.Tests.Common.Action;
 using Nito.AsyncEx;
 using Serilog;
 using xRetry;
 using Xunit;
 using Xunit.Abstractions;
+using static Libplanet.Tests.TestUtils;
 using AsyncEnumerable = System.Linq.AsyncEnumerable;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class BlockCompletionTest
     {
@@ -292,10 +292,10 @@ namespace Libplanet.Tests.Net
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
             HashAlgorithmGetter hashAlgoGetter = _ => HashAlgorithmType.Of<SHA256>();
-            Block<DumbAction> genesis = TestUtils.MineGenesisBlock<DumbAction>(
-                    hashAlgoGetter, TestUtils.GenesisMiner),
-                demand = TestUtils.MineNextBlock(genesis, hashAlgoGetter, TestUtils.GenesisMiner),
-                wrong = TestUtils.MineNextBlock(genesis, hashAlgoGetter, TestUtils.GenesisMiner);
+            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(
+                    hashAlgoGetter, GenesisMiner),
+                demand = MineNextBlock(genesis, hashAlgoGetter, GenesisMiner),
+                wrong = MineNextBlock(genesis, hashAlgoGetter, GenesisMiner);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
             _logger.Debug("Demand:  #{Index} {Hash}", demand.Index, demand.Hash);
             _logger.Debug("Wrong:   #{Index} {Hash}", wrong.Index, wrong.Hash);
@@ -405,13 +405,13 @@ namespace Libplanet.Tests.Net
             if (count >= 1)
             {
                 Block<T> block =
-                    TestUtils.MineGenesisBlock<T>(hashAlgorithmGetter, TestUtils.GenesisMiner);
+                    MineGenesisBlock<T>(hashAlgorithmGetter, GenesisMiner);
                 yield return block;
 
                 for (int i = 1; i < count; i++)
                 {
                     block =
-                        TestUtils.MineNextBlock(block, hashAlgorithmGetter, TestUtils.GenesisMiner);
+                        MineNextBlock(block, hashAlgorithmGetter, GenesisMiner);
                     yield return block;
                 }
             }

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -5,10 +5,9 @@ using System.IO;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class BoundPeerTest
     {

--- a/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
+++ b/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
@@ -2,10 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Libplanet.Net;
 using xRetry;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public sealed class FactOnlyTurnAvailableAttribute : RetryFactAttribute
     {

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -2,11 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Libplanet.Net;
 using Libplanet.Stun;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class IceServerTest
     {

--- a/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
+++ b/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
@@ -3,10 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using Libplanet.Net;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class InvalidMessageTimestampExceptionTest
     {

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -5,12 +5,11 @@ using System.Linq;
 using System.Net;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using NetMQ;
 using Xunit;
 
-namespace Libplanet.Tests.Net.Messages
+namespace Libplanet.Net.Tests.Messages
 {
     [Collection("NetMQConfiguration")]
     public class BlockHashesTest : IDisposable

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -6,13 +6,13 @@ using System.Net;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
 using NetMQ;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net.Messages
+namespace Libplanet.Net.Tests.Messages
 {
     [Collection("NetMQConfiguration")]
     public class MessageTest : IDisposable
@@ -95,9 +95,9 @@ namespace Libplanet.Tests.Net.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var dateTimeOffset = DateTimeOffset.UtcNow;
-            Block<DumbAction> genesis = TestUtils.MineGenesisBlock<DumbAction>(
+            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(
                 _ => HashAlgorithmType.Of<SHA256>(),
-                TestUtils.GenesisMiner
+                GenesisMiner
             );
             var message = new BlockHeaderMessage(genesis.Hash, genesis.Header);
             var codec = new NetMQMessageCodec();

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -7,15 +7,15 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using NetMQ;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net.Messages
+namespace Libplanet.Net.Tests.Messages
 {
     [Collection("NetMQConfiguration")]
     public class NetMQMessageCodecTest : IDisposable
@@ -68,7 +68,7 @@ namespace Libplanet.Tests.Net.Messages
             var privateKey = new PrivateKey();
             var boundPeer = new BoundPeer(privateKey.PublicKey, new DnsEndPoint("localhost", 1000));
             IBlockPolicy<DumbAction> policy = new BlockPolicy<DumbAction>();
-            BlockChain<DumbAction> chain = TestUtils.MakeBlockChain(
+            BlockChain<DumbAction> chain = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore())

--- a/Libplanet.Net.Tests/PeerTest.cs
+++ b/Libplanet.Net.Tests/PeerTest.cs
@@ -4,10 +4,9 @@ using System.IO;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public class PeerTest
     {

--- a/Libplanet.Net.Tests/Protocols/KBucketTest.cs
+++ b/Libplanet.Net.Tests/Protocols/KBucketTest.cs
@@ -5,12 +5,11 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Protocols;
 using Serilog.Core;
 using Xunit;
 
-namespace Libplanet.Tests.Net.Protocols
+namespace Libplanet.Net.Tests.Protocols
 {
     public class KBucketTest
     {

--- a/Libplanet.Net.Tests/Protocols/KBucketTest.cs
+++ b/Libplanet.Net.Tests/Protocols/KBucketTest.cs
@@ -8,6 +8,9 @@ using Libplanet.Crypto;
 using Libplanet.Net.Protocols;
 using Serilog.Core;
 using Xunit;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 
 namespace Libplanet.Net.Tests.Protocols
 {

--- a/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
+++ b/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
@@ -10,6 +10,9 @@ using Libplanet.Net.Transports;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 using static Libplanet.Net.Tests.TestUtils;
 
 namespace Libplanet.Net.Tests.Protocols

--- a/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
+++ b/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
 using Serilog;
@@ -13,7 +12,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static Libplanet.Net.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net.Protocols
+namespace Libplanet.Net.Tests.Protocols
 {
     public class ProtocolTest
     {

--- a/Libplanet.Net.Tests/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Net.Tests/Protocols/RoutingTableTest.cs
@@ -8,6 +8,9 @@ using Libplanet.Net.Protocols;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 
 namespace Libplanet.Net.Tests.Protocols
 {

--- a/Libplanet.Net.Tests/Protocols/RoutingTableTest.cs
+++ b/Libplanet.Net.Tests/Protocols/RoutingTableTest.cs
@@ -4,13 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Protocols;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Tests.Net.Protocols
+namespace Libplanet.Net.Tests.Protocols
 {
     public class RoutingTableTest
     {

--- a/Libplanet.Net.Tests/Protocols/TestMessage.cs
+++ b/Libplanet.Net.Tests/Protocols/TestMessage.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Libplanet.Net.Messages;
 
-namespace Libplanet.Tests.Net.Protocols
+namespace Libplanet.Net.Tests.Protocols
 {
     internal class TestMessage : Message
     {

--- a/Libplanet.Net.Tests/Protocols/TestTransport.cs
+++ b/Libplanet.Net.Tests/Protocols/TestTransport.cs
@@ -8,14 +8,13 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
 using Nito.AsyncEx;
 using Serilog;
 
-namespace Libplanet.Tests.Net.Protocols
+namespace Libplanet.Net.Tests.Protocols
 {
     internal class TestTransport : ITransport
     {

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -4,11 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Protocols;
 using Xunit;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public partial class SwarmTest
     {

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -20,6 +20,9 @@ using Serilog;
 using Serilog.Events;
 using xRetry;
 using Xunit;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 using static Libplanet.Tests.LoggerExtensions;
 using static Libplanet.Tests.TestUtils;
 

--- a/Libplanet.Net.Tests/SwarmTest.Consensus.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Consensus.cs
@@ -6,13 +6,14 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
+using Libplanet.Tests;
 using Libplanet.Tests.Common.Action;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public partial class SwarmTest
     {
@@ -43,12 +44,12 @@ namespace Libplanet.Tests.Net
                 new MinerReward(1),
                 canonicalChainComparer: canonComparer
             );
-            BlockChain<DumbAction> chain1 = TestUtils.MakeBlockChain(
+            BlockChain<DumbAction> chain1 = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore())
             );
-            BlockChain<DumbAction> chain2 = TestUtils.MakeBlockChain(
+            BlockChain<DumbAction> chain2 = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore())
@@ -69,13 +70,13 @@ namespace Libplanet.Tests.Net
                 default:
                     long nextDifficulty =
                         (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
-                    bestBlock = TestUtils.MineNext(
+                    bestBlock = MineNext(
                         chain2.Tip,
                         policy.GetHashAlgorithm,
                         difficulty: nextDifficulty,
                         blockInterval: TimeSpan.FromMilliseconds(1),
-                        miner: TestUtils.ChainPrivateKey.PublicKey
-                    ).Evaluate(TestUtils.ChainPrivateKey, chain2);
+                        miner: ChainPrivateKey.PublicKey
+                    ).Evaluate(ChainPrivateKey, chain2);
                     _output.WriteLine("chain1's total difficulty: {0}", chain1.Tip.TotalDifficulty);
                     _output.WriteLine("chain2's total difficulty: {0}", bestBlock.TotalDifficulty);
                     break;
@@ -85,13 +86,13 @@ namespace Libplanet.Tests.Net
                     string hashStr;
                     do
                     {
-                        bestBlock = TestUtils.MineNext(
+                        bestBlock = MineNext(
                             chain2.Tip,
                             policy.GetHashAlgorithm,
                             difficulty: policy.GetNextBlockDifficulty(chain2),
                             blockInterval: TimeSpan.FromMilliseconds(1),
-                            miner: TestUtils.ChainPrivateKey.PublicKey
-                        ).Evaluate(TestUtils.ChainPrivateKey, chain2);
+                            miner: ChainPrivateKey.PublicKey
+                        ).Evaluate(ChainPrivateKey, chain2);
                         hashStr = bestBlock.Hash.ToString();
                         _output.WriteLine("chain1's tip hash: {0}", chain1.Tip.Hash);
                         _output.WriteLine("chain2's tip hash: {0}", bestBlock.Hash);

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -119,6 +119,7 @@ namespace Libplanet.Net.Tests
 
             options ??= new SwarmOptions();
             string type = Environment.GetEnvironmentVariable("TRANSPORT_TYPE");
+            _logger.Debug("Transport type: {Type}", type);
             switch (type)
             {
                 case "tcp":

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -117,6 +117,18 @@ namespace Libplanet.Net.Tests
                 host = IPAddress.Loopback.ToString();
             }
 
+            options ??= new SwarmOptions();
+            string type = Environment.GetEnvironmentVariable("TRANSPORT_TYPE");
+            switch (type)
+            {
+                case "tcp":
+                    options.Type = SwarmOptions.TransportType.TcpTransport;
+                    break;
+                case "netmq":
+                    options.Type = SwarmOptions.TransportType.NetMQTransport;
+                    break;
+            }
+
             var swarm = new Swarm<T>(
                 blockChain,
                 privateKey ?? new PrivateKey(),

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -9,12 +9,12 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
+using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     public partial class SwarmTest
     {
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Net
                 var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
                 using (var storeFx = new MemoryStoreFixture())
                 {
-                    var chain = TestUtils.MakeBlockChain(policy, storeFx.Store, storeFx.StateStore);
+                    var chain = MakeBlockChain(policy, storeFx.Store, storeFx.StateStore);
                     var miner = new PrivateKey();
                     var signer = new PrivateKey();
                     Address address = signer.ToAddress();
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Net
         {
             policy = policy ?? new BlockPolicy<DumbAction>(new MinerReward(1));
             var fx = new MemoryStoreFixture(policy.BlockAction);
-            var blockchain = TestUtils.MakeBlockChain(
+            var blockchain = MakeBlockChain(
                 policy,
                 fx.Store,
                 fx.StateStore,

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -532,8 +532,8 @@ namespace Libplanet.Net.Tests
 
                 // FIXME: this test does not ensures block download in order
                 Assert.Equal(
-                    Enumerable.ToHashSet(expectedStates),
-                    Enumerable.ToHashSet(actualStates)
+                    new HashSet<PreloadState>(expectedStates),
+                    new HashSet<PreloadState>(actualStates)
                 );
             }
             finally

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -567,7 +567,16 @@ namespace Libplanet.Net.Tests
             var expected = new DnsEndPoint("1.2.3.4", 5678);
             using (Swarm<DumbAction> s = CreateSwarm(host: "1.2.3.4", listenPort: 5678))
             {
-                await ((TcpTransport)s.Transport).Initialize();
+                // Looks weired, but inevitable because Initialize() is internal.
+                if (s.Transport is TcpTransport t)
+                {
+                    await t.Initialize();
+                }
+                else if (s.Transport is NetMQTransport n)
+                {
+                    await n.Initialize();
+                }
+
                 Assert.Equal(expected, s.EndPoint);
                 Assert.Equal(expected, (s.AsPeer as BoundPeer)?.EndPoint);
             }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -15,7 +15,6 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blockchain.Renderers.Debug;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
@@ -31,7 +30,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net
+namespace Libplanet.Net.Tests
 {
     [Collection("NetMQConfiguration")]
     public partial class SwarmTest : IDisposable
@@ -539,7 +538,7 @@ namespace Libplanet.Tests.Net
         {
             var fx = new MemoryStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
-            var blockchain = TestUtils.MakeBlockChain(policy, fx.Store, fx.StateStore);
+            var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var key = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(key, 1);
             Assert.Throws<ArgumentNullException>(() => { new Swarm<DumbAction>(null, key, ver); });
@@ -750,8 +749,8 @@ namespace Libplanet.Tests.Net
             var fx1 = new MemoryStoreFixture();
             var fx2 = new MemoryStoreFixture();
 
-            var chain1 = TestUtils.MakeBlockChain(policy1, fx1.Store, fx1.StateStore);
-            var chain2 = TestUtils.MakeBlockChain(policy2, fx2.Store, fx2.StateStore);
+            var chain1 = MakeBlockChain(policy1, fx1.Store, fx1.StateStore);
+            var chain2 = MakeBlockChain(policy2, fx2.Store, fx2.StateStore);
 
             var key1 = new PrivateKey();
             var key2 = new PrivateKey();
@@ -765,13 +764,13 @@ namespace Libplanet.Tests.Net
             await chain2.MineBlock(key2);
 
             // Creates a block that will make chain 2's total difficulty is higher than chain 1's.
-            Block<DumbAction> block3 = TestUtils.MineNext(
+            Block<DumbAction> block3 = MineNext(
                 chain2.Tip,
                 policy2.GetHashAlgorithm,
-                miner: TestUtils.ChainPrivateKey.PublicKey,
+                miner: ChainPrivateKey.PublicKey,
                 difficulty: (long)chain1.Tip.TotalDifficulty + 1,
                 blockInterval: TimeSpan.FromMilliseconds(1)
-            ).Evaluate(TestUtils.ChainPrivateKey, chain2);
+            ).Evaluate(ChainPrivateKey, chain2);
             chain2.Append(block3);
             try
             {
@@ -803,7 +802,7 @@ namespace Libplanet.Tests.Net
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
             var renderer = new RecordingActionRenderer<DumbAction>();
-            var chain = TestUtils.MakeBlockChain(
+            var chain = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore()),
@@ -815,7 +814,7 @@ namespace Libplanet.Tests.Net
 
             var miner1 = CreateSwarm(chain, key1);
             var miner2 = CreateSwarm(
-                TestUtils.MakeBlockChain(
+                MakeBlockChain(
                     policy,
                     new MemoryStore(),
                     new TrieStateStore(new MemoryKeyValueStore())
@@ -860,11 +859,11 @@ namespace Libplanet.Tests.Net
         public async Task ForkByDifficulty()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var chain1 = TestUtils.MakeBlockChain(
+            var chain1 = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore()));
-            var chain2 = TestUtils.MakeBlockChain(
+            var chain2 = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore()));
@@ -879,13 +878,13 @@ namespace Libplanet.Tests.Net
             await chain1.MineBlock(key2);
             long nextDifficulty =
                 (long)chain1.Tip.TotalDifficulty + policy.GetNextBlockDifficulty(chain2);
-            Block<DumbAction> block = TestUtils.MineNext(
+            Block<DumbAction> block = MineNext(
                 chain2.Tip,
                 policy.GetHashAlgorithm,
-                miner: TestUtils.ChainPrivateKey.PublicKey,
+                miner: ChainPrivateKey.PublicKey,
                 difficulty: nextDifficulty,
                 blockInterval: TimeSpan.FromMilliseconds(1)
-            ).Evaluate(TestUtils.ChainPrivateKey, chain2);
+            ).Evaluate(ChainPrivateKey, chain2);
             chain2.Append(block);
 
             Assert.True(chain1.Tip.Index > chain2.Tip.Index);
@@ -921,7 +920,7 @@ namespace Libplanet.Tests.Net
 
             Swarm<Sleep> MakeSwarm(PrivateKey key = null) =>
                 CreateSwarm(
-                    TestUtils.MakeBlockChain(
+                    MakeBlockChain(
                         policy,
                         new MemoryStore(),
                         new TrieStateStore(new MemoryKeyValueStore())
@@ -1078,9 +1077,9 @@ namespace Libplanet.Tests.Net
             var fx2 = new MemoryStoreFixture();
 
             var swarmA = CreateSwarm(
-                TestUtils.MakeBlockChain(policy, fx1.Store, fx1.StateStore, privateKey: validKey));
+                MakeBlockChain(policy, fx1.Store, fx1.StateStore, privateKey: validKey));
             var swarmB = CreateSwarm(
-                TestUtils.MakeBlockChain(policy, fx2.Store, fx2.StateStore, privateKey: validKey));
+                MakeBlockChain(policy, fx2.Store, fx2.StateStore, privateKey: validKey));
 
             var invalidKey = new PrivateKey();
 
@@ -1137,14 +1136,14 @@ namespace Libplanet.Tests.Net
             var fx2 = new MemoryStoreFixture();
 
             var swarmA = CreateSwarm(
-                TestUtils.MakeBlockChain(
+                MakeBlockChain(
                     policy,
                     fx1.Store,
                     fx1.StateStore,
                     privateKey: validKey,
                     timestamp: DateTimeOffset.MinValue));
             var swarmB = CreateSwarm(
-                TestUtils.MakeBlockChain(
+                MakeBlockChain(
                     policy,
                     fx2.Store,
                     fx2.StateStore,
@@ -1527,12 +1526,12 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = TestUtils.MineNext(
+                Block<DumbAction> block = MineNext(
                     chain.Tip,
                     chain.Policy.GetHashAlgorithm,
-                    miner: TestUtils.ChainPrivateKey.PublicKey,
+                    miner: ChainPrivateKey.PublicKey,
                     difficulty: 1024
-                ).Evaluate(TestUtils.ChainPrivateKey, chain);
+                ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }
 
@@ -1571,12 +1570,12 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = TestUtils.MineNext(
+                Block<DumbAction> block = MineNext(
                     chain.Tip,
                     chain.Policy.GetHashAlgorithm,
-                    miner: TestUtils.ChainPrivateKey.PublicKey,
+                    miner: ChainPrivateKey.PublicKey,
                     difficulty: 1024
-                ).Evaluate(TestUtils.ChainPrivateKey, chain);
+                ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }
 
@@ -1616,12 +1615,12 @@ namespace Libplanet.Tests.Net
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = TestUtils.MineNext(
+                Block<DumbAction> block = MineNext(
                     chain.Tip,
                     chain.Policy.GetHashAlgorithm,
-                    miner: TestUtils.ChainPrivateKey.PublicKey,
+                    miner: ChainPrivateKey.PublicKey,
                     difficulty: 1024
-                ).Evaluate(TestUtils.ChainPrivateKey, chain);
+                ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -28,6 +28,9 @@ using Serilog;
 using xRetry;
 using Xunit;
 using Xunit.Abstractions;
+#if NETFRAMEWORK && (NET47 || NET471)
+using static Libplanet.Tests.HashSetExtensions;
+#endif
 using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Net.Tests

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -5,15 +5,15 @@ using System.Net.Sockets;
 using System.Threading.Tasks;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Transports;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using NetMQ;
 using Xunit;
 using Xunit.Sdk;
+using static Libplanet.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     [Collection("NetMQConfiguration")]
     public class BoundPeerExtensionsTest : IDisposable
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Net.Transports
         {
             var fx = new MemoryStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
-            var blockchain = TestUtils.MakeBlockChain(policy, fx.Store, fx.StateStore);
+            var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var apvKey = new PrivateKey();
             var swarmKey = new PrivateKey();
             AppProtocolVersion apv = AppProtocolVersion.Sign(apvKey, 1);

--- a/Libplanet.Net.Tests/Transports/InvalidMagicCookieExceptionTest.cs
+++ b/Libplanet.Net.Tests/Transports/InvalidMagicCookieExceptionTest.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Net.Transports;
 using Xunit;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     public class InvalidMagicCookieExceptionTest
     {

--- a/Libplanet.Net.Tests/Transports/MessageSendFailedExceptionTest.cs
+++ b/Libplanet.Net.Tests/Transports/MessageSendFailedExceptionTest.cs
@@ -3,12 +3,11 @@ using System.IO;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
 using Xunit;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     public class MessageSendFailedExceptionTest
     {

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -4,14 +4,13 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Transports;
 using NetMQ;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     [Collection("NetMQConfiguration")]
     public class NetMQTransportTest : TransportTest, IDisposable

--- a/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
@@ -8,14 +8,13 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     public class TcpTransportTest : TransportTest
     {

--- a/Libplanet.Net.Tests/Transports/TransportExceptionTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportExceptionTest.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Net.Transports;
 using Xunit;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     public class TransportExceptionTest
     {

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -8,7 +8,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
@@ -18,7 +17,7 @@ using Xunit;
 using Xunit.Sdk;
 using static Libplanet.Net.Tests.TestUtils;
 
-namespace Libplanet.Tests.Net.Transports
+namespace Libplanet.Net.Tests.Transports
 {
     public abstract class TransportTest
     {


### PR DESCRIPTION
XUnit does not supports parameterized runsettings, I've used environment variables to switch between "tcp" and "netmq" transport. This will resolve #1761.