### PR TITLE
`StaticPeers` are now `ConsensusPeers`

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Net.Consensus
     {
         private ITransport _consensusTransport;
         private ILogger _logger;
-        private IImmutableSet<BoundPeer>? _validatorPeers;
+        private IImmutableSet<BoundPeer> _validatorPeers;
         private List<PublicKey>? _validators;
         private ConsensusContext<T> _consensusContext;
         private BlockChain<T> _blockChain;
@@ -37,7 +37,8 @@ namespace Libplanet.Net.Consensus
             _consensusTransport = consensusTransport;
             _validators = validators;
             _validatorPeers = validatorPeers?
-                .Where(peer => !peer.PublicKey.Equals(privateKey.PublicKey)).ToImmutableHashSet();
+                .Where(peer => !peer.PublicKey.Equals(privateKey.PublicKey)).ToImmutableHashSet()
+                              ?? ImmutableHashSet<BoundPeer>.Empty;
             _consensusTransport.ProcessMessageHandler.Register(ProcessMessageHandler);
             _blockChain = blockChain;
             _nodeId = nodeId;
@@ -103,7 +104,7 @@ namespace Libplanet.Net.Consensus
             if (_consensusTransport.AsPeer is BoundPeer boundPeer)
             {
                 _consensusTransport.BroadcastMessage(
-                    _validatorPeers!.Add(boundPeer), message);
+                    _validatorPeers.Add(boundPeer), message);
             }
         }
 

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Net.Consensus
         private ITransport _consensusTransport;
         private ILogger _logger;
         private IImmutableSet<BoundPeer> _validatorPeers;
-        private List<PublicKey>? _validators;
+        private List<PublicKey> _validators;
         private ConsensusContext<T> _consensusContext;
         private BlockChain<T> _blockChain;
         private long _nodeId;
@@ -30,35 +30,35 @@ namespace Libplanet.Net.Consensus
             BlockChain<T> blockChain,
             PrivateKey privateKey,
             long nodeId,
-            List<PublicKey>? validators,
-            IImmutableSet<BoundPeer>? validatorPeers,
+            List<PublicKey> validators,
+            IImmutableSet<BoundPeer> validatorPeers,
             TimeSpan newHeightDelay)
         {
             _consensusTransport = consensusTransport;
             _validators = validators;
-            _validatorPeers = validatorPeers?
-                .Where(peer => !peer.PublicKey.Equals(privateKey.PublicKey)).ToImmutableHashSet()
-                              ?? ImmutableHashSet<BoundPeer>.Empty;
+            _validatorPeers = validatorPeers;
             _consensusTransport.ProcessMessageHandler.Register(ProcessMessageHandler);
             _blockChain = blockChain;
             _nodeId = nodeId;
 
+            var peersAndValidatorsAreSame
+                = validatorPeers.Select(x => x.PublicKey).All(validators.Contains);
+            if (!peersAndValidatorsAreSame)
+            {
+                throw new ArgumentException($"{nameof(validators)} " +
+                                            $"and {nameof(validatorPeers)}" +
+                                            $"are must contain same public key.");
+            }
+
             // TODO: Height and round should be serialized.
-            if (validators != null)
-            {
-                _consensusContext = new ConsensusContext<T>(
-                    BroadcastMessage,
-                    blockChain,
-                    nodeId,
-                    blockChain.Tip.Index,
-                    privateKey,
-                    validators,
-                    newHeightDelay);
-            }
-            else
-            {
-                throw new ArgumentNullException(nameof(validators));
-            }
+            _consensusContext = new ConsensusContext<T>(
+                BroadcastMessage,
+                blockChain,
+                nodeId,
+                blockChain.Tip.Index,
+                privateKey,
+                validators,
+                newHeightDelay);
 
             _logger = Log
                 .ForContext("Tag", "Consensus")
@@ -101,11 +101,7 @@ namespace Libplanet.Net.Consensus
 
         internal void BroadcastMessage(ConsensusMessage message)
         {
-            if (_consensusTransport.AsPeer is BoundPeer boundPeer)
-            {
-                _consensusTransport.BroadcastMessage(
-                    _validatorPeers.Add(boundPeer), message);
-            }
+            _consensusTransport.BroadcastMessage(_validatorPeers, message);
         }
 
         private async Task ProcessMessageHandler(Message message)

--- a/Libplanet.Net/SwarmOptions.cs
+++ b/Libplanet.Net/SwarmOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using Libplanet.Blockchain;
+using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Protocols;
 using Libplanet.Net.Transports;
@@ -49,18 +50,11 @@ namespace Libplanet.Net
         public TimeSpan RefreshLifespan { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
-        /// The list of <see cref="Peer"/>s to keep in routing table permanently.
-        /// The <see cref="Peer"/>s in the list will be maintained periodically within
-        /// <see cref="StaticPeersMaintainPeriod"/>.
+        /// The list of <see cref="Peer"/>s for <see cref="ConsensusReactor{T}"/>.
+        /// It must have all validator's <see cref="Peer"/>.
         /// </summary>
-        public IImmutableSet<BoundPeer> StaticPeers { get; set; } =
+        public IImmutableSet<BoundPeer> ConsensusPeers { get; set; } =
             ImmutableHashSet<BoundPeer>.Empty;
-
-        /// <summary>
-        /// The period of <c>Task</c> maintains static peer.
-        /// </summary>
-        /// <seealso cref="StaticPeers"/>
-        public TimeSpan StaticPeersMaintainPeriod { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The threshold for detecting branchpoint when block synchronization.


### PR DESCRIPTION
## Context
1. Recent `libplanet` development ecosystem, we don't use `StaticPeers` nowadays.
2. Instead, PBFT needs its own `PeerTable` and `ITransport` for consensus validator.

## Rationale
- Remove `StaticPeers` related logic. 
- Rename `StaticPeers` to `ConsensusPeers`