### PR TITLE
Fix some flaky unit tests in `Libplanet.Net.Tests`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.26.5
 
 To be released.
 
+ -  (Libplanet.Net) Fixed a bug where `Swarm<T>.PreloadAsync()`
+    had not thrown `OperationCanceledException` even cancellation
+    was requested.  [[#1547], [#1796]]
+
+[#1547]: https://github.com/planetarium/libplanet/issues/1547
+[#1796]: https://github.com/planetarium/libplanet/pull/1796
 
 
 Version 0.26.4

--- a/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Broadcast.cs
@@ -305,12 +305,7 @@ namespace Libplanet.Tests.Net
                 Assert.Contains(swarmC.AsPeer, swarmA.Peers);
                 Assert.Contains(swarmA.AsPeer, swarmC.Peers);
 
-                for (var i = 0; i < 100; i++)
-                {
-                    swarmA.BroadcastTxs(txs);
-                }
-
-                var t = Task.Run(async () =>
+                Task miningTask = Task.Run(async () =>
                 {
                     for (var i = 0; i < 10; i++)
                     {
@@ -318,12 +313,15 @@ namespace Libplanet.Tests.Net
                     }
                 });
 
-                while (!chainC.GetStagedTransactionIds().Any())
+                Task txReceivedTask = swarmC.TxReceived.WaitAsync();
+
+                for (var i = 0; i < 100; i++)
                 {
-                    await swarmC.TxReceived.WaitAsync();
+                    swarmA.BroadcastTxs(txs);
                 }
 
-                await t;
+                await txReceivedTask;
+                await miningTask;
 
                 for (var i = 0; i < txCount; i++)
                 {

--- a/Libplanet.Tests/Net/SwarmTest.Preload.cs
+++ b/Libplanet.Tests/Net/SwarmTest.Preload.cs
@@ -586,15 +586,19 @@ namespace Libplanet.Tests.Net
             var startedStop = false;
             var shouldStopSwarm =
                 swarm0.AsPeer.Equals(receiverSwarm.Peers.First()) ? swarm0 : swarm1;
-            await receiverSwarm.PreloadAsync(
-                progress: new ActionProgress<PreloadState>(async (state) =>
+
+            async void Action(PreloadState state)
+            {
+                if (!startedStop && state is BlockDownloadState)
                 {
-                    if (!startedStop && state is BlockDownloadState)
-                    {
-                        startedStop = true;
-                        await shouldStopSwarm.StopAsync(TimeSpan.Zero);
-                    }
-                }));
+                    startedStop = true;
+                    await shouldStopSwarm.StopAsync(TimeSpan.Zero);
+                }
+            }
+
+            await receiverSwarm.PreloadAsync(
+                dialTimeout: TimeSpan.FromSeconds(5),
+                progress: new ActionProgress<PreloadState>(Action));
 
             Assert.Equal(swarm1.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);
             Assert.Equal(swarm0.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1242,8 +1242,8 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await StartAsync(minerSwarmA);
-                await StartAsync(minerSwarmB);
+                await StartAsync(minerSwarmA, 5000);
+                await StartAsync(minerSwarmB, 5000);
                 await StartAsync(receiverSwarm);
 
                 await BootstrapAsync(minerSwarmA, receiverSwarm.AsPeer);
@@ -1256,8 +1256,10 @@ namespace Libplanet.Tests.Net
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),
                     15_000,
+                    output: _output,
                     conditionLabel:
-                        $"{nameof(receiverChain)}'s tip being same to {nameof(minerChainA)}'s tip"
+                        $"{nameof(receiverChain)}'s tip being same to " +
+                        $"{nameof(minerChainA)}'s tip 1st"
                 );
 
                 // Broadcast SwarmB's second block.
@@ -1267,8 +1269,10 @@ namespace Libplanet.Tests.Net
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainB.Tip),
                     15_000,
+                    output: _output,
                     conditionLabel:
-                        $"{nameof(receiverChain)}'s tip being same to {nameof(minerChainA)}'s tip"
+                        $"{nameof(receiverChain)}'s tip being same to " +
+                        $"{nameof(minerChainB)}'s tip 2nd"
                 );
 
                 // Broadcast SwarmA's third block.
@@ -1277,8 +1281,10 @@ namespace Libplanet.Tests.Net
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),
                     15_000,
+                    output: _output,
                     conditionLabel:
-                        $"{nameof(receiverChain)}'s tip being same to {nameof(minerChainA)}'s tip"
+                        $"{nameof(receiverChain)}'s tip being same to " +
+                        $"{nameof(minerChainA)}'s tip 3rd"
                 );
             }
             finally
@@ -1754,13 +1760,14 @@ namespace Libplanet.Tests.Net
 
         private async Task<Task> StartAsync<T>(
             Swarm<T> swarm,
+            int millisecondsBroadcastBlockInterval = 15 * 1000,
             CancellationToken cancellationToken = default
         )
             where T : IAction, new()
         {
             Task task = swarm.StartAsync(
                 millisecondsDialTimeout: 200,
-                millisecondsBroadcastBlockInterval: 15 * 1000,
+                millisecondsBroadcastBlockInterval: millisecondsBroadcastBlockInterval,
                 millisecondsBroadcastTxInterval: 200,
                 cancellationToken: cancellationToken
             );

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -521,9 +521,11 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             {
                 output?.WriteLine(
                     "[{0}/{1}] Waiting for {2}...",
-                    until - started,
+                    DateTimeOffset.UtcNow - started,
                     timeout,
-                    conditionLabel is string c ? c : $"satisfying the condition ({condition.Body})"
+                    conditionLabel is string c1
+                        ? c1
+                        : $"satisfying the condition ({condition.Body})"
                 );
                 await Task.Delay(delay);
             }
@@ -533,6 +535,13 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 $"Waited {timeout} but the condition (" +
                     (conditionLabel is string l ? l : condition.Body.ToString()) +
                     ") has never been satisfied."
+            );
+
+            output?.WriteLine(
+                "[{0}/{1}] Done {2}...",
+                DateTimeOffset.UtcNow - started,
+                timeout,
+                conditionLabel is string c2 ? c2 : $"satisfying the condition ({condition.Body})"
             );
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -639,6 +639,8 @@ namespace Libplanet.Net
                     cancellationToken: cancellationToken);
                 renderSwap();
             }
+
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes some flaky tests which are:
- `PreloadRetryWithNextPeers`
- `CreateNewChainWhenBranchPointNotExist`
- `BroadcastTxWhileMining`