### PR TITLE
Fix unit test bug in linux-unity-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,7 +331,10 @@ commands:
             args+=("--exclude-class=$c")
           done
           for project in *.Tests; do
-            args+=("$PWD/$project/bin/Release/net47/$project.dll")
+            if [[ $project !=  *"Explorer"* ]]
+            then
+              args+=("$PWD/$project/bin/Release/net47/$project.dll")
+            fi
           done
           "$xur_path" "${args[@]}"
         no_output_timeout: 65s

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -657,7 +657,8 @@ namespace Libplanet.Store
                 throw new InvalidOperationException("Canonical chain ID is not assigned.");
             }
 
-            foreach (Guid id in ListChainIds().Where(id => !id.Equals(ccid)))
+            Guid[] chainIds = ListChainIds().ToArray();
+            foreach (Guid id in chainIds.Where(id => !id.Equals(ccid)))
             {
                 DeleteChainId(id);
             }


### PR DESCRIPTION
Fixed bug in `DefaultStore.PruneOutdatedChains()`.

Closes #1898 

Additionally it excludes `Libplanet.Explorer.Tests` from linux-unity-test because `Libplanet.Explorer` does not support net47 build because of `Microsoft.AspNetCore.Mvc.NewtonsoftJson 3.1.6` package.