### PR TITLE
Add --path flag in `key` command, and implemented `key derive`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ To be released.
     [2.0.\*][Cocona.Lite 2.0.0].  [[#2101]]
 
  - Implemented *planet key derive*, now you can get public key and
-   address from private key directly! [[#2108]]
+   address from private key directly!  [[#2108]]
 
 [#2101]: https://github.com/planetarium/libplanet/pull/2101
 [#2108]: https://github.com/planetarium/libplanet/pull/2108

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,11 @@ To be released.
  - (Libplanet.Extensions.Cocona) Upgraded *Cocona.Lite* from 1.6.\* to
     [2.0.\*][Cocona.Lite 2.0.0].  [[#2101]]
 
+ - Implemented *planet key derive*, now you can get public key and
+   address from private key directly! [[#2108]]
+
 [#2101]: https://github.com/planetarium/libplanet/pull/2101
+[#2108]: https://github.com/planetarium/libplanet/pull/2108
 [Cocona.Lite 2.0.0]: https://www.nuget.org/packages/Cocona.Lite/2.0.0
 
 

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         public void Create(
             PassphraseParameters passphrase,
             [Option(
-                Description = "print created private key as Web3 Secret Storage format."
+                Description = "Print created private key as Web3 Secret Storage format."
             )]
             bool json = false,
             [Option(Description = "Do not add to the key store, but only show the created key.")]

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -66,7 +66,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             PassphraseParameters passphrase,
             [Option(Description = "Remove without asking passphrase.")]
             bool noPassphrase = false,
-            [Option(Description = "Path to key store")]
+            [Option(Description = "Path to key store.")]
             string? path = null
         )
         {

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -25,11 +25,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             )]
             string? path = null)
         {
-            if (path != null)
-            {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-            }
-
+            ChangeKeyStorePath(path);
             PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
         }
 
@@ -46,11 +42,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             string? path = null
         )
         {
-            if (path != null)
-            {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-            }
-
+            ChangeKeyStorePath(path);
             string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
             PrivateKey pkey = new PrivateKey();
             ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(pkey, passphraseValue);
@@ -78,13 +70,9 @@ namespace Libplanet.Extensions.Cocona.Commands
             string? path = null
         )
         {
+            ChangeKeyStorePath(path);
             try
             {
-                if (path != null)
-                {
-                    KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-                }
-
                 if (!noPassphrase)
                 {
                     UnprotectKey(keyId, passphrase);
@@ -117,11 +105,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             string? path = null
         )
         {
-            if (path != null)
-            {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-            }
-
+            ChangeKeyStorePath(path);
             if (json)
             {
                 try
@@ -162,11 +146,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             string? path = null
         )
         {
-            if (path != null)
-            {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-            }
-
+            ChangeKeyStorePath(path);
             PrivateKey key = UnprotectKey(keyId, passphrase);
             byte[] rawKey = publicKey ? key.PublicKey.Format(true) : key.ToByteArray();
             using Stream stdout = Console.OpenStandardOutput();
@@ -244,11 +224,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             string? storePath = null
         )
         {
-            if (storePath != null)
-            {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
-            }
-
+            ChangeKeyStorePath(storePath);
             PrivateKey key = UnprotectKey(keyId, passphrase);
 
             byte[] message;
@@ -290,7 +266,7 @@ namespace Libplanet.Extensions.Cocona.Commands
                 "PRIVATE-KEY",
                 Description = "A raw private key to import."
             )]
-            string key,
+            string key
         )
         {
             PrivateKey privateKey = ValidateRawHex(key);
@@ -378,6 +354,18 @@ namespace Libplanet.Extensions.Cocona.Commands
             {
                 Utils.Error("This file does not exist.");
                 return string.Empty;
+            }
+        }
+
+        private void ChangeKeyStorePath(string? path)
+        {
+            if (path != null)
+            {
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
+            }
+            else
+            {
+                KeyStore = Web3KeyStore.DefaultKeyStore;
             }
         }
     }

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -101,7 +101,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             bool json = false,
             [Option(Description = "Do not add to the key store, but only show the created key.")]
             bool dryRun = false,
-            [Option(Description = "Path to key store")]
+            [Option(Description = "Path to key store.")]
             string? path = null
         )
         {

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -291,15 +291,11 @@ namespace Libplanet.Extensions.Cocona.Commands
                 Description = "A raw private key to import."
             )]
             string key,
-            PassphraseParameters passphrase
         )
         {
             PrivateKey privateKey = ValidateRawHex(key);
-            string passphraseValue = passphrase.Take("Passphrase: ");
             string addr = privateKey.ToAddress().ToString();
             string pub = ByteUtil.Hex(privateKey.PublicKey.Format(compress: true));
-            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(
-                privateKey, passphraseValue);
             Utils.PrintTable(("Public Key", "Address"), new[] { (pub, addr) });
         }
 

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -102,8 +102,8 @@ namespace Libplanet.Extensions.Cocona.Commands
         public void Import(
             [Argument(
                 "PRIVATE-KEY",
-                Description = @"A raw private key in hexadecimal string, or path to Web3 Secret
-                Storage to import"
+                Description = "A raw private key in hexadecimal string, or path to Web3 Secret " +
+                              "Storage to import"
             )]
             string key,
             PassphraseParameters passphrase,

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -121,7 +121,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             else
             {
                 PrivateKey privateKey = ValidateRawHex(key);
-                string passphraseValue = passphrase.Take("Passphrase: ");
+                string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
                 ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(
                     privateKey, passphraseValue);
                 PrintKeys(new[] { (Add(ppk, dryRun), ppk) });

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         [Command(Description = "List all private keys.")]
         public void List(
             [Option(
-                Description = "Specify KeyStore path to list."
+                Description = "Specify key store path to list."
             )]
             string? path = null)
         {

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -284,6 +284,25 @@ namespace Libplanet.Extensions.Cocona.Commands
             }
         }
 
+        [Command(Description = "Derive Public key and Address from Private key.")]
+        public void Derive(
+            [Argument(
+                "PRIVATE-KEY",
+                Description = "A raw private key to import."
+            )]
+            string key,
+            PassphraseParameters passphrase
+        )
+        {
+            PrivateKey privateKey = ValidateRawHex(key);
+            string passphraseValue = passphrase.Take("Passphrase: ");
+            string addr = privateKey.ToAddress().ToString();
+            string pub = ByteUtil.Hex(privateKey.PublicKey.Format(compress: true));
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(
+                privateKey, passphraseValue);
+            Utils.PrintTable(("Public Key", "Address"), new[] { (pub, addr) });
+        }
+
         public PrivateKey UnprotectKey(
             Guid keyId,
             PassphraseParameters passphrase,

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -380,7 +380,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             }
             catch (Exception)
             {
-                Utils.Error("This is not valid json file or file does not exists.");
+                Utils.Error("This file does not exist.");
                 return string.Empty;
             }
         }

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -350,10 +350,9 @@ namespace Libplanet.Extensions.Cocona.Commands
                 string json = new StreamReader(jsonPath).ReadToEnd();
                 return json;
             }
-            catch (Exception)
+            catch (System.IO.FileNotFoundException)
             {
-                Utils.Error("This file does not exist.");
-                return string.Empty;
+                throw Utils.Error("This file does not exist.");
             }
         }
 

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         {
             if (path != null)
             {
-                KeyStore = new Web3KeyStore(path);
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
             }
 
             PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
@@ -48,7 +48,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         {
             if (path != null)
             {
-                KeyStore = new Web3KeyStore(path);
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
             }
 
             string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
@@ -82,7 +82,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             {
                 if (path != null)
                 {
-                    KeyStore = new Web3KeyStore(path);
+                    KeyStore = new Web3KeyStore(Path.GetFullPath(path));
                 }
 
                 if (!noPassphrase)
@@ -119,7 +119,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         {
             if (path != null)
             {
-                KeyStore = new Web3KeyStore(path);
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
             }
 
             if (json)
@@ -164,7 +164,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         {
             if (path != null)
             {
-                KeyStore = new Web3KeyStore(path);
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
             }
 
             PrivateKey key = UnprotectKey(keyId, passphrase);
@@ -246,7 +246,7 @@ namespace Libplanet.Extensions.Cocona.Commands
         {
             if (storePath != null)
             {
-                KeyStore = new Web3KeyStore(path);
+                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
             }
 
             PrivateKey key = UnprotectKey(keyId, passphrase);

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -260,7 +260,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             }
         }
 
-        [Command(Description = "Derive Public key and Address from Private key.")]
+        [Command(Description = "Derive public key and address from private key.")]
         public void Derive(
             [Argument(
                 "PRIVATE-KEY",

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -113,9 +113,13 @@ namespace Libplanet.Extensions.Cocona.Commands
                     ProtectedPrivateKey ppk = ProtectedPrivateKey.FromJson(ValidateJsonPath(key));
                     PrintKeys(new[] { (Add(ppk, dryRun), ppk) });
                 }
+                catch (CommandExitedException)
+                {
+                    throw;
+                }
                 catch (Exception)
                 {
-                    Utils.Error("Couldn't load ppk from json.");
+                    throw Utils.Error("Couldn't load ppk from json.");
                 }
             }
             else

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Extensions.Cocona.Commands
             KeyStore = Web3KeyStore.DefaultKeyStore;
         }
 
-        public IKeyStore KeyStore { get; }
+        public IKeyStore KeyStore { get; set; }
 
         [PrimaryCommand]
         [Command(Description = "List all private keys.")]

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -241,7 +241,7 @@ namespace Libplanet.Extensions.Cocona.Commands
                                   "to stdout as default behaviour.")]
             string? binaryOutput = null,
             [Option(Description = "Path to key store to use key from.")]
-            string? storePath = ""
+            string? storePath = null
         )
         {
             if (storePath != null)


### PR DESCRIPTION
this addresses #2017 and  #2107.

- `key derive [private key]` introduced.
- now most of key command accepts --path or --store-path flag to specify the KeyStore path.
- because of that, key export --path behaves differently now, not exporting file to that path, but use that path as keystore to import 'from'
- key export behavior changed 
    - BEFORE : with --json and --path flag, JSON file has been exported to specified path.
    - AFTER  : always outputs as stdout, regardless of json or raw hex key.