### PR TITLE
Context agnostic `IMessageCodec`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,24 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Net) `IMessageCodec` and its implementations `NetMQMessageCodec`
+    and `TcpMessageCodec` overhauled.  [[#1906]]
+     -  `AppProtocolVersion` type parameter added to `IMessageCodec.Encode()`.
+     -  Both `NetMQMessageCodec()` and `TcpMessageCodec()` constructors are
+        made parameterless.
+     -  `IMessageCodec.Decode()` no longer throws
+        `InvalidMessageTimestampException` or
+        `DifferentAppProtocolVersionException`.
+ -  (Libplanet.Net) Irrelevant context related properties removed from
+    `InvalidMessageTimestampException` and
+    `DifferentAppProtocolVersionException`.  [[#1906]]
+     -  `InvalidMessageTimestampException.Peer` property removed.
+     -  `DifferentAppProtocolVersionException.Peer` property removed.
+     -  `DifferentAppProtocolVersionException.Identity` property removed.
+ -  (Libplanet.Net) Both `MessageValidator.ValidateTimestamp()` and
+    `MessageValidator.ValidateAppProtocolVersion()` now only accepts single
+    `Message` type parameter.  [[#1906]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -30,8 +48,8 @@ To be released.
 
 ### Dependencies
 
- -  No longer depend on *Fody*.  [[#1866], [#1891]]
- -  No longer depend on *Equals.Fody*.  [[#1866], [#1891]]
+ -  No longer depends on *Fody*.  [[#1866], [#1891]]
+ -  No longer depends on *Equals.Fody*.  [[#1866], [#1891]]
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@ To be released.
 [#1891]: https://github.com/planetarium/libplanet/pull/1891
 [#1904]: https://github.com/planetarium/libplanet/issues/1904
 [#1905]: https://github.com/planetarium/libplanet/pull/1905
+[#1906]: https://github.com/planetarium/libplanet/pull/1906
 
 
 Version 0.32.1

--- a/Libplanet.Net.Tests/DifferentAppProtocolVersionExceptionTest.cs
+++ b/Libplanet.Net.Tests/DifferentAppProtocolVersionExceptionTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
 using Xunit;
@@ -30,8 +29,6 @@ namespace Libplanet.Net.Tests
 
             var e1 = new DifferentAppProtocolVersionException(
                 "An error message",
-                new Peer(publicKey),
-                identity,
                 apv1,
                 apv2,
                 false);
@@ -46,8 +43,6 @@ namespace Libplanet.Net.Tests
             }
 
             Assert.Equal(e1.Message, e2.Message);
-            Assert.Equal(e1.Peer, e2.Peer);
-            Assert.True(e1.Identity.SequenceEqual(e2.Identity));
             Assert.Equal(e1.ExpectedApv, e2.ExpectedApv);
             Assert.Equal(e1.ActualApv, e2.ActualApv);
             Assert.Equal(e1.Trusted, e2.Trusted);

--- a/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
+++ b/Libplanet.Net.Tests/InvalidMessageTimestampExceptionTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using Libplanet.Crypto;
 using Xunit;
 
 namespace Libplanet.Net.Tests
@@ -21,7 +20,6 @@ namespace Libplanet.Net.Tests
         {
             var e1 = new InvalidMessageTimestampException(
                 "An error message",
-                new Peer(new PrivateKey().PublicKey),
                 DateTimeOffset.UtcNow,
                 buffer,
                 DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1));

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -44,6 +44,7 @@ namespace Libplanet.Net.Tests.Messages
             NetMQMessage encoded = messageCodec.Encode(
                 msg,
                 privateKey,
+                apv,
                 peer,
                 DateTimeOffset.UtcNow);
             BlockHashes restored = (BlockHashes)messageCodec.Decode(encoded, true);

--- a/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Net.Tests.Messages
             var privateKey = new PrivateKey();
             AppProtocolVersion apv = AppProtocolVersion.Sign(privateKey, 3);
             Peer peer = new BoundPeer(privateKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
-            var messageCodec = new NetMQMessageCodec(appProtocolVersion: apv);
+            var messageCodec = new NetMQMessageCodec();
             NetMQMessage encoded = messageCodec.Encode(
                 msg,
                 privateKey,

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -22,63 +22,6 @@ namespace Libplanet.Net.Tests.Messages
         }
 
         [Fact]
-        public void DifferentAppProtocolVersionStructure()
-        {
-            var privateKey = new PrivateKey();
-            var peer = new Peer(privateKey.PublicKey);
-            var apv1 = new AppProtocolVersion(
-                1,
-                new Bencodex.Types.Integer(0),
-                ImmutableArray<byte>.Empty,
-                default(Address));
-            var apv2 = new AppProtocolVersion(
-                2,
-                new Bencodex.Types.Integer(0),
-                ImmutableArray<byte>.Empty,
-                default(Address));
-            var message = new Ping();
-            var codec = new NetMQMessageCodec(appProtocolVersion: apv1);
-            NetMQMessage netMQMessage = codec.Encode(
-                message,
-                privateKey,
-                apv2,
-                peer,
-                DateTimeOffset.UtcNow);
-
-            Assert.Throws<DifferentAppProtocolVersionException>(() =>
-                codec.Decode(netMQMessage, true));
-        }
-
-        [Fact]
-        public void InvalidMessageTimestamp()
-        {
-            var privateKey = new PrivateKey();
-            var peer = new Peer(privateKey.PublicKey);
-            var futureOffset = DateTimeOffset.MaxValue;
-            var pastOffset = DateTimeOffset.MinValue;
-            var apv = new AppProtocolVersion(
-                1,
-                new Bencodex.Types.Integer(0),
-                ImmutableArray<byte>.Empty,
-                default(Address));
-            var buffer = TimeSpan.FromSeconds(1);
-            var message = new Ping();
-            var codec = new NetMQMessageCodec(
-                appProtocolVersion: apv,
-                messageTimestampBuffer: buffer);
-            NetMQMessage futureRaw =
-                codec.Encode(message, privateKey, apv, peer, futureOffset);
-            // Messages from the future throws InvalidMessageTimestampException.
-            Assert.Throws<InvalidMessageTimestampException>(() =>
-                codec.Decode(futureRaw, true));
-            NetMQMessage pastRaw =
-                codec.Encode(message, privateKey, apv, peer, pastOffset);
-            // Messages from the far past throws InvalidMessageTimestampException.
-            Assert.Throws<InvalidMessageTimestampException>(() =>
-                codec.Decode(pastRaw, true));
-        }
-
-        [Fact]
         public void BlockHeaderMessage()
         {
             var privateKey = new PrivateKey();

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Net.Tests.Messages
                 GenesisMiner
             );
             var message = new BlockHeaderMessage(genesis.Hash, genesis.Header);
-            var codec = new NetMQMessageCodec(appProtocolVersion: apv);
+            var codec = new NetMQMessageCodec();
             NetMQMessage raw =
                 codec.Encode(message, privateKey, apv, peer, dateTimeOffset);
             var parsed = codec.Decode(raw, true);
@@ -75,7 +75,7 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var ping = new Ping();
-            var codec = new NetMQMessageCodec(appProtocolVersion: apv);
+            var codec = new NetMQMessageCodec();
             var netMqMessage = codec.Encode(ping, privateKey, apv, peer, timestamp).ToArray();
 
             // Attacker

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -24,25 +24,17 @@ namespace Libplanet.Net.Tests.Messages
 
             // Within buffer window is okay.
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow + halfBuffer });
+                new Ping() { Timestamp = DateTimeOffset.UtcNow + halfBuffer });
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow - halfBuffer });
+                new Ping() { Timestamp = DateTimeOffset.UtcNow - halfBuffer });
 
             // Outside buffer throws an exception.
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    new Ping()
-                    {
-                        Remote = peer,
-                        Timestamp = DateTimeOffset.UtcNow + doubleBuffer,
-                    }));
+                    new Ping() { Timestamp = DateTimeOffset.UtcNow + doubleBuffer }));
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    new Ping()
-                    {
-                        Remote = peer,
-                        Timestamp = DateTimeOffset.UtcNow - doubleBuffer,
-                    }));
+                    new Ping() { Timestamp = DateTimeOffset.UtcNow - doubleBuffer }));
 
             // If buffer is null, no exception gets thrown.
             messageValidator = new MessageValidator(default, null, null, null);

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -24,30 +24,32 @@ namespace Libplanet.Net.Tests.Messages
 
             // Within buffer window is okay.
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow + halfBuffer },
-                DateTimeOffset.UtcNow);
+                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow + halfBuffer });
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow - halfBuffer },
-                DateTimeOffset.UtcNow);
+                new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow - halfBuffer });
 
             // Outside buffer throws an exception.
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow + doubleBuffer },
-                    DateTimeOffset.UtcNow));
+                    new Ping()
+                    {
+                        Remote = peer,
+                        Timestamp = DateTimeOffset.UtcNow + doubleBuffer,
+                    }));
             Assert.Throws<InvalidMessageTimestampException>(() =>
                 messageValidator.ValidateTimestamp(
-                    new Ping() { Remote = peer, Timestamp = DateTimeOffset.UtcNow - doubleBuffer },
-                    DateTimeOffset.UtcNow));
+                    new Ping()
+                    {
+                        Remote = peer,
+                        Timestamp = DateTimeOffset.UtcNow - doubleBuffer,
+                    }));
 
             // If buffer is null, no exception gets thrown.
             messageValidator = new MessageValidator(default, null, null, null);
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.MaxValue },
-                DateTimeOffset.UtcNow);
+                new Ping() { Remote = peer, Timestamp = DateTimeOffset.MaxValue });
             messageValidator.ValidateTimestamp(
-                new Ping() { Remote = peer, Timestamp = DateTimeOffset.MinValue },
-                DateTimeOffset.UtcNow);
+                new Ping() { Remote = peer, Timestamp = DateTimeOffset.MinValue });
         }
 
         [Fact]

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = CreateMessage(type);
             var codec = new NetMQMessageCodec(appProtocolVersion: apv);
             NetMQMessage raw =
-                codec.Encode(message, privateKey, peer, dateTimeOffset);
+                codec.Encode(message, privateKey, apv, peer, dateTimeOffset);
             var parsed = codec.Decode(raw, true);
             Assert.Equal(apv, parsed.Version);
             Assert.Equal(peer, parsed.Remote);

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var message = CreateMessage(type);
-            var codec = new NetMQMessageCodec(appProtocolVersion: apv);
+            var codec = new NetMQMessageCodec();
             NetMQMessage raw =
                 codec.Encode(message, privateKey, apv, peer, dateTimeOffset);
             var parsed = codec.Decode(raw, true);

--- a/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TcpTransportTest.cs
@@ -125,6 +125,7 @@ namespace Libplanet.Net.Tests.Transports
                 byte[] serialized = codec.Encode(
                     message,
                     privateKey,
+                    apv,
                     transport.AsPeer,
                     DateTimeOffset.UtcNow);
                 int length = serialized.Length;

--- a/Libplanet.Net/DifferentAppProtocolVersionException.cs
+++ b/Libplanet.Net/DifferentAppProtocolVersionException.cs
@@ -18,10 +18,6 @@ namespace Libplanet.Net
         /// <see cref="DifferentAppProtocolVersionException"/> class.
         /// </summary>
         /// <param name="message">Specifies an <see cref="Exception.Message"/>.</param>
-        /// <param name="peer">The <see cref="Message.Remote"/> of the <see cref="Message"/>
-        /// received.</param>
-        /// <param name="identity">The <see cref="Message.Identity"/> of the <see cref="Message"/>
-        /// received.</param>
         /// <param name="expectedAppProtocolVersion">The protocol version of
         /// the local <see cref="Swarm{T}"/>.</param>
         /// <param name="actualAppProtocolVersion">The protocol version of the <see cref="Peer"/>
@@ -30,15 +26,11 @@ namespace Libplanet.Net
         /// is signed by a trusted signer.</param>
         public DifferentAppProtocolVersionException(
             string message,
-            Peer peer,
-            byte[] identity,
             AppProtocolVersion expectedAppProtocolVersion,
             AppProtocolVersion actualAppProtocolVersion,
             bool trusted)
             : base(message)
         {
-            Peer = peer;
-            Identity = identity;
             ExpectedApv = expectedAppProtocolVersion;
             ActualApv = actualAppProtocolVersion;
             Trusted = trusted;
@@ -49,21 +41,12 @@ namespace Libplanet.Net
             StreamingContext context)
             : base(info, context)
         {
-            Peer = info.GetValue<Peer>(nameof(Peer));
-            Identity = info.GetValue<byte[]>(nameof(Identity));
             ExpectedApv = AppProtocolVersion.FromToken(
                 info.GetValue<string>(nameof(ExpectedApv)));
             ActualApv = AppProtocolVersion.FromToken(
                 info.GetValue<string>(nameof(ActualApv)));
             Trusted = info.GetValue<bool>(nameof(Trusted));
         }
-
-        public Peer Peer { get; private set; }
-
-        /// <summary>
-        /// The identity of the message received.
-        /// </summary>
-        public byte[] Identity { get; }
 
         /// <summary>
         /// The protocol version of the current <see cref="Swarm{T}"/>.
@@ -85,8 +68,6 @@ namespace Libplanet.Net
             SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), Peer);
-            info.AddValue(nameof(Identity), Identity);
             info.AddValue(nameof(ExpectedApv), ExpectedApv.Token);
             info.AddValue(nameof(ActualApv), ActualApv.Token);
             info.AddValue(nameof(Trusted), Trusted);

--- a/Libplanet.Net/InvalidMessageTimestampException.cs
+++ b/Libplanet.Net/InvalidMessageTimestampException.cs
@@ -14,13 +14,11 @@ namespace Libplanet.Net
     {
         internal InvalidMessageTimestampException(
             string message,
-            Peer peer,
             DateTimeOffset createdOffset,
             TimeSpan? buffer,
             DateTimeOffset currentOffset)
             : base(message)
         {
-            Peer = peer;
             CreatedOffset = createdOffset;
             Buffer = buffer;
             CurrentOffset = currentOffset;
@@ -31,13 +29,10 @@ namespace Libplanet.Net
             StreamingContext context)
             : base(info, context)
         {
-            Peer = info.GetValue<Peer>(nameof(Peer));
             CreatedOffset = info.GetValue<DateTimeOffset>(nameof(CreatedOffset));
             Buffer = info.GetValue<TimeSpan?>(nameof(Buffer));
             CurrentOffset = info.GetValue<DateTimeOffset>(nameof(CurrentOffset));
         }
-
-        internal Peer Peer { get; private set; }
 
         internal DateTimeOffset CreatedOffset { get; private set; }
 
@@ -49,7 +44,6 @@ namespace Libplanet.Net
             SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), Peer);
             info.AddValue(nameof(CreatedOffset), CreatedOffset);
             info.AddValue(nameof(Buffer), Buffer);
             info.AddValue(nameof(CurrentOffset), CurrentOffset);

--- a/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/Libplanet.Net/Messages/IMessageCodec.cs
@@ -41,14 +41,8 @@ namespace Libplanet.Net.Messages
         /// <param name="reply">A flag to express whether the target is a reply of other message.
         /// </param>
         /// <returns>A <see cref="Message"/> parsed from <paramref name="encoded"/>.</returns>
-        /// <exception cref="ArgumentException">
-        /// Thrown when empty <paramref name="encoded"/> is given.</exception>
-        /// <exception cref="DifferentAppProtocolVersionException">Thrown when
-        /// local version does not match with given <paramref name="encoded"/>'s
-        /// <see cref="AppProtocolVersion"/>.
-        /// </exception>
-        /// <exception cref="InvalidMessageTimestampException">Thrown when the timestamp of
-        /// <paramref name="encoded"/> is invalid.</exception>
+        /// <exception cref="ArgumentException">Thrown when empty <paramref name="encoded"/>
+        /// is given.</exception>
         /// <exception cref="InvalidMessageSignatureException">Thrown when the signer of
         /// <paramref name="encoded"/> is invalid.</exception>
         Message Decode(

--- a/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/Libplanet.Net/Messages/IMessageCodec.cs
@@ -10,14 +10,16 @@ namespace Libplanet.Net.Messages
         /// Encodes the message to <see typeref="T"/>-typed instance with given
         /// <paramref name="privateKey"/> and <paramref name="peer"/>.
         /// </summary>
-        /// <param name="message">A message to encode.</param>
-        /// <param name="privateKey">The <see cref="PrivateKey"/> to sign
-        /// <paramref name="message"/> with.  This should be a matching <see cref="PrivateKey"/>
-        /// for the <see cref="PublicKey"/> of <paramref name="peer"/>.</param>
-        /// <param name="peer"><see cref="Peer"/>-typed representation of the
-        /// sender's transport layer.
+        /// <param name="message">The message to encode.</param>
+        /// <param name="privateKey">The <see cref="PrivateKey"/> to sign the encoded message.
+        /// </param>
+        /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> of
+        /// the transport layer.</param>
+        /// <param name="peer">The <see cref="Peer"/>-typed representation of
+        /// the transport layer.
         /// <seealso cref="ITransport.AsPeer"/></param>
-        /// <param name="timestamp">The <see cref="DateTimeOffset"/> of the message is created.
+        /// <param name="timestamp">The <see cref="DateTimeOffset"/> of the time
+        /// <paramref name="message"/> is encoded.
         /// </param>
         /// <returns>A <see typeref="T"/> containing the signed <see cref="Message"/>.
         /// </returns>
@@ -26,6 +28,7 @@ namespace Libplanet.Net.Messages
         T Encode(
             Message message,
             PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
             Peer peer,
             DateTimeOffset timestamp);
 

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -111,6 +111,10 @@ namespace Libplanet.Net.Messages
         /// If <see cref="Message.Version"/> of <paramref name="message"/> is not valid but
         /// is signed by a trusted signer, then <see cref="DifferentApvEncountered"/> is called.
         /// </remarks>
+        /// <exception cref="DifferentAppProtocolVersionException">Thrown when
+        /// local version does not match with given <paramref name="message"/>'s
+        /// <see cref="Message.Version"/>.
+        /// </exception>
         /// <seealso cref="Apv"/>
         /// <seealso cref="TrustedApvSigners"/>
         /// <seealso cref="DifferentApvEncountered"/>
@@ -138,6 +142,8 @@ namespace Libplanet.Net.Messages
         /// </summary>
         /// <param name="message">The <see cref="Message"/> to validate.</param>
         /// <param name="timestamp">Current timestamp.</param>
+        /// <exception cref="InvalidMessageTimestampException">Thrown when the timestamp of
+        /// <paramref name="message"/> is invalid.</exception>
         /// <seealso cref="MessageTimestampBuffer"/>.
         public void ValidateTimestamp(Message message, DateTimeOffset timestamp)
         {

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -141,18 +141,17 @@ namespace Libplanet.Net.Messages
         /// Validates a <see cref="DateTimeOffset"/> timestamp against current timestamp.
         /// </summary>
         /// <param name="message">The <see cref="Message"/> to validate.</param>
-        /// <param name="timestamp">Current timestamp.</param>
         /// <exception cref="InvalidMessageTimestampException">Thrown when the timestamp of
         /// <paramref name="message"/> is invalid.</exception>
         /// <seealso cref="MessageTimestampBuffer"/>.
-        public void ValidateTimestamp(Message message, DateTimeOffset timestamp)
+        public void ValidateTimestamp(Message message)
         {
             if (message.Remote is { } peer)
             {
                 ValidateTimestampTemplate(
                     MessageTimestampBuffer,
                     peer,
-                    timestamp,
+                    DateTimeOffset.UtcNow,
                     message.Timestamp);
             }
             else

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -106,50 +106,57 @@ namespace Libplanet.Net.Messages
         /// considered invalid and an <see cref="DifferentAppProtocolVersionException"/> will be
         /// thrown.
         /// </summary>
-        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
-        /// with <paramref name="peerAppProtocolVersion"/>.</param>
-        /// <param name="identity">The <see cref="Message.Identity"/> attached to the
-        /// <see cref="Message"/> with <paramref name="peerAppProtocolVersion"/>.</param>
-        /// <param name="peerAppProtocolVersion">The <see cref="AppProtocolVersion"/> to validate.
-        /// </param>
-        /// <exception cref="DifferentAppProtocolVersionException">Thrown when
-        /// <paramref name="peerAppProtocolVersion"/> is different from <see cref="Apv"/>.
-        /// </exception>
+        /// <param name="message">The <see cref="Message"/> to validate.</param>
         /// <remarks>
-        /// If <paramref name="peerAppProtocolVersion"/> is not valid but is signed by
-        /// a trusted signer, then <see cref="DifferentApvEncountered"/> is called.
+        /// If <see cref="Message.Version"/> of <paramref name="message"/> is not valid but
+        /// is signed by a trusted signer, then <see cref="DifferentApvEncountered"/> is called.
         /// </remarks>
         /// <seealso cref="Apv"/>
         /// <seealso cref="TrustedApvSigners"/>
         /// <seealso cref="DifferentApvEncountered"/>
-        public void ValidateAppProtocolVersion(
-            Peer peer, byte[] identity, AppProtocolVersion peerAppProtocolVersion) =>
-            ValidateAppProtocolVersionTemplate(
-                Apv,
-                TrustedApvSigners,
-                DifferentApvEncountered,
-                peer,
-                identity,
-                peerAppProtocolVersion);
+        public void ValidateAppProtocolVersion(Message message)
+        {
+            if (message.Remote is { } peer)
+            {
+                ValidateAppProtocolVersion(
+                    Apv,
+                    TrustedApvSigners,
+                    DifferentApvEncountered,
+                    peer,
+                    message.Identity ?? new byte[] { },
+                    message.Version);
+            }
+            else
+            {
+                throw new NullReferenceException(
+                    $"Property {nameof(message.Remote)} of {nameof(message)} cannot be null.");
+            }
+        }
 
         /// <summary>
         /// Validates a <see cref="DateTimeOffset"/> timestamp against current timestamp.
         /// </summary>
-        /// <param name="peer">The <see cref="Peer"/> that has sent the <see cref="Message"/>
-        /// with <paramref name="messageTimestamp"/>.</param>
-        /// <param name="currentTimestamp">Current timestamp.</param>
-        /// <param name="messageTimestamp">The <see cref="Message.Timestamp"/> of
-        /// the <see cref="Message"/> in question.</param>
+        /// <param name="message">The <see cref="Message"/> to validate.</param>
+        /// <param name="timestamp">Current timestamp.</param>
         /// <seealso cref="MessageTimestampBuffer"/>.
-        public void ValidateTimestamp(
-            Peer peer, DateTimeOffset currentTimestamp, DateTimeOffset messageTimestamp) =>
-            ValidateTimestampTemplate(
-                MessageTimestampBuffer,
-                peer,
-                currentTimestamp,
-                messageTimestamp);
+        public void ValidateTimestamp(Message message, DateTimeOffset timestamp)
+        {
+            if (message.Remote is { } peer)
+            {
+                ValidateTimestampTemplate(
+                    MessageTimestampBuffer,
+                    peer,
+                    timestamp,
+                    message.Timestamp);
+            }
+            else
+            {
+                throw new NullReferenceException(
+                    $"Property {nameof(message.Remote)} of {nameof(message)} cannot be null.");
+            }
+        }
 
-        private static void ValidateAppProtocolVersionTemplate(
+        private static void ValidateAppProtocolVersion(
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
             DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -117,17 +117,11 @@ namespace Libplanet.Net.Messages
                 remotePeer = new Peer(dictionary);
             }
 
-            _messageValidator.ValidateAppProtocolVersion(
-                remotePeer,
-                reply ? new byte[] { } : encoded[0].ToByteArray(),
-                remoteVersion);
-
             var type =
                 (Message.MessageType)remains[(int)Message.MessageFrame.Type].ConvertToInt32();
             var ticks = remains[(int)Message.MessageFrame.Timestamp].ConvertToInt64();
             var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
             var currentTime = DateTimeOffset.UtcNow;
-            _messageValidator.ValidateTimestamp(remotePeer, currentTime, timestamp);
 
             byte[] signature = remains[(int)Message.MessageFrame.Sign].ToByteArray();
 
@@ -165,6 +159,8 @@ namespace Libplanet.Net.Messages
                 message.Identity = encoded[0].Buffer.ToArray();
             }
 
+            _messageValidator.ValidateAppProtocolVersion(message);
+            _messageValidator.ValidateTimestamp(message, currentTime);
             return message;
         }
 

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -45,6 +45,7 @@ namespace Libplanet.Net.Messages
         public NetMQMessage Encode(
             Message message,
             PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
             Peer peer,
             DateTimeOffset timestamp)
         {
@@ -70,7 +71,7 @@ namespace Libplanet.Net.Messages
             netMqMessage.Push(timestamp.Ticks);
             netMqMessage.Push(_codec.Encode(peer.ToBencodex()));
             netMqMessage.Push((int)message.Type);
-            netMqMessage.Push(_messageValidator.Apv.Token);
+            netMqMessage.Push(appProtocolVersion.Token);
 
             // Make and insert signature
             byte[] signature = privateKey.Sign(netMqMessage.ToByteArray());

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -159,8 +159,6 @@ namespace Libplanet.Net.Messages
                 message.Identity = encoded[0].Buffer.ToArray();
             }
 
-            _messageValidator.ValidateAppProtocolVersion(message);
-            _messageValidator.ValidateTimestamp(message, currentTime);
             return message;
         }
 

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Bencodex;
 using Libplanet.Crypto;
@@ -13,32 +12,13 @@ namespace Libplanet.Net.Messages
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         private readonly Codec _codec;
-        private readonly MessageValidator _messageValidator;
 
         /// <summary>
         /// Creates a <see cref="NetMQMessageCodec"/> instance.
         /// </summary>
-        /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> to use
-        /// when encoding and decoding.</param>
-        /// <param name="trustedAppProtocolVersionSigners">The set of signers to trust when
-        /// decoding a message.</param>
-        /// <param name="differentAppProtocolVersionEncountered">A callback method that gets
-        /// invoked when an <see cref="AppProtocolVersion"/> by a <em>trusted</em> signer that is
-        /// different from <paramref name="appProtocolVersion"/> is encountered.</param>
-        /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
-        /// when decoding <see cref="Message"/>s.</param>
-        public NetMQMessageCodec(
-            AppProtocolVersion appProtocolVersion = default,
-            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners = null,
-            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered = null,
-            TimeSpan? messageTimestampBuffer = null)
+        public NetMQMessageCodec()
         {
             _codec = new Codec();
-            _messageValidator = new MessageValidator(
-                appProtocolVersion,
-                trustedAppProtocolVersionSigners,
-                differentAppProtocolVersionEncountered,
-                messageTimestampBuffer);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -14,32 +13,13 @@ namespace Libplanet.Net.Messages
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         private readonly Codec _codec;
-        private readonly MessageValidator _messageValidator;
 
         /// <summary>
         /// Creates a <see cref="TcpMessageCodec"/> instance.
         /// </summary>
-        /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> to use
-        /// when encoding and decoding.</param>
-        /// <param name="trustedAppProtocolVersionSigners">The set of signers to trust when
-        /// decoding a message.</param>
-        /// <param name="differentAppProtocolVersionEncountered">A callback method that gets
-        /// invoked when an <see cref="AppProtocolVersion"/> by a <em>trusted</em> signer that is
-        /// different from <paramref name="appProtocolVersion"/> is encountered.</param>
-        /// <param name="messageTimestampBuffer">A <see cref="TimeSpan"/> to use as a buffer
-        /// when decoding <see cref="Message"/>s.</param>
-        public TcpMessageCodec(
-            AppProtocolVersion appProtocolVersion = default,
-            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners = null,
-            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered = null,
-            TimeSpan? messageTimestampBuffer = null)
+        public TcpMessageCodec()
         {
             _codec = new Codec();
-            _messageValidator = new MessageValidator(
-                appProtocolVersion,
-                trustedAppProtocolVersionSigners,
-                differentAppProtocolVersionEncountered,
-                messageTimestampBuffer);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -182,8 +182,6 @@ namespace Libplanet.Net.Messages
                 message.Identity = frames[0];
             }
 
-            _messageValidator.ValidateAppProtocolVersion(message);
-            _messageValidator.ValidateTimestamp(message, currentTime);
             return message;
         }
 

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -46,6 +46,7 @@ namespace Libplanet.Net.Messages
         public byte[] Encode(
             Message message,
             PrivateKey privateKey,
+            AppProtocolVersion appProtocolVersion,
             Peer peer,
             DateTimeOffset timestamp)
         {
@@ -71,7 +72,7 @@ namespace Libplanet.Net.Messages
             frames.Insert(0, BitConverter.GetBytes(timestamp.Ticks));
             frames.Insert(0, _codec.Encode(peer.ToBencodex()));
             frames.Insert(0, BitConverter.GetBytes((int)message.Type));
-            frames.Insert(0, Encoding.ASCII.GetBytes(_messageValidator.Apv.Token));
+            frames.Insert(0, Encoding.ASCII.GetBytes(appProtocolVersion.Token));
 
             // Make and insert signature
             byte[] signature = privateKey.Sign(

--- a/Libplanet.Net/Messages/TcpMessageCodec.cs
+++ b/Libplanet.Net/Messages/TcpMessageCodec.cs
@@ -106,10 +106,10 @@ namespace Libplanet.Net.Messages
             }
 
             using var stream = new MemoryStream(encoded);
-            var buffer = new byte[sizeof(int)];
+            byte[] buffer = new byte[sizeof(int)];
             stream.Read(buffer, 0, sizeof(int));
             int frameCount = BitConverter.ToInt32(buffer, 0);
-            var frames = new List<byte[]>();
+            List<byte[]> frames = new List<byte[]>();
             for (var i = 0; i < frameCount; i++)
             {
                 buffer = new byte[sizeof(int)];
@@ -139,11 +139,6 @@ namespace Libplanet.Net.Messages
                 remotePeer = new Peer(dictionary);
             }
 
-            _messageValidator.ValidateAppProtocolVersion(
-                remotePeer,
-                reply ? new byte[] { } : frames[0],
-                remoteVersion);
-
             var type =
                 (Message.MessageType)BitConverter.ToInt32(
                     remains[(int)Message.MessageFrame.Type],
@@ -151,7 +146,6 @@ namespace Libplanet.Net.Messages
             long ticks = BitConverter.ToInt64(remains[(int)Message.MessageFrame.Timestamp], 0);
             var timestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
             var currentTime = DateTimeOffset.UtcNow;
-            _messageValidator.ValidateTimestamp(remotePeer, currentTime, timestamp);
 
             byte[] signature = remains[(int)Message.MessageFrame.Sign];
 
@@ -188,6 +182,8 @@ namespace Libplanet.Net.Messages
                 message.Identity = frames[0];
             }
 
+            _messageValidator.ValidateAppProtocolVersion(message);
+            _messageValidator.ValidateTimestamp(message, currentTime);
             return message;
         }
 

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -440,6 +440,12 @@ namespace Libplanet.Net.Protocols
 
                 AddPeer(peer);
             }
+            catch (MessageSendFailedException)
+            {
+                throw new PingTimeoutException(
+                    peer,
+                    $"Failed to send Ping to {peer}.");
+            }
             catch (TimeoutException)
             {
                 throw new PingTimeoutException(

--- a/Libplanet.Net/Transports/BoundPeerExtensions.cs
+++ b/Libplanet.Net/Transports/BoundPeerExtensions.cs
@@ -36,6 +36,7 @@ namespace Libplanet.Net.Transports
             NetMQMessage request = netMQMessageCodec.Encode(
                 ping,
                 privateKey,
+                default,
                 new Peer(privateKey.PublicKey),
                 DateTimeOffset.UtcNow);
 
@@ -100,6 +101,7 @@ namespace Libplanet.Net.Transports
             byte[] serialized = messageCodec.Encode(
                 ping,
                 privateKey,
+                default,
                 new Peer(privateKey.PublicKey),
                 DateTimeOffset.UtcNow);
             int length = serialized.Length;

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -381,30 +381,6 @@ namespace Libplanet.Net.Transports
                     return new Message[0];
                 }
             }
-            catch (DifferentAppProtocolVersionException dapve)
-            {
-                const string errMsg =
-                    "{Peer} sent a reply to {Message} {RequestId} " +
-                    "with a different app protocol version.";
-                _logger.Error(dapve, errMsg, message, peer, reqId);
-                throw;
-            }
-            catch (InvalidMessageTimestampException imte)
-            {
-                const string errMsg =
-                    "{Peer} sent a reply to {Message} {RequestId} with a stale timestamp.";
-                _logger.Error(imte, errMsg, message, peer, reqId);
-                throw;
-            }
-            catch (TimeoutException toe)
-            {
-                const string dbgMsg =
-                    "{FName}() timed out after {Timeout} while waiting for a reply to " +
-                    "{Message} {RequestId} from {Peer}.";
-                _logger.Debug(
-                    toe, dbgMsg, nameof(SendMessageAsync), timeout, message, reqId, peer);
-                throw;
-            }
             catch (TaskCanceledException tce)
             {
                 const string dbgMsg =
@@ -412,6 +388,19 @@ namespace Libplanet.Net.Transports
                     "{Message} {RequestId} from {Peer}.";
                 _logger.Debug(
                     tce, dbgMsg, nameof(SendMessageAsync), message, reqId, peer);
+                throw;
+            }
+            catch (Exception e) when (
+                e is MessageSendFailedException ||
+                e is InvalidMessageSignatureException ||
+                e is InvalidMessageTimestampException ||
+                e is DifferentAppProtocolVersionException ||
+                e is TimeoutException)
+            {
+                const string errMsg =
+                    "Failed to send and receive replies from {Peer} for request " +
+                    "{Message} {RequestId}.";
+                _logger.Error(e, errMsg, peer, message, reqId);
                 throw;
             }
             catch (Exception e)
@@ -523,8 +512,34 @@ namespace Libplanet.Net.Transports
                         message,
                         message.Remote);
                 _logger.Debug("Received peer is boundpeer? {0}", message.Remote is BoundPeer);
-                _messageValidator.ValidateTimestamp(message);
-                _messageValidator.ValidateAppProtocolVersion(message);
+                try
+                {
+                    _messageValidator.ValidateTimestamp(message);
+                    _messageValidator.ValidateAppProtocolVersion(message);
+                }
+                catch (InvalidMessageTimestampException imte)
+                {
+                    _logger.Debug(
+                        imte,
+                        "Received request {Message} from {Peer} has an invalid timestamp.",
+                        message,
+                        message.Remote);
+                    return;
+                }
+                catch (DifferentAppProtocolVersionException dapve)
+                {
+                    _logger.Debug(
+                        dapve,
+                        "Received request {Message} from {Peer} has an invalid APV.",
+                        message,
+                        message.Remote);
+                    var differentVersion = new DifferentVersion() { Identity = dapve.Identity };
+                    _logger.Debug(
+                        "Replying to {Peer} with {Reply}.",
+                        differentVersion);
+                    _ = ReplyMessageAsync(differentVersion, _runtimeCancellationTokenSource.Token);
+                    return;
+                }
 
                 LastMessageTimestamp = DateTimeOffset.UtcNow;
 
@@ -542,22 +557,6 @@ namespace Libplanet.Net.Transports
                         throw;
                     }
                 });
-            }
-            catch (DifferentAppProtocolVersionException dapve)
-            {
-                _logger.Debug("Message from peer with a different version received.");
-                var differentVersion = new DifferentVersion()
-                {
-                    Identity = dapve.Identity,
-                };
-                _ = ReplyMessageAsync(differentVersion, _runtimeCancellationTokenSource.Token);
-            }
-            catch (InvalidMessageTimestampException imte)
-            {
-                const string logMsg =
-                    "Received message has an invalid timestamp: " +
-                    "(timestamp: {Timestamp}, buffer: {Buffer}, current: {Current})";
-                _logger.Debug(logMsg, imte.CreatedOffset, imte.Buffer, imte.CurrentOffset);
             }
             catch (InvalidMessageException ex)
             {
@@ -732,7 +731,7 @@ namespace Libplanet.Net.Transports
                         req.Peer);
 
                     throw new MessageSendFailedException(
-                        $"{nameof(DealerSocket)} failed to accept {req.Message}",
+                        $"Failed to send {req.Message} to {req.Peer}.",
                         req.Message.Type,
                         req.Peer);
                 }
@@ -758,8 +757,39 @@ namespace Libplanet.Net.Transports
                             req.Id,
                             reply.Remote,
                             reply);
-                        _messageValidator.ValidateTimestamp(reply);
-                        _messageValidator.ValidateAppProtocolVersion(reply);
+                        try
+                        {
+                            _messageValidator.ValidateTimestamp(reply);
+                            _messageValidator.ValidateAppProtocolVersion(reply);
+                        }
+                        catch (InvalidMessageTimestampException imte)
+                        {
+                            const string dbgMsg =
+                                "Received reply {Reply} from {Peer} to request {Message} " +
+                                "{RequestId} has an invalid timestamp.";
+                            _logger.Debug(
+                                imte,
+                                dbgMsg,
+                                reply,
+                                reply.Remote,
+                                message,
+                                req.Id);
+                            throw;
+                        }
+                        catch (DifferentAppProtocolVersionException dapve)
+                        {
+                            const string dbgMsg =
+                                "Received reply {Reply} from {Peer} to request {Message} " +
+                                "{RequestId} has an invalid APV.";
+                            _logger.Debug(
+                                dapve,
+                                dbgMsg,
+                                reply,
+                                reply.Remote,
+                                message,
+                                req.Id);
+                            throw;
+                        }
 
                         result.Add(reply);
                     }
@@ -788,10 +818,10 @@ namespace Libplanet.Net.Transports
                 tcs.TrySetResult(result);
             }
             catch (Exception e) when (
-                e is DifferentAppProtocolVersionException ||
-                e is InvalidMessageTimestampException ||
-                e is InvalidMessageSignatureException ||
                 e is MessageSendFailedException ||
+                e is InvalidMessageSignatureException ||
+                e is InvalidMessageTimestampException ||
+                e is DifferentAppProtocolVersionException ||
                 e is TimeoutException)
             {
                 tcs.TrySetException(e);

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -533,7 +533,7 @@ namespace Libplanet.Net.Transports
                         "Received request {Message} from {Peer} has an invalid APV.",
                         message,
                         message.Remote);
-                    var differentVersion = new DifferentVersion() { Identity = dapve.Identity };
+                    var differentVersion = new DifferentVersion() { Identity = message.Identity };
                     _logger.Debug(
                         "Replying to {Peer} with {Reply}.",
                         differentVersion);

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -27,6 +27,7 @@ namespace Libplanet.Net.Transports
         private readonly string _host;
         private readonly IList<IceServer> _iceServers;
         private readonly ILogger _logger;
+        private readonly AppProtocolVersion _appProtocolVersion;
         private readonly NetMQMessageCodec _messageCodec;
 
         private NetMQQueue<Message> _replyQueue;
@@ -118,6 +119,7 @@ namespace Libplanet.Net.Transports
             _host = host;
             _iceServers = iceServers?.ToList();
             _listenPort = listenPort ?? 0;
+            _appProtocolVersion = appProtocolVersion;
             _messageCodec = new NetMQMessageCodec(
                 appProtocolVersion,
                 trustedAppProtocolVersionSigners,
@@ -576,6 +578,7 @@ namespace Libplanet.Net.Transports
             NetMQMessage netMqMessage = _messageCodec.Encode(
                             message,
                             _privateKey,
+                            _appProtocolVersion,
                             AsPeer,
                             DateTimeOffset.UtcNow);
 
@@ -700,6 +703,7 @@ namespace Libplanet.Net.Transports
             var message = _messageCodec.Encode(
                 req.Message,
                 _privateKey,
+                _appProtocolVersion,
                 AsPeer,
                 DateTimeOffset.UtcNow);
             var result = new List<Message>();

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -684,7 +684,7 @@ namespace Libplanet.Net.Transports
                         "Received request {Message} from {Peer} has an invalid APV.",
                         message,
                         message.Remote);
-                    var differentVersion = new DifferentVersion() { Identity = dapve.Identity };
+                    var differentVersion = new DifferentVersion() { Identity = message.Identity };
                     _logger.Debug(
                         "Replying to {Peer} with {Reply}.",
                         differentVersion);

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -35,6 +35,7 @@ namespace Libplanet.Net.Transports
 
         private readonly IList<IceServer>? _iceServers;
         private readonly ILogger _logger;
+        private readonly AppProtocolVersion _appProtocolVersion;
         private readonly TcpMessageCodec _messageCodec;
 
         private readonly ConcurrentDictionary<Guid, ReplyStream> _streams;
@@ -76,6 +77,7 @@ namespace Libplanet.Net.Transports
             _privateKey = privateKey;
             _host = host;
             _iceServers = iceServers.ToList();
+            _appProtocolVersion = appProtocolVersion;
             _messageCodec = new TcpMessageCodec(
                 appProtocolVersion,
                 trustedAppProtocolVersionSigners,
@@ -490,6 +492,7 @@ namespace Libplanet.Net.Transports
             byte[] serialized = _messageCodec.Encode(
                 message,
                 _privateKey,
+                _appProtocolVersion,
                 AsPeer,
                 DateTimeOffset.UtcNow);
             int length = serialized.Length;

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -84,11 +84,7 @@ namespace Libplanet.Net.Transports
                 trustedAppProtocolVersionSigners,
                 differentAppProtocolVersionEncountered,
                 messageTimestampBuffer);
-            _messageCodec = new TcpMessageCodec(
-                appProtocolVersion,
-                trustedAppProtocolVersionSigners,
-                differentAppProtocolVersionEncountered,
-                messageTimestampBuffer);
+            _messageCodec = new TcpMessageCodec();
             _streams = new ConcurrentDictionary<Guid, ReplyStream>();
             _runtimeCancellationTokenSource = new CancellationTokenSource();
             _turnCancellationTokenSource = new CancellationTokenSource();
@@ -596,12 +592,12 @@ namespace Libplanet.Net.Transports
             _logger.Verbose("Received {Bytes} bytes from network stream.", content.Count);
 
             Message message = _messageCodec.Decode(content.ToArray(), false);
-            _messageValidator.ValidateTimestamp(message, DateTimeOffset.UtcNow);
-            _messageValidator.ValidateAppProtocolVersion(message);
-
             _logger.Verbose(
                 "ReadMessageAsync success. Received message {Message} from network stream.",
                 message);
+            _messageValidator.ValidateTimestamp(message);
+            _messageValidator.ValidateAppProtocolVersion(message);
+
             return message;
         }
 

--- a/Libplanet.Net/Transports/TcpTransport.cs
+++ b/Libplanet.Net/Transports/TcpTransport.cs
@@ -259,18 +259,28 @@ namespace Libplanet.Net.Transports
             var client = new TcpClient { LingerState = new LingerOption(true, 1) };
             try
             {
-                await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
-                _logger.Verbose(
-                    "SendMessageAsync client: {EndPoint}",
-                    (IPEndPoint)client.Client.LocalEndPoint);
-                client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
-                await WriteMessageAsync(message, client, linkedTokenSource.Token);
-                _logger.Verbose(
-                    "Successfully sent request {RequestId} to {Peer}: {Message}.",
-                    reqId,
-                    peer,
-                    message
-                );
+                try
+                {
+                    await client.ConnectAsync(peer.EndPoint.Host, peer.EndPoint.Port);
+                    _logger.Verbose(
+                        "SendMessageAsync client: {EndPoint}",
+                        (IPEndPoint)client.Client.LocalEndPoint);
+                    client.ReceiveTimeout = timeout?.Milliseconds ?? 0;
+                    await WriteMessageAsync(message, client, linkedTokenSource.Token);
+                    _logger.Verbose(
+                        "Successfully sent request {RequestId} to {Peer}: {Message}.",
+                        reqId,
+                        peer,
+                        message);
+                }
+                catch (Exception e) when (e is ArgumentException || e is SocketException)
+                {
+                    // ArgumentException is thrown on .NET framework and
+                    // SocketException is thrown on .Net core when the given peer is invalid.
+                    // To match with NetMQTransport implementation, convert to TimeoutException
+                    // when failed to find the peer to send message.
+                    throw new TimeoutException($"Failed to send {message} {reqId} to {peer}.");
+                }
 
                 var replies = new List<Message>();
                 using var timeoutCts = new CancellationTokenSource();
@@ -288,14 +298,47 @@ namespace Libplanet.Net.Transports
                 {
                     try
                     {
-                        Message received = await ReadMessageAsync(
-                            client,
-                            timeoutTokenSource.Token);
+                        Message reply = await ReadMessageAsync(client, timeoutTokenSource.Token);
                         _logger.Verbose(
                             "Received message was {Message}. Total: {Count}",
-                            received,
+                            reply,
                             replies.Count);
-                        replies.Add(received);
+
+                        try
+                        {
+                            _messageValidator.ValidateTimestamp(reply);
+                            _messageValidator.ValidateAppProtocolVersion(reply);
+                        }
+                        catch (InvalidMessageTimestampException imte)
+                        {
+                            const string dbgMsg =
+                                "Received reply {Reply} from {Peer} to request {Message} " +
+                                "{RequestId} has an invalid timestamp.";
+                            _logger.Debug(
+                                imte,
+                                dbgMsg,
+                                reply,
+                                reply.Remote,
+                                message,
+                                reqId);
+                            throw;
+                        }
+                        catch (DifferentAppProtocolVersionException dapve)
+                        {
+                            const string dbgMsg =
+                                "Received reply {Reply} from {Peer} to request {Message} " +
+                                "{RequestId} has an invalid APV.";
+                            _logger.Debug(
+                                dapve,
+                                dbgMsg,
+                                reply,
+                                reply.Remote,
+                                message,
+                                reqId);
+                            throw;
+                        }
+
+                        replies.Add(reply);
                         expectedResponses--;
                     }
                     catch (TaskCanceledException)
@@ -317,7 +360,8 @@ namespace Libplanet.Net.Transports
                                 break;
                             }
 
-                            throw new TimeoutException();
+                            throw new TimeoutException(
+                                $"The operation was canceled due to timeout {timeout}.");
                         }
 
                         throw;
@@ -334,47 +378,17 @@ namespace Libplanet.Net.Transports
 
                 return replies;
             }
-            catch (DifferentAppProtocolVersionException e)
+            catch (Exception e) when (
+                e is InvalidMagicCookieException ||
+                e is InvalidMessageSignatureException ||
+                e is InvalidMessageTimestampException ||
+                e is DifferentAppProtocolVersionException ||
+                e is TimeoutException)
             {
-                _logger.Error(
-                    e,
-                    "{Peer} sent a reply to {RequestId} with a different app protocol version.",
-                    peer,
-                    reqId);
-                throw;
-            }
-            catch (ArgumentException e)
-            {
-                // This exception is thrown on .NET framework when the given peer is invalid.
-                _logger.Error(
-                    e,
-                    "ArgumentException occurred during {FName} to {RequestId}.",
-                    nameof(SendMessageAsync),
-                    reqId);
-
-                // To match with previous implementation, throws TimeoutException when it failed to
-                // find peer to send message.
-                throw new TimeoutException($"Cannot find peer {peer}.", e);
-            }
-            catch (SocketException e)
-            {
-                // This exception is thrown on .NET core when the given peer is invalid.
-                _logger.Error(
-                    e,
-                    "SocketException occurred during {FName} to {Peer}.",
-                    nameof(SendMessageAsync),
-                    peer);
-
-                // To match with previous implementation, throws TimeoutException when it failed to
-                // find peer to send message.
-                throw new TimeoutException($"Cannot find peer {peer}.", e);
-            }
-            catch (InvalidMagicCookieException e)
-            {
-                _logger.Verbose(
-                    "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
-                    e.Expected,
-                    e.Actual);
+                const string errMsg =
+                    "Failed to send and receive replies from {Peer} for request " +
+                    "{Message} {RequestId}.";
+                _logger.Error(e, errMsg, peer, message, reqId);
                 throw;
             }
             finally
@@ -595,8 +609,6 @@ namespace Libplanet.Net.Transports
             _logger.Verbose(
                 "ReadMessageAsync success. Received message {Message} from network stream.",
                 message);
-            _messageValidator.ValidateTimestamp(message);
-            _messageValidator.ValidateAppProtocolVersion(message);
 
             return message;
         }
@@ -651,6 +663,35 @@ namespace Libplanet.Net.Transports
             {
                 _logger.Verbose("Trying to receive message");
                 Message message = await ReadMessageAsync(client, cancellationToken);
+                try
+                {
+                    _messageValidator.ValidateTimestamp(message);
+                    _messageValidator.ValidateAppProtocolVersion(message);
+                }
+                catch (InvalidMessageTimestampException imte)
+                {
+                    _logger.Debug(
+                        imte,
+                        "Received request {Message} from {Peer} has an invalid timestamp.",
+                        message,
+                        message.Remote);
+                    return;
+                }
+                catch (DifferentAppProtocolVersionException dapve)
+                {
+                    _logger.Debug(
+                        dapve,
+                        "Received request {Message} from {Peer} has an invalid APV.",
+                        message,
+                        message.Remote);
+                    var differentVersion = new DifferentVersion() { Identity = dapve.Identity };
+                    _logger.Debug(
+                        "Replying to {Peer} with {Reply}.",
+                        differentVersion);
+                    await WriteMessageAsync(differentVersion, client, cancellationToken);
+                    return;
+                }
+
                 LastMessageTimestamp = DateTimeOffset.UtcNow;
                 _logger.Debug(
                     "A message has parsed: {Message}, from {Remove}",
@@ -668,25 +709,17 @@ namespace Libplanet.Net.Transports
                 await TryAddStreamAsync(id, client, cancellationToken);
                 await ProcessMessageHandler.InvokeAsync(message);
             }
-            catch (DifferentAppProtocolVersionException dapve)
+            catch (IOException ioe)
             {
-                _logger.Debug("Message from peer with different version received.");
-                var differentVersion = new DifferentVersion
-                {
-                    Identity = dapve.Identity,
-                };
-                await WriteMessageAsync(differentVersion, client, cancellationToken);
+                _logger.Verbose(ioe, "Connection is lost.");
             }
-            catch (IOException)
-            {
-                _logger.Verbose("Connection is lost.");
-            }
-            catch (InvalidMagicCookieException e)
+            catch (InvalidMagicCookieException imce)
             {
                 _logger.Verbose(
+                    imce,
                     "Magic cookie mismatch, ignored. (Expected: {Expected}, Actual: {Actual})",
-                    e.Expected,
-                    e.Actual);
+                    imce.Expected,
+                    imce.Actual);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
More preparatory work for #1867.

Massive API overhaul is mainly to move `Message` validation logic from `IMessageCodec` to `ITransport` layer. Other than that, there is no noticeable behavioral change from `ITransport` and the layers above.