### PR TITLE
Introduce `Vote` and `VoteSet`

### DIFF
--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class VoteSetTest
+    {
+         [Fact]
+         public void AddVoteTest()
+         {
+             var validators = Enumerable.Range(0, 4)
+                 .Select(x => new PrivateKey())
+                 .ToArray();
+             var voteSet = new VoteSet(
+                 1,
+                 2,
+                 validators.Select(x => x.PublicKey).ToImmutableArray());
+
+             var fx = new MemoryStoreFixture();
+             var now = DateTimeOffset.UtcNow;
+
+             Assert.False(voteSet.HasTwoThirdAny());
+             Assert.False(voteSet.HasTwoThirdPrevote());
+             Assert.False(voteSet.HasTwoThirdCommit());
+
+             for (int i = 0; i < 3; i++)
+             {
+                 var vote = new Vote(
+                     1,
+                     2,
+                     fx.Hash1,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Absent,
+                     i,
+                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                 voteSet.Add(vote);
+             }
+
+             Assert.True(voteSet.HasTwoThirdAny());
+             Assert.True(voteSet.HasTwoThirdPrevote());
+             Assert.False(voteSet.HasTwoThirdCommit());
+
+             voteSet = new VoteSet(
+                 1,
+                 2,
+                 validators.Select(x => x.PublicKey));
+
+             for (int i = 0; i < 3; i++)
+             {
+                 var vote = new Vote(
+                     1,
+                     2,
+                     fx.Hash1,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Commit,
+                     i,
+                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                 voteSet.Add(vote);
+             }
+
+             Assert.True(voteSet.HasTwoThirdAny());
+             Assert.False(voteSet.HasTwoThirdPrevote());
+             Assert.True(voteSet.HasTwoThirdCommit());
+         }
+
+         [Fact]
+         public void AddWrongVoteTest()
+         {
+             var validators = Enumerable.Range(0, 4)
+                 .Select(x => new PrivateKey())
+                 .ToArray();
+             var voteSet = new VoteSet(
+                 1,
+                 2,
+                 validators.Select(x => x.PublicKey).ToImmutableArray());
+
+             var fx = new MemoryStoreFixture();
+             var now = DateTimeOffset.UtcNow;
+
+             Assert.False(voteSet.HasTwoThirdAny());
+             Assert.False(voteSet.HasTwoThirdPrevote());
+             Assert.False(voteSet.HasTwoThirdCommit());
+
+             for (int i = 0; i < 3; i++)
+             {
+                 var vote = new Vote(
+                     1,
+                     1,
+                     fx.Hash1,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Absent,
+                     i,
+                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                 voteSet.Add(vote);
+             }
+
+             Assert.False(voteSet.HasTwoThirdAny());
+             Assert.False(voteSet.HasTwoThirdPrevote());
+             Assert.False(voteSet.HasTwoThirdCommit());
+         }
+    }
+}

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Tests.Store;
@@ -14,15 +15,17 @@ namespace Libplanet.Tests.Consensus
          [Fact]
          public void AddVoteTest()
          {
+             var fx = new MemoryStoreFixture();
+             BlockHash targetBlockHash = fx.Hash1;
              var validators = Enumerable.Range(0, 4)
                  .Select(x => new PrivateKey())
                  .ToArray();
              var voteSet = new VoteSet(
                  1,
                  2,
+                 targetBlockHash,
                  validators.Select(x => x.PublicKey).ToImmutableArray());
 
-             var fx = new MemoryStoreFixture();
              var now = DateTimeOffset.UtcNow;
 
              Assert.False(voteSet.HasTwoThirdAny());
@@ -34,7 +37,7 @@ namespace Libplanet.Tests.Consensus
                  var vote = new Vote(
                      1,
                      2,
-                     fx.Hash1,
+                     targetBlockHash,
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,
@@ -50,6 +53,7 @@ namespace Libplanet.Tests.Consensus
              voteSet = new VoteSet(
                  1,
                  2,
+                 targetBlockHash,
                  validators.Select(x => x.PublicKey));
 
              for (int i = 0; i < 3; i++)
@@ -72,17 +76,19 @@ namespace Libplanet.Tests.Consensus
          }
 
          [Fact]
-         public void AddWrongVoteTest()
+         public void AddWrongRoundVoteTest()
          {
+             var fx = new MemoryStoreFixture();
+             BlockHash targetBlockHash = fx.Hash1;
              var validators = Enumerable.Range(0, 4)
                  .Select(x => new PrivateKey())
                  .ToArray();
              var voteSet = new VoteSet(
                  1,
                  2,
+                 targetBlockHash,
                  validators.Select(x => x.PublicKey).ToImmutableArray());
 
-             var fx = new MemoryStoreFixture();
              var now = DateTimeOffset.UtcNow;
 
              Assert.False(voteSet.HasTwoThirdAny());
@@ -94,7 +100,7 @@ namespace Libplanet.Tests.Consensus
                  var vote = new Vote(
                      1,
                      1,
-                     fx.Hash1,
+                     targetBlockHash,
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -1,0 +1,30 @@
+using System;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class VoteTest
+    {
+        [Fact]
+        public void MarshalVote()
+        {
+            var fx = new MemoryStoreFixture();
+            var now = DateTimeOffset.UtcNow;
+            var vote = new Vote(
+                1,
+                2,
+                fx.Hash1,
+                now,
+                new PrivateKey().PublicKey,
+                VoteFlag.Commit,
+                7,
+                null);
+            byte[] marshaled = vote.ByteArray;
+            var unMarshaled = new Vote(marshaled);
+            Assert.Equal(vote, unMarshaled);
+        }
+    }
+}

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -9,7 +9,7 @@ using Libplanet.Crypto;
 namespace Libplanet.Consensus
 {
     /// <summary>
-    /// Represents a any vote from validators for consensus.
+    /// Represents any vote from validators for consensus.
     /// </summary>
     public readonly struct Vote : IEquatable<Vote>
     {
@@ -24,7 +24,7 @@ namespace Libplanet.Consensus
         private const string SignatureKey = "signature";
 
         /// <summary>
-        /// Create vote instance.
+        /// Create a vote instance.
         /// </summary>
         /// <param name="height">Height of the vote target block.</param>
         /// <param name="round">Round of the vote in given height.</param>
@@ -58,7 +58,7 @@ namespace Libplanet.Consensus
         }
 
         /// <summary>
-        /// Create vote instance.
+        /// Create a vote instance.
         /// </summary>
         /// <param name="marshaled">Marshaled value of the vote. <seealso cref="ByteArray"/></param>
         /// <exception cref="ArgumentException">

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// Represents a any vote from validators for consensus.
+    /// </summary>
+    public readonly struct Vote : IEquatable<Vote>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private const string HeightKey = "height";
+        private const string RoundKey = "round";
+        private const string BlockHashKey = "block_hash";
+        private const string TimestampKey = "timestamp";
+        private const string ValidatorKey = "validator";
+        private const string FlagKey = "vote_flag";
+        private const string NodeIdKey = "node_id";
+        private const string SignatureKey = "signature";
+
+        /// <summary>
+        /// Create vote instance.
+        /// </summary>
+        /// <param name="height">Height of the vote target block.</param>
+        /// <param name="round">Round of the vote in given height.</param>
+        /// <param name="blockHash"><see cref="BlockHash"/> of the block in vote.</param>
+        /// <param name="timestamp">The time at which the voting took place.</param>
+        /// <param name="validator">
+        /// <see cref="PublicKey"/> of the validator made the vote.
+        /// </param>
+        /// <param name="flag">
+        /// <see cref="VoteFlag"/> for the vote's status.</param>
+        /// <param name="nodeId">The Id of the validator made the vote.</param>
+        /// <param name="signature">Signature of the vote.</param>
+        public Vote(
+            long height,
+            long round,
+            BlockHash blockHash,
+            DateTimeOffset timestamp,
+            PublicKey validator,
+            VoteFlag flag,
+            long nodeId,
+            ImmutableArray<byte>? signature)
+        {
+            Height = height;
+            Round = round;
+            BlockHash = blockHash;
+            Timestamp = timestamp;
+            Validator = validator;
+            Flag = flag;
+            NodeId = nodeId;
+            Signature = signature;
+        }
+
+        /// <summary>
+        /// Create vote instance.
+        /// </summary>
+        /// <param name="marshaled">Marshaled value of the vote. <seealso cref="ByteArray"/></param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when given bytearray cannot be unmarshaled into <see cref="Vote"/>.
+        /// </exception>
+        public Vote(byte[] marshaled)
+        {
+            var codec = new Codec();
+            try
+            {
+                var dict = (Dictionary)codec.Decode(marshaled);
+                Height = dict.GetValue<Integer>(HeightKey);
+                Round = dict.GetValue<Integer>(RoundKey);
+                BlockHash = new BlockHash(dict.GetValue<Binary>(BlockHashKey).ByteArray);
+                Timestamp = DateTimeOffset.ParseExact(
+                    dict.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture);
+                Validator = new PublicKey(dict.GetValue<Binary>(ValidatorKey).ByteArray);
+                Flag = (VoteFlag)(long)dict.GetValue<Integer>(FlagKey);
+                NodeId = dict.GetValue<Integer>(NodeIdKey);
+                Signature = dict.ContainsKey(SignatureKey)
+                    ? dict.GetValue<Binary>(SignatureKey)
+                    : (ImmutableArray<byte>?)null;
+            }
+            catch (Exception)
+            {
+                throw new ArgumentException(
+                    "Cannot unmarshal given bytearray into vote.",
+                    nameof(marshaled));
+            }
+        }
+
+        /// <summary>
+        /// Height of the vote target block.
+        /// </summary>
+        public long Height { get; }
+
+        /// <summary>
+        /// Round of the vote in given height.
+        /// </summary>
+        public long Round { get; }
+
+        /// <summary>
+        /// <see cref="BlockHash"/> of the block in vote.
+        /// </summary>
+        public BlockHash BlockHash { get; }
+
+        /// <summary>
+        /// The time at which the voting took place.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// <see cref="PublicKey"/> of the validator made the vote.
+        /// </summary>
+        public PublicKey Validator { get; }
+
+        /// <summary>
+        /// <see cref="VoteFlag"/> for the vote's status.
+        /// </summary>
+        public VoteFlag Flag { get; }
+
+        /// <summary>
+        /// The Id of the validator made the vote.
+        /// </summary>
+        public long NodeId { get; }
+
+        /// <summary>
+        /// Signature of the vote.
+        /// </summary>
+        public ImmutableArray<byte>? Signature { get; }
+
+        /// <summary>
+        /// Marshaled vote data.
+        /// </summary>
+        public byte[] ByteArray
+        {
+            get
+            {
+                var codec = new Codec();
+                var dict = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(BlockHashKey, BlockHash.ByteArray)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorKey, Validator.Format(compress: true))
+                    .Add(FlagKey, (long)Flag)
+                    .Add(NodeIdKey, NodeId);
+
+                if (Signature is { } signature)
+                {
+                    dict = dict.Add(SignatureKey, signature);
+                }
+
+                return codec.Encode(dict);
+            }
+        }
+
+        public bool Equals(Vote other)
+        {
+            return Height == other.Height &&
+                   Round == other.Round &&
+                   BlockHash.Equals(other.BlockHash) &&
+                   Timestamp
+                       .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                           other.Timestamp.ToString(
+                               TimestampFormat,
+                               CultureInfo.InvariantCulture)) &&
+                   Validator.Equals(other.Validator) &&
+                   NodeId == other.NodeId &&
+                   Flag == other.Flag &&
+                   Nullable.Equals(Signature, other.Signature);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is Vote other && Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                BlockHash,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                Validator,
+                NodeId,
+                Signature);
+        }
+    }
+}

--- a/Libplanet/Consensus/VoteFlag.cs
+++ b/Libplanet/Consensus/VoteFlag.cs
@@ -6,23 +6,23 @@ namespace Libplanet.Consensus
     public enum VoteFlag
     {
         /// <summary>
+        /// Error.
+        /// </summary>
+        Null = 0,
+
+        /// <summary>
         /// No response.
         /// </summary>
-        Unknown = 0,
+        Unknown = 1,
 
         /// <summary>
         /// Vote. but not commit.
         /// </summary>
-        Absent = 1,
+        Absent = 2,
 
         /// <summary>
         /// Vote and Commit.
         /// </summary>
-        Commit = 2,
-
-        /// <summary>
-        /// Error.
-        /// </summary>
-        Null = 3,
+        Commit = 3,
     }
 }

--- a/Libplanet/Consensus/VoteFlag.cs
+++ b/Libplanet/Consensus/VoteFlag.cs
@@ -1,0 +1,25 @@
+namespace Libplanet.Consensus
+{
+    public enum VoteFlag
+    {
+        /// <summary>
+        /// No response.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Vote.
+        /// </summary>
+        Absent = 1,
+
+        /// <summary>
+        /// Commit.
+        /// </summary>
+        Commit = 2,
+
+        /// <summary>
+        /// Error.
+        /// </summary>
+        Null = 3,
+    }
+}

--- a/Libplanet/Consensus/VoteFlag.cs
+++ b/Libplanet/Consensus/VoteFlag.cs
@@ -1,5 +1,8 @@
 namespace Libplanet.Consensus
 {
+    /// <summary>
+    /// A State about <see cref="Vote"/>.
+    /// </summary>
     public enum VoteFlag
     {
         /// <summary>
@@ -8,12 +11,12 @@ namespace Libplanet.Consensus
         Unknown = 0,
 
         /// <summary>
-        /// Vote.
+        /// Vote. but not commit.
         /// </summary>
         Absent = 1,
 
         /// <summary>
-        /// Commit.
+        /// Vote and Commit.
         /// </summary>
         Commit = 2,
 

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A set of <see cref="Vote"/>.
+    /// <see cref="VoteSet"/> is storing some <see cref="Vote"/> for elect vote.
+    /// </summary>
+    public class VoteSet
+    {
+        // FIXME: Should separate prevote lock and commit vote lock?
+        private readonly object _lock;
+        private Vote[] _prevotes;
+        private Vote[] _commits;
+
+        public VoteSet(long height, long round, IEnumerable<PublicKey> validatorSet)
+        {
+            Height = height;
+            Round = round;
+            ValidatorSet = validatorSet.ToImmutableArray();
+            _prevotes = new Vote[ValidatorSet.Length];
+            _commits = new Vote[ValidatorSet.Length];
+
+            // TODO: Fill Votes with null Signature?
+            Sum = 0;
+
+            _lock = new object();
+        }
+
+        public long Height { get; }
+
+        public long Round { get; }
+
+        public ImmutableArray<PublicKey> ValidatorSet { get; }
+
+        public long Sum { get; }
+
+        public bool Add(Vote vote)
+        {
+            lock (_lock)
+            {
+                if (!IsVoteValid(vote))
+                {
+                    return false;
+                }
+
+                return vote.Flag switch
+                {
+                    VoteFlag.Absent => AddVote(vote),
+                    VoteFlag.Commit => AddCommit(vote),
+                    _ => false,
+                };
+            }
+        }
+
+        public bool HasTwoThirdAny()
+        {
+            var twoThird = ValidatorSet.Length * 2.0 / 3.0;
+            if (_prevotes.Count(x => !(x.Signature is null)) > twoThird)
+            {
+                return true;
+            }
+
+            if (_commits.Count(x => !(x.Signature is null)) > twoThird)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool HasTwoThirdPrevote()
+        {
+            var twoThird = ValidatorSet.Length * 2.0 / 3.0;
+            return _prevotes.Count(x => !(x.Signature is null)) > twoThird;
+        }
+
+        public bool HasTwoThirdCommit()
+        {
+            var twoThird = ValidatorSet.Length * 2.0 / 3.0;
+            return _commits.Count(x => !(x.Signature is null)) > twoThird;
+        }
+
+        private bool IsVoteValid(Vote vote)
+        {
+            if (vote.Height != Height)
+            {
+                return false;
+            }
+
+            if (vote.Round != Round)
+            {
+                return false;
+            }
+
+            if (!ValidatorSet.Contains(vote.Validator))
+            {
+                // The voter is not a validator.
+                return false;
+            }
+
+            // TODO: Should check signature :)
+            return true;
+        }
+
+        private bool AddVote(Vote vote)
+        {
+            if (_prevotes[vote.NodeId].Signature is null)
+            {
+                _prevotes[vote.NodeId] = vote;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool AddCommit(Vote vote)
+        {
+            if (_commits[vote.NodeId].Signature is null)
+            {
+                _commits[vote.NodeId] = vote;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Context
For migration PoS, We need some struct for recording who participated in the block validation.

## Rationale
```mermaid
classDiagram
    Block~T~ o-- Commit
    Commit *-- Vote
    VoteSet *-- Vote
    class Block~T~ {
        +Commit LastCommit
    }

    class Commit {
        +Vote[] Votes
    }
    
    class Vote {
        + long Height
        + int Round
        + PublicKey Validator
        + TimeStmap timeStamp 
    }

    class VoteSet {
        -Vote[] _prevote
        -Vote[] _commit
    }
```