### PR TITLE
Revert IndexDB migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,10 +22,6 @@ To be released.
 
 ### Backward-incompatible storage format changes
 
- -  (Libplanet.RocksDBStore) `RocksDBStore` became not to use [column families]
-    to manage chain ids. Instead, chain id is concatenated into key prefix.
-    [[#1838]]
-
 ### Added APIs
 
 ### Behavioral changes
@@ -45,16 +41,12 @@ To be released.
 
 ### CLI tools
 
-  - Added `planet store migrate-index` for index database migration
-    (from column families based to key-prefix).  [[#1838]]
 
 [#1828]: https://github.com/planetarium/libplanet/issues/1828
 [#1831]: https://github.com/planetarium/libplanet/pull/1831
 [#1832]: https://github.com/planetarium/libplanet/pull/1832
-[#1838]: https://github.com/planetarium/libplanet/pull/1838
 [#1845]: https://github.com/planetarium/libplanet/pull/1845
 [#1849]: https://github.com/planetarium/libplanet/pull/1849
-[column families]: https://github.com/facebook/rocksdb/wiki/Column-Families
 
 
 Version 0.28.2

--- a/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
@@ -126,19 +126,6 @@ namespace Libplanet.Extensions.Cocona.Commands
             store?.Dispose();
         }
 
-        [Command]
-        public void MigrateIndex(string storePath)
-        {
-            if (RocksDBStore.RocksDBStore.MigrateChainDBFromColumnFamilies(storePath))
-            {
-                Console.WriteLine("Successfully migrated.");
-            }
-            else
-            {
-                Console.WriteLine("Already migrated, no need to migrate.");
-            }
-        }
-
         private static Block<T> GetBlock<T>(IStore store, BlockHash blockHash)
             where T : IAction, new()
         {

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -103,34 +103,6 @@ namespace Libplanet.RocksDBStore.Tests
         }
 
         [SkippableFact]
-        public void ListChainIds()
-        {
-            var path = Path.Combine(Path.GetTempPath(), $"rocksdb_test_{Guid.NewGuid()}");
-            var store = new RocksDBStore(path);
-            try
-            {
-                Guid cid = Guid.NewGuid();
-                store.AppendIndex(cid, Fx.Block1.Hash);
-                store.AppendIndex(cid, Fx.Block2.Hash);
-                store.AppendIndex(cid, Fx.Block3.Hash);
-
-                store.PutBlock(Fx.Block1);
-                store.PutBlock(Fx.Block2);
-                store.PutBlock(Fx.Block3);
-
-                Assert.Single(store.ListChainIds());
-
-                store.ForkBlockIndexes(cid, Guid.NewGuid(), Fx.Block3.Hash);
-                Assert.Equal(2, store.ListChainIds().Count());
-            }
-            finally
-            {
-                store.Dispose();
-                Directory.Delete(path, true);
-            }
-        }
-
-        [SkippableFact]
         public void ParallelGetTransaction()
         {
             var path = Path.Combine(Path.GetTempPath(), $"rocksdb_test_{Guid.NewGuid()}");


### PR DESCRIPTION
This PR reverts following commits in order to release 0.29.

Revert "Merge pull request #1838 from longfin/feature/cf-remove"

This reverts commit 0e007e61359f45ff4884571d1fc1ee14f31dfec9, reversing
changes made to a25079609b6c70d076dc9a73ca57c36a5e8ee40f. (+1 squashed commits)

Revert "Merge pull request #1847 from limebell/bugfix/migration-indexes"

This reverts commit e3ff1aaaa85fbc3b48d255d33a6747f7b950c058, reversing
changes made to 0e007e61359f45ff4884571d1fc1ee14f31dfec9.