### PR TITLE
Using `Vote` and `VoteSet` on the PBFT

### DIFF
--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -433,6 +433,8 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public int GetMaxTransactionsPerSignerPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerSignerPerBlock(index);
+
+            public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
         }
 
         internal class Startup : IBlockChainContext<NullAction>

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new ConsensusContext<DumbAction>(
                     0,
-                    new List<Address>(),
+                    new List<PublicKey>(),
                     _blockChain));
         }
 
@@ -74,7 +74,9 @@ namespace Libplanet.Net.Tests.Consensus
         public void ToStringTest()
         {
             long nodeId = 3;
-            var validators = new Address[4].ToList();
+            var validators = Enumerable.Range(0, 7)
+                                             .Select(x => new PrivateKey().PublicKey)
+                                             .ToList();
             long height = 6;
             long round = 5;
             string step = "DefaultState";

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Net.Tests.Consensus
             string host = "localhost",
             int port = 5001,
             long id = 0,
-            List<Address> validators = null!)
+            List<PublicKey> validators = null!)
         {
             key ??= new PrivateKey();
             var transport = new NetMQTransport(

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Net.Tests.Consensus
             string host = "localhost",
             int port = 5001,
             long id = 0,
-            List<Address> validators = null!);
+            List<PublicKey> validators = null!);
 
         [Fact(Timeout = (TimerTestTimeout * 2) + TimerTestMargin)]
         public async void VoteCommitTimeout()
@@ -59,10 +59,10 @@ namespace Libplanet.Net.Tests.Consensus
             // For preventing one man Vote-Commit-newHeight.
             var fakeKey = new PrivateKey();
             var key = new PrivateKey();
-            var validators = new List<Address>
+            var validators = new List<PublicKey>
             {
-                key.ToAddress(),
-                fakeKey.ToAddress(),
+                key.PublicKey,
+                fakeKey.PublicKey,
             };
             const int proposeProcessWaitTime = 100;
             const int yieldTime = 200;
@@ -146,7 +146,7 @@ namespace Libplanet.Net.Tests.Consensus
             var keys = new PrivateKey[count];
             var tables = new RoutingTable[count];
             var reactors = new IReactor[count];
-            var validators = new List<Address>();
+            var validators = new List<PublicKey>();
             var stores = new IStore[count];
             var blockChains = new BlockChain<DumbAction>[count];
 
@@ -154,7 +154,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 keys[i] = new PrivateKey();
                 tables[i] = new RoutingTable(keys[i].ToAddress());
-                validators.Add(keys[i].ToAddress());
+                validators.Add(keys[i].PublicKey);
                 stores[i] = new MemoryStore();
                 blockChains[i] = new BlockChain<DumbAction>(
                     TestUtils.Policy,

--- a/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Tests.Common.Action;
@@ -16,30 +17,33 @@ namespace Libplanet.Net.Tests.Consensus
         public void RoundContext()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new RoundContext<DumbAction>(0, new List<Address>(), 0, 0));
+                () => new RoundContext<DumbAction>(0, new List<PublicKey>(), 0, 0));
         }
 
         [Fact]
         public void Vote()
         {
-            Address duplicatedAddress = new PrivateKey().ToAddress();
-            Address uniqueAddress = new PrivateKey().ToAddress();
-            RoundContext<DumbAction> context = TestUtils.CreateRoundContext();
+            var validator = Enumerable.Range(0, 2)
+                .Select(x => new PrivateKey().PublicKey)
+                .ToList();
+            Vote duplicatedVote = TestUtils.CreateVote(validator[0], VoteFlag.Absent, id: 0);
+            Vote uniqueVote = TestUtils.CreateVote(validator[1], VoteFlag.Absent, id: 1);
+            RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validator);
             long initialVoteCount = context.VoteCount;
-            context.Vote(duplicatedAddress);
+            context.Vote(duplicatedVote);
             Assert.Equal(initialVoteCount + 1, context.VoteCount);
-            context.Vote(duplicatedAddress);
+            context.Vote(duplicatedVote);
             Assert.Equal(initialVoteCount + 1, context.VoteCount);
-            context.Vote(uniqueAddress);
+            context.Vote(uniqueVote);
             Assert.Equal(initialVoteCount + 2, context.VoteCount);
-            Assert.Throws<ArgumentNullException>(() => context.Vote(null));
         }
 
         [Fact]
         public void ResetVote()
         {
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext();
-            context.Vote(new PrivateKey().ToAddress());
+            Vote vote = TestUtils.CreateVote(new PrivateKey().PublicKey, VoteFlag.Absent);
+            context.Vote(vote);
             context.ResetVote();
             Assert.Equal(0, context.VoteCount);
         }
@@ -47,42 +51,46 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void HasTwoThirdsAny()
         {
-            List<Address> validator = new Address[3].ToList();
+            List<PublicKey> validator = Enumerable.Range(0, 4)
+                .Select(x => new PrivateKey().PublicKey)
+                .ToList();
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validator);
             // 0 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(new PrivateKey().ToAddress());
+            context.Vote(TestUtils.CreateVote(validator[0], VoteFlag.Absent, id: 0));
             // 1 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(new PrivateKey().ToAddress());
+            context.Vote(TestUtils.CreateVote(validator[1], VoteFlag.Absent, id: 1));
             // 2 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(new PrivateKey().ToAddress());
+            context.Vote(TestUtils.CreateVote(validator[2], VoteFlag.Absent, id: 2));
             // 3 > 2
             Assert.True(context.HasTwoThirdsAny());
-            context.Vote(new PrivateKey().ToAddress());
+            context.Vote(TestUtils.CreateVote(validator[3], VoteFlag.Absent, id: 3));
         }
 
         [Fact]
         public void LeaderElection()
         {
-            List<Address> validator = new Address[3].ToList();
+            List<PublicKey> validator = Enumerable.Range(0, 3)
+                .Select(x => new PrivateKey().PublicKey)
+                .ToList();
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validator, round: 0);
             Assert.Equal(0, context.Round);
             Assert.Equal(0, context.LeaderElection());
-            Assert.Equal(validator[0], context.Proposer());
+            Assert.Equal(validator[0].ToAddress(), context.Proposer());
             context = TestUtils.CreateRoundContext(validator, round: 1);
             Assert.Equal(1, context.Round);
             Assert.Equal(1, context.LeaderElection());
-            Assert.Equal(validator[1], context.Proposer());
+            Assert.Equal(validator[1].ToAddress(), context.Proposer());
             context = TestUtils.CreateRoundContext(validator, round: 2);
             Assert.Equal(2, context.Round);
             Assert.Equal(2, context.LeaderElection());
-            Assert.Equal(validator[2], context.Proposer());
+            Assert.Equal(validator[2].ToAddress(), context.Proposer());
             context = TestUtils.CreateRoundContext(validator, round: 3);
             Assert.Equal(3, context.Round);
             Assert.Equal(0, context.LeaderElection());
-            Assert.Equal(validator[0], context.Proposer());
+            Assert.Equal(validator[0].ToAddress(), context.Proposer());
         }
 
         [Fact]
@@ -93,7 +101,9 @@ namespace Libplanet.Net.Tests.Consensus
             const long id = 3;
             const long height = 8;
             const long round = 20;
-            List<Address> validators = new Address[7].ToList();
+            List<PublicKey> validators = Enumerable.Range(0, 7)
+                .Select(x => new PrivateKey().PublicKey)
+                .ToList();
             const long numberOfValidators = 7;
             const string step = "PreCommitState";
             const int voteCount = 2;
@@ -106,7 +116,8 @@ namespace Libplanet.Net.Tests.Consensus
             context.BlockHash = blockHash;
             for (int i = 0; i < voteCount; i++)
             {
-                context.Vote(new PrivateKey().ToAddress());
+                context.Vote(
+                    TestUtils.CreateVote(validators[i], VoteFlag.Absent, i, height, round));
             }
 
             // replace data field with encoding

--- a/Libplanet.Net.Tests/Consensus/States/DefaultStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/DefaultStateTest.cs
@@ -1,6 +1,7 @@
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
@@ -34,7 +35,8 @@ namespace Libplanet.Net.Tests.Consensus.States
             Assert.Throws<TryUnexpectedMessageHandleException>(
                 () => state.Handle(
                     context,
-                    new ConsensusCommit(0, 0, 0, blockHash) { Remote = TestUtils.Peer0 }));
+                    new ConsensusCommit(TestUtils.CreateVote(blockHash, VoteFlag.Commit, 0, 0, 0))
+                        { Remote = TestUtils.Peer0 }));
             Assert.Throws<UnexpectedRoundProposeException>(
                 () => state.Handle(
                     context,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Protocols;
@@ -15,9 +19,13 @@ namespace Libplanet.Net.Tests
                 ByteUtil.ParseHex(
                     "0204b09e833560269d0dc1100c221442b9969e74a3949ca306aecda20a6a2afba4")));
 
-        public static readonly List<Address> Validators = new List<Address>
+        public static readonly BlockHash BlockHash0 =
+            BlockHash.FromString(
+                "042b81bef7d4bca6e01f5975ce9ac7ed9f75248903d08836bed6566488c8089d");
+
+        public static readonly List<PublicKey> Validators = new List<PublicKey>
         {
-            Peer0.Address,
+            Peer0.PublicKey,
         };
 
         public static AppProtocolVersion AppProtocolVersion = AppProtocolVersion.FromToken(
@@ -35,7 +43,7 @@ namespace Libplanet.Net.Tests
             CreateConsensusContext(Validators, blockChain, id);
 
         public static ConsensusContext<DumbAction> CreateConsensusContext(
-            List<Address> validator,
+            List<PublicKey> validator,
             BlockChain<DumbAction> blockChain,
             long id = 0) =>
             new ConsensusContext<DumbAction>(
@@ -50,11 +58,59 @@ namespace Libplanet.Net.Tests
             new RoundContext<DumbAction>(id, Validators, height, round);
 
         public static RoundContext<DumbAction> CreateRoundContext(
-            List<Address> validators,
+            List<PublicKey> validators,
             long id = 0,
             long height = 0,
             long round = 0) =>
             new RoundContext<DumbAction>(id, validators, height, round);
+
+        public static Vote CreateVote(
+            PublicKey publicKey,
+            VoteFlag flag = VoteFlag.Null,
+            long id = 0,
+            long height = 0,
+            long round = 0) =>
+            new Vote(
+                height,
+                round,
+                BlockHash0,
+                DateTimeOffset.Now,
+                publicKey,
+                flag,
+                id,
+                ImmutableArray<byte>.Empty);
+
+        public static Vote CreateVote(
+            BlockHash hash,
+            VoteFlag flag = VoteFlag.Null,
+            long id = 0,
+            long height = 0,
+            long round = 0,
+            PublicKey? publicKey = null) =>
+            new Vote(
+                height,
+                round,
+                hash,
+                DateTimeOffset.Now,
+                publicKey ?? Peer0.PublicKey,
+                flag,
+                id,
+                ImmutableArray<byte>.Empty);
+
+        public static Vote CreateVote(
+            VoteFlag flag = VoteFlag.Null,
+            long id = 0,
+            long height = 0,
+            long round = 0) =>
+            new Vote(
+                height,
+                round,
+                BlockHash0,
+                DateTimeOffset.Now,
+                new PrivateKey().PublicKey,
+                flag,
+                id,
+                ImmutableArray<byte>.Empty);
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
         {

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -6,6 +6,7 @@ using System.Timers;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Serilog;
 
@@ -19,14 +20,14 @@ namespace Libplanet.Net.Consensus
         private readonly BlockChain<T> _blockChain;
         private readonly ILogger _logger;
         private readonly TimeoutTicker _timoutTicker;
-        private readonly List<Address> _validators;
+        private readonly List<PublicKey> _validators;
         private readonly object _commitLock;
 
         private ConcurrentDictionary<long, RoundContext<T>> _roundContexts;
 
         public ConsensusContext(
             long nodeId,
-            List<Address> validators,
+            List<PublicKey> validators,
             BlockChain<T> blockChain)
         {
             if (validators.Count <= 0)

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
@@ -25,14 +27,17 @@ namespace Libplanet.Net.Consensus
             ITransport transport,
             BlockChain<T> blockChain,
             long nodeId,
-            List<Address> validators)
+            List<PublicKey>? validators)
         {
             _routingTable = routingTable;
             _transport = transport;
             _logger = Log
                 .ForContext<ConsensusReactor<T>>()
                 .ForContext("Source", nameof(ConsensusReactor<T>));
-            _context = new ConsensusContext<T>(nodeId, validators, blockChain);
+            _context = new ConsensusContext<T>(
+                nodeId,
+                validators ?? blockChain.Policy.GetValidators().ToList(),
+                blockChain);
         }
 
         public void Dispose()

--- a/Libplanet.Net/Consensus/DefaultState.cs
+++ b/Libplanet.Net/Consensus/DefaultState.cs
@@ -1,4 +1,5 @@
 using Libplanet.Action;
+using Libplanet.Consensus;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -44,11 +45,7 @@ namespace Libplanet.Net.Consensus
 
             roundContext.BlockHash = propose.BlockHash;
             roundContext.State = new PreVoteState<T>();
-            return new ConsensusVote(
-                context.NodeId,
-                context.Height,
-                context.Round,
-                roundContext.BlockHash);
+            return new ConsensusVote(roundContext.Voting(VoteFlag.Absent));
         }
     }
 }

--- a/Libplanet.Net/Consensus/PreCommitState.cs
+++ b/Libplanet.Net/Consensus/PreCommitState.cs
@@ -1,4 +1,5 @@
 using Libplanet.Action;
+using Libplanet.Consensus;
 using Libplanet.Net.Messages;
 using Serilog;
 
@@ -40,7 +41,7 @@ namespace Libplanet.Net.Consensus
 
             RoundContext<T> roundContext = context.CurrentRoundContext;
 
-            roundContext.Vote(commit.Remote?.Address);
+            roundContext.Vote(commit.CommitVote);
 
             if (!roundContext.HasTwoThirdsAny())
             {
@@ -65,7 +66,7 @@ namespace Libplanet.Net.Consensus
             }
 
             RoundContext<T> targetContext = context.RoundContextOf(vote.Round);
-            targetContext.Vote(vote.Remote?.Address);
+            targetContext.Vote(vote.ProposeVote);
 
             if (!targetContext.HasTwoThirdsAny())
             {
@@ -74,11 +75,7 @@ namespace Libplanet.Net.Consensus
 
             context.Round = vote.Round;
             targetContext.BlockHash = vote.BlockHash;
-            return new ConsensusCommit(
-                context.NodeId,
-                context.Height,
-                context.Round,
-                targetContext.BlockHash);
+            return new ConsensusCommit(targetContext.Voting(VoteFlag.Commit));
         }
     }
 }

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -43,7 +43,6 @@ namespace Libplanet.Net.Consensus
                 return null;
             }
 
-            roundContext.ResetVote();
             roundContext.State = new PreCommitState<T>();
             return new ConsensusCommit(roundContext.Voting(VoteFlag.Commit));
         }

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -1,4 +1,5 @@
 using Libplanet.Action;
+using Libplanet.Consensus;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -35,7 +36,7 @@ namespace Libplanet.Net.Consensus
             }
 
             RoundContext<T> roundContext = context.CurrentRoundContext;
-            roundContext.Vote(vote.Remote?.Address);
+            roundContext.Vote(vote.ProposeVote);
 
             if (!roundContext.HasTwoThirdsAny())
             {
@@ -44,11 +45,7 @@ namespace Libplanet.Net.Consensus
 
             roundContext.ResetVote();
             roundContext.State = new PreCommitState<T>();
-            return new ConsensusCommit(
-                context.NodeId,
-                context.Height,
-                context.Round,
-                roundContext.BlockHash);
+            return new ConsensusCommit(roundContext.Voting(VoteFlag.Commit));
         }
     }
 }

--- a/Libplanet.Net/Consensus/RoundContext.cs
+++ b/Libplanet.Net/Consensus/RoundContext.cs
@@ -99,24 +99,22 @@ namespace Libplanet.Net.Consensus
             lock (_lock)
             {
                 Log.Debug(
-                    "Vote({Before}/{Total}) NodeID: {Id}, Validator: {Address}, " +
-                    "Height: {Height}, Round: {Round}",
-                    _voteSet.Votes.Length,
+                    "Vote({Vote}/{Commit}/{Total}) NodeID: {Id}, " +
+                    "Validator: {Address}, Height: {Height}, Round: {Round}",
+                    VoteCount,
+                    CommitCount,
                     _numberOfValidator,
                     NodeId,
                     vote.Validator.ToAddress(),
                     Height,
                     Round);
-            }
-
-            lock (_lock)
-            {
                 if (_voteSet.Add(vote))
                 {
                     Log.Debug(
-                        "Vote Success({After}/{Total}) NodeID: {Id}, " +
+                        "Vote Success({Vote}/{Commit}/{Total}) NodeID: {Id}, " +
                         "Validator: {Address}, Height: {Height}, Round: {Round}",
-                        _voteSet.Votes.Length,
+                        VoteCount,
+                        CommitCount,
                         _numberOfValidator,
                         NodeId,
                         vote.Validator.ToAddress(),

--- a/Libplanet.Net/Messages/ConsensusCommit.cs
+++ b/Libplanet.Net/Messages/ConsensusCommit.cs
@@ -1,19 +1,35 @@
-using Libplanet.Blocks;
+using System.Collections.Generic;
+using Libplanet.Consensus;
 
 namespace Libplanet.Net.Messages
 {
     public class ConsensusCommit : ConsensusMessage
     {
-         public ConsensusCommit(long nodeId, long height, long round, BlockHash blockHash)
-         : base(nodeId, height, round, blockHash)
-         {
-         }
+        public ConsensusCommit(Vote vote)
+            : base(vote.NodeId, vote.Height, vote.Round, vote.BlockHash)
+        {
+            CommitVote = vote;
+        }
 
-         public ConsensusCommit(byte[][] dataframes)
-         : base(dataframes)
-         {
-         }
+        public ConsensusCommit(byte[][] dataframes)
+            : this(new Vote(dataframes[0]))
+        {
+        }
 
-         public override MessageType Type => MessageType.ConsensusCommit;
+        public Vote CommitVote { get; }
+
+        public override IEnumerable<byte[]> DataFrames
+        {
+            get
+            {
+                var frames = new List<byte[]>
+                {
+                    CommitVote.ByteArray,
+                };
+                return frames;
+            }
+        }
+
+        public override MessageType Type => MessageType.ConsensusCommit;
     }
 }

--- a/Libplanet.Net/Messages/ConsensusVote.cs
+++ b/Libplanet.Net/Messages/ConsensusVote.cs
@@ -1,17 +1,33 @@
-using Libplanet.Blocks;
+using System.Collections.Generic;
+using Libplanet.Consensus;
 
 namespace Libplanet.Net.Messages
 {
     public class ConsensusVote : ConsensusMessage
     {
-        public ConsensusVote(long nodeId, long height, long round, BlockHash blockHash)
-            : base(nodeId, height, round, blockHash)
+        public ConsensusVote(Vote vote)
+            : base(vote.NodeId, vote.Height, vote.Round, vote.BlockHash)
         {
+            ProposeVote = vote;
         }
 
         public ConsensusVote(byte[][] dataframes)
-            : base(dataframes)
+            : this(new Vote(dataframes[0]))
         {
+        }
+
+        public Vote ProposeVote { get; }
+
+        public override IEnumerable<byte[]> DataFrames
+        {
+            get
+            {
+                var frames = new List<byte[]>
+                {
+                    ProposeVote.ByteArray,
+                };
+                return frames;
+            }
         }
 
         public override MessageType Type => MessageType.ConsensusVote;

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
@@ -253,5 +254,7 @@ namespace Libplanet.Blockchain.Policies
         [Pure]
         public int GetMaxTransactionsPerSignerPerBlock(long index)
             => _getMaxTransactionsPerSignerPerBlock(index);
+
+        public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
     }
 }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
@@ -141,5 +142,12 @@ namespace Libplanet.Blockchain.Policies
         /// a valid <see cref="Block{T}"/> can accept.</returns>
         [Pure]
         int GetMaxTransactionsPerSignerPerBlock(long index);
+
+        /// <summary>
+        /// Gets <see cref="IEnumerable{T}"/> of validator.
+        /// </summary>
+        /// <returns><see cref="IEnumerable{T}"/> of validator.</returns>
+        [Pure]
+        IEnumerable<PublicKey> GetValidators();
     }
 }

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Tx;
 
 namespace Libplanet.Blockchain.Policies
@@ -60,5 +61,7 @@ namespace Libplanet.Blockchain.Policies
 
         public int GetMaxTransactionsPerSignerPerBlock(long index) =>
             GetMaxTransactionsPerBlock(index);
+
+        public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
     }
 }


### PR DESCRIPTION
continue on the https://github.com/planetarium/libplanet/pull/1968

## Context
Previously, voting was conducted based on the peer's public key. However, this has the following problems:

1. It can be trusted that the message comes from the node that signed the message, but it cannot be verified that the message is a signed message with the validator's key.
2. In order to save the Vote to the Block, it was necessary to directly sign the Vote.

## Decision
For the same reason as above, it has been implemented to ship and send `Vote` in the message.

```mermaid
classDiagram
    ConsensusContext o-- RoundContext~T~
    RoundContext~T~ o-- VoteSet
    ConsensusVote *-- Vote
    VoteSet *-- Vote
    ConsensusCommit *-- Vote
    class ConsensusContext {
        -Dict~< long, RoundContext< T>>~ _roundContexts
    }

    class RoundContext~T~ {
        -VoteSet _voteSet
        +Vote Voting(VoteFlag flag)
        +long Vote(Vote vote)
    }

    class ConsensusVote {
        + ConsensusVote(Vote)
    }

    class ConsensusCommit {
        + ConsensusCommit(Vote)
    }
    
    class Vote {
        + long Height
        + int Round
        + PublicKey Validator
        + TimeStmap timeStamp 
    }

    class VoteSet {
        -Vote[] _votes
        + bool Add()
    }
```