### PR TITLE
Verify signature when received PBFT vote message

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -34,6 +34,7 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new ConsensusContext<DumbAction>(
                     0,
+                    new PrivateKey(),
                     new List<PublicKey>(),
                     _blockChain));
         }
@@ -75,13 +76,17 @@ namespace Libplanet.Net.Tests.Consensus
         {
             long nodeId = 3;
             var validators = Enumerable.Range(0, 7)
-                                             .Select(x => new PrivateKey().PublicKey)
+                                             .Select(x => new PrivateKey())
                                              .ToList();
             long height = 6;
             long round = 5;
             string step = "DefaultState";
             ConsensusContext<DumbAction> context =
-                TestUtils.CreateConsensusContext(validators, _blockChain, nodeId);
+                TestUtils.CreateConsensusContext(
+                    validators.Select(x => x.PublicKey).ToList(),
+                    validators[(int)nodeId],
+                    _blockChain,
+                    nodeId);
             context.Height = height;
             context.Round = round;
             Assert.Equal(

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -49,6 +49,7 @@ namespace Libplanet.Net.Tests.Consensus
                 table ?? new RoutingTable(key.ToAddress()),
                 transport,
                 blockChain,
+                key,
                 id,
                 validators);
         }

--- a/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
@@ -23,12 +23,15 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void Vote()
         {
-            var validator = Enumerable.Range(0, 2)
-                .Select(x => new PrivateKey().PublicKey)
+            var validators = Enumerable.Range(0, 2)
+                .Select(x => new PrivateKey())
                 .ToList();
-            Vote duplicatedVote = TestUtils.CreateVote(validator[0], VoteFlag.Absent, id: 0);
-            Vote uniqueVote = TestUtils.CreateVote(validator[1], VoteFlag.Absent, id: 1);
-            RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validator);
+            var validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
+            Vote duplicatedVote = TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0), validators[0]);
+            Vote uniqueVote = TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1), validators[1]);
+            RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validatorsPubKey);
             long initialVoteCount = context.VoteCount;
             context.Vote(duplicatedVote);
             Assert.Equal(initialVoteCount + 1, context.VoteCount);
@@ -51,22 +54,27 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void HasTwoThirdsAny()
         {
-            List<PublicKey> validator = Enumerable.Range(0, 4)
-                .Select(x => new PrivateKey().PublicKey)
+            List<PrivateKey> validators = Enumerable.Range(0, 4)
+                .Select(x => new PrivateKey())
                 .ToList();
-            RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validator);
+            List<PublicKey> validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
+            RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validatorsPubKey);
             // 0 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.CreateVote(validator[0], VoteFlag.Absent, id: 0));
+            context.Vote(TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0), validators[0]));
             // 1 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.CreateVote(validator[1], VoteFlag.Absent, id: 1));
+            context.Vote(TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1), validators[1]));
             // 2 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.CreateVote(validator[2], VoteFlag.Absent, id: 2));
+            context.Vote(TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[2], VoteFlag.Absent, id: 2), validators[2]));
             // 3 > 2
             Assert.True(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.CreateVote(validator[3], VoteFlag.Absent, id: 3));
+            context.Vote(TestUtils.SignVote(
+                TestUtils.CreateVote(validatorsPubKey[3], VoteFlag.Absent, id: 3), validators[3]));
         }
 
         [Fact]
@@ -101,15 +109,16 @@ namespace Libplanet.Net.Tests.Consensus
             const long id = 3;
             const long height = 8;
             const long round = 20;
-            List<PublicKey> validators = Enumerable.Range(0, 7)
-                .Select(x => new PrivateKey().PublicKey)
+            List<PrivateKey> validators = Enumerable.Range(0, 7)
+                .Select(x => new PrivateKey())
                 .ToList();
+            List<PublicKey> validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
             const long numberOfValidators = 7;
             const string step = "PreCommitState";
             const int voteCount = 2;
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext(
                 id: id,
-                validators: validators,
+                validators: validatorsPubKey,
                 height: height,
                 round: round);
             context.State = new PreCommitState<DumbAction>();
@@ -117,7 +126,14 @@ namespace Libplanet.Net.Tests.Consensus
             for (int i = 0; i < voteCount; i++)
             {
                 context.Vote(
-                    TestUtils.CreateVote(validators[i], VoteFlag.Absent, i, height, round));
+                    TestUtils.SignVote(
+                        TestUtils.CreateVote(
+                            validatorsPubKey[i],
+                            VoteFlag.Absent,
+                            i,
+                            height,
+                            round),
+                        validators[i]));
             }
 
             // replace data field with encoding

--- a/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/RoundContextTest.cs
@@ -27,10 +27,12 @@ namespace Libplanet.Net.Tests.Consensus
                 .Select(x => new PrivateKey())
                 .ToList();
             var validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
-            Vote duplicatedVote = TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0), validators[0]);
-            Vote uniqueVote = TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1), validators[1]);
+            Vote duplicatedVote =
+                TestUtils.CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0)
+                    .Sign(validators[0]);
+            Vote uniqueVote =
+                TestUtils.CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1)
+                    .Sign(validators[1]);
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validatorsPubKey);
             long initialVoteCount = context.VoteCount;
             context.Vote(duplicatedVote);
@@ -61,20 +63,28 @@ namespace Libplanet.Net.Tests.Consensus
             RoundContext<DumbAction> context = TestUtils.CreateRoundContext(validatorsPubKey);
             // 0 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0), validators[0]));
+            context.Vote(
+                TestUtils
+                    .CreateVote(validatorsPubKey[0], VoteFlag.Absent, id: 0)
+                    .Sign(validators[0]));
             // 1 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1), validators[1]));
+            context.Vote(
+                TestUtils
+                    .CreateVote(validatorsPubKey[1], VoteFlag.Absent, id: 1)
+                    .Sign(validators[1]));
             // 2 > 2
             Assert.False(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[2], VoteFlag.Absent, id: 2), validators[2]));
+            context.Vote(
+                TestUtils
+                    .CreateVote(validatorsPubKey[2], VoteFlag.Absent, id: 2)
+                    .Sign(validators[2]));
             // 3 > 2
             Assert.True(context.HasTwoThirdsAny());
-            context.Vote(TestUtils.SignVote(
-                TestUtils.CreateVote(validatorsPubKey[3], VoteFlag.Absent, id: 3), validators[3]));
+            context.Vote(
+                TestUtils
+                    .CreateVote(validatorsPubKey[3], VoteFlag.Absent, id: 3)
+                    .Sign(validators[3]));
         }
 
         [Fact]
@@ -126,14 +136,12 @@ namespace Libplanet.Net.Tests.Consensus
             for (int i = 0; i < voteCount; i++)
             {
                 context.Vote(
-                    TestUtils.SignVote(
                         TestUtils.CreateVote(
                             validatorsPubKey[i],
                             VoteFlag.Absent,
                             i,
                             height,
-                            round),
-                        validators[i]));
+                            round).Sign(validators[i]));
             }
 
             // replace data field with encoding

--- a/Libplanet.Net.Tests/Consensus/States/PreCommitStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreCommitStateTest.cs
@@ -59,9 +59,9 @@ namespace Libplanet.Net.Tests.Consensus.States
             for (int i = 0; i < 5; i++)
             {
                 contextAlreadyVoted.CurrentRoundContext.Vote(
-                    TestUtils.SignVote(
-                        TestUtils.CreateVote(validatorsPubKey[i], VoteFlag.Commit, id: i),
-                        validators[i])
+                        TestUtils
+                            .CreateVote(validatorsPubKey[i], VoteFlag.Commit, id: i)
+                            .Sign(validators[i])
                 );
             }
 
@@ -89,27 +89,25 @@ namespace Libplanet.Net.Tests.Consensus.States
                 state.Handle(
                     context,
                     new ConsensusCommit(
-                            TestUtils.SignVote(
                                 TestUtils.CreateVote(
                                     validBlockHash,
                                     VoteFlag.Commit,
                                     0,
                                     0,
                                     0,
-                                    validatorsPubKey[0]), validators[0]))
+                                    validatorsPubKey[0]).Sign(validators[0]))
                         { Remote = TestUtils.Peer0 }));
             Assert.Equal(1, context.CurrentRoundContext.CommitCount);
             ConsensusMessage? res = state.Handle(
                 contextAlreadyVoted,
                 new ConsensusCommit(
-                        TestUtils.SignVote(
                             TestUtils.CreateVote(
                                 validBlockHash,
                                 VoteFlag.Commit,
                                 5,
                                 0,
                                 0,
-                                validatorsPubKey[5]), validators[5]))
+                                validatorsPubKey[5]).Sign(validators[5]))
                     { Remote = TestUtils.Peer0 });
             Assert.Null(res);
             Assert.Equal(0, contextAlreadyVoted.Round);

--- a/Libplanet.Net.Tests/Consensus/States/PreCommitStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreCommitStateTest.cs
@@ -47,18 +47,22 @@ namespace Libplanet.Net.Tests.Consensus.States
             BlockHash validBlockHash = block.Hash;
             BlockHash invalidBlockHash = _fx.Block2.Hash;
             var validators = Enumerable.Range(0, 6)
-                                             .Select(x => new PrivateKey().PublicKey)
-                                             .ToList();
+                .Select(x => new PrivateKey())
+                .ToList();
+            var validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
             ConsensusContext<DumbAction> contextAlreadyVoted =
-                TestUtils.CreateConsensusContext(validators, _blockChain);
+                TestUtils.CreateConsensusContext(validatorsPubKey, validators[0], _blockChain, 0);
             contextAlreadyVoted.CurrentRoundContext.BlockHash = validBlockHash;
             ConsensusContext<DumbAction> context =
-                TestUtils.CreateConsensusContext(validators, _blockChain);
+                TestUtils.CreateConsensusContext(validatorsPubKey, validators[1], _blockChain, 1);
             context.CurrentRoundContext.BlockHash = validBlockHash;
             for (int i = 0; i < 5; i++)
             {
                 contextAlreadyVoted.CurrentRoundContext.Vote(
-                    TestUtils.CreateVote(validators[i], VoteFlag.Commit, id: i));
+                    TestUtils.SignVote(
+                        TestUtils.CreateVote(validatorsPubKey[i], VoteFlag.Commit, id: i),
+                        validators[i])
+                );
             }
 
             var state = new PreCommitState<DumbAction>();
@@ -85,25 +89,27 @@ namespace Libplanet.Net.Tests.Consensus.States
                 state.Handle(
                     context,
                     new ConsensusCommit(
-                            TestUtils.CreateVote(
-                                validBlockHash,
-                                VoteFlag.Commit,
-                                0,
-                                0,
-                                0,
-                                validators[0]))
+                            TestUtils.SignVote(
+                                TestUtils.CreateVote(
+                                    validBlockHash,
+                                    VoteFlag.Commit,
+                                    0,
+                                    0,
+                                    0,
+                                    validatorsPubKey[0]), validators[0]))
                         { Remote = TestUtils.Peer0 }));
             Assert.Equal(1, context.CurrentRoundContext.CommitCount);
             ConsensusMessage? res = state.Handle(
                 contextAlreadyVoted,
                 new ConsensusCommit(
-                        TestUtils.CreateVote(
-                            validBlockHash,
-                            VoteFlag.Commit,
-                            5,
-                            0,
-                            0,
-                            validators[5]))
+                        TestUtils.SignVote(
+                            TestUtils.CreateVote(
+                                validBlockHash,
+                                VoteFlag.Commit,
+                                5,
+                                0,
+                                0,
+                                validatorsPubKey[5]), validators[5]))
                     { Remote = TestUtils.Peer0 });
             Assert.Null(res);
             Assert.Equal(0, contextAlreadyVoted.Round);
@@ -122,11 +128,20 @@ namespace Libplanet.Net.Tests.Consensus.States
             Assert.Null(
                 state.Handle(
                     context,
-                    new ConsensusVote(TestUtils.CreateVote(blockHash, VoteFlag.Absent, 0, 0, 0))
+                    new ConsensusVote(
+                            context.SignVote(
+                                TestUtils.CreateVote(
+                                    blockHash,
+                                    VoteFlag.Absent,
+                                    0,
+                                    0,
+                                    0)))
                         { Remote = TestUtils.Peer0 }));
             ConsensusMessage? res = state.Handle(
                 context,
-                new ConsensusVote(TestUtils.CreateVote(blockHash, VoteFlag.Absent, 0, 0, 2))
+                new ConsensusVote(
+                    context.SignVote(
+                        TestUtils.CreateVote(blockHash, VoteFlag.Absent, 0, 0, 2)))
                     { Remote = TestUtils.Peer0 });
             Assert.NotNull(res);
             Assert.IsType<ConsensusCommit>(res);
@@ -134,7 +149,9 @@ namespace Libplanet.Net.Tests.Consensus.States
             Assert.Equal(blockHash, context.CurrentRoundContext.BlockHash);
             res = state.Handle(
                 context,
-                new ConsensusVote(TestUtils.CreateVote(blockHash, VoteFlag.Absent, 0, 1, 3))
+                new ConsensusVote(
+                        context.SignVote(
+                        TestUtils.CreateVote(blockHash, VoteFlag.Absent, 0, 1, 3)))
                     { Remote = TestUtils.Peer0 });
             Assert.Null(res);
         }

--- a/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
@@ -34,18 +34,21 @@ namespace Libplanet.Net.Tests.Consensus.States
             BlockHash validBlockHash = _fx.Block1.Hash;
             BlockHash invalidBlockHash = _fx.Block2.Hash;
             var validators = Enumerable.Range(0, 6)
-                                             .Select(x => new PrivateKey().PublicKey)
+                                             .Select(x => new PrivateKey())
                                              .ToList();
+            var validatorsPubKey = validators.Select(x => x.PublicKey).ToList();
             ConsensusContext<DumbAction> contextAlreadyVoted =
-                TestUtils.CreateConsensusContext(validators, _blockChain);
+                TestUtils.CreateConsensusContext(validatorsPubKey, validators[0], _blockChain, 0);
             contextAlreadyVoted.CurrentRoundContext.BlockHash = validBlockHash;
             ConsensusContext<DumbAction> context =
-                TestUtils.CreateConsensusContext(validators, _blockChain);
+                TestUtils.CreateConsensusContext(validatorsPubKey, validators[1], _blockChain, 1);
             context.CurrentRoundContext.BlockHash = validBlockHash;
             for (int i = 0; i < 5; i++)
             {
                 contextAlreadyVoted.CurrentRoundContext.Vote(
-                    TestUtils.CreateVote(validators[i], VoteFlag.Absent, id: i));
+                    TestUtils.SignVote(
+                        TestUtils.CreateVote(validatorsPubKey[i], VoteFlag.Absent, id: i),
+                        validators[i]));
             }
 
             var state = new PreVoteState<DumbAction>();
@@ -76,25 +79,28 @@ namespace Libplanet.Net.Tests.Consensus.States
                 state.Handle(
                     context,
                     new ConsensusVote(
-                            TestUtils.CreateVote(
-                                validBlockHash,
-                                VoteFlag.Absent,
-                                0,
-                                0,
-                                0,
+                            TestUtils.SignVote(
+                                TestUtils.CreateVote(
+                                    validBlockHash,
+                                    VoteFlag.Absent,
+                                    0,
+                                    0,
+                                    0,
+                                    validatorsPubKey[0]),
                                 validators[0]))
                         { Remote = TestUtils.Peer0 }));
             Assert.Equal(1, context.CurrentRoundContext.VoteCount);
             ConsensusMessage? res = state.Handle(
                 contextAlreadyVoted,
                 new ConsensusVote(
-                        TestUtils.CreateVote(
-                            validBlockHash,
-                            VoteFlag.Absent,
-                            5,
-                            0,
-                            0,
-                            validators[5]))
+                        TestUtils.SignVote(
+                            TestUtils.CreateVote(
+                                validBlockHash,
+                                VoteFlag.Absent,
+                                5,
+                                0,
+                                0,
+                                validatorsPubKey[5]), validators[5]))
                     { Remote = TestUtils.Peer0 });
             Assert.NotNull(res);
             Assert.IsType<ConsensusCommit>(res);

--- a/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
+++ b/Libplanet.Net.Tests/Consensus/States/PreVoteStateTest.cs
@@ -46,9 +46,9 @@ namespace Libplanet.Net.Tests.Consensus.States
             for (int i = 0; i < 5; i++)
             {
                 contextAlreadyVoted.CurrentRoundContext.Vote(
-                    TestUtils.SignVote(
-                        TestUtils.CreateVote(validatorsPubKey[i], VoteFlag.Absent, id: i),
-                        validators[i]));
+                        TestUtils
+                            .CreateVote(validatorsPubKey[i], VoteFlag.Absent, id: i)
+                            .Sign(validators[i]));
             }
 
             var state = new PreVoteState<DumbAction>();
@@ -79,28 +79,26 @@ namespace Libplanet.Net.Tests.Consensus.States
                 state.Handle(
                     context,
                     new ConsensusVote(
-                            TestUtils.SignVote(
                                 TestUtils.CreateVote(
                                     validBlockHash,
                                     VoteFlag.Absent,
                                     0,
                                     0,
                                     0,
-                                    validatorsPubKey[0]),
+                                    validatorsPubKey[0]).Sign(
                                 validators[0]))
                         { Remote = TestUtils.Peer0 }));
             Assert.Equal(1, context.CurrentRoundContext.VoteCount);
             ConsensusMessage? res = state.Handle(
                 contextAlreadyVoted,
                 new ConsensusVote(
-                        TestUtils.SignVote(
                             TestUtils.CreateVote(
                                 validBlockHash,
                                 VoteFlag.Absent,
                                 5,
                                 0,
                                 0,
-                                validatorsPubKey[5]), validators[5]))
+                                validatorsPubKey[5]).Sign(validators[5]))
                     { Remote = TestUtils.Peer0 });
             Assert.NotNull(res);
             Assert.IsType<ConsensusCommit>(res);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -14,10 +14,15 @@ namespace Libplanet.Net.Tests
 {
     public static class TestUtils
     {
-        public static readonly Peer Peer0 = new Peer(
-            new PublicKey(
+        public static readonly PrivateKey Peer0Priv =
+            new PrivateKey(
                 ByteUtil.ParseHex(
-                    "0204b09e833560269d0dc1100c221442b9969e74a3949ca306aecda20a6a2afba4")));
+                    "b17c919b07320edfb3e6da2f1cfed75910322de2e49377d6d4d226505afca550"));
+
+        public static readonly Peer Peer0 = new Peer(
+            new PrivateKey(
+                ByteUtil.ParseHex(
+                    "b17c919b07320edfb3e6da2f1cfed75910322de2e49377d6d4d226505afca550")).PublicKey);
 
         public static readonly BlockHash BlockHash0 =
             BlockHash.FromString(
@@ -40,14 +45,16 @@ namespace Libplanet.Net.Tests
         public static ConsensusContext<DumbAction> CreateConsensusContext(
             BlockChain<DumbAction> blockChain,
             long id = 0) =>
-            CreateConsensusContext(Validators, blockChain, id);
+            CreateConsensusContext(Validators, Peer0Priv, blockChain, id);
 
         public static ConsensusContext<DumbAction> CreateConsensusContext(
             List<PublicKey> validator,
+            PrivateKey privateKey,
             BlockChain<DumbAction> blockChain,
             long id = 0) =>
             new ConsensusContext<DumbAction>(
                 id,
+                privateKey,
                 validator,
                 blockChain);
 
@@ -111,6 +118,21 @@ namespace Libplanet.Net.Tests
                 flag,
                 id,
                 ImmutableArray<byte>.Empty);
+
+        public static Vote SignVote(Vote vote, PrivateKey privateKey)
+        {
+            Vote voteWithoutSign = vote.RemoveSignature;
+            byte[] sign = privateKey.Sign(voteWithoutSign.ByteArray);
+            return new Vote(
+                vote.Height,
+                vote.Round,
+                vote.BlockHash,
+                vote.Timestamp,
+                vote.Validator,
+                vote.Flag,
+                vote.NodeId,
+                sign.ToImmutableArray());
+        }
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
         {

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -104,36 +104,6 @@ namespace Libplanet.Net.Tests
                 id,
                 ImmutableArray<byte>.Empty);
 
-        public static Vote CreateVote(
-            VoteFlag flag = VoteFlag.Null,
-            long id = 0,
-            long height = 0,
-            long round = 0) =>
-            new Vote(
-                height,
-                round,
-                BlockHash0,
-                DateTimeOffset.Now,
-                new PrivateKey().PublicKey,
-                flag,
-                id,
-                ImmutableArray<byte>.Empty);
-
-        public static Vote SignVote(Vote vote, PrivateKey privateKey)
-        {
-            Vote voteWithoutSign = vote.RemoveSignature;
-            byte[] sign = privateKey.Sign(voteWithoutSign.ByteArray);
-            return new Vote(
-                vote.Height,
-                vote.Round,
-                vote.BlockHash,
-                vote.Timestamp,
-                vote.Validator,
-                vote.Flag,
-                vote.NodeId,
-                sign.ToImmutableArray());
-        }
-
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
         {
             var table = new RoutingTable(tableAddress);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Text.Json;
 using System.Timers;
 using Libplanet.Action;
@@ -147,17 +146,7 @@ namespace Libplanet.Net.Consensus
 
         public Vote SignVote(Vote vote)
         {
-            Vote voteWithoutSign = vote.RemoveSignature;
-            byte[] sign = _privateKey.Sign(voteWithoutSign.ByteArray);
-            return new Vote(
-                vote.Height,
-                vote.Round,
-                vote.BlockHash,
-                vote.Timestamp,
-                vote.Validator,
-                vote.Flag,
-                vote.NodeId,
-                sign.ToImmutableArray());
+            return vote.Sign(_privateKey);
         }
 
         public ConsensusMessage? HandleMessage(ConsensusMessage message)

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -20,12 +20,14 @@ namespace Libplanet.Net.Consensus
         private RoutingTable _routingTable;
         private ITransport _transport;
         private ConsensusContext<T> _context;
+        private PrivateKey _privateKey;
         private ILogger _logger;
 
         public ConsensusReactor(
             RoutingTable routingTable,
             ITransport transport,
             BlockChain<T> blockChain,
+            PrivateKey privateKey,
             long nodeId,
             List<PublicKey>? validators)
         {
@@ -34,8 +36,10 @@ namespace Libplanet.Net.Consensus
             _logger = Log
                 .ForContext<ConsensusReactor<T>>()
                 .ForContext("Source", nameof(ConsensusReactor<T>));
+            _privateKey = privateKey;
             _context = new ConsensusContext<T>(
                 nodeId,
+                privateKey,
                 validators ?? blockChain.Policy.GetValidators().ToList(),
                 blockChain);
         }

--- a/Libplanet.Net/Consensus/DefaultState.cs
+++ b/Libplanet.Net/Consensus/DefaultState.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Net.Consensus
 
             roundContext.BlockHash = propose.BlockHash;
             roundContext.State = new PreVoteState<T>();
-            return new ConsensusVote(roundContext.Voting(VoteFlag.Absent));
+            return new ConsensusVote(context.SignVote(roundContext.Voting(VoteFlag.Absent)));
         }
     }
 }

--- a/Libplanet.Net/Consensus/PreCommitState.cs
+++ b/Libplanet.Net/Consensus/PreCommitState.cs
@@ -75,7 +75,7 @@ namespace Libplanet.Net.Consensus
 
             context.Round = vote.Round;
             targetContext.BlockHash = vote.BlockHash;
-            return new ConsensusCommit(targetContext.Voting(VoteFlag.Commit));
+            return new ConsensusCommit(context.SignVote(targetContext.Voting(VoteFlag.Commit)));
         }
     }
 }

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Net.Consensus
             }
 
             roundContext.State = new PreCommitState<T>();
-            return new ConsensusCommit(roundContext.Voting(VoteFlag.Commit));
+            return new ConsensusCommit(context.SignVote(roundContext.Voting(VoteFlag.Commit)));
         }
     }
 }

--- a/Libplanet.Net/Consensus/RoundContext.cs
+++ b/Libplanet.Net/Consensus/RoundContext.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -91,7 +90,7 @@ namespace Libplanet.Net.Consensus
                 CurrentNodePublicKey,
                 flag,
                 NodeId,
-                Encoding.Default.GetBytes("sign").ToImmutableArray());
+                null);
         }
 
         public long Vote(Vote vote)

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
@@ -34,6 +33,15 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
+                 var voteWithoutSign = new Vote(
+                     1,
+                     2,
+                     targetBlockHash,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Absent,
+                     i,
+                     null);
                  var vote = new Vote(
                      1,
                      2,
@@ -42,7 +50,7 @@ namespace Libplanet.Tests.Consensus
                      validators[i].PublicKey,
                      VoteFlag.Absent,
                      i,
-                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }
 
@@ -58,15 +66,24 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
-                 var vote = new Vote(
+                 var voteWithoutSign = new Vote(
                      1,
                      2,
-                     fx.Hash1,
+                     targetBlockHash,
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Commit,
                      i,
-                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                     null);
+                 var vote = new Vote(
+                     1,
+                     2,
+                     targetBlockHash,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Commit,
+                     i,
+                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }
 
@@ -97,6 +114,15 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
+                 var voteWithoutSign = new Vote(
+                     1,
+                     1,
+                     targetBlockHash,
+                     now,
+                     validators[i].PublicKey,
+                     VoteFlag.Absent,
+                     i,
+                     null);
                  var vote = new Vote(
                      1,
                      1,
@@ -105,7 +131,7 @@ namespace Libplanet.Tests.Consensus
                      validators[i].PublicKey,
                      VoteFlag.Absent,
                      i,
-                     Encoding.Default.GetBytes("sign").ToImmutableArray());
+                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }
 

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -163,6 +163,21 @@ namespace Libplanet.Consensus
         public Vote RemoveSignature =>
             new Vote(Height, Round, BlockHash, Timestamp, Validator, Flag, NodeId, null);
 
+        public Vote Sign(PrivateKey privateKey)
+        {
+            Vote voteWithoutSign = RemoveSignature;
+            byte[] sign = privateKey.Sign(voteWithoutSign.ByteArray);
+            return new Vote(
+                Height,
+                Round,
+                BlockHash,
+                Timestamp,
+                Validator,
+                Flag,
+                NodeId,
+                sign.ToImmutableArray());
+        }
+
         public bool Equals(Vote other)
         {
             return Height == other.Height &&

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -160,6 +160,9 @@ namespace Libplanet.Consensus
             }
         }
 
+        public Vote RemoveSignature =>
+            new Vote(Height, Round, BlockHash, Timestamp, Validator, Flag, NodeId, null);
+
         public bool Equals(Vote other)
         {
             return Height == other.Height &&

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -93,6 +93,19 @@ namespace Libplanet.Consensus
 
         private bool IsVoteValid(Vote vote)
         {
+            if (vote.Signature is null)
+            {
+                return false;
+            }
+
+            Vote voteWithoutSign = vote.RemoveSignature;
+            if (!vote.Validator.Verify(
+                voteWithoutSign.ByteArray.ToImmutableArray(),
+                vote.Signature))
+            {
+                return false;
+            }
+
             if (vote.Height != Height)
             {
                 return false;
@@ -114,7 +127,6 @@ namespace Libplanet.Consensus
                 return false;
             }
 
-            // TODO: Should check signature :)
             return true;
         }
     }


### PR DESCRIPTION
# Context
Previously, each node did not validate the `Vote` message when they received it.
This vulnerability causes counterfeit of the `Vote` message from the attacker.

# Decision
For the same reason as above, this PR is implemented to verify and sign about `Vote`.  

```mermaid
sequenceDiagram
    State ->> RoundContext: call `Voting()`.
    RoundContext ->> State: return `Vote` with unsigned.
    State ->> ConsensusContext: call `SignVote()`.
    ConsensusContext ->> State: return `Vote` with signed.
    State ->> VoteSet: call `Add()`
    VoteSet ->> VoteSet: verify and validate `Vote`
    VoteSet ->> State: return bool which `Add()` is success
```