### PR TITLE
Unncessary/inappropriate uses of timeout removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@ To be released.
 ### Backward-incompatible API changes
 
  -  `BlockCompletion<TPeer, TAction>.Complete()` no longer accepts
-    an argument to regulate a single session.  [[#1961]]
+    neither parmeter `TimeSpan singleSessionTimeout` nor
+    `int millisecondsSingleSessionTimeout` to regulate a single session length.
+    [[#1961]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `BlockCompletion<TPeer, TAction>.Complete()` no longer accepts
+    an argument to regulate a single session.  [[#1961]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -26,6 +29,7 @@ To be released.
 
 ### CLI tools
 
+[#1961]: https://github.com/planetarium/libplanet/pull/1961
 [#1966]: https://github.com/planetarium/libplanet/pull/1966
 
 

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -337,7 +337,7 @@ namespace Libplanet.Net.Tests
                     // Peer A does not respond and Peer B does respond.
                     if (peer == 'A')
                     {
-                        int transportTimeout = 3_000;
+                        const int transportTimeout = 3_000;
                         await Task.Delay(transportTimeout, yield.CancellationToken);
 
                         // Technically this should throw CommunicationException, but that would

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -337,10 +337,12 @@ namespace Libplanet.Net.Tests
                     // Peer A does not respond and Peer B does respond.
                     if (peer == 'A')
                     {
-                        while (true)
-                        {
-                            await Task.Delay(5000, yield.CancellationToken);
-                        }
+                        int transportTimeout = 3_000;
+                        await Task.Delay(transportTimeout, yield.CancellationToken);
+
+                        // Technically this should throw CommunicationException, but that would
+                        // require much more scaffolding.
+                        throw new Exception("Peer failed to respond");
                     }
 
                     foreach (Block<DumbAction> b in fixture)
@@ -354,10 +356,7 @@ namespace Libplanet.Net.Tests
 
             Tuple<Block<DumbAction>, char>[] result =
                 await AsyncEnumerable.ToArrayAsync(
-                    bc.Complete(
-                        new[] { 'A', 'B' }, blockFetcher, millisecondsSingleSessionTimeout: 3000
-                    )
-                );
+                    bc.Complete(new[] { 'A', 'B' }, blockFetcher));
             Assert.Equal(
                 fixture.Select(b => Tuple.Create(b, 'B')).ToHashSet(),
                 result.ToHashSet()

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -12,7 +12,6 @@ namespace Libplanet.Net
     public partial class Swarm<T>
     {
         private async Task ConsumeBlockCandidates(
-            TimeSpan timeout,
             CancellationToken cancellationToken)
         {
             var checkInterval = TimeSpan.FromMilliseconds(10);
@@ -36,7 +35,6 @@ namespace Libplanet.Net
                             BlockCandidateTable.Count);
                         _ = BlockCandidateProcess(
                             blocks,
-                            timeout,
                             cancellationToken);
                         BlockAppended.Set();
                     }
@@ -53,7 +51,6 @@ namespace Libplanet.Net
 
         private bool BlockCandidateProcess(
             SortedList<long, Block<T>> candidate,
-            TimeSpan timeout,
             CancellationToken cancellationToken)
         {
             BlockChain<T> synced = null;
@@ -70,7 +67,6 @@ namespace Libplanet.Net
                 synced = AppendPreviousBlocks(
                     blockChain: BlockChain,
                     candidate: candidate,
-                    timeout: timeout,
                     evaluateActions: true);
                 ProcessFillBlocksFinished.Set();
                 _logger.Debug(
@@ -119,7 +115,6 @@ namespace Libplanet.Net
         private BlockChain<T> AppendPreviousBlocks(
             BlockChain<T> blockChain,
             SortedList<long, Block<T>> candidate,
-            TimeSpan timeout,
             bool evaluateActions)
         {
              BlockChain<T> workspace = blockChain;
@@ -285,7 +280,6 @@ namespace Libplanet.Net
 
         private async Task<bool> ProcessBlockDemandAsync(
             BlockDemand demand,
-            TimeSpan timeout,
             CancellationToken cancellationToken)
         {
             var sessionRandom = new Random();
@@ -320,7 +314,6 @@ namespace Libplanet.Net
                     peer: peer,
                     blockChain: BlockChain,
                     stop: demand.Header,
-                    timeout: timeout,
                     logSessionId: sessionId,
                     cancellationToken: cancellationToken);
 
@@ -370,7 +363,6 @@ namespace Libplanet.Net
             BoundPeer peer,
             BlockChain<T> blockChain,
             BlockHeader stop,
-            TimeSpan timeout,
             int logSessionId,
             CancellationToken cancellationToken)
         {
@@ -383,7 +375,7 @@ namespace Libplanet.Net
                 peer: peer,
                 locator: locator,
                 stop: stop.Hash,
-                timeout: timeout,
+                timeout: null,
                 logSessionIds: (logSessionId, subSessionId),
                 cancellationToken: cancellationToken);
             IEnumerable<Tuple<long, BlockHash>> hashes = await hashesAsync.ToArrayAsync();

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -228,7 +228,6 @@ namespace Libplanet.Net
         }
 
         private async Task FillBlocksAsync(
-            TimeSpan timeout,
             CancellationToken cancellationToken
         )
         {
@@ -246,7 +245,6 @@ namespace Libplanet.Net
                         BlockDemandTable.Remove(blockDemand.Peer);
                         _ = ProcessBlockDemandAsync(
                             blockDemand,
-                            timeout,
                             cancellationToken);
                     }
                 }

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -137,7 +137,6 @@ namespace Libplanet.Net
                     blockCompletion.Complete(
                         peers: peersWithBlockExcerpt.Select(pair => pair.Item1).ToList(),
                         blockFetcher: GetBlocksAsync,
-                        singleSessionTimeout: Options.MaxTimeout,
                         cancellationToken: cancellationToken
                     );
 
@@ -389,7 +388,6 @@ namespace Libplanet.Net
                     blockCompletion.Complete(
                         peers: peersWithExcerpt.Select(pair => pair.Item1).ToList(),
                         blockFetcher: GetBlocksAsync,
-                        singleSessionTimeout: Options.MaxTimeout,
                         cancellationToken: cancellationToken
                     );
 

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -361,8 +361,8 @@ namespace Libplanet.Net
                 tasks.Add(Transport.StartAsync(_cancellationToken));
                 tasks.Add(BroadcastBlockAsync(broadcastBlockInterval, _cancellationToken));
                 tasks.Add(BroadcastTxAsync(broadcastTxInterval, _cancellationToken));
-                tasks.Add(FillBlocksAsync(dialTimeout, _cancellationToken));
-                tasks.Add(ConsumeBlockCandidates(dialTimeout, _cancellationToken));
+                tasks.Add(FillBlocksAsync(_cancellationToken));
+                tasks.Add(ConsumeBlockCandidates(_cancellationToken));
                 tasks.Add(
                     PollBlocksAsync(
                         dialTimeout,


### PR DESCRIPTION
Session timeouts are different from network timeouts and should be implemented accordingly, if we want such features that is. Simply passing along timeouts willy-nilly is bad. 😕

For example the call sequence for `timeout` is

- `FillBlocksAsync()` -> `ProcessBlockDemandAsync()` -> `BlockCandidateDownload()` -> `GetBlockHashes()`.

Multiple issues here:

- From `FillBlocksAsync()`, it is unclear what `timeout` is for.
- I don't think anyone is fully aware of the consequences of overriding the default `GetBlockHashes()` timeout period provided by `SwarmOptions.BlockHashRecvTimeout` as it is not immediately apparent this is overridden with different values from several places.

If we want a finer control for `GetBlockHashes()` from different long running processes (then again, I don't know what the purpose of `SwarmOptions.BlockHashRecvTimeout` would be in that case) it should be more clearly documented and implemented with care.

----

Additional removal of parameters resulted in an API change. Both `millisecondsSingleSessionTimeout` and `singleSessionTimeout` for `BlockCompletion<P, A>.Complete()` removed. Single session length is already capped by
the `ITransport` in use. Some ancient code was modified, so @dahlia should take a closer look. 😗