### PR TITLE
Fix `VersionPrefix` & release 0.26.4

### DIFF
--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Libplanet</PackageId>
     <Title>Libplanet</Title>
-    <VersionPrefix>0.26.3</VersionPrefix>
+    <VersionPrefix>0.26.4</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:
       Version: 1.2.3-dev.456


### PR DESCRIPTION
It was missed in <https://github.com/planetarium/libplanet/pull/1804>.