### PR TITLE
Remove rethrowing of caught exception

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2048,9 +2048,7 @@ namespace Libplanet.Tests.Blockchain
                 catch (TxPolicyViolationException e)
                 {
                     Assert.NotNull(e.InnerException);
-
-                    _logger.Debug("Exception: {Exception}", e.ToString());
-                    _logger.Debug("InnerException: {InnerException}", e.InnerException.ToString());
+                    throw;
                 }
             });
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2049,12 +2049,8 @@ namespace Libplanet.Tests.Blockchain
                 {
                     Assert.NotNull(e.InnerException);
 
-                    // This is visual representation of the test.
-                    // In actual use-case, this debugging lines do
-                    // not show.
                     _logger.Debug("Exception: {Exception}", e.ToString());
                     _logger.Debug("InnerException: {InnerException}", e.InnerException.ToString());
-                    throw e;
                 }
             });
         }


### PR DESCRIPTION
Rethrowing a caught exception causes an error on .NET 6, so I would like to remove this from the test code.

I guess the `catch` branch intended to give some textual demonstration of the test, thus intercepted the received exception `e`. It seems better to me that the demonstration be given elsewhere (maybe as a separate documentation).