### PR TITLE
Reference to a wrong constant fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.35.1
 
 To be released.
 
+### Bug fixes
+
+-  (Libplanet.Net) Wrongly assigned default value to
+   `TimeoutOptions.PreloadDialTimeout` fixed.  [[#1983]]
+
+[#1983]: https://github.com/planetarium/libplanet/pull/1983
+
 
 Version 0.35.0
 --------------

--- a/Libplanet.Net/TimeoutOptions.cs
+++ b/Libplanet.Net/TimeoutOptions.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Net
         /// </summary>
         /// <seealso cref="DialTimeout"/>
         public TimeSpan PreloadDialTimeout { get; set; }
-            = TimeSpan.FromSeconds(DefaultBootstrapDialTimeout);
+            = TimeSpan.FromSeconds(DefaultPreloadDialTimeout);
 
         /// <summary>
         /// Determines how long an <see cref="ITransport"/> should wait before timing out


### PR DESCRIPTION
🐛 