### PR TITLE
Expose `VoteSetOf` and `Propose`

### DIFF
--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -13,6 +13,7 @@ using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
@@ -259,6 +260,10 @@ namespace Libplanet.Net
         internal AsyncAutoResetEvent BlockDownloadStarted { get; } = new AsyncAutoResetEvent();
 
         internal SwarmOptions Options { get; }
+
+        public VoteSet VoteSetOf(long height) => _consensusReactor.VoteSetOf(height);
+
+        public void Propose(BlockHash blockHash) => _consensusReactor.Propose(blockHash);
 
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.


### PR DESCRIPTION
`Swarm` needs to expose `VoteSetOf` and `Propose` for following method  : https://github.com/planetarium/NineChronicles.Headless/commit/7fd77a8518e66a22353978299d7ac7740fd8ff28