### PR TITLE
DealerSocket linger added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ To be released
  -  Fixed an evaluation log to output `IPreEvaluationBlock<T>.PreEvaluationHash`
     as a hex formatted string.  [[#1835], [#1837]]
  -  Fixed a bug where some messages could not be sent using `NetMQTransport`
-    due to premature `DealerSocket` disposal.
+    due to premature `DealerSocket` disposal.  [[#1836], [#1839]]
 
 [#1835]: https://github.com/planetarium/libplanet/issues/1835
 [#1836]: https://github.com/planetarium/libplanet/issues/1836

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,13 @@ To be released
 
  -  Fixed an evaluation log to output `IPreEvaluationBlock<T>.PreEvaluationHash`
     as a hex formatted string.  [[#1835], [#1837]]
+ -  Fixed a bug where some messages could not be sent using `NetMQTransport`
+    due to premature `DealerSocket` disposal.
 
 [#1835]: https://github.com/planetarium/libplanet/issues/1835
+[#1836]: https://github.com/planetarium/libplanet/issues/1836
 [#1837]: https://github.com/planetarium/libplanet/pull/1837
+[#1839]: https://github.com/planetarium/libplanet/pull/1839
 
 
 Version 0.28.0

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -730,6 +730,7 @@ namespace Libplanet.Net.Transports
             try
             {
                 DealerSocket dealer = new DealerSocket(request.Peer.ToNetMQAddress());
+                dealer.Options.Linger = TimeSpan.FromSeconds(3);
                 long incrementedSocketCount = Interlocked.Increment(ref _socketCount);
                 _logger
                     .ForContext("Tag", "Metric")
@@ -899,9 +900,6 @@ namespace Libplanet.Net.Transports
             }
             finally
             {
-                // FIXME: Immediate disposal of DealerSocket results in a crash in
-                // a Windows environment.
-                await Task.Delay(1);
                 Interlocked.Decrement(ref _socketCount);
                 timerCts.Dispose();
             }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -730,7 +730,6 @@ namespace Libplanet.Net.Transports
             try
             {
                 DealerSocket dealer = new DealerSocket(request.Peer.ToNetMQAddress());
-                dealer.Options.Linger = TimeSpan.FromSeconds(3);
                 long incrementedSocketCount = Interlocked.Increment(ref _socketCount);
                 _logger
                     .ForContext("Tag", "Metric")
@@ -900,6 +899,12 @@ namespace Libplanet.Net.Transports
             }
             finally
             {
+                if (req.ExpectedResponses == 0)
+                {
+                    // FIXME: Temporary fix to wait for a message to be sent.
+                    await Task.Delay(1000);
+                }
+
                 Interlocked.Decrement(ref _socketCount);
                 timerCts.Dispose();
             }


### PR DESCRIPTION
Partially addresses #1836.

Few things to note:
- This further relies on the reliability of `NetMQ`.
  - There is no explicit check on whether a `Message` was actually sent.
  - ~`DealerSocket` count is only an estimate as it can linger before actually getting disposed by `NetMQ` behind the scene.~

Tested with a local chain on 9c-internal [v100120 rc1] based client.

[v100120 rc1]: https://github.com/planetarium/NineChronicles/commit/cd871445c9fde4dcd0200a28516728f63f469032