### PR TITLE
Block Synchronization

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -205,10 +205,8 @@ namespace Libplanet.Net.Tests.Consensus
                     Block<DumbAction> block = await blockChains[proposeNode].MineBlock(
                         keys[proposeNode],
                         append: false);
-                    foreach (IStore store in stores)
-                    {
-                        store.PutBlock(block);
-                    }
+
+                    stores[proposeNode].PutBlock(block);
 
                     reactors[proposeNode].Propose(block.Hash);
 

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -77,6 +77,7 @@ namespace Libplanet.Net.Tests.Consensus
 
             try
             {
+                _fx.Store.PutBlock(_fx.Block1);
                 reactor.Propose(_fx.Block1.Hash);
                 await Task.Delay(proposeProcessWaitTime);
 

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -99,7 +99,10 @@ namespace Libplanet.Net.Consensus
             }
         }
 
-        public Block<T> GetBlockFromStore(BlockHash blockHash) =>
+        public bool ContainBlock(BlockHash blockHash) =>
+            _blockChain.Store.ContainsBlock(blockHash);
+
+        public Block<T>? GetBlockFromStore(BlockHash blockHash) =>
             _blockChain.Store.GetBlock<T>(HashAlgorithm, blockHash);
 
         public void PutBlockToStore(Block<T> block) =>

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -67,6 +67,8 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         public long NodeId { get; internal set; }
 
+        public HashAlgorithmGetter HashAlgorithm => _blockChain.Policy.GetHashAlgorithm;
+
         public RoundContext<T> CurrentRoundContext => RoundContextOf(Round);
 
         public void CommitBlock(long height, BlockHash hash)
@@ -96,6 +98,12 @@ namespace Libplanet.Net.Consensus
                 _roundContexts = new ConcurrentDictionary<long, RoundContext<T>>();
             }
         }
+
+        public Block<T> GetBlockFromStore(BlockHash blockHash) =>
+            _blockChain.Store.GetBlock<T>(HashAlgorithm, blockHash);
+
+        public void PutBlockToStore(Block<T> block) =>
+            _blockChain.Store.PutBlock(block);
 
         public long NextRound(long round)
         {

--- a/Libplanet.Net/Consensus/IReactor.cs
+++ b/Libplanet.Net/Consensus/IReactor.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Net.Consensus
 {
     public interface IReactor : IDisposable
     {
-        public Task ReceivedMessage(ConsensusMessage message);
+        public Task ReceivedMessage(Message message);
 
         public void Propose(BlockHash blockHash);
 


### PR DESCRIPTION
## In Sequence
1. A node proposes, Block is broadcasted and after then the proposal is broadcasted in following.
2. Some nodes will have a proposal with a block and some nodes won't.
3. In case when a node receives a proposal and the proposed Block is not present in its store, request a block from the proposal 
sender. (This is not always same as proposer)

## Changes
1. Appending block is happened in `ConsensusContext<T>` (Message can be processed in `ConsensusContext<T>`)
2. `BroadcastBlock()` is added and it is called before `BroadcastMessage()` in `Propose()`
3. Split Message handler for `Messages` and `ConsensusMessage`

## TODO
1. Lock should be implemented for the waiting proposal block.
    - Vote should proceed with validating block (Not implemented, for now, It's out of current development scope)