### PR TITLE
Recomitting Failed Round / Preparing Swarm

### DIFF
--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -72,7 +72,12 @@ namespace Libplanet.Benchmarks
                     _blockChains[i],
                     _keys[i],
                     _appProtocolVersion,
-                    host: IPAddress.Loopback.ToString());
+                    host: IPAddress.Loopback.ToString(),
+                    nodeId: i,
+                    validators: new List<PublicKey>()
+                    {
+                        _keys[i].PublicKey,
+                    });
                 tasks.Add(StartAsync(_swarms[i]));
             }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -232,6 +232,7 @@ If omitted (default) explorer only the local blockchain store.")]
                         MaxTimeout = TimeSpan.FromSeconds(10),
                     };
 
+                    // TODO: Add nodeId getter/setter and validators getter!
                     swarm = new Swarm<NullAction>(
                         blockChain,
                         privateKey,
@@ -241,7 +242,9 @@ If omitted (default) explorer only the local blockchain store.")]
                         differentAppProtocolVersionEncountered: (p, pv, lv) => { },
                         workers: options.Workers,
                         iceServers: new[] { options.IceServer },
-                        options: swarmOptions
+                        options: swarmOptions,
+                        nodeId: 0,
+                        validators: null
                     );
                 }
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -53,5 +53,24 @@ namespace Libplanet.Net.Tests.Consensus
                 id,
                 validators);
         }
+
+        public override ConsensusReactor<DumbAction> CreateConcreteReactor(
+            BlockChain<DumbAction> blockChain,
+            PrivateKey? key = null,
+            RoutingTable? table = null,
+            string host = "localhost",
+            int port = 5001,
+            long id = 0,
+            List<PublicKey> validators = null!)
+        {
+            return (ConsensusReactor<DumbAction>)CreateReactor(
+                blockChain,
+                key,
+                table,
+                host,
+                port,
+                id,
+                validators);
+        }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -108,7 +107,7 @@ namespace Libplanet.Net.Tests.Consensus
 
                 if (json["step"].GetString() != "PreCommitState")
                 {
-                    Thread.Sleep(yieldTime);
+                    await Task.Delay(yieldTime);
 
                     json =
                         JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
@@ -120,7 +119,7 @@ namespace Libplanet.Net.Tests.Consensus
                 Assert.Equal(0L, json["height"].GetInt32());
                 Assert.Equal("PreCommitState", json["step"].GetString());
 
-                Thread.Sleep((int)ConsensusContext<DumbAction>.TimeoutMillisecond);
+                await Task.Delay((int)ConsensusContext<DumbAction>.TimeoutMillisecond);
 
                 json =
                     JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
@@ -128,7 +127,7 @@ namespace Libplanet.Net.Tests.Consensus
 
                 if (json["step"].GetString() != "DefaultState")
                 {
-                    Thread.Sleep(yieldTime);
+                    await Task.Delay(yieldTime);
 
                     json =
                         JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
@@ -225,7 +224,7 @@ namespace Libplanet.Net.Tests.Consensus
                     reactors[proposeNode].Propose(block.Hash);
 
                     // For test accuracy, this test should not run in parallel.
-                    Thread.Sleep(propagationDelay);
+                    await Task.Delay(propagationDelay);
                     var isPolka = new bool[count];
 
                     for (var node = 0; node < count; ++node)

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -69,6 +69,8 @@ namespace Libplanet.Net.Tests
 
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
+            long nodeId = 0,
+            List<PublicKey> validators = null,
             AppProtocolVersion? appProtocolVersion = null,
             string host = null,
             int? listenPort = null,
@@ -90,6 +92,8 @@ namespace Libplanet.Net.Tests
             return CreateSwarm(
                 blockchain,
                 privateKey,
+                nodeId,
+                validators,
                 appProtocolVersion,
                 host,
                 listenPort,
@@ -102,6 +106,8 @@ namespace Libplanet.Net.Tests
         private Swarm<T> CreateSwarm<T>(
             BlockChain<T> blockChain,
             PrivateKey privateKey = null,
+            long nodeId = 0,
+            List<PublicKey> validators = null,
             AppProtocolVersion? appProtocolVersion = null,
             string host = null,
             int? listenPort = null,
@@ -130,10 +136,18 @@ namespace Libplanet.Net.Tests
                     break;
             }
 
+            privateKey ??= new PrivateKey();
+            validators ??= new List<PublicKey>()
+            {
+                privateKey.PublicKey,
+            };
+
             var swarm = new Swarm<T>(
                 blockChain,
-                privateKey ?? new PrivateKey(),
+                privateKey,
                 appProtocolVersion ?? DefaultAppProtocolVersion,
+                nodeId,
+                validators,
                 5,
                 host,
                 listenPort,

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -544,23 +544,32 @@ namespace Libplanet.Net.Tests
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var key = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(key, 1);
-            Assert.Throws<ArgumentNullException>(() => { new Swarm<DumbAction>(null, key, ver); });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                new Swarm<DumbAction>(null, key, ver, nodeId: 0, validators: null);
+            });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(blockchain, null, ver);
+                new Swarm<DumbAction>(blockchain, null, ver, nodeId: 0, validators: null);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(blockchain, key, ver);
+                new Swarm<DumbAction>(blockchain, key, ver, nodeId: 0, validators: null);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
             {
-                new Swarm<DumbAction>(blockchain, key, ver, iceServers: new IceServer[] { });
+                new Swarm<DumbAction>(
+                    blockchain,
+                    key,
+                    ver,
+                    iceServers: new IceServer[] { },
+                    nodeId: 0,
+                    validators: null);
             });
         }
 

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -33,6 +34,10 @@ namespace Libplanet.Net.Tests.Transports
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var apvKey = new PrivateKey();
             var swarmKey = new PrivateKey();
+            var validators = new List<PublicKey>()
+            {
+                swarmKey.PublicKey,
+            };
             AppProtocolVersion apv = AppProtocolVersion.Sign(apvKey, 1);
 
             string host = IPAddress.Loopback.ToString();
@@ -47,6 +52,8 @@ namespace Libplanet.Net.Tests.Transports
                 blockchain,
                 swarmKey,
                 apv,
+                nodeId: 0,
+                validators: validators,
                 host: host,
                 listenPort: port,
                 options: option))

--- a/Libplanet.Net/Consensus/CommitBlockNotExistsException.cs
+++ b/Libplanet.Net/Consensus/CommitBlockNotExistsException.cs
@@ -1,0 +1,13 @@
+using System;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Consensus
+{
+    public class CommitBlockNotExistsException : Exception
+    {
+        public CommitBlockNotExistsException(VoteSet voteset)
+            : base(voteset.ToString())
+        {
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -77,10 +77,17 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         public long NodeId { get; internal set; }
 
+        /// <summary>
+        /// The HashAlgorithm used in <see cref="BlockChain{T}"/>.
+        /// </summary>
         public HashAlgorithmGetter HashAlgorithm => _blockChain.Policy.GetHashAlgorithm;
 
         public RoundContext<T> CurrentRoundContext => RoundContextOf(Round);
 
+        /// <summary>
+        /// A <see cref="AsyncManualResetEvent"/> whether A vote is in hold for waiting
+        /// <see cref="CurrentRoundContext"/> block.
+        /// </summary>
         public AsyncManualResetEvent VoteHolding { get; }
 
         /// <summary>
@@ -135,9 +142,15 @@ namespace Libplanet.Net.Consensus
             }
         }
 
+        /// <inheritdoc cref="IStore.ContainsBlock"/>
         public bool ContainsBlock(BlockHash blockHash) =>
             _blockChain.Store.ContainsBlock(blockHash);
 
+        /// <inheritdoc cref="IStore.GetBlock{T}"/>
+        public Block<T>? GetBlockFromStore(BlockHash blockHash) =>
+            _blockChain.Store.GetBlock<T>(HashAlgorithm, blockHash);
+
+        /// <inheritdoc cref="IStore.PutBlock{T}"/>
         public void PutBlockToStore(Block<T> block) =>
             _blockChain.Store.PutBlock(block);
 

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -230,6 +230,14 @@ namespace Libplanet.Net.Consensus
             {
                 await _context.VoteHolding.WaitAsync();
 
+                _logger.Debug(
+                    "{MethodName}: Waiting for Block for voting... Requesting" +
+                    " Round #{Round}, Height #{Height} Block #{Block} from neighbors...",
+                    nameof(RequestBlockInVoteHolding),
+                    _context.CurrentRoundContext.Round,
+                    _context.CurrentRoundContext.Height,
+                    _context.CurrentRoundContext.BlockHash);
+
                 var block = await RequestCurrentRoundBlock();
 
                 if (block is null)

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -164,6 +164,12 @@ namespace Libplanet.Net.Consensus
             }
         }
 
+        /// <summary>
+        /// Send a <see cref="Messages.GetBlocks"/> request for proposed <see cref="Block{T}"/> in
+        /// <see cref="ConsensusContext{T}.CurrentRoundContext"/> to neighbors.
+        /// </summary>
+        /// <returns>returns null if neighbors also don't have block or any network failure (e.g.
+        /// Timeout) or returns the unmarshalled <see cref="Block{T}"/>.</returns>
         private async Task<Block<T>?> RequestCurrentRoundBlock()
         {
             var neighbors = _routingTable.PeersToBroadcast(null);
@@ -211,6 +217,13 @@ namespace Libplanet.Net.Consensus
             return block;
         }
 
+        /// <summary>
+        /// A <see cref="Task"/> for requesting block while the state of node is in
+        /// <see cref="PreVoteState{T}"/>, however, node does not have the proposed
+        /// <see cref="Block{T}"/> to validate and vote.
+        /// </summary>
+        /// <remarks>This <see cref="Task"/> will be triggered when the
+        /// <see cref="ConsensusContext{T}.VoteHolding"/> is set.</remarks>
         private async Task RequestBlockInVoteHolding()
         {
             while (true)
@@ -234,6 +247,11 @@ namespace Libplanet.Net.Consensus
             }
         }
 
+        /// <summary>
+        /// A <see cref="Task"/> for requesting failed commit block from neighbors and recommit.
+        /// </summary>
+        /// <remarks>This <see cref="Task"/> will be triggered when the
+        /// <see cref="ConsensusContext{T}.CommitFailed"/> is set.</remarks>
         private async Task RecommittingFailedRound()
         {
             while (true)
@@ -253,6 +271,7 @@ namespace Libplanet.Net.Consensus
                 var targetHash = _context.CurrentRoundContext.BlockHash;
                 var targetHeight = _context.CurrentRoundContext.Height;
 
+                // This order is intended to test recommitting in Unit Test.
                 if (_context.ContainsBlock(targetHash))
                 {
                     block = _context.GetBlockFromStore(targetHash);

--- a/Libplanet.Net/Consensus/DefaultState.cs
+++ b/Libplanet.Net/Consensus/DefaultState.cs
@@ -46,10 +46,15 @@ namespace Libplanet.Net.Consensus
             roundContext.BlockHash = propose.BlockHash;
             roundContext.State = new PreVoteState<T>();
 
-            return context.ContainsBlock(propose.BlockHash) ?
-                new ConsensusVote(
+            if (context.ContainsBlock(propose.BlockHash))
+            {
+                return new ConsensusVote(
                     context.SignVote(
-                    roundContext.Voting(VoteFlag.Absent))) : null;
+                        roundContext.Voting(VoteFlag.Absent)));
+            }
+
+            context.VoteHolding.Set();
+            return null;
         }
     }
 }

--- a/Libplanet.Net/Consensus/IReactor.cs
+++ b/Libplanet.Net/Consensus/IReactor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
@@ -22,7 +23,7 @@ namespace Libplanet.Net.Consensus
         /// </returns>
         public VoteSet? VoteSetOf(long height);
 
-        public Task<Task> StartAsync(CancellationToken ctx);
+        public Task<List<Task>> StartAsync(CancellationToken ctx);
 
         public Task StopAsync(CancellationToken ctx);
 

--- a/Libplanet.Net/Consensus/PreVoteState.cs
+++ b/Libplanet.Net/Consensus/PreVoteState.cs
@@ -41,6 +41,7 @@ namespace Libplanet.Net.Consensus
                 vote.BlockHash.Equals(roundContext.BlockHash) &&
                 !context.ContainsBlock(vote.BlockHash))
             {
+                context.VoteHolding.Set();
                 throw new VoteBlockNotExistsException(vote);
             }
 
@@ -49,6 +50,7 @@ namespace Libplanet.Net.Consensus
                 vote.BlockHash.Equals(roundContext.BlockHash) &&
                 context.ContainsBlock(vote.BlockHash))
             {
+                context.VoteHolding.Reset();
                 roundContext.Vote(vote.ProposeVote);
                 return new ConsensusVote(roundContext.Voting(VoteFlag.Absent));
             }


### PR DESCRIPTION
- Block synchronization has been replaced with Event. (`VoteHolding`, `RequestBlockInVoteHolding`)
- If committing was failed before, getting block and recommit will be retried in methodically. (`CommitFailed`, `RecommittingFailedRound`). This is not guaranteed in `IState` level yet.
  - Answering `Blocks` is removed for letting Swarm answering (TODO: Swarm answers messages?). Above implementations should work without Swarm If response method with `Blocks` is added.
- Some Preparation for migration to Swarm.