### PR TITLE
Bump `Cocona.Lite` to `2.0.*`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ To be released.
 
 ### CLI tools
 
+ - (Libplanet.Extensions.Cocona) Upgraded *Cocona.Lite* from 1.6.\* to
+    [2.0.\*][Cocona.Lite 2.0.0].  [[#2101]]
+
+[#2101]: https://github.com/planetarium/libplanet/pull/2101
+[Cocona.Lite 2.0.0]: https://www.nuget.org/packages/Cocona.Lite/2.0.0
+
 
 Version 0.38.0
 --------------

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cocona.Lite" Version="1.6.*" />
+    <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cocona.Lite" Version="1.6.*" />
+    <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tools
             "cli.json");
 
         public static Task Main(string[] args) =>
-            CoconaLiteApp.Create()
+            CoconaLiteApp.CreateHostBuilder()
                 .ConfigureServices(services =>
                 {
                     services.AddJsonConfigurationService(FileConfigurationServiceRoot);


### PR DESCRIPTION
This pull request bumps the` Cocona.Lite` package to `2.0.*`, the latest major version.