### PR TITLE
Store all messages for consensus regardless of it's height

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex;
 using Libplanet.Blockchain;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
+using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
@@ -31,6 +36,27 @@ namespace Libplanet.Net.Tests.Consensus
 
             _logger = Log.ForContext<ReactorTest>();
             _fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
+        }
+
+        [Fact(Timeout = Timeout)]
+        public void Ctor()
+        {
+            var privateKey = new PrivateKey();
+            var blockChain = TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
+            using var transport = TestUtils.CreateNetMQTransport(
+                privateKey,
+                "localhost",
+                17192);
+            var consensusContext =
+                TestUtils.CreateStandaloneConsensusContext(
+                    blockChain,
+                    transport,
+                    TimeSpan.FromSeconds(1),
+                    port: 17192,
+                    privateKey: privateKey);
+
+            Assert.Equal(Step.Null, consensusContext.Step);
+            Assert.Equal("No context", consensusContext.ToString());
         }
 
         [Fact(Timeout = Timeout)]
@@ -90,6 +116,117 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.Equal(0, context.Height);
             await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
             Assert.Equal(blockChain.Tip.Index + 1, context.Height);
+        }
+
+        [Fact(Timeout = Timeout)]
+        public void IgnoreMessagesFromLowerHeight()
+        {
+            BlockChain<DumbAction> blockChain =
+                TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
+            TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
+            var context = new ConsensusContext<DumbAction>(
+                _ => { },
+                blockChain,
+                0,
+                blockChain.Tip.Index + 1,
+                new PrivateKey(),
+                new List<PublicKey> { new PrivateKey().PublicKey, new PrivateKey().PublicKey },
+                newHeightDelay);
+
+            Assert.True(context.Height > 0);
+            Assert.Throws<InvalidHeightMessageException>(
+                () => context.HandleMessage(
+                    new ConsensusPropose(0, 0, 0, _fx.Block1.Hash, new byte[] { }, -1)));
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async void HandleProposeMessageFromHigherHeight()
+        {
+            BlockChain<DumbAction> blockChain1 =
+                TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
+            BlockChain<DumbAction> blockChain2 =
+                TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
+            TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
+            var privateKey = new PrivateKey();
+            var codec = new Codec();
+            var context = new ConsensusContext<DumbAction>(
+                _ => { },
+                blockChain1,
+                0,
+                blockChain1.Tip.Index + 1,
+                new PrivateKey(),
+                new List<PublicKey> { privateKey.PublicKey },
+                newHeightDelay);
+            var block1 = await blockChain2.MineBlock(privateKey, append: true);
+            var block2 = await blockChain2.MineBlock(privateKey, append: true);
+            var validatorPeer = new BoundPeer(
+                privateKey.PublicKey,
+                new DnsEndPoint("localhost", 12345));
+
+            // Message from higher height
+            context.HandleMessage(
+                new ConsensusPropose(
+                    0,
+                    2,
+                    0,
+                    block2.Hash,
+                    codec.Encode(block2.MarshalBlock()),
+                    -1)
+                {
+                    Remote = validatorPeer,
+                });
+
+            context.NewHeight(blockChain1.Tip.Index + 1);
+            Assert.Equal(1, context.Height);
+            context.HandleMessage(
+                new ConsensusPropose(
+                    0,
+                    1,
+                    0,
+                    block1.Hash,
+                    codec.Encode(block1.MarshalBlock()),
+                    -1)
+                {
+                    Remote = validatorPeer,
+                });
+            Assert.Equal(Step.PreVote, context.Step);
+
+            context.HandleMessage(
+                new ConsensusVote(
+                    new Vote(
+                        1,
+                        0,
+                        block1.Hash,
+                        DateTimeOffset.UtcNow,
+                        privateKey.PublicKey,
+                        VoteFlag.Absent,
+                        0,
+                        null).Sign(privateKey))
+                {
+                    Remote = validatorPeer,
+                });
+            Assert.Equal(Step.PreCommit, context.Step);
+
+            context.HandleMessage(
+                new ConsensusCommit(
+                    new Vote(
+                        1,
+                        0,
+                        block1.Hash,
+                        DateTimeOffset.UtcNow,
+                        privateKey.PublicKey,
+                        VoteFlag.Commit,
+                        0,
+                        null).Sign(privateKey))
+                {
+                    Remote = validatorPeer,
+                });
+            Assert.Equal(Step.EndCommit, context.Step);
+            await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
+            Assert.Equal(2, context.Height);
+
+            // Already received propose message for height 2, skip to PreVote step not Propose step.
+            Assert.Equal(Step.PreVote, context.Step);
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -90,7 +90,7 @@ namespace Libplanet.Net.Tests.Consensus
                     privateKey.PublicKey,
                 });
 
-            context.Start();
+            await context.StartAsync();
             messageReceived.Wait();
 
             Assert.Equal(Step.Propose, context.Step);
@@ -145,7 +145,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[0], append: false);
 
-            context.Start();
+            await context.StartAsync();
             context.HandleMessage(
                 new ConsensusPropose(
                     1,
@@ -193,7 +193,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[0], append: false);
 
-            context.Start();
+            await context.StartAsync();
             Assert.Throws<InvalidBlockProposeMessageException>(
                 () =>
                     context.HandleMessage(
@@ -237,7 +237,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[0], append: false);
 
-            context.Start();
+            await context.StartAsync();
             Assert.Throws<InvalidProposerProposeMessageException>(
                 () =>
                     context.HandleMessage(
@@ -285,7 +285,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[0], append: false);
 
-            context.Start();
+            await context.StartAsync();
             // Vote's validator does not match with remote
             Assert.Throws<InvalidValidatorVoteMessageException>(
                 () =>
@@ -388,7 +388,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[1], append: false);
 
-            context.Start();
+            await context.StartAsync();
             context.HandleMessage(
                 new ConsensusPropose(
                     1,
@@ -664,7 +664,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            context.Start();
+            await context.StartAsync();
             await timeoutOccurred.WaitAsync();
             await enterPreVote.WaitAsync();
             messageReceived.Wait();
@@ -721,7 +721,7 @@ namespace Libplanet.Net.Tests.Consensus
                 validators);
             var block = await blockChain.MineBlock(privateKeys[0], append: false);
 
-            context.Start();
+            await context.StartAsync();
             context.HandleMessage(
                 new ConsensusPropose(
                     0,

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Net.Tests.Consensus
         }
 
         [Fact(Timeout = Timeout)]
-        public async void Start()
+        public async void StartAsync()
         {
             BlockChain<DumbAction> blockChain =
                 TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -20,6 +20,7 @@ namespace Libplanet.Net.Consensus
         private readonly List<PublicKey> _validators;
         private readonly TimeSpan _newHeightDelay;
         private readonly ILogger _logger;
+        private readonly Dictionary<long, Context<T>> _contexts;
 
         private CancellationTokenSource? _newHeightCts;
 
@@ -40,14 +41,7 @@ namespace Libplanet.Net.Consensus
             Height = height;
             _newHeightDelay = newHeightDelay;
 
-            HeightContext = new Context<T>(
-                this,
-                _blockChain,
-                _nodeId,
-                Height,
-                _privateKey,
-                validators);
-
+            _contexts = new Dictionary<long, Context<T>>();
             _blockChain.TipChanged += OnBlockChainTipChanged;
 
             _logger = Log
@@ -63,16 +57,17 @@ namespace Libplanet.Net.Consensus
 
         public long Height { get; private set; }
 
-        public long Round => HeightContext.Round;
+        public long Round => _contexts.ContainsKey(Height) ? _contexts[Height].Round : -1;
 
-        public Step Step => HeightContext.Step;
-
-        internal Context<T> HeightContext { get; private set; }
+        public Step Step => _contexts.ContainsKey(Height) ? _contexts[Height].Step : Step.Null;
 
         public void Dispose()
         {
             _newHeightCts?.Cancel();
-            HeightContext.Dispose();
+            foreach (Context<T> context in _contexts.Values)
+            {
+                context.Dispose();
+            }
         }
 
         public void NewHeight(long height)
@@ -86,20 +81,28 @@ namespace Libplanet.Net.Consensus
                     $" (expected: {_blockChain.Tip.Index + 1}, actual: {height})");
             }
 
-            HeightContext.Dispose();
+            if (_contexts.ContainsKey(Height))
+            {
+                _contexts[Height].Dispose();
+                _contexts.Remove(Height);
+            }
+
             Height = height;
 
             _logger.Debug("Start consensus for height {Height}.", Height);
 
-            HeightContext = new Context<T>(
-                this,
-                _blockChain,
-                _nodeId,
-                Height,
-                _privateKey,
-                _validators);
+            if (!_contexts.ContainsKey(height))
+            {
+                _contexts[height] = new Context<T>(
+                    this,
+                    _blockChain,
+                    _nodeId,
+                    height,
+                    _privateKey,
+                    _validators);
+            }
 
-            HeightContext.Start();
+            _contexts[height].Start();
         }
 
         public void Commit(Block<T> block)
@@ -108,18 +111,38 @@ namespace Libplanet.Net.Consensus
             _blockChain.Append(block);
         }
 
-        public void HandleMessage(ConsensusMessage consensusMessage) =>
-            HeightContext.HandleMessage(consensusMessage);
+        public void HandleMessage(ConsensusMessage consensusMessage)
+        {
+            long height = consensusMessage.Height;
+            if (height < Height)
+            {
+                throw new InvalidHeightMessageException(
+                    $"Received message's height {height} is lower than " +
+                    $"current context's height {Height}.",
+                    consensusMessage);
+            }
+
+            if (!_contexts.ContainsKey(height))
+            {
+                _contexts[height] = new Context<T>(
+                    this,
+                    _blockChain,
+                    _nodeId,
+                    height,
+                    _privateKey,
+                    _validators);
+            }
+
+            _contexts[height].HandleMessage(consensusMessage);
+        }
 
         public override string ToString()
         {
-            return HeightContext.ToString();
+            return _contexts.ContainsKey(Height) ? _contexts[Height].ToString() : "No context";
         }
 
         private void OnBlockChainTipChanged(object? sender, (Block<T> OldTip, Block<T> NewTip) e)
         {
-            HeightContext.Dispose();
-
             // TODO: Should set delay by using GST.
             _newHeightCts?.Cancel();
             _newHeightCts?.Dispose();

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -102,7 +102,7 @@ namespace Libplanet.Net.Consensus
                     _validators);
             }
 
-            _contexts[height].Start();
+            _ = _contexts[height].StartAsync();
         }
 
         public void Commit(Block<T> block)

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -173,6 +173,11 @@ namespace Libplanet.Net.Consensus
                 message.NodeId,
                 _messagesInRound[Round].Count,
                 ToString());
+            if (Step == Step.Default || Step == Step.EndCommit)
+            {
+                _logger.Debug("Operation will not run in {State} state.", Step.ToString());
+                return;
+            }
 
             if (GetPropose(Round) is
                     (Block<T> block1, int validRound1) &&
@@ -495,6 +500,11 @@ namespace Libplanet.Net.Consensus
 
         private void SetStep(Step step)
         {
+            _logger.Debug(
+                "Translate step from {Before} to {After}. {Info}",
+                Step.ToString(),
+                step.ToString(),
+                ToString());
             Step = step;
             StepChanged?.Invoke(this, step);
         }
@@ -572,7 +582,7 @@ namespace Libplanet.Net.Consensus
         {
             TimeSpan timeout = TimeoutPreCommit(round);
             await Task.Delay(timeout, _cancellationTokenSource.Token);
-            if (height == Height && round == Round)
+            if (height == Height && round == Round && Step < Step.EndCommit)
             {
                 _logger.Debug(
                     "TimeoutPreCommit has occurred in {Timeout}. {Info}",

--- a/Libplanet.Net/Consensus/Step.cs
+++ b/Libplanet.Net/Consensus/Step.cs
@@ -26,5 +26,10 @@ namespace Libplanet.Net.Consensus
         /// Commit end step.
         /// </summary>
         EndCommit,
+
+        /// <summary>
+        /// Only when context does not exists.
+        /// </summary>
+        Null = 0x99,
     }
 }


### PR DESCRIPTION
## Rationale
All nodes in network may fail to receive `ConsensusPropose` message because of GST mismatch.

## Feature
`ConsensusContext<T>` now have `Context<T>` for each height and remove it when consensus for higher height is started. It helps storing messages from higher height. Only messages from current consensus height will cause operation by limiting step in `Context<T>.DoHandleMessage()` to `Step.Propose`, `Step.PreVote` and `Step.PreCommit`.

## Tests
A newly added test `ConsensusContextTest.HandleProposeMessageFromHigherHeight()` tests scenario that propose of higher height is received, and consensus completed in current height thus leads to next height's `Step.PreVote` fluently.