### PR TITLE
Start consensus when new block is appended

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Libplanet.Blockchain;
+using Libplanet.Crypto;
+using Libplanet.Net.Consensus;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Net.Tests.Consensus
+{
+    public class ConsensusContextTest
+    {
+        private const int Timeout = 60_000;
+        private readonly StoreFixture _fx;
+        private readonly ILogger _logger;
+
+        public ConsensusContextTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ReactorTest>();
+
+            _logger = Log.ForContext<ReactorTest>();
+            _fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async void NewHeightWhenTipChanged()
+        {
+            BlockChain<DumbAction> blockChain =
+                TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
+            long targetHeightBeforeAppend = blockChain.Tip.Index + 1;
+            TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
+            var context = new ConsensusContext<DumbAction>(
+                _ => { },
+                blockChain,
+                0,
+                targetHeightBeforeAppend,
+                new PrivateKey(),
+                new List<PublicKey> { new PrivateKey().PublicKey, new PrivateKey().PublicKey },
+                newHeightDelay);
+            Assert.Equal(targetHeightBeforeAppend, context.Height);
+            await blockChain.MineBlock(new PrivateKey(), append: true);
+            Assert.Equal(targetHeightBeforeAppend, context.Height);
+            await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
+            Assert.Equal(targetHeightBeforeAppend + 1, context.Height);
+        }
+    }
+}

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Protocols;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
 
 namespace Libplanet.Net.Tests
 {
@@ -84,6 +88,19 @@ namespace Libplanet.Net.Tests
             while (table.GetBucketIndexOf(privateKey.ToAddress()) != target);
 
             return privateKey;
+        }
+
+        public static BlockChain<DumbAction> CreateDummyBlockChain(MemoryStoreFixture fx)
+        {
+            var store = new MemoryStore();
+            var blockChain = new BlockChain<DumbAction>(
+                TestUtils.Policy,
+                new VolatileStagePolicy<DumbAction>(),
+                store,
+                new TrieStateStore(new MemoryKeyValueStore()),
+                fx.GenesisBlock);
+
+            return blockChain;
         }
     }
 }


### PR DESCRIPTION
### Rationale
- Consensus should go on when block is synced by non-consensus way.