### PR TITLE
Increase `Message` receive throughput

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,16 @@ To be released.
 
 ### Bug fixes
 
+ -  (Libplanet.Stun) Increased the number of internal proxies to increase
+    the inbound network traffic throughput of a node when using a `TurnClient`.
+    [[#1864], [#1876]]
+
 ### Dependencies
 
 ### CLI tools
+
+[#1864]: https://github.com/planetarium/libplanet/issues/1864
+[#1876]: https://github.com/planetarium/libplanet/pull/1876
 
 
 Version 0.30.0

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -18,6 +18,7 @@ namespace Libplanet.Stun
     {
         public const int TurnDefaultPort = 3478;
         private const int AllocateRetry = 5;
+        private const int ProxyCount = 16;
 
         // TURN Permission lifetime was defined in RFC 5766
         // see also https://tools.ietf.org/html/rfc5766#section-8
@@ -99,7 +100,8 @@ namespace Libplanet.Stun
                 {
                     if (BehindNAT)
                     {
-                        _turnTasks = BindMultipleProxies(listenPort, 3, _turnTaskCts.Token);
+                        _turnTasks = BindMultipleProxies(
+                            listenPort, ProxyCount, _turnTaskCts.Token);
                         _turnTasks.Add(RefreshAllocate(_turnTaskCts.Token));
                     }
 


### PR DESCRIPTION
Temporarily resolves #1864. `16` is just some random number I chose. 😶
This might eventually run into a scaling issue again eventually.