### PR TITLE
Feature/consensus chain height

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -55,6 +55,7 @@ namespace Libplanet.Net.Consensus
 
             _timoutTicker = new TimeoutTicker(TimeoutMillisecond, TimerTimeoutCallback);
             VoteSets = new Dictionary<long, VoteSet?>();
+            Height = blockChain.Tip.Index;
             _logger = Log
                 .ForContext<ConsensusContext<T>>()
                 .ForContext("Source", nameof(ConsensusContext<T>));

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Net.Consensus
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(validators),
-                    $"Number of validator should be greater than 0. ({validators.Count}is given)");
+                    $"Number of validator should be greater than 0. ({validators.Count} is given)");
             }
 
             NodeId = nodeId;

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -107,7 +107,7 @@ namespace Libplanet.Net.Consensus
         {
             _logger.Debug(
                 "NodeID: {Id}, Height: {Height}, Round: {Round}, " +
-                "State: {State}, HandleMessage: {@Message},",
+                "State: {State}, HandleMessage: {Message},",
                 _context.NodeId,
                 _context.Height,
                 _context.Round,

--- a/Libplanet.Net/Consensus/PreCommitState.cs
+++ b/Libplanet.Net/Consensus/PreCommitState.cs
@@ -1,7 +1,6 @@
 using Libplanet.Action;
 using Libplanet.Consensus;
 using Libplanet.Net.Messages;
-using Serilog;
 
 namespace Libplanet.Net.Consensus
 {
@@ -22,8 +21,6 @@ namespace Libplanet.Net.Consensus
 
         private ConsensusMessage? HandleCommit(ConsensusContext<T> context, ConsensusCommit commit)
         {
-            Log.Debug("Context: {@Context}, HandleCommit: {@Message}", context, commit);
-
             if (context.Height != commit.Height)
             {
                 throw new UnexpectedHeightProposeException(commit);


### PR DESCRIPTION
`0` was used for current height field of pbft consensus, now uses chain tip's index. Additionally squashed some nested loggings and fixed typo.