### PR TITLE
Separate `MessageValidator` for `IMessageCodec`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,17 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Added `IStore.PruneOutdatedChains(bool noopWithoutCanon)` method.
-   [[#1874], [#1878]]
+    [[#1874], [#1878]]
+ -  `IMessageCodec` interface and its implementations overhauled.  [[#1890]]
+     -  Removed `AppProtocolVersion version` parameter from
+        `IMessageCodec.Encode()`.
+     -  Removed `Action appProtocolVersionValidator` parameter from
+        `IMessageCodec.Decode()`.
+     -  Both `TcpMessageCodec()` and `NetMQMessageCodec()` now takes
+        additional parameters for setting up its `MessageValidator` instance
+        for running context.
+ -  `DifferentAppProtocolVersionEncountered` delegate now returns `void`.
+    [[#1885], [#1890]]
 
 ### Backward-incompatible network protocol changes
 
@@ -24,11 +34,14 @@ To be released.
  -  (Libplanet.Net) `InvalidMessageSignatureException` and
     `InvalidMessageTimestampException` gained additional properties.
     [[#1889]]
+ -  (Libplanet.Net) `MessageValidator` helper class introduced.  [[#1890]]
 
 ### Behavioral changes
 
  -  (Libplanet.Net) Internal cache size of a `KBucket` is now capped.
     [[#1879]]
+ -  (Libplanet.Net) `IMessageCodec` now never decodes a `Message` with
+    a different `AppProtocolVersion` from the local version.  [[#1885], [#1890]]
 
 ### Bug fixes
 
@@ -46,6 +59,9 @@ To be released.
 [#1874]: https://github.com/planetarium/libplanet/issues/1874
 [#1878]: https://github.com/planetarium/libplanet/pull/1878
 [#1879]: https://github.com/planetarium/libplanet/pull/1879
+[#1885]: https://github.com/planetarium/libplanet/issues/1885
+[#1889]: https://github.com/planetarium/libplanet/pull/1889
+[#1890]: https://github.com/planetarium/libplanet/pull/1890
 
 
 Version 0.31.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@ To be released.
     [[#1879]]
  -  (Libplanet.Net) `IMessageCodec` now never decodes a `Message` with
     a different `AppProtocolVersion` from the local version.  [[#1885], [#1890]]
+ -  (Libplanet.Net) `ITransport` no longer replies with `DifferentVersion` type
+    `Message` to a `Peer` with a different `AppProtocolVersion` that is not
+    signed by a trusted source.  [[#1890]]
 
 ### Bug fixes
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -238,7 +238,7 @@ If omitted (default) explorer only the local blockchain store.")]
                         options.AppProtocolVersionToken is string t
                             ? AppProtocolVersion.FromToken(t)
                             : default(AppProtocolVersion),
-                        differentAppProtocolVersionEncountered: (p, pv, lv) => true,
+                        differentAppProtocolVersionEncountered: (p, pv, lv) => { },
                         workers: options.Workers,
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -47,10 +47,7 @@ namespace Libplanet.Net.Tests.Messages
                 peer,
                 DateTimeOffset.UtcNow,
                 apv);
-            BlockHashes restored = (BlockHashes)messageCodec.Decode(
-                encoded,
-                true,
-                (b, p, a) => { });
+            BlockHashes restored = (BlockHashes)messageCodec.Decode(encoded, true);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);
         }

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -45,8 +45,7 @@ namespace Libplanet.Net.Tests.Messages
                 msg,
                 privKey,
                 peer,
-                DateTimeOffset.UtcNow,
-                apv);
+                DateTimeOffset.UtcNow);
             BlockHashes restored = (BlockHashes)messageCodec.Decode(encoded, true);
             Assert.Equal(msg.StartIndex, restored.StartIndex);
             Assert.Equal(msg.Hashes, restored.Hashes);

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -38,15 +38,15 @@ namespace Libplanet.Net.Tests.Messages
             Assert.Equal(123, msg.StartIndex);
             Assert.Equal(blockHashes, msg.Hashes);
             var privKey = new PrivateKey();
-            AppProtocolVersion ver = AppProtocolVersion.Sign(privKey, 3);
+            AppProtocolVersion apv = AppProtocolVersion.Sign(privKey, 3);
             Peer peer = new BoundPeer(privKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
-            var messageCodec = new NetMQMessageCodec();
+            var messageCodec = new NetMQMessageCodec(appProtocolVersion: apv);
             NetMQMessage encoded = messageCodec.Encode(
                 msg,
                 privKey,
                 peer,
                 DateTimeOffset.UtcNow,
-                ver);
+                apv);
             BlockHashes restored = (BlockHashes)messageCodec.Decode(
                 encoded,
                 true,

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -41,16 +41,7 @@ namespace Libplanet.Net.Tests.Messages
                 apv);
 
             Assert.Throws<DifferentAppProtocolVersionException>(() =>
-                codec.Decode(
-                    netMQMessage,
-                    true,
-                    (i, p, v) => throw new DifferentAppProtocolVersionException(
-                        string.Empty,
-                        peer,
-                        i,
-                        v,
-                        v,
-                        true)));
+                codec.Decode(netMQMessage, true));
         }
 
         [Fact]
@@ -74,18 +65,12 @@ namespace Libplanet.Net.Tests.Messages
                 codec.Encode(message, privateKey, peer, futureOffset, apv);
             // Messages from the future throws InvalidMessageTimestampException.
             Assert.Throws<InvalidMessageTimestampException>(() =>
-                codec.Decode(
-                    futureRaw,
-                    true,
-                    (i, p, v) => { }));
+                codec.Decode(futureRaw, true));
             NetMQMessage pastRaw =
                 codec.Encode(message, privateKey, peer, pastOffset, apv);
             // Messages from the far past throws InvalidMessageTimestampException.
             Assert.Throws<InvalidMessageTimestampException>(() =>
-                codec.Decode(
-                    pastRaw,
-                    true,
-                    (i, p, v) => { }));
+                codec.Decode(pastRaw, true));
         }
 
         [Fact]
@@ -107,7 +92,7 @@ namespace Libplanet.Net.Tests.Messages
             var codec = new NetMQMessageCodec(appProtocolVersion: apv);
             NetMQMessage raw =
                 codec.Encode(message, privateKey, peer, dateTimeOffset, apv);
-            var parsed = codec.Decode(raw, true, (i, p, v) => { });
+            var parsed = codec.Decode(raw, true);
             Assert.Equal(peer, parsed.Remote);
         }
 
@@ -139,12 +124,7 @@ namespace Libplanet.Net.Tests.Messages
             frames.Push(netMqMessage[0]);
 
             Assert.Throws<InvalidMessageSignatureException>(() =>
-            {
-                codec.Decode(
-                    frames,
-                    true,
-                    (i, p, v) => { });
-            });
+                codec.Decode(frames, true));
         }
 
         [Fact]
@@ -159,10 +139,7 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             Assert.Throws<ArgumentException>(
-                () => codec.Decode(
-                    new NetMQMessage(),
-                    true,
-                    (i, p, v) => { }));
+                () => codec.Decode(new NetMQMessage(), true));
         }
     }
 }

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Net;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Xunit;
@@ -41,30 +40,6 @@ namespace Libplanet.Net.Tests.Messages
                 peer, DateTimeOffset.UtcNow, DateTimeOffset.MinValue);
             messageValidator.ValidateTimestamp(
                 peer, DateTimeOffset.UtcNow, DateTimeOffset.MaxValue);
-        }
-
-        [Fact]
-        public void ValidateSignature()
-        {
-            var goodPrivateKey = new PrivateKey();
-            var badPrivateKey = new PrivateKey();
-            var peer = new Peer(goodPrivateKey.PublicKey, new IPAddress(1024L));
-
-            var random = new Random();
-            var message = new byte[128];
-            random.NextBytes(message);
-            var signature = goodPrivateKey.Sign(message);
-            var messageValidator = new MessageValidator(
-                appProtocolVersion: default,
-                trustedAppProtocolVersionSigners: null,
-                messageTimestampBuffer: null,
-                differentAppProtocolVersionEncountered: null);
-
-            messageValidator.ValidateSignature(
-                peer, goodPrivateKey.PublicKey, message, signature);
-            Assert.Throws<InvalidMessageSignatureException>(() =>
-                messageValidator.ValidateSignature(
-                    peer, badPrivateKey.PublicKey, message, signature));
         }
 
         [Fact]

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Net;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using Xunit;
+
+namespace Libplanet.Net.Tests.Messages
+{
+    public class MessageValidatorTest
+    {
+        [Fact]
+        public void ValidateTimestamp()
+        {
+            var peer = new Peer(new PrivateKey().PublicKey);
+            var buffer = TimeSpan.FromSeconds(1);
+            var messageValidator = new MessageValidator(
+                appProtocolVersion: default,
+                trustedAppProtocolVersionSigners: null,
+                messageTimestampBuffer: buffer,
+                differentAppProtocolVersionEncountered: null);
+
+            // Within buffer window is okay.
+            messageValidator.ValidateTimestamp(
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + (buffer / 2));
+            messageValidator.ValidateTimestamp(
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - (buffer / 2));
+
+            // Outside buffer throws an exception.
+            Assert.Throws<InvalidMessageTimestampException>(() =>
+                messageValidator.ValidateTimestamp(
+                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + (buffer * 2)));
+            Assert.Throws<InvalidMessageTimestampException>(() =>
+                messageValidator.ValidateTimestamp(
+                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - (buffer * 2)));
+
+            // If buffer is null, no exception gets thrown.
+            messageValidator = new MessageValidator(default, null, null, null);
+            messageValidator.ValidateTimestamp(
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.MinValue);
+            messageValidator.ValidateTimestamp(
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.MaxValue);
+        }
+
+        [Fact]
+        public void ValidateSignature()
+        {
+            var goodPrivateKey = new PrivateKey();
+            var badPrivateKey = new PrivateKey();
+            var peer = new Peer(goodPrivateKey.PublicKey, new IPAddress(1024L));
+
+            var random = new Random();
+            var message = new byte[128];
+            random.NextBytes(message);
+            var signature = goodPrivateKey.Sign(message);
+            var messageValidator = new MessageValidator(
+                appProtocolVersion: default,
+                trustedAppProtocolVersionSigners: null,
+                messageTimestampBuffer: null,
+                differentAppProtocolVersionEncountered: null);
+
+            messageValidator.ValidateSignature(
+                peer, goodPrivateKey.PublicKey, message, signature);
+            Assert.Throws<InvalidMessageSignatureException>(() =>
+                messageValidator.ValidateSignature(
+                    peer, badPrivateKey.PublicKey, message, signature));
+        }
+
+        [Fact]
+        public void ValidateAppProtocolVersion()
+        {
+            var random = new Random();
+            var identity = new byte[16];
+            random.NextBytes(identity);
+            var called = false;
+            var trustedSigner = new PrivateKey();
+            var unknownSigner = new PrivateKey();
+            var version1 = 1;
+            var version2 = 2;
+            var extra1 = new Bencodex.Types.Integer(13);
+            var extra2 = new Bencodex.Types.Integer(17);
+            var trustedApv1 = AppProtocolVersion.Sign(trustedSigner, version1, extra1);
+            var trustedApv2 = AppProtocolVersion.Sign(trustedSigner, version2, extra2);
+            var unknownApv1 = AppProtocolVersion.Sign(unknownSigner, version1, extra1);
+            var unknownApv2 = AppProtocolVersion.Sign(unknownSigner, version1, extra2);
+            ImmutableHashSet<PublicKey>? trustedApvSigners1 =
+                new HashSet<PublicKey>() { trustedSigner.PublicKey }.ToImmutableHashSet();
+            ImmutableHashSet<PublicKey>? trustedApvSigners2 =
+                new HashSet<PublicKey>() { }.ToImmutableHashSet();
+            ImmutableHashSet<PublicKey>? trustedApvSigners3 = null;
+            DifferentAppProtocolVersionEncountered callback = (p, pv, lv) => { called = true; };
+            var peer = new Peer(trustedSigner.PublicKey);
+
+            DifferentAppProtocolVersionException exception;
+            MessageValidator messageValidator;
+
+            // Trust specific signers.
+            messageValidator = new MessageValidator(
+                appProtocolVersion: trustedApv1,
+                trustedAppProtocolVersionSigners: trustedApvSigners1,
+                messageTimestampBuffer: null,
+                differentAppProtocolVersionEncountered: callback);
+            messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv1);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv1));
+            Assert.False(exception.Trusted);
+            Assert.False(called);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv2));
+            Assert.True(exception.Trusted);
+            Assert.True(called);
+            called = false;
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv2));
+            Assert.False(exception.Trusted);
+            Assert.False(called);
+
+            // Trust no one.
+            messageValidator = new MessageValidator(
+                appProtocolVersion: trustedApv1,
+                trustedAppProtocolVersionSigners: trustedApvSigners2,
+                messageTimestampBuffer: null,
+                differentAppProtocolVersionEncountered: callback);
+            messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv1);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv1));
+            Assert.False(exception.Trusted);
+            Assert.False(called);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv2));
+            Assert.False(exception.Trusted);
+            Assert.False(called);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv2));
+            Assert.False(exception.Trusted);
+            Assert.False(called);
+
+            // Trust anyone.
+            messageValidator = new MessageValidator(
+                appProtocolVersion: trustedApv1,
+                trustedAppProtocolVersionSigners: trustedApvSigners3,
+                messageTimestampBuffer: null,
+                differentAppProtocolVersionEncountered: callback);
+            messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv1);
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv1));
+            Assert.True(exception.Trusted);
+            Assert.True(called);
+            called = false;
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, trustedApv2));
+            Assert.True(exception.Trusted);
+            Assert.True(called);
+            called = false;
+            exception = Assert.Throws<DifferentAppProtocolVersionException>(
+                () => messageValidator.ValidateAppProtocolVersion(peer, identity, unknownApv2));
+            Assert.True(exception.Trusted);
+            Assert.True(called);
+        }
+    }
+}

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -52,9 +52,9 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var message = CreateMessage(type);
-            var codec = new NetMQMessageCodec(apv);
+            var codec = new NetMQMessageCodec(appProtocolVersion: apv);
             NetMQMessage raw =
-                codec.Encode(message, privateKey, peer, dateTimeOffset, apv);
+                codec.Encode(message, privateKey, peer, dateTimeOffset);
             var parsed = codec.Decode(raw, true);
             Assert.Equal(apv, parsed.Version);
             Assert.Equal(peer, parsed.Remote);

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -55,7 +55,7 @@ namespace Libplanet.Net.Tests.Messages
             var codec = new NetMQMessageCodec(apv);
             NetMQMessage raw =
                 codec.Encode(message, privateKey, peer, dateTimeOffset, apv);
-            var parsed = codec.Decode(raw, true, (i, p, v) => { });
+            var parsed = codec.Decode(raw, true);
             Assert.Equal(apv, parsed.Version);
             Assert.Equal(peer, parsed.Remote);
             Assert.Equal(dateTimeOffset, parsed.Timestamp);

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -46,17 +46,17 @@ namespace Libplanet.Net.Tests.Messages
             var privateKey = new PrivateKey();
             var peer = new Peer(privateKey.PublicKey);
             var dateTimeOffset = DateTimeOffset.UtcNow;
-            var appProtocolVersion = new AppProtocolVersion(
+            var apv = new AppProtocolVersion(
                 1,
                 new Bencodex.Types.Integer(0),
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var message = CreateMessage(type);
-            var codec = new NetMQMessageCodec();
+            var codec = new NetMQMessageCodec(apv);
             NetMQMessage raw =
-                codec.Encode(message, privateKey, peer, dateTimeOffset, appProtocolVersion);
+                codec.Encode(message, privateKey, peer, dateTimeOffset, apv);
             var parsed = codec.Decode(raw, true, (i, p, v) => { });
-            Assert.Equal(appProtocolVersion, parsed.Version);
+            Assert.Equal(apv, parsed.Version);
             Assert.Equal(peer, parsed.Remote);
             Assert.Equal(dateTimeOffset, parsed.Timestamp);
             Assert.IsType(message.GetType(), parsed);

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -150,8 +151,21 @@ namespace Libplanet.Net.Tests
 
                 foreach (var peer in peers)
                 {
-                    await a.AddPeersAsync(new[] { peer }, null);
-                    await b.AddPeersAsync(new[] { peer }, null);
+                    try
+                    {
+                        await a.AddPeersAsync(new[] { peer }, TimeSpan.FromSeconds(1));
+                    }
+                    catch (PingTimeoutException)
+                    {
+                    }
+
+                    try
+                    {
+                        await b.AddPeersAsync(new[] { peer }, TimeSpan.FromSeconds(1));
+                    }
+                    catch (PingTimeoutException)
+                    {
+                    }
                 }
 
                 Assert.Equal(new[] { c.AsPeer }, a.Peers.ToArray());
@@ -173,11 +187,15 @@ namespace Libplanet.Net.Tests
             {
                 await StopAsync(c);
                 await StopAsync(d);
+                await StopAsync(e);
+                await StopAsync(f);
 
                 a.Dispose();
                 b.Dispose();
                 c.Dispose();
                 d.Dispose();
+                e.Dispose();
+                f.Dispose();
             }
         }
     }

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -66,7 +66,6 @@ namespace Libplanet.Net.Tests
                 differentAppProtocolVersionEncountered: (_, ver, __) =>
                 {
                     isCalled = true;
-                    return false;
                 }
             );
             var b = CreateSwarm(appProtocolVersion: v2);
@@ -105,14 +104,13 @@ namespace Libplanet.Net.Tests
 
             var logs = new ConcurrentDictionary<Peer, AppProtocolVersion>();
 
-            bool DifferentAppProtocolVersionEncountered(
+            void DifferentAppProtocolVersionEncountered(
                 Peer peer,
                 AppProtocolVersion peerVersion,
                 AppProtocolVersion localVersion
             )
             {
                 logs[peer] = peerVersion;
-                return false;
             }
 
             var a = CreateSwarm(

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -146,26 +146,19 @@ namespace Libplanet.Net.Tests
                 await StartAsync(e);
                 await StartAsync(f);
 
-                var peers = new[] { c.AsPeer, d.AsPeer, e.AsPeer, f.AsPeer };
+                await a.AddPeersAsync(new[] { c.AsPeer }, TimeSpan.FromSeconds(1));
+                await a.AddPeersAsync(new[] { d.AsPeer }, TimeSpan.FromSeconds(1));
+                await Assert.ThrowsAsync<PingTimeoutException>(
+                    () => a.AddPeersAsync(new[] { e.AsPeer }, TimeSpan.FromSeconds(1)));
+                await Assert.ThrowsAsync<PingTimeoutException>(
+                    () => a.AddPeersAsync(new[] { f.AsPeer }, TimeSpan.FromSeconds(1)));
 
-                foreach (var peer in peers)
-                {
-                    try
-                    {
-                        await a.AddPeersAsync(new[] { peer }, TimeSpan.FromSeconds(1));
-                    }
-                    catch (PingTimeoutException)
-                    {
-                    }
-
-                    try
-                    {
-                        await b.AddPeersAsync(new[] { peer }, TimeSpan.FromSeconds(1));
-                    }
-                    catch (PingTimeoutException)
-                    {
-                    }
-                }
+                await b.AddPeersAsync(new[] { c.AsPeer }, TimeSpan.FromSeconds(1));
+                await b.AddPeersAsync(new[] { d.AsPeer }, TimeSpan.FromSeconds(1));
+                await Assert.ThrowsAsync<PingTimeoutException>(
+                    () => b.AddPeersAsync(new[] { e.AsPeer }, TimeSpan.FromSeconds(1)));
+                await Assert.ThrowsAsync<PingTimeoutException>(
+                    () => b.AddPeersAsync(new[] { f.AsPeer }, TimeSpan.FromSeconds(1)));
 
                 Assert.Equal(new[] { c.AsPeer }, a.Peers.ToArray());
                 Assert.Equal(new[] { d.AsPeer }, b.Peers.ToArray());

--- a/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
@@ -109,8 +109,8 @@ namespace Libplanet.Net.Tests.Transports
             await client.ConnectAsync("127.0.0.1", ((IPEndPoint)listener.LocalEndpoint).Port);
             TcpClient listenerSocket = await listener.AcceptTcpClientAsync();
 
-            AppProtocolVersion version = AppProtocolVersion.Sign(new PrivateKey(), 1);
-            TcpTransport transport = CreateTcpTransport(appProtocolVersion: version);
+            AppProtocolVersion apv = AppProtocolVersion.Sign(new PrivateKey(), 1);
+            TcpTransport transport = CreateTcpTransport(appProtocolVersion: apv);
             try
             {
                 var message = new Ping
@@ -123,8 +123,7 @@ namespace Libplanet.Net.Tests.Transports
                     message,
                     new PrivateKey(),
                     transport.AsPeer,
-                    DateTimeOffset.UtcNow,
-                    version);
+                    DateTimeOffset.UtcNow);
                 int length = serialized.Length;
                 var buffer = new byte[invalidCookie.Length + sizeof(int) + length];
                 invalidCookie.CopyTo(buffer, 0);

--- a/Libplanet.Net/DifferentAppProtocolVersionEncountered.cs
+++ b/Libplanet.Net/DifferentAppProtocolVersionEncountered.cs
@@ -1,19 +1,18 @@
-#nullable disable
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A delegate called back when a <see cref="Swarm{T}"/> encounters
-    /// a peer with different <see cref="AppProtocolVersion"/> in the network.
+    /// A delegate to call back when a <see cref="Swarm{T}"/> encounters
+    /// a peer with a different <see cref="AppProtocolVersion"/> signed by
+    /// a trusted signer in the network.
     /// </summary>
-    /// <param name="peer">An encountered peer with a different <see cref="AppProtocolVersion"/>.
+    /// <param name="peer">The encountered <see cref="BoundPeer"/> with
+    /// a different <see cref="AppProtocolVersion"/>.
     /// </param>
-    /// <param name="peerVersion">An encountered different <see cref="AppProtocolVersion"/>.</param>
+    /// <param name="peerVersion">The encountered different <see cref="AppProtocolVersion"/>.
+    /// </param>
     /// <param name="localVersion">The currently running application's
     /// <see cref="AppProtocolVersion"/>.</param>
-    /// <returns>Whether to recognize the encountered <paramref name="peer"/> as a valid
-    /// participant of the network or not.  The <paramref name="peer"/> is ignored if
-    /// it returns <c>false</c>.</returns>
-    public delegate bool DifferentAppProtocolVersionEncountered(
+    public delegate void DifferentAppProtocolVersionEncountered(
         Peer peer,
         AppProtocolVersion peerVersion,
         AppProtocolVersion localVersion

--- a/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/Libplanet.Net/Messages/IMessageCodec.cs
@@ -36,15 +36,12 @@ namespace Libplanet.Net.Messages
         /// <param name="encoded">A <see typeref="T"/>-typed instance to parse.</param>
         /// <param name="reply">A flag to express whether the target is a reply of other message.
         /// </param>
-        /// <param name="appProtocolVersionValidator">
-        /// The delegate validates the app protocol version of the message.
-        /// </param>
         /// <returns>A <see cref="Message"/> parsed from <paramref name="encoded"/>.</returns>
         /// <exception cref="ArgumentException">
         /// Thrown when empty <paramref name="encoded"/> is given.</exception>
         /// <exception cref="DifferentAppProtocolVersionException">Thrown when
         /// local version does not match with given <paramref name="encoded"/>'s
-        /// <see cref="Version"/> by given <paramref name="appProtocolVersionValidator"/>.
+        /// <see cref="AppProtocolVersion"/>.
         /// </exception>
         /// <exception cref="InvalidMessageTimestampException"> Thrown when the timestamp of
         /// <paramref name="encoded"/> is invalid.</exception>
@@ -52,7 +49,6 @@ namespace Libplanet.Net.Messages
         /// <paramref name="encoded"/> is invalid.</exception>
         Message Decode(
             T encoded,
-            bool reply,
-            Action<byte[], Peer, AppProtocolVersion> appProtocolVersionValidator);
+            bool reply);
     }
 }

--- a/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/Libplanet.Net/Messages/IMessageCodec.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Net.Messages
     {
         /// <summary>
         /// Encodes the message to <see typeref="T"/>-typed instance with given
-        /// <paramref name="privateKey"/>, <paramref name="peer"/> and <paramref name="version"/>.
+        /// <paramref name="privateKey"/> and <paramref name="peer"/>.
         /// </summary>
         /// <param name="message">A message to encode.</param>
         /// <param name="privateKey">A <see cref="PrivateKey"/> to sign message.</param>
@@ -17,16 +17,13 @@ namespace Libplanet.Net.Messages
         /// <seealso cref="ITransport.AsPeer"/></param>
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> of the message is created.
         /// </param>
-        /// <param name="version"><see cref="AppProtocolVersion"/>-typed version of the
-        /// transport layer.</param>
         /// <returns>A <see typeref="T"/> containing the signed <see cref="Message"/>.
         /// </returns>
         T Encode(
             Message message,
             PrivateKey privateKey,
             Peer peer,
-            DateTimeOffset timestamp,
-            AppProtocolVersion version);
+            DateTimeOffset timestamp);
 
         /// <summary>
         /// Decodes given <see typeref="T"/>-typed <paramref name="encoded"/> into

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -17,13 +17,13 @@ namespace Libplanet.Net.Messages
         internal MessageValidator(
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
-            TimeSpan? messageTimestampBuffer,
-            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered)
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            TimeSpan? messageTimestampBuffer)
         {
             Apv = appProtocolVersion;
             TrustedApvSigners = trustedAppProtocolVersionSigners;
-            MessageTimestampBuffer = messageTimestampBuffer;
             DifferentApvEncountered = differentAppProtocolVersionEncountered;
+            MessageTimestampBuffer = messageTimestampBuffer;
         }
 
         /// <summary>
@@ -71,6 +71,15 @@ namespace Libplanet.Net.Messages
         public IImmutableSet<PublicKey>? TrustedApvSigners { get; }
 
         /// <summary>
+        /// A callback method that gets invoked when a an <see cref="AppProtocolVersion"/>
+        /// by a <em>trusted</em> signer that is different from <see cref="Apv"/> is encountered.
+        /// </summary>
+        /// <remarks>
+        /// If <c>null</c>, no action is taken.
+        /// </remarks>
+        public DifferentAppProtocolVersionEncountered? DifferentApvEncountered { get; }
+
+        /// <summary>
         /// <para>
         /// The <see cref="TimeSpan"/> to use as a buffer when decoding <see cref="Message"/>s.
         /// </para>
@@ -90,15 +99,6 @@ namespace Libplanet.Net.Messages
         /// </para>
         /// </summary>
         public TimeSpan? MessageTimestampBuffer { get; }
-
-        /// <summary>
-        /// A callback method that gets invoked when a an <see cref="AppProtocolVersion"/>
-        /// by a <em>trusted</em> signer that is different from <see cref="Apv"/> is encountered.
-        /// </summary>
-        /// <remarks>
-        /// If <c>null</c>, no action is taken.
-        /// </remarks>
-        public DifferentAppProtocolVersionEncountered? DifferentApvEncountered { get; }
 
         /// <summary>
         /// Validates an <see cref="AppProtocolVersion"/> against <see cref="Apv"/>.

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -149,34 +149,6 @@ namespace Libplanet.Net.Messages
                 currentTimestamp,
                 messageTimestamp);
 
-        /// <summary>
-        /// Validates a signature of a <see cref="Message"/>.
-        /// </summary>
-        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
-        /// with <paramref name="signature"/>.</param>
-        /// <param name="publicKey">The <see cref="PublicKey"/> of <paramref name="peer"/>.</param>
-        /// <param name="messageToVerify">The portion of the <see cref="Message"/> to verify.
-        /// </param>
-        /// <param name="signature">The signature of the <see cref="Message"/> to verify.</param>
-        /// <exception cref="InvalidMessageSignatureException">Thrown when
-        /// <paramref name="signature"/> is invalid.</exception>
-        public void ValidateSignature(
-            Peer peer,
-            PublicKey publicKey,
-            byte[] messageToVerify,
-            byte[] signature)
-        {
-            if (!publicKey.Verify(messageToVerify, signature))
-            {
-                throw new InvalidMessageSignatureException(
-                    "The signature of an encoded message is invalid.",
-                    peer,
-                    publicKey,
-                    messageToVerify,
-                    signature);
-            }
-        }
-
         private static void ValidateAppProtocolVersionTemplate(
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using Libplanet.Crypto;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A helper class for an <see cref="IMessageCodec{T}"/> to validate
+    /// a decoded <see cref="Message"/>.
+    /// </summary>
+    public class MessageValidator
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+
+        internal MessageValidator(
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
+            TimeSpan? messageTimestampBuffer,
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered)
+        {
+            Apv = appProtocolVersion;
+            TrustedApvSigners = trustedAppProtocolVersionSigners;
+            MessageTimestampBuffer = messageTimestampBuffer;
+            DifferentApvEncountered = differentAppProtocolVersionEncountered;
+        }
+
+        /// <summary>
+        /// <para>
+        /// The local <see cref="AppProtocolVersion"/> used for
+        /// <see cref="IMessageCodec{T}.Encode"/> and <see cref="IMessageCodec{T}.Decode"/> methods.
+        /// </para>
+        /// <para>
+        /// In particular, this is used in the following cases:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         When encoding, this value is attached to the encoded output.
+        ///     </description></item>
+        ///     <item><description>
+        ///         When decoding, the encoded message's <see cref="AppProtocolVersion"/> must
+        ///         match this value.
+        ///     </description></item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        public AppProtocolVersion Apv { get; }
+
+        /// <summary>
+        /// <para>
+        /// An <see cref="IImmutableSet{T}"/> of <see cref="Address"/>es to trust as a signer
+        /// when a different <see cref="AppProtocolVersion"/> is encountered.
+        /// </para>
+        /// <para>
+        /// Whether to trust an unknown <see cref="AppProtocolVersion"/>, i.e.
+        /// an <see cref="AppProtocolVersion"/> that is different
+        /// from <see cref="Apv"/>, depends on this value:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         If <c>null</c>, the <see cref="AppProtocolVersion"/> in question is trusted
+        ///         regardless of its signer.
+        ///     </description></item>
+        ///     <item><description>
+        ///         If not <c>null</c>, an <see cref="AppProtocolVersion"/> is trusted if it is
+        ///         signed by one of the signers in the set.  In particular, if the set is empty,
+        ///         no <see cref="AppProtocolVersion"/> is trusted.
+        ///     </description></item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        public IImmutableSet<PublicKey>? TrustedApvSigners { get; }
+
+        /// <summary>
+        /// <para>
+        /// The <see cref="TimeSpan"/> to use as a buffer when decoding <see cref="Message"/>s.
+        /// </para>
+        /// <para>
+        /// Whether a decoded <see cref="Message"/> is valid or not depends on this value:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         If <c>null</c>, there is no restriction on <see cref="Message.Timestamp"/>
+        ///         for received <see cref="Message"/>s.
+        ///     </description></item>
+        ///     <item><description>
+        ///         If not <c>null</c>, the absolute difference between the timestamp of
+        ///         a received <see cref="Message"/> and current time should be less than
+        ///         this value.
+        ///     </description></item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        public TimeSpan? MessageTimestampBuffer { get; }
+
+        /// <summary>
+        /// A callback method that gets invoked when a an <see cref="AppProtocolVersion"/>
+        /// by a <em>trusted</em> signer that is different from <see cref="Apv"/> is encountered.
+        /// </summary>
+        /// <remarks>
+        /// If <c>null</c>, no action is taken.
+        /// </remarks>
+        public DifferentAppProtocolVersionEncountered? DifferentApvEncountered { get; }
+
+        /// <summary>
+        /// Validates an <see cref="AppProtocolVersion"/> against <see cref="Apv"/>.
+        /// Any <see cref="AppProtocolVersion"/> that is different from <see cref="Apv"/> is
+        /// considered invalid and an <see cref="DifferentAppProtocolVersionException"/> will be
+        /// thrown.
+        /// </summary>
+        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
+        /// with <paramref name="peerAppProtocolVersion"/>.</param>
+        /// <param name="identity">The <see cref="Message.Identity"/> attached to the
+        /// <see cref="Message"/> with <paramref name="peerAppProtocolVersion"/>.</param>
+        /// <param name="peerAppProtocolVersion">The <see cref="AppProtocolVersion"/> to validate.
+        /// </param>
+        /// <exception cref="DifferentAppProtocolVersionException">Thrown when
+        /// <paramref name="peerAppProtocolVersion"/> is different from <see cref="Apv"/>.
+        /// </exception>
+        /// <remarks>
+        /// If <paramref name="peerAppProtocolVersion"/> is not valid but is signed by
+        /// a trusted signer, then <see cref="DifferentApvEncountered"/> is called.
+        /// </remarks>
+        /// <seealso cref="Apv"/>
+        /// <seealso cref="TrustedApvSigners"/>
+        /// <seealso cref="DifferentApvEncountered"/>
+        public void ValidateAppProtocolVersion(
+            Peer peer, byte[] identity, AppProtocolVersion peerAppProtocolVersion) =>
+            ValidateAppProtocolVersionTemplate(
+                Apv,
+                TrustedApvSigners,
+                DifferentApvEncountered,
+                peer,
+                identity,
+                peerAppProtocolVersion);
+
+        /// <summary>
+        /// Validates a <see cref="DateTimeOffset"/> timestamp against current timestamp.
+        /// </summary>
+        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
+        /// with <paramref name="messageTimestamp"/>.</param>
+        /// <param name="currentTimestamp">Current timestamp.</param>
+        /// <param name="messageTimestamp">The <see cref="Message.Timestamp"/> of
+        /// the <see cref="Message"/> in question.</param>
+        /// <seealso cref="MessageTimestampBuffer"/>.
+        public void ValidateTimestamp(
+            Peer peer, DateTimeOffset currentTimestamp, DateTimeOffset messageTimestamp) =>
+            ValidateTimestampTemplate(
+                MessageTimestampBuffer,
+                peer,
+                currentTimestamp,
+                messageTimestamp);
+
+        /// <summary>
+        /// Validates a signature of a <see cref="Message"/>.
+        /// </summary>
+        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
+        /// with <paramref name="signature"/>.</param>
+        /// <param name="publicKey">The <see cref="PublicKey"/> of <paramref name="peer"/>.</param>
+        /// <param name="messageToVerify">The portion of the <see cref="Message"/> to verify.
+        /// </param>
+        /// <param name="signature">The signature of the <see cref="Message"/> to verify.</param>
+        /// <exception cref="InvalidMessageSignatureException">Thrown when
+        /// <paramref name="signature"/> is invalid.</exception>
+        public void ValidateSignature(
+            Peer peer,
+            PublicKey publicKey,
+            byte[] messageToVerify,
+            byte[] signature)
+        {
+            if (!publicKey.Verify(messageToVerify, signature))
+            {
+                throw new InvalidMessageSignatureException(
+                    "The signature of an encoded message is invalid.",
+                    peer,
+                    publicKey,
+                    messageToVerify,
+                    signature);
+            }
+        }
+
+        private static void ValidateAppProtocolVersionTemplate(
+            AppProtocolVersion appProtocolVersion,
+            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            Peer peer,
+            byte[] identity,
+            AppProtocolVersion peerAppProtocolVersion)
+        {
+            if (peerAppProtocolVersion.Equals(appProtocolVersion))
+            {
+                return;
+            }
+
+            bool trusted = !(
+                trustedAppProtocolVersionSigners is { } tapvs &&
+                tapvs.All(publicKey => !peerAppProtocolVersion.Verify(publicKey)));
+            if (trusted && differentAppProtocolVersionEncountered is { } dapve)
+            {
+                dapve(peer, peerAppProtocolVersion, appProtocolVersion);
+            }
+
+            throw new DifferentAppProtocolVersionException(
+                $"The APV of a received message is invalid; " +
+                $"Local: APV {appProtocolVersion} " +
+                $"with signature {ByteUtil.Hex(appProtocolVersion.Signature)} " +
+                $"by signer {appProtocolVersion.Signer}\n" +
+                $"Remote: APV {peerAppProtocolVersion} " +
+                $"with signature {ByteUtil.Hex(peerAppProtocolVersion.Signature)} " +
+                $"by signer {peerAppProtocolVersion.Signer}\n" +
+                $"Signed by a trusted signer: {trusted}",
+                peer,
+                identity,
+                appProtocolVersion,
+                peerAppProtocolVersion,
+                trusted);
+        }
+
+        private static void ValidateTimestampTemplate(
+            TimeSpan? timestampBuffer,
+            Peer peer,
+            DateTimeOffset currentTimestamp,
+            DateTimeOffset messageTimestamp)
+        {
+            if (timestampBuffer is TimeSpan buffer &&
+                (currentTimestamp - messageTimestamp).Duration() > buffer)
+            {
+                var cultureInfo = CultureInfo.InvariantCulture;
+                throw new InvalidMessageTimestampException(
+                    $"The timestamp of a received message is invalid:\n" +
+                    $"Message timestamp buffer: {buffer}\n" +
+                    $"Current timestamp: " +
+                    $"{currentTimestamp.ToString(TimestampFormat, cultureInfo)}\n" +
+                    $"Message timestamp: " +
+                    $"{messageTimestamp.ToString(TimestampFormat, cultureInfo)}",
+                    peer,
+                    messageTimestamp,
+                    buffer,
+                    currentTimestamp);
+            }
+        }
+    }
+}

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -80,8 +80,7 @@ namespace Libplanet.Net.Messages
         /// <inheritdoc/>
         public Message Decode(
             NetMQMessage encoded,
-            bool reply,
-            Action<byte[], Peer, AppProtocolVersion> appProtocolVersionValidator)
+            bool reply)
         {
             if (encoded.FrameCount == 0)
             {

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -46,8 +46,7 @@ namespace Libplanet.Net.Messages
             Message message,
             PrivateKey privateKey,
             Peer peer,
-            DateTimeOffset timestamp,
-            AppProtocolVersion version)
+            DateTimeOffset timestamp)
         {
             var netMqMessage = new NetMQMessage();
 
@@ -61,7 +60,7 @@ namespace Libplanet.Net.Messages
             netMqMessage.Push(timestamp.Ticks);
             netMqMessage.Push(_codec.Encode(peer.ToBencodex()));
             netMqMessage.Push((int)message.Type);
-            netMqMessage.Push(version.Token);
+            netMqMessage.Push(_messageValidator.Apv.Token);
 
             // Make and insert signature
             byte[] signature = privateKey.Sign(netMqMessage.ToByteArray());

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.Collections.Immutable;
 using System.Linq;
 using Bencodex;
 using Libplanet.Crypto;
@@ -13,17 +13,32 @@ namespace Libplanet.Net.Messages
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         private readonly Codec _codec;
-        private readonly TimeSpan? _messageTimestampBuffer;
+        private readonly MessageValidator _messageValidator;
 
         /// <summary>
         /// Creates a <see cref="NetMQMessageCodec"/> instance.
         /// </summary>
+        /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> to use
+        /// when encoding and decoding.</param>
+        /// <param name="trustedAppProtocolVersionSigners">The set of signers to trust when
+        /// decoding a message.</param>
+        /// <param name="differentAppProtocolVersionEncountered">A callback method that gets
+        /// invoked when a an <see cref="AppProtocolVersion"/> by a <em>trusted</em> signer that is
+        /// different from <paramref name="appProtocolVersion"/> is encountered.</param>
         /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
         /// when decoding <see cref="Message"/>s.</param>
-        public NetMQMessageCodec(TimeSpan? messageTimestampBuffer = null)
+        public NetMQMessageCodec(
+            AppProtocolVersion appProtocolVersion = default,
+            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners = null,
+            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered = null,
+            TimeSpan? messageTimestampBuffer = null)
         {
             _codec = new Codec();
-            _messageTimestampBuffer = messageTimestampBuffer;
+            _messageValidator = new MessageValidator(
+                appProtocolVersion,
+                trustedAppProtocolVersionSigners,
+                messageTimestampBuffer,
+                differentAppProtocolVersionEncountered);
         }
 
         /// <inheritdoc/>
@@ -93,28 +108,17 @@ namespace Libplanet.Net.Messages
                 remotePeer = new Peer(dictionary);
             }
 
-            appProtocolVersionValidator(
-                reply ? new byte[] { } : encoded[0].ToByteArray(),
+            _messageValidator.ValidateAppProtocolVersion(
                 remotePeer,
+                reply ? new byte[] { } : encoded[0].ToByteArray(),
                 remoteVersion);
 
             var type =
                 (Message.MessageType)remains[(int)Message.MessageFrame.Type].ConvertToInt32();
             var ticks = remains[(int)Message.MessageFrame.Timestamp].ConvertToInt64();
             var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
-
             var currentTime = DateTimeOffset.UtcNow;
-            if (_messageTimestampBuffer is TimeSpan timestampBuffer &&
-                (currentTime - timestamp).Duration() > timestampBuffer)
-            {
-                var msg = $"Received message is invalid, created at " +
-                          $"{timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture)} " +
-                          $"but designated lifetime is {timestampBuffer} and " +
-                          $"the current datetime offset is " +
-                          $"{currentTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}.";
-                throw new InvalidMessageTimestampException(
-                    msg, remotePeer, timestamp, _messageTimestampBuffer, currentTime);
-            }
+            _messageValidator.ValidateTimestamp(remotePeer, currentTime, timestamp);
 
             byte[] signature = remains[(int)Message.MessageFrame.Sign].ToByteArray();
 
@@ -137,16 +141,11 @@ namespace Libplanet.Net.Messages
             };
 
             var messageForVerify = headerWithoutSign.Concat(body).ToByteArray();
-
-            if (!remotePeer.PublicKey.Verify(messageForVerify, signature))
-            {
-                throw new InvalidMessageSignatureException(
-                    "The message signature is invalid",
-                    remotePeer,
-                    remotePeer.PublicKey,
-                    messageForVerify,
-                    signature);
-            }
+            _messageValidator.ValidateSignature(
+                remotePeer,
+                remotePeer.PublicKey,
+                messageForVerify,
+                signature);
 
             if (!reply)
             {

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -37,8 +37,8 @@ namespace Libplanet.Net.Messages
             _messageValidator = new MessageValidator(
                 appProtocolVersion,
                 trustedAppProtocolVersionSigners,
-                messageTimestampBuffer,
-                differentAppProtocolVersionEncountered);
+                differentAppProtocolVersionEncountered,
+                messageTimestampBuffer);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Net.Messages
         /// <param name="trustedAppProtocolVersionSigners">The set of signers to trust when
         /// decoding a message.</param>
         /// <param name="differentAppProtocolVersionEncountered">A callback method that gets
-        /// invoked when a an <see cref="AppProtocolVersion"/> by a <em>trusted</em> signer that is
+        /// invoked when an <see cref="AppProtocolVersion"/> by a <em>trusted</em> signer that is
         /// different from <paramref name="appProtocolVersion"/> is encountered.</param>
         /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
         /// when decoding <see cref="Message"/>s.</param>
@@ -138,12 +138,16 @@ namespace Libplanet.Net.Messages
                 remains[(int)Message.MessageFrame.Timestamp],
             };
 
-            var messageForVerify = headerWithoutSign.Concat(body).ToByteArray();
-            _messageValidator.ValidateSignature(
-                remotePeer,
-                remotePeer.PublicKey,
-                messageForVerify,
-                signature);
+            var messageToVerify = headerWithoutSign.Concat(body).ToByteArray();
+            if (!remotePeer.PublicKey.Verify(messageToVerify, signature))
+            {
+                throw new InvalidMessageSignatureException(
+                    "The signature of an encoded message is invalid.",
+                    remotePeer,
+                    remotePeer.PublicKey,
+                    messageToVerify,
+                    signature);
+            }
 
             if (!reply)
             {

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -88,8 +88,7 @@ namespace Libplanet.Net.Messages
         /// <inheritdoc/>
         public Message Decode(
             byte[] encoded,
-            bool reply,
-            Action<byte[], Peer, AppProtocolVersion> appProtocolVersionValidator)
+            bool reply)
         {
             if (encoded.Length == 0)
             {

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -38,8 +38,8 @@ namespace Libplanet.Net.Messages
             _messageValidator = new MessageValidator(
                 appProtocolVersion,
                 trustedAppProtocolVersionSigners,
-                messageTimestampBuffer,
-                differentAppProtocolVersionEncountered);
+                differentAppProtocolVersionEncountered,
+                messageTimestampBuffer);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -47,8 +47,7 @@ namespace Libplanet.Net.Messages
             Message message,
             PrivateKey privateKey,
             Peer peer,
-            DateTimeOffset timestamp,
-            AppProtocolVersion version)
+            DateTimeOffset timestamp)
         {
             var frames = new List<byte[]>();
 
@@ -62,7 +61,7 @@ namespace Libplanet.Net.Messages
             frames.Insert(0, BitConverter.GetBytes(timestamp.Ticks));
             frames.Insert(0, _codec.Encode(peer.ToBencodex()));
             frames.Insert(0, BitConverter.GetBytes((int)message.Type));
-            frames.Insert(0, Encoding.ASCII.GetBytes(version.Token));
+            frames.Insert(0, Encoding.ASCII.GetBytes(_messageValidator.Apv.Token));
 
             // Make and insert signature
             byte[] signature = privateKey.Sign(

--- a/Libplanet.Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet.Net/Transports/BoundPeerExtensions.cs
@@ -37,9 +37,7 @@ namespace Libplanet.Net.Transports
                 ping,
                 key,
                 new Peer(key.PublicKey),
-                DateTimeOffset.UtcNow,
-                default
-            );
+                DateTimeOffset.UtcNow);
 
             TimeSpan timeoutNotNull = timeout ?? TimeSpan.FromSeconds(5);
             try
@@ -103,8 +101,7 @@ namespace Libplanet.Net.Transports
                 ping,
                 key,
                 peer,
-                DateTimeOffset.UtcNow,
-                default);
+                DateTimeOffset.UtcNow);
             int length = serialized.Length;
             var buffer = new byte[TcpTransport.MagicCookie.Length + sizeof(int) + length];
             TcpTransport.MagicCookie.CopyTo(buffer, 0);

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -539,12 +539,15 @@ namespace Libplanet.Net.Transports
             }
             catch (DifferentAppProtocolVersionException dapve)
             {
-                var differentVersion = new DifferentVersion()
-                {
-                    Identity = dapve.Identity,
-                };
-                _ = ReplyMessageAsync(differentVersion, _runtimeCancellationTokenSource.Token);
                 _logger.Debug("Message from peer with a different version received.");
+                if (dapve.Trusted)
+                {
+                    var differentVersion = new DifferentVersion()
+                    {
+                        Identity = dapve.Identity,
+                    };
+                    _ = ReplyMessageAsync(differentVersion, _runtimeCancellationTokenSource.Token);
+                }
             }
             catch (InvalidMessageTimestampException imte)
             {

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -24,7 +24,6 @@ namespace Libplanet.Net.Transports
     public class NetMQTransport : ITransport
     {
         private readonly PrivateKey _privateKey;
-        private readonly AppProtocolVersion _appProtocolVersion;
         private readonly string _host;
         private readonly IList<IceServer> _iceServers;
         private readonly ILogger _logger;
@@ -116,12 +115,11 @@ namespace Libplanet.Net.Transports
 
             _socketCount = 0;
             _privateKey = privateKey;
-            _appProtocolVersion = appProtocolVersion;
             _host = host;
             _iceServers = iceServers?.ToList();
             _listenPort = listenPort ?? 0;
             _messageCodec = new NetMQMessageCodec(
-                _appProtocolVersion,
+                appProtocolVersion,
                 trustedAppProtocolVersionSigners,
                 differentAppProtocolVersionEncountered,
                 messageTimestampBuffer);
@@ -579,8 +577,7 @@ namespace Libplanet.Net.Transports
                             message,
                             _privateKey,
                             AsPeer,
-                            DateTimeOffset.UtcNow,
-                            _appProtocolVersion);
+                            DateTimeOffset.UtcNow);
 
             // FIXME The current timeout value(1 sec) is arbitrary.
             // We should make this configurable or fix it to an unneeded structure.
@@ -704,8 +701,7 @@ namespace Libplanet.Net.Transports
                 req.Message,
                 _privateKey,
                 AsPeer,
-                DateTimeOffset.UtcNow,
-                _appProtocolVersion);
+                DateTimeOffset.UtcNow);
             var result = new List<Message>();
 
             // Normal OperationCanceledException initiated from outside should bubble up.

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -664,12 +664,14 @@ namespace Libplanet.Net.Transports
             catch (DifferentAppProtocolVersionException dapve)
             {
                 _logger.Debug("Message from peer with different version received.");
-                var differentVersion = new DifferentVersion
+                if (dapve.Trusted)
                 {
-                    Identity = dapve.Identity,
-                };
-
-                await WriteMessageAsync(differentVersion, client, cancellationToken);
+                    var differentVersion = new DifferentVersion
+                    {
+                        Identity = dapve.Identity,
+                    };
+                    await WriteMessageAsync(differentVersion, client, cancellationToken);
+                }
             }
             catch (IOException)
             {

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -32,10 +32,7 @@ namespace Libplanet.Net.Transports
 
         private readonly PrivateKey _privateKey;
         private readonly AppProtocolVersion _appProtocolVersion;
-        private readonly IImmutableSet<PublicKey>? _trustedAppProtocolVersionSigners;
         private readonly string? _host;
-        private readonly DifferentAppProtocolVersionEncountered?
-            _differentAppProtocolVersionEncountered;
 
         private readonly IList<IceServer>? _iceServers;
         private readonly ILogger _logger;
@@ -79,14 +76,12 @@ namespace Libplanet.Net.Transports
 
             _privateKey = privateKey;
             _appProtocolVersion = appProtocolVersion;
-            _trustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners;
             _host = host;
             _iceServers = iceServers.ToList();
-            _differentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered;
             _messageCodec = new TcpMessageCodec(
                 _appProtocolVersion,
-                _trustedAppProtocolVersionSigners,
-                _differentAppProtocolVersionEncountered,
+                trustedAppProtocolVersionSigners,
+                differentAppProtocolVersionEncountered,
                 messageTimestampBuffer);
             _streams = new ConcurrentDictionary<Guid, ReplyStream>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
@@ -594,51 +589,12 @@ namespace Libplanet.Net.Transports
 
             _logger.Verbose("Received {Bytes} bytes from network stream.", content.Count);
 
-            Message message = _messageCodec.Decode(
-                content.ToArray(),
-                false,
-                AppProtocolVersionValidator);
+            Message message = _messageCodec.Decode(content.ToArray(), false);
 
             _logger.Verbose(
                 "ReadMessageAsync success. Received message {Message} from network stream.",
                 message);
             return message;
-        }
-
-        private void AppProtocolVersionValidator(
-            byte[] identity,
-            Peer remotePeer,
-            AppProtocolVersion remoteVersion)
-        {
-            bool valid = false;
-            bool trusted = true;
-            if (remoteVersion.Equals(_appProtocolVersion))
-            {
-                valid = true;
-            }
-            else if (!(_trustedAppProtocolVersionSigners is null) &&
-                     !_trustedAppProtocolVersionSigners.Any(remoteVersion.Verify))
-            {
-                trusted = false;
-            }
-            else if (_differentAppProtocolVersionEncountered is { } callback)
-            {
-                callback(
-                    remotePeer,
-                    remoteVersion,
-                    _appProtocolVersion);
-            }
-
-            if (!valid)
-            {
-                throw new DifferentAppProtocolVersionException(
-                    "The version of the received message is not valid.",
-                    remotePeer,
-                    identity,
-                    _appProtocolVersion,
-                    remoteVersion,
-                    trusted);
-            }
         }
 
         private async Task ReceiveMessageAsync(CancellationToken cancellationToken)

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -31,7 +31,6 @@ namespace Libplanet.Net.Transports
         private static readonly TimeSpan TurnPermissionLifetime = TimeSpan.FromMinutes(5);
 
         private readonly PrivateKey _privateKey;
-        private readonly AppProtocolVersion _appProtocolVersion;
         private readonly string? _host;
 
         private readonly IList<IceServer>? _iceServers;
@@ -75,11 +74,10 @@ namespace Libplanet.Net.Transports
             Running = false;
 
             _privateKey = privateKey;
-            _appProtocolVersion = appProtocolVersion;
             _host = host;
             _iceServers = iceServers.ToList();
             _messageCodec = new TcpMessageCodec(
-                _appProtocolVersion,
+                appProtocolVersion,
                 trustedAppProtocolVersionSigners,
                 differentAppProtocolVersionEncountered,
                 messageTimestampBuffer);
@@ -493,8 +491,7 @@ namespace Libplanet.Net.Transports
                 message,
                 _privateKey,
                 AsPeer,
-                DateTimeOffset.UtcNow,
-                _appProtocolVersion);
+                DateTimeOffset.UtcNow);
             int length = serialized.Length;
             var buffer = new byte[MagicCookie.Length + sizeof(int) + length];
             MagicCookie.CopyTo(buffer, 0);


### PR DESCRIPTION
Closes #1885 for now.

Aside from generally dealing with #1885, `IMessageCodec` instances now have a fixed context for encoding and decoding in regards to `APV`s. We can also probably do away with `privatekey` and `timestamp` considering its lifecycle.