### PR TITLE
update action evaluation log [skip changelog]

### DIFF
--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -487,7 +487,7 @@ namespace Libplanet.Action
                         "with timestamp {TxTimestamp} evaluated in {DurationMs:F0}ms.",
                         tx.Actions.Count,
                         tx.Actions.Select(action => action.ToString()!.Split('.')
-                            .LastOrDefault()?.Replace(">", string.Empty)).FirstOrDefault(),
+                            .LastOrDefault()?.Replace(">", string.Empty)),
                         tx.Id,
                         tx.Signer,
                         tx.Timestamp.ToString(

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -479,13 +479,21 @@ namespace Libplanet.Action
                 // FIXME: This is dependant on when the returned value is enumerated.
                 TimeSpan evalDuration = DateTimeOffset.Now - startTime;
                 const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+                string? actionType = tx.Actions.FirstOrDefault()?.ToString()!.Replace(
+                        "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
+                        string.Empty)
+                    .Remove(tx.Actions.FirstOrDefault()?.ToString()!.Replace(
+                        "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
+                        string.Empty).Length - 1 ?? 0);
+
                 _logger
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "TxEvaluationDuration")
                     .Debug(
-                        "{ActionCount} actions in transaction {TxId} by {Signer} " +
+                        "{ActionCount} {ActionType} actions in transaction {TxId} by {Signer} " +
                         "with timestamp {TxTimestamp} evaluated in {DurationMs:F0}ms.",
                         tx.Actions.Count,
+                        actionType,
                         tx.Id,
                         tx.Signer,
                         tx.Timestamp.ToString(

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -483,10 +483,11 @@ namespace Libplanet.Action
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "TxEvaluationDuration")
                     .Debug(
-                        "{ActionCount} actions {ActionType} in transaction {TxId} by {Signer} " +
+                        "{ActionCount} actions {ActionTypes} in transaction {TxId} by {Signer} " +
                         "with timestamp {TxTimestamp} evaluated in {DurationMs:F0}ms.",
                         tx.Actions.Count,
-                        tx.Actions.FirstOrDefault(),
+                        tx.Actions.Select(action => action.ToString()!.Split('.')
+                            .LastOrDefault()?.Replace(">", string.Empty)).FirstOrDefault(),
                         tx.Id,
                         tx.Signer,
                         tx.Timestamp.ToString(

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -479,14 +479,6 @@ namespace Libplanet.Action
                 // FIXME: This is dependant on when the returned value is enumerated.
                 TimeSpan evalDuration = DateTimeOffset.Now - startTime;
                 const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-                string? actionType = tx.Actions.FirstOrDefault()?.ToString()!.Replace(
-                        "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
-                        string.Empty)
-                    .Remove(tx.Actions.FirstOrDefault()?.ToString()
-                        ?.Replace(
-                        "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
-                        string.Empty).Length - 1 ?? 0);
-
                 _logger
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "TxEvaluationDuration")
@@ -494,7 +486,7 @@ namespace Libplanet.Action
                         "{ActionCount} {ActionType} actions in transaction {TxId} by {Signer} " +
                         "with timestamp {TxTimestamp} evaluated in {DurationMs:F0}ms.",
                         tx.Actions.Count,
-                        actionType,
+                        tx.Actions.FirstOrDefault(),
                         tx.Id,
                         tx.Signer,
                         tx.Timestamp.ToString(

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -483,7 +483,7 @@ namespace Libplanet.Action
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "TxEvaluationDuration")
                     .Debug(
-                        "{ActionCount} {ActionType} actions in transaction {TxId} by {Signer} " +
+                        "{ActionCount} actions {ActionType} in transaction {TxId} by {Signer} " +
                         "with timestamp {TxTimestamp} evaluated in {DurationMs:F0}ms.",
                         tx.Actions.Count,
                         tx.Actions.FirstOrDefault(),

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -482,7 +482,8 @@ namespace Libplanet.Action
                 string? actionType = tx.Actions.FirstOrDefault()?.ToString()!.Replace(
                         "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
                         string.Empty)
-                    .Remove(tx.Actions.FirstOrDefault()?.ToString()!.Replace(
+                    .Remove(tx.Actions.FirstOrDefault()?.ToString()
+                        ?.Replace(
                         "Libplanet.Action.PolymorphicAction<Nekoyume.Action.",
                         string.Empty).Length - 1 ?? 0);
 


### PR DESCRIPTION
This PR adds the `actionType` in the action evaluation log so that you can check how long it takes for specific actions to be evaluated at a glance without needing to look up the `TxId` each time. Also, this will be helpful in visualizing the evaluation time for each action type through log parsing.

**Note)** Blank txs are logged as `null`.

Before:
```
[16:37:47 DBG] 1 actions in transaction 9156218e694d63397df1cc8be0641a28e117742b60bff9c39403678b5529a0ec by 0x625D3aF1b2D9f6D13fc91b7AF6dde41A3c72B2AC with timestamp 2022-04-12T07:29:53.666732Z evaluated in 143ms.
[16:37:48 DBG] 1 actions in transaction 38889b212dd058635b5d8a953114f2595ee0a05ccaab0d8b52af18143aee3bad by 0x5b8da5757E3de0D07AA2BB8Eb04ed0c45f0BD625 with timestamp 2022-04-12T07:29:37.680461Z evaluated in 156ms.
[16:37:48 DBG] 1 actions in transaction 5871877d9886f6619ffd9ba3077b94d71fa77ff70406b362acbe3ea0f065a901 by 0x59a97BAc819DEe2b68Ed625633b1D2cDfEF82691 with timestamp 2022-04-12T07:29:37.903797Z evaluated in 146ms.
[16:37:48 DBG] 1 actions in transaction 61e741b941e46d1535a188c5ba7cdcb32727850a4ebe152646e96c39a531fd1e by 0x54C8C21243967d925A2C6396fB68563e49F7D4E2 with timestamp 2022-04-12T07:30:05.560615Z evaluated in 64ms.
[16:37:48 DBG] 0 actions in transaction 744b0d265db81c3429e527b35816d52570190e696f9a74358c814bc17f921121 by 0x474CB59Dea21159CeFcC828b30a8D864e0b94a6B with timestamp 2022-04-12T07:30:09.513029Z evaluated in 0ms.
[16:37:48 DBG] 1 actions in transaction ba6d1cfc9d9e98c8f0e79b48bdbf4ffa0c885a51733b2a305db300319868e812 by 0x4656Ab4eEB7a22C7B9A7740c70551F7069f5F185 with timestamp 2022-04-12T07:29:45.870498Z evaluated in 66ms.
[16:37:48 DBG] 1 actions in transaction 8895d4c50e9678458380b81e1ffcb6b97dd0b9ebf02927ae2a52741938926f0d by 0x421A6064ABC1C03c00EdC8b1A7f488e45B9E0484 with timestamp 2022-04-12T07:29:43.687094Z evaluated in 126ms.
```

After:
```
[16:37:47 DBG] 1 HackAndSlash actions in transaction 9156218e694d63397df1cc8be0641a28e117742b60bff9c39403678b5529a0ec by 0x625D3aF1b2D9f6D13fc91b7AF6dde41A3c72B2AC with timestamp 2022-04-12T07:29:53.666732Z evaluated in 143ms.
[16:37:48 DBG] 1 HackAndSlash actions in transaction 38889b212dd058635b5d8a953114f2595ee0a05ccaab0d8b52af18143aee3bad by 0x5b8da5757E3de0D07AA2BB8Eb04ed0c45f0BD625 with timestamp 2022-04-12T07:29:37.680461Z evaluated in 156ms.
[16:37:48 DBG] 1 HackAndSlash actions in transaction 5871877d9886f6619ffd9ba3077b94d71fa77ff70406b362acbe3ea0f065a901 by 0x59a97BAc819DEe2b68Ed625633b1D2cDfEF82691 with timestamp 2022-04-12T07:29:37.903797Z evaluated in 146ms.
[16:37:48 DBG] 1 DailyReward actions in transaction 61e741b941e46d1535a188c5ba7cdcb32727850a4ebe152646e96c39a531fd1e by 0x54C8C21243967d925A2C6396fB68563e49F7D4E2 with timestamp 2022-04-12T07:30:05.560615Z evaluated in 64ms.
[16:37:48 DBG] 0 null actions in transaction 744b0d265db81c3429e527b35816d52570190e696f9a74358c814bc17f921121 by 0x474CB59Dea21159CeFcC828b30a8D864e0b94a6B with timestamp 2022-04-12T07:30:09.513029Z evaluated in 0ms.
[16:37:48 DBG] 1 ItemEnhancement actions in transaction ba6d1cfc9d9e98c8f0e79b48bdbf4ffa0c885a51733b2a305db300319868e812 by 0x4656Ab4eEB7a22C7B9A7740c70551F7069f5F185 with timestamp 2022-04-12T07:29:45.870498Z evaluated in 66ms.
[16:37:48 DBG] 1 HackAndSlash actions in transaction 8895d4c50e9678458380b81e1ffcb6b97dd0b9ebf02927ae2a52741938926f0d by 0x421A6064ABC1C03c00EdC8b1A7f488e45B9E0484 with timestamp 2022-04-12T07:29:43.687094Z evaluated in 126ms.
```