### PR TITLE
Remove Fody dependency from Libplanet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,20 @@ To be released.
 
 ### Behavioral changes
 
+ -  Inner logic of `ByteUtil.CalculateHashCode(byte[] bytes)` has modified.
+    [[#1866], [#1891]]
+
 ### Bug fixes
 
 ### Dependencies
 
+ -  No longer depend on *Fody*.  [[#1866], [#1891]]
+ -  No longer depend on *Equals.Fody*.  [[#1866], [#1891]]
+
 ### CLI tools
+
+[#1866]: https://github.com/planetarium/libplanet/issues/1866
+[#1891]: https://github.com/planetarium/libplanet/pull/1891
 
 
 Version 0.32.0

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -14,6 +14,8 @@ namespace Libplanet.Net.Tests.Messages
         {
             var peer = new Peer(new PrivateKey().PublicKey);
             var buffer = TimeSpan.FromSeconds(1);
+            var halfBuffer = TimeSpan.FromSeconds(0.5);
+            var doubleBuffer = TimeSpan.FromSeconds(2);
             var messageValidator = new MessageValidator(
                 appProtocolVersion: default,
                 trustedAppProtocolVersionSigners: null,
@@ -22,17 +24,17 @@ namespace Libplanet.Net.Tests.Messages
 
             // Within buffer window is okay.
             messageValidator.ValidateTimestamp(
-                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + (buffer / 2));
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + halfBuffer);
             messageValidator.ValidateTimestamp(
-                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - (buffer / 2));
+                peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - halfBuffer);
 
             // Outside buffer throws an exception.
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + (buffer * 2)));
+                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow + doubleBuffer));
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - (buffer * 2)));
+                    peer, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow - doubleBuffer));
 
             // If buffer is null, no exception gets thrown.
             messageValidator = new MessageValidator(default, null, null, null);

--- a/Libplanet.Net/ActionExecutionState.cs
+++ b/Libplanet.Net/ActionExecutionState.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Blocks;
 
 namespace Libplanet.Net
@@ -5,8 +6,7 @@ namespace Libplanet.Net
     /// <summary>
     /// Indicates a progress of executing block actions.
     /// </summary>
-    [Equals]
-    public class ActionExecutionState : PreloadState
+    public class ActionExecutionState : PreloadState, IEquatable<ActionExecutionState>
     {
         /// <summary>
         /// Total number of blocks to execute in the current batch.
@@ -27,9 +27,36 @@ namespace Libplanet.Net
         public override int CurrentPhase => 5;
 
         public static bool operator ==(ActionExecutionState left, ActionExecutionState right) =>
-            Operator.Weave(left, right);
+            left.Equals(right);
 
         public static bool operator !=(ActionExecutionState left, ActionExecutionState right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(ActionExecutionState? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) &&
+                   TotalBlockCount == other.TotalBlockCount &&
+                   ExecutedBlockCount == other.ExecutedBlockCount &&
+                   ExecutedBlockHash.Equals(other.ExecutedBlockHash);
+        }
+
+        public override bool Equals(object? obj) =>
+            obj is ActionExecutionState other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(
+                base.GetHashCode(),
+                TotalBlockCount,
+                ExecutedBlockCount,
+                ExecutedBlockHash);
     }
 }

--- a/Libplanet.Net/BlockDownloadState.cs
+++ b/Libplanet.Net/BlockDownloadState.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Blocks;
 
 namespace Libplanet.Net
@@ -5,8 +6,7 @@ namespace Libplanet.Net
     /// <summary>
     /// Indicates a progress of downloading blocks.
     /// </summary>
-    [Equals]
-    public class BlockDownloadState : PreloadState
+    public class BlockDownloadState : PreloadState, IEquatable<BlockDownloadState>
     {
         /// <summary>
         /// Total number of blocks to receive in the current batch.
@@ -32,9 +32,39 @@ namespace Libplanet.Net
         public BoundPeer? SourcePeer { get; internal set; }
 
         public static bool operator ==(BlockDownloadState left, BlockDownloadState right) =>
-            Operator.Weave(left, right);
+            left.Equals(right);
 
         public static bool operator !=(BlockDownloadState left, BlockDownloadState right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(BlockDownloadState? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) &&
+                   TotalBlockCount == other.TotalBlockCount &&
+                   ReceivedBlockCount == other.ReceivedBlockCount &&
+                   ReceivedBlockHash.Equals(other.ReceivedBlockHash) &&
+                   ((SourcePeer is null && other.SourcePeer is null) ||
+                    (SourcePeer is { } p1 && other.SourcePeer is { } p2 && p1.Equals(p2)));
+        }
+
+        public override bool Equals(object? obj) =>
+            obj is BlockDownloadState other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(
+                base.GetHashCode(),
+                TotalBlockCount,
+                ReceivedBlockCount,
+                ReceivedBlockHash,
+                SourcePeer);
     }
 }

--- a/Libplanet.Net/BlockHashDownloadState.cs
+++ b/Libplanet.Net/BlockHashDownloadState.cs
@@ -1,11 +1,11 @@
-#nullable disable
+using System;
+
 namespace Libplanet.Net
 {
     /// <summary>
     /// Indicates a progress of downloading block hashes.
     /// </summary>
-    [Equals]
-    public class BlockHashDownloadState : PreloadState
+    public class BlockHashDownloadState : PreloadState, IEquatable<BlockHashDownloadState>
     {
         /// <summary>
         /// The estimated number of block hashes to receive in the current batch.
@@ -20,15 +20,43 @@ namespace Libplanet.Net
         /// <summary>
         /// The peer which sent the block hashes.
         /// </summary>
-        public BoundPeer SourcePeer { get; internal set; }
+        public BoundPeer? SourcePeer { get; internal set; }
 
         /// <inheritdoc />
         public override int CurrentPhase => 1;
 
         public static bool operator ==(BlockHashDownloadState left, BlockHashDownloadState right) =>
-            Operator.Weave(left, right);
+            left.Equals(right);
 
         public static bool operator !=(BlockHashDownloadState left, BlockHashDownloadState right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(BlockHashDownloadState? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) &&
+                   EstimatedTotalBlockHashCount == other.EstimatedTotalBlockHashCount &&
+                   ReceivedBlockHashCount == other.ReceivedBlockHashCount &&
+                   ((SourcePeer is null && other.SourcePeer is null) ||
+                    (SourcePeer is { } p1 && other.SourcePeer is { } p2 && p1.Equals(p2)));
+        }
+
+        public override bool Equals(object? obj) =>
+            obj is BlockHashDownloadState other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(
+                base.GetHashCode(),
+                EstimatedTotalBlockHashCount,
+                ReceivedBlockHashCount,
+                SourcePeer);
     }
 }

--- a/Libplanet.Net/BlockVerificationState.cs
+++ b/Libplanet.Net/BlockVerificationState.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Blocks;
 
 namespace Libplanet.Net
@@ -5,8 +6,7 @@ namespace Libplanet.Net
     /// <summary>
     /// Indicates a progress of verifying blocks.
     /// </summary>
-    [Equals]
-    public class BlockVerificationState : PreloadState
+    public class BlockVerificationState : PreloadState, IEquatable<BlockVerificationState>
     {
         /// <summary>
         /// Total number of blocks to verify in the current batch.
@@ -27,9 +27,36 @@ namespace Libplanet.Net
         public override int CurrentPhase => 3;
 
         public static bool operator ==(BlockVerificationState left, BlockVerificationState right) =>
-            Operator.Weave(left, right);
+            left.Equals(right);
 
         public static bool operator !=(BlockVerificationState left, BlockVerificationState right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(BlockVerificationState? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) &&
+                   TotalBlockCount == other.TotalBlockCount &&
+                   VerifiedBlockCount == other.VerifiedBlockCount &&
+                   VerifiedBlockHash.Equals(other.VerifiedBlockHash);
+        }
+
+        public override bool Equals(object? obj) =>
+            obj is BlockVerificationState other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(
+            base.GetHashCode(),
+            TotalBlockCount,
+            VerifiedBlockCount,
+            VerifiedBlockHash);
     }
 }

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -10,8 +10,7 @@ using Libplanet.Crypto;
 namespace Libplanet.Net
 {
     [Serializable]
-    [Equals]
-    public sealed class BoundPeer : Peer
+    public sealed class BoundPeer : Peer, IEquatable<BoundPeer>
     {
         private static readonly byte[] EndPointHostKey = { 0x68 }; // 'h'
         private static readonly byte[] EndPointPortKey = { 0x65 }; // 'e'
@@ -62,11 +61,9 @@ namespace Libplanet.Net
         [Pure]
         public DnsEndPoint EndPoint { get; }
 
-        public static bool operator ==(BoundPeer left, BoundPeer right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(BoundPeer left, BoundPeer right) => left.Equals(right);
 
-        public static bool operator !=(BoundPeer left, BoundPeer right) =>
-            Operator.Weave(left, right);
+        public static bool operator !=(BoundPeer left, BoundPeer right) => !left.Equals(right);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BoundPeer"/> class from
@@ -121,6 +118,25 @@ namespace Libplanet.Net
                 );
             }
         }
+
+        public bool Equals(BoundPeer? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) && EndPoint.Equals(other.EndPoint);
+        }
+
+        public override bool Equals(object? obj) => obj is BoundPeer other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), EndPoint);
 
         /// <inheritdoc/>
         public override void GetObjectData(

--- a/Libplanet.Net/FodyWeavers.xml
+++ b/Libplanet.Net/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Weavers
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-
-  <Equals />
-</Weavers>

--- a/Libplanet.Net/Libplanet.Net.csproj
+++ b/Libplanet.Net/Libplanet.Net.csproj
@@ -27,9 +27,8 @@
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
-    <!-- CS0660/CS0661/S3875 are turned off due to https://github.com/Fody/Equals/pull/96 -->
-    <!-- FIXME: CS1591 should be turned on eventually. -->
+    <NoWarn>$(NoWarn);S4035;CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
+    <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -45,10 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equals.Fody" Version="4.0.1" />
-    <PackageReference Include="Fody" Version="6.1.1">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Net/Peer.cs
+++ b/Libplanet.Net/Peer.cs
@@ -14,8 +14,7 @@ namespace Libplanet.Net
     /// </summary>
     /// <seealso cref="Swarm{T}"/>
     [Serializable]
-    [Equals]
-    public class Peer : ISerializable
+    public class Peer : ISerializable, IEquatable<Peer>
     {
         private static readonly byte[] PublicKeyKey = { 0x70 }; // 'p'
         private static readonly byte[] PublicIpAddressKey = { 0x50 }; // 'P'
@@ -63,7 +62,6 @@ namespace Libplanet.Net
         /// </summary>
         /// <seealso cref="PublicKey"/>
         [LogAsScalar]
-        [IgnoreDuringEquals]
         [Pure]
         public Address Address => new Address(PublicKey);
 
@@ -71,9 +69,31 @@ namespace Libplanet.Net
         [Pure]
         public IPAddress? PublicIPAddress { get; }
 
-        public static bool operator ==(Peer left, Peer right) => Operator.Weave(left, right);
+        public static bool operator ==(Peer left, Peer right) => left.Equals(right);
 
-        public static bool operator !=(Peer left, Peer right) => Operator.Weave(left, right);
+        public static bool operator !=(Peer left, Peer right) => !left.Equals(right);
+
+        public bool Equals(Peer? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return PublicKey.Equals(other.PublicKey) &&
+                   (PublicIPAddress?.Equals(other.PublicIPAddress) ??
+                    other.PublicIPAddress is null);
+        }
+
+        public override bool Equals(object? obj) => obj is Peer other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(PublicKey.GetHashCode(), PublicIPAddress?.GetHashCode());
 
         /// <inheritdoc/>
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/Libplanet.Net/PreloadState.cs
+++ b/Libplanet.Net/PreloadState.cs
@@ -1,10 +1,11 @@
+using System;
+
 namespace Libplanet.Net
 {
     // <summary>
     // Indicates a progress of preloading things from the network.
     // </summary>
-    [Equals]
-    public abstract class PreloadState
+    public abstract class PreloadState : IEquatable<PreloadState>
     {
         /// <summary>
         /// The number of total phases.
@@ -16,10 +17,28 @@ namespace Libplanet.Net
         /// </summary>
         public abstract int CurrentPhase { get; }
 
-        public static bool operator ==(PreloadState left, PreloadState right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(PreloadState left, PreloadState right) => left.Equals(right);
 
         public static bool operator !=(PreloadState left, PreloadState right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(PreloadState? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return CurrentPhase == other.CurrentPhase;
+        }
+
+        public override bool Equals(object? obj) => obj is PreloadState other && Equals(other);
+
+        public override int GetHashCode() => CurrentPhase;
     }
 }

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Tests
                 0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
             };
 
-            Assert.Equal(465595541, ByteUtil.CalculateHashCode(bytes));
+            Assert.Equal(-1026516859, ByteUtil.CalculateHashCode(bytes));
 
             var otherBytes = TestUtils.GetRandomBytes(20);
             otherBytes[19] = 0xdd;

--- a/Libplanet.Tests/Store/StoreTrackLog.cs
+++ b/Libplanet.Tests/Store/StoreTrackLog.cs
@@ -3,7 +3,6 @@ using System.Linq;
 
 namespace Libplanet.Tests.Store
 {
-    [Equals]
     public sealed class StoreTrackLog : IEquatable<StoreTrackLog>
     {
         private StoreTrackLog(string method, object[] @params)

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -39,7 +39,6 @@ namespace Libplanet
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
     [Serializable]
-    [Equals]
     public readonly struct Address : ISerializable, IComparable<Address>, IComparable
     {
         /// <summary>
@@ -174,9 +173,15 @@ namespace Libplanet
             }
         }
 
-        public static bool operator ==(Address left, Address right) => Operator.Weave(left, right);
+        public static bool operator ==(Address left, Address right) => left.Equals(right);
 
-        public static bool operator !=(Address left, Address right) => Operator.Weave(left, right);
+        public static bool operator !=(Address left, Address right) => !left.Equals(right);
+
+        public bool Equals(Address other) => ByteArray.SequenceEqual(other.ByteArray);
+
+        public override bool Equals(object? obj) => obj is Address other && Equals(other);
+
+        public override int GetHashCode() => ByteUtil.CalculateHashCode(ToByteArray());
 
         /// <summary>
         /// Gets a mutable array of 20 <see cref="byte"/>s that represent

--- a/Libplanet/Blocks/InvalidBlockPreEvaluationHashException.cs
+++ b/Libplanet/Blocks/InvalidBlockPreEvaluationHashException.cs
@@ -12,8 +12,8 @@ namespace Libplanet.Blocks
     /// <see cref="Block{T}.PreEvaluationHash"/> is invalid.
     /// </summary>
     [Serializable]
-    [Equals]
-    public class InvalidBlockPreEvaluationHashException : InvalidBlockException
+    public class InvalidBlockPreEvaluationHashException
+        : InvalidBlockException, IEquatable<InvalidBlockPreEvaluationHashException>
     {
         /// <summary>
         /// Initializes a new instance of the
@@ -59,12 +59,12 @@ namespace Libplanet.Blocks
         public static bool operator ==(
             InvalidBlockPreEvaluationHashException left,
             InvalidBlockPreEvaluationHashException right
-        ) => Operator.Weave(left, right);
+        ) => left.Equals(right);
 
         public static bool operator !=(
             InvalidBlockPreEvaluationHashException left,
             InvalidBlockPreEvaluationHashException right
-        ) => Operator.Weave(left, right);
+        ) => !left.Equals(right);
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -73,5 +73,28 @@ namespace Libplanet.Blocks
             info.AddValue(nameof(ActualPreEvaluationHash), ActualPreEvaluationHash.ToArray());
             info.AddValue(nameof(ExpectedPreEvaluationHash), ExpectedPreEvaluationHash.ToArray());
         }
+
+        public bool Equals(InvalidBlockPreEvaluationHashException? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return ActualPreEvaluationHash.SequenceEqual(other.ActualPreEvaluationHash) &&
+                   ExpectedPreEvaluationHash.SequenceEqual(other.ExpectedPreEvaluationHash) &&
+                   Message.Equals(other.Message);
+        }
+
+        public override bool Equals(object? obj) =>
+            obj is InvalidBlockPreEvaluationHashException other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(ActualPreEvaluationHash, ExpectedPreEvaluationHash, Message);
     }
 }

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -114,10 +114,7 @@ namespace Libplanet
                 throw new ArgumentNullException(nameof(bytes));
             }
 
-            return bytes.Aggregate(
-                0,
-                (current, t) => unchecked(current * (bytes.Length + 1) + t)
-            );
+            return bytes.Aggregate(0, (current, b) => unchecked(current * 397) ^ b);
         }
 
         /// <summary>

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -39,8 +39,7 @@ namespace Libplanet.Crypto
     /// <para>Every <see cref="PrivateKey"/> object is immutable.</para>
     /// </remarks>
     /// <seealso cref="Libplanet.Crypto.PublicKey"/>
-    [Equals]
-    public class PrivateKey
+    public class PrivateKey : IEquatable<PrivateKey>
     {
         private const int KeyByteSize = 32;
         private PublicKey? _publicKey;
@@ -101,7 +100,6 @@ namespace Libplanet.Crypto
         /// The corresponding <see cref="Libplanet.Crypto.PublicKey"/> of
         /// this private key.
         /// </summary>
-        [IgnoreDuringEquals]
         public PublicKey PublicKey
         {
             get
@@ -140,11 +138,9 @@ namespace Libplanet.Crypto
 
         internal ECPrivateKeyParameters KeyParam { get; }
 
-        public static bool operator ==(PrivateKey left, PrivateKey right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(PrivateKey left, PrivateKey right) => left.Equals(right);
 
-        public static bool operator !=(PrivateKey left, PrivateKey right) =>
-            Operator.Weave(left, right);
+        public static bool operator !=(PrivateKey left, PrivateKey right) => !left.Equals(right);
 
         /// <summary>
         /// Creates a <see cref="PrivateKey"/> instance from hexadecimal string of bytes.
@@ -172,6 +168,14 @@ namespace Libplanet.Crypto
 
             return new PrivateKey(unverifiedKey: bytes, informedConsent: true);
         }
+
+        public bool Equals(PrivateKey? other) => KeyParam.Equals(other?.KeyParam);
+
+        public override bool Equals(object? obj) => obj is PrivateKey other && Equals(other);
+
+        public override int GetHashCode() =>
+            unchecked(ByteUtil.CalculateHashCode(ToByteArray()) * 397 ^
+                      KeyParam.GetHashCode());
 
         /// <summary>
         /// Creates a signature from the given <paramref name="message"/>.

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -26,8 +26,7 @@ namespace Libplanet.Crypto
     /// <remarks>Every <see cref="PublicKey"/> object is immutable.</remarks>
     /// <seealso cref="PrivateKey"/>
     /// <seealso cref="Address"/>
-    [Equals]
-    public class PublicKey
+    public class PublicKey : IEquatable<PublicKey>
     {
         /// <summary>
         /// Creates a <see cref="PublicKey"/> instance from the given
@@ -55,11 +54,15 @@ namespace Libplanet.Crypto
 
         internal ECPublicKeyParameters KeyParam { get; }
 
-        public static bool operator ==(PublicKey left, PublicKey right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(PublicKey left, PublicKey right) => left.Equals(right);
 
-        public static bool operator !=(PublicKey left, PublicKey right) =>
-            Operator.Weave(left, right);
+        public static bool operator !=(PublicKey left, PublicKey right) => !left.Equals(right);
+
+        public bool Equals(PublicKey? other) => KeyParam.Equals(other?.KeyParam);
+
+        public override bool Equals(object? obj) => obj is PublicKey other && Equals(other);
+
+        public override int GetHashCode() => KeyParam.GetHashCode();
 
         /// <summary>
         /// Encodes this public key into a mutable <see cref="byte"/> array representation.

--- a/Libplanet/Crypto/SymmetricKey.cs
+++ b/Libplanet/Crypto/SymmetricKey.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
@@ -21,8 +20,7 @@ namespace Libplanet.Crypto
     /// cryptography, it uses the same <see cref="SymmetricKey"/> for both
     /// encrypting a plaintext and decrypting a ciphertext.
     /// </summary>
-    [Equals]
-    public class SymmetricKey
+    public class SymmetricKey : IEquatable<SymmetricKey>
     {
         private const int KeyBitSize = 256;
         private const int MacBitSize = 128;
@@ -73,11 +71,29 @@ namespace Libplanet.Crypto
         [Pure]
         public ImmutableArray<byte> ByteArray => _key.ToImmutableArray();
 
-        public static bool operator ==(SymmetricKey left, SymmetricKey right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(SymmetricKey left, SymmetricKey right) => left.Equals(right);
 
         public static bool operator !=(SymmetricKey left, SymmetricKey right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(SymmetricKey? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return ByteArray.SequenceEqual(other.ByteArray);
+        }
+
+        public override bool Equals(object? obj) => obj is SymmetricKey other && Equals(other);
+
+        public override int GetHashCode() => ByteUtil.CalculateHashCode(ToByteArray());
 
         /// <summary>
         /// Converts a plain <paramref name="message"/> to a ciphertext
@@ -96,7 +112,7 @@ namespace Libplanet.Crypto
         /// </returns>
         /// <seealso cref="Decrypt(byte[], int)"/>
         [Pure]
-        public byte[] Encrypt(byte[] message, byte[] nonSecret = null)
+        public byte[] Encrypt(byte[] message, byte[]? nonSecret = null)
         {
             var nonce = new byte[NonceBitSize / 8];
             _secureRandom.NextBytes(nonce, 0, nonce.Length);

--- a/Libplanet/FodyWeavers.xml
+++ b/Libplanet/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Weavers
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-
-  <Equals />
-</Weavers>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -44,9 +44,8 @@ https://docs.libplanet.io/</Description>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
-    <!-- CS0660/CS0661/S3875 are turned off due to https://github.com/Fody/Equals/pull/96 -->
-    <!-- FIXME: CS1591 should be turned on eventually. -->
+    <NoWarn>$(NoWarn);S4035;CS1591;NU5104;MEN001</NoWarn>
+    <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
     <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -67,12 +66,9 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-    <PackageReference Include="Equals.Fody" Version="4.0.1" />
-    <PackageReference Include="Fody" Version="6.1.1">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="ImmutableTrie" Version="1.0.0-alpha" />
     <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Libplanet/Nonce.cs
+++ b/Libplanet/Nonce.cs
@@ -9,8 +9,7 @@ namespace Libplanet
     /// An arbitrary <see cref="byte"/>s that determines a
     /// <see cref="Hashcash.Stamp"/>.
     /// </summary>
-    [Equals]
-    public struct Nonce
+    public struct Nonce : IEquatable<Nonce>
     {
         private ImmutableArray<byte> _byteArray;
 
@@ -59,9 +58,15 @@ namespace Libplanet
             }
         }
 
-        public static bool operator ==(Nonce left, Nonce right) => Operator.Weave(left, right);
+        public static bool operator ==(Nonce left, Nonce right) => left.Equals(right);
 
-        public static bool operator !=(Nonce left, Nonce right) => Operator.Weave(left, right);
+        public static bool operator !=(Nonce left, Nonce right) => !left.Equals(right);
+
+        public bool Equals(Nonce other) => ByteArray.SequenceEqual(other.ByteArray);
+
+        public override bool Equals(object? obj) => obj is Nonce other && Equals(other);
+
+        public override int GetHashCode() => ByteUtil.CalculateHashCode(ToByteArray());
 
         /// <summary>
         /// Gets a bare mutable <see cref="byte"/> array of the nonce.

--- a/Libplanet/Store/Trie/MerkleTrie.cs
+++ b/Libplanet/Store/Trie/MerkleTrie.cs
@@ -16,7 +16,6 @@ namespace Libplanet.Store.Trie
     /// <see href="https://eth.wiki/fundamentals/patricia-tree">Merkle Patricia Trie</see>.
     /// </summary>
     // TODO: implement 'logs' for debugging.
-    [Equals]
     public partial class MerkleTrie : ITrie
     {
         public static readonly HashDigest<SHA256> EmptyRootHash;
@@ -83,12 +82,6 @@ namespace Libplanet.Store.Trie
         internal INode? Root { get; }
 
         private IKeyValueStore KeyValueStore { get; }
-
-        public static bool operator ==(MerkleTrie left, MerkleTrie right) =>
-            Operator.Weave(left, right);
-
-        public static bool operator !=(MerkleTrie left, MerkleTrie right) =>
-            Operator.Weave(left, right);
 
         /// <inheritdoc/>
         public ITrie Set(in KeyBytes key, IValue value)

--- a/Libplanet/Store/Trie/Nodes/HashNode.cs
+++ b/Libplanet/Store/Trie/Nodes/HashNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using Bencodex.Types;
 
@@ -6,8 +7,7 @@ namespace Libplanet.Store.Trie.Nodes
     /// <summary>
     /// <see cref="HashDigest{T}"/>'s wrapper class, used in <see cref="ITrie"/> interface.
     /// </summary>
-    [Equals]
-    internal class HashNode : INode
+    internal class HashNode : INode, IEquatable<HashNode>
     {
         public HashNode(HashDigest<SHA256> hashDigest)
         {
@@ -16,11 +16,13 @@ namespace Libplanet.Store.Trie.Nodes
 
         public HashDigest<SHA256> HashDigest { get; }
 
-        public static bool operator ==(HashNode left, HashNode right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(HashNode left, HashNode right) => left.Equals(right);
 
-        public static bool operator !=(HashNode left, HashNode right) =>
-            Operator.Weave(left, right);
+        public static bool operator !=(HashNode left, HashNode right) => !left.Equals(right);
+
+        public bool Equals(HashNode? other) => HashDigest.Equals(other?.HashDigest);
+
+        public override bool Equals(object? obj) => obj is HashNode other && Equals(other);
 
         public byte[] Serialize()
         {
@@ -31,9 +33,6 @@ namespace Libplanet.Store.Trie.Nodes
         public IValue ToBencodex() =>
             new Binary(HashDigest.ToByteArray());
 
-        public override int GetHashCode()
-        {
-            return HashDigest.GetHashCode();
-        }
+        public override int GetHashCode() => HashDigest.GetHashCode();
     }
 }

--- a/Libplanet/Store/Trie/Nodes/ValueNode.cs
+++ b/Libplanet/Store/Trie/Nodes/ValueNode.cs
@@ -1,3 +1,4 @@
+using System;
 using Bencodex.Types;
 
 namespace Libplanet.Store.Trie.Nodes
@@ -5,8 +6,7 @@ namespace Libplanet.Store.Trie.Nodes
     /// <summary>
     /// Wrapper class.
     /// </summary>
-    [Equals]
-    internal class ValueNode : INode
+    internal class ValueNode : INode, IEquatable<ValueNode>
     {
         public ValueNode(IValue value)
         {
@@ -15,11 +15,26 @@ namespace Libplanet.Store.Trie.Nodes
 
         public IValue Value { get; }
 
-        public static bool operator ==(ValueNode left, ValueNode right) =>
-            Operator.Weave(left, right);
+        public static bool operator ==(ValueNode left, ValueNode right) => left.Equals(right);
 
-        public static bool operator !=(ValueNode left, ValueNode right) =>
-            Operator.Weave(left, right);
+        public static bool operator !=(ValueNode left, ValueNode right) => !left.Equals(right);
+
+        public bool Equals(ValueNode? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Value.Equals(other.Value);
+        }
+
+        public override bool Equals(object? obj) => obj is ValueNode other && Equals(other);
 
         /// <inheritdoc cref="INode.ToBencodex()"/>
         public IValue ToBencodex() =>

--- a/Libplanet/Tx/RawTransaction.cs
+++ b/Libplanet/Tx/RawTransaction.cs
@@ -1,4 +1,4 @@
-#nullable disable
+using System;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
@@ -6,8 +6,7 @@ using Bencodex.Types;
 
 namespace Libplanet.Tx
 {
-    [Equals]
-    internal readonly struct RawTransaction
+    internal readonly struct RawTransaction : IEquatable<RawTransaction>
     {
         public static readonly byte[] NonceKey = { 0x6e }; // 'n'
 
@@ -103,10 +102,22 @@ namespace Libplanet.Tx
         public ImmutableArray<IValue> Actions { get; }
 
         public static bool operator ==(RawTransaction left, RawTransaction right) =>
-            Operator.Weave(left, right);
+            left.Equals(right);
 
         public static bool operator !=(RawTransaction left, RawTransaction right) =>
-            Operator.Weave(left, right);
+            !left.Equals(right);
+
+        public bool Equals(RawTransaction other) => Nonce == other.Nonce &&
+                                                    Signer.SequenceEqual(other.Signer) &&
+                                                    PublicKey.SequenceEqual(other.PublicKey) &&
+                                                    GenesisHash.SequenceEqual(other.GenesisHash) &&
+                                                    UpdatedAddresses.SequenceEqual(
+                                                        other.UpdatedAddresses) &&
+                                                    Timestamp == other.Timestamp &&
+                                                    Signature.SequenceEqual(other.Signature) &&
+                                                    Actions.SequenceEqual(other.Actions);
+
+        public override bool Equals(object? obj) => obj is RawTransaction other && Equals(other);
 
         public RawTransaction AddSignature(byte[] signature)
         {
@@ -147,10 +158,7 @@ namespace Libplanet.Tx
             return dict;
         }
 
-        public override int GetHashCode()
-        {
-            return ByteUtil.CalculateHashCode(Signature.ToArray());
-        }
+        public override int GetHashCode() => ByteUtil.CalculateHashCode(Signature.ToArray());
 
         public override string ToString()
         {

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -647,27 +647,13 @@ namespace Libplanet.Tx
         }
 
         /// <inheritdoc />
-        public bool Equals(Transaction<T> other)
-        {
-            return Id.Equals(other.Id);
-        }
+        public bool Equals(Transaction<T> other) => Id.Equals(other?.Id);
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Transaction<T> other && Equals(other);
-        }
+        public override bool Equals(object obj) => obj is Transaction<T> other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return Id.GetHashCode();
-        }
+        public override int GetHashCode() => Id.GetHashCode();
 
         internal RawTransaction ToRawTransaction(bool includeSign)
         {

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -18,7 +18,6 @@ namespace Libplanet.Tx
     /// </summary>
     /// <seealso cref="Transaction{T}.Id"/>
     [Serializable]
-    [Equals]
     public struct TxId : ISerializable, IComparable<TxId>, IComparable
     {
         /// <summary>
@@ -87,9 +86,15 @@ namespace Libplanet.Tx
             }
         }
 
-        public static bool operator ==(TxId left, TxId right) => Operator.Weave(left, right);
+        public static bool operator ==(TxId left, TxId right) => left.Equals(right);
 
-        public static bool operator !=(TxId left, TxId right) => Operator.Weave(left, right);
+        public static bool operator !=(TxId left, TxId right) => !left.Equals(right);
+
+        public bool Equals(TxId other) => ByteArray.SequenceEqual(other.ByteArray);
+
+        public override bool Equals(object obj) => obj is TxId other && Equals(other);
+
+        public override int GetHashCode() => ByteUtil.CalculateHashCode(ToByteArray());
 
         /// <summary>
         /// Gets a bare mutable <see cref="byte"/> array of


### PR DESCRIPTION
Remove `Fody.Equals` and classes using `[Equals]` attributed now implements `IEquatable<T>`.

Implementation `GetHashCode()` override method referenced:
https://github.com/Fody/Equals/blob/master/Equals.Fody/Injectors/GetHashCodeInjector.cs

due to compatibility.