### PR TITLE
Porting #1791 (Bump RocksDbSharp for support arm64)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@ Version 0.26.4
 To be released.
 
  -  Upgraded *Planetarium.RocksDbSharp* from 6.2.4-planetarium to
-    [6.2.6-planetarium][Planetarium.RocksDbSharp 6.2.6-planetarium].  [[#1791]]
+    [6.2.6-planetarium][Planetarium.RocksDbSharp 6.2.6-planetarium].
+    [[#1791], [#1803]]
 
 [#1791]: https://github.com/planetarium/libplanet/pull/1791
+[#1803]: https://github.com/planetarium/libplanet/pull/1803
 [Planetarium.RocksDbSharp 6.2.6-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.6-planetarium
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.26.4
 
 To be released.
 
+ -  Upgraded *Planetarium.RocksDbSharp* from 6.2.4-planetarium to
+    [6.2.6-planetarium][Planetarium.RocksDbSharp 6.2.6-planetarium].  [[#1791]]
+
+[#1791]: https://github.com/planetarium/libplanet/pull/1791
+[Planetarium.RocksDbSharp 6.2.6-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.6-planetarium
+
 
 Version 0.26.3
 --------------

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -47,7 +47,7 @@
       runtime; build; native; contentfiles; analyzers; buildtransitive
     </IncludeAssets>
   </PackageReference>
-  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.4-planetarium" />
+  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.6-planetarium" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>


### PR DESCRIPTION
This PR (back) ports #1791 to 0.26 due to support arm64 build. (sadly, we can't use 0.27 because there is a bug related tx transfer).