### PR TITLE
Introduce `BlockCommit`

### DIFF
--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Libplanet.Tests.Store;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blocks
+{
+    public class BlockCommitTest
+    {
+         private readonly ITestOutputHelper _output;
+
+         public BlockCommitTest(ITestOutputHelper output)
+         {
+             _output = output;
+         }
+
+         [Fact]
+         public void Marshalling()
+         {
+             var fx = new MemoryStoreFixture();
+             var votes = Enumerable.Range(0, 4)
+                                          .Select(x => new Vote(
+                                              1,
+                                              0,
+                                              fx.Hash1,
+                                              DateTimeOffset.Now,
+                                              new PrivateKey().PublicKey,
+                                              VoteFlag.Absent,
+                                              x,
+                                              ImmutableArray<byte>.Empty))
+                                          .ToImmutableArray();
+             var blockCommit = new BlockCommit(1, 0, fx.Hash1, votes);
+
+             byte[] marshaled = blockCommit.ByteArray;
+             var unMarshaled = new BlockCommit(marshaled);
+
+             Assert.Equal(blockCommit, unMarshaled);
+         }
+    }
+}

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -143,6 +143,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _preEvaluationBlock.TxHash;
 
+        public BlockCommit? LastCommit { get; }
+
         /// <inheritdoc cref="IBlockContent{T}.Transactions"/>
         public IReadOnlyList<Transaction<T>> Transactions => _preEvaluationBlock.Transactions;
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -143,7 +143,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _preEvaluationBlock.TxHash;
 
-        public BlockCommit? LastCommit { get; }
+        /// <inheritdoc cref="IBlockMetadata.LastCommit"/>
+        public BlockCommit? LastCommit => _preEvaluationBlock.LastCommit;
 
         /// <inheritdoc cref="IBlockContent{T}.Transactions"/>
         public IReadOnlyList<Transaction<T>> Transactions => _preEvaluationBlock.Transactions;

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Consensus;
+
+namespace Libplanet.Blocks
+{
+    public readonly struct BlockCommit
+    {
+        private const string HeightKey = "height";
+        private const string RoundKey = "round";
+        private const string BlockHashKey = "block_hash";
+        private const string VotesKey = "votes";
+
+        public BlockCommit(
+            long height,
+            long round,
+            BlockHash hash,
+            ImmutableArray<Vote>? votes)
+        {
+            Height = height;
+            Round = round;
+            BlockHash = hash;
+            if (Height != 0 && votes is null)
+            {
+                // TODO: Make new exception.
+                throw new Exception("Null votes are only allow genesis block.");
+            }
+
+            Votes = votes;
+        }
+
+        public BlockCommit(byte[] marshaled)
+        {
+            var codec = new Codec();
+            try
+            {
+                var dict = (Dictionary)codec.Decode(marshaled);
+                Height = dict.GetValue<Integer>(HeightKey);
+                Round = dict.GetValue<Integer>(RoundKey);
+                BlockHash = new BlockHash(dict.GetValue<Binary>(BlockHashKey).ByteArray);
+                Votes = dict.ContainsKey(VotesKey)
+                    ? ((IEnumerable<IValue>)dict.GetValue<IValue>(VotesKey)).Select(x =>
+                        new Vote((Binary)x)).ToImmutableArray()
+                    : (ImmutableArray<Vote>?)null;
+            }
+            catch (Exception)
+            {
+                throw new ArgumentException(
+                    "Cannot unmarshal given bytearray into vote.",
+                    nameof(marshaled));
+            }
+        }
+
+        public BlockCommit(VoteSet set, BlockHash hash)
+            : this(set.Height, set.Round, hash, set.Votes)
+        {
+        }
+
+        public long Height { get; }
+
+        public long Round { get; }
+
+        public BlockHash BlockHash { get; }
+
+        public ImmutableArray<Vote>? Votes { get; }
+
+        public byte[] ByteArray
+        {
+            get
+            {
+                var codec = new Codec();
+                var dict = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(BlockHashKey, BlockHash.ByteArray);
+
+                if (Votes is { } votes)
+                {
+                    var bencodexVotes = votes.Select(x => (IValue)(Binary)x.ByteArray);
+                    dict = dict.Add(VotesKey, bencodexVotes);
+                }
+
+                return codec.Encode(dict);
+            }
+        }
+
+        public bool Equals(BlockCommit other)
+        {
+            if (Height == 0)
+            {
+                return Height == other.Height
+                       && Round == other.Round
+                       && BlockHash.Equals(other.BlockHash);
+            }
+
+            return other.Votes != null && Votes != null && Height == other.Height &&
+                   Round == other.Round && BlockHash.Equals(other.BlockHash) &&
+                   Votes.Value.SequenceEqual(other.Votes.Value);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is BlockCommit other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Height, Round, BlockHash, Votes);
+        }
+    }
+}

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -150,6 +150,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _preEvaluationBlockHeader.TxHash;
 
+        public BlockCommit? LastCommit => _preEvaluationBlockHeader.LastCommit;
+
         /// <inheritdoc cref="IBlockHeader.Signature"/>
         public ImmutableArray<byte>? Signature { get; }
 

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -33,6 +33,7 @@ namespace Libplanet.Blocks
         private static readonly byte[] StateRootHashKey = { 0x73 }; // 's'
         private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
         private static readonly byte[] PreEvaluationHashKey = { 0x63 }; // 'c'
+        private static readonly byte[] LastCommitKey = { 0x43 }; // 'C'
 
         // Block fields:
         private static readonly byte[] HeaderKey = { 0x48 }; // 'H'
@@ -66,6 +67,11 @@ namespace Libplanet.Blocks
             dict = metadata.PublicKey is { } pubKey
                 ? dict.Add(PublicKeyKey, pubKey.Format(compress: true))
                 : dict.Add(MinerKey, metadata.Miner.ByteArray);
+
+            if (metadata.LastCommit is { } commit)
+            {
+                dict = dict.Add(LastCommitKey, commit.ByteArray);
+            }
 
             return dict;
         }
@@ -195,6 +201,9 @@ namespace Libplanet.Blocks
                     ? new HashDigest<SHA256>(
                         marshaled.GetValue<Binary>(TxHashKey).ByteArray)
                     : (HashDigest<SHA256>?)null,
+                LastCommit = marshaled.ContainsKey(LastCommitKey)
+                ? new BlockCommit(marshaled.GetValue<Binary>(LastCommitKey).ByteArray.ToArray())
+                : (BlockCommit?)null,
             };
 
             if (marshaled.ContainsKey(PublicKeyKey))

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -67,6 +67,7 @@ namespace Libplanet.Blocks
         /// than its <see cref="IBlockMetadata.Difficulty"/>.</exception>
         public BlockMetadata(IBlockMetadata metadata)
         {
+            LastCommit = metadata.LastCommit;
             ProtocolVersion = metadata.ProtocolVersion;
             Index = metadata.Index;
             Timestamp = metadata.Timestamp;
@@ -234,6 +235,8 @@ namespace Libplanet.Blocks
             get => _txHash;
             set => _txHash = value;
         }
+
+        public BlockCommit? LastCommit { get; set; }
 
         /// <summary>
         /// Serializes data of a possible candidate shifted from it into a Bencodex dictionary.

--- a/Libplanet/Blocks/IBlockMetadata.cs
+++ b/Libplanet/Blocks/IBlockMetadata.cs
@@ -66,5 +66,10 @@ namespace Libplanet.Blocks
         /// transactions.
         /// </summary>
         HashDigest<SHA256>? TxHash { get; }
+
+        /// <summary>
+        /// The <see cref="BlockCommit"/> about previous block's vote information.
+        /// </summary>
+        BlockCommit? LastCommit { get; }
     }
 }

--- a/Libplanet/Blocks/PreEvaluationBlockHeader.cs
+++ b/Libplanet/Blocks/PreEvaluationBlockHeader.cs
@@ -276,6 +276,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => Metadata.TxHash;
 
+        public BlockCommit? LastCommit => Metadata.LastCommit;
+
         /// <inheritdoc cref="IPreEvaluationBlockHeader.HashAlgorithm"/>
         public HashAlgorithmType HashAlgorithm { get; }
 

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -52,6 +52,11 @@ namespace Libplanet.Consensus
 
         public long Sum { get; }
 
+        public ImmutableArray<Vote> Votes
+        {
+            get => _votes.ToImmutableArray();
+        }
+
         public bool Add(Vote vote)
         {
             lock (_lock)

--- a/Libplanet/Store/BlockDigest.cs
+++ b/Libplanet/Store/BlockDigest.cs
@@ -96,6 +96,8 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _metadata.TxHash;
 
+        public BlockCommit? LastCommit => _metadata.LastCommit;
+
         /// <summary>
         /// The block hash.
         /// </summary>


### PR DESCRIPTION
continue on the #1968 

## Context
For migration PoS, We need some struct for recording who participated in the block validation.

## Decision
```mermaid
classDiagram
    Block~T~ o-- Commit
    Commit *-- Vote
    VoteSet *-- Vote
    class Block~T~ {
        +Commit LastCommit
    }

    class Commit {
        +Vote[] Votes
    }
    
    class Vote {
        + long Height
        + int Round
        + PublicKey Validator
        + TimeStmap timeStamp 
    }

    class VoteSet {
        -Vote[] _votes
    }
```