### PR TITLE
Block Synchronization (refactored)

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -79,6 +79,7 @@ namespace Libplanet.Net.Tests.Consensus
             try
             {
                 reactor.Propose(_fx.Block1.Hash);
+                _fx.Store.PutBlock(_fx.Block1);
                 await Task.Delay(proposeProcessWaitTime);
 
                 var json =
@@ -206,10 +207,8 @@ namespace Libplanet.Net.Tests.Consensus
                     Block<DumbAction> block = await blockChains[proposeNode].MineBlock(
                         keys[proposeNode],
                         append: false);
-                    foreach (IStore store in stores)
-                    {
-                        store.PutBlock(block);
-                    }
+
+                    stores[proposeNode].PutBlock(block);
 
                     reactors[proposeNode].Propose(block.Hash);
 

--- a/Libplanet.Net.Tests/Consensus/States/DefaultStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/DefaultStateTest.cs
@@ -52,6 +52,11 @@ namespace Libplanet.Net.Tests.Consensus.States
             ConsensusMessage? res = state.Handle(
                 context,
                 new ConsensusPropose(0, 0, 0, blockHash) { Remote = TestUtils.Peer0 });
+            Assert.Null(res);
+            _fx.Store.PutBlock(_fx.Block1);
+            res = state.Handle(
+                context,
+                new ConsensusPropose(0, 0, 0, blockHash) { Remote = TestUtils.Peer0 });
             Assert.NotNull(res);
             Assert.IsType<ConsensusVote>(res);
             Assert.Equal(blockHash, context.CurrentRoundContext.BlockHash);

--- a/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
@@ -75,6 +75,33 @@ namespace Libplanet.Net.Tests.Consensus.States
                             TestUtils.CreateVote(invalidBlockHash, VoteFlag.Absent, 0, 0, 0))
                         { Remote = TestUtils.Peer0 }));
             Assert.Equal(0, context.CurrentRoundContext.VoteCount);
+            Assert.Throws<VoteBlockNotExistsException>(
+                () => state.Handle(
+                    context,
+                    new ConsensusVote(
+                            TestUtils.CreateVote(
+                                validBlockHash,
+                                VoteFlag.Absent,
+                                0,
+                                0,
+                                0,
+                                validatorsPubKey[0]).Sign(
+                                validators[0]))
+                        { Remote = TestUtils.Peer0 }));
+            _fx.Store.PutBlock(_fx.Block1);
+            Assert.NotNull(
+                state.Handle(
+                    context,
+                    new ConsensusVote(
+                            TestUtils.CreateVote(
+                                validBlockHash,
+                                VoteFlag.Absent,
+                                0,
+                                0,
+                                0,
+                                validatorsPubKey[0]).Sign(
+                                validators[0]))
+                        { Remote = TestUtils.Peer0 }));
             Assert.Null(
                 state.Handle(
                     context,

--- a/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
@@ -82,7 +82,7 @@ namespace Libplanet.Net.Tests.Consensus.States
                             TestUtils.CreateVote(
                                 validBlockHash,
                                 VoteFlag.Absent,
-                                0,
+                                1,
                                 0,
                                 0,
                                 validatorsPubKey[0]).Sign(
@@ -96,7 +96,7 @@ namespace Libplanet.Net.Tests.Consensus.States
                             TestUtils.CreateVote(
                                 validBlockHash,
                                 VoteFlag.Absent,
-                                0,
+                                1,
                                 0,
                                 0,
                                 validatorsPubKey[0]).Sign(
@@ -109,7 +109,7 @@ namespace Libplanet.Net.Tests.Consensus.States
                                 TestUtils.CreateVote(
                                     validBlockHash,
                                     VoteFlag.Absent,
-                                    0,
+                                    1,
                                     0,
                                     0,
                                     validatorsPubKey[0]).Sign(

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -103,8 +103,8 @@ namespace Libplanet.Net.Consensus
                     hash,
                     NodeId);
 
-                // TODO: There's no coping mechanism when the proposed block is not present
-                // in commit stage.
+                // TODO: Needs additional block synchronization and recommit sequence if proposed
+                // block is not present in commit stage.
                 Block<T> block = _blockChain.Store.GetBlock<T>(
                     _blockChain.Policy.GetHashAlgorithm,
                     hash);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -72,6 +72,8 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         public long NodeId { get; internal set; }
 
+        public HashAlgorithmGetter HashAlgorithm => _blockChain.Policy.GetHashAlgorithm;
+
         public RoundContext<T> CurrentRoundContext => RoundContextOf(Round);
 
         // FIXME: Storing all voteset on memory is not required. Leave only 1~2 votesets.
@@ -107,6 +109,15 @@ namespace Libplanet.Net.Consensus
                 _roundContexts = new ConcurrentDictionary<long, RoundContext<T>>();
             }
         }
+
+        public bool ContainsBlock(BlockHash blockHash) =>
+            _blockChain.Store.ContainsBlock(blockHash);
+
+        public Block<T> GetBlockFromStore(BlockHash blockHash) =>
+            _blockChain.Store.GetBlock<T>(_blockChain.Policy.GetHashAlgorithm, blockHash);
+
+        public void PutBlockToStore(Block<T> block) =>
+            _blockChain.Store.PutBlock(block);
 
         public long NextRound(long round)
         {

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -78,6 +78,10 @@ namespace Libplanet.Net.Consensus
 
         public RoundContext<T> CurrentRoundContext => RoundContextOf(Round);
 
+        public bool IsVoteOnHold =>
+            CurrentRoundContext.State is PreVoteState<T> &&
+            CurrentRoundContext.CurrentNodeVoteFlag is VoteFlag.Null;
+
         // FIXME: Storing all voteset on memory is not required. Leave only 1~2 votesets.
         public Dictionary<long, VoteSet?> VoteSets { get; }
 
@@ -99,6 +103,8 @@ namespace Libplanet.Net.Consensus
                     hash,
                     NodeId);
 
+                // TODO: There's no coping mechanism when the proposed block is not present
+                // in commit stage.
                 Block<T> block = _blockChain.Store.GetBlock<T>(
                     _blockChain.Policy.GetHashAlgorithm,
                     hash);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Timers;
+using Bencodex;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -18,6 +19,7 @@ namespace Libplanet.Net.Consensus
     {
         public const long TimeoutMillisecond = 10 * 1000;
 
+        private readonly Codec _codec = new Codec();
         private readonly BlockChain<T> _blockChain;
         private readonly ILogger _logger;
         private readonly TimeoutTicker _timoutTicker;
@@ -113,8 +115,8 @@ namespace Libplanet.Net.Consensus
         public bool ContainsBlock(BlockHash blockHash) =>
             _blockChain.Store.ContainsBlock(blockHash);
 
-        public Block<T> GetBlockFromStore(BlockHash blockHash) =>
-            _blockChain.Store.GetBlock<T>(_blockChain.Policy.GetHashAlgorithm, blockHash);
+        public Block<T>? GetBlockFromStore(BlockHash blockHash) =>
+            _blockChain.Store.GetBlock<T>(HashAlgorithm, blockHash);
 
         public void PutBlockToStore(Block<T> block) =>
             _blockChain.Store.PutBlock(block);

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -230,6 +230,10 @@ namespace Libplanet.Net.Consensus
 
                 await _transport.ReplyMessageAsync(sending, CancellationToken.None);
             }
+            else
+            {
+                await ReplyPongAsync(message);
+            }
         }
 
         private async Task ReplyPongAsync(Message message)

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -18,6 +19,8 @@ namespace Libplanet.Net.Consensus
     public class ConsensusReactor<T> : IReactor
         where T : IAction, new()
     {
+        private readonly Codec _codec = new Codec();
+
         private RoutingTable _routingTable;
         private ITransport _transport;
         private ConsensusContext<T> _context;
@@ -143,12 +146,67 @@ namespace Libplanet.Net.Consensus
         {
             switch (message)
             {
-                case ConsensusMessage consensusMessage:
+                case Messages.Blocks block:
                     var pong = new Pong { Identity = message.Identity };
                     await _transport.ReplyMessageAsync(pong, CancellationToken.None);
+                    PutReceivedBlockToStore(block);
+                    break;
+                case GetBlocks hashes:
+                    await ResponseBlockAsync(hashes);
+                    break;
+                case ConsensusMessage consensusMessage:
+                    pong = new Pong { Identity = message.Identity };
+                    await _transport.ReplyMessageAsync(pong, CancellationToken.None);
+                    if (consensusMessage is ConsensusPropose consensusPropose &&
+                        !_context.ContainsBlock(consensusPropose.BlockHash))
+                    {
+                        await RequestBlockAsync(consensusMessage);
+                    }
+
                     await ReceivedMessage(consensusMessage);
                     break;
             }
+        }
+
+        private void PutReceivedBlockToStore(Messages.Blocks message)
+        {
+            var block = BlockMarshaler.UnmarshalBlock<T>(
+                _context.HashAlgorithm,
+                (Bencodex.Types.Dictionary)_codec.Decode(message.DataFrames.Last())
+            );
+
+            _context.PutBlockToStore(block);
+        }
+
+        private async Task RequestBlockAsync(ConsensusMessage consensusMessage)
+        {
+            var message = new GetBlocks(new[] { consensusMessage.BlockHash })
+            {
+                Identity = consensusMessage.Identity,
+                Remote = _transport.AsPeer,
+            };
+
+            await _transport.SendMessageAsync(
+                _routingTable.GetPeer(consensusMessage.Remote!.Address),
+                message,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+        }
+
+        private async Task ResponseBlockAsync(GetBlocks message)
+        {
+            var listBlock = new List<byte[]>()
+            {
+                _codec.Encode(
+                    _context.GetBlockFromStore(message.BlockHashes.First()).MarshalBlock()),
+            };
+            var sending = new Messages.Blocks(listBlock)
+            {
+                Identity = message.Identity,
+                Remote = _transport.AsPeer,
+            };
+
+            await _transport.ReplyMessageAsync(sending, CancellationToken.None);
         }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -200,7 +200,8 @@ namespace Libplanet.Net.Consensus
                     if (_context.IsVoteOnHold)
                     {
                         HandleMessage(
-                            new ConsensusVote(_context.CurrentRoundContext.Voting(VoteFlag.Absent)));
+                            new ConsensusVote(
+                                _context.CurrentRoundContext.Voting(VoteFlag.Absent)));
                     }
                 }
             }

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -144,19 +144,17 @@ namespace Libplanet.Net.Consensus
 
         private async Task ProcessMessageHandler(Message message)
         {
+            await ReplyPongAsync(message);
+
             switch (message)
             {
                 case Messages.Blocks block:
-                    var pong = new Pong { Identity = message.Identity };
-                    await _transport.ReplyMessageAsync(pong, CancellationToken.None);
                     PutReceivedBlockToStore(block);
                     break;
                 case GetBlocks hashes:
                     await ResponseBlockAsync(hashes);
                     break;
                 case ConsensusMessage consensusMessage:
-                    pong = new Pong { Identity = message.Identity };
-                    await _transport.ReplyMessageAsync(pong, CancellationToken.None);
                     if (consensusMessage is ConsensusPropose consensusPropose &&
                         !_context.ContainsBlock(consensusPropose.BlockHash))
                     {
@@ -175,16 +173,38 @@ namespace Libplanet.Net.Consensus
                 (Bencodex.Types.Dictionary)_codec.Decode(message.DataFrames.Last())
             );
 
-            _context.PutBlockToStore(block);
+            if (!_context.ContainsBlock(block.Hash))
+            {
+                _context.PutBlockToStore(block);
+
+                _logger.Debug(
+                    "{MethodName}: Received Block {BlockHash} from {Remote}",
+                    nameof(PutReceivedBlockToStore),
+                    block.Hash,
+                    message.Remote);
+
+                HandleMessage(
+                    new ConsensusVote(_context.CurrentRoundContext.Voting(VoteFlag.Absent)));
+            }
         }
 
         private async Task RequestBlockAsync(ConsensusMessage consensusMessage)
         {
-            var message = new GetBlocks(new[] { consensusMessage.BlockHash })
+            var hashList = new List<BlockHash>
             {
-                Identity = consensusMessage.Identity,
+                consensusMessage.BlockHash,
+            };
+            var message = new GetBlocks(hashList)
+            {
+                Version = consensusMessage.Version,
                 Remote = _transport.AsPeer,
             };
+
+            _logger.Debug(
+                "{MethodName}: Requesting Block {BlockHash} derived from {@Message}",
+                nameof(RequestBlockAsync),
+                consensusMessage.BlockHash,
+                consensusMessage);
 
             await _transport.SendMessageAsync(
                 _routingTable.GetPeer(consensusMessage.Remote!.Address),
@@ -195,18 +215,38 @@ namespace Libplanet.Net.Consensus
 
         private async Task ResponseBlockAsync(GetBlocks message)
         {
-            var listBlock = new List<byte[]>()
+            var block = _context.GetBlockFromStore(message.BlockHashes.Last());
+            if (block != null)
             {
-                _codec.Encode(
-                    _context.GetBlockFromStore(message.BlockHashes.First()).MarshalBlock()),
-            };
-            var sending = new Messages.Blocks(listBlock)
-            {
-                Identity = message.Identity,
-                Remote = _transport.AsPeer,
-            };
+                var listBlock = new List<byte[]>
+                {
+                    _codec.Encode(
+                        block.MarshalBlock()),
+                };
+                var sending = new Messages.Blocks(listBlock)
+                {
+                    Version = message.Version,
+                    Remote = _transport.AsPeer,
+                };
 
-            await _transport.ReplyMessageAsync(sending, CancellationToken.None);
+                _logger.Debug(
+                    "{MethodName}: Received Block request {BlockHash} from {Remote}",
+                    nameof(RequestBlockAsync),
+                    message.BlockHashes.First(),
+                    message.Remote);
+
+                await _transport.SendMessageAsync(
+                    _routingTable.GetPeer(message.Remote!.Address),
+                    sending,
+                    TimeSpan.FromSeconds(1),
+                    CancellationToken.None);
+            }
+        }
+
+        private async Task ReplyPongAsync(Message message)
+        {
+            var pong = new Pong { Identity = message.Identity };
+            await _transport.ReplyMessageAsync(pong, CancellationToken.None);
         }
     }
 }

--- a/Libplanet.Net/Consensus/DefaultState.cs
+++ b/Libplanet.Net/Consensus/DefaultState.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Net.Consensus
     {
         public string Name { get; } = "DefaultState";
 
-        public ConsensusMessage Handle(ConsensusContext<T> context, ConsensusMessage message)
+        public ConsensusMessage? Handle(ConsensusContext<T> context, ConsensusMessage message)
         {
             return message switch
             {
@@ -18,7 +18,7 @@ namespace Libplanet.Net.Consensus
             };
         }
 
-        private ConsensusMessage HandlePropose(
+        private ConsensusMessage? HandlePropose(
             ConsensusContext<T> context,
             ConsensusPropose propose)
         {
@@ -45,7 +45,11 @@ namespace Libplanet.Net.Consensus
 
             roundContext.BlockHash = propose.BlockHash;
             roundContext.State = new PreVoteState<T>();
-            return new ConsensusVote(context.SignVote(roundContext.Voting(VoteFlag.Absent)));
+
+            return context.ContainsBlock(propose.BlockHash) ?
+                new ConsensusVote(
+                    context.SignVote(
+                    roundContext.Voting(VoteFlag.Absent))) : null;
         }
     }
 }

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -36,6 +36,23 @@ namespace Libplanet.Net.Consensus
             }
 
             RoundContext<T> roundContext = context.CurrentRoundContext;
+
+            if (context.NodeId == vote.NodeId &&
+                vote.BlockHash.Equals(roundContext.BlockHash) &&
+                !context.ContainsBlock(vote.BlockHash))
+            {
+                throw new VoteBlockNotExistsException(vote);
+            }
+
+            if (context.NodeId == vote.NodeId &&
+                roundContext.CurrentNodeVoteFlag is VoteFlag.Null &&
+                vote.BlockHash.Equals(roundContext.BlockHash) &&
+                context.ContainsBlock(vote.BlockHash))
+            {
+                roundContext.Vote(vote.ProposeVote);
+                return new ConsensusVote(roundContext.Voting(VoteFlag.Absent));
+            }
+
             roundContext.Vote(vote.ProposeVote);
 
             if (!roundContext.VoteSet.HasTwoThirdPrevote())

--- a/Libplanet.Net/Consensus/RoundContext.cs
+++ b/Libplanet.Net/Consensus/RoundContext.cs
@@ -55,6 +55,8 @@ namespace Libplanet.Net.Consensus
 
         public PublicKey CurrentNodePublicKey => _validators[(int)NodeId];
 
+        public VoteFlag CurrentNodeVoteFlag => VoteSet.Votes[(int)NodeId].Flag;
+
         // FIXME: Should be thread-safe
         public VoteSet VoteSet { get; private set; }
 

--- a/Libplanet.Net/Consensus/VoteBlockNotExistsException.cs
+++ b/Libplanet.Net/Consensus/VoteBlockNotExistsException.cs
@@ -1,0 +1,13 @@
+using System;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public class VoteBlockNotExistsException : Exception
+    {
+        public VoteBlockNotExistsException(ConsensusMessage message)
+            : base(message.ToString())
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ConsensusPropose` will not broadcast 'ConsensusVote` if Block is not present in the store. (= Hold the vote)
- `PreVoteState<T>` will hold the node's vote until the proposed block is present in the store.
- When a node doesn't have a proposed block from `ConsensusMessage`, it will request the proposed block from the sender.

## Further notices
- Currently, `CommitBlock()` will be called even if the Block does not exist in the store. 