### PR TITLE
Separate `ITransport`s (+ Prepare for PBFT Headless)

### DIFF
--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -54,6 +54,7 @@ namespace Libplanet.Benchmarks
         public void InitializeSwarms()
         {
             _keys = TestUtils.AdjacentKeys;
+            var consensusKeys = new PrivateKey[SwarmNumber];
             _fxs = new DefaultStoreFixture[SwarmNumber];
             _blockChains = new BlockChain<DumbAction>[SwarmNumber];
             _swarms = new Swarm<DumbAction>[SwarmNumber];
@@ -65,6 +66,7 @@ namespace Libplanet.Benchmarks
             for (int i = 0; i < SwarmNumber; i++)
             {
                 _keys[i] = _keys[i] ?? new PrivateKey();
+                consensusKeys[i] = consensusKeys[i] ?? new PrivateKey();
                 _fxs[i] = new DefaultStoreFixture(memory: true);
                 _blockChains[i] = new BlockChain<DumbAction>(
                     _policy, _stagePolicy, _fxs[i].Store, _fxs[i].StateStore, _blocks[0]);
@@ -72,11 +74,12 @@ namespace Libplanet.Benchmarks
                     _blockChains[i],
                     _keys[i],
                     _appProtocolVersion,
+                    consensusPrivateKey: consensusKeys[i],
                     host: IPAddress.Loopback.ToString(),
                     nodeId: i,
                     validators: new List<PublicKey>()
                     {
-                        _keys[i].PublicKey,
+                        consensusKeys[i].PublicKey,
                     });
                 tasks.Add(StartAsync(_swarms[i]));
             }

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -225,6 +225,7 @@ If omitted (default) explorer only the local blockchain store.")]
                     Console.Error.WriteLine("Creating Swarm.");
 
                     var privateKey = new PrivateKey();
+                    var consensusPrivateKey = new PrivateKey();
 
                     // FIXME: The appProtocolVersion should be fixed properly.
                     var swarmOptions = new SwarmOptions
@@ -244,7 +245,11 @@ If omitted (default) explorer only the local blockchain store.")]
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions,
                         nodeId: 0,
-                        validators: null
+                        validators: new List<PublicKey>()
+                        {
+                            consensusPrivateKey.PublicKey,
+                        },
+                        consensusPrivateKey: consensusPrivateKey
                     );
                 }
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -28,39 +28,40 @@ namespace Libplanet.Net.Tests.Consensus
         public override IReactor CreateReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? blockTable = null,
-            RoutingTable? messageTable = null,
+            RoutingTable? swarmTable = null,
+            RoutingTable? consensusTable = null,
             string host = "localhost",
-            int port = 5001,
+            int swarmPort = 5001,
+            int consensusPort = 5101,
             long id = 0,
             List<PublicKey> validators = null!)
         {
             key ??= new PrivateKey();
-            var blockTransport = new NetMQTransport(
+            var swarmTransport = new NetMQTransport(
                 key,
                 TestUtils.AppProtocolVersion,
                 null,
                 8,
                 host,
-                port,
+                swarmPort,
                 Array.Empty<IceServer>(),
                 null);
 
-            var messageTransport = new NetMQTransport(
+            var consensusTransport = new NetMQTransport(
                 key,
                 TestUtils.AppProtocolVersion,
                 null,
                 8,
                 host,
-                port + 1000,
+                consensusPort,
                 Array.Empty<IceServer>(),
                 null);
 
             return new ConsensusReactor<DumbAction>(
-                blockTable ?? new RoutingTable(key.ToAddress()),
-                messageTable ?? new RoutingTable(key.ToAddress()),
-                blockTransport,
-                messageTransport,
+                swarmTable ?? new RoutingTable(key.ToAddress()),
+                consensusTable ?? new RoutingTable(key.ToAddress()),
+                swarmTransport,
+                consensusTransport,
                 blockChain,
                 key,
                 id,
@@ -70,20 +71,22 @@ namespace Libplanet.Net.Tests.Consensus
         public override ConsensusReactor<DumbAction> CreateConcreteReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? blockTable = null,
-            RoutingTable? messageTable = null,
+            RoutingTable? swarmTable = null,
+            RoutingTable? consensusTable = null,
             string host = "localhost",
-            int port = 5001,
+            int swarmPort = 5001,
+            int consensusPort = 5101,
             long id = 0,
             List<PublicKey> validators = null!)
         {
             return (ConsensusReactor<DumbAction>)CreateReactor(
                 blockChain,
                 key,
-                blockTable,
-                messageTable,
+                swarmTable,
+                consensusTable,
                 host,
-                port,
+                swarmPort,
+                consensusPort,
                 id,
                 validators);
         }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -28,14 +28,15 @@ namespace Libplanet.Net.Tests.Consensus
         public override IReactor CreateReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? table = null,
+            RoutingTable? blockTable = null,
+            RoutingTable? messageTable = null,
             string host = "localhost",
             int port = 5001,
             long id = 0,
             List<PublicKey> validators = null!)
         {
             key ??= new PrivateKey();
-            var transport = new NetMQTransport(
+            var blockTransport = new NetMQTransport(
                 key,
                 TestUtils.AppProtocolVersion,
                 null,
@@ -45,9 +46,21 @@ namespace Libplanet.Net.Tests.Consensus
                 Array.Empty<IceServer>(),
                 null);
 
+            var messageTransport = new NetMQTransport(
+                key,
+                TestUtils.AppProtocolVersion,
+                null,
+                8,
+                host,
+                port + 1000,
+                Array.Empty<IceServer>(),
+                null);
+
             return new ConsensusReactor<DumbAction>(
-                table ?? new RoutingTable(key.ToAddress()),
-                transport,
+                blockTable ?? new RoutingTable(key.ToAddress()),
+                messageTable ?? new RoutingTable(key.ToAddress()),
+                blockTransport,
+                messageTransport,
                 blockChain,
                 key,
                 id,
@@ -57,7 +70,8 @@ namespace Libplanet.Net.Tests.Consensus
         public override ConsensusReactor<DumbAction> CreateConcreteReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? table = null,
+            RoutingTable? blockTable = null,
+            RoutingTable? messageTable = null,
             string host = "localhost",
             int port = 5001,
             long id = 0,
@@ -66,7 +80,8 @@ namespace Libplanet.Net.Tests.Consensus
             return (ConsensusReactor<DumbAction>)CreateReactor(
                 blockChain,
                 key,
-                table,
+                blockTable,
+                messageTable,
                 host,
                 port,
                 id,

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -384,7 +384,7 @@ namespace Libplanet.Net.Tests.Consensus
             }
         }
 
-        [Fact]
+        [Fact(Timeout = Timeout)]
         public async Task RecommitFailedBlockWoNet()
         {
             const int count = 4;

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -47,7 +47,8 @@ namespace Libplanet.Net.Tests.Consensus
         public abstract IReactor CreateReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? table = null,
+            RoutingTable? blockTable = null,
+            RoutingTable? messageTable = null,
             string host = "localhost",
             int port = 5001,
             long id = 0,
@@ -56,7 +57,8 @@ namespace Libplanet.Net.Tests.Consensus
         public abstract ConsensusReactor<DumbAction> CreateConcreteReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            RoutingTable? table = null,
+            RoutingTable? blockTable = null,
+            RoutingTable? messageTable = null,
             string host = "localhost",
             int port = 5001,
             long id = 0,
@@ -150,11 +152,12 @@ namespace Libplanet.Net.Tests.Consensus
         {
             const int count = 4;
             // INFO : This test uses local ports 6000 to 6003.
-            const int startPort = 6000;
+            const int blockPort = 6000;
+            const int messagePort = blockPort + 1000;
 
             const int propagationDelay = 4000;
             var keys = new PrivateKey[count];
-            var tables = new RoutingTable[count];
+            var messageTables = new RoutingTable[count];
             var reactors = new IReactor[count];
             var validators = new List<PublicKey>();
             var stores = new IStore[count];
@@ -163,7 +166,7 @@ namespace Libplanet.Net.Tests.Consensus
             for (var i = 0; i < count; i++)
             {
                 keys[i] = new PrivateKey();
-                tables[i] = new RoutingTable(keys[i].ToAddress());
+                messageTables[i] = new RoutingTable(keys[i].ToAddress());
                 validators.Add(keys[i].PublicKey);
                 stores[i] = new MemoryStore();
                 blockChains[i] = new BlockChain<DumbAction>(
@@ -179,8 +182,8 @@ namespace Libplanet.Net.Tests.Consensus
                 reactors[i] = CreateReactor(
                     blockChain: blockChains[i],
                     key: keys[i],
-                    table: tables[i],
-                    port: startPort + i,
+                    messageTable: messageTables[i],
+                    port: blockPort + i,
                     id: i,
                     validators: validators);
             }
@@ -201,10 +204,10 @@ namespace Libplanet.Net.Tests.Consensus
                             continue;
                         }
 
-                        tables[i].AddPeer(
+                        messageTables[i].AddPeer(
                             new BoundPeer(
                                 keys[j].PublicKey,
-                                new DnsEndPoint("localhost", startPort + j)));
+                                new DnsEndPoint("localhost", messagePort + j)));
                     }
                 }
 
@@ -286,11 +289,12 @@ namespace Libplanet.Net.Tests.Consensus
         {
             const int count = 4;
             // INFO : This test uses local ports 7000 to 7003.
-            const int startPort = 7000;
+            const int blockPort = 7000;
+            const int messagePort = blockPort + 1000;
             const int propagationDelay = 4000;
 
             var keys = new PrivateKey[count];
-            var tables = new RoutingTable[count];
+            var messageTables = new RoutingTable[count];
             var reactors = new ConsensusReactor<DumbAction>[count];
             var validators = new List<PublicKey>();
             var stores = new IStore[count];
@@ -299,7 +303,7 @@ namespace Libplanet.Net.Tests.Consensus
             for (var i = 0; i < count; i++)
             {
                 keys[i] = new PrivateKey();
-                tables[i] = new RoutingTable(keys[i].ToAddress());
+                messageTables[i] = new RoutingTable(keys[i].ToAddress());
                 validators.Add(keys[i].PublicKey);
                 stores[i] = new MemoryStore();
                 blockChains[i] = new BlockChain<DumbAction>(
@@ -315,8 +319,8 @@ namespace Libplanet.Net.Tests.Consensus
                 reactors[i] = CreateConcreteReactor(
                     blockChain: blockChains[i],
                     key: keys[i],
-                    table: tables[i],
-                    port: startPort + i,
+                    messageTable: messageTables[i],
+                    port: blockPort + i,
                     id: i,
                     validators: validators);
             }
@@ -337,10 +341,10 @@ namespace Libplanet.Net.Tests.Consensus
                             continue;
                         }
 
-                        tables[i].AddPeer(
+                        messageTables[i].AddPeer(
                             new BoundPeer(
                                 keys[j].PublicKey,
-                                new DnsEndPoint("localhost", startPort + j)));
+                                new DnsEndPoint("localhost", messagePort + j)));
                     }
                 }
 
@@ -376,10 +380,11 @@ namespace Libplanet.Net.Tests.Consensus
         {
             const int count = 4;
             // INFO : This test uses local ports 8000 to 8003.
-            const int startPort = 8000;
+            const int blockPort = 8000;
+            const int messagePort = blockPort + 1000;
 
             var keys = new PrivateKey[count];
-            var tables = new RoutingTable[count];
+            var messageTables = new RoutingTable[count];
             var reactors = new ConsensusReactor<DumbAction>[count];
             var validators = new List<PublicKey>();
             var stores = new IStore[count];
@@ -388,7 +393,7 @@ namespace Libplanet.Net.Tests.Consensus
             for (var i = 0; i < count; i++)
             {
                 keys[i] = new PrivateKey();
-                tables[i] = new RoutingTable(keys[i].ToAddress());
+                messageTables[i] = new RoutingTable(keys[i].ToAddress());
                 validators.Add(keys[i].PublicKey);
                 stores[i] = new MemoryStore();
                 blockChains[i] = new BlockChain<DumbAction>(
@@ -404,8 +409,8 @@ namespace Libplanet.Net.Tests.Consensus
                 reactors[i] = CreateConcreteReactor(
                     blockChain: blockChains[i],
                     key: keys[i],
-                    table: tables[i],
-                    port: startPort + i,
+                    messageTable: messageTables[i],
+                    port: blockPort + i,
                     id: i,
                     validators: validators);
             }
@@ -426,10 +431,10 @@ namespace Libplanet.Net.Tests.Consensus
                             continue;
                         }
 
-                        tables[i].AddPeer(
+                        messageTables[i].AddPeer(
                             new BoundPeer(
                                 keys[j].PublicKey,
-                                new DnsEndPoint("localhost", startPort + j)));
+                                new DnsEndPoint("localhost", messagePort + j)));
                     }
                 }
 

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -69,6 +69,7 @@ namespace Libplanet.Net.Tests
 
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
+            PrivateKey consensusPrivateKey = null,
             long nodeId = 0,
             List<PublicKey> validators = null,
             AppProtocolVersion? appProtocolVersion = null,
@@ -92,6 +93,7 @@ namespace Libplanet.Net.Tests
             return CreateSwarm(
                 blockchain,
                 privateKey,
+                consensusPrivateKey,
                 nodeId,
                 validators,
                 appProtocolVersion,
@@ -106,6 +108,7 @@ namespace Libplanet.Net.Tests
         private Swarm<T> CreateSwarm<T>(
             BlockChain<T> blockChain,
             PrivateKey privateKey = null,
+            PrivateKey consensusPrivateKey = null,
             long nodeId = 0,
             List<PublicKey> validators = null,
             AppProtocolVersion? appProtocolVersion = null,
@@ -137,9 +140,11 @@ namespace Libplanet.Net.Tests
             }
 
             privateKey ??= new PrivateKey();
+            consensusPrivateKey ??= new PrivateKey();
+
             validators ??= new List<PublicKey>()
             {
-                privateKey.PublicKey,
+                consensusPrivateKey.PublicKey,
             };
 
             var swarm = new Swarm<T>(
@@ -148,13 +153,14 @@ namespace Libplanet.Net.Tests
                 appProtocolVersion ?? DefaultAppProtocolVersion,
                 nodeId,
                 validators,
-                5,
-                host,
-                listenPort,
-                iceServers,
-                differentAppProtocolVersionEncountered,
-                trustedAppProtocolVersionSigners,
-                options);
+                consensusPrivateKey,
+                workers: 5,
+                host: host,
+                listenPort: listenPort,
+                iceServers: iceServers,
+                differentAppProtocolVersionEncountered: differentAppProtocolVersionEncountered,
+                trustedAppProtocolVersionSigners: trustedAppProtocolVersionSigners,
+                options: options);
             _finalizers.Add(async () =>
             {
                 try

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -543,21 +543,29 @@ namespace Libplanet.Net.Tests
             var policy = new BlockPolicy<DumbAction>();
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var key = new PrivateKey();
+            var consensusPrivateKey = new PrivateKey();
             AppProtocolVersion ver = AppProtocolVersion.Sign(key, 1);
+            // TODO: Check Consensus Parameters.
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(null, key, ver, nodeId: 0, validators: null);
+                new Swarm<DumbAction>(
+                    null,
+                    key,
+                    ver,
+                    consensusPrivateKey: consensusPrivateKey,
+                    nodeId: 0,
+                    validators: null);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Swarm<DumbAction>(blockchain, null, ver, nodeId: 0, validators: null);
-            });
-
-            // Swarm<DumbAction> needs host or iceServers.
-            Assert.Throws<ArgumentException>(() =>
-            {
-                new Swarm<DumbAction>(blockchain, key, ver, nodeId: 0, validators: null);
+                new Swarm<DumbAction>(
+                    blockchain,
+                    null,
+                    ver,
+                    consensusPrivateKey: consensusPrivateKey,
+                    nodeId: 0,
+                    validators: null);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
@@ -567,6 +575,19 @@ namespace Libplanet.Net.Tests
                     blockchain,
                     key,
                     ver,
+                    consensusPrivateKey: consensusPrivateKey,
+                    nodeId: 0,
+                    validators: null);
+            });
+
+            // Swarm<DumbAction> needs host or iceServers.
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new Swarm<DumbAction>(
+                    blockchain,
+                    key,
+                    ver,
+                    consensusPrivateKey: consensusPrivateKey,
                     iceServers: new IceServer[] { },
                     nodeId: 0,
                     validators: null);

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -34,6 +34,7 @@ namespace Libplanet.Net.Tests.Transports
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var apvKey = new PrivateKey();
             var swarmKey = new PrivateKey();
+            var consensusKey = new PrivateKey();
             var validators = new List<PublicKey>()
             {
                 swarmKey.PublicKey,
@@ -52,6 +53,7 @@ namespace Libplanet.Net.Tests.Transports
                 blockchain,
                 swarmKey,
                 apv,
+                consensusPrivateKey: consensusKey,
                 nodeId: 0,
                 validators: validators,
                 host: host,

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -240,6 +240,8 @@ namespace Libplanet.Net.Consensus
             {
                 await _context.VoteHolding.WaitAsync();
 
+                await Task.Delay(50);
+
                 _logger.Debug(
                     "{MethodName}: Waiting for Block for voting... Requesting" +
                     " Round #{Round}, Height #{Height} Block #{Block} from neighbors...",
@@ -275,6 +277,8 @@ namespace Libplanet.Net.Consensus
             while (true)
             {
                 await _context.CommitFailed.WaitAsync();
+
+                await Task.Delay(50);
 
                 _logger.Error(
                     "{MethodName}: Caught Commit failure. In Round #{Round}, " +

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -135,20 +135,20 @@ namespace Libplanet.Net
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
 
-            MessageTransport = InitializeTransport(
+            ConsensusTransport = InitializeTransport(
                 consensusWorkers,
                 host,
                 consensusPort,
                 iceServers,
                 differentAppProtocolVersionEncountered);
 
-            MessageRoutingTable = new RoutingTable(
+            ConsensusRoutingTable = new RoutingTable(
                 consensusPrivateKey.ToAddress(), consensusTableSize, consensusTableBucket);
             _consensusReactor = new ConsensusReactor<T>(
                 RoutingTable,
-                MessageRoutingTable,
+                ConsensusRoutingTable,
                 Transport,
-                MessageTransport,
+                ConsensusTransport,
                 BlockChain,
                 privateKey,
                 nodeId,
@@ -234,13 +234,13 @@ namespace Libplanet.Net
 
         internal RoutingTable RoutingTable { get; }
 
-        internal RoutingTable MessageRoutingTable { get; }
+        internal RoutingTable ConsensusRoutingTable { get; }
 
         internal IProtocol PeerDiscovery { get; }
 
         internal ITransport Transport { get; private set; }
 
-        internal ITransport MessageTransport { get; private set; }
+        internal ITransport ConsensusTransport { get; private set; }
 
         internal TxCompletion<BoundPeer, T> TxCompletion { get; }
 

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -275,6 +275,7 @@ namespace Libplanet.Net
                 _workerCancellationTokenSource?.Cancel();
                 TxCompletion?.Dispose();
                 Transport?.Dispose();
+                _consensusReactor.Dispose();
                 _workerCancellationTokenSource?.Dispose();
                 _disposed = true;
             }
@@ -299,6 +300,7 @@ namespace Libplanet.Net
             using (await _runningMutex.LockAsync())
             {
                 await Transport.StopAsync(waitFor, cancellationToken);
+                await _consensusReactor.StopAsync(cancellationToken);
             }
 
             BlockDemandTable = new BlockDemandTable<T>(Options.BlockDemandLifespan);
@@ -415,6 +417,7 @@ namespace Libplanet.Net
                         _cancellationToken
                     )
                 );
+                tasks.AddRange(await _consensusReactor.StartAsync(cancellationToken));
                 if (Options.StaticPeers.Any())
                 {
                     tasks.Add(


### PR DESCRIPTION
# Summary
- This PR addresses remaining undone work in Block Synchronization PR, which is the `ConsensusReactor` and `Swarm` use separate `ITransport` for each.