### PR TITLE
Refactor `DataModel`

### DIFF
--- a/Libplanet.Benchmarks/DataModel/DataModelBenchmark.LeafModel.cs
+++ b/Libplanet.Benchmarks/DataModel/DataModelBenchmark.LeafModel.cs
@@ -9,12 +9,12 @@ namespace Libplanet.Benchmarks.DataModel
 {
     public partial class DataModelBenchmark
     {
-        private class LeafModel : StoreDataModel
+        public class LeafModel : StoreDataModel
         {
             public LeafModel()
                 : base()
             {
-                System.Random random = new System.Random();
+                System.Random random = new System.Random(2);
                 BigList = Enumerable
                     .Range(0, 1000)
                     .Select(_ => random.Next())
@@ -37,24 +37,9 @@ namespace Libplanet.Benchmarks.DataModel
             public ImmutableDictionary<Address, string> BigDict { get; private set; }
         }
 
-        private class PlainValueLeaf
+        public class RawLeafModel
         {
-            public PlainValueLeaf()
-            {
-                System.Random random = new System.Random();
-                BigList = Enumerable
-                    .Range(0, 1000)
-                    .Select(_ => random.Next())
-                    .ToImmutableList();
-                BigDict = Enumerable
-                    .Range(0, 1000)
-                    .Select(_ => new KeyValuePair<Address, string>(
-                        new PrivateKey().ToAddress(),
-                        new PrivateKey().ToAddress().ToString()))
-                    .ToImmutableDictionary();
-            }
-
-            public PlainValueLeaf(Bencodex.Types.Dictionary encoded)
+            public RawLeafModel(Bencodex.Types.Dictionary encoded)
             {
                 BigList = ((BTypes.List)encoded[nameof(BigList)])
                     .Select(x => (int)((BTypes.Integer)x).Value)
@@ -86,6 +71,5 @@ namespace Libplanet.Benchmarks.DataModel
 
             public ImmutableDictionary<Address, string> BigDict { get; private set; }
         }
-
     }
 }

--- a/Libplanet.Benchmarks/DataModel/DataModelBenchmark.MidModel.cs
+++ b/Libplanet.Benchmarks/DataModel/DataModelBenchmark.MidModel.cs
@@ -8,12 +8,12 @@ namespace Libplanet.Benchmarks.DataModel
 {
     public partial class DataModelBenchmark
     {
-        private class MidModel : StoreDataModel
+        public class MidModel : StoreDataModel
         {
             public MidModel()
                 : base()
             {
-                System.Random random = new System.Random();
+                System.Random random = new System.Random(1);
                 LeafModel = new LeafModel();
                 BigList = Enumerable
                     .Range(0, 1000)

--- a/Libplanet.Benchmarks/DataModel/DataModelBenchmark.RootModel.cs
+++ b/Libplanet.Benchmarks/DataModel/DataModelBenchmark.RootModel.cs
@@ -8,12 +8,12 @@ namespace Libplanet.Benchmarks.DataModel
 {
     public partial class DataModelBenchmark
     {
-        private class RootModel : StoreDataModel
+        public class RootModel : StoreDataModel
         {
             public RootModel()
                 : base()
             {
-                System.Random random = new System.Random();
+                System.Random random = new System.Random(0);
                 MidModel = new MidModel();
                 BigList = Enumerable
                     .Range(0, 1000)

--- a/Libplanet.Benchmarks/DataModel/DataModelBenchmark.cs
+++ b/Libplanet.Benchmarks/DataModel/DataModelBenchmark.cs
@@ -7,55 +7,56 @@ namespace Libplanet.Benchmarks.DataModel
     {
         private RootModel _rootModel;
         private LeafModel _leafModel;
-        private PlainValueLeaf _plainValueLeaf;
+        private RawLeafModel _rawLeafModel;
 
         private BTypes.Dictionary _encodedRootModel;
         private BTypes.Dictionary _encodedLeafModel;
 
-        public DataModelBenchmark()
+        [GlobalSetup]
+        public void Setup()
         {
             _rootModel = new RootModel();
             _leafModel = new LeafModel();
             _encodedRootModel = _rootModel.Encode();
             _encodedLeafModel = _leafModel.Encode();
 
-            _plainValueLeaf = new PlainValueLeaf(_encodedLeafModel);
+            _rawLeafModel = new RawLeafModel(_encodedLeafModel);
         }
 
         [Benchmark]
-        public void EncodeRoot()
+        public Bencodex.Types.IValue EncodeRootModel()
         {
-            _rootModel.Encode();
+            return _rootModel.Encode();
         }
 
         [Benchmark]
-        public void EncodeLeaf()
+        public Bencodex.Types.IValue EncodeLeafModel()
         {
-            _leafModel.Encode();
+            return _leafModel.Encode();
         }
 
         [Benchmark]
-        public void EncodePlainValueLeaf()
+        public Bencodex.Types.IValue EncodeRawLeafModel()
         {
-            _plainValueLeaf.Encode();
+            return _rawLeafModel.Encode();
         }
 
         [Benchmark]
-        public void DecodeRoot()
+        public Libplanet.Store.DataModel DecodeRootModel()
         {
-            _ = new RootModel(_encodedRootModel);
+            return new RootModel(_encodedRootModel);
         }
 
         [Benchmark]
-        public void DecodeLeaf()
+        public Libplanet.Store.DataModel DecodeLeafModel()
         {
-            _ = new LeafModel(_encodedLeafModel);
+            return new LeafModel(_encodedLeafModel);
         }
 
         [Benchmark]
-        public void DecodePlainValueLeaf()
+        public RawLeafModel DecodeRawLeafModel()
         {
-            _ = new PlainValueLeaf(_encodedLeafModel);
+            return new RawLeafModel(_encodedLeafModel);
         }
     }
 }

--- a/Libplanet.Tests/Store/DataModelTest.cs
+++ b/Libplanet.Tests/Store/DataModelTest.cs
@@ -384,7 +384,7 @@ namespace Libplanet.Tests.Store
                     (BTypes.IValue)BTypes.List.Empty
                         .Add((BTypes.IValue)new BTypes.Integer(5))
                         .Add(BTypes.Null.Value));
-            Assert.Throws<ArgumentException>(() => new ListIntWrapper(encoded));
+            Assert.Throws<NotSupportedException>(() => new ListIntWrapper(encoded));
             encoded = BTypes.Dictionary.Empty
                 .Add(
                     nameof(DictStrIntWrapper.Value),

--- a/Libplanet.Tests/Store/DataModelTest.cs
+++ b/Libplanet.Tests/Store/DataModelTest.cs
@@ -395,7 +395,7 @@ namespace Libplanet.Tests.Store
                         .Add(
                             (BTypes.IKey)new BTypes.Text("bar"),
                             (BTypes.IValue)BTypes.Null.Value));
-            Assert.Throws<ArgumentException>(() => new DictStrIntWrapper(encoded));
+            Assert.Throws<NotSupportedException>(() => new DictStrIntWrapper(encoded));
         }
 
         [Fact]

--- a/Libplanet/Store/DataModel.Decode.cs
+++ b/Libplanet/Store/DataModel.Decode.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -59,6 +58,7 @@ namespace Libplanet.Store
 
                 switch (tempList)
                 {
+#pragma warning disable MEN002
                     case IEnumerable<object> listBool when genericType == typeof(bool):
                         return listBool.Cast<bool>().ToImmutableList();
                     case IEnumerable<object> listInt when genericType == typeof(int):
@@ -67,8 +67,7 @@ namespace Libplanet.Store
                         return listLong.Cast<long>().ToImmutableList();
                     case IEnumerable<object> listBigInteger when genericType == typeof(BigInteger):
                         return listBigInteger.Cast<BigInteger>().ToImmutableList();
-                    case IEnumerable<object> listBytes
-                        when genericType == typeof(ImmutableArray<byte>):
+                    case IEnumerable<object> listBytes when genericType == typeof(ImmutableArray<byte>):
                         return listBytes.Cast<ImmutableArray<byte>>().ToImmutableList();
                     case IEnumerable<object> listGuid when genericType == typeof(Guid):
                         return listGuid.Cast<Guid>().ToImmutableList();
@@ -79,6 +78,7 @@ namespace Libplanet.Store
                     default:
                         throw new ArgumentException(
                             $"Invalid generic type {genericType} encountered.");
+#pragma warning restore MEN002
                 }
             }
             else
@@ -88,7 +88,6 @@ namespace Libplanet.Store
             }
         }
 
-#pragma warning disable MEN003
         private static object DecodeFromDictionaryIValue(BTypes.Dictionary dict, Type type)
         {
             if (type.IsGenericType &&
@@ -97,392 +96,192 @@ namespace Libplanet.Store
                 Type[] genericTypes = type.GetGenericArguments();
                 Type keyType = genericTypes[0];
                 Type valueType = genericTypes[1];
-                IEnumerable<object> keys = DecodedKeys(dict, keyType).Cast<object>();
-                IEnumerable<object> values = DecodedValues(dict, valueType).Cast<object>();
-                if (keyType == typeof(ImmutableArray<byte>))
+
+                IEnumerable<KeyValuePair<dynamic, dynamic>> tempDict = dict.Select(
+                    kv => new KeyValuePair<dynamic, dynamic>(
+                        DecodeFromIValue(kv.Key, keyType),
+                        DecodeFromIValue(kv.Value, valueType)));
+
+                switch (tempDict)
                 {
-                    if (valueType == typeof(bool))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, bool>(
-                                (ImmutableArray<byte>)first, (bool)second))
+#pragma warning disable MEN002
+                    // ImmutabeArray<byte> type keys.
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBoolDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(bool):
+                        return bytesBoolDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, bool>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(int))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, int>(
-                                (ImmutableArray<byte>)first, (int)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesIntDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(int):
+                        return bytesIntDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, int>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(long))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, long>(
-                                (ImmutableArray<byte>)first, (long)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesLongDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(long):
+                        return bytesLongDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, long>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(BigInteger))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, BigInteger>(
-                                (ImmutableArray<byte>)first, (BigInteger)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBigIntegerDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(BigInteger):
+                        return bytesBigIntegerDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, BigInteger>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(ImmutableArray<byte>))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>(
-                                (ImmutableArray<byte>)first, (ImmutableArray<byte>)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBytesDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(ImmutableArray<byte>):
+                        return bytesBytesDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Guid))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, Guid>(
-                                (ImmutableArray<byte>)first, (Guid)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesGuidDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(Guid):
+                        return bytesGuidDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Guid>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Address))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, Address>(
-                                (ImmutableArray<byte>)first, (Address)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesAddressDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(Address):
+                        return bytesAddressDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Address>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(string))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<ImmutableArray<byte>, string>(
-                                (ImmutableArray<byte>)first, (string)second))
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesStringDict
+                        when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(string):
+                        return bytesStringDict
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, string>(kv.Key, kv.Value))
                             .ToImmutableDictionary();
-                    }
-                    else
-                    {
+
+                    // Guid type keys.
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBoolDict
+                        when keyType == typeof(Guid) && valueType == typeof(bool):
+                        return guidBoolDict
+                            .Select(kv => new KeyValuePair<Guid, bool>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidIntDict
+                        when keyType == typeof(Guid) && valueType == typeof(int):
+                        return guidIntDict
+                            .Select(kv => new KeyValuePair<Guid, int>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidLongDict
+                        when keyType == typeof(Guid) && valueType == typeof(long):
+                        return guidLongDict
+                            .Select(kv => new KeyValuePair<Guid, long>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBigIntegerDict
+                        when keyType == typeof(Guid) && valueType == typeof(BigInteger):
+                        return guidBigIntegerDict
+                            .Select(kv => new KeyValuePair<Guid, BigInteger>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBytesDict
+                        when keyType == typeof(Guid) && valueType == typeof(ImmutableArray<byte>):
+                        return guidBytesDict
+                            .Select(kv => new KeyValuePair<Guid, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidGuidDict
+                        when keyType == typeof(Guid) && valueType == typeof(Guid):
+                        return guidGuidDict
+                            .Select(kv => new KeyValuePair<Guid, Guid>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidAddressDict
+                        when keyType == typeof(Guid) && valueType == typeof(Address):
+                        return guidAddressDict
+                            .Select(kv => new KeyValuePair<Guid, Address>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidStringDict
+                        when keyType == typeof(Guid) && valueType == typeof(string):
+                        return guidStringDict
+                            .Select(kv => new KeyValuePair<Guid, string>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+
+                    // Address type keys.
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBoolDict
+                        when keyType == typeof(Address) && valueType == typeof(bool):
+                        return addressBoolDict
+                            .Select(kv => new KeyValuePair<Address, bool>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressIntDict
+                        when keyType == typeof(Address) && valueType == typeof(int):
+                        return addressIntDict
+                            .Select(kv => new KeyValuePair<Address, int>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressLongDict
+                        when keyType == typeof(Address) && valueType == typeof(long):
+                        return addressLongDict
+                            .Select(kv => new KeyValuePair<Address, long>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBigIntegerDict
+                        when keyType == typeof(Address) && valueType == typeof(BigInteger):
+                        return addressBigIntegerDict
+                            .Select(kv => new KeyValuePair<Address, BigInteger>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBytesDict
+                        when keyType == typeof(Address) && valueType == typeof(ImmutableArray<byte>):
+                        return addressBytesDict
+                            .Select(kv => new KeyValuePair<Address, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressGuidDict
+                        when keyType == typeof(Address) && valueType == typeof(Guid):
+                        return addressGuidDict
+                            .Select(kv => new KeyValuePair<Address, Guid>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressAddressDict
+                        when keyType == typeof(Address) && valueType == typeof(Address):
+                        return addressAddressDict
+                            .Select(kv => new KeyValuePair<Address, Address>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressStringDict
+                        when keyType == typeof(Address) && valueType == typeof(string):
+                        return addressStringDict
+                            .Select(kv => new KeyValuePair<Address, string>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+
+                    // string type keys.
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBoolDict
+                        when keyType == typeof(string) && valueType == typeof(bool):
+                        return stringBoolDict
+                            .Select(kv => new KeyValuePair<string, bool>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringIntDict
+                        when keyType == typeof(string) && valueType == typeof(int):
+                        return stringIntDict
+                            .Select(kv => new KeyValuePair<string, int>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringLongDict
+                        when keyType == typeof(string) && valueType == typeof(long):
+                        return stringLongDict
+                            .Select(kv => new KeyValuePair<string, long>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBigIntegerDict
+                        when keyType == typeof(string) && valueType == typeof(BigInteger):
+                        return stringBigIntegerDict
+                            .Select(kv => new KeyValuePair<string, BigInteger>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBytesDict
+                        when keyType == typeof(string) && valueType == typeof(ImmutableArray<byte>):
+                        return stringBytesDict
+                            .Select(kv => new KeyValuePair<string, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringGuidDict
+                        when keyType == typeof(string) && valueType == typeof(Guid):
+                        return stringGuidDict
+                            .Select(kv => new KeyValuePair<string, Guid>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringAddressDict
+                        when keyType == typeof(string) && valueType == typeof(Address):
+                        return stringAddressDict
+                            .Select(kv => new KeyValuePair<string, Address>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringStringDict
+                        when keyType == typeof(string) && valueType == typeof(string):
+                        return stringStringDict
+                            .Select(kv => new KeyValuePair<string, string>(kv.Key, kv.Value))
+                            .ToImmutableDictionary();
+                    default:
                         throw new ArgumentException(
-                            $"Invalid target value type {valueType} encountered.");
-                    }
-                }
-                else if (keyType == typeof(Guid))
-                {
-                    if (valueType == typeof(bool))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, bool>(
-                                (Guid)first, (bool)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(int))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, int>(
-                                (Guid)first, (int)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(long))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, long>(
-                                (Guid)first, (long)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(BigInteger))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, BigInteger>(
-                                (Guid)first, (BigInteger)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(ImmutableArray<byte>))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, ImmutableArray<byte>>(
-                                (Guid)first, (ImmutableArray<byte>)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Guid))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, Guid>(
-                                (Guid)first, (Guid)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Address))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, Address>(
-                                (Guid)first, (Address)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(string))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Guid, string>(
-                                (Guid)first, (string)second))
-                            .ToImmutableDictionary();
-                    }
-                    else
-                    {
-                        throw new ArgumentException(
-                            $"Invalid target value type {valueType} encountered.");
-                    }
-                }
-                else if (keyType == typeof(Address))
-                {
-                    if (valueType == typeof(bool))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, bool>(
-                                (Address)first, (bool)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(int))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, int>(
-                                (Address)first, (int)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(long))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, long>(
-                                (Address)first, (long)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(BigInteger))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, BigInteger>(
-                                (Address)first, (BigInteger)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(ImmutableArray<byte>))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, ImmutableArray<byte>>(
-                                (Address)first, (ImmutableArray<byte>)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Guid))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, Guid>(
-                                (Address)first, (Guid)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Address))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, Address>(
-                                (Address)first, (Address)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(string))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                            new KeyValuePair<Address, string>(
-                                (Address)first, (string)second))
-                            .ToImmutableDictionary();
-                    }
-                    else
-                    {
-                        throw new ArgumentException(
-                            $"Invalid target value type {valueType} encountered.");
-                    }
-                }
-                else if (keyType == typeof(string))
-                {
-                    if (valueType == typeof(bool))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, bool>((string)first, (bool)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(int))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, int>((string)first, (int)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(long))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, long>((string)first, (long)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(BigInteger))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, BigInteger>(
-                                    (string)first, (BigInteger)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(ImmutableArray<byte>))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, ImmutableArray<byte>>(
-                                    (string)first, (ImmutableArray<byte>)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Guid))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, Guid>(
-                                    (string)first, (Guid)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(Address))
-                    {
-                        return keys
-                            .Zip(values, (first, second) =>
-                                new KeyValuePair<string, Address>(
-                                    (string)first, (Address)second))
-                            .ToImmutableDictionary();
-                    }
-                    else if (valueType == typeof(string))
-                    {
-                        return keys.Zip(values, (first, second) =>
-                                new KeyValuePair<string, string>((string)first, (string)second))
-                            .ToImmutableDictionary();
-                    }
-                    else
-                    {
-                        throw new ArgumentException(
-                            $"Invalid target value type {valueType} encountered.");
-                    }
-                }
-                else
-                {
-                    throw new ArgumentException(
-                        $"Invalid target key type {keyType} encountered.");
+                            $"Invalid key {keyType} type and/or value {valueType} type encountered.");
+#pragma warning restore MEN002
                 }
             }
             else
             {
                 throw new ArgumentException(
                     $"Invalid target property type {type} encountered.");
-            }
-        }
-#pragma warning restore MEN003
-
-        private static IEnumerable DecodedKeys(BTypes.Dictionary dict, Type keyType)
-        {
-            if (keyType == typeof(ImmutableArray<byte>))
-            {
-                return dict.Select(kv =>
-                    kv.Key is BTypes.Binary bytes
-                        ? bytes.ByteArray
-                        : throw new ArgumentException(
-                            $"Invalid encoded key type {kv.Key.GetType()} encountered."));
-            }
-            else if (keyType == typeof(Guid))
-            {
-                return dict.Select(kv =>
-                    kv.Key is BTypes.Binary address
-                        ? new Guid(address.ToByteArray())
-                        : throw new ArgumentException(
-                            $"Invalid encoded key type {kv.Key.GetType()} encountered."));
-            }
-            else if (keyType == typeof(Address))
-            {
-                return dict.Select(kv =>
-                    kv.Key is BTypes.Binary address
-                        ? new Address(address.ByteArray)
-                        : throw new ArgumentException(
-                            $"Invalid encoded key type {kv.Key.GetType()} encountered."));
-            }
-            else if (keyType == typeof(string))
-            {
-                return dict.Select(kv =>
-                    kv.Key is BTypes.Text s
-                        ? s.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded key type {kv.Key.GetType()} encountered."));
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"Invalid target key type {keyType} encountered.");
-            }
-        }
-
-        private static IEnumerable DecodedValues(BTypes.Dictionary dict, Type valueType)
-        {
-            if (valueType == typeof(bool))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Boolean b
-                        ? b.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(int))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Integer i
-                        ? (int)i.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(long))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Integer l
-                        ? (long)l.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(BigInteger))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Integer bigInteger
-                        ? bigInteger.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(ImmutableArray<byte>))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Binary bytes
-                        ? bytes.ByteArray
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(Guid))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Binary address
-                        ? new Guid(address.ToByteArray())
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(Address))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Binary address
-                        ? new Address(address.ByteArray)
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else if (valueType == typeof(string))
-            {
-                return dict.Select(kv =>
-                    kv.Value is BTypes.Text s
-                        ? s.Value
-                        : throw new ArgumentException(
-                            $"Invalid encoded type {kv.Value.GetType()} encountered."));
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"Invalid target value type {valueType} encountered.");
             }
         }
     }

--- a/Libplanet/Store/DataModel.Decode.cs
+++ b/Libplanet/Store/DataModel.Decode.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Store
 {
     public abstract partial class DataModel
     {
-        private static object DecodeFromIValue(BTypes.IValue value, Type type)
+        private static dynamic DecodeFromIValue(BTypes.IValue value, Type type)
         {
             switch (value)
             {
@@ -53,28 +53,28 @@ namespace Libplanet.Store
                 Type[] genericTypes = type.GetGenericArguments();
                 Type genericType = genericTypes[0];
 
-                IEnumerable<object> tempList = list
+                IEnumerable<dynamic> tempList = list
                     .Select(x => DecodeFromIValue(x, genericType));
 
                 switch (tempList)
                 {
 #pragma warning disable MEN002
-                    case IEnumerable<object> listBool when genericType == typeof(bool):
-                        return listBool.Cast<bool>().ToImmutableList();
-                    case IEnumerable<object> listInt when genericType == typeof(int):
-                        return listInt.Cast<int>().ToImmutableList();
-                    case IEnumerable<object> listLong when genericType == typeof(long):
-                        return listLong.Cast<long>().ToImmutableList();
-                    case IEnumerable<object> listBigInteger when genericType == typeof(BigInteger):
-                        return listBigInteger.Cast<BigInteger>().ToImmutableList();
-                    case IEnumerable<object> listBytes when genericType == typeof(ImmutableArray<byte>):
-                        return listBytes.Cast<ImmutableArray<byte>>().ToImmutableList();
-                    case IEnumerable<object> listGuid when genericType == typeof(Guid):
-                        return listGuid.Cast<Guid>().ToImmutableList();
-                    case IEnumerable<object> listAddress when genericType == typeof(Address):
-                        return listAddress.Cast<Address>().ToImmutableList();
-                    case IEnumerable<object> listString when genericType == typeof(string):
-                        return listString.Cast<string>().ToImmutableList();
+                    case IEnumerable<dynamic> listBool when genericType == typeof(bool):
+                        return listBool.Select(x => (bool)x).ToImmutableList();
+                    case IEnumerable<dynamic> listInt when genericType == typeof(int):
+                        return listInt.Select(x => (int)x).ToImmutableList();
+                    case IEnumerable<dynamic> listLong when genericType == typeof(long):
+                        return listLong.Select(x => (long)x).ToImmutableList();
+                    case IEnumerable<dynamic> listBigInteger when genericType == typeof(BigInteger):
+                        return listBigInteger.Select(x => (BigInteger)x).ToImmutableList();
+                    case IEnumerable<dynamic> listBytes when genericType == typeof(ImmutableArray<byte>):
+                        return listBytes.Select(x => (ImmutableArray<byte>)x).ToImmutableList();
+                    case IEnumerable<dynamic> listGuid when genericType == typeof(Guid):
+                        return listGuid.Select(x => (Guid)x).ToImmutableList();
+                    case IEnumerable<dynamic> listAddress when genericType == typeof(Address):
+                        return listAddress.Select(x => (Address)x).ToImmutableList();
+                    case IEnumerable<dynamic> listString when genericType == typeof(string):
+                        return listString.Select(x => (string)x).ToImmutableList();
                     default:
                         throw new ArgumentException(
                             $"Invalid generic type {genericType} encountered.");

--- a/Libplanet/Store/DataModel.Encode.cs
+++ b/Libplanet/Store/DataModel.Encode.cs
@@ -55,8 +55,8 @@ namespace Libplanet.Store
                     return new BTypes.Binary(address.ByteArray);
                 case string s:
                     return new BTypes.Text(s);
-                case DataModel pvt:
-                    return pvt.Encode();
+                case DataModel dm:
+                    return dm.Encode();
                 case IList list:
                     return EncodeToListIValue(list);
                 case IDictionary dict:


### PR DESCRIPTION
Closes #1956.

Revisiting #1980.

To make sure that there will be no substantial performance, for reference, I'm leaving a benchmark result here.

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.413
  [Host]     : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT
  DefaultJob : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT


|             Method |       Mean |     Error |    StdDev |
|------------------- |-----------:|----------:|----------:|
|    EncodeRootModel | 5,661.5 us | 107.83 us | 110.74 us |
|    EncodeLeafModel | 1,645.6 us |  28.50 us |  25.26 us |
| EncodeRawLeafModel | 1,246.0 us |  22.13 us |  20.70 us |
|    DecodeRootModel | 3,246.3 us |  64.89 us |  88.82 us |
|    DecodeLeafModel | 1,034.1 us |  20.03 us |  18.73 us |
| DecodeRawLeafModel |   854.3 us |  16.65 us |  17.10 us |