### PR TITLE
Allow `planet` command to take passphrase from stdin 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
     "formulahendry.dotnet-test-explorer",
     "ms-vscode.powershell",
     "ms-vsliveshare.vsliveshare",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "GitHub.vscode-pull-request-github"
   ],
 
   // Use 'postCreateCommand' to run commands after the container is created.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "ms-dotnettools.csharp",
     "formulahendry.dotnet-test-explorer",
     "ms-vscode.powershell",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "GitHub.vscode-pull-request-github"
   ]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,16 +10,22 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  The return type of `MerkleTrieExtensions.DifferentNodes()` became
+    `IEnumerable<Tuple<KeyBytes, IValue, IValue>>` from
+    `IEnumerable<IGrouping<string, (HashDigest<SHA256> Root, IValue Value)>>`.
+    [[#1729]]
+ -  (Libplanet.Extensions.Cocona) Replaced `string? passphrase = null` parameter
+    of methods belonging `KeyCommand` and `ApvCommand` with
+    `PassphraseParameters passphrase`.  [[#1593], [#1823]]
+ -  (Libplanet.Extensions.Cocona) Replaced `KeyCommand.UnprotectKey(Guid keyId,
+    string? passphrase = null)` method with `UnprotectedKey(Guid,
+    PassphraseParameters, bool)` method.  [[#1593], [#1823]]
  -  (Libplanet.Net) `IMessageCodec<T>.Decode()` now throws
     `InvalidMessageSignatureException` and `InvalidMessageTimestampException`
     instead of `InvalidMessageException` and `InvalidTimestampException`
     respectively.  [[#1771]]
  -  (Libplanet.Net) Added `long tipDeltaThreshold = 25L` option to
     `Swarm<T>.PreloadAsync()` method.  [[#1775], [#1777], [#1779]]
- -  The return type of `MerkleTrieExtensions.DifferentNodes()` became
-    `IEnumerable<Tuple<KeyBytes, IValue, IValue>>` from
-    `IEnumerable<IGrouping<string, (HashDigest<SHA256> Root, IValue Value)>>`.
-    [[#1729]]
 
 ### Backward-incompatible network protocol changes
 
@@ -27,7 +33,12 @@ To be released.
 
 ### Added APIs
 
- -  (Libplanet.Net) `MessageSendFailedException` class added.
+ -  (Libplanet.Extensions.Cocona) Added `PassphraseParameters` class.
+    [[#1593], [#1823]]
+ -  (Libplanet.Extensions.Cocona) Added `KeyCommand.UnprotectKey(Guid keyId,
+    PassphraseParameters passphrase, bool ignoreStdin = false)` method.
+    [[#1593], [#1823]]
+ -  (Libplanet.Net) Added `MessageSendFailedException` class.
     [[#1781], [#1786]]
 
 ### Behavioral changes
@@ -41,12 +52,22 @@ To be released.
 
 ### Dependencies
 
+ -  (Libplanet.Extensions.Cocona) Upgraded *Cocona.Lite* from 1.5.\* to
+    [1.6.\*][Cocona.Lite 1.6.0].  [[#1593], [#1823]]
+
 ### CLI tools
 
+ -  All `planet` subcommands taking passphrase now have `--passphrase-file`
+    option besides `-p`/`--passphrase` option to read it from the specified
+    file or standard input (`-`) instead.  [[#1593], [#1823]]
+ -  Fixed a bug where `planet` subcommands taking passphrase had unexpectedly
+    terminated with an uncaught `InvalidOperationException` when it's not
+    associated to any terminal device (tty), i.e., piped.  [[#1593], [#1823]]
  -  `planet mpt diff` command became to output the key and its values
     in one line as JSON whenever a different key is found,
     than it outputs all of the different nodes at once.  [[#1729]]
 
+[#1593]: https://github.com/planetarium/libplanet/pull/1593
 [#1729]: https://github.com/planetarium/libplanet/pull/1729
 [#1734]: https://github.com/planetarium/libplanet/issues/1734
 [#1771]: https://github.com/planetarium/libplanet/pull/1771
@@ -54,7 +75,8 @@ To be released.
 [#1781]: https://github.com/planetarium/libplanet/issues/1781
 [#1786]: https://github.com/planetarium/libplanet/pull/1786
 [#1789]: https://github.com/planetarium/libplanet/pull/1789
-[Planetarium.RocksDbSharp 6.2.6-planetarium]: https://www.nuget.org/packages/Planetarium.RocksDbSharp/6.2.6-planetarium
+[#1823]: https://github.com/planetarium/libplanet/pull/1823
+[Cocona.Lite 1.6.0]: https://www.nuget.org/packages/Cocona.Lite/1.6.0
 
 
 Version 0.27.7

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cocona.Lite" Version="1.5.*" />
+    <PackageReference Include="Cocona.Lite" Version="1.6.*" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Libplanet.Extensions.Cocona/PassphraseParameters.cs
+++ b/Libplanet.Extensions.Cocona/PassphraseParameters.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using global::Cocona;
+
+namespace Libplanet.Extensions.Cocona
+{
+    public class PassphraseParameters : ICommandParameterSet
+    {
+        [Option(
+            'p',
+            ValueName = "PASSPHRASE",
+            Description = "Take passphrase through this option instead of prompt.  " +
+                "Mutually exclusive with --passphrase-file option."
+        )]
+        [HasDefaultValue]
+        public string? Passphrase { get; set; } = null;
+
+        [Option(
+            ValueName = "FILE",
+            Description = "Read passphrase from the specified file instead of taking it " +
+                "through prompt.  Mutually exclusive with -p/--passphrase option.  " +
+                "For standard input, use a hyphen (`-').  For an actual file named a hyphen, " +
+                "prepend `./', i.e., `./-'.  Note that the trailing CR/LF is trimmed."
+        )]
+        [HasDefaultValue]
+        public string? PassphraseFile { get; set; } = null;
+
+        public string Take(string prompt, string? retypePrompt = null, bool ignoreStdin = false)
+        {
+            if (Passphrase is { } passphrase)
+            {
+                if (PassphraseFile is { })
+                {
+                    throw Utils.Error(
+                        $"-p/--passphrase and --passphrase-file options are mutually exclusive."
+                    );
+                }
+
+                return passphrase;
+            }
+            else if (PassphraseFile is { } filePath)
+            {
+                if (filePath == "-")
+                {
+                    if (File.Exists("-"))
+                    {
+                        Console.Error.WriteLine(
+                            "Note: Passphrase is read from standard input (`-').  If you want " +
+                            "to read from a file, prepend `./', i.e.: --passphrase-file=./-"
+                        );
+                    }
+
+                    return Console.In.ReadToEnd().TrimEnd('\r', '\n');
+                }
+
+                try
+                {
+                    return File.ReadAllText(filePath).TrimEnd('\r', '\n');
+                }
+                catch (FileNotFoundException)
+                {
+                    throw Utils.Error($"Passphrase file is not found: {filePath}");
+                }
+            }
+
+            if (Console.IsInputRedirected && !ignoreStdin)
+            {
+                throw Utils.Error(
+                    "Error: The standard input is not associated to any terminal device (tty), " +
+                    "which means it probably is piped.  If you need to pass the passphrase " +
+                    "through pipe, use --passphrase-file=- option instead (`-' means stdin)."
+                );
+            }
+
+            string first = ConsolePasswordReader.Read(prompt);
+            if (retypePrompt is { })
+            {
+                string retype = ConsolePasswordReader.Read(retypePrompt);
+                if (first != retype)
+                {
+                    throw Utils.Error("Passphrases do not match.");
+                }
+            }
+
+            return first;
+        }
+    }
+}

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cocona.Lite" Version="1.5.*" />
+    <PackageReference Include="Cocona.Lite" Version="1.6.*" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This patch is the second take of @moreal's patch <https://github.com/planetarium/libplanet/pull/1593>.  In particular, this tried to address a [review suggestion on that made by myself][1]:

> As @riemannulus said, avoiding to get a passphrase through stdin was basically intended.
>
> IMHO the method to get a passphrase shouldn't be silently switched.  Instead, it'd better have an explicit option to turn on the such mode, e.g., `--passphrase-stdin`.  Of course, such option and the existing `-p`/`--passphrase` option should be mutually exclusive.
>
> On the other hand, however, exposing an uncaught exception to end-users is also a bug.  For the case `Console.IsInputRedirected` (i.e., `!isatty()`) without `--passphrase-stdin`, it should print an explicit error message instead of uncaught exception, for example:
>
> > Error: The standard input is not associated to any terminal device (tty), which means it probably is piped.  If you need to pass the passphrase through pipe, turn on `--passphrase-stdin` option.

From user's perspective, there are two changes:

- The `planet` command no more unexpectedly terminates with an uncaught `InvalidOperationException` when the standard input is piped (to put in passphrase), which is the issue that PR <https://github.com/planetarium/libplanet/pull/1593> originally tried to address.  Instead, it suggests `--passphrase-file=-` option.

- The `planet` subcommands taking passphrase now have a new option named `--passphrase-file`.  As the name implies, it basically reads passphrase from the specified file, and `--passphrase-file=-` reads passphrase from the standard input, just like many other Unix/Linux programs.

API-wise, `PassphraseParameters` type was introduced to group `-p`/`--passphrase` & `--passphrase-file` options.  As it utilizes `ICommandParameterSet`, *Cocona.Lite* was upgraded from 1.5 to 1.6.

[1]: https://github.com/planetarium/libplanet/pull/1593#pullrequestreview-800822286