### PR TITLE
refactor: ReactorTest and ConsensusReactorTest

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Net.Tests.Consensus
         }
 
         [Fact(Timeout = Timeout)]
-        public void Ctor()
+        public async void Ctor()
         {
             var privateKey = new PrivateKey();
             var blockChain = TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
@@ -48,7 +48,7 @@ namespace Libplanet.Net.Tests.Consensus
                 privateKey,
                 "localhost",
                 17192);
-            var consensusContext =
+            using var consensusContext =
                 TestUtils.CreateStandaloneConsensusContext(
                     blockChain,
                     transport,
@@ -58,6 +58,7 @@ namespace Libplanet.Net.Tests.Consensus
 
             Assert.Equal(Step.Null, consensusContext.Step);
             Assert.Equal("No context", consensusContext.ToString());
+            await transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -70,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus
                 privateKey,
                 "localhost",
                 17192);
-            var consensusContext =
+            using var consensusContext =
                 TestUtils.CreateStandaloneConsensusContext(
                     blockChain,
                     transport,
@@ -96,6 +97,7 @@ namespace Libplanet.Net.Tests.Consensus
             // Next NewHeight is not called yet.
             Assert.Equal(1, consensusContext.Height);
             Assert.Equal(0, consensusContext.Round);
+            await transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -104,7 +106,7 @@ namespace Libplanet.Net.Tests.Consensus
             BlockChain<DumbAction> blockChain =
                 TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
             TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
-            var context = new ConsensusContext<DumbAction>(
+            using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain,
                 0,
@@ -125,7 +127,7 @@ namespace Libplanet.Net.Tests.Consensus
             BlockChain<DumbAction> blockChain =
                 TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
             TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
-            var context = new ConsensusContext<DumbAction>(
+            using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain,
                 0,
@@ -150,7 +152,7 @@ namespace Libplanet.Net.Tests.Consensus
             TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
             var privateKey = new PrivateKey();
             var codec = new Codec();
-            var context = new ConsensusContext<DumbAction>(
+            using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain1,
                 0,
@@ -246,7 +248,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Peer1Priv,
                 "localhost",
                 17193);
-            var consensusContext =
+            using var consensusContext =
                 TestUtils.CreateStandaloneConsensusContext(
                     blockChain,
                     transport,
@@ -323,6 +325,7 @@ namespace Libplanet.Net.Tests.Consensus
                 () => consensusContext.Round == 1,
                 5_000,
                 conditionLabel: "Round does not changed.");
+            await transport.StopAsync(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -72,12 +72,5 @@ namespace Libplanet.Net.Tests.Consensus
                 Assert.Equal("EndCommit", json["step"].GetString());
             }
         }
-
-        [Fact(Timeout = Timeout)]
-        public async void IncreaseRoundWhenTimeout()
-        {
-            await Task.Yield();
-            Assert.True(true);
-        }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Libplanet.Blocks;
@@ -49,6 +50,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -112,6 +114,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(0, json["valid_round"].GetInt64());
             Assert.Equal(block.Hash.ToString(), json["locked_value"].GetString());
             Assert.Equal(block.Hash.ToString(), json["valid_value"].GetString());
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -166,6 +169,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreCommit, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -196,6 +200,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -224,6 +229,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -281,6 +287,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreCommit, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -331,6 +338,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Consensus;
@@ -67,6 +68,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreCommit, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -120,6 +122,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreCommit, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -180,6 +183,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -226,6 +230,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
             Assert.True(BlockChain.ContainsBlock(block.Hash));
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -255,6 +260,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -286,6 +292,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Consensus;
@@ -76,6 +77,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(2, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -146,6 +148,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(2, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -43,6 +43,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(0, Context.Round);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -58,10 +59,11 @@ namespace Libplanet.Net.Tests.Consensus.Context
                             block,
                             TestUtils.PrivateKeys[0],
                             nodeId: NodeId)));
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
-        public void ThrowNilPropose()
+        public async void ThrowNilPropose()
         {
             Assert.Throws<InvalidBlockProposeMessageException>(
                 () =>
@@ -70,6 +72,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                             default,
                             TestUtils.PrivateKeys[NodeId],
                             nodeId: NodeId)));
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -149,6 +152,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                         {
                             Remote = new Peer(TestUtils.Validators[0]),
                         }));
+
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -188,6 +193,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     {
                         Remote = new Peer(TestUtils.Validators[2]),
                     }));
+
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact(Timeout = Timeout)]
@@ -233,6 +240,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(VoteFlag.Commit, roundVoteSet.Votes[1].Flag);
             Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[2].Flag);
             Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[3].Flag);
+            await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -10,6 +10,7 @@ using Libplanet.Net.Transports;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
+using NetMQ;
 using Serilog;
 using Xunit.Abstractions;
 
@@ -104,6 +105,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Transport.Dispose();
             _consensusContext.Dispose();
             Context.Dispose();
+            NetMQConfig.Cleanup(false);
         }
 
         protected Block<DumbAction> GetInvalidBlock() =>

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -113,7 +113,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             {
                 Index = BlockChain.Tip.Index + 1,
                 Difficulty = BlockChain.Tip.Difficulty,
-                TotalDifficulty = BlockChain.Tip.TotalDifficulty + 1,
+                TotalDifficulty = BlockChain.Tip.TotalDifficulty + BlockChain.Tip.Difficulty,
                 PublicKey = Fx.Miner.PublicKey,
                 PreviousHash = BlockChain.Tip.Hash,
                 Timestamp = BlockChain.Tip.Timestamp.Subtract(TimeSpan.FromSeconds(1)),

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -97,10 +97,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Transport.ProcessMessageHandler.Register(ContextHandle);
         }
 
-        public async void Dispose()
+        public void Dispose()
         {
-            await Transport.StopAsync(default);
-
             Fx.Dispose();
             Transport.Dispose();
             _consensusContext.Dispose();

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -1,30 +1,37 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using System.Net;
-using System.Text.Json;
 using System.Threading;
-using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
+using NetMQ;
 using Serilog;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Libplanet.Net.Tests.Consensus
 {
-    public abstract class ReactorTest
+    public abstract class ReactorTest : IDisposable
     {
-        private const int Timeout = 60 * 1000;
-        private const int TimerTestMargin = 500;
+        protected const int Count = 4;
+        protected const int PropagationDelay = 10_000;
 
+        protected readonly ConsensusReactor<DumbAction>[] ConsensusReactors;
+        protected readonly BlockChain<DumbAction>[] BlockChains;
+        protected readonly CancellationTokenSource CancellationTokenSource;
+
+        private const int Port = 6100;
         private readonly StoreFixture _fx;
+        private readonly PrivateKey[] _privateKey;
+        private readonly List<BoundPeer> _validatorPeers;
+        private readonly IStore[] _stores;
 
         private ILogger _logger;
 
@@ -40,137 +47,86 @@ namespace Libplanet.Net.Tests.Consensus
 
             _logger = Log.ForContext<ReactorTest>();
             _fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
+
+            CancellationTokenSource = new CancellationTokenSource();
+
+            _privateKey = new PrivateKey[Count];
+            ConsensusReactors = new ConsensusReactor<DumbAction>[Count];
+            _validatorPeers = new List<BoundPeer>();
+            _stores = new IStore[Count];
+            BlockChains = new BlockChain<DumbAction>[Count];
+
+            for (var i = 0; i < Count; i++)
+            {
+                _privateKey[i] = new PrivateKey();
+                _validatorPeers.Add(
+                    new BoundPeer(
+                        _privateKey[i].PublicKey,
+                        new DnsEndPoint("localhost", Port + i)));
+                _stores[i] = new MemoryStore();
+                BlockChains[i] = new BlockChain<DumbAction>(
+                    TestUtils.Policy,
+                    new VolatileStagePolicy<DumbAction>(),
+                    _stores[i],
+                    new TrieStateStore(new MemoryKeyValueStore()),
+                    _fx.GenesisBlock);
+            }
+
+            for (var i = 0; i < Count; i++)
+            {
+                ConsensusReactors[i] = (ConsensusReactor<DumbAction>)CreateReactor(
+                    blockChain: BlockChains[i],
+                    key: _privateKey[i],
+                    consensusPort: Port + i,
+                    id: i,
+                    validatorPeers: _validatorPeers,
+                    newHeightDelayMilliseconds: PropagationDelay * 2);
+            }
         }
 
-        public abstract IReactor CreateReactor(
+        public async void Dispose()
+        {
+            foreach (var reactor in ConsensusReactors)
+            {
+                if (reactor.Running)
+                {
+                    await reactor.StopAsync(default);
+                    reactor.Dispose();
+                }
+            }
+
+            CancellationTokenSource.Cancel();
+            NetMQConfig.Cleanup(false);
+        }
+
+        private IReactor CreateReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
             string host = "localhost",
             int consensusPort = 5101,
             long id = 0,
-            List<PublicKey> validators = null!,
             List<BoundPeer> validatorPeers = null!,
-            int newHeightDelayMilliseconds = 10_000);
-
-        [Fact(Timeout = Timeout)]
-        public async void StartAsync()
+            int newHeightDelayMilliseconds = 10_000)
         {
-            const int count = 4;
-            // INFO : This test uses local ports 6100 to 6103.
-            const int consensusPort = 6100;
+            key ??= new PrivateKey();
 
-            const int propagationDelay = 10_000;
-            var keys = new PrivateKey[count];
-            var reactors = new ConsensusReactor<DumbAction>[count];
-            var validators = new List<PublicKey>();
-            var validatorPeers = new List<BoundPeer>();
-            var stores = new IStore[count];
-            var blockChains = new BlockChain<DumbAction>[count];
+            var consensusTransport = new NetMQTransport(
+                key,
+                TestUtils.AppProtocolVersion,
+                null,
+                8,
+                host,
+                consensusPort,
+                Array.Empty<IceServer>(),
+                null);
 
-            for (var i = 0; i < count; i++)
-            {
-                keys[i] = new PrivateKey();
-                validators.Add(keys[i].PublicKey);
-                validatorPeers.Add(
-                    new BoundPeer(
-                        keys[i].PublicKey,
-                        new DnsEndPoint("localhost", consensusPort + i)));
-                stores[i] = new MemoryStore();
-                blockChains[i] = new BlockChain<DumbAction>(
-                    TestUtils.Policy,
-                    new VolatileStagePolicy<DumbAction>(),
-                    stores[i],
-                    new TrieStateStore(new MemoryKeyValueStore()),
-                    _fx.GenesisBlock);
-            }
-
-            for (var i = 0; i < count; i++)
-            {
-                reactors[i] = (ConsensusReactor<DumbAction>)CreateReactor(
-                    blockChain: blockChains[i],
-                    key: keys[i],
-                    consensusPort: consensusPort + i,
-                    id: i,
-                    validators: validators,
-                    validatorPeers: validatorPeers,
-                    newHeightDelayMilliseconds: propagationDelay * 2);
-            }
-
-            var reactorCtx = new CancellationTokenSource();
-            try
-            {
-                foreach (var reactor in reactors)
-                {
-                    _ = reactor.StartAsync(reactorCtx.Token);
-                }
-
-                Dictionary<string, JsonElement> json;
-
-                // For test accuracy, this test should not run in parallel.
-                await Task.Delay(propagationDelay, reactorCtx.Token);
-                foreach (var reactor in reactors)
-                {
-                    await reactor.StopAsync(reactorCtx.Token);
-                }
-
-                var isPolka = new bool[count];
-
-                for (var node = 0; node < count; ++node)
-                {
-                    json =
-                        JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
-                            reactors[node].ToString());
-
-                    // Genesis block exists, add 1 to the height.
-                    if (json["step"].GetString() == "EndCommit")
-                    {
-                        isPolka[node] = true;
-                    }
-                    else
-                    {
-                        Log.Error(
-                            "[Failed]: {0} {1}",
-                            json["step"].GetString(),
-                            blockChains[node].Count);
-                        isPolka[node] = false;
-                    }
-                }
-
-                Assert.Equal(count, isPolka.Sum(x => x ? 1 : 0));
-
-                for (var node = 0; node < count; ++node)
-                {
-                    json =
-                        JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
-                            reactors[node].ToString());
-
-                    Assert.Equal((long)node, json["node_id"].GetInt32());
-                    Assert.Equal(1, json["height"].GetInt32());
-                    Assert.Equal(2, blockChains[node].Count);
-                    Assert.Equal(0L, json["round"].GetInt32());
-                    Assert.Equal("EndCommit", json["step"].GetString());
-                }
-            }
-            finally
-            {
-                foreach (var reactor in reactors)
-                {
-                    if (reactor.Running)
-                    {
-                        await reactor.StopAsync(default);
-                        reactor.Dispose();
-                    }
-                }
-
-                reactorCtx.Cancel();
-            }
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async void IncreaseRoundWhenTimeout()
-        {
-            await Task.Yield();
-            Assert.True(true);
+            return new ConsensusReactor<DumbAction>(
+                consensusTransport,
+                blockChain,
+                key,
+                id,
+                validatorPeers.ToImmutableList(),
+                TimeSpan.FromMilliseconds(newHeightDelayMilliseconds));
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -84,18 +84,14 @@ namespace Libplanet.Net.Tests.Consensus
             }
         }
 
-        public async void Dispose()
+        public void Dispose()
         {
+            CancellationTokenSource.Cancel();
             foreach (var reactor in ConsensusReactors)
             {
-                if (reactor.Running)
-                {
-                    await reactor.StopAsync(default);
-                    reactor.Dispose();
-                }
+                reactor.Dispose();
             }
 
-            CancellationTokenSource.Cancel();
             NetMQConfig.Cleanup(false);
         }
 

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -214,9 +214,10 @@ namespace Libplanet.Net.Tests
 
             foreach (var publicKey in exceptList)
             {
+                port += 1;
                 validatorPeers.Add(
                     new BoundPeer(
-                        publicKey, new DnsEndPoint("localhost", port++)));
+                        publicKey, new DnsEndPoint("localhost", port)));
             }
 
             void BroadcastMessage(ConsensusMessage message) =>

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -38,7 +38,6 @@ namespace Libplanet.Net.Consensus
             _blockChain = blockChain;
             _nodeId = nodeId;
 
-            // TODO: Height and round should be serialized.
             _consensusContext = new ConsensusContext<T>(
                 BroadcastMessage,
                 blockChain,

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -190,17 +190,17 @@ namespace Libplanet.Net.Consensus
             return JsonSerializer.Serialize(dict);
         }
 
-        internal TimeSpan TimeoutPropose(long round)
+        internal static TimeSpan TimeoutPropose(long round)
         {
             return TimeSpan.FromSeconds(TimeoutProposeBase + round * TimeoutProposeMultiplier);
         }
 
-        internal TimeSpan TimeoutPreVote(long round)
+        internal static TimeSpan TimeoutPreVote(long round)
         {
             return TimeSpan.FromSeconds(TimeoutPreVoteBase + round + TimeoutPreVoteMultiplier);
         }
 
-        internal TimeSpan TimeoutPreCommit(long round)
+        internal static TimeSpan TimeoutPreCommit(long round)
         {
             return TimeSpan.FromSeconds(TimeoutPreCommitBase + round + TimeoutPreCommitMultiplier);
         }


### PR DESCRIPTION
# Summary
This PR is refactoring `ConsensusReactorTest`, `ReactorTest` majorly.

+ Change `CreateReator` abstract to the concrete method.
+ `ReactorTest` defines and creates required objects to create `ConsensusReactor` in `ConsensusReactorTest`.
+ Some clean-up and bugfix created from https://github.com/planetarium/libplanet/pull/2100
+ Move `IncreaseRoundWhenTimeout` to `ConsensusContextTest`.
  + Testing timeout in `ConsensusReactor` is hard to imitates the situation.

---
+ Fix some of `Timeout` methods that does not multiply its multiplier.
+ Remove no longer needed TODO
+ Move responsibility `StopAsync()` in `ConsensusContextTest`, `ConsensusReactorTest`.
  +  xUnit supports `IAsyncDispose` in v3 https://github.com/xunit/xunit/issues/2017