### PR TITLE
Fix `HashDigest<T>.DeriveFrom()` on .NET Standard 2.0 & release 0.25.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ Version 0.25.5
 
 To be released.
 
+ -  Fixed `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` method's bug where
+    it had thrown `IndexOutOfRangeException` for the input longer or shorter
+    than `HashDigest<T>.Size` on .NET Standard 2.0. [[#1706], [#1815]]
+ -  Fixed `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` method's bug where
+    it had returned the wrong digest on .NET Standard 2.0. [[#1706], [#1815]]
+
+[#1706]: https://github.com/planetarium/libplanet/issues/1706
+[#1815]: https://github.com/planetarium/libplanet/pull/1815
+
 
 Version 0.25.4
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.25.5
 --------------
 
-To be released.
+Released on February 18, 2022.
 
  -  Fixed `HashDigest<T>.DeriveFrom(ReadOnlySpan<byte>)` method's bug where
     it had thrown `IndexOutOfRangeException` for the input longer or shorter

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -205,8 +205,8 @@ namespace Libplanet
         public static HashDigest<T> DeriveFrom(ReadOnlySpan<byte> input)
         {
 #if NETSTANDARD2_0
-            var array = new byte[Size];
-            for (int i = 0; i < Size; i++)
+            var array = new byte[input.Length];
+            for (int i = 0; i < input.Length; i++)
             {
                 array[i] = input[i];
             }


### PR DESCRIPTION
This fixed <https://github.com/planetarium/libplanet/issues/1706>.