### PR TITLE
refactor: Remove argument, parameter 'validators' from 'Swarm<T>' and 'ConsensusReactor<T>'

### DIFF
--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -76,11 +76,7 @@ namespace Libplanet.Benchmarks
                     _appProtocolVersion,
                     consensusPrivateKey: consensusKeys[i],
                     host: IPAddress.Loopback.ToString(),
-                    nodeId: i,
-                    validators: new List<PublicKey>()
-                    {
-                        consensusKeys[i].PublicKey,
-                    });
+                    nodeId: i);
                 tasks.Add(StartAsync(_swarms[i]));
             }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -253,10 +253,6 @@ If omitted (default) explorer only the local blockchain store.")]
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions,
                         nodeId: 0,
-                        validators: new List<PublicKey>()
-                        {
-                            consensusPrivateKey.PublicKey,
-                        },
                         consensusPrivateKey: consensusPrivateKey
                     );
                 }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -52,7 +52,6 @@ namespace Libplanet.Net.Tests.Consensus
                 blockChain,
                 key,
                 id,
-                validators,
                 validatorPeers.ToImmutableHashSet(),
                 TimeSpan.FromMilliseconds(newHeightDelayMilliseconds));
         }

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -152,7 +152,6 @@ namespace Libplanet.Net.Tests
                 privateKey,
                 appProtocolVersion ?? DefaultAppProtocolVersion,
                 nodeId,
-                validators,
                 consensusPrivateKey,
                 workers: 5,
                 host: host,

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -495,8 +495,7 @@ namespace Libplanet.Net.Tests
                     key,
                     ver,
                     consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0,
-                    validators: null);
+                    nodeId: 0);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
@@ -506,8 +505,7 @@ namespace Libplanet.Net.Tests
                     null,
                     ver,
                     consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0,
-                    validators: null);
+                    nodeId: 0);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
@@ -518,8 +516,7 @@ namespace Libplanet.Net.Tests
                     key,
                     ver,
                     consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0,
-                    validators: null);
+                    nodeId: 0);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
@@ -531,8 +528,7 @@ namespace Libplanet.Net.Tests
                     ver,
                     consensusPrivateKey: consensusPrivateKey,
                     iceServers: new IceServer[] { },
-                    nodeId: 0,
-                    validators: null);
+                    nodeId: 0);
             });
         }
 

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -55,7 +55,6 @@ namespace Libplanet.Net.Tests.Transports
                 apv,
                 consensusPrivateKey: consensusKey,
                 nodeId: 0,
-                validators: validators,
                 host: host,
                 listenPort: port,
                 options: option))

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -54,7 +54,6 @@ namespace Libplanet.Net
         /// this key become a part of its end address for being pointed by peers.</param>
         /// <param name="appProtocolVersion">An app protocol to comply.</param>
         /// <param name="nodeId">(Experimental) The Id of Node.</param>
-        /// <param name="validators">(Experimental) The fixed list of validator set.</param>
         /// <param name="consensusPrivateKey">(Experimental) The private key that is using
         /// for Consensus Signing.</param>
         /// <param name="consensusPort">(Experimental) The port for ConsensusReactor.</param>
@@ -86,7 +85,6 @@ namespace Libplanet.Net
             PrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
             long nodeId,
-            List<PublicKey> validators,
             PrivateKey consensusPrivateKey,
             int? consensusPort = null,
             int consensusWorkers = 100,
@@ -150,7 +148,6 @@ namespace Libplanet.Net
                 BlockChain,
                 consensusPrivateKey,
                 nodeId,
-                validators,
                 Options.ConsensusPeers,
                 TimeSpan.FromMilliseconds(10_000));
         }


### PR DESCRIPTION
## Changes
- Remove argument, parameter `validators` from `Swarm<T>`
- Remove argument, parameter `validators` from `ConsensusReactor<T>`
- Remove checking between parameters `validators` and `validatorPeers`
- Subsitute `validators` paremeter with `PublicKey` obtained from`validatorPeers`

## Related issues
- Resolves https://github.com/planetarium/libplanet/issues/2093