### PR TITLE
Silence `RocksDBStore.GetBlockDigest()` for non-existent block hashes & release 0.28.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.28.2
 --------------
 
-To be released.
+Released on March 15, 2022.
 
  -  (Libplanet.RocksDBStore) `RocksDBStore.GetBlockDigest()` became to silently
     return `null` with no misleading error log when it's asked a non-existent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,9 @@ Released on March 3, 2022.
 
  -  Fixed an evaluation log to output `IPreEvaluationBlock<T>.PreEvaluationHash`
     as a hex formatted string.  [[#1835], [#1837]]
- -  Fixed a bug where some messages could not be sent using `NetMQTransport`
-    due to premature `DealerSocket` disposal.  [[#1836], [#1839]]
+ -  (Libplanet.Net) Fixed a bug where some messages could not be sent using
+    `NetMQTransport` due to premature `DealerSocket` disposal.
+    [[#1836], [#1839]]
 
 [#1835]: https://github.com/planetarium/libplanet/issues/1835
 [#1836]: https://github.com/planetarium/libplanet/issues/1836

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.28.2
 
 To be released.
 
+ -  (Libplanet.RocksDBStore) `RocksDBStore.GetBlockDigest()` became to silently
+    return `null` with no misleading error log when it's asked a non-existent
+    block hash.  [[#1500], [#1852]]
+
+[[#1500]]: https://github.com/planetarium/libplanet/issues/1500
+[[#1852]]: https://github.com/planetarium/libplanet/pull/1852
+
 
 Version 0.28.1
 --------------

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -639,7 +639,10 @@ namespace Libplanet.RocksDBStore
                     }
                 }
 
-                byte[] blockBytes = blockDb.Get(key);
+                if (!(blockDb.Get(key) is byte[] blockBytes))
+                {
+                    return null;
+                }
 
                 BlockDigest blockDigest = BlockDigest.Deserialize(blockBytes);
 

--- a/Libplanet/Store/BlockDigest.cs
+++ b/Libplanet/Store/BlockDigest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
@@ -135,11 +136,18 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="bytes">Serialized <see cref="BlockDigest"/>.</param>
         /// <returns>Deserialized <see cref="BlockDigest"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the passed <paramref name="bytes"/>
+        /// is <see langword="null"/>.</exception>
         /// <exception cref="DecodingException">Thrown when decoded value is not
         /// <see cref="Bencodex.Types.Dictionary"/> type.</exception>
         public static BlockDigest Deserialize(byte[] bytes)
         {
-            IValue value = new Codec().Decode(bytes);
+            if (!(bytes is byte[] bytesArray))
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+
+            IValue value = new Codec().Decode(bytesArray);
             if (!(value is Bencodex.Types.Dictionary dict))
             {
                 throw new DecodingException(

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -415,15 +415,7 @@ namespace Libplanet.Store
             BlockDigest blockDigest;
             try
             {
-                IValue value = Codec.Decode(_blocks.ReadAllBytes(path));
-                if (!(value is Bencodex.Types.Dictionary dict))
-                {
-                    throw new DecodingException(
-                        $"Expected {typeof(Bencodex.Types.Dictionary)} but " +
-                        $"{value.GetType()}");
-                }
-
-                blockDigest = new BlockDigest(dict);
+                blockDigest = BlockDigest.Deserialize(_blocks.ReadAllBytes(path));
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
This addresses <https://github.com/planetarium/libplanet/issues/1500#issuecomment-1067793388> and releases this fix as 0.28.2.