### PR TITLE
Store voteset on memory when commit new block and access from reactor

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -51,6 +51,7 @@ namespace Libplanet.Net.Consensus
             };
 
             _timoutTicker = new TimeoutTicker(TimeoutMillisecond, TimerTimeoutCallback);
+            VoteSets = new Dictionary<long, VoteSet?>();
             _logger = Log
                 .ForContext<ConsensusContext<T>>()
                 .ForContext("Source", nameof(ConsensusContext<T>));
@@ -72,6 +73,9 @@ namespace Libplanet.Net.Consensus
         public long NodeId { get; internal set; }
 
         public RoundContext<T> CurrentRoundContext => RoundContextOf(Round);
+
+        // FIXME: Storing all voteset on memory is not required. Leave only 1~2 votesets.
+        public Dictionary<long, VoteSet?> VoteSets { get; }
 
         public void CommitBlock(long height, BlockHash hash)
         {
@@ -95,6 +99,9 @@ namespace Libplanet.Net.Consensus
                     _blockChain.Policy.GetHashAlgorithm,
                     hash);
                 _blockChain.Append(block);
+
+                // FIXME: Gets voteset by reference, it can be modified in other place.
+                VoteSets.Add(Height, CurrentRoundContext.VoteSet);
                 Height++;
                 Round = 0;
                 _roundContexts = new ConcurrentDictionary<long, RoundContext<T>>();

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
@@ -47,6 +48,17 @@ namespace Libplanet.Net.Consensus
         public void Dispose()
         {
             _transport.Dispose();
+        }
+
+        public VoteSet? VoteSetOf(long height)
+        {
+            Dictionary<long, VoteSet?> voteSets = _context.VoteSets;
+            if (voteSets.ContainsKey(height))
+            {
+                return voteSets[height];
+            }
+
+            return null;
         }
 
         public async Task<Task> StartAsync(CancellationToken ctx)

--- a/Libplanet.Net/Consensus/IReactor.cs
+++ b/Libplanet.Net/Consensus/IReactor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -11,6 +12,15 @@ namespace Libplanet.Net.Consensus
         public Task ReceivedMessage(ConsensusMessage message);
 
         public void Propose(BlockHash blockHash);
+
+        /// <summary>
+        /// Returns a collected <see cref="VoteSet"/> for the certain block index.
+        /// </summary>
+        /// <param name="height">Block index to get <see cref="VoteSet"/>.</param>
+        /// <returns>A <see cref="VoteSet"/> for the block of index <paramref name="height"/>.
+        /// If <see cref="VoteSet"/> does not exist, return <c>null</c>.
+        /// </returns>
+        public VoteSet? VoteSetOf(long height);
 
         public Task<Task> StartAsync(CancellationToken ctx);
 

--- a/Libplanet.Net/Consensus/PreCommitState.cs
+++ b/Libplanet.Net/Consensus/PreCommitState.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Consensus
 
             roundContext.Vote(commit.CommitVote);
 
-            if (!roundContext.HasTwoThirdsAny())
+            if (!roundContext.VoteSet.HasTwoThirdCommit())
             {
                 return null;
             }
@@ -68,7 +68,7 @@ namespace Libplanet.Net.Consensus
             RoundContext<T> targetContext = context.RoundContextOf(vote.Round);
             targetContext.Vote(vote.ProposeVote);
 
-            if (!targetContext.HasTwoThirdsAny())
+            if (!targetContext.VoteSet.HasTwoThirdPrevote())
             {
                 return null;
             }

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Net.Consensus
             RoundContext<T> roundContext = context.CurrentRoundContext;
             roundContext.Vote(vote.ProposeVote);
 
-            if (!roundContext.HasTwoThirdsAny())
+            if (!roundContext.VoteSet.HasTwoThirdPrevote())
             {
                 return null;
             }

--- a/Libplanet.Net/Consensus/RoundContext.cs
+++ b/Libplanet.Net/Consensus/RoundContext.cs
@@ -133,14 +133,6 @@ namespace Libplanet.Net.Consensus
             }
         }
 
-        public bool HasTwoThirdsAny()
-        {
-            lock (_lock)
-            {
-                return VoteSet.HasTwoThirdAny();
-            }
-        }
-
         public long LeaderElection()
         {
             // FIXME: Not correct, should be changed


### PR DESCRIPTION
When commiting a new block, the votes for the block is stored in order to make next block. The votes collected will be included in `BlockHeader.LastCommit` field.

Additionally, fixed a bug where context committed block even commit count does not met the condition (2/3+).