### PR TITLE
Add `BlockCommit` of last block when mine a new block

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -11,6 +11,7 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blockchain.Renderers.Debug;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
@@ -549,6 +550,29 @@ namespace Libplanet.Tests.Blockchain
                 txsA.Concat(txsB.Take(2)).Select(tx => tx.Id).ToHashSet(),
                 block.Transactions.Select(tx => tx.Id).ToHashSet()
             );
+        }
+
+        // TODO: Should add test with invalid commits.
+        [Fact]
+        public async Task MineBlockWithLastCommit()
+        {
+            var keyA = new PrivateKey();
+            var keyB = new PrivateKey();
+            var keyC = new PrivateKey();
+
+            var voteSet = new VoteSet(
+                _blockChain.Count,
+                0,
+                _blockChain.Tip.Hash,
+                new[] { keyA.PublicKey, keyB.PublicKey, keyC.PublicKey });
+            var blockCommit = new BlockCommit(voteSet, _blockChain.Tip.Hash);
+
+            Block<DumbAction> block = await _blockChain.MineBlock(
+                new PrivateKey(),
+                lastCommit: blockCommit);
+
+            Assert.NotNull(block.LastCommit);
+            AssertBytesEqual(block.LastCommit.Value.ByteArray, blockCommit.ByteArray);
         }
 
         [RetryFact]

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Tx;
@@ -32,7 +34,23 @@ namespace Libplanet.Tests.Blocks
                 nonce: new byte[] { 0x02, 0x00, 0x00, 0x00 },
                 protocolVersion: ProtocolVersion,
                 stateRootHash: HashDigest<SHA256>.FromString(
-                    "6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")
+                    "6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa"),
+                lastCommit: new BlockCommit(
+                    height: Genesis.Index,
+                    round: 0,
+                    hash: Genesis.Hash,
+                    votes: new[]
+                    {
+                        new Vote(
+                            Genesis.Index,
+                            0,
+                            Genesis.Hash,
+                            Genesis.Timestamp,
+                            Miner.PublicKey,
+                            VoteFlag.Commit,
+                            0,
+                            null),
+                    }.ToImmutableArray())
             );
             byte[] hasTxNonce =
             {
@@ -49,7 +67,23 @@ namespace Libplanet.Tests.Blocks
                 nonce: hasTxNonce,
                 protocolVersion: ProtocolVersion,
                 stateRootHash: HashDigest<SHA256>.FromString(
-                    "aaeda4f1a6a4aee7fc9a29014cff005109176e83a8e5d28876f2d889680e6421")
+                    "aaeda4f1a6a4aee7fc9a29014cff005109176e83a8e5d28876f2d889680e6421"),
+                lastCommit: new BlockCommit(
+                    height: Next.Index,
+                    round: 0,
+                    hash: Next.Hash,
+                    votes: new[]
+                    {
+                        new Vote(
+                            Next.Index,
+                            0,
+                            Next.Hash,
+                            Next.Timestamp,
+                            Miner.PublicKey,
+                            VoteFlag.Commit,
+                            0,
+                            null),
+                    }.ToImmutableArray())
             );
         }
 

--- a/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
@@ -32,6 +32,7 @@ namespace Libplanet.Tests
         private static readonly byte[] StateRootHashKey = { 0x73 }; // 's'
         private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
         private static readonly byte[] PreEvaluationHashKey = { 0x63 }; // 'c'
+        private static readonly byte[] LastCommitKey = { 0x43 }; // 'C'
 
         // Block fields:
         private static readonly byte[] HeaderKey = { 0x48 }; // 'H'
@@ -84,7 +85,8 @@ namespace Libplanet.Tests
                     _fx.Next.Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                 .Add(DifficultyKey, _fx.Next.Difficulty)
                 .Add(TotalDifficultyKey, (IValue)(Integer)_fx.Next.TotalDifficulty)
-                .Add(PublicKeyKey, _fx.Next.PublicKey.Format(compress: true));
+                .Add(PublicKeyKey, _fx.Next.PublicKey.Format(compress: true))
+                .Add(LastCommitKey, _fx.Next.LastCommit.Value.ByteArray);
             var expectedNextHeader = _marshaledNextMetadata
                 .Add(NonceKey, _fx.Next.Nonce.ByteArray)
                 .Add(PreEvaluationHashKey, _fx.Next.PreEvaluationHash)
@@ -104,7 +106,8 @@ namespace Libplanet.Tests
                 .Add(DifficultyKey, _fx.HasTx.Difficulty)
                 .Add(TotalDifficultyKey, (IValue)(Integer)_fx.HasTx.TotalDifficulty)
                 .Add(PublicKeyKey, _fx.HasTx.PublicKey.Format(true))
-                .Add(TxHashKey, _fx.HasTx.TxHash.Value.ByteArray);
+                .Add(TxHashKey, _fx.HasTx.TxHash.Value.ByteArray)
+                .Add(LastCommitKey, _fx.HasTx.LastCommit.Value.ByteArray);
             var expectedHasTxHeader = _marshaledHasTxMetadata
                 .Add(NonceKey, _fx.HasTx.Nonce.ByteArray)
                 .Add(PreEvaluationHashKey, _fx.HasTx.PreEvaluationHash)

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -372,7 +372,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             long difficulty = 1,
             PublicKey miner = null,
             TimeSpan? blockInterval = null,
-            int protocolVersion = Block<T>.CurrentProtocolVersion
+            int protocolVersion = Block<T>.CurrentProtocolVersion,
+            BlockCommit? lastCommit = null
         )
             where T : IAction, new()
         {
@@ -387,6 +388,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 Timestamp = previousBlock.Timestamp.Add(blockInterval ?? TimeSpan.FromSeconds(15)),
                 Transactions = txs ?? Array.Empty<Transaction<T>>(),
                 ProtocolVersion = protocolVersion,
+                LastCommit = lastCommit,
             };
 
             HashAlgorithmType hashAlgorithm = hashAlgorithmGetter(previousBlock.Index + 1);
@@ -407,7 +409,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             long difficulty = 1,
             TimeSpan? blockInterval = null,
             int protocolVersion = Block<T>.CurrentProtocolVersion,
-            HashDigest<SHA256> stateRootHash = default
+            HashDigest<SHA256> stateRootHash = default,
+            BlockCommit? lastCommit = null
         )
             where T : IAction, new()
         {
@@ -419,7 +422,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 difficulty,
                 miner?.PublicKey,
                 blockInterval,
-                protocolVersion
+                protocolVersion,
+                lastCommit
             );
             return protocolVersion < 2
                 ? new Block<T>(preEval, stateRootHash, null)

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -42,6 +42,8 @@ namespace Libplanet.Blockchain
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
         /// <param name="txPriority">An optional comparer for give certain transactions to
         /// priority to belong to the block.  No certain priority by default.</param>
+        /// <param name="lastCommit"><see cref="BlockCommit"/> of previous <see cref="Block{T}"/>.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is mined.</returns>
@@ -55,6 +57,7 @@ namespace Libplanet.Blockchain
             int? maxTransactions = null,
             int? maxTransactionsPerSigner = null,
             IComparer<Transaction<T>> txPriority = null,
+            BlockCommit? lastCommit = null,
             CancellationToken? cancellationToken = null) =>
 #pragma warning disable SA1118
                 await MineBlock(
@@ -68,6 +71,7 @@ namespace Libplanet.Blockchain
                     maxTransactionsPerSigner: maxTransactionsPerSigner
                         ?? Policy.GetMaxTransactionsPerSignerPerBlock(Count),
                     txPriority: txPriority,
+                    lastCommit: lastCommit,
                     cancellationToken: cancellationToken ?? default(CancellationToken));
 #pragma warning restore SA1118
 
@@ -87,6 +91,8 @@ namespace Libplanet.Blockchain
         /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
         /// <param name="txPriority">An optional comparer for give certain transactions to
         /// priority to belong to the block.  No certain priority by default.</param>
+        /// <param name="lastCommit"><see cref="BlockCommit"/> of previous <see cref="Block{T}"/>.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is mined.</returns>
@@ -100,6 +106,7 @@ namespace Libplanet.Blockchain
             int maxTransactions,
             int maxTransactionsPerSigner,
             IComparer<Transaction<T>> txPriority = null,
+            BlockCommit? lastCommit = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             using var cts = new CancellationTokenSource();
@@ -135,6 +142,7 @@ namespace Libplanet.Blockchain
 
             HashAlgorithmType hashAlgorithm = Policy.GetHashAlgorithm(index);
 
+            // TODO: Should validate LastCommit somewhere?
             var metadata = new BlockMetadata
             {
                 Index = index,
@@ -143,6 +151,7 @@ namespace Libplanet.Blockchain
                 PublicKey = miner.PublicKey,
                 PreviousHash = prevHash,
                 Timestamp = timestamp,
+                LastCommit = lastCommit,
             };
 
             var transactionsToMine = GatherTransactionsToMine(


### PR DESCRIPTION
This adds `lastCommit` argument for `BlockChain<T>.MineBlock()`.

But there are still no validation for `BlockCommit` given in `BlockChain<T>.MineBlock()`, should add logic for it somewhere ASAP.