### PR TITLE
Improve `BlockCandidateTable<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,12 +32,18 @@ To be released.
 
 ### Behavioral changes
 
+ -  (Libplanet.Net) `BlockCandidateTable<T>` updated for reducing the chance
+    of dropping the possible longest chain while `ProcessBlockDemandAsync()`
+    and `PullBlocksAsync()` are in progress. [[#1892], [#1917]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+[#1892]: https://github.com/planetarium/libplanet/issues/1892
+[#1917]: https://github.com/planetarium/libplanet/pull/1917
 [#2024]: https://github.com/planetarium/libplanet/pull/2024
 
 

--- a/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
+++ b/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Net.Tests
 
             var branchBetweenB = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
-            var table = new BlockCandidateTable<DumbAction>();
+            var table = new BlockCandidateTable<DumbAction>(chainA.Policy.CanonicalChainComparer);
             table.Add(branchBetweenA);
             table.Add(branchBetweenB);
             CandidateBranch<DumbAction> bestBranch = table.BestBranch;
@@ -90,7 +90,7 @@ namespace Libplanet.Net.Tests
 
             var branch = new CandidateBranch<DumbAction>(blocksForBranch);
 
-            var table = new BlockCandidateTable<DumbAction>();
+            var table = new BlockCandidateTable<DumbAction>(chainB.Policy.CanonicalChainComparer);
             table.Add(branch);
 
             CandidateBranch<DumbAction> bestBranch = table.BestBranch;
@@ -98,9 +98,7 @@ namespace Libplanet.Net.Tests
             Assert.Equal(branch.Tip.Hash, bestBranch?.Tip.Hash);
             Assert.NotEqual(chainB.Tip.Hash, bestBranch?.Root.PreviousHash);
 
-            table.Update(
-                path,
-                block => block.TotalDifficulty > path.NewTip.TotalDifficulty);
+            table.Update(path);
             bestBranch = table.BestBranch;
 
             Assert.NotEqual(branch.Root.Hash, bestBranch?.Root.Hash);
@@ -132,8 +130,12 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = await miner.MineBlock(minerKey);
                 if (i < 5)
                 {
-                    blocksForPath.Add(block);
-                    chainB.Append(block);
+                    if (i < 4)
+                    {
+                        blocksForPath.Add(block);
+                        chainB.Append(block);
+                    }
+
                     branchBlocksBetweenB.Add(block);
                 }
 
@@ -147,7 +149,7 @@ namespace Libplanet.Net.Tests
 
             var branchB = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
-            var table = new BlockCandidateTable<DumbAction>();
+            var table = new BlockCandidateTable<DumbAction>(chainA.Policy.CanonicalChainComparer);
             table.Add(branchA);
             table.Add(branchB);
 
@@ -156,9 +158,7 @@ namespace Libplanet.Net.Tests
             Assert.Equal(branchA.Tip.Hash, bestBranch?.Tip.Hash);
             Assert.Equal(2, table.Count);
 
-            table.Update(
-                path,
-                block => block.TotalDifficulty > path.NewTip.TotalDifficulty);
+            table.Update(path);
             bestBranch = table.BestBranch;
 
             Assert.Equal(chainB.Tip.Hash, bestBranch?.Root.PreviousHash);
@@ -175,7 +175,7 @@ namespace Libplanet.Net.Tests
             var miner = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var branchBlocksBetweenB = new List<Block<DumbAction>>();
             var blocksForPath = new List<Block<DumbAction>>();
-            var table = new BlockCandidateTable<DumbAction>();
+            var table = new BlockCandidateTable<DumbAction>(miner.Policy.CanonicalChainComparer);
 
             Block<DumbAction> branchpoint = null;
 
@@ -237,9 +237,7 @@ namespace Libplanet.Net.Tests
             var branchBtoA = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
             table.Add(branchBtoA);
-            table.Update(
-                mergedAPath,
-                block => block.TotalDifficulty > chainA.Tip.TotalDifficulty);
+            table.Update(mergedAPath);
             CandidateBranch<DumbAction> bestBranch = table.BestBranch;
 
             Assert.Equal(chainB.Tip.Hash, bestBranch.Tip.Hash);

--- a/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
+++ b/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
@@ -46,17 +46,9 @@ namespace Libplanet.Net.Tests
                 branchBlocksBetweenA.Add(block);
             }
 
-            var branchBetweenA = new CandidateBranch<DumbAction>(
-                branchBlocksBetweenA,
-                branchBlocksBetweenA.First(),
-                branchBlocksBetweenA.Last()
-            );
+            var branchBetweenA = new CandidateBranch<DumbAction>(branchBlocksBetweenA);
 
-            var branchBetweenB = new CandidateBranch<DumbAction>(
-                branchBlocksBetweenB,
-                branchBlocksBetweenB.First(),
-                branchBlocksBetweenB.Last()
-            );
+            var branchBetweenB = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
             var table = new BlockCandidateTable<DumbAction>();
             table.Add(branchBetweenA);
@@ -94,17 +86,9 @@ namespace Libplanet.Net.Tests
                 blocksForBranch.Add(block);
             }
 
-            var path = new UpdatePath<DumbAction>(
-                blocksForPath,
-                blocksForPath.First(),
-                blocksForPath.First(),
-                blocksForPath.Last());
+            var path = new UpdatePath<DumbAction>(blocksForPath, blocksForPath.First());
 
-            var branch = new CandidateBranch<DumbAction>(
-                blocksForBranch,
-                blocksForBranch.First(),
-                blocksForBranch.Last()
-            );
+            var branch = new CandidateBranch<DumbAction>(blocksForBranch);
 
             var table = new BlockCandidateTable<DumbAction>();
             table.Add(branch);
@@ -157,23 +141,11 @@ namespace Libplanet.Net.Tests
                 branchBlocksBetweenA.Add(block);
             }
 
-            var path = new UpdatePath<DumbAction>(
-                blocksForPath,
-                blocksForPath.First(),
-                blocksForPath.First(),
-                blocksForPath.Last());
+            var path = new UpdatePath<DumbAction>(blocksForPath, blocksForPath.First());
 
-            var branchA = new CandidateBranch<DumbAction>(
-                branchBlocksBetweenA,
-                branchBlocksBetweenA.First(),
-                branchBlocksBetweenA.Last()
-            );
+            var branchA = new CandidateBranch<DumbAction>(branchBlocksBetweenA);
 
-            var branchB = new CandidateBranch<DumbAction>(
-                branchBlocksBetweenB,
-                branchBlocksBetweenB.First(),
-                branchBlocksBetweenB.Last()
-            );
+            var branchB = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
             var table = new BlockCandidateTable<DumbAction>();
             table.Add(branchA);
@@ -260,17 +232,9 @@ namespace Libplanet.Net.Tests
                 }
             }
 
-            var mergedAPath = new UpdatePath<DumbAction>(
-                blocksForPath,
-                oldTip,
-                branchpoint,
-                blocksForPath.Last());
+            var mergedAPath = new UpdatePath<DumbAction>(blocksForPath, oldTip);
 
-            var branchBtoA = new CandidateBranch<DumbAction>(
-                branchBlocksBetweenB,
-                branchBlocksBetweenB.First(),
-                branchBlocksBetweenB.Last()
-            );
+            var branchBtoA = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 
             table.Add(branchBtoA);
             table.Update(

--- a/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
+++ b/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
@@ -1,0 +1,69 @@
+#nullable disable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Xunit;
+
+using static Libplanet.Tests.TestUtils;
+
+namespace Libplanet.Net.Tests
+{
+    public partial class SwarmTest
+    {
+        [Fact(Timeout = Timeout)]
+        public async Task CanGetCorrectBestBranch()
+        {
+            var minerA = new PrivateKey();
+            var policy = new NullBlockPolicy<DumbAction>();
+            var fx = new MemoryStoreFixture(policy.BlockAction);
+            var chainA = MakeBlockChain(policy, fx.Store, fx.StateStore);
+            var branchBlocksBetweenA = new List<Block<DumbAction>>();
+            var branchBlocksBetweenB = new List<Block<DumbAction>>();
+
+            foreach (int i in Enumerable.Range(0, 10))
+            {
+                await chainA.MineBlock(minerA);
+            }
+
+            BlockChain<DumbAction> chainB = chainA.Fork(chainA.Tip.Hash);
+
+            foreach (int i in Enumerable.Range(0, 10))
+            {
+                Block<DumbAction> block = await chainA.MineBlock(minerA);
+                chainB.Append(block);
+                branchBlocksBetweenA.Add(block);
+                branchBlocksBetweenB.Add(block);
+            }
+
+            foreach (int i in Enumerable.Range(0, 10))
+            {
+                Block<DumbAction> block = await chainA.MineBlock(minerA);
+                branchBlocksBetweenA.Add(block);
+            }
+
+            var branchBetweenA = new CandidateBranch<DumbAction>(
+                branchBlocksBetweenA,
+                branchBlocksBetweenA.First(),
+                branchBlocksBetweenA.Last()
+            );
+
+            var branchBetweenB = new CandidateBranch<DumbAction>(
+                branchBlocksBetweenB,
+                branchBlocksBetweenB.First(),
+                branchBlocksBetweenB.Last()
+            );
+
+            var table = new BlockCandidateTable<DumbAction>();
+            table.Add(branchBetweenA);
+            table.Add(branchBetweenB);
+            CandidateBranch<DumbAction> bestBranch = table.BestBranch;
+            Assert.Equal(branchBetweenA, bestBranch);
+        }
+    }
+}

--- a/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
+++ b/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
@@ -87,7 +87,9 @@ namespace Libplanet.Net.Tests
                 blocksForBranch.Add(block);
             }
 
-            var path = new UpdatePath<DumbAction>(blocksForPath, blocksForPath.First());
+            var previousBranch = new CandidateBranch<DumbAction>(blocksForPath);
+
+            var path = new UpdatePath<DumbAction>(previousBranch, previousBranch.Root);
 
             var branch = new CandidateBranch<DumbAction>(blocksForBranch);
 
@@ -145,7 +147,9 @@ namespace Libplanet.Net.Tests
                 branchBlocksBetweenA.Add(block);
             }
 
-            var path = new UpdatePath<DumbAction>(blocksForPath, blocksForPath.First());
+            var previousBranch = new CandidateBranch<DumbAction>(blocksForPath);
+
+            var path = new UpdatePath<DumbAction>(previousBranch, previousBranch.Root);
 
             var branchA = new CandidateBranch<DumbAction>(branchBlocksBetweenA);
 
@@ -379,7 +383,9 @@ namespace Libplanet.Net.Tests
                 }
             }
 
-            var mergedAPath = new UpdatePath<DumbAction>(blocksForPath, oldTip);
+            var previousBranch = new CandidateBranch<DumbAction>(blocksForPath);
+
+            var mergedAPath = new UpdatePath<DumbAction>(previousBranch, oldTip);
 
             var branchBtoA = new CandidateBranch<DumbAction>(branchBlocksBetweenB);
 

--- a/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
+++ b/Libplanet.Net.Tests/SwarmTest.BlockSync.cs
@@ -309,14 +309,8 @@ namespace Libplanet.Net.Tests
 
             branchBlocksBetweenA.RemoveAt(5);
 
-            var branchA = new CandidateBranch<DumbAction>(branchBlocksBetweenA);
-
-            var table = new BlockCandidateTable<DumbAction>(chainA.Policy.CanonicalChainComparer);
-            table.Add(branchA, chainA.Tip);
-
-            CandidateBranch<DumbAction> bestBranch = table.BestBranch;
-            Assert.Null(bestBranch);
-            Assert.Equal(0, table.Count);
+            Assert.Throws<CreateCandidateBranchException>(
+                () => new CandidateBranch<DumbAction>(branchBlocksBetweenA));
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -92,13 +92,22 @@ namespace Libplanet.Net
                         continue;
                     }
 
-                    var newBlocks =
-                        branch.Blocks.ToList().FindAll(x => x.Index > path.NewTip.Index)
-                            .ToList();
-                    var newBranch = new CandidateBranch<T>(newBlocks);
+                    try
+                    {
+                        var newBlocks =
+                            branch.Blocks.ToList().FindAll(x => x.Index > path.NewTip.Index)
+                                .ToList();
+                        var newBranch = new CandidateBranch<T>(newBlocks);
 
-                    longestBranch ??= newBranch;
-                    longestBranch = CompareBranch(longestBranch, newBranch);
+                        longestBranch ??= newBranch;
+                        longestBranch = CompareBranch(longestBranch, newBranch);
+                    }
+                    catch (ArgumentNullException)
+                    {
+                        // FIXME: This has to be done to prevent stopping Update() by
+                        // exception thrown from FindAll().
+                        continue;
+                    }
                 }
             }
             else
@@ -120,7 +129,9 @@ namespace Libplanet.Net
                             index = path.Blocks.Single(x => x.Hash.Equals(index.PreviousHash));
                             newBlocks.Insert(0, index);
                         }
-                        catch (ArgumentNullException)
+                        catch (Exception e) when (
+                            e is ArgumentException ||
+                            e is InvalidOperationException)
                         {
                             break;
                         }

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -93,11 +93,9 @@ namespace Libplanet.Net
                     }
 
                     var newBlocks =
-                        branch.Blocks.FindAll(x => x.Index > path.NewTip.Index).ToList();
-                    var newBranch = new CandidateBranch<T>(
-                        newBlocks,
-                        newBlocks.First(),
-                        newBlocks.Last());
+                        branch.Blocks.ToList().FindAll(x => x.Index > path.NewTip.Index)
+                            .ToList();
+                    var newBranch = new CandidateBranch<T>(newBlocks);
 
                     longestBranch ??= newBranch;
                     longestBranch = CompareBranch(longestBranch, newBranch);
@@ -112,7 +110,7 @@ namespace Libplanet.Net
                         continue;
                     }
 
-                    var newBlocks = branch.Blocks;
+                    var newBlocks = branch.Blocks.ToList();
                     Block<T> index = branch.Root;
                     while (index.PreviousHash != null &&
                            path.Blocks.Contains(index))
@@ -128,15 +126,7 @@ namespace Libplanet.Net
                         }
                     }
 
-                    if (newBlocks.First().PreviousHash.Equals(path.OldTip.Hash))
-                    {
-                        newBlocks.Insert(0, path.BranchPoint);
-                    }
-
-                    var newBranch = new CandidateBranch<T>(
-                        newBlocks,
-                        newBlocks.First(),
-                        newBlocks.Last());
+                    var newBranch = new CandidateBranch<T>(newBlocks);
 
                     longestBranch ??= newBranch;
                     longestBranch = CompareBranch(longestBranch, newBranch);

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -33,10 +33,7 @@ namespace Libplanet.Net
         /// </summary>
         public CandidateBranch<T>? BestBranch { get; private set; }
 
-        public long Count
-        {
-            get => Branches.Count;
-        }
+        public long Count => Branches.Count;
 
         /// <summary>
         /// An <see cref="IEnumerable{T}"/> of
@@ -46,7 +43,7 @@ namespace Libplanet.Net
         private ConcurrentBag<CandidateBranch<T>> Branches { get; set; }
 
         /// <summary>
-        /// Adds an <see cref="CandidateBranch{T}"/> to <see cref="Branches"/>.
+        /// Adds a <see cref="CandidateBranch{T}"/> to <see cref="Branches"/>.
         /// </summary>
         /// <param name="branch">The <see cref="CandidateBranch{T}"/>
         /// to add to <see cref="Branches"/>.
@@ -61,7 +58,6 @@ namespace Libplanet.Net
                 return;
             }
 
-            // If BestBranch is not initialized, set incoming branch as BestBranch.
             if (BestBranch is null)
             {
                 if (AreBlocksContinuous(branch.Blocks))
@@ -73,7 +69,6 @@ namespace Libplanet.Net
                 return;
             }
 
-            // Check if branch has continuous blocks
             if (!AreBlocksContinuous(branch.Blocks))
             {
                 return;

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -60,17 +60,8 @@ namespace Libplanet.Net
 
             if (BestBranch is null)
             {
-                if (AreBlocksContinuous(branch.Blocks))
-                {
-                    BestBranch = branch;
-                    Branches.Add(branch);
-                }
-
-                return;
-            }
-
-            if (!AreBlocksContinuous(branch.Blocks))
-            {
+                BestBranch = branch;
+                Branches.Add(branch);
                 return;
             }
 
@@ -191,52 +182,12 @@ namespace Libplanet.Net
 
         public bool Any() => Branches.Any();
 
-        /// <summary>
-        /// Check every blocks are continuous by <see cref="Block{T}.PreviousHash"/>-wise each
-        /// other.
-        /// <remarks>
-        /// This method does not check whether branch is appendable to <see cref="BlockChain{T}"/>.
-        /// </remarks>
-        /// </summary>
-        /// <param name="branch">A series of <see cref="Block{T}"/>.
-        /// </param>
-        /// <returns>
-        /// returns true if <paramref name="branch"/> is continuous or its count is 1; returns false
-        /// if <paramref name="branch"/> is not continuous or its count is 0.
-        /// </returns>
-        private static bool AreBlocksContinuous(IEnumerable<Block<T>> branch)
-        {
-            var enumerable = branch as Block<T>[] ?? branch.ToArray();
-
-            if (!enumerable.Any())
-            {
-                return false;
-            }
-
-            if (enumerable.Count() == 1)
-            {
-                return true;
-            }
-
-            var precedingBlocks = enumerable.Skip(1);
-            foreach (var block in precedingBlocks)
-            {
-                if (!enumerable.Any(x => block.PreviousHash != null &&
-                                         x.Hash.Equals(block.PreviousHash.Value)))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         // FIXME: This method is duplicated with Swarm<T>.IsBlockNeeded()
         private bool IsBlockNeeded(IBlockExcerpt block, IBlockExcerpt tip) =>
             _canonicalChainComparer.Compare(block, tip) > 0;
 
         /// <summary>
-        /// Comparing two <see cref="CandidateBranch{T}"/>.
+        /// Comparing two <see cref="CandidateBranch{T}"/>s.
         /// </summary>
         /// <param name="source">
         /// a <see cref="CandidateBranch{T}"/> to be compared.

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -143,10 +143,14 @@ namespace Libplanet.Net
                         }
                     }
 
-                    var newBranch = new CandidateBranch<T>(newBlocks);
+                    if (newBlocks.First().Hash.Equals(path.OldTip.Hash) ||
+                        newBlocks.First().Hash.Equals(path.BranchPoint.Hash))
+                    {
+                        var newBranch = new CandidateBranch<T>(newBlocks);
 
-                    longestBranch ??= newBranch;
-                    longestBranch = CompareBranch(newBranch, longestBranch);
+                        longestBranch ??= newBranch;
+                        longestBranch = CompareBranch(newBranch, longestBranch);
+                    }
                 }
             }
 

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -99,7 +99,7 @@ namespace Libplanet.Net
         {
             lock (_lock)
             {
-                var newBag = new ConcurrentBag<CandidateBranch<T>>();
+                var newBranches = new List<CandidateBranch<T>>();
                 CandidateBranch<T>? longestBranch = null;
 
                 // if OldTip is equals to BranchPoint, means it is not reorg.
@@ -170,11 +170,11 @@ namespace Libplanet.Net
 
                 if (longestBranch is { })
                 {
-                    newBag.Add(longestBranch);
+                    newBranches.Add(longestBranch);
                     BestBranch = longestBranch;
                 }
 
-                Branches = newBag;
+                Branches = new ConcurrentBag<CandidateBranch<T>>(newBranches);
             }
         }
 

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -56,7 +56,29 @@ namespace Libplanet.Net
         /// </param>
         public void Add(CandidateBranch<T> branch, IBlockHeader currentTip)
         {
-            BestBranch ??= branch;
+            if (!IsBlockNeeded(branch.Tip, currentTip))
+            {
+                return;
+            }
+
+            // If BestBranch is not initialized, set incoming branch as BestBranch.
+            if (BestBranch is null)
+            {
+                if (AreBlocksContinuous(branch.Blocks))
+                {
+                    BestBranch = branch;
+                    Branches.Add(branch);
+                }
+
+                return;
+            }
+
+            // Check if branch has continuous blocks
+            if (!AreBlocksContinuous(branch.Blocks))
+            {
+                return;
+            }
+
             BestBranch = CompareBranch(BestBranch, branch);
 
             Branches.Add(branch);

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -74,7 +74,7 @@ namespace Libplanet.Net
                 return;
             }
 
-            BestBranch = CompareBranch(BestBranch, branch);
+            BestBranch = CompareSourceBranch(BestBranch, branch);
 
             Branches.Add(branch);
         }
@@ -123,7 +123,7 @@ namespace Libplanet.Net
                         var newBranch = new CandidateBranch<T>(newBlocks);
 
                         longestBranch ??= newBranch;
-                        longestBranch = CompareBranch(newBranch, longestBranch);
+                        longestBranch = CompareSourceBranch(longestBranch, newBranch);
                     }
                     catch (ArgumentNullException)
                     {
@@ -166,7 +166,7 @@ namespace Libplanet.Net
                         var newBranch = new CandidateBranch<T>(newBlocks);
 
                         longestBranch ??= newBranch;
-                        longestBranch = CompareBranch(newBranch, longestBranch);
+                        longestBranch = CompareSourceBranch(longestBranch, newBranch);
                     }
                 }
             }
@@ -235,9 +235,25 @@ namespace Libplanet.Net
         private bool IsBlockNeeded(IBlockExcerpt block, IBlockExcerpt tip) =>
             _canonicalChainComparer.Compare(block, tip) > 0;
 
-        private CandidateBranch<T> CompareBranch(
-            CandidateBranch<T> lf,
-            CandidateBranch<T> rf)
-            => _canonicalChainComparer.Compare(lf.Tip, rf.Tip) > 0 ? lf : rf;
+        /// <summary>
+        /// Comparing two <see cref="CandidateBranch{T}"/>.
+        /// </summary>
+        /// <param name="source">
+        /// a <see cref="CandidateBranch{T}"/> to be compared.
+        /// </param>
+        /// <param name="relative">
+        /// a <see cref="CandidateBranch{T}"/> to compare with the <paramref name="source"/>.
+        /// </param>
+        /// <returns>
+        /// returns <see cref="CandidateBranch{T}"/> with the higher comparer value between two.
+        /// </returns>
+        /// <remarks>
+        /// If the comparer value of <paramref name="relative"/> is same as source, then
+        /// <paramref name="source"/> will be returned as the comparison result.
+        /// </remarks>
+        private CandidateBranch<T> CompareSourceBranch(
+            CandidateBranch<T> source,
+            CandidateBranch<T> relative) =>
+            _canonicalChainComparer.Compare(source.Tip, relative.Tip) > 0 ? source : relative;
     }
 }

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -178,15 +178,6 @@ namespace Libplanet.Net
             }
         }
 
-        /// <summary>
-        /// Removes every <see cref="CandidateBranch{T}"/> in <see cref="Branches"/>.
-        /// </summary>
-        public void Clear()
-        {
-            Branches = new ConcurrentBag<CandidateBranch<T>>();
-            BestBranch = null;
-        }
-
         public bool Any() => Branches.Any();
 
         // FIXME: This method is duplicated with Swarm<T>.IsBlockNeeded()

--- a/Libplanet.Net/CandidateBranch.cs
+++ b/Libplanet.Net/CandidateBranch.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// A class to store an appendable <see cref="CandidateBranch{T}"/> for
+    /// a <see cref="BlockChain{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    public class CandidateBranch<T>
+        where T : IAction, new()
+    {
+        public CandidateBranch(
+            List<Block<T>> blocks,
+            Block<T> root,
+            Block<T> tip)
+        {
+            Blocks = blocks;
+            Root = root;
+            Tip = tip;
+        }
+
+        /// <summary>
+        /// A list of <see cref="Block{T}"/>s in sorted order where each <see cref="Block{T}"/>
+        /// in the list has <see cref="Block{T}.PreviousHash"/> pointing to the previous
+        /// <see cref="Block{T}"/> in the list, except for the first <see cref="Block{T}"/>
+        /// in the list.
+        /// </summary>
+        public List<Block<T>> Blocks { get; }
+
+        /// <summary>
+        /// The root of this branch. The same as the first element in <see cref="Blocks"/>.
+        /// </summary>
+        public Block<T> Root { get; }
+
+        /// <summary>
+        /// The tip of this branch. The same as the last element in <see cref="Blocks"/>.
+        /// </summary>
+        public Block<T> Tip { get; }
+    }
+}

--- a/Libplanet.Net/CandidateBranch.cs
+++ b/Libplanet.Net/CandidateBranch.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -14,14 +15,12 @@ namespace Libplanet.Net
     public class CandidateBranch<T>
         where T : IAction, new()
     {
+        private readonly List<Block<T>> _blocks;
+
         public CandidateBranch(
-            List<Block<T>> blocks,
-            Block<T> root,
-            Block<T> tip)
+            List<Block<T>> blocks)
         {
-            Blocks = blocks;
-            Root = root;
-            Tip = tip;
+            _blocks = blocks;
         }
 
         /// <summary>
@@ -30,16 +29,16 @@ namespace Libplanet.Net
         /// <see cref="Block{T}"/> in the list, except for the first <see cref="Block{T}"/>
         /// in the list.
         /// </summary>
-        public List<Block<T>> Blocks { get; }
+        public IEnumerable<Block<T>> Blocks => _blocks;
 
         /// <summary>
         /// The root of this branch. The same as the first element in <see cref="Blocks"/>.
         /// </summary>
-        public Block<T> Root { get; }
+        public Block<T> Root => Blocks.First();
 
         /// <summary>
         /// The tip of this branch. The same as the last element in <see cref="Blocks"/>.
         /// </summary>
-        public Block<T> Tip { get; }
+        public Block<T> Tip => Blocks.Last();
     }
 }

--- a/Libplanet.Net/CandidateBranch.cs
+++ b/Libplanet.Net/CandidateBranch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Action;
@@ -7,19 +8,55 @@ using Libplanet.Blocks;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// A class to store an appendable <see cref="CandidateBranch{T}"/> for
-    /// a <see cref="BlockChain{T}"/>.
+    /// A class to store an appendable <see cref="CandidateBranch{T}"/> for a
+    /// <see cref="BlockChain{T}"/>. If Any <see cref="Block{T}.PreviousHash"/> of
+    /// <see cref="Block{T}"/>, except for the first block, is not pointing to any unique
+    /// <see cref="Block{T}.Hash"/>.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// <typeparam name="T">An <see cref="IAction"/> type. It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
     public class CandidateBranch<T>
         where T : IAction, new()
     {
         private readonly List<Block<T>> _blocks;
 
-        public CandidateBranch(
-            List<Block<T>> blocks)
+        /// <summary>
+        /// Creates a new <see cref="CandidateBranch{T}"/>.
+        /// </summary>
+        /// <param name="blocks">A series of <see cref="Block{T}"/> that every
+        /// <see cref="Block{T}"/>s, except for the first block, are pointing to any
+        /// <see cref="Block{T}.Hash"/>.
+        /// </param>
+        /// <exception cref="CreateCandidateBranchException">Some <paramref name="blocks"/>
+        /// does not have <see cref="Block{T}.PreviousHash"/> that is pointing to any
+        /// <see cref="Block{T}.Hash"/> or given <paramref name="blocks"/>
+        /// are empty.
+        /// </exception>
+        public CandidateBranch(List<Block<T>> blocks)
         {
+            if (!blocks.Any())
+            {
+                throw new CreateCandidateBranchException(
+                    "No block has given for creating a new CandidateBranch");
+            }
+
+            if (blocks.Count == 1)
+            {
+                _blocks = blocks;
+                return;
+            }
+
+            var precedingBlocks = blocks.Skip(1);
+            foreach (var block in precedingBlocks)
+            {
+                if (!blocks.Any(x => block.PreviousHash != null &&
+                                     x.Hash.Equals(block.PreviousHash.Value)))
+                {
+                    throw new CreateCandidateBranchException(
+                        $"Some blocks are orphans. Blocks : {blocks}");
+                }
+            }
+
             _blocks = blocks;
         }
 

--- a/Libplanet.Net/CandidatePath.cs
+++ b/Libplanet.Net/CandidatePath.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// <para>
+    /// A class representing a path from an old <see cref="BlockChain{T}.Tip"/>
+    /// to a new <see cref="BlockChain{T}.Tip"/> when a change is made to
+    /// a <see cref="BlockChain{T}"/>.
+    /// </para>
+    /// <para>
+    /// The following properties must always hold:
+    /// <list type="bullet">
+    ///     <item><description>
+    ///         <see cref="NewTip"/> always has a higher <see cref="Block{T}.TotalDifficulty"/>
+    ///         than that of <see cref="OldTip"/>.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Each <see cref="Block{T}"/> in <see cref="Blocks"/> is unique.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Each adjacent pair of <see cref="Block{T}"/>s in <see cref="Blocks"/> has
+    ///         <see cref="Block{T}.Index"/> difference of exactly one.
+    ///     </description></item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// By the first property, <see cref="Blocks"/> should always have at least
+    /// two <see cref="Block{T}"/>s.
+    /// </remarks>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    public class CandidatePath<T>
+        where T : IAction, new()
+    {
+        public CandidatePath(
+            IEnumerable<Block<T>> blocks,
+            Block<T> oldTip,
+            Block<T> branchPoint,
+            Block<T> newTip)
+        {
+            Blocks = blocks;
+            OldTip = oldTip;
+            BranchPoint = branchPoint;
+            NewTip = newTip;
+        }
+
+        /// <summary>
+        /// The <see cref="IEnumerable{T}"/> of <see cref="Block{T}"/> in the path.
+        /// </summary>
+        public IEnumerable<Block<T>> Blocks { get; }
+
+        /// <summary>
+        /// The old <see cref="BlockChain{T}.Tip"/> before the update of
+        /// a <see cref="BlockChain{T}"/>. The same as the first element in <see cref="Blocks"/>.
+        /// </summary>
+        public Block<T> OldTip { get; }
+
+        /// <summary>
+        /// The branchpoint used when updating a <see cref="BlockChain{T}"/>.
+        /// </summary>
+        public Block<T> BranchPoint { get; }
+
+        /// <summary>
+        /// The old <see cref="BlockChain{T}.Tip"/> after the update of
+        /// a <see cref="BlockChain{T}"/>. The same as the last element in <see cref="Blocks"/>.
+        /// </summary>
+        public Block<T> NewTip { get; }
+    }
+}

--- a/Libplanet.Net/CreateCandidateBranchException.cs
+++ b/Libplanet.Net/CreateCandidateBranchException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Libplanet.Net
+{
+    [Serializable]
+    public class CreateCandidateBranchException : SwarmException
+    {
+        public CreateCandidateBranchException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Net
                                 branch,
                                 cancellationToken);
                             BlockAppended.Set();
-                            BlockCandidateTable.Update(path, IsBlockNeeded);
+                            BlockCandidateTable.Update(path);
                         }
                         catch (Exception)
                         {

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -234,7 +234,8 @@ namespace Libplanet.Net
                 {
                     newTip = newBlocks.Single(x => x.Hash.Equals(bPrev));
                 }
-                catch (ArgumentNullException)
+                catch (Exception e) when (e is ArgumentNullException ||
+                                          e is InvalidOperationException)
                 {
                     newTip = BlockChain[bPrev];
                 }
@@ -263,7 +264,8 @@ namespace Libplanet.Net
                     {
                         newTip = newBlocks.Single(x => x.Hash.Equals(bPrev));
                     }
-                    catch (ArgumentNullException)
+                    catch (Exception e) when (e is ArgumentNullException ||
+                                              e is InvalidOperationException)
                     {
                         newTip = BlockChain[bPrev];
                     }

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -41,7 +41,11 @@ namespace Libplanet.Net
                         }
                         catch (Exception)
                         {
+                            UpdatePath<T> path = new UpdatePath<T>(
+                                new[] { BlockChain.Tip },
+                                BlockChain.Tip);
                             FillBlocksAsyncFailed.Set();
+                            BlockCandidateTable.Update(path);
                         }
                     }
                 }

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -396,7 +396,7 @@ namespace Libplanet.Net
                 cancellationToken);
             var blocks = await blocksAsync.ToArrayAsync(cancellationToken);
             var branch = new CandidateBranch<T>(blocks.ToList());
-            BlockCandidateTable.Add(branch);
+            BlockCandidateTable.Add(branch, blockChain.Tip);
             return true;
         }
     }

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Net
 
              Block<T> oldTip = workspace.Tip;
              Block<T> newTip = branch.Tip;
-             List<Block<T>> blocks = branch.Blocks;
+             List<Block<T>> blocks = branch.Blocks.ToList();
              Block<T> branchpoint = FindBranchpoint(oldTip, newTip, blocks);
              UpdatePath<T> path = null;
 
@@ -132,7 +132,7 @@ namespace Libplanet.Net
                  );
                  if (oldTip is { })
                  {
-                     path = new UpdatePath<T>(blocks, oldTip, oldTip, newTip);
+                     path = new UpdatePath<T>(blocks, oldTip);
                  }
              }
              else if (!workspace.ContainsBlock(branchpoint.Hash))
@@ -166,7 +166,7 @@ namespace Libplanet.Net
                      "Fork finished. at {MethodName}",
                      nameof(AppendPreviousBlocks)
                  );
-                 path = new UpdatePath<T>(blocks, oldTip, branchpoint, newTip);
+                 path = new UpdatePath<T>(blocks, oldTip);
              }
 
              if (!(workspace.Tip is null) &&
@@ -393,7 +393,7 @@ namespace Libplanet.Net
                 hashes.Select(pair => pair.Item2),
                 cancellationToken);
             var blocks = await blocksAsync.ToArrayAsync(cancellationToken);
-            var branch = new CandidateBranch<T>(blocks.ToList(), blocks.First(), blocks.Last());
+            var branch = new CandidateBranch<T>(blocks.ToList());
             BlockCandidateTable.Add(branch);
             return true;
         }

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -19,7 +19,6 @@ namespace Libplanet.Net
             {
                 if (BlockCandidateTable.Any())
                 {
-                    BlockHeader tipHeader = BlockChain.Tip.Header;
                     CandidateBranch<T> branch = BlockCandidateTable.BestBranch;
                     if (!(branch is null))
                     {

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -47,7 +47,10 @@ namespace Libplanet.Net
                                 branch.Tip.Index,
                                 e.ToString());
                             UpdatePath<T> path = new UpdatePath<T>(
-                                new[] { BlockChain.Tip },
+                                new CandidateBranch<T>(new List<Block<T>>()
+                                {
+                                    BlockChain.Tip,
+                                }),
                                 BlockChain.Tip);
                             FillBlocksAsyncFailed.Set();
                             BlockCandidateTable.Update(path);
@@ -140,7 +143,7 @@ namespace Libplanet.Net
                  );
                  if (oldTip is { })
                  {
-                     path = new UpdatePath<T>(branch.Blocks, oldTip);
+                     path = new UpdatePath<T>(branch, oldTip);
                  }
              }
              else if (!workspace.ContainsBlock(branchpoint.Hash))
@@ -174,15 +177,15 @@ namespace Libplanet.Net
                      "Fork finished. at {MethodName}",
                      nameof(AppendPreviousBlocks)
                  );
-                 path = new UpdatePath<T>(branch.Blocks, oldTip);
+                 path = new UpdatePath<T>(branch, oldTip);
              }
 
-             var appendingBlocks = new List<Block<T>>();
+             var appendingBlocks = branch.Blocks;
 
              if (!(workspace.Tip is null) &&
                  !workspace.Tip.Hash.Equals(branch.Root.PreviousHash))
              {
-                  appendingBlocks = branch.Blocks.Skip(1).ToList();
+                 appendingBlocks = branch.Blocks.Skip(1).ToList();
              }
 
              try

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -20,23 +20,29 @@ namespace Libplanet.Net
                 if (BlockCandidateTable.Any())
                 {
                     BlockHeader tipHeader = BlockChain.Tip.Header;
-                    SortedList<long, Block<T>> blocks =
-                        BlockCandidateTable.GetCurrentRoundCandidate(tipHeader);
-                    if (!(blocks is null))
+                    CandidateBranch<T> branch = BlockCandidateTable.BestBranch;
+                    if (!(branch is null))
                     {
-                        var latest = blocks.Last();
                         _logger.Debug(
                             "{MethodName} has started. Excerpt: #{BlockIndex} {BlockHash} " +
                             "Count of {BlockCandidateTable}: {Count}",
                             nameof(ConsumeBlockCandidates),
-                            latest.Value.Index,
-                            latest.Value.Header,
+                            branch.Tip.Index,
+                            branch.Tip.Hash,
                             nameof(BlockCandidateTable),
                             BlockCandidateTable.Count);
-                        _ = BlockCandidateProcess(
-                            blocks,
-                            cancellationToken);
-                        BlockAppended.Set();
+                        try
+                        {
+                            UpdatePath<T> path = BlockCandidateProcess(
+                                branch,
+                                cancellationToken);
+                            BlockAppended.Set();
+                            BlockCandidateTable.Update(path, IsBlockNeeded);
+                        }
+                        catch (Exception)
+                        {
+                            FillBlocksAsyncFailed.Set();
+                        }
                     }
                 }
                 else
@@ -44,42 +50,32 @@ namespace Libplanet.Net
                     await Task.Delay(checkInterval, cancellationToken);
                     continue;
                 }
-
-                BlockCandidateTable.Cleanup(IsBlockNeeded);
             }
         }
 
-        private bool BlockCandidateProcess(
-            SortedList<long, Block<T>> candidate,
+        private UpdatePath<T> BlockCandidateProcess(
+            CandidateBranch<T> branch,
             CancellationToken cancellationToken)
         {
             BlockChain<T> synced = null;
+            UpdatePath<T> path = null;
             System.Action renderSwap = () => { };
             const string methodName =
                 nameof(Swarm<T>) + "<T>." + nameof(BlockCandidateProcess) + "()";
-            try
-            {
-                FillBlocksAsyncStarted.Set();
-                _logger.Debug(
-                    methodName + " starts to append. Current tip: #{BlockIndex}.",
-                    BlockChain.Tip.Index
-                );
-                synced = AppendPreviousBlocks(
-                    blockChain: BlockChain,
-                    candidate: candidate,
-                    evaluateActions: true);
-                ProcessFillBlocksFinished.Set();
-                _logger.Debug(
-                    methodName + " finished appending blocks. Synced tip: #{BlockIndex}.",
-                    synced.Tip.Index
-                );
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, methodName + " failed to append blocks.");
-                FillBlocksAsyncFailed.Set();
-                return false;
-            }
+            FillBlocksAsyncStarted.Set();
+            _logger.Debug(
+                methodName + " starts to append. Current tip: #{BlockIndex}.",
+                BlockChain.Tip.Index
+            );
+            (synced, path) = AppendPreviousBlocks(
+                blockChain: BlockChain,
+                branch: branch,
+                evaluateActions: true);
+            ProcessFillBlocksFinished.Set();
+            _logger.Debug(
+                methodName + " finished appending blocks. Synced tip: #{BlockIndex}.",
+                synced.Tip.Index
+            );
 
             var canonComparer = BlockChain.Policy.CanonicalChainComparer;
 
@@ -109,12 +105,12 @@ namespace Libplanet.Net
 
             renderSwap();
             BroadcastBlock(BlockChain.Tip);
-            return true;
+            return path;
         }
 
-        private BlockChain<T> AppendPreviousBlocks(
+        private (BlockChain<T>, UpdatePath<T>) AppendPreviousBlocks(
             BlockChain<T> blockChain,
-            SortedList<long, Block<T>> candidate,
+            CandidateBranch<T> branch,
             bool evaluateActions)
         {
              BlockChain<T> workspace = blockChain;
@@ -123,9 +119,10 @@ namespace Libplanet.Net
              bool renderBlocks = true;
 
              Block<T> oldTip = workspace.Tip;
-             Block<T> newTip = candidate.Last().Value;
-             List<Block<T>> blocks = candidate.Values.ToList();
+             Block<T> newTip = branch.Tip;
+             List<Block<T>> blocks = branch.Blocks;
              Block<T> branchpoint = FindBranchpoint(oldTip, newTip, blocks);
+             UpdatePath<T> path = null;
 
              if (oldTip is null || branchpoint.Equals(oldTip))
              {
@@ -133,6 +130,10 @@ namespace Libplanet.Net
                      "No need to fork. at {MethodName}",
                      nameof(AppendPreviousBlocks)
                  );
+                 if (oldTip is { })
+                 {
+                     path = new UpdatePath<T>(blocks, oldTip, oldTip, newTip);
+                 }
              }
              else if (!workspace.ContainsBlock(branchpoint.Hash))
              {
@@ -165,6 +166,7 @@ namespace Libplanet.Net
                      "Fork finished. at {MethodName}",
                      nameof(AppendPreviousBlocks)
                  );
+                 path = new UpdatePath<T>(blocks, oldTip, branchpoint, newTip);
              }
 
              if (!(workspace.Tip is null) &&
@@ -214,7 +216,7 @@ namespace Libplanet.Net
                  );
              }
 
-             return workspace;
+             return (workspace, path);
         }
 
         private Block<T> FindBranchpoint(Block<T> oldTip, Block<T> newTip, List<Block<T>> newBlocks)
@@ -391,7 +393,8 @@ namespace Libplanet.Net
                 hashes.Select(pair => pair.Item2),
                 cancellationToken);
             var blocks = await blocksAsync.ToArrayAsync(cancellationToken);
-            BlockCandidateTable.Add(tip.Header, blocks);
+            var branch = new CandidateBranch<T>(blocks.ToList(), blocks.First(), blocks.Last());
+            BlockCandidateTable.Add(branch);
             return true;
         }
     }

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -217,7 +217,8 @@ namespace Libplanet.Net
             {
                 if (blocks.Count != 0)
                 {
-                    var branch = new CandidateBranch<T>(blocks, blocks.First(), blocks.Last());
+                    var branch = new CandidateBranch<T>(blocks);
+
                     BlockCandidateTable.Add(branch);
                     BlockReceived.Set();
                 }

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -217,7 +217,8 @@ namespace Libplanet.Net
             {
                 if (blocks.Count != 0)
                 {
-                    BlockCandidateTable.Add(BlockChain.Tip.Header, blocks);
+                    var branch = new CandidateBranch<T>(blocks, blocks.First(), blocks.Last());
+                    BlockCandidateTable.Add(branch);
                     BlockReceived.Set();
                 }
 

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -217,10 +217,22 @@ namespace Libplanet.Net
             {
                 if (blocks.Count != 0)
                 {
-                    var branch = new CandidateBranch<T>(blocks);
+                    try
+                    {
+                        var branch = new CandidateBranch<T>(blocks);
+                        BlockCandidateTable.Add(branch, BlockChain.Tip);
+                        BlockReceived.Set();
+                    }
+                    catch (CreateCandidateBranchException e)
+                    {
+                        _logger.Error(
+                            "{MethodName}: Failed to create a CandidateTable. " +
+                            "Exception : {Exception}",
+                            nameof(FillBlocksAsync),
+                            e.ToString());
 
-                    BlockCandidateTable.Add(branch, BlockChain.Tip);
-                    BlockReceived.Set();
+                        FillBlocksAsyncFailed.Set();
+                    }
                 }
 
                 ProcessFillBlocksFinished.Set();

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -219,7 +219,7 @@ namespace Libplanet.Net
                 {
                     var branch = new CandidateBranch<T>(blocks);
 
-                    BlockCandidateTable.Add(branch);
+                    BlockCandidateTable.Add(branch, BlockChain.Tip);
                     BlockReceived.Set();
                 }
 

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -224,7 +224,10 @@ namespace Libplanet.Net
                 }
 
                 ProcessFillBlocksFinished.Set();
-                _logger.Debug($"{nameof(PullBlocksAsync)}() has finished successfully.");
+                _logger.Debug(
+                    "{MethodName}() has finished successfully with #{TipIndex}",
+                    nameof(PullBlocksAsync),
+                    tempTip.Index);
             }
         }
 

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -264,7 +264,8 @@ namespace Libplanet.Net
             }
 
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
-            BlockCandidateTable = new BlockCandidateTable<T>();
+            BlockCandidateTable = new BlockCandidateTable<T>(
+                BlockChain.Policy.CanonicalChainComparer);
             _logger.Debug($"{nameof(Swarm<T>)} stopped.");
         }
 
@@ -334,7 +335,8 @@ namespace Libplanet.Net
                     _workerCancellationTokenSource.Token, cancellationToken
                 ).Token;
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
-            BlockCandidateTable = new BlockCandidateTable<T>();
+            BlockCandidateTable = new BlockCandidateTable<T>(
+                BlockChain.Policy.CanonicalChainComparer);
             if (Transport.Running)
             {
                 throw new SwarmException("Swarm is already running.");

--- a/Libplanet.Net/UpdatePath.cs
+++ b/Libplanet.Net/UpdatePath.cs
@@ -34,10 +34,10 @@ namespace Libplanet.Net
     /// </remarks>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
-    public class CandidatePath<T>
+    public class UpdatePath<T>
         where T : IAction, new()
     {
-        public CandidatePath(
+        public UpdatePath(
             IEnumerable<Block<T>> blocks,
             Block<T> oldTip,
             Block<T> branchPoint,

--- a/Libplanet.Net/UpdatePath.cs
+++ b/Libplanet.Net/UpdatePath.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -37,16 +38,10 @@ namespace Libplanet.Net
     public class UpdatePath<T>
         where T : IAction, new()
     {
-        public UpdatePath(
-            IEnumerable<Block<T>> blocks,
-            Block<T> oldTip,
-            Block<T> branchPoint,
-            Block<T> newTip)
+        public UpdatePath(IEnumerable<Block<T>> blocks, Block<T> oldTip)
         {
             Blocks = blocks;
             OldTip = oldTip;
-            BranchPoint = branchPoint;
-            NewTip = newTip;
         }
 
         /// <summary>
@@ -56,19 +51,20 @@ namespace Libplanet.Net
 
         /// <summary>
         /// The old <see cref="BlockChain{T}.Tip"/> before the update of
-        /// a <see cref="BlockChain{T}"/>. The same as the first element in <see cref="Blocks"/>.
+        /// a <see cref="BlockChain{T}"/>.
         /// </summary>
         public Block<T> OldTip { get; }
 
         /// <summary>
-        /// The branchpoint used when updating a <see cref="BlockChain{T}"/>.
+        /// The branchpoint used when updating a <see cref="BlockChain{T}"/>. The same as the first
+        /// element in <see cref="Blocks"/>.
         /// </summary>
-        public Block<T> BranchPoint { get; }
+        public Block<T> BranchPoint => Blocks.First();
 
         /// <summary>
         /// The old <see cref="BlockChain{T}.Tip"/> after the update of
         /// a <see cref="BlockChain{T}"/>. The same as the last element in <see cref="Blocks"/>.
         /// </summary>
-        public Block<T> NewTip { get; }
+        public Block<T> NewTip => Blocks.Last();
     }
 }

--- a/Libplanet.Net/UpdatePath.cs
+++ b/Libplanet.Net/UpdatePath.cs
@@ -7,40 +7,27 @@ using Libplanet.Blocks;
 namespace Libplanet.Net
 {
     /// <summary>
-    /// <para>
-    /// A class representing a path from an old <see cref="BlockChain{T}.Tip"/>
-    /// to a new <see cref="BlockChain{T}.Tip"/> when a change is made to
-    /// a <see cref="BlockChain{T}"/>.
-    /// </para>
-    /// <para>
-    /// The following properties must always hold:
-    /// <list type="bullet">
-    ///     <item><description>
-    ///         <see cref="NewTip"/> always has a higher <see cref="Block{T}.TotalDifficulty"/>
-    ///         than that of <see cref="OldTip"/>.
-    ///     </description></item>
-    ///     <item><description>
-    ///         Each <see cref="Block{T}"/> in <see cref="Blocks"/> is unique.
-    ///     </description></item>
-    ///     <item><description>
-    ///         Each adjacent pair of <see cref="Block{T}"/>s in <see cref="Blocks"/> has
-    ///         <see cref="Block{T}.Index"/> difference of exactly one.
-    ///     </description></item>
-    /// </list>
-    /// </para>
+    /// A class representing a path, <see cref="CandidateBranch{T}"/>, from an old
+    /// <see cref="BlockChain{T}.Tip"/> to a new <see cref="BlockChain{T}.Tip"/> when a change is
+    /// made to a <see cref="BlockChain{T}"/>.
     /// </summary>
-    /// <remarks>
-    /// By the first property, <see cref="Blocks"/> should always have at least
-    /// two <see cref="Block{T}"/>s.
-    /// </remarks>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
     public class UpdatePath<T>
         where T : IAction, new()
     {
-        public UpdatePath(IEnumerable<Block<T>> blocks, Block<T> oldTip)
+        /// <summary>
+        /// Creates a new <see cref="UpdatePath{T}"/>.
+        /// </summary>
+        /// <param name="branch"> A <see cref="CandidateBranch{T}"/> used to update
+        /// <see cref="BlockChain{T}"/>.
+        /// </param>
+        /// <param name="oldTip"> A <see cref="BlockChain{T}.Tip"/> before the given
+        /// <paramref name="branch"/> is appended into <see cref="BlockChain{T}"/>.
+        /// </param>
+        public UpdatePath(CandidateBranch<T> branch, Block<T> oldTip)
         {
-            Blocks = blocks;
+            Blocks = branch.Blocks;
             OldTip = oldTip;
         }
 


### PR DESCRIPTION
This resolves #1892.

I'd like to recommend checking the original issue. The following details are well-documented and discussed in the issue.

### Abstract
This improvement is based on the assumption that the current `Swarm<T>` misses the opportunity of getting the longest chain. 

For example, `Swarm<T>` got two branches in parallel, which are oriented from the same ancestor (BranchPoint), from two nodes for each. One's has 10 blocks, and the other has 20 blocks. Now, 10 blocks come in first (e.g.. Downloaded or Processed first) after then, those blocks are appended into `Swarm<T>` and change `Swarm<T>.Blockchain.Tip` to the Tip of 10 blocks.  

20 blocks will be considered lost due to the current Tip policy. Because the `PreviousHash` of `Root` of 20 blocks `Branch` is not the same as `Tip` in `Swarm<T>` anymore. 

If we could trace the branch and `Tip` where we can connect, then `Swarm<T>` might get additional 10 blocks.

### Word
- `Branch` : A set of `Block<T>`s that every `Block<T>`s have their pair that has the same `Hash` and `PreviousHash`, except the first element. This is used in updating a `Tip` of `Blockchain<T>`.
- `Root` : A `Block<T>` that is the first element in a `Branch`.
- `OldTip` : A `Tip` of `Blockchain<T>` currently have.
- `NewTip` : A `Block<T>` that is the last element in a `Branch`. the _New_ prefix appears because if this branch is appended with a `Blockchain<T>`, then this `Block<T>` will be the new `Tip` of `Blockchain<T>`.
- `Branchpoint` : A `Block<T>` where the `PreviousHash` of `Root` of `Branch` is same as `OldTip`.

### What's new

- `UpdatePath<T>`
  - A path from `Blockchain<T>`. `Blocks` is `Block<T>` to `Tip` which are continuous `Block<T>`s in `PreviousHash`-wise for each `Block<T>`.

- `BlockCandidateTable.Add`
   - `Add()` takes branch only if `CandidateBranch<T>` has a higher comparer value than `Blockchain<T>` and Blocks has their PreviousHash Blocks except for the first block of the list. 
   - Because of where `BlockCandidateTable.Add()` is called, `BlockCandidateTable.Update()` is called with `UpdatePath<T>(oldTip, oldTip)` when `BlockCandidateProcess()` is failed.

- `BlockCandidateTable.Update`
  Before going through the explanation, we need to make sure if the `CandidateBranch.Tip` is not higher than the current tip of the `Blockchain` branch `TotalDifficulty`, then the branch will be discarded. 
For convenience, I will use the term `Tip` as the current `Blockchain` Tip. any other `Tip` will be explained with its term.

  - Case 1. The reorganization did not happen (Branchpoint is equal to the current `Blockchain` branch)
    - A. We define a `LongestBranch`, which is a branch that has the highest `TotalDifficulty` in `Branches`.
    - B. Pick a `CandidateBranch<T>`, Collect all the blocks from it, In the condition of having a high `Block.Index` then `Tip.Index`.
    - C. If `TotalDifficulty` of blocks (`Branch`) from B is higher than the current `LongestBranch`, then replace `LongestBranch`.
    - D. Go back to B and repeat until visit the all the other `Branches`.

  - Case 2. The reorganization did happen (Branchpoint is not equal to the current `Blockchain` branch)
    - A. We define `LongestBranch` the same as Case 1.
    - B.  Pick a `CandidateBranch<T>`, Find the longest block from `Root`  (= its most previous block) to `BranchTip`
    - C. If the previous block of `BranchRoot` is the same as `Tip`, then insert `BranchPoint` into the branch as `BranchRoot`.
    - D. If `TotalDifficulty` of blocks (`Branch`) from B is higher than the current `LongestBranch`, then replace `LongestBranch`.
    - E. Go back to B and repeat until visit the all the other `Branches`.
  - In conclusion, if there's a branch that can be "connected" with `Tip`, and if `TotalDifficulty` of the branch is high enough, then we've got a new `Tip`.
    - On the other hand, If it is "connected" with another block but if it is more past block, then we've got a new branch and new Tip.
    - Any other case that isn't illustrated cannot be connected with the current `Blockchain`. those will be discarded. However, it will be stored short amount of moment, if any incoming block can be "connected" with any block AND branch in `BlockCandidateTable` and `Blockchain` then we can use the "cached" branch.

To be updated (2022/05/23)