### PR TITLE
Unnecessary parameters removed for `IceServer()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Net) Removed `username` and `credential` parameters from
+    `IceServer(string, string?, string?)` and
+    `IceServer(Uri, string?, string?)`.  [[#2048], [#2049]]
+ -  (Libplanet.Net) Properties `IceServer.Username` and `IceServer.Credential`
+    are no longer nullable.  [[#2048], [#2049]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -43,6 +49,8 @@ To be released.
 [#2018]: https://github.com/planetarium/libplanet/pull/2018
 [#2021]: https://github.com/planetarium/libplanet/pull/2021
 [#2022]: https://github.com/planetarium/libplanet/pull/2022
+[#2048]: https://github.com/planetarium/libplanet/issues/2048
+[#2049]: https://github.com/planetarium/libplanet/pull/2049
 
 
 Version 0.37.0

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -125,34 +125,8 @@ namespace Libplanet.Explorer.Executable
 
         public string IceServerUrl
         {
-            get
-            {
-                if (IceServer is null)
-                {
-                    return null;
-                }
-
-                Uri uri = IceServer.Url;
-                var uriBuilder = new UriBuilder(uri)
-                {
-                    UserName = IceServer.Username,
-                    Password = IceServer.Credential,
-                };
-                return uriBuilder.Uri.ToString();
-            }
-
-            set
-            {
-                if (value is null)
-                {
-                    IceServer = null;
-                    return;
-                }
-
-                var uri = new Uri(value);
-                string[] userInfo = uri.UserInfo.Split(':', count: 2);
-                IceServer = new IceServer(uri, userInfo[0], userInfo[1]);
-            }
+            get => IceServer is null ? null : IceServer.Url.ToString();
+            set => IceServer = value is null ? null : new IceServer(value);
         }
 
         public IceServer IceServer { get; set; }

--- a/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
+++ b/Libplanet.Net.Tests/FactOnlyTurnAvailableAttribute.cs
@@ -22,12 +22,7 @@ namespace Libplanet.Net.Tests
             {
                 try
                 {
-                    string[] userInfo = turnUri.UserInfo.Split(':');
-                    return new IceServer(
-                        url: turnUri,
-                        username: userInfo[0],
-                        credential: userInfo[1]
-                    );
+                    return new IceServer(url: turnUri);
                 }
                 catch (ArgumentNullException)
                 {

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -11,6 +11,48 @@ namespace Libplanet.Net.Tests
     {
         private const int Timeout = 60 * 1000;
 
+        [Fact]
+        public void ParseUrl()
+        {
+            string urlString;
+            IceServer iceServer;
+
+            urlString = "turn://only.path.component";
+            iceServer = new IceServer(urlString);
+            Assert.Empty(iceServer.Username);
+            Assert.Empty(iceServer.Credential);
+
+            urlString = "turn://@path.with.at.symbol";
+            iceServer = new IceServer(urlString);
+            Assert.Empty(iceServer.Username);
+            Assert.Empty(iceServer.Credential);
+
+            urlString = "turn://path@with.username";
+            iceServer = new IceServer(urlString);
+            Assert.Equal("path", iceServer.Username);
+            Assert.Empty(iceServer.Credential);
+
+            urlString = "turn://username:@with.empty.credential";
+            iceServer = new IceServer(urlString);
+            Assert.Equal("username", iceServer.Username);
+            Assert.Empty(iceServer.Credential);
+
+            urlString = "turn://:empty@username.with.credential";
+            iceServer = new IceServer(urlString);
+            Assert.Empty(iceServer.Username);
+            Assert.Equal("empty", iceServer.Credential);
+
+            urlString = "turn://:@only.userinfo.seperator";
+            iceServer = new IceServer(urlString);
+            Assert.Empty(iceServer.Username);
+            Assert.Empty(iceServer.Credential);
+
+            urlString = "turn://user:info@some.path";
+            iceServer = new IceServer(urlString);
+            Assert.Equal("user", iceServer.Username);
+            Assert.Equal("info", iceServer.Credential);
+        }
+
         [FactOnlyTurnAvailable(Timeout = Timeout)]
         public async Task CreateTurnClient()
         {
@@ -32,7 +74,7 @@ namespace Libplanet.Net.Tests
             await Assert.ThrowsAsync<IceServerException>(
                 async () => { await IceServer.CreateTurnClient(servers); });
 
-            servers.Add(new IceServer(turnUri, userInfo[0], userInfo[1]));
+            servers.Add(new IceServer(turnUri));
             for (int i = 3; i > 0; i--)
             {
                 TurnClient turnClient;

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Net.Tests
             Assert.Empty(iceServer.Username);
             Assert.Equal("empty", iceServer.Credential);
 
-            urlString = "turn://:@only.userinfo.seperator";
+            urlString = "turn://:@only.userinfo.separator";
             iceServer = new IceServer(urlString);
             Assert.Empty(iceServer.Username);
             Assert.Empty(iceServer.Credential);

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -680,7 +680,7 @@ namespace Libplanet.Net.Tests
 
             IEnumerable<IceServer> iceServers = new[]
             {
-                new IceServer(url: proxyUri, username: username, credential: password),
+                new IceServer(url: proxyUri),
             };
 
             var cts = new CancellationTokenSource();

--- a/Libplanet.Node.Tests/SwarmConfigTest.cs
+++ b/Libplanet.Node.Tests/SwarmConfigTest.cs
@@ -18,8 +18,8 @@ namespace Libplanet.Node.Tests
                 1001,
                 new List<IceServer>()
                 {
-                    new IceServer(new Uri("turn://user:cred@www.foo.com:1002"), "user", "cred"),
-                    new IceServer(new Uri("turn://www.bar.com:1003"), null, null),
+                    new IceServer(new Uri("turn://user:cred@www.foo.com:1002")),
+                    new IceServer(new Uri("turn://www.bar.com:1003")),
                 },
                 new List<BoundPeer>()
                 {

--- a/Libplanet.Node/SwarmConfig.cs
+++ b/Libplanet.Node/SwarmConfig.cs
@@ -157,28 +157,7 @@ namespace Libplanet.Node
                 Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                Uri uri = new Uri(reader.GetString());
-                string? username = null;
-                string? credential = null;
-                if (uri.UserInfo.Length > 0)
-                {
-                    string[] userInfo = uri.UserInfo.Split(':');
-                    if (userInfo.Length == 1)
-                    {
-                        username = userInfo[0];
-                    }
-                    else if (userInfo.Length == 2)
-                    {
-                        username = userInfo[0];
-                        credential = userInfo[1];
-                    }
-                    else
-                    {
-                        throw new UriFormatException($"Invalid URI format: {uri}");
-                    }
-                }
-
-                return new IceServer(uri, username, credential);
+                return new IceServer(new Uri(reader.GetString()));
             }
 
             public override void Write(


### PR DESCRIPTION
Closes #2048.

I couldn't find a fully unambiguous specification for parsing `username:credential` for `UserInfo` field. In [RFC3986], it only specifies  such form is allowed but **not recommended**. So I took the liberty of equating `null` and `string.Empty` and interpreting most, if not all, edge cases as I fit to see as most intuitive. 🙄

[RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1