### PR TITLE
Deprecate `ITransport.SendMessageAsync()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ To be released.
     `SwarmOptions.MessageTimestampBuffer`  [[#1828], [#1831]]
  -  (Libplanet.Net) Unused parameter `dealerSocketLifetime` removed from
     `NetMQTransport()`.  [[#1832]]
+ -  (Libplanet.Net) Old `ITransport.SendMessageAsync()` method is deprecated.
+    `ITransport.SendMessageWithReplyAsync()` methods are renamed as
+    `ITransport.SendMessageAsync()`.  [[#1849]]
 
 ### Backward-incompatible network protocol changes
 
@@ -48,6 +51,7 @@ To be released.
 [#1831]: https://github.com/planetarium/libplanet/pull/1831
 [#1832]: https://github.com/planetarium/libplanet/pull/1832
 [#1838]: https://github.com/planetarium/libplanet/pull/1838
+[#1849]: https://github.com/planetarium/libplanet/pull/1849
 [column families]: https://github.com/facebook/rocksdb/wiki/Column-Families
 
 

--- a/Libplanet.Net.Tests/Protocols/TestTransport.cs
+++ b/Libplanet.Net.Tests/Protocols/TestTransport.cs
@@ -216,7 +216,7 @@ namespace Libplanet.Net.Tests.Protocols
             BoundPeer peer,
             Message message,
             CancellationToken cancellationToken)
-            => SendMessageWithReplyAsync(
+            => SendMessageAsync(
                 peer,
                 message,
                 TimeSpan.FromSeconds(3),
@@ -361,7 +361,7 @@ namespace Libplanet.Net.Tests.Protocols
         }
 
 #pragma warning disable S4457 // Cannot split the method since method is in interface
-        public async Task<Message> SendMessageWithReplyAsync(
+        public async Task<Message> SendMessageAsync(
             BoundPeer peer,
             Message message,
             TimeSpan? timeout,
@@ -408,7 +408,7 @@ namespace Libplanet.Net.Tests.Protocols
                         message.Identity,
                         timeout ?? TimeSpan.MaxValue);
                     throw new TimeoutException(
-                        $"Timeout occurred during {nameof(SendMessageWithReplyAsync)}().");
+                        $"Timeout occurred during {nameof(SendMessageAsync)}().");
                 }
 
                 await Task.Delay(10, cancellationToken);
@@ -417,7 +417,7 @@ namespace Libplanet.Net.Tests.Protocols
             if (cancellationToken.IsCancellationRequested)
             {
                 throw new OperationCanceledException(
-                    $"Operation is canceled during {nameof(SendMessageWithReplyAsync)}().");
+                    $"Operation is canceled during {nameof(SendMessageAsync)}().");
             }
 
             if (_replyToReceive.TryRemove(message.Identity, out Message reply))
@@ -436,13 +436,13 @@ namespace Libplanet.Net.Tests.Protocols
             {
                 _logger.Error(
                     "Unexpected error occurred during " +
-                    $"{nameof(SendMessageWithReplyAsync)}()");
+                    $"{nameof(SendMessageAsync)}()");
                 throw new SwarmException();
             }
         }
 #pragma warning restore S4457 // Cannot split the method since method is in interface
 
-        public async Task<IEnumerable<Message>> SendMessageWithReplyAsync(
+        public async Task<IEnumerable<Message>> SendMessageAsync(
             BoundPeer peer,
             Message message,
             TimeSpan? timeout,
@@ -452,7 +452,7 @@ namespace Libplanet.Net.Tests.Protocols
         {
             return new[]
             {
-                await SendMessageWithReplyAsync(peer, message, timeout, cancellationToken),
+                await SendMessageAsync(peer, message, timeout, cancellationToken),
             };
         }
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -946,7 +946,7 @@ namespace Libplanet.Net.Tests
 
                 var transport = swarm1.Transport;
                 var msg = new GetTxs(new[] { tx1.Id, tx2.Id, tx3.Id, tx4.Id });
-                var replies = (await transport.SendMessageWithReplyAsync(
+                var replies = (await transport.SendMessageAsync(
                     (BoundPeer)swarm2.AsPeer,
                     msg,
                     TimeSpan.FromSeconds(1),

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -469,7 +469,7 @@ namespace Libplanet.Net.Tests
                 ITransport transport = swarmB.Transport;
 
                 var request = new GetBlocks(hashes.Select(pair => pair.Item2), 2);
-                Message[] responses = (await transport.SendMessageWithReplyAsync(
+                Message[] responses = (await transport.SendMessageAsync(
                     (BoundPeer)swarmA.AsPeer,
                     request,
                     null,

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -91,15 +91,13 @@ namespace Libplanet.Net.Tests.Transports
                 await Assert.ThrowsAsync<ObjectDisposedException>(
                     async () => await transport.StopAsync(TimeSpan.Zero));
                 await Assert.ThrowsAsync<ObjectDisposedException>(
-                    async () => await transport.SendMessageAsync(boundPeer, message, default));
-                await Assert.ThrowsAsync<ObjectDisposedException>(
-                    async () => await transport.SendMessageWithReplyAsync(
+                    async () => await transport.SendMessageAsync(
                         boundPeer,
                         message,
                         null,
                         default));
                 await Assert.ThrowsAsync<ObjectDisposedException>(
-                    async () => await transport.SendMessageWithReplyAsync(
+                    async () => await transport.SendMessageAsync(
                         boundPeer,
                         message,
                         null,
@@ -161,47 +159,9 @@ namespace Libplanet.Net.Tests.Transports
             }
         }
 
-        [SkippableFact(Timeout = Timeout, Skip = "Target method is broken.")]
-        public async Task SendMessageAsync()
-        {
-            ITransport transportA = CreateTransport();
-            ITransport transportB = CreateTransport();
-
-            TaskCompletionSource<Message> tcs = new TaskCompletionSource<Message>();
-
-            transportB.ProcessMessageHandler.Register(async message =>
-            {
-                tcs.SetResult(message);
-                await Task.Yield();
-            });
-
-            try
-            {
-                await InitializeAsync(transportA);
-                await InitializeAsync(transportB);
-
-                Assert.True(transportA.Running);
-                Assert.True(transportB.Running);
-
-                await transportA.SendMessageAsync(
-                    (BoundPeer)transportB.AsPeer,
-                    new Ping(),
-                    CancellationToken.None);
-
-                Message message = await tcs.Task;
-
-                Assert.IsType<Ping>(message);
-            }
-            finally
-            {
-                transportA.Dispose();
-                transportB.Dispose();
-            }
-        }
-
         // This also tests ITransport.ReplyMessageAsync at the same time.
         [SkippableFact(Timeout = Timeout)]
-        public async Task SendMessageWithReplyAsync()
+        public async Task SendMessageAsync()
         {
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
@@ -224,7 +184,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportA);
                 await InitializeAsync(transportB);
 
-                Message reply = await transportA.SendMessageWithReplyAsync(
+                Message reply = await transportA.SendMessageAsync(
                     (BoundPeer)transportB.AsPeer,
                     new Ping(),
                     TimeSpan.FromSeconds(3),
@@ -240,7 +200,7 @@ namespace Libplanet.Net.Tests.Transports
         }
 
         [SkippableFact(Timeout = Timeout)]
-        public async Task SendMessageWithReplyCancelAsync()
+        public async Task SendMessageCancelAsync()
         {
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
@@ -253,7 +213,7 @@ namespace Libplanet.Net.Tests.Transports
 
                 cts.CancelAfter(TimeSpan.FromSeconds(1));
                 await Assert.ThrowsAsync<TaskCanceledException>(
-                    async () => await transportA.SendMessageWithReplyAsync(
+                    async () => await transportA.SendMessageAsync(
                         (BoundPeer)transportB.AsPeer,
                         new Ping(),
                         null,
@@ -268,7 +228,7 @@ namespace Libplanet.Net.Tests.Transports
         }
 
         [SkippableFact(Timeout = Timeout)]
-        public async Task SendMessageWithMultipleRepliesAsync()
+        public async Task SendMessageMultipleRepliesAsync()
         {
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
@@ -297,7 +257,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportA);
                 await InitializeAsync(transportB);
 
-                var replies = (await transportA.SendMessageWithReplyAsync(
+                var replies = (await transportA.SendMessageAsync(
                     (BoundPeer)transportB.AsPeer,
                     new Ping(),
                     TimeSpan.FromSeconds(3),
@@ -317,7 +277,7 @@ namespace Libplanet.Net.Tests.Transports
 
         // This also tests ITransport.ReplyMessage at the same time.
         [SkippableFact(Timeout = Timeout)]
-        public async Task SendMessageWithReplyAsyncTimeout()
+        public async Task SendMessageAsyncTimeout()
         {
             ITransport transportA = CreateTransport();
             ITransport transportB = CreateTransport();
@@ -328,7 +288,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportB);
 
                 await Assert.ThrowsAsync<TimeoutException>(
-                    async () => await transportA.SendMessageWithReplyAsync(
+                    async () => await transportA.SendMessageAsync(
                         (BoundPeer)transportB.AsPeer,
                         new Ping(),
                         TimeSpan.FromSeconds(3),
@@ -359,7 +319,7 @@ namespace Libplanet.Net.Tests.Transports
                     new DnsEndPoint(
                         "0.0.0.0",
                         port));
-                Task task = transport.SendMessageWithReplyAsync(
+                Task task = transport.SendMessageAsync(
                     peer,
                     new Ping(),
                     TimeSpan.FromSeconds(5),
@@ -385,7 +345,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportA);
                 await InitializeAsync(transportB);
 
-                Task t = transportA.SendMessageWithReplyAsync(
+                Task t = transportA.SendMessageAsync(
                         (BoundPeer)transportB.AsPeer,
                         new Ping(),
                         null,

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -430,7 +430,7 @@ namespace Libplanet.Net.Protocols
             try
             {
                 _logger.Verbose("Trying to ping async to {Peer}.", peer);
-                Message reply = await _transport.SendMessageWithReplyAsync(
+                Message reply = await _transport.SendMessageAsync(
                     peer,
                     new Ping(),
                     timeout,
@@ -631,7 +631,7 @@ namespace Libplanet.Net.Protocols
             var findPeer = new Messages.FindNeighbors(target);
             try
             {
-                Message reply = await _transport.SendMessageWithReplyAsync(
+                Message reply = await _transport.SendMessageAsync(
                     peer,
                     findPeer,
                     timeout,

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -744,7 +744,7 @@ namespace Libplanet.Net
                 nameof(Messages.GetBlockHashes),
                 locator.FirstOrDefault(),
                 stop);
-            Message parsedMessage = await Transport.SendMessageWithReplyAsync(
+            Message parsedMessage = await Transport.SendMessageAsync(
                 peer,
                 request,
                 timeout: transportTimeout,
@@ -811,7 +811,7 @@ namespace Libplanet.Net
                 blockRecvTimeout = Options.MaxTimeout;
             }
 
-            IEnumerable<Message> replies = await Transport.SendMessageWithReplyAsync(
+            IEnumerable<Message> replies = await Transport.SendMessageAsync(
                 peer,
                 request,
                 blockRecvTimeout,
@@ -876,7 +876,7 @@ namespace Libplanet.Net
                 txRecvTimeout = Options.MaxTimeout;
             }
 
-            IEnumerable<Message> replies = await Transport.SendMessageWithReplyAsync(
+            IEnumerable<Message> replies = await Transport.SendMessageAsync(
                 peer,
                 request,
                 txRecvTimeout,
@@ -1237,7 +1237,7 @@ namespace Libplanet.Net
             IEnumerable<Task<(BoundPeer, ChainStatus)>> tasks = Peers.OrderBy(_ => rnd.Next())
                 .Take(maxPeersToDial)
                 .Select(
-                    peer => Transport.SendMessageWithReplyAsync(
+                    peer => Transport.SendMessageAsync(
                         peer,
                         new GetChainStatus(),
                         dialTimeout,

--- a/Libplanet.Net/Transports/ITransport.cs
+++ b/Libplanet.Net/Transports/ITransport.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Net.Transports
         /// <summary>
         /// The list of tasks invoked when a message that is not
         /// a reply is received. To handle reply, please use <see cref=
-        /// "SendMessageWithReplyAsync(BoundPeer, Message, TimeSpan?, CancellationToken)"/>.
+        /// "SendMessageAsync(BoundPeer, Message, TimeSpan?, CancellationToken)"/>.
         /// </summary>
         AsyncDelegate<Message> ProcessMessageHandler { get; }
 
@@ -74,19 +74,6 @@ namespace Libplanet.Net.Transports
         Task WaitForRunningAsync();
 
         /// <summary>
-        /// Sends a <see cref="Message"/> to a given <see cref="BoundPeer"/>.
-        /// </summary>
-        /// <param name="peer">A <see cref="Peer"/> to send message to.</param>
-        /// <param name="message">A <see cref="Message"/> to send.</param>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.</param>
-        /// <returns>An awaitable task without value.</returns>
-        /// <exception cref="ObjectDisposedException">
-        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
-        Task SendMessageAsync(BoundPeer peer, Message message, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Sends a <see cref="Message"/> to a given <see cref="BoundPeer"/>
         /// and waits for its single reply.
         /// </summary>
@@ -100,7 +87,7 @@ namespace Libplanet.Net.Transports
         /// sent by <paramref name="peer"/>.</returns>
         /// <exception cref="ObjectDisposedException">
         /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
-        Task<Message> SendMessageWithReplyAsync(
+        Task<Message> SendMessageAsync(
             BoundPeer peer,
             Message message,
             TimeSpan? timeout,
@@ -123,7 +110,7 @@ namespace Libplanet.Net.Transports
         /// sent by <paramref name="peer"/>.</returns>
         /// <exception cref="ObjectDisposedException">Thrown when <see cref="ITransport"/> instance
         /// is already disposed.</exception>
-        Task<IEnumerable<Message>> SendMessageWithReplyAsync(
+        Task<IEnumerable<Message>> SendMessageAsync(
             BoundPeer peer,
             Message message,
             TimeSpan? timeout,


### PR DESCRIPTION
See #1839 for the rationale.

To elaborate,

- With a proper pub/sub model, the responsibility of acknowledging a transportation of a `Message` that requires no reply is shifted from the sender to a receiver. In this model, the sender's application layer should not have a control to send a `Message` to a specific peer.
- With a req/rep model, 
  - It is unintuitive to implicitly expect a reply for `SendMessageAsync()`.
  - Every initiating `Message`s is a request, hence expects a reply.

In either case, there is no need for `SendMessageAsync()`.