### PR TITLE
Port 0.28.2 to main (0.29.x)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,25 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
+    - if: github.event_name != 'schedule' && github.ref_type == 'tag'
+      run: |
+        set -evx
+        pushd /tmp
+        wget $WEB_FLOW_KEY_URL
+        popd
+        gpg --import /tmp/web-flow.gpg
+        if ! git verify-commit "$GITHUB_REF_NAME" && \
+           [[ "$( git cat-file -p "$GITHUB_REF_NAME" \
+                | grep -Ei '^parent\s+[0-9a-f]{40}$' | wc -l )" -lt 2 ]]; then
+          echo "::error title=Invalid tag commit::Tags must refer to a merge" \
+               "commit or a commit signed by GitHub web-flow" \
+               "($WEB_FLOW_KEY_URL).  The tag $GITHUB_REF_NAME refers to " \
+               "a commit $(git rev-parse $GITHUB_REF_NAME) which is neither" \
+               "a merge commit nor signed by GitHub web-flow."
+          exit 1
+        fi
+      env:
+        $WEB_FLOW_KEY_URL: https://github.com/web-flow.gpg
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,19 @@ To be released.
 [column families]: https://github.com/facebook/rocksdb/wiki/Column-Families
 
 
+Version 0.28.2
+--------------
+
+Released on March 15, 2022.
+
+ -  (Libplanet.RocksDBStore) `RocksDBStore.GetBlockDigest()` became to silently
+    return `null` with no misleading error log when it's asked a non-existent
+    block hash.  [[#1500], [#1852]]
+
+[#1500]: https://github.com/planetarium/libplanet/issues/1500
+[#1852]: https://github.com/planetarium/libplanet/pull/1852
+
+
 Version 0.28.1
 --------------
 
@@ -62,8 +75,9 @@ Released on March 3, 2022.
 
  -  Fixed an evaluation log to output `IPreEvaluationBlock<T>.PreEvaluationHash`
     as a hex formatted string.  [[#1835], [#1837]]
- -  Fixed a bug where some messages could not be sent using `NetMQTransport`
-    due to premature `DealerSocket` disposal.  [[#1836], [#1839]]
+ -  (Libplanet.Net) Fixed a bug where some messages could not be sent using
+    `NetMQTransport` due to premature `DealerSocket` disposal.
+    [[#1836], [#1839]]
 
 [#1835]: https://github.com/planetarium/libplanet/issues/1835
 [#1836]: https://github.com/planetarium/libplanet/issues/1836

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,12 @@ Version 0.29.0
 
 To be released.
 
-
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
 
- -  `SwarmOptions.MessageLifespan` property changed to
-    `SwarmOptions.MessageTimestampBuffer`  [[#1828], [#1831]]
+ -  (Libplanet.Net) `SwarmOptions.MessageLifespan` property changed to
+    `SwarmOptions.MessageTimestampBuffer`.  [[#1828], [#1831]]
  -  (Libplanet.Net) Unused parameter `dealerSocketLifetime` removed from
     `NetMQTransport()`.  [[#1832]]
  -  (Libplanet.Net) Old `ITransport.SendMessageAsync()` method is deprecated.
@@ -23,17 +22,17 @@ To be released.
 
 ### Backward-incompatible storage format changes
 
- -  `RocksDBStore` became not to use [column families] to manage
-    chain ids. Instead, chain id is concatenated into key prefix.
+ -  (Libplanet.RocksDBStore) `RocksDBStore` became not to use [column families]
+    to manage chain ids. Instead, chain id is concatenated into key prefix.
     [[#1838]]
 
 ### Added APIs
 
 ### Behavioral changes
 
- -  Default value of `SwarmOptions.MessageTimestampBuffer` is set to 60 seconds
-    instead of `null`.  [[#1828], [#1831]]
- -  (Libplanet.Net) Acceptible timestamp range for `Message`s, when non-null
+ -  (Libplanet.Net) Default value of `SwarmOptions.MessageTimestampBuffer` is
+    set to 60 seconds instead of `null`.  [[#1828], [#1831]]
+ -  (Libplanet.Net) Acceptable timestamp range for `Message`s, when non-null
     `SwarmOptions.MessageTimestampBuffer` is provided, has changed to allow
     `Message`s with future timestamps.
     [[#1828], [#1831]]
@@ -44,8 +43,8 @@ To be released.
 
 ### CLI tools
 
-  - Added `planet store migrate-index` for index database migration.
-    (from column families based to key-prefix)  [[#1838]]
+  - Added `planet store migrate-index` for index database migration
+    (from column families based to key-prefix).  [[#1838]]
 
 [#1828]: https://github.com/planetarium/libplanet/issues/1828
 [#1831]: https://github.com/planetarium/libplanet/pull/1831
@@ -64,7 +63,6 @@ Released on March 15, 2022.
     return `null` with no misleading error log when it's asked a non-existent
     block hash.  [[#1500], [#1852]]
 
-[#1500]: https://github.com/planetarium/libplanet/issues/1500
 [#1852]: https://github.com/planetarium/libplanet/pull/1852
 
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -764,7 +764,10 @@ namespace Libplanet.RocksDBStore
                     }
                 }
 
-                byte[] blockBytes = blockDb.Get(key);
+                if (!(blockDb.Get(key) is byte[] blockBytes))
+                {
+                    return null;
+                }
 
                 BlockDigest blockDigest = BlockDigest.Deserialize(blockBytes);
 

--- a/Libplanet/Store/BlockDigest.cs
+++ b/Libplanet/Store/BlockDigest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
@@ -135,11 +136,18 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="bytes">Serialized <see cref="BlockDigest"/>.</param>
         /// <returns>Deserialized <see cref="BlockDigest"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the passed <paramref name="bytes"/>
+        /// is <see langword="null"/>.</exception>
         /// <exception cref="DecodingException">Thrown when decoded value is not
         /// <see cref="Bencodex.Types.Dictionary"/> type.</exception>
         public static BlockDigest Deserialize(byte[] bytes)
         {
-            IValue value = new Codec().Decode(bytes);
+            if (!(bytes is byte[] bytesArray))
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+
+            IValue value = new Codec().Decode(bytesArray);
             if (!(value is Bencodex.Types.Dictionary dict))
             {
                 throw new DecodingException(

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -415,15 +415,7 @@ namespace Libplanet.Store
             BlockDigest blockDigest;
             try
             {
-                IValue value = Codec.Decode(_blocks.ReadAllBytes(path));
-                if (!(value is Bencodex.Types.Dictionary dict))
-                {
-                    throw new DecodingException(
-                        $"Expected {typeof(Bencodex.Types.Dictionary)} but " +
-                        $"{value.GetType()}");
-                }
-
-                blockDigest = new BlockDigest(dict);
+                blockDigest = BlockDigest.Deserialize(_blocks.ReadAllBytes(path));
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
Note that I merged 66a1b9f41e7386e50e5976807f3bb3e2fc1afe48 instead of tag 0.28.2, because it does not refer to 66a1b9f41e7386e50e5976807f3bb3e2fc1afe48 the merge commit, but its parent commit instead.  It was my mistake, and it indeed didn't work with the release script on GitHub Actions.  (So I had to manually upload files to NuGet and GitHub releases).

In order to prevent such mistakes from now on, I added a small check to the main workflow.  It ensures if a new tag refers to a proper merge commit or a commit signed by GitHub @web-flow.[^1]

[^1]: As pull requests can be squashed when it's merged, sometimes tags may refer to a non-merge commit.  In such case, the commit is still signed by GitHub @web-flow.