### PR TITLE
Fix/message timestamp buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `SwarmOptions.MessageLifespan` property changed to
+    `SwarmOptions.MessageTimestampBuffer`  [[#1828], [#1831]]
  -  (Libplanet.Net) Unused parameter `dealerSocketLifetime` removed from
     `NetMQTransport()`.  [[#1832]]
 
@@ -22,12 +24,21 @@ To be released.
 
 ### Behavioral changes
 
+ -  Default value of `SwarmOptions.MessageTimestampBuffer` is set to 60 seconds
+    instead of `null`.  [[#1828], [#1831]]
+ -  (Libplanet.Net) Acceptible timestamp range for `Message`s, when non-null
+    `SwarmOptions.MessageTimestampBuffer` is provided, has changed to allow
+    `Message`s with future timestamps.
+    [[#1828], [#1831]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+[#1828]: https://github.com/planetarium/libplanet/issues/1828
+[#1831]: https://github.com/planetarium/libplanet/pull/1831
 [#1832]: https://github.com/planetarium/libplanet/pull/1832
 
 

--- a/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
+++ b/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
@@ -17,12 +17,12 @@ namespace Libplanet.Net.Tests
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public void Serialization(TimeSpan? lifespan)
+        public void Serialization(TimeSpan? buffer)
         {
             var e = new InvalidMessageTimestampException(
                 "An error message",
                 DateTimeOffset.UtcNow,
-                lifespan,
+                buffer,
                 DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1));
             var f = new BinaryFormatter();
             InvalidMessageTimestampException e2;
@@ -36,7 +36,7 @@ namespace Libplanet.Net.Tests
 
             Assert.Equal(e.Message, e2.Message);
             Assert.Equal(e.CreatedOffset, e2.CreatedOffset);
-            Assert.Equal(e.Lifespan, e2.Lifespan);
+            Assert.Equal(e.Buffer, e2.Buffer);
             Assert.Equal(e.CurrentOffset, e2.CurrentOffset);
         }
     }

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Net.Tests.Messages
         }
 
         [Fact]
-        public void InvalidTimestamp()
+        public void InvalidMessageTimestamp()
         {
             var privateKey = new PrivateKey();
             var peer = new Peer(privateKey.PublicKey);
@@ -68,7 +68,7 @@ namespace Libplanet.Net.Tests.Messages
             var codec = new NetMQMessageCodec(TimeSpan.FromSeconds(1));
             NetMQMessage futureRaw =
                 codec.Encode(message, privateKey, peer, futureOffset, appProtocolVersion);
-            // Messages from the future throws InvalidTimestampException.
+            // Messages from the future throws InvalidMessageTimestampException.
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 codec.Decode(
                     futureRaw,
@@ -76,7 +76,7 @@ namespace Libplanet.Net.Tests.Messages
                     (i, p, v) => { }));
             NetMQMessage pastRaw =
                 codec.Encode(message, privateKey, peer, pastOffset, appProtocolVersion);
-            // Messages from the far past throws InvalidTimestampException.
+            // Messages from the far past throws InvalidMessageTimestampException.
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 codec.Decode(
                     pastRaw,

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Tests.Transports
                     listenPort,
                     iceServers,
                     differentAppProtocolVersionEncountered,
-                    messageLifespan
+                    messageTimestampBuffer
                 )
                 => CreateNetMQTransport(
                     privateKey,
@@ -36,7 +36,7 @@ namespace Libplanet.Net.Tests.Transports
                     listenPort,
                     iceServers,
                     differentAppProtocolVersionEncountered,
-                    messageLifespan);
+                    messageTimestampBuffer);
 
             const string outputTemplate =
                 "{Timestamp:HH:mm:ss:ffffff}[{ThreadId}] - {Message}";
@@ -63,7 +63,7 @@ namespace Libplanet.Net.Tests.Transports
             int? listenPort,
             IEnumerable<IceServer> iceServers,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
-            TimeSpan? messageLifespan
+            TimeSpan? messageTimestampBuffer
         )
         {
             privateKey = privateKey ?? new PrivateKey();
@@ -79,7 +79,7 @@ namespace Libplanet.Net.Tests.Transports
                 listenPort,
                 iceServers,
                 differentAppProtocolVersionEncountered,
-                messageLifespan);
+                messageTimestampBuffer);
         }
     }
 }

--- a/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
@@ -155,7 +155,7 @@ namespace Libplanet.Net.Tests.Transports
             int? listenPort = null,
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
-            TimeSpan? messageLifespan = null
+            TimeSpan? messageTimestampBuffer = null
         )
         {
             privateKey = privateKey ?? new PrivateKey();
@@ -170,7 +170,7 @@ namespace Libplanet.Net.Tests.Transports
                 listenPort,
                 iceServers,
                 differentAppProtocolVersionEncountered,
-                messageLifespan);
+                messageTimestampBuffer);
         }
     }
 }

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -490,7 +490,7 @@ namespace Libplanet.Net.Tests.Transports
             int? listenPort = null,
             IEnumerable<IceServer> iceServers = null,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
-            TimeSpan? messageLifespan = null
+            TimeSpan? messageTimestampBuffer = null
         )
         {
             if (TransportConstructor is null)
@@ -509,7 +509,7 @@ namespace Libplanet.Net.Tests.Transports
                 listenPort,
                 iceServers ?? Enumerable.Empty<IceServer>(),
                 differentAppProtocolVersionEncountered,
-                messageLifespan);
+                messageTimestampBuffer);
         }
     }
 }

--- a/Libplanet.Net/InvalidMessageTimestampException.cs
+++ b/Libplanet.Net/InvalidMessageTimestampException.cs
@@ -15,26 +15,26 @@ namespace Libplanet.Net
         internal InvalidMessageTimestampException(
             string message,
             DateTimeOffset createdOffset,
-            TimeSpan? lifespan,
+            TimeSpan? buffer,
             DateTimeOffset currentOffset,
             Exception innerException
         )
             : base(message, innerException)
         {
             CreatedOffset = createdOffset;
-            Lifespan = lifespan;
+            Buffer = buffer;
             CurrentOffset = currentOffset;
         }
 
         internal InvalidMessageTimestampException(
             string message,
             DateTimeOffset createdOffset,
-            TimeSpan? lifespan,
+            TimeSpan? buffer,
             DateTimeOffset currentOffset)
             : base(message)
         {
             CreatedOffset = createdOffset;
-            Lifespan = lifespan;
+            Buffer = buffer;
             CurrentOffset = currentOffset;
         }
 
@@ -45,13 +45,13 @@ namespace Libplanet.Net
             : base(info, context)
         {
             CreatedOffset = info.GetValue<DateTimeOffset>(nameof(CreatedOffset));
-            Lifespan = info.GetValue<TimeSpan?>(nameof(Lifespan));
+            Buffer = info.GetValue<TimeSpan?>(nameof(Buffer));
             CurrentOffset = info.GetValue<DateTimeOffset>(nameof(CurrentOffset));
         }
 
         internal DateTimeOffset CreatedOffset { get; private set; }
 
-        internal TimeSpan? Lifespan { get; private set; }
+        internal TimeSpan? Buffer { get; private set; }
 
         internal DateTimeOffset CurrentOffset { get; private set; }
 
@@ -60,7 +60,7 @@ namespace Libplanet.Net
         {
             base.GetObjectData(info, context);
             info.AddValue(nameof(CreatedOffset), CreatedOffset);
-            info.AddValue(nameof(Lifespan), Lifespan);
+            info.AddValue(nameof(Buffer), Buffer);
             info.AddValue(nameof(CurrentOffset), CurrentOffset);
         }
     }

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -13,16 +13,17 @@ namespace Libplanet.Net.Messages
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         private readonly Codec _codec;
-        private readonly TimeSpan? _messageLifespan;
+        private readonly TimeSpan? _messageTimestampBuffer;
 
         /// <summary>
         /// Creates a <see cref="NetMQMessageCodec"/> instance.
         /// </summary>
-        /// <param name="messageLifespan">Lifespan to use for messages when decoding.</param>
-        public NetMQMessageCodec(TimeSpan? messageLifespan = null)
+        /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
+        /// when decoding <see cref="Message"/>s.</param>
+        public NetMQMessageCodec(TimeSpan? messageTimestampBuffer = null)
         {
             _codec = new Codec();
-            _messageLifespan = messageLifespan;
+            _messageTimestampBuffer = messageTimestampBuffer;
         }
 
         /// <inheritdoc/>
@@ -103,16 +104,16 @@ namespace Libplanet.Net.Messages
             var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
 
             var currentTime = DateTimeOffset.UtcNow;
-            if (_messageLifespan is TimeSpan lifespan &&
-                (currentTime - timestamp).Duration() > lifespan)
+            if (_messageTimestampBuffer is TimeSpan timestampBuffer &&
+                (currentTime - timestamp).Duration() > timestampBuffer)
             {
                 var msg = $"Received message is invalid, created at " +
                           $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +
-                          $"but designated lifetime is {lifespan} and " +
+                          $"but designated lifetime is {timestampBuffer} and " +
                           $"the current datetime offset is " +
                           $"{currentTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}.";
                 throw new InvalidMessageTimestampException(
-                    msg, timestamp, _messageLifespan, currentTime);
+                    msg, timestamp, _messageTimestampBuffer, currentTime);
             }
 
             byte[] signature = remains[(int)Message.MessageFrame.Sign].ToByteArray();

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -104,7 +104,7 @@ namespace Libplanet.Net.Messages
 
             var currentTime = DateTimeOffset.UtcNow;
             if (_messageLifespan is TimeSpan lifespan &&
-                (currentTime < timestamp || timestamp + lifespan < currentTime))
+                (currentTime - timestamp).Duration() > lifespan)
             {
                 var msg = $"Received message is invalid, created at " +
                           $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -128,7 +128,7 @@ namespace Libplanet.Net.Messages
 
             var currentTime = DateTimeOffset.UtcNow;
             if (_messageLifespan is TimeSpan lifespan &&
-                (currentTime < timestamp || timestamp + lifespan < currentTime))
+                (currentTime - timestamp).Duration() > lifespan)
             {
                 var msg = $"Received message is invalid, created at " +
                           $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -14,16 +14,17 @@ namespace Libplanet.Net.Messages
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         private readonly Codec _codec;
-        private readonly TimeSpan? _messageLifespan;
+        private readonly TimeSpan? _messageTimestampBuffer;
 
         /// <summary>
         /// Creates a <see cref="TcpMessageCodec"/> instance.
         /// </summary>
-        /// <param name="messageLifespan">Lifespan to use for messages when decoding.</param>
-        public TcpMessageCodec(TimeSpan? messageLifespan = null)
+        /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
+        /// when decoding <see cref="Message"/>s.</param>
+        public TcpMessageCodec(TimeSpan? messageTimestampBuffer = null)
         {
             _codec = new Codec();
-            _messageLifespan = messageLifespan;
+            _messageTimestampBuffer = messageTimestampBuffer;
         }
 
         /// <inheritdoc/>
@@ -127,16 +128,16 @@ namespace Libplanet.Net.Messages
             var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
 
             var currentTime = DateTimeOffset.UtcNow;
-            if (_messageLifespan is TimeSpan lifespan &&
-                (currentTime - timestamp).Duration() > lifespan)
+            if (_messageTimestampBuffer is TimeSpan timestampBuffer &&
+                (currentTime - timestamp).Duration() > timestampBuffer)
             {
                 var msg = $"Received message is invalid, created at " +
                           $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +
-                          $"but designated lifetime is {lifespan} and " +
+                          $"but designated lifetime is {timestampBuffer} and " +
                           $"the current datetime offset is " +
                           $"{currentTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}.";
                 throw new InvalidMessageTimestampException(
-                    msg, timestamp, _messageLifespan, currentTime);
+                    msg, timestamp, _messageTimestampBuffer, currentTime);
             }
 
             byte[] signature = remains[(int)Message.MessageFrame.Sign];

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -1112,7 +1112,7 @@ namespace Libplanet.Net
                         listenPort,
                         iceServers ?? new IceServer[0],
                         differentAppProtocolVersionEncountered,
-                        Options.MessageLifespan);
+                        Options.MessageTimestampBuffer);
 
                 case SwarmOptions.TransportType.TcpTransport:
                     return new TcpTransport(
@@ -1123,7 +1123,7 @@ namespace Libplanet.Net
                         listenPort,
                         iceServers ?? new IceServer[0],
                         differentAppProtocolVersionEncountered,
-                        Options.MessageLifespan);
+                        Options.MessageTimestampBuffer);
 
                 default:
                     throw new ArgumentException(nameof(SwarmOptions.Type));

--- a/Libplanet.Net/SwarmOptions.cs
+++ b/Libplanet.Net/SwarmOptions.cs
@@ -62,7 +62,7 @@ namespace Libplanet.Net
         /// <summary>
         /// The lifespan of <see cref="Message"/>.
         /// </summary>
-        public TimeSpan? MessageLifespan { get; set; } = null;
+        public TimeSpan? MessageLifespan { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// The frequency of <see cref="IProtocol.RefreshTableAsync" />.

--- a/Libplanet.Net/SwarmOptions.cs
+++ b/Libplanet.Net/SwarmOptions.cs
@@ -60,9 +60,10 @@ namespace Libplanet.Net
         public TimeSpan BlockDemandLifespan { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>
-        /// The lifespan of <see cref="Message"/>.
+        /// The amount of difference in <see cref="TimeSpan"/> allowed from current local time for
+        /// a received <see cref="Message"/>.
         /// </summary>
-        public TimeSpan? MessageLifespan { get; set; } = TimeSpan.FromSeconds(60);
+        public TimeSpan? MessageTimestampBuffer { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// The frequency of <see cref="IProtocol.RefreshTableAsync" />.

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -606,9 +606,9 @@ namespace Libplanet.Net.Transports
             catch (InvalidMessageTimestampException imte)
             {
                 const string logMsg =
-                    "Received message has a stale timestamp: " +
-                    "(timestamp: {Timestamp}, lifespan: {Lifespan}, current: {Current})";
-                _logger.Debug(logMsg, imte.CreatedOffset, imte.Lifespan, imte.CurrentOffset);
+                    "Received message has an invalid timestamp: " +
+                    "(timestamp: {Timestamp}, buffer: {Buffer}, current: {Current})";
+                _logger.Debug(logMsg, imte.CreatedOffset, imte.Buffer, imte.CurrentOffset);
             }
             catch (InvalidMessageException ex)
             {

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -93,10 +93,11 @@ namespace Libplanet.Net.Transports
         /// If this callback returns <c>false</c>, an encountered peer is ignored.  If this callback
         /// is omitted, all peers with different <see cref="AppProtocolVersion"/>s are ignored.
         /// </param>
-        /// <param name="messageLifespan">
-        /// The lifespan of a message.
-        /// Messages generated before this value from the current time are ignored.
-        /// If <c>null</c> is given, messages will not be ignored by its timestamp.</param>
+        /// <param name="messageTimestampBuffer">The amount in <see cref="TimeSpan"/>
+        /// that is allowed for the timestamp of a <see cref="Message"/> to differ from
+        /// the current time of a local node.  Every <see cref="Message"/> with its timestamp
+        /// differing greater than <paramref name="messageTimestampBuffer"/> will be ignored.
+        /// If <c>null</c>, any timestamp is accepted.</param>
         /// <exception cref="ArgumentException">Thrown when both <paramref name="host"/> and
         /// <paramref name="iceServers"/> are <c>null</c>.</exception>
         public NetMQTransport(
@@ -108,7 +109,7 @@ namespace Libplanet.Net.Transports
             int? listenPort,
             IEnumerable<IceServer> iceServers,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
-            TimeSpan? messageLifespan = null)
+            TimeSpan? messageTimestampBuffer = null)
         {
             _logger = Log
                 .ForContext<NetMQTransport>()
@@ -130,7 +131,7 @@ namespace Libplanet.Net.Transports
             _iceServers = iceServers?.ToList();
             _listenPort = listenPort ?? 0;
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
-            _messageCodec = new NetMQMessageCodec(messageLifespan);
+            _messageCodec = new NetMQMessageCodec(messageTimestampBuffer);
 
             _requests = Channel.CreateUnbounded<MessageRequest>();
             _runtimeProcessorCancellationTokenSource = new CancellationTokenSource();

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -62,7 +62,7 @@ namespace Libplanet.Net.Transports
             int? listenPort,
             IEnumerable<IceServer> iceServers,
             DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
-            TimeSpan? messageLifespan = null)
+            TimeSpan? messageTimestampBuffer = null)
         {
             _logger = Log
                 .ForContext<TcpTransport>()
@@ -83,7 +83,7 @@ namespace Libplanet.Net.Transports
             _host = host;
             _iceServers = iceServers.ToList();
             _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
-            _messageCodec = new TcpMessageCodec(messageLifespan);
+            _messageCodec = new TcpMessageCodec(messageTimestampBuffer);
             _streams = new ConcurrentDictionary<Guid, ReplyStream>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
Closes #1828.

This PR turns on `Messge` timestamp filtering by default. Any `Message` with its timestamp differing too much from a node's local time will not be processed.

Two preliminary tests were performed on 9c-main with no adverse effect; tested with `SwarmOptions.MessageTimestampBuffer` set to 60 seconds and 5 seconds.