### PR TITLE
Add PrivateKey constructor for hexadecimal string.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ To be released.
 ### Added APIs
 
 ### Behavioral changes
+ -  Added `PrivateKey(string)` constructor for hexadecimal string. [[#2012]]
 
 ### Bug fixes
 
@@ -24,6 +25,7 @@ To be released.
 
 ### CLI tools
 
+[#2012]: https://github.com/planetarium/libplanet/issues/2012
 
 Version 0.36.1
 --------------

--- a/Libplanet.Tests/Crypto/PrivateKeyTest.cs
+++ b/Libplanet.Tests/Crypto/PrivateKeyTest.cs
@@ -294,5 +294,36 @@ namespace Libplanet.Tests.Crypto
             Assert.False(key1 != key2);
             Assert.True(key2 != key3);
         }
+
+        [Fact]
+        public void HexStringConstructor()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PrivateKey(string.Empty));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PrivateKey("a"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PrivateKey("870912"));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new PrivateKey(
+                    "00000000000000000000000000000000000000000000000000000000870912"
+                )
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new PrivateKey(
+                    "000000000000000000000000000000000000000000000000000000000000870912"
+                )
+            );
+            Assert.Throws<FormatException>(() => new PrivateKey("zz"));
+            PrivateKey actual = new PrivateKey(
+                "e07107ca4b0d19147fa1152a0f2c7884705d59cbb6318e2f901bd28dd9ff78e3"
+            );
+            AssertBytesEqual(
+                new byte[]
+                {
+                    0xe0, 0x71, 0x07, 0xca, 0x4b, 0x0d, 0x19, 0x14, 0x7f, 0xa1, 0x15,
+                    0x2a, 0x0f, 0x2c, 0x78, 0x84, 0x70, 0x5d, 0x59, 0xcb, 0xb6, 0x31,
+                    0x8e, 0x2f, 0x90, 0x1b, 0xd2, 0x8d, 0xd9, 0xff, 0x78, 0xe3,
+                },
+                actual.ToByteArray()
+            );
+        }
     }
 }

--- a/Libplanet/Crypto/PrivateKey.cs
+++ b/Libplanet/Crypto/PrivateKey.cs
@@ -77,6 +77,23 @@ namespace Libplanet.Crypto
             }
         }
 
+        /// <summary>
+        /// Creates a <see cref="PrivateKey"/> instance from the given hexadecimal
+        /// <see cref="string"/> (i.e.,<paramref name="hex"/>).
+        /// </summary>
+        /// <param name="hex">A hexadecimal string of a private key's
+        /// <see cref="ByteArray"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the given <paramref name="hex"/>
+        /// string is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of the given
+        /// <paramref name="hex"/> string is too short or too long.</exception>
+        /// <exception cref="FormatException">Thrown when the given <paramref name="hex"/> string is
+        /// not a valid hexadecimal string.</exception>
+        public PrivateKey(string hex)
+            : this(unverifiedKey: GenerateBytesFromHexString(hex), informedConsent: true)
+        {
+        }
+
         internal PrivateKey(byte[] unverifiedKey, bool informedConsent)
             : this(GenerateKeyFromBytes(unverifiedKey))
         {
@@ -157,16 +174,10 @@ namespace Libplanet.Crypto
         [Pure]
         public static PrivateKey FromString(string hex)
         {
-            byte[] bytes = ByteUtil.ParseHex(hex);
-            if (bytes.Length != KeyByteSize)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(hex),
-                    $"Expected {KeyByteSize * 2} hexadecimal digits."
-                );
-            }
-
-            return new PrivateKey(unverifiedKey: bytes, informedConsent: true);
+            return new PrivateKey(
+                unverifiedKey: GenerateBytesFromHexString(hex),
+                informedConsent: true
+            );
         }
 
         public bool Equals(PrivateKey? other) => KeyParam.Equals(other?.KeyParam);
@@ -380,6 +391,20 @@ namespace Libplanet.Crypto
             var _ = new PrivateKey(param).PublicKey;
 #pragma warning restore SA1312, S1481
             return param;
+        }
+
+        private static byte[] GenerateBytesFromHexString(string hex)
+        {
+            byte[] bytes = ByteUtil.ParseHex(hex);
+            if (bytes.Length != KeyByteSize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(hex),
+                    $"Expected {KeyByteSize * 2} hexadecimal digits."
+                );
+            }
+
+            return bytes;
         }
 
         private ECPoint CalculatePoint(ECPublicKeyParameters pubKeyParams)


### PR DESCRIPTION
- Add PrivateKey(string) constructor
- Create GenerateBytesFromHexString(string) private method.
- Modify FromString method.
- Add PrivatKey(string) constructor test.

It addresses #2012.
