### PR TITLE
feat(cli): introduce `planet key sign` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,9 +28,13 @@ To be released.
 
 ### CLI tools
 
+ - Added `planet key sign` to sign a message.  [[#1920]]
+
 [#1830]: https://github.com/planetarium/libplanet/issues/1830
 [#1912]: https://github.com/planetarium/libplanet/pull/1912
 [#1916]: https://github.com/planetarium/libplanet/pull/1916
+[#1920]: https://github.com/planetarium/libplanet/pull/1920
+
 
 
 Version 0.33.1

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -165,6 +165,22 @@ namespace Libplanet.Extensions.Cocona.Commands
             }
         }
 
+        [Command(Description = "Sign a message.")]
+        public void Sign(
+            [Argument("KEY-ID", Description = "A key UUID to sign.")]
+            Guid keyId,
+            [Argument(
+                "MESSAGE",
+                Description = "A message encoded by base64 encoding to sign."
+            )]
+            string message,
+            PassphraseParameters passphrase
+        )
+        {
+            PrivateKey key = UnprotectKey(keyId, passphrase);
+            Console.WriteLine(Convert.ToBase64String(key.Sign(Convert.FromBase64String(message))));
+        }
+
         public PrivateKey UnprotectKey(
             Guid keyId,
             PassphraseParameters passphrase,

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -175,7 +175,13 @@ namespace Libplanet.Extensions.Cocona.Commands
                               "it will receive the message to sign from stdin."
             )]
             string path,
-            PassphraseParameters passphrase
+            PassphraseParameters passphrase,
+            [Option(Description = "A path of the file to save the signature. " +
+                                  "If you pass '-' dash character, it will print to stdout " +
+                                  "as raw bytes not hexadecimal string or else. " +
+                                  "If this option isn't given, it will print hexadecimal string " +
+                                  "to stdout as default behaviour.")]
+            string? binaryOutput = null
         )
         {
             PrivateKey key = UnprotectKey(keyId, passphrase);
@@ -197,7 +203,20 @@ namespace Libplanet.Extensions.Cocona.Commands
                 message = File.ReadAllBytes(path);
             }
 
-            Console.WriteLine(Convert.ToBase64String(key.Sign(message)));
+            var signature = key.Sign(message);
+            if (binaryOutput is null)
+            {
+                Console.WriteLine(ByteUtil.Hex(signature));
+            }
+            else if (binaryOutput == "-")
+            {
+                using Stream stdout = Console.OpenStandardOutput();
+                stdout.Write(signature, 0, signature.Length);
+            }
+            else
+            {
+                File.WriteAllBytes(binaryOutput, signature);
+            }
         }
 
         public PrivateKey UnprotectKey(


### PR DESCRIPTION
This pull requests introduces `planet key sign` command through `KeyCommand` in `Libplanet.Extensions.Cocona`.

The command provides a feature to sign the given message encoded by base64 with the given private key, and prints the signature encoded by base64.

```
$ dotnet run --project Libplanet.Tools/Libplanet.Tools.csproj -- key sign b8b01397-eee7-4c03-9a8d-4beee26ca7b9 AA== --passphrase ""
MEUCIQCvyRlQMqtuowjNSoR+5FCvzr/hcRWeWYAsZCQpAjtq7gIgJJLwq5YPCHktTKExhsyiiQmWj+aMQFVP6ZVucf+g5Rg=
```