### PR TITLE
Fix `KeyNotFoundException` thrown by `Transaction<T>()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.36.1
 
 To be released.
 
+ -  Fixed `Transaction<T>()` constructor's bug that it had thrown
+    `KeyNotFoundException` when a Bencodex dictionary without
+    signature.  [[#2005]]
+
+[#2005]: https://github.com/planetarium/libplanet/pull/2005
+
 
 Version 0.36.0
 --------------

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -108,6 +108,19 @@ namespace Libplanet.Tests.Tx
         }
 
         [Fact]
+        public void CreateUnsignedFromBencodex()
+        {
+            var expected = Transaction<PolymorphicAction<BaseAction>>.CreateUnsigned(
+                0,
+                _fx.PublicKey1,
+                null,
+                _fx.TxWithActions.Actions);
+            Bencodex.Types.Dictionary dict = expected.ToBencodex(false);
+            var actual = new Transaction<PolymorphicAction<BaseAction>>(dict);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void CreateWithDefaultUpdatedAddresses()
         {
             Transaction<DumbAction> emptyTx = Transaction<DumbAction>.Create(

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -142,7 +142,10 @@ namespace Libplanet.Tx
             Actions = dict.GetValue<List>(TxMetadata.ActionsKey)
                 .Select(ToAction)
                 .ToImmutableList();
-            _signature = dict.GetValue<Binary>(TxMetadata.SignatureKey).ToByteArray();
+            _signature
+                = dict.TryGetValue((Binary)TxMetadata.SignatureKey, out IValue s) && s is Binary sig
+                ? sig.ToByteArray()
+                : Array.Empty<byte>();
         }
 
         private Transaction(


### PR DESCRIPTION
This fixes <https://github.com/planetarium/NineChronicles.Headless/runs/6603180738>.