### PR TITLE
Import unity dll dependency

### DIFF
--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -10,6 +10,7 @@ projects=(
   "Libplanet.RocksDBStore"
   "Libplanet.Analyzers"
   "Libplanet.Tools"
+  "Libplanet.Unity"
   "Libplanet.Explorer"
   "Libplanet.Explorer.Executable"
   "Libplanet.Extensions.Cocona"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,9 @@ on GitHub consists of several projects:
  -  *Libplanet.Explorer.Executable*: Turns Libplanet Explorer into a single
     executable binary so that it is easy to distribute.
 
+ -  *Libplanet.Unity*: User-friendly pluggable API for developing and running
+    a *Libplanet* blockchain node within Unity.
+
  -  *Libplanet.Benchmarks*: Performance benchmarks.
     See the [*Benchmarks*](#benchmarks) section below.
 
@@ -134,6 +137,9 @@ on GitHub consists of several projects:
     project.
 
  -  *Libplanet.Explorer.Tests*: Unit tests of the *Libplanet.Explorer*
+    project.
+
+ -  *Libplanet.Unity.Tests*: Unit tests of the *Libplanet.Unity*
     project.
 
  -  *Libplanet.Extensions.Cocona.Tests*: Unit tests of the

--- a/Docs/docfx.json
+++ b/Docs/docfx.json
@@ -7,6 +7,7 @@
             "Libplanet/Libplanet.csproj",
             "Libplanet.Net/Libplanet.Net.csproj",
             "Libplanet.Node/Libplanet.Node.csproj",
+            "Libplanet.Unity/Libplanet.Unity.csproj",
             "Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj",
             "Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj",
             "Libplanet.Stun/Libplanet.Stun.csproj"

--- a/Libplanet.Unity.Tests/Libplanet.Unity.csproj
+++ b/Libplanet.Unity.Tests/Libplanet.Unity.csproj
@@ -83,7 +83,7 @@
       <HintPath>.\UnityReference\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-        <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Libplanet.Unity.Tests/Libplanet.Unity.csproj
+++ b/Libplanet.Unity.Tests/Libplanet.Unity.csproj
@@ -77,4 +77,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="UnityEngine">
+      <HintPath>.\UnityReference\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+        <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/Libplanet.Unity/Libplanet.Unity.csproj
+++ b/Libplanet.Unity/Libplanet.Unity.csproj
@@ -78,13 +78,13 @@
       <HintPath>.\UnityReference\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-        <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEditor">
-        <HintPath>.\UnityReference\UnityEditor.dll</HintPath>
+      <HintPath>.\UnityReference\UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="UnityEditor.CoreModule">
-        <HintPath>.\UnityReference\UnityEditor.CoreModule.dll</HintPath>
+      <HintPath>.\UnityReference\UnityEditor.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Libplanet.Unity/Libplanet.Unity.csproj
+++ b/Libplanet.Unity/Libplanet.Unity.csproj
@@ -80,5 +80,11 @@
     <Reference Include="UnityEngine.CoreModule">
         <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEditor">
+        <HintPath>.\UnityReference\UnityEditor.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.CoreModule">
+        <HintPath>.\UnityReference\UnityEditor.CoreModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/Libplanet.Unity/Libplanet.Unity.csproj
+++ b/Libplanet.Unity/Libplanet.Unity.csproj
@@ -1,15 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>
-
-<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Libplanet.Unity</PackageId>
     <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
@@ -82,5 +71,14 @@
     <ProjectReference Include="..\Libplanet.Node\Libplanet.Node.csproj" />
     <ProjectReference Include="..\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="UnityEngine">
+      <HintPath>.\UnityReference\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+        <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Node", "Libplanet
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Node.Tests", "Libplanet.Node.Tests\Libplanet.Node.Tests.csproj", "{67E63D26-F3CE-4D9E-B1B9-851C5945391D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Unity", "Libplanet.Unity\Libplanet.Unity.csproj", "{92670203-5DB1-4D10-922E-D7EC2A80C2FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -279,6 +281,18 @@ Global
 		{67E63D26-F3CE-4D9E-B1B9-851C5945391D}.Release|x64.Build.0 = Release|Any CPU
 		{67E63D26-F3CE-4D9E-B1B9-851C5945391D}.Release|x86.ActiveCfg = Release|Any CPU
 		{67E63D26-F3CE-4D9E-B1B9-851C5945391D}.Release|x86.Build.0 = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Debug|x86.Build.0 = Debug|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|x64.Build.0 = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{92670203-5DB1-4D10-922E-D7EC2A80C2FE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Import UnityEngine, UnityEngine.CoreModule dll

Current method is temporary...
1. Install Unity Version 2021.3.0f1
2. Copy `UnityEngine.dll` and `UnityEngine.CoreModule.dll` FYI https://docs.unity3d.com/Manual/UsingDLL.html
3. Paste in Libplanet.Unity/UnityReference/~