### PR TITLE
`NodeUtils` private key handling

### DIFF
--- a/Libplanet.Node.Tests/Libplanet.Node.Tests.csproj
+++ b/Libplanet.Node.Tests/Libplanet.Node.Tests.csproj
@@ -65,7 +65,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Libplanet\Libplanet.Node.csproj" />
     <ProjectReference Include="..\Libplanet.Node\Libplanet.Node.csproj" />
+    <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">

--- a/Libplanet.Node.Tests/NodeUtilsTest.cs
+++ b/Libplanet.Node.Tests/NodeUtilsTest.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using Bencodex;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Tests.Common.Action;
+using Xunit;
+
+namespace Libplanet.Node.Tests
+{
+    public class NodeUtilsTest
+    {
+        public NodeUtilsTest()
+        {
+        }
+
+        [Fact]
+        public void SaveAndLoadGenesisBlock()
+        {
+            string tempFilePath = Path.GetTempFileName();
+            try
+            {
+                // Try loading from empty data, bad data, non-existent path.
+                Assert.Throws<DecodingException>(
+                    () => NodeUtils<DumbAction>.LoadGenesisBlock(tempFilePath));
+                File.WriteAllText(tempFilePath, "foo");
+                Assert.ThrowsAny<DecodingException>(
+                    () => NodeUtils<DumbAction>.LoadGenesisBlock(tempFilePath));
+                File.Delete(tempFilePath);
+                Assert.Throws<FileNotFoundException>(
+                    () => NodeUtils<DumbAction>.LoadGenesisBlock(tempFilePath));
+
+                // Try overwriting an existing file.
+                Block<DumbAction> genesisBlock = NodeUtils<DumbAction>.CreateGenesisBlock();
+                NodeUtils<DumbAction>.SaveGenesisBlock(tempFilePath, genesisBlock);
+                Assert.Throws<ArgumentException>(
+                    () => NodeUtils<DumbAction>.SaveGenesisBlock(tempFilePath, genesisBlock));
+
+                // Load from a saved file.
+                Block<DumbAction> loadedGenesisBlock =
+                    NodeUtils<DumbAction>.LoadGenesisBlock(tempFilePath);
+                Assert.Equal(genesisBlock, loadedGenesisBlock);
+            }
+            finally
+            {
+                File.Delete(tempFilePath);
+                Assert.False(File.Exists(tempFilePath));
+            }
+        }
+
+        [Fact]
+        public void SaveAndLoadPrivateKey()
+        {
+            string tempFilePath = Path.GetTempFileName();
+            try
+            {
+                // Try loading from empty data, bad data, non-existent path.
+                Assert.ThrowsAny<ArgumentException>(
+                    () => NodeUtils<DumbAction>.LoadPrivateKey(tempFilePath));
+                File.WriteAllText(tempFilePath, "foo");
+                Assert.ThrowsAny<ArgumentException>(
+                    () => NodeUtils<DumbAction>.LoadPrivateKey(tempFilePath));
+                File.Delete(tempFilePath);
+                Assert.Throws<FileNotFoundException>(
+                    () => NodeUtils<DumbAction>.LoadPrivateKey(tempFilePath));
+
+                // Try overwriting an existing file.
+                PrivateKey privateKey = new PrivateKey();
+                NodeUtils<DumbAction>.SavePrivateKey(tempFilePath, privateKey);
+                Assert.Throws<ArgumentException>(
+                    () => NodeUtils<DumbAction>.SavePrivateKey(tempFilePath, privateKey));
+
+                // Load from a saved file.
+                PrivateKey loadedPrivateKey = NodeUtils<DumbAction>.LoadPrivateKey(tempFilePath);
+                Assert.Equal(privateKey, loadedPrivateKey);
+            }
+            finally
+            {
+                File.Delete(tempFilePath);
+                Assert.False(File.Exists(tempFilePath));
+            }
+        }
+    }
+}

--- a/Libplanet.Node/NodeUtils.cs
+++ b/Libplanet.Node/NodeUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -168,5 +169,33 @@ namespace Libplanet.Node
         public static (IStore Store, IStateStore StateStore) LoadStore(Uri uri)
             => StoreLoaderAttribute.LoadStore(uri)
                 ?? throw new ArgumentException($"Invalid URI was given: {uri}", nameof(uri));
+
+        /// <summary>
+        /// Loads a <see cref="PrivateKey"/> from <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">The location of which a <see cref="PrivateKey"/> is saved.</param>
+        /// <returns>A <see cref="PrivateKey"/> loaded from <paramref name="path"/>.</returns>
+        public static PrivateKey LoadPrivateKey(string path)
+        {
+            using (StreamReader stream = new StreamReader(path, Encoding.UTF8))
+            {
+                string privateKeyString = stream.ReadLine();
+                return new PrivateKey(ByteUtil.ParseHex(privateKeyString));
+            }
+        }
+
+        /// <summary>
+        /// Saves a <see cref="PrivateKey"/> from <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">The location of which a <see cref="PrivateKey"/> is to be saved.
+        /// </param>
+        /// <param name="privateKey">The <see cref="PrivateKey"/> to save.</param>
+        public static void SavePrivateKey(string path, PrivateKey privateKey)
+        {
+            using (StreamWriter stream = new StreamWriter(path, false, Encoding.UTF8))
+            {
+                stream.WriteLine(ByteUtil.Hex(privateKey.ByteArray));
+            }
+        }
     }
 }

--- a/Libplanet.Node/NodeUtils.cs
+++ b/Libplanet.Node/NodeUtils.cs
@@ -121,13 +121,19 @@ namespace Libplanet.Node
         /// is to be saved. </param>
         /// <param name="genesisBlock">The genesis <see cref="Block{T}"/> to save.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="genesisBlock"/>
-        /// is not a genesis <see cref="Block{T}"/>, i.e. does not have an index of 0.</exception>
+        /// is not a genesis <see cref="Block{T}"/>, i.e. does not have an index of 0, or
+        /// a file already exists at <paramref name="path"/>.</exception>
         public static void SaveGenesisBlock(string path, Block<T> genesisBlock)
         {
             if (genesisBlock.Index != 0L)
             {
                 throw new ArgumentException(
-                    $"A genesis block should have an index of 0.", nameof(genesisBlock));
+                    "A genesis block should have an index of 0.", nameof(genesisBlock));
+            }
+            else if (File.Exists(path))
+            {
+                throw new ArgumentException(
+                    $"File already exists at {path}.", nameof(path));
             }
             else
             {
@@ -190,11 +196,21 @@ namespace Libplanet.Node
         /// <param name="path">The location of which a <see cref="PrivateKey"/> is to be saved.
         /// </param>
         /// <param name="privateKey">The <see cref="PrivateKey"/> to save.</param>
+        /// <exception cref="ArgumentException">Thrown when a file already exists
+        /// at <paramref name="path"/>.</exception>
         public static void SavePrivateKey(string path, PrivateKey privateKey)
         {
-            using (StreamWriter stream = new StreamWriter(path, false, Encoding.UTF8))
+            if (File.Exists(path))
             {
-                stream.WriteLine(ByteUtil.Hex(privateKey.ByteArray));
+                throw new ArgumentException(
+                    $"File already exists at {path}.", nameof(path));
+            }
+            else
+            {
+                using (StreamWriter stream = new StreamWriter(path, false, Encoding.UTF8))
+                {
+                    stream.WriteLine(ByteUtil.Hex(privateKey.ByteArray));
+                }
             }
         }
     }

--- a/Libplanet.Node/NodeUtils.cs
+++ b/Libplanet.Node/NodeUtils.cs
@@ -64,7 +64,10 @@ namespace Libplanet.Node
             PrivateKey privateKey,
             IBlockPolicy<T> blockPolicy)
         {
-            return new BlockContent<T>()
+            return new BlockContent<T>(new BlockMetadata()
+                {
+                    PublicKey = privateKey.PublicKey,
+                })
                 .Mine(blockPolicy.GetHashAlgorithm(0L))
                 .Evaluate(
                     privateKey,


### PR DESCRIPTION
Just some QoL methods. Eventually, those not requiring `<IAction>` should be separated out. 🙄