### PR TITLE
Fix `ThreadStateException` thrown by `NonblockRenderer<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,13 @@ To be released.
  -  Fixed a bug where `Swarm<T>.PreloadAsync()`
     had not thrown `OperationCanceledException` even cancellation
     was requested.  [[#1547], [#1796]]
+ -  Fixed `ThreadStateException` thrown by `NonblockRenderer<T>` and
+    `NonblockActionRenderer<T>` classes.  [[#1772], [#1810]]
 
 [#1547]: https://github.com/planetarium/libplanet/issues/1547
+[#1772]: https://github.com/planetarium/libplanet/issues/1772
 [#1796]: https://github.com/planetarium/libplanet/pull/1796
+[#1810]: https://github.com/planetarium/libplanet/pull/1810
 
 
 Version 0.26.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Version 0.26.5
 
 To be released.
 
- -  (Libplanet.Net) Fixed a bug where `Swarm<T>.PreloadAsync()`
+ -  Fixed a bug where `Swarm<T>.PreloadAsync()`
     had not thrown `OperationCanceledException` even cancellation
     was requested.  [[#1547], [#1796]]
 

--- a/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
@@ -236,7 +236,18 @@ namespace Libplanet.Blockchain.Renderers
                     Thread.CurrentThread.ManagedThreadId,
                     Environment.StackTrace
                 );
-                _worker.Start();
+                try
+                {
+                    _worker.Start();
+                }
+                catch (ThreadStateException e)
+                {
+                    _logger.Error(
+                        e,
+                        "The rendering thread #{WorkerThreadId} failed to start.",
+                        _worker.ManagedThreadId
+                    );
+                }
             }
         }
     }

--- a/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockRenderer.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Blockchain.Renderers
         private readonly ChannelReader<System.Action> _reader;
         private readonly FullFallback? _fullFallback;
         private readonly Thread _worker;
-        private readonly object _workerLock = new object();
+        private int _workerStarted = 0;
         private (string StackTrace, DateTimeOffset Time)? _disposedContext;
 
         /// <summary>
@@ -116,13 +116,20 @@ namespace Libplanet.Blockchain.Renderers
             _fullFallback = fullFallback;
             _worker = new Thread(async () =>
             {
+                ulong events = 0UL;
                 while (await _reader.WaitToReadAsync())
                 {
                     while (_reader.TryRead(out System.Action? action))
                     {
                         action?.Invoke();
+                        events++;
                     }
                 }
+
+                const string log =
+                    "Terminating the rendering thread #{WorkerThreadId} after processed " +
+                    "{RenderEvents} events...";
+                Log.ForContext(GetType()).Debug(log, Thread.CurrentThread.ManagedThreadId, events);
             })
             {
                 IsBackground = true,
@@ -218,17 +225,18 @@ namespace Libplanet.Blockchain.Renderers
                 return;
             }
 
-            if (!_worker.IsAlive)
+            if (!_worker.IsAlive && Interlocked.Increment(ref _workerStarted) == 1)
             {
-                // ↑ To avoid entering the below lock at all except of the first time,
-                // checks one more time if the worker is alive before we try to lock.
-                lock (_workerLock)
-                {
-                    if (!_worker.IsAlive && _disposedContext is null)
-                    {
-                        _worker.Start();
-                    }
-                }
+                const string logMsg =
+                    "Starting the rendering thread #{WorkerThreadId} (spawned from thread " +
+                    "#{CurrentThreadId})\n{StackTrace}";
+                _logger.Debug(
+                    logMsg,
+                    _worker.ManagedThreadId,
+                    Thread.CurrentThread.ManagedThreadId,
+                    Environment.StackTrace
+                );
+                _worker.Start();
             }
         }
     }

--- a/Libplanet/Net/Swarm.BlockCandidate.cs
+++ b/Libplanet/Net/Swarm.BlockCandidate.cs
@@ -57,13 +57,15 @@ namespace Libplanet.Net
         {
             BlockChain<T> synced = null;
             System.Action renderSwap = () => { };
+            const string methodName =
+                nameof(Swarm<T>) + "<T>." + nameof(BlockCandidateProcess) + "()";
             try
             {
                 FillBlocksAsyncStarted.Set();
                 _logger.Debug(
-                    "{MethodName} start append. Current tip: #{BlockIndex}",
-                    nameof(BlockCandidateProcess),
-                    BlockChain.Tip.Index);
+                    methodName + " starts to append. Current tip: #{BlockIndex}.",
+                    BlockChain.Tip.Index
+                );
                 synced = AppendPreviousBlocks(
                     blockChain: BlockChain,
                     candidate: candidate,
@@ -71,17 +73,13 @@ namespace Libplanet.Net
                     evaluateActions: true);
                 ProcessFillBlocksFinished.Set();
                 _logger.Debug(
-                    "{MethodName} finish append. Synced tip: #{BlockIndex}",
-                    nameof(BlockCandidateProcess),
-                    synced.Tip.Index);
+                    methodName + " finished appending blocks. Synced tip: #{BlockIndex}.",
+                    synced.Tip.Index
+                );
             }
             catch (Exception e)
             {
-                _logger.Error(
-                    "Cannot append blocks at {MethodName}. " +
-                    "InnerException: {InnerException}",
-                    nameof(BlockCandidateTable),
-                    e.Message);
+                _logger.Error(e, methodName + " failed to append blocks.");
                 FillBlocksAsyncFailed.Set();
                 return false;
             }


### PR DESCRIPTION
This addresses <https://github.com/planetarium/libplanet/issues/1772>.

There were multiple tries to prevent `NonblockRenderer<T>.Queue()` from calling `Thread.Start()`, and utilizing `Interlock` was indeed the most simple but robust way to achieve that.  A side story: `Thread.IsAlive` property can be more complex than you thought.  (Or it was to me at least.)

I tried to write a substantial regression test for this bug, but I couldn't find any way to make it clear without decreasing its reproducibility.  I concluded it's better to reproduce the situation well through less clear test logic, rather than clear one that does not reproduce it well.

Apart from the automated regression test, I tested _Nine Chronicles_[^1] with this patch for days, and I believe this is now quite stable.

[^1]: FYI, `NineChronicles.Executable` already has `--nonblock-renderer` option.  Give it a try by adding it to `"HeadlessArgs"` list in your 9c-launcher configuration.