### PR TITLE
Add `IStore.PruneOutdatedChains()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Added `IStore.PruneOutdatedChains(bool noopWithoutCanon)` method.
+   [[#1874], [#1878]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +26,9 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#1874]: https://github.com/planetarium/libplanet/issues/1874
+[#1878]: https://github.com/planetarium/libplanet/pull/1878
 
 
 Version 0.31.0

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -184,9 +184,16 @@ namespace Libplanet.Explorer.Store
             return _store.CountBlocks();
         }
 
+        /// <inheritdoc cref="IStore.ForkTxNonces(Guid, Guid)"/>
         public void ForkTxNonces(Guid sourceChainId, Guid destinationChainId)
         {
             _store.ForkTxNonces(sourceChainId, destinationChainId);
+        }
+
+        /// <inheritdoc cref="IStore.PruneOutdatedChains(bool)"/>
+        public void PruneOutdatedChains(bool noopWithoutCanon = false)
+        {
+            _store.PruneOutdatedChains(noopWithoutCanon);
         }
 
         /// <inheritdoc cref="IStore.PutBlock{T}(Block{T})"/>

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -152,9 +152,16 @@ namespace Libplanet.Explorer.Store
             return _store.CountBlocks();
         }
 
+        /// <inheritdoc cref="IStore.ForkTxNonces(Guid, Guid)"/>
         public void ForkTxNonces(Guid sourceChainId, Guid destinationChainId)
         {
             _store.ForkTxNonces(sourceChainId, destinationChainId);
+        }
+
+        /// <inheritdoc cref="IStore.PruneOutdatedChains(bool)"/>
+        public void PruneOutdatedChains(bool noopWithoutCanon = false)
+        {
+            _store.PruneOutdatedChains(noopWithoutCanon);
         }
 
         /// <inheritdoc cref="IStore.PutBlock{T}(Block{T})"/>

--- a/Libplanet.Tests/Store/ProxyStore.cs
+++ b/Libplanet.Tests/Store/ProxyStore.cs
@@ -199,5 +199,9 @@ namespace Libplanet.Tests.Store
         /// <inheritdoc cref="IStore.ForkTxNonces(Guid, Guid)"/>
         public virtual void ForkTxNonces(Guid sourceChainId, Guid destinationChainId) =>
             Store.ForkTxNonces(sourceChainId, destinationChainId);
+
+        /// <inheritdoc cref="IStore.PruneOutdatedChains(bool)"/>
+        public void PruneOutdatedChains(bool noopWithoutCanon = false) =>
+            Store.PruneOutdatedChains(noopWithoutCanon);
     }
 }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1115,6 +1115,51 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
+        public void PruneOutdatedChains()
+        {
+            IStore store = Fx.Store;
+            store.PutBlock(Fx.GenesisBlock);
+            store.PutBlock(Fx.Block1);
+            store.PutBlock(Fx.Block2);
+            store.PutBlock(Fx.Block3);
+
+            Guid cid1 = Guid.NewGuid();
+            store.AppendIndex(cid1, Fx.GenesisBlock.Hash);
+            store.AppendIndex(cid1, Fx.Block1.Hash);
+            store.AppendIndex(cid1, Fx.Block2.Hash);
+            Assert.Single(store.ListChainIds());
+            Assert.Equal(
+                new[] { Fx.GenesisBlock.Hash, Fx.Block1.Hash, Fx.Block2.Hash },
+                store.IterateIndexes(cid1, 0, null));
+
+            Guid cid2 = Guid.NewGuid();
+            store.ForkBlockIndexes(cid1, cid2, Fx.Block1.Hash);
+            store.AppendIndex(cid2, Fx.Block2.Hash);
+            store.AppendIndex(cid2, Fx.Block3.Hash);
+            Assert.Equal(2, store.ListChainIds().Count());
+            Assert.Equal(
+                new[] { Fx.GenesisBlock.Hash, Fx.Block1.Hash, Fx.Block2.Hash, Fx.Block3.Hash },
+                store.IterateIndexes(cid2, 0, null));
+
+            Guid cid3 = Guid.NewGuid();
+            store.ForkBlockIndexes(cid1, cid3, Fx.Block2.Hash);
+            Assert.Equal(3, store.ListChainIds().Count());
+            Assert.Equal(
+                new[] { Fx.GenesisBlock.Hash, Fx.Block1.Hash, Fx.Block2.Hash },
+                store.IterateIndexes(cid3, 0, null));
+
+            Assert.Throws<InvalidOperationException>(() => store.PruneOutdatedChains());
+            store.PruneOutdatedChains(true);
+            store.SetCanonicalChainId(cid3);
+            store.PruneOutdatedChains();
+            Assert.Single(store.ListChainIds());
+            Assert.Equal(
+                new[] { Fx.GenesisBlock.Hash, Fx.Block1.Hash, Fx.Block2.Hash },
+                store.IterateIndexes(cid3, 0, null));
+            Assert.Equal(3, store.CountIndex(cid3));
+        }
+
+        [SkippableFact]
         public void IdempotentDispose()
         {
 #pragma warning disable S3966 // Objects should not be disposed more than once

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -228,6 +228,12 @@ namespace Libplanet.Tests.Store
             _store.ForkTxNonces(sourceChainId, destinationChainId);
         }
 
+        public void PruneOutdatedChains(bool noopWithoutCanon = false)
+        {
+            Log(nameof(PruneOutdatedChains));
+            _store.PruneOutdatedChains();
+        }
+
         public Guid? GetCanonicalChainId()
         {
             Log(nameof(GetCanonicalChainId));

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -179,6 +179,9 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public abstract void ForkTxNonces(Guid sourceChainId, Guid destinationChainId);
 
+        /// <inheritdoc/>
+        public abstract void PruneOutdatedChains(bool noopWithoutCanon = false);
+
         protected static IValue SerializeTxExecution(TxSuccess txSuccess)
         {
             var sDelta = new Dictionary(

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -645,6 +645,25 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc/>
+        public override void PruneOutdatedChains(bool noopWithoutCanon = false)
+        {
+            if (!(GetCanonicalChainId() is { } ccid))
+            {
+                if (noopWithoutCanon)
+                {
+                    return;
+                }
+
+                throw new InvalidOperationException("Canonical chain ID is not assigned.");
+            }
+
+            foreach (Guid id in ListChainIds().Where(id => !id.Equals(ccid)))
+            {
+                DeleteChainId(id);
+            }
+        }
+
+        /// <inheritdoc/>
         public override long CountTransactions()
         {
             // FIXME: This implementation is too inefficient.  Fortunately, this method seems

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -332,5 +332,22 @@ namespace Libplanet.Store
         /// <exception cref="ChainIdNotFoundException">Thrown when the given
         /// <paramref name="sourceChainId"/> does not exist.</exception>
         void ForkTxNonces(Guid sourceChainId, Guid destinationChainId);
+
+        /// <summary>
+        /// Delete all non-canonical chains.
+        /// </summary>
+        /// <param name="noopWithoutCanon">
+        /// Flag to determine whether the function throws exception
+        /// when the canonical chain is not assigned.  <c>false</c> by default.
+        /// If it set to <c>true</c>, does not throw exception when
+        /// there is no canonical chain.
+        /// Otherwise, throws <see cref="InvalidOperationException"/> when
+        /// there is no canonical chain.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when there is no canonical chain and
+        /// <paramref name="noopWithoutCanon"/> is false.
+        /// </exception>
+        void PruneOutdatedChains(bool noopWithoutCanon = false);
     }
 }

--- a/Libplanet/Store/MemoryStore.cs
+++ b/Libplanet/Store/MemoryStore.cs
@@ -264,5 +264,23 @@ namespace Libplanet.Store
                 $"No such chain ID: {sourceChainId}."
             );
         }
+
+        void IStore.PruneOutdatedChains(bool noopWithoutCanon)
+        {
+            if (!(_canonicalChainId is { } ccid))
+            {
+                if (noopWithoutCanon)
+                {
+                    return;
+                }
+
+                throw new InvalidOperationException("Canonical chain ID is not assigned.");
+            }
+
+            foreach (Guid id in _indices.Keys.Where(id => !id.Equals(ccid)))
+            {
+                ((IStore)this).DeleteChainId(id);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds `IStore.PruneOutdatedChains()` which deletes all non-canonical chains from the storage.

Closes #1874.