### PR TITLE
fix: Prevent improper parsing on 'Uri.UserInfo' with exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ To be released.
 
 ### Bug fixes
 
+ -  (Libplanet.Net) Invalid `Uri.UserInfo` with multiple colons is now
+    rejected by `IceServer(Uri url)` constructor and exception is thrown.
+    [[#2116]]
+
 ### Dependencies
 
 ### CLI tools

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -51,6 +51,9 @@ namespace Libplanet.Net.Tests
             iceServer = new IceServer(urlString);
             Assert.Equal("user", iceServer.Username);
             Assert.Equal("info", iceServer.Credential);
+
+            urlString = "turn://user:info:invalid@some.path";
+            Assert.Throws<ArgumentException>(() => new IceServer(urlString));
         }
 
         [FactOnlyTurnAvailable(Timeout = Timeout)]


### PR DESCRIPTION
## Changes
- Replace improper handling on invalid url with throwing exception

## Related issue
- Resolves https://github.com/planetarium/libplanet/issues/2058