### PR TITLE
Validate vote message

### DIFF
--- a/Libplanet.Net/Consensus/InvalidValidatorVoteMessageException.cs
+++ b/Libplanet.Net/Consensus/InvalidValidatorVoteMessageException.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public class InvalidValidatorVoteMessageException : InvalidMessageException
+    {
+        internal InvalidValidatorVoteMessageException(
+            string message,
+            Message receivedMessage,
+            Exception innerException)
+            : base(message, receivedMessage, innerException)
+        {
+        }
+
+        internal InvalidValidatorVoteMessageException(string message, Message receivedMessage)
+            : base(message, receivedMessage)
+        {
+        }
+
+        protected InvalidValidatorVoteMessageException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -98,11 +98,14 @@ namespace Libplanet.Consensus
                 return false;
             }
 
-            Vote voteWithoutSign = vote.RemoveSignature;
-            if (!vote.Validator.Verify(
-                voteWithoutSign.ByteArray.ToImmutableArray(),
-                vote.Signature))
+            if (!vote.Verify(vote.Validator))
             {
+                return false;
+            }
+
+            if (!ValidatorSet.Contains(vote.Validator))
+            {
+                // The voter is not a validator.
                 return false;
             }
 
@@ -113,12 +116,6 @@ namespace Libplanet.Consensus
 
             if (vote.Round != Round)
             {
-                return false;
-            }
-
-            if (!ValidatorSet.Contains(vote.Validator))
-            {
-                // The voter is not a validator.
                 return false;
             }
 


### PR DESCRIPTION
Added `Vote.Verify(PublicKey)` method for signature validation, and use method to validate received voting messages (`ConsensusVote`, `ConsensusCommit`).