### PR TITLE
refactor: remove parameter `nodeId` from `Swarm<T>`

### DIFF
--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -75,8 +75,7 @@ namespace Libplanet.Benchmarks
                     _keys[i],
                     _appProtocolVersion,
                     consensusPrivateKey: consensusKeys[i],
-                    host: IPAddress.Loopback.ToString(),
-                    nodeId: i);
+                    host: IPAddress.Loopback.ToString());
                 tasks.Add(StartAsync(_swarms[i]));
             }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -241,7 +241,6 @@ If omitted (default) explorer only the local blockchain store.")]
                         },
                     };
 
-                    // TODO: Add nodeId getter/setter and validators getter!
                     swarm = new Swarm<NullAction>(
                         blockChain,
                         privateKey,
@@ -252,7 +251,6 @@ If omitted (default) explorer only the local blockchain store.")]
                         workers: options.Workers,
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions,
-                        nodeId: 0,
                         consensusPrivateKey: consensusPrivateKey
                     );
                 }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Libplanet.Net.Tests.Consensus
 {
+    [Collection("NetMQConfiguration")]
     public class ConsensusContextTest
     {
         private const int Timeout = 60_000;

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -109,7 +109,6 @@ namespace Libplanet.Net.Tests.Consensus
             using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain,
-                0,
                 blockChain.Tip.Index,
                 new PrivateKey(),
                 new List<PublicKey> { new PrivateKey().PublicKey, new PrivateKey().PublicKey },
@@ -130,7 +129,6 @@ namespace Libplanet.Net.Tests.Consensus
             using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain,
-                0,
                 blockChain.Tip.Index + 1,
                 new PrivateKey(),
                 new List<PublicKey> { new PrivateKey().PublicKey, new PrivateKey().PublicKey },
@@ -139,7 +137,7 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.True(context.Height > 0);
             Assert.Throws<InvalidHeightMessageException>(
                 () => context.HandleMessage(
-                    new ConsensusPropose(0, 0, 0, _fx.Block1.Hash, new byte[] { }, -1)));
+                    new ConsensusPropose(0, 0, _fx.Block1.Hash, new byte[] { }, -1)));
         }
 
         [Fact(Timeout = Timeout)]
@@ -155,7 +153,6 @@ namespace Libplanet.Net.Tests.Consensus
             using var context = new ConsensusContext<DumbAction>(
                 _ => { },
                 blockChain1,
-                0,
                 blockChain1.Tip.Index + 1,
                 new PrivateKey(),
                 new List<PublicKey> { privateKey.PublicKey },
@@ -169,7 +166,6 @@ namespace Libplanet.Net.Tests.Consensus
             // Message from higher height
             context.HandleMessage(
                 new ConsensusPropose(
-                    0,
                     2,
                     0,
                     block2.Hash,
@@ -188,7 +184,6 @@ namespace Libplanet.Net.Tests.Consensus
             };
             context.HandleMessage(
                 new ConsensusPropose(
-                    0,
                     1,
                     0,
                     block1.Hash,
@@ -209,7 +204,6 @@ namespace Libplanet.Net.Tests.Consensus
                         DateTimeOffset.UtcNow,
                         privateKey.PublicKey,
                         VoteFlag.Absent,
-                        0,
                         null).Sign(privateKey))
                 {
                     Remote = validatorPeer,
@@ -226,7 +220,6 @@ namespace Libplanet.Net.Tests.Consensus
                         DateTimeOffset.UtcNow,
                         privateKey.PublicKey,
                         VoteFlag.Commit,
-                        0,
                         null).Sign(privateKey))
                 {
                     Remote = validatorPeer,
@@ -253,7 +246,6 @@ namespace Libplanet.Net.Tests.Consensus
                     blockChain,
                     transport,
                     TimeSpan.FromSeconds(1),
-                    nodeId: 1,
                     port: 17193,
                     privateKey: TestUtils.Peer1Priv,
                     validators: TestUtils.Validators);
@@ -272,7 +264,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusVote(
                     TestUtils.CreateVote(
                         TestUtils.Peer2Priv,
-                        2,
                         1,
                         hash: null,
                         flag: VoteFlag.Absent))
@@ -284,7 +275,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusVote(
                     vote: TestUtils.CreateVote(
                         TestUtils.Peer3Priv,
-                        3,
                         1,
                         hash: null,
                         flag: VoteFlag.Absent))
@@ -298,7 +288,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusCommit(
                     TestUtils.CreateVote(
                         TestUtils.Peer2Priv,
-                        2,
                         1,
                         hash: null,
                         flag: VoteFlag.Commit))
@@ -310,7 +299,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusCommit(
                     vote: TestUtils.CreateVote(
                         TestUtils.Peer3Priv,
-                        3,
                         1,
                         hash: null,
                         flag: VoteFlag.Commit))

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -65,7 +65,7 @@ namespace Libplanet.Net.Tests.Consensus
                     JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
                         ConsensusReactors[node].ToString());
 
-                Assert.Equal((long)node, json["node_id"].GetInt32());
+                Assert.Equal(ValidatorPeers[node].Address.ToString(), json["node_id"].GetString());
                 Assert.Equal(1, json["height"].GetInt32());
                 Assert.Equal(2, BlockChains[node].Count);
                 Assert.Equal(0L, json["round"].GetInt32());

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -33,16 +33,16 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], nodeId: 1, round: 0));
+                    block, TestUtils.PrivateKeys[1], round: 0));
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[2], nodeId: 2, round: 1));
+                    block, TestUtils.PrivateKeys[2], round: 1));
 
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[2], 1, 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -76,12 +76,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
             blockHash = block.Hash;
 
             Context.HandleMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1], nodeId: 1));
+                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
 
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[1]),
                 });
@@ -89,7 +89,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[2], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -97,7 +97,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -139,12 +139,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
             blockHash = block.Hash;
 
             Context.HandleMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1], nodeId: 1));
+                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
 
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[1], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[1]),
                 });
@@ -152,7 +152,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[2], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -160,7 +160,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -183,16 +183,16 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], nodeId: 1, round: 0));
+                    block, TestUtils.PrivateKeys[1], round: 0));
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[2], nodeId: 2, round: 1));
+                    block, TestUtils.PrivateKeys[2], round: 1));
 
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 1, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[2], 1, 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -256,12 +256,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], nodeId: 1, round: 0));
+                    block, TestUtils.PrivateKeys[1], round: 0));
 
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 1, 0, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[1]),
                 });
@@ -269,7 +269,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -277,7 +277,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -306,12 +306,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.AddMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], nodeId: 1, round: 0));
+                    block, TestUtils.PrivateKeys[1], round: 0));
 
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 1, 0, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[1]),
                 });
@@ -319,7 +319,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, 0, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -327,7 +327,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, 0, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -45,21 +45,21 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[NodeId]));
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0], 0, 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[0], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 2, 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[2], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 3, 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[3], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -99,21 +99,21 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0], 0, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 2, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[2], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 3, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.PrivateKeys[3], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -154,7 +154,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 0, 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[0], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
@@ -162,7 +162,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[2], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -170,7 +170,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[3], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
@@ -204,7 +204,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 0, 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
@@ -212,7 +212,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 2, 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[2], 1, hash: block.Hash, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
@@ -220,7 +220,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 3, 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[3], 1, hash: block.Hash, flag: VoteFlag.Commit))
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -33,15 +33,14 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 block, TestUtils.PrivateKeys[NodeId], round: 0, validRound: -1));
 
             Context.AddMessage(TestUtils.CreateConsensusPropose(
-                block, TestUtils.PrivateKeys[2], nodeId: 2, round: 1, validRound: 0));
+                block, TestUtils.PrivateKeys[2], round: 1, validRound: 0));
 
             Context.AddMessage(TestUtils.CreateConsensusPropose(
-                block, TestUtils.PrivateKeys[3], nodeId: 3, round: 2, validRound: 1));
+                block, TestUtils.PrivateKeys[3], round: 2, validRound: 1));
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
-                    0,
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -53,7 +52,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(new
                 ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
-                    2,
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -65,7 +63,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
-                    3,
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -103,15 +100,14 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 invalidBlock, TestUtils.PrivateKeys[NodeId], round: 0, validRound: -1));
 
             Context.AddMessage(TestUtils.CreateConsensusPropose(
-                invalidBlock, TestUtils.PrivateKeys[2], nodeId: 2, round: 1, validRound: 0));
+                invalidBlock, TestUtils.PrivateKeys[2], round: 1, validRound: 0));
 
             Context.AddMessage(TestUtils.CreateConsensusPropose(
-                invalidBlock, TestUtils.PrivateKeys[3], nodeId: 3, round: 2, validRound: 1));
+                invalidBlock, TestUtils.PrivateKeys[3], round: 2, validRound: 1));
 
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
-                    0,
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,
@@ -123,7 +119,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(new
                 ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
-                    2,
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,
@@ -135,7 +130,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
-                    3,
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -57,8 +57,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     Context.AddMessage(
                         TestUtils.CreateConsensusPropose(
                             block,
-                            TestUtils.PrivateKeys[0],
-                            nodeId: NodeId)));
+                            TestUtils.PrivateKeys[0])));
             await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
@@ -70,8 +69,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     Context.AddMessage(
                         TestUtils.CreateConsensusPropose(
                             default,
-                            TestUtils.PrivateKeys[NodeId],
-                            nodeId: NodeId)));
+                            TestUtils.PrivateKeys[NodeId])));
             await Transport.StopAsync(TimeSpan.FromSeconds(1));
         }
 
@@ -93,7 +91,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                                 DateTimeOffset.UtcNow,
                                 TestUtils.Validators[0],
                                 VoteFlag.Absent,
-                                NodeId,
                                 null).Sign(TestUtils.PrivateKeys[NodeId]))
                         {
                             Remote = new Peer(TestUtils.Validators[NodeId]),
@@ -111,7 +108,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                                 DateTimeOffset.UtcNow,
                                 TestUtils.Validators[0],
                                 VoteFlag.Absent,
-                                1,
                                 null).Sign(TestUtils.PrivateKeys[NodeId]))
                         {
                             Remote = new Peer(TestUtils.Validators[0]),
@@ -129,7 +125,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                                 DateTimeOffset.UtcNow,
                                 TestUtils.Validators[NodeId],
                                 VoteFlag.Absent,
-                                1,
                                 null).Sign(TestUtils.PrivateKeys[NodeId]))
                         {
                             Remote = new Peer(TestUtils.Validators[0]),
@@ -147,7 +142,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                                 DateTimeOffset.UtcNow,
                                 TestUtils.Validators[0],
                                 VoteFlag.Absent,
-                                1,
                                 null).Sign(TestUtils.PrivateKeys[NodeId]))
                         {
                             Remote = new Peer(TestUtils.Validators[0]),
@@ -172,7 +166,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                         TestUtils.CreateVote(
                             TestUtils.PrivateKeys[2],
                             2,
-                            2,
                             0,
                             block.Hash,
                             VoteFlag.Absent))
@@ -185,7 +178,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     new ConsensusCommit(
                         TestUtils.CreateVote(
                             TestUtils.PrivateKeys[2],
-                            2,
                             2,
                             0,
                             block.Hash,
@@ -210,7 +202,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 0, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
@@ -218,7 +210,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.PrivateKeys[1], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = new Peer(TestUtils.Validators[1]),
                 });
@@ -228,9 +220,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.PrivateKeys[1], 1, hash: block.Hash, flag: VoteFlag.Commit))
                 {
-                    Remote = new Peer(TestUtils.Validators[2]),
+                    Remote = new Peer(TestUtils.Validators[1]),
                 });
             roundVoteSet = Context.VoteSet(0);
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -66,7 +66,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _consensusContext = new ConsensusContext<DumbAction>(
                 BroadcastMessage,
                 BlockChain,
-                nodeId,
                 height,
                 privateKey: TestUtils.PrivateKeys[(int)nodeId],
                 validators: TestUtils.Validators,
@@ -75,7 +74,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context = new Context<DumbAction>(
                 _consensusContext,
                 BlockChain,
-                nodeId,
                 height,
                 TestUtils.PrivateKeys[(int)nodeId],
                 TestUtils.Validators,

--- a/Libplanet.Net.Tests/Consensus/ReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ReactorTest.cs
@@ -26,11 +26,11 @@ namespace Libplanet.Net.Tests.Consensus
         protected readonly ConsensusReactor<DumbAction>[] ConsensusReactors;
         protected readonly BlockChain<DumbAction>[] BlockChains;
         protected readonly CancellationTokenSource CancellationTokenSource;
+        protected readonly List<BoundPeer> ValidatorPeers;
 
         private const int Port = 6100;
         private readonly StoreFixture _fx;
         private readonly PrivateKey[] _privateKey;
-        private readonly List<BoundPeer> _validatorPeers;
         private readonly IStore[] _stores;
 
         private ILogger _logger;
@@ -52,14 +52,14 @@ namespace Libplanet.Net.Tests.Consensus
 
             _privateKey = new PrivateKey[Count];
             ConsensusReactors = new ConsensusReactor<DumbAction>[Count];
-            _validatorPeers = new List<BoundPeer>();
+            ValidatorPeers = new List<BoundPeer>();
             _stores = new IStore[Count];
             BlockChains = new BlockChain<DumbAction>[Count];
 
             for (var i = 0; i < Count; i++)
             {
                 _privateKey[i] = new PrivateKey();
-                _validatorPeers.Add(
+                ValidatorPeers.Add(
                     new BoundPeer(
                         _privateKey[i].PublicKey,
                         new DnsEndPoint("localhost", Port + i)));
@@ -78,8 +78,7 @@ namespace Libplanet.Net.Tests.Consensus
                     blockChain: BlockChains[i],
                     key: _privateKey[i],
                     consensusPort: Port + i,
-                    id: i,
-                    validatorPeers: _validatorPeers,
+                    validatorPeers: ValidatorPeers,
                     newHeightDelayMilliseconds: PropagationDelay * 2);
             }
         }
@@ -100,7 +99,6 @@ namespace Libplanet.Net.Tests.Consensus
             PrivateKey? key = null,
             string host = "localhost",
             int consensusPort = 5101,
-            long id = 0,
             List<BoundPeer> validatorPeers = null!,
             int newHeightDelayMilliseconds = 10_000)
         {
@@ -120,7 +118,6 @@ namespace Libplanet.Net.Tests.Consensus
                 consensusTransport,
                 blockChain,
                 key,
-                id,
                 validatorPeers.ToImmutableList(),
                 TimeSpan.FromMilliseconds(newHeightDelayMilliseconds));
         }

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -151,7 +151,6 @@ namespace Libplanet.Net.Tests
                 blockChain,
                 privateKey,
                 appProtocolVersion ?? DefaultAppProtocolVersion,
-                nodeId,
                 consensusPrivateKey,
                 workers: 5,
                 host: host,

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -494,8 +494,7 @@ namespace Libplanet.Net.Tests
                     null,
                     key,
                     ver,
-                    consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0);
+                    consensusPrivateKey: consensusPrivateKey);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
@@ -504,8 +503,17 @@ namespace Libplanet.Net.Tests
                     blockchain,
                     null,
                     ver,
-                    consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0);
+                    consensusPrivateKey: consensusPrivateKey);
+            });
+
+            // Swarm<DumbAction> needs host or iceServers.
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new Swarm<DumbAction>(
+                    blockchain,
+                    key,
+                    ver,
+                    consensusPrivateKey: consensusPrivateKey);
             });
 
             // Swarm<DumbAction> needs host or iceServers.
@@ -516,19 +524,7 @@ namespace Libplanet.Net.Tests
                     key,
                     ver,
                     consensusPrivateKey: consensusPrivateKey,
-                    nodeId: 0);
-            });
-
-            // Swarm<DumbAction> needs host or iceServers.
-            Assert.Throws<ArgumentException>(() =>
-            {
-                new Swarm<DumbAction>(
-                    blockchain,
-                    key,
-                    ver,
-                    consensusPrivateKey: consensusPrivateKey,
-                    iceServers: new IceServer[] { },
-                    nodeId: 0);
+                    iceServers: new IceServer[] { });
             });
         }
 

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -97,7 +97,6 @@ namespace Libplanet.Net.Tests
         public static Vote CreateVote(
             PublicKey publicKey,
             VoteFlag flag = VoteFlag.Null,
-            long id = 0,
             long height = 0,
             int round = 0) =>
             new Vote(
@@ -107,12 +106,10 @@ namespace Libplanet.Net.Tests
                 DateTimeOffset.Now,
                 publicKey,
                 flag,
-                id,
                 ImmutableArray<byte>.Empty);
 
         public static Vote CreateVote(
             PrivateKey privateKey,
-            long id = 0,
             long height = 0,
             int round = 0,
             BlockHash? hash = null,
@@ -124,7 +121,6 @@ namespace Libplanet.Net.Tests
                 DateTimeOffset.Now,
                 privateKey.PublicKey,
                 flag,
-                id,
                 ImmutableArray<byte>.Empty).Sign(privateKey);
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
@@ -169,14 +165,12 @@ namespace Libplanet.Net.Tests
         public static ConsensusPropose CreateConsensusPropose(
             Block<DumbAction>? block,
             PrivateKey privateKey,
-            long nodeId = 1,
             long height = 1,
             int round = 0,
             int validRound = -1)
         {
             var codec = new Codec();
             return new ConsensusPropose(
-                nodeId,
                 height,
                 round,
                 block?.Hash ?? default,
@@ -192,7 +186,6 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> blockChain,
             ITransport transport,
             TimeSpan newHeightDelay,
-            long nodeId = 0,
             long height = 0,
             string host = "localhost",
             int port = 18192,
@@ -226,7 +219,6 @@ namespace Libplanet.Net.Tests
             var consensusContext = new ConsensusContext<DumbAction>(
                 BroadcastMessage,
                 blockChain,
-                nodeId,
                 height,
                 privateKey,
                 validators,

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -54,7 +54,6 @@ namespace Libplanet.Net.Tests.Transports
                 swarmKey,
                 apv,
                 consensusPrivateKey: consensusKey,
-                nodeId: 0,
                 host: host,
                 listenPort: port,
                 options: option))

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -15,7 +15,6 @@ namespace Libplanet.Net.Consensus
         where T : IAction, new()
     {
         private readonly BlockChain<T> _blockChain;
-        private readonly long _nodeId;
         private readonly PrivateKey _privateKey;
         private readonly List<PublicKey> _validators;
         private readonly TimeSpan _newHeightDelay;
@@ -27,7 +26,6 @@ namespace Libplanet.Net.Consensus
         public ConsensusContext(
             DelegateBroadcastMessage broadcastMessage,
             BlockChain<T> blockChain,
-            long nodeId,
             long height,
             PrivateKey privateKey,
             List<PublicKey> validators,
@@ -35,7 +33,6 @@ namespace Libplanet.Net.Consensus
         {
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
-            _nodeId = nodeId;
             _privateKey = privateKey;
             _validators = validators;
             Height = height;
@@ -98,7 +95,6 @@ namespace Libplanet.Net.Consensus
                 _contexts[height] = new Context<T>(
                     this,
                     _blockChain,
-                    _nodeId,
                     height,
                     _privateKey,
                     _validators);
@@ -129,7 +125,6 @@ namespace Libplanet.Net.Consensus
                 _contexts[height] = new Context<T>(
                     this,
                     _blockChain,
-                    _nodeId,
                     height,
                     _privateKey,
                     _validators);

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -22,13 +22,11 @@ namespace Libplanet.Net.Consensus
         private IImmutableList<BoundPeer> _validatorPeers;
         private ConsensusContext<T> _consensusContext;
         private BlockChain<T> _blockChain;
-        private long _nodeId;
 
         public ConsensusReactor(
             ITransport consensusTransport,
             BlockChain<T> blockChain,
             PrivateKey privateKey,
-            long nodeId,
             ImmutableList<BoundPeer> validatorPeers,
             TimeSpan newHeightDelay)
         {
@@ -36,12 +34,10 @@ namespace Libplanet.Net.Consensus
             _validatorPeers = validatorPeers;
             _consensusTransport.ProcessMessageHandler.Register(ProcessMessageHandler);
             _blockChain = blockChain;
-            _nodeId = nodeId;
 
             _consensusContext = new ConsensusContext<T>(
                 BroadcastMessage,
                 blockChain,
-                nodeId,
                 blockChain.Tip.Index,
                 privateKey,
                 validatorPeers.Select(x => x.PublicKey).ToList(),

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -30,7 +30,6 @@ namespace Libplanet.Net.Consensus
 
         private readonly BlockChain<T> _blockChain;
         private readonly Codec _codec;
-        private readonly long _id;
         private readonly List<PublicKey> _validators;
         private readonly Channel<ConsensusMessage> _messageRequests;
         private readonly ConcurrentDictionary<int, ConcurrentBag<ConsensusMessage>>
@@ -54,14 +53,12 @@ namespace Libplanet.Net.Consensus
         public Context(
             ConsensusContext<T> consensusContext,
             BlockChain<T> blockChain,
-            long id,
             long height,
             PrivateKey privateKey,
             List<PublicKey> validators)
             : this(
                 consensusContext,
                 blockChain,
-                id,
                 height,
                 privateKey,
                 validators,
@@ -73,14 +70,12 @@ namespace Libplanet.Net.Consensus
         internal Context(
             ConsensusContext<T> consensusContext,
             BlockChain<T> blockChain,
-            long id,
             long height,
             PrivateKey privateKey,
             List<PublicKey> validators,
             Step step,
             int round = 0)
         {
-            _id = id;
             _privateKey = privateKey;
             Height = height;
             Round = round;
@@ -177,7 +172,7 @@ namespace Libplanet.Net.Consensus
         {
             var dict = new Dictionary<string, object>
             {
-                { "node_id", _id },
+                { "node_id", _privateKey.ToAddress().ToString() },
                 { "number_of_validator", _validators!.Count },
                 { "height", Height },
                 { "round", Round },
@@ -288,13 +283,13 @@ namespace Libplanet.Net.Consensus
         {
             _logger.Debug(
                 "{FName}: Message: {Message} => " +
-                "Height: {Height}, Round: {Round}, NodeId: {NodeId}, Hash: {BlockHash}. " +
+                "Height: {Height}, Round: {Round}, Address: {Address}, Hash: {BlockHash}. " +
                 "MessageCount: {Count}. (context: {Context})",
                 nameof(ProcessMessage),
                 message,
                 message.Height,
                 message.Round,
-                message.NodeId,
+                message.Remote!.Address,
                 message.BlockHash,
                 _messagesInRound[Round].Count,
                 ToString());
@@ -495,7 +490,6 @@ namespace Libplanet.Net.Consensus
                 _ = SendMessageAfter(
                     TimeSpan.FromMilliseconds(500),
                     new ConsensusPropose(
-                        _id,
                         Height,
                         Round,
                         proposal.Hash,
@@ -536,7 +530,6 @@ namespace Libplanet.Net.Consensus
                 DateTimeOffset.UtcNow,
                 _privateKey.PublicKey,
                 flag,
-                _id,
                 null).Sign(_privateKey);
         }
 

--- a/Libplanet.Net/Messages/ConsensusCommit.cs
+++ b/Libplanet.Net/Messages/ConsensusCommit.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Net.Messages
     public class ConsensusCommit : ConsensusMessage
     {
         public ConsensusCommit(Vote vote)
-            : base(vote.NodeId, vote.Height, vote.Round, vote.BlockHash)
+            : base(vote.Height, vote.Round, vote.BlockHash)
         {
             CommitVote = vote;
         }

--- a/Libplanet.Net/Messages/ConsensusMessage.cs
+++ b/Libplanet.Net/Messages/ConsensusMessage.cs
@@ -8,26 +8,24 @@ namespace Libplanet.Net.Messages
     {
         protected const byte Nil = 0x00;
 
-        protected ConsensusMessage(long nodeId, long height, int round, BlockHash? blockHash)
+        protected ConsensusMessage(long height, int round, BlockHash? blockHash)
         {
             Round = round;
             Height = height;
             BlockHash = blockHash;
-            NodeId = nodeId;
         }
 
         protected ConsensusMessage(byte[][] dataframes)
         {
-            NodeId = BitConverter.ToInt64(dataframes[0], 0);
-            Height = BitConverter.ToInt64(dataframes[1], 0);
-            Round = BitConverter.ToInt32(dataframes[2], 0);
-            if (dataframes[3].Length == 1 && dataframes[3][0] == Nil)
+            Height = BitConverter.ToInt64(dataframes[0], 0);
+            Round = BitConverter.ToInt32(dataframes[1], 0);
+            if (dataframes[2].Length == 1 && dataframes[2][0] == Nil)
             {
                 BlockHash = null;
             }
             else
             {
-                BlockHash = new BlockHash(dataframes[3]);
+                BlockHash = new BlockHash(dataframes[2]);
             }
         }
 
@@ -35,13 +33,10 @@ namespace Libplanet.Net.Messages
 
         public int Round { get; }
 
-        public long NodeId { get; }
-
         public BlockHash? BlockHash { get; }
 
         public override IEnumerable<byte[]> DataFrames => new[]
         {
-            BitConverter.GetBytes(NodeId),
             BitConverter.GetBytes(Height),
             BitConverter.GetBytes(Round),
             BlockHash is { } blockHash ? blockHash.ToByteArray() : new[] { Nil },

--- a/Libplanet.Net/Messages/ConsensusPropose.cs
+++ b/Libplanet.Net/Messages/ConsensusPropose.cs
@@ -7,13 +7,12 @@ namespace Libplanet.Net.Messages
     public class ConsensusPropose : ConsensusMessage
     {
         public ConsensusPropose(
-            long nodeId,
             long height,
             int round,
             BlockHash blockHash,
             byte[] payload,
             int validRound)
-        : base(nodeId, height, round, blockHash)
+        : base(height, round, blockHash)
         {
             Payload = payload;
             ValidRound = validRound;
@@ -22,8 +21,8 @@ namespace Libplanet.Net.Messages
         public ConsensusPropose(byte[][] dataframes)
         : base(dataframes)
         {
-            Payload = dataframes[4];
-            ValidRound = BitConverter.ToInt32(dataframes[5], 0);
+            Payload = dataframes[3];
+            ValidRound = BitConverter.ToInt32(dataframes[4], 0);
         }
 
         public byte[] Payload { get; }
@@ -36,7 +35,6 @@ namespace Libplanet.Net.Messages
             {
                 var frames = new List<byte[]>
                 {
-                    BitConverter.GetBytes(NodeId),
                     BitConverter.GetBytes(Height),
                     BitConverter.GetBytes(Round),
                     BlockHash is { } blockHash ? blockHash.ToByteArray() : new[] { Nil },

--- a/Libplanet.Net/Messages/ConsensusVote.cs
+++ b/Libplanet.Net/Messages/ConsensusVote.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Net.Messages
     public class ConsensusVote : ConsensusMessage
     {
         public ConsensusVote(Vote vote)
-            : base(vote.NodeId, vote.Height, vote.Round, vote.BlockHash)
+            : base(vote.Height, vote.Round, vote.BlockHash)
         {
             ProposeVote = vote;
         }

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -53,7 +53,6 @@ namespace Libplanet.Net
         /// <param name="privateKey">A private key to sign messages.  The public part of
         /// this key become a part of its end address for being pointed by peers.</param>
         /// <param name="appProtocolVersion">An app protocol to comply.</param>
-        /// <param name="nodeId">(Experimental) The Id of Node.</param>
         /// <param name="consensusPrivateKey">(Experimental) The private key that is using
         /// for Consensus Signing.</param>
         /// <param name="consensusPort">(Experimental) The port for ConsensusReactor.</param>
@@ -80,7 +79,6 @@ namespace Libplanet.Net
             BlockChain<T> blockChain,
             PrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
-            long nodeId,
             PrivateKey consensusPrivateKey,
             int? consensusPort = null,
             int consensusWorkers = 100,
@@ -138,7 +136,6 @@ namespace Libplanet.Net
                 ConsensusTransport,
                 BlockChain,
                 consensusPrivateKey,
-                nodeId,
                 Options.ConsensusPeers,
                 TimeSpan.FromMilliseconds(10_000));
         }

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -31,7 +31,6 @@ namespace Libplanet.Tests.Blocks
                                               DateTimeOffset.Now,
                                               new PrivateKey().PublicKey,
                                               VoteFlag.Absent,
-                                              x,
                                               ImmutableArray<byte>.Empty))
                                           .ToImmutableArray();
              var blockCommit = new BlockCommit(1, 0, fx.Hash1, votes);

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -48,7 +48,6 @@ namespace Libplanet.Tests.Blocks
                             Genesis.Timestamp,
                             Miner.PublicKey,
                             VoteFlag.Commit,
-                            0,
                             null),
                     }.ToImmutableArray())
             );
@@ -81,7 +80,6 @@ namespace Libplanet.Tests.Blocks
                             Next.Timestamp,
                             Miner.PublicKey,
                             VoteFlag.Commit,
-                            0,
                             null),
                     }.ToImmutableArray())
             );

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -40,7 +40,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,
-                     i,
                      null);
                  var vote = new Vote(
                      1,
@@ -49,7 +48,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,
-                     i,
                      validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }
@@ -73,7 +71,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Commit,
-                     i,
                      null);
                  var vote = new Vote(
                      1,
@@ -82,7 +79,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Commit,
-                     i,
                      validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }
@@ -121,7 +117,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,
-                     i,
                      null);
                  var vote = new Vote(
                      1,
@@ -130,7 +125,6 @@ namespace Libplanet.Tests.Consensus
                      now,
                      validators[i].PublicKey,
                      VoteFlag.Absent,
-                     i,
                      validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
                  voteSet.Add(vote);
              }

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -20,7 +20,6 @@ namespace Libplanet.Tests.Consensus
                 now,
                 new PrivateKey().PublicKey,
                 VoteFlag.Commit,
-                7,
                 null);
             byte[] marshaled = vote.ByteArray;
             var unMarshaled = new Vote(marshaled);

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -36,7 +36,6 @@ namespace Libplanet.Consensus
         /// </param>
         /// <param name="flag">
         /// <see cref="VoteFlag"/> for the vote's status.</param>
-        /// <param name="nodeId">The Id of the validator made the vote.</param>
         /// <param name="signature">Signature of the vote.</param>
         public Vote(
             long height,
@@ -45,7 +44,6 @@ namespace Libplanet.Consensus
             DateTimeOffset timestamp,
             PublicKey validator,
             VoteFlag flag,
-            long nodeId,
             ImmutableArray<byte>? signature)
         {
             Height = height;
@@ -54,7 +52,6 @@ namespace Libplanet.Consensus
             Timestamp = timestamp;
             Validator = validator;
             Flag = flag;
-            NodeId = nodeId;
             Signature = signature;
         }
 
@@ -82,7 +79,6 @@ namespace Libplanet.Consensus
                     CultureInfo.InvariantCulture);
                 Validator = new PublicKey(dict.GetValue<Binary>(ValidatorKey).ByteArray);
                 Flag = (VoteFlag)(long)dict.GetValue<Integer>(FlagKey);
-                NodeId = dict.GetValue<Integer>(NodeIdKey);
                 Signature = dict.ContainsKey(SignatureKey)
                     ? dict.GetValue<Binary>(SignatureKey)
                     : (ImmutableArray<byte>?)null;
@@ -126,11 +122,6 @@ namespace Libplanet.Consensus
         public VoteFlag Flag { get; }
 
         /// <summary>
-        /// The Id of the validator made the vote.
-        /// </summary>
-        public long NodeId { get; }
-
-        /// <summary>
         /// Signature of the vote.
         /// </summary>
         public ImmutableArray<byte>? Signature { get; }
@@ -150,8 +141,7 @@ namespace Libplanet.Consensus
                         TimestampKey,
                         Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                     .Add(ValidatorKey, Validator.Format(compress: true))
-                    .Add(FlagKey, (long)Flag)
-                    .Add(NodeIdKey, NodeId);
+                    .Add(FlagKey, (long)Flag);
 
                 if (BlockHash is { } blockHash)
                 {
@@ -168,7 +158,7 @@ namespace Libplanet.Consensus
         }
 
         public Vote RemoveSignature =>
-            new Vote(Height, Round, BlockHash, Timestamp, Validator, Flag, NodeId, null);
+            new Vote(Height, Round, BlockHash, Timestamp, Validator, Flag, null);
 
         /// <summary>
         /// Sign a <see cref="Vote"/> using the given private key.
@@ -188,7 +178,6 @@ namespace Libplanet.Consensus
                 Timestamp,
                 Validator,
                 Flag,
-                NodeId,
                 sign.ToImmutableArray());
         }
 
@@ -215,7 +204,6 @@ namespace Libplanet.Consensus
                                TimestampFormat,
                                CultureInfo.InvariantCulture)) &&
                    Validator.Equals(other.Validator) &&
-                   NodeId == other.NodeId &&
                    Flag == other.Flag &&
                    Nullable.Equals(Signature, other.Signature);
         }
@@ -235,7 +223,6 @@ namespace Libplanet.Consensus
                 BlockHash,
                 Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
                 Validator,
-                NodeId,
                 Signature);
         }
     }


### PR DESCRIPTION
# Summary
This resolves https://github.com/planetarium/libplanet/issues/2104
+ Remove `nodeId` from `Swarm<T>`, `ConsensusReactor`, `ConsensusContext`, `Context`
+ `VoteSet` stores votes in `Dictionary<PublicKey, Vote>` where key is vote of Validator's `PublicKey`.
  + `VoteSet.Votes` returns a new `IImutableList<Vote>` by indexing `Dictionary<PublicKey, Vote>` in order of `ValidatorSet`. `ToDictionary()` does not keep the order of list.