### PR TITLE
IceServer now accepts only one URI.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@ To be released.
 [#2024]: https://github.com/planetarium/libplanet/pull/2024
 [#2026]: https://github.com/planetarium/libplanet/pull/2026
 
+
 Version 0.36.1
 --------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ To be released.
     CancellationToken)` and made non-optional.  [[#2024]]
  -  (Libplanet.Net) `Swarm<T>.BootstrapAsync(IEnumerable<Peer>, depth,
     CancellationToken)` removed.  [[#2024]]
+ -  (Libplanet.Net) Parameter name `Urls` changed to `Url` for `IceServer`
+    and no longer accepts multiple Urls for single instance. [[#2026]]
 
 ### Backward-incompatible network protocol changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ To be released.
 ### CLI tools
 
 [#2024]: https://github.com/planetarium/libplanet/pull/2024
-
+[#2026]: https://github.com/planetarium/libplanet/pull/2026
 
 Version 0.36.1
 --------------

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -132,7 +132,7 @@ namespace Libplanet.Explorer.Executable
                     return null;
                 }
 
-                Uri uri = IceServer.Urls.First();
+                Uri uri = IceServer.Url;
                 var uriBuilder = new UriBuilder(uri)
                 {
                     UserName = IceServer.Username,
@@ -151,7 +151,7 @@ namespace Libplanet.Explorer.Executable
 
                 var uri = new Uri(value);
                 string[] userInfo = uri.UserInfo.Split(':', count: 2);
-                IceServer = new IceServer(new[] { uri }, userInfo[0], userInfo[1]);
+                IceServer = new IceServer(uri, userInfo[0], userInfo[1]);
             }
         }
 

--- a/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
+++ b/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net.Tests
                 {
                     string[] userInfo = turnUri.UserInfo.Split(':');
                     return new IceServer(
-                        urls: new[] { turnUri },
+                        url: turnUri,
                         username: userInfo[0],
                         credential: userInfo[1]
                     );

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -20,19 +20,19 @@ namespace Libplanet.Net.Tests
                 async () =>
                 {
                     await IceServer.CreateTurnClient(
-                       new[] { new IceServer(new[] { "stun://stun.l.google.com:19302" }) }
+                       new[] { new IceServer("stun://stun.l.google.com:19302")}
                     );
                 }
             );
             var servers = new List<IceServer>()
             {
-                new IceServer(new[] { "turn://turn.does-not-exists.org" }),
+                new IceServer("turn://turn.does-not-exists.org"),
             };
 
             await Assert.ThrowsAsync<IceServerException>(
                 async () => { await IceServer.CreateTurnClient(servers); });
 
-            servers.Add(new IceServer(new[] { turnUri }, userInfo[0], userInfo[1]));
+            servers.Add(new IceServer(turnUri, userInfo[0], userInfo[1]));
             for (int i = 3; i > 0; i--)
             {
                 TurnClient turnClient;

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Net.Tests
                 async () =>
                 {
                     await IceServer.CreateTurnClient(
-                       new[] { new IceServer("stun://stun.l.google.com:19302")}
+                       new[] { new IceServer("stun://stun.l.google.com:19302") }
                     );
                 }
             );

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -679,7 +679,7 @@ namespace Libplanet.Net.Tests
 
             IEnumerable<IceServer> iceServers = new[]
             {
-                new IceServer(urls: new[] { proxyUri }, username: username, credential: password),
+                new IceServer(url: proxyUri, username: username, credential: password),
             };
 
             var cts = new CancellationTokenSource();

--- a/Libplanet.Net/IceServer.cs
+++ b/Libplanet.Net/IceServer.cs
@@ -12,10 +12,8 @@ namespace Libplanet.Net
             string url,
             string? username = null,
             string? credential = null)
+            : this(new Uri(url), username, credential)
         {
-            Url = new Uri(url);
-            Username = username;
-            Credential = credential;
         }
 
         public IceServer(

--- a/Libplanet.Net/IceServer.cs
+++ b/Libplanet.Net/IceServer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Libplanet.Stun;
 using Serilog;
@@ -40,23 +39,24 @@ namespace Libplanet.Net
         {
             foreach (IceServer server in iceServers)
             {
-                if (server.Url.Scheme != "turn")
+                Uri url = server.Url;
+                if (url.Scheme != "turn")
                 {
-                    throw new ArgumentException($"{server.Url} is not a valid TURN url.");
+                    throw new ArgumentException($"{url} is not a valid TURN url.");
                 }
 
-                int port = server.Url.IsDefaultPort
+                int port = url.IsDefaultPort
                     ? TurnClient.TurnDefaultPort
-                    : server.Url.Port;
+                    : url.Port;
                 var turnClient = new TurnClient(
-                    server.Url.Host,
+                    url.Host,
                     server.Username,
                     server.Credential,
                     port);
 
                 if (await turnClient.IsConnectable())
                 {
-                    Log.Debug("TURN client created: {Host}:{Port}", server.Url.Host, server.Url.Port);
+                    Log.Debug("TURN client created: {Host}:{Port}", url.Host, url.Port);
                     return turnClient;
                 }
             }


### PR DESCRIPTION
Addresses https://github.com/planetarium/libplanet/issues/1995,
Also changed test conditions accordingly.

In my point of view, accepting multiple URI seems redundant, and may cause serious confusion. so I choose to accept only one URI. however, this might cause some side effects to the current codebase. I tested some use cases but cannot assure about that. 