### PR TITLE
Enforce concurrency on `KBucket` internal dictionaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,14 +21,22 @@ To be released.
 
 ### Behavioral changes
 
+ -  (Libplanet.Net) Internal cache size of a `KBucket` is now capped.
+    [[#1879]]
+
 ### Bug fixes
+
+ -  (Libplanet.Net) Internal dictionaries of a `KBucket` are made to be
+    concurrent.  [[#1872], [#1879]]
 
 ### Dependencies
 
 ### CLI tools
 
+[#1872]: https://github.com/planetarium/libplanet/issues/1872
 [#1874]: https://github.com/planetarium/libplanet/issues/1874
 [#1878]: https://github.com/planetarium/libplanet/pull/1878
+[#1879]: https://github.com/planetarium/libplanet/pull/1879
 
 
 Version 0.31.0

--- a/Libplanet.Net.Tests/Protocols/KBucketDictionaryTest.cs
+++ b/Libplanet.Net.Tests/Protocols/KBucketDictionaryTest.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Net;
+using Libplanet.Crypto;
+using Libplanet.Net.Protocols;
+using Serilog.Core;
+using Xunit;
+
+namespace Libplanet.Net.Tests.Protocols
+{
+    public class KBucketDictionaryTest
+    {
+        [Fact]
+        public void KBucketDictionary()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new KBucketDictionary(size: 0, replace: false, logger: Logger.None));
+        }
+
+        [Fact]
+        public void MutateWithoutReplacement()
+        {
+            var kBucketDictionary = new KBucketDictionary(
+                size: 4, replace: false, logger: Logger.None);
+            var peer1 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer2 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer3 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer4 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer5 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+
+            // Initial state
+            Assert.Equal(0, kBucketDictionary.Count);
+            Assert.Null(kBucketDictionary.Head);
+            Assert.Null(kBucketDictionary.Tail);
+
+            // Add more peers than allowed
+            Assert.True(kBucketDictionary.AddOrUpdate(peer1));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer2));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer3));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer4));
+            Assert.False(kBucketDictionary.AddOrUpdate(peer5));
+            Assert.Equal(4, kBucketDictionary.Count);
+            Assert.Equal(peer1.Address, kBucketDictionary.Tail!.Peer.Address);
+            Assert.Equal(peer4.Address, kBucketDictionary.Head!.Peer.Address);
+            Assert.True(kBucketDictionary.Contains(peer1));
+            Assert.False(kBucketDictionary.Contains(peer5));
+
+            // Replace one of the peers
+            Assert.True(kBucketDictionary.AddOrUpdate(peer2));
+            Assert.Equal(peer1.Address, kBucketDictionary.Tail!.Peer.Address);
+            Assert.Equal(peer2.Address, kBucketDictionary.Head!.Peer.Address);
+
+            // Remove
+            Assert.True(kBucketDictionary.Remove(peer3));
+            Assert.False(kBucketDictionary.Remove(peer5));
+
+            // Clear
+            kBucketDictionary.Clear();
+            Assert.Equal(0, kBucketDictionary.Count);
+            Assert.Null(kBucketDictionary.Head);
+            Assert.Null(kBucketDictionary.Tail);
+        }
+
+        [Fact]
+        public void MutateWithReplacement()
+        {
+            var kBucketDictionary = new KBucketDictionary(
+                size: 4, replace: true, logger: Logger.None);
+            var peer1 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer2 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer3 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer4 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var peer5 = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+
+            // Initial state
+            Assert.Equal(0, kBucketDictionary.Count);
+            Assert.Null(kBucketDictionary.Head);
+            Assert.Null(kBucketDictionary.Tail);
+
+            // Add more peers than allowed
+            Assert.True(kBucketDictionary.AddOrUpdate(peer1));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer2));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer3));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer4));
+            Assert.True(kBucketDictionary.AddOrUpdate(peer5));
+            Assert.Equal(4, kBucketDictionary.Count);
+            Assert.Equal(peer2.Address, kBucketDictionary.Tail!.Peer.Address);
+            Assert.Equal(peer5.Address, kBucketDictionary.Head!.Peer.Address);
+            Assert.False(kBucketDictionary.Contains(peer1));
+            Assert.True(kBucketDictionary.Contains(peer5));
+
+            // Replace one of the peers
+            Assert.True(kBucketDictionary.AddOrUpdate(peer2));
+            Assert.Equal(peer3.Address, kBucketDictionary.Tail!.Peer.Address);
+            Assert.Equal(peer2.Address, kBucketDictionary.Head!.Peer.Address);
+
+            // Remove
+            Assert.True(kBucketDictionary.Remove(peer2));
+            Assert.False(kBucketDictionary.Remove(peer1));
+        }
+    }
+}

--- a/Libplanet.Net.Tests/Protocols/KBucketTest.cs
+++ b/Libplanet.Net.Tests/Protocols/KBucketTest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,8 +53,8 @@ namespace Libplanet.Net.Tests.Protocols
             Assert.NotNull(bucket.GetRandomPeer());
             Assert.Null(bucket.GetRandomPeer(peer1.Address));
             Assert.NotNull(bucket.GetRandomPeer(peer2.Address));
-            Assert.Equal(peer1, bucket.Head.Peer);
-            Assert.Equal(peer1, bucket.Tail.Peer);
+            Assert.Equal(peer1, bucket.Head?.Peer);
+            Assert.Equal(peer1, bucket.Tail?.Peer);
 
             // Sleep statement is used to distinguish updated times.
             Thread.Sleep(100);
@@ -90,14 +89,14 @@ namespace Libplanet.Net.Tests.Protocols
                 new HashSet<BoundPeer> { peer1, peer2, peer3, peer4 }
             );
             Assert.False(bucket.Contains(peer5));
-            Assert.Equal(peer4, bucket.Head.Peer);
-            Assert.Equal(peer1, bucket.Tail.Peer);
+            Assert.Equal(peer4, bucket.Head?.Peer);
+            Assert.Equal(peer1, bucket.Tail?.Peer);
 
             // Check order has changed.
             Thread.Sleep(100);
             bucket.AddPeer(peer1, DateTimeOffset.UtcNow);
-            Assert.Equal(peer1, bucket.Head.Peer);
-            Assert.Equal(peer2, bucket.Tail.Peer);
+            Assert.Equal(peer1, bucket.Head?.Peer);
+            Assert.Equal(peer2, bucket.Tail?.Peer);
 
             Assert.False(bucket.RemovePeer(peer5));
             Assert.True(bucket.RemovePeer(peer1));

--- a/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
+++ b/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
@@ -290,6 +290,7 @@ namespace Libplanet.Net.Tests.Protocols
             Assert.Single(transportA.Peers);
             Assert.Contains(transportA.AsPeer, transport.Peers);
             Assert.DoesNotContain(transportB.AsPeer, transport.Peers);
+            Assert.DoesNotContain(transportC.AsPeer, transport.Peers);
 
             await transportA.StopAsync(TimeSpan.Zero);
             await transport.Protocol.RefreshTableAsync(TimeSpan.Zero, default(CancellationToken));
@@ -297,8 +298,8 @@ namespace Libplanet.Net.Tests.Protocols
 
             Assert.Single(transport.Peers);
             Assert.DoesNotContain(transportA.AsPeer, transport.Peers);
-            Assert.Contains(transportB.AsPeer, transport.Peers);
-            Assert.DoesNotContain(transportC.AsPeer, transport.Peers);
+            Assert.DoesNotContain(transportB.AsPeer, transport.Peers);
+            Assert.Contains(transportC.AsPeer, transport.Peers);
 
             transport.Dispose();
             transportA.Dispose();

--- a/Libplanet.Net/Protocols/KBucket.cs
+++ b/Libplanet.Net/Protocols/KBucket.cs
@@ -12,7 +12,6 @@ namespace Libplanet.Net.Protocols
         private readonly Random _random;
         private readonly ConcurrentDictionary<Address, PeerState> _peerStates;
         private readonly ILogger _logger;
-        private DateTimeOffset _lastUpdated;
 
         public KBucket(int size, Random random, ILogger logger)
         {
@@ -27,8 +26,6 @@ namespace Libplanet.Net.Protocols
             _logger = logger;
             _peerStates = new ConcurrentDictionary<Address, PeerState>();
             ReplacementCache = new ConcurrentDictionary<BoundPeer, DateTimeOffset>();
-
-            _lastUpdated = DateTimeOffset.UtcNow;
         }
 
         public int Count => _peerStates.Count;
@@ -89,11 +86,9 @@ namespace Libplanet.Net.Protocols
                 else
                 {
                     _logger.Verbose("Bucket does not contains peer {Peer}", peer);
-                    _lastUpdated = updated;
                     if (_peerStates.TryAdd(peer.Address, new PeerState(peer, updated)))
                     {
                         _logger.Verbose("Peer {Peer} is added to bucket", peer);
-                        _lastUpdated = updated;
 
                         if (ReplacementCache.TryRemove(peer, out var dateTimeOffset))
                         {
@@ -128,7 +123,6 @@ namespace Libplanet.Net.Protocols
         public void Clear()
         {
             _peerStates.Clear();
-            _lastUpdated = DateTimeOffset.UtcNow;
         }
 
         /// <summary>

--- a/Libplanet.Net/Protocols/KBucket.cs
+++ b/Libplanet.Net/Protocols/KBucket.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Protocols
             _random = random;
             _logger = logger;
             _peerStates = new KBucketDictionary(_size, false, logger);
-            _replacementCache = new KBucketDictionary(int.MaxValue, true, logger);
+            _replacementCache = new KBucketDictionary(_size, true, logger);
         }
 
         public int Count => _peerStates.Count;

--- a/Libplanet.Net/Protocols/KBucketDictionary.cs
+++ b/Libplanet.Net/Protocols/KBucketDictionary.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog;
+
+namespace Libplanet.Net.Protocols
+{
+    /// <summary>
+    /// <para>
+    /// An internal dictionary with a size limit used for <see cref="KBucket"/>s.
+    /// </para>
+    /// <para>
+    /// Purposely designed with the following features:
+    /// <list type="bullet">
+    ///     <item><description>
+    ///         Fixed maximum size.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Exception free.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Enforced concurrency.
+    ///     </description></item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    internal class KBucketDictionary
+    {
+        private readonly object _lock;
+        private readonly int _size;
+        private readonly ILogger _logger;
+        private Dictionary<Address, PeerState> _dictionary;
+
+        /// <summary>
+        /// Creates an instance with a size limit given by <paramref name="size"/>.
+        /// </summary>
+        /// <param name="size">The maximum number of elements the dictionary can hold.</param>
+        /// <param name="logger">The <see cref="ILogger"/> to write log messages to.</param>
+        public KBucketDictionary(int size, ILogger logger)
+        {
+            _lock = new object();
+            _size = size;
+            _dictionary = new Dictionary<Address, PeerState>();
+            _logger = logger;
+        }
+
+        public List<BoundPeer> Peers
+        {
+            get
+            {
+                return PeerStates.Select(peerState => peerState.Peer).ToList();
+            }
+        }
+
+        public List<PeerState> PeerStates
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _dictionary.Values.ToList();
+                }
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _dictionary.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="PeerState"/> updated most recently. <c>null</c> if the dictionary
+        /// is empty.
+        /// </summary>
+        public PeerState? Head
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _dictionary.Values
+                        .OrderBy(peerState => peerState.LastUpdated)
+                        .LastOrDefault();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="PeerState"/> updated least recently. <c>null</c> if the dictionary
+        /// is empty.
+        /// </summary>
+        public PeerState? Tail
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _dictionary.Values
+                        .OrderBy(peerState => peerState.LastUpdated)
+                        .FirstOrDefault();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrievees the <see cref="BoundPeer"/> associated with <paramref name="peer"/>'s
+        /// <see cref="Address"/>.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to check.</param>
+        /// <returns>The <see cref="BoundPeer"/> with its address equal to
+        /// that of the <paramref name="peer"/>'s. <c>null</c> if not found.</returns>
+        public PeerState? Get(BoundPeer peer)
+        {
+            return Get(peer.Address);
+        }
+
+        /// <summary>
+        /// Retrievees the <see cref="BoundPeer"/> associated with <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> to check.</param>
+        /// <returns>The <see cref="BoundPeer"/> with its address equal to
+        /// that of <paramref name="address"/>. <c>null</c> if not found.</returns>
+        public PeerState? Get(Address address)
+        {
+            lock (_lock)
+            {
+                if (_dictionary.ContainsKey(address))
+                {
+                    return _dictionary[address];
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if the dictionary contains <paramref name="peer"/>'s <see cref="Address"/>
+        /// as a key.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to check.</param>
+        /// <returns><c>true</c> if the <paramref name="peer"/>'s <see cref="Address"/> exists,
+        /// <c>false</c> otherwise.</returns>
+        public bool Contains(BoundPeer peer)
+        {
+            return Contains(peer.Address);
+        }
+
+        /// <summary>
+        /// Checks if the dictionary contains <paramref name="address"/> as a key.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> to check.</param>
+        /// <returns><c>true</c> if <paramref name="address"/> exists,
+        /// <c>false</c> otherwise.</returns>
+        public bool Contains(Address address)
+        {
+            lock (_lock)
+            {
+                return _dictionary.ContainsKey(address);
+            }
+        }
+
+        /// <summary>
+        /// Adds or updates the dictionary with <paramref name="peer"/>.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to add or update.</param>
+        /// <returns><c>true</c> if <paramref name="peer"/> was either added or updated,
+        /// <c>false</c> otherwise.</returns>
+        /// <seealso cref="AddOrUpdate(BoundPeer, PeerState)"/>.
+        public bool AddOrUpdate(BoundPeer peer)
+        {
+            return AddOrUpdate(peer, new PeerState(peer, DateTimeOffset.UtcNow));
+        }
+
+        /// <summary>
+        /// Adds or updates the dictionary with a key/value pair.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to add or update.</param>
+        /// <param name="peerState">The <see cref="PeerState"/> to use as a value.</param>
+        /// <returns><c>true</c> if <paramref name="peer"/> was either added or updated,
+        /// <c>false</c> otherwise.</returns>
+        /// <seealso cref="AddOrUpdate(Address, PeerState)"/>.
+        public bool AddOrUpdate(BoundPeer peer, PeerState peerState)
+        {
+            return AddOrUpdate(peer.Address, peerState);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Adds or updates the dictionary with a key/value pair.
+        /// </para>
+        /// <para>
+        /// Internal logic is as the following:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         If <paramref name="address"/> is found, update its value
+        ///         with <paramref name="peerState"/>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         Else, if the dictionary is not full, i.e. has not reached its limit in size,
+        ///         add <paramref name="address"/> and <paramref name="peerState"/> as
+        ///         a key/value pair.
+        ///     </description></item>
+        ///     <item><description>
+        ///         Otherwise, ignore.
+        ///     </description></item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> to use as a key.</param>
+        /// <param name="peerState">The <see cref="PeerState"/> to use as a value.</param>
+        /// <returns><c>true</c> if the key/value pair was either added or updated,
+        /// <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// The only way this returns <c>false</c> is for the dictionary to be full already
+        /// <em>and</em> not contain <paramref name="address"/> as a key.
+        /// </remarks>
+        public bool AddOrUpdate(Address address, PeerState peerState)
+        {
+            lock (_lock)
+            {
+                if (_dictionary.ContainsKey(address))
+                {
+                    _dictionary[address] = peerState;
+                    _logger.Verbose(
+                        "{Address} found in the dictionary; updating its state...",
+                        address);
+                    return true;
+                }
+                else
+                {
+                    if (_dictionary.Count >= _size)
+                    {
+                        _logger.Verbose(
+                            "Cannot add {Address}; " +
+                            "the dictionary size is already at its limit of {Size}.",
+                            address,
+                            _size);
+                        return false;
+                    }
+                    else
+                    {
+                        _dictionary[address] = peerState;
+                        _logger.Verbose(
+                            "Added {Address} to the dictionary.", address);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes <paramref name="peer"/> from the dictionary.
+        /// </summary>
+        /// <param name="peer">The <see cref="BoundPeer"/> to remove.</param>
+        /// <returns><c>true</c> if <paramref name="peer"/> was successfully removed,
+        /// <c>false</c> otherwise.</returns>
+        public bool Remove(BoundPeer peer)
+        {
+            return Remove(peer.Address);
+        }
+
+        /// <summary>
+        /// Removes <paramref name="address"/> from the dictionary.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> to remove.</param>
+        /// <returns><c>true</c> if <paramref name="address"/> was successfully removed,
+        /// <c>false</c> otherwise.</returns>
+        public bool Remove(Address address)
+        {
+            lock (_lock)
+            {
+                return _dictionary.Remove(address);
+            }
+        }
+
+        /// <summary>
+        /// Empties the dictionary.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _dictionary = new Dictionary<Address, PeerState>();
+            }
+
+            return;
+        }
+    }
+}

--- a/Libplanet.Net/Protocols/KBucketDictionary.cs
+++ b/Libplanet.Net/Protocols/KBucketDictionary.cs
@@ -39,8 +39,16 @@ namespace Libplanet.Net.Protocols
         /// <param name="replace">Whether to replace the oldest <see cref="PeerState"/>,
         /// i.e. <see cref="Tail"/>, if the dictionary is already full.</param>
         /// <param name="logger">The <see cref="ILogger"/> to write log messages to.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/>
+        /// is not positive..</exception>
         public KBucketDictionary(int size, bool replace, ILogger logger)
         {
+            if (size <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"The value of {nameof(size)} must be positive.");
+            }
+
             _lock = new object();
             _size = size;
             _replace = replace;
@@ -201,7 +209,7 @@ namespace Libplanet.Net.Protocols
         /// Adds or updates the dictionary with a key/value pair.
         /// </para>
         /// <para>
-        /// Internal logic is as the following:
+        /// Internal logic is as follows:
         /// <list type="bullet">
         ///     <item><description>
         ///         If <paramref name="address"/> is found, update its value
@@ -213,7 +221,12 @@ namespace Libplanet.Net.Protocols
         ///         a key/value pair.
         ///     </description></item>
         ///     <item><description>
-        ///         Otherwise, ignore.
+        ///         Else, if the dictionary is full and replace option is set to <c>true</c>,
+        ///         replace the oldest <see cref="PeerState"/>, i.e. <see cref="Tail"/>,
+        ///         with <paramref name="peerState"/>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         Else, ignore.
         ///     </description></item>
         /// </list>
         /// </para>
@@ -262,7 +275,7 @@ namespace Libplanet.Net.Protocols
                     {
                         if (_replace)
                         {
-                            // Tail is never null.
+                            // Tail is never null since the dictionary size is always positive.
                             _dictionary.Remove(Tail!.Peer.Address);
                             _dictionary[address] = peerState;
                             return true;

--- a/Libplanet.Net/Protocols/RoutingTable.cs
+++ b/Libplanet.Net/Protocols/RoutingTable.cs
@@ -88,9 +88,9 @@ namespace Libplanet.Net.Protocols
             get
             {
                 return NonFullBuckets.Select(
-                    bucket => bucket.ReplacementCache
-                        .OrderBy(kv => kv.Value)
-                        .Select(kv => kv.Key)
+                    bucket => bucket.ReplacementCache.PeerStates
+                        .OrderBy(peerState => peerState.LastUpdated)
+                        .Select(peerState => peerState.Peer)
                         .ToArray()
                 ).ToArray();
             }
@@ -263,7 +263,7 @@ namespace Libplanet.Net.Protocols
         internal bool RemoveCache(BoundPeer peer)
         {
             KBucket bucket = BucketOf(peer);
-            return bucket.ReplacementCache.TryRemove(peer, out var _);
+            return bucket.ReplacementCache.Remove(peer);
         }
 
         internal KBucket BucketOf(BoundPeer peer)


### PR DESCRIPTION
Partially addresses #1872. Note that only internal dictionaries are now concurrent, but `KBucket` itself is *not*. `KBucket` needs to orchestrate access to two internal dictionaries. Overall orchestration of the dictionaries will be handled in a different PR while also dealing with #1880.

Additionally, internal replacement cache size is limited to the size of a `KBucket`, i.e. the total number of `Address`es a `KBucket` can hold up to is twice its "bucket size". This results in a slight behavioral change of a `KBucket`. See `ProtocolTest.cs` in the code.