### PR TITLE
Fill `Block<T>.LastCommit` by getting voteset from last block's consensus context

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -80,8 +80,14 @@ namespace Libplanet.Net.Consensus
                     $" (expected: {_blockChain.Tip.Index + 1}, actual: {height})");
             }
 
+            BlockCommit? lastCommit = null;
             if (_contexts.ContainsKey(Height))
             {
+                lastCommit = _contexts[Height].CommittedRound == -1
+                    ? (BlockCommit?)null
+                    : new BlockCommit(
+                        _contexts[Height].VoteSet(_contexts[Height].CommittedRound),
+                        _blockChain.Tip.Hash);
                 _contexts[Height].Dispose();
                 _contexts.Remove(Height);
             }
@@ -100,7 +106,7 @@ namespace Libplanet.Net.Consensus
                     _validators);
             }
 
-            _ = _contexts[height].StartAsync();
+            _ = _contexts[height].StartAsync(lastCommit);
         }
 
         public void Commit(Block<T> block)

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Blocks
 
         public BlockCommit(
             long height,
-            long round,
+            int round,
             BlockHash hash,
             ImmutableArray<Vote>? votes)
         {
@@ -62,7 +62,7 @@ namespace Libplanet.Blocks
 
         public long Height { get; }
 
-        public long Round { get; }
+        public int Round { get; }
 
         public BlockHash BlockHash { get; }
 

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Consensus
 
         public long Height { get; }
 
-        public long Round { get; }
+        public int Round { get; }
 
         public ImmutableArray<PublicKey> ValidatorSet { get; }
 


### PR DESCRIPTION
By storing `Vote`s from previous round, chain can be validated.