### PR TITLE
Expose BlockLocator and Libplanet.Net related functions in BlockChain<T>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,13 @@ To be released.
 
 ### Added APIs
 
+ - Added `BlockLocator` class. [[#1762], [#2140]]
+ - Added methods required for decoupling `Libplanet.Net` from
+   `Libplanet`. [[#1762], [#2140]]
+   - Added `BlockChain<T>.FindNextHashes(BlockLocator, BlockHash?, int)` method.
+   - Added `BlockChain<T>.Fork(BlockHash, bool)` method.
+   - Added `BlockChain<T>.GetBlockLocator(int)` method.
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -23,6 +30,9 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#1762]: https://github.com/planetarium/libplanet/issues/1762
+[#2140]: https://github.com/planetarium/libplanet/pull/2140
 
 
 Version 0.39.0

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -840,6 +840,170 @@ namespace Libplanet.Blockchain
             return evaluations;
         }
 
+        /// <summary>
+        /// Find the branching point between this blockchain and <paramref name="locator"/>, and
+        /// the hashes of subsequent blocks from the point.</summary>
+        /// <param name="locator">The <see cref="BlockLocator"/> to find the branching point
+        /// from.</param>
+        /// <param name="stop">A block hash to stop looking for subsequent blocks once encountered.
+        /// </param>
+        /// <param name="count">Maximum number of block hashes to return.</param>
+        /// <returns>A tuple of the index of the branching point and block hashes.</returns>
+        public Tuple<long?, IReadOnlyList<BlockHash>> FindNextHashes(
+            BlockLocator locator,
+            BlockHash? stop = null,
+            int count = 500)
+        {
+            DateTimeOffset startTime = DateTimeOffset.Now;
+
+            // FIXME Theoretically, we don't accept empty chain. so `tip` can't be null on this
+            // assumption. but during some test case(e.g. GetDemandBlockHashesDuringReorg),
+            // it had been occurred.
+            // We should find a reason for that and fix it before remote this early return.
+            BlockHash? tip = Store.IndexBlockHash(Id, -1);
+            if (tip is null)
+            {
+                return new Tuple<long?, IReadOnlyList<BlockHash>>(null, new BlockHash[0]);
+            }
+
+            BlockHash? branchpoint = FindBranchpoint(locator);
+            var branchpointIndex = branchpoint is { } h ? (int)Store.GetBlockIndex(h)! : 0;
+
+            // FIXME: Currently, increasing count by one to satisfy
+            // the number defined by FindNextHashesChunkSize variable
+            // when branchPointIndex didn't indicate genesis block.
+            // Since branchPointIndex is same as the latest block of
+            // requesting peer.
+            if (branchpointIndex > 0)
+            {
+                count++;
+            }
+
+            var result = new List<BlockHash>();
+            foreach (BlockHash hash in Store.IterateIndexes(Id, branchpointIndex, count))
+            {
+                if (count == 0)
+                {
+                    break;
+                }
+
+                result.Add(hash);
+
+                if (hash.Equals(stop))
+                {
+                    break;
+                }
+
+                count--;
+            }
+
+            TimeSpan duration = DateTimeOffset.Now - startTime;
+            _logger
+                .ForContext("Tag", "Metric")
+                .ForContext("Subtag", "FindHashesDuration")
+                .Debug(
+                    "Found {HashCount} hashes from storage with {ChainIdCount} chain ids " +
+                    "in {DurationMs:F0}ms.",
+                    result.Count,
+                    Store.ListChainIds().Count(),
+                    duration.TotalMilliseconds);
+
+            return new Tuple<long?, IReadOnlyList<BlockHash>>(branchpointIndex, result);
+        }
+
+        /// <summary>
+        /// Forks the chain at <paramref name="point"/> and returns the newly forked chain.
+        /// </summary>
+        /// <param name="point">The hash in which to fork from.</param>
+        /// <param name="inheritRenderers">Whether to inherit the renderers from the existing chain.
+        /// </param>
+        /// <returns>An instance of the newly forked chain.</returns>
+        /// <exception cref="ArgumentException">Throws when the provided <paramref name="point"/>
+        /// does not exist in the current chain.</exception>
+        public BlockChain<T> Fork(BlockHash point, bool inheritRenderers = true)
+        {
+            if (!ContainsBlock(point))
+            {
+                throw new ArgumentException(
+                    $"The block [{point}] doesn't exist.",
+                    nameof(point));
+            }
+
+            Block<T> pointBlock = this[point];
+
+            if (!point.Equals(this[pointBlock.Index].Hash))
+            {
+                throw new ArgumentException(
+                    $"The block [{point}] doesn't exist in the chain index.",
+                    nameof(point));
+            }
+
+            IEnumerable<IRenderer<T>> renderers = inheritRenderers
+                ? Renderers
+                : Enumerable.Empty<IRenderer<T>>();
+            var forked = new BlockChain<T>(
+                Policy, StagePolicy, Store, StateStore, Guid.NewGuid(), Genesis, true, renderers);
+            Guid forkedId = forked.Id;
+            _logger.Debug(
+                "Trying to fork chain at {branchPoint}" +
+                "(prevId: {prevChainId}) (forkedId: {forkedChainId})",
+                point,
+                Id,
+                forkedId);
+            try
+            {
+                _rwlock.EnterReadLock();
+
+                Store.ForkBlockIndexes(Id, forkedId, point);
+                Store.ForkTxNonces(Id, forked.Id);
+
+                for (Block<T> block = Tip;
+                     block.PreviousHash is { } hash && !block.Hash.Equals(point);
+                     block = _blocks[hash])
+                {
+                    IEnumerable<(Address, int)> signers = block
+                        .Transactions
+                        .GroupBy(tx => tx.Signer)
+                        .Select(g => (g.Key, g.Count()));
+
+                    foreach ((Address address, int txCount) in signers)
+                    {
+                        Store.IncreaseTxNonce(forked.Id, address, -txCount);
+                    }
+                }
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
+
+            return forked;
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="BlockLocator"/> from the tip of current chain.
+        /// </summary>
+        /// <param name="threshold">The amount of consequent blocks to include before sampling.
+        /// </param>
+        /// <returns>A instance of block locator.</returns>
+        public BlockLocator GetBlockLocator(int threshold = 10)
+        {
+            try
+            {
+                _rwlock.EnterReadLock();
+
+                return new BlockLocator(
+                    indexBlockHash: idx => Store.IndexBlockHash(Id, idx),
+                    indexByBlockHash: hash => _blocks[hash].Index,
+                    sampleAfter: threshold
+                );
+            }
+            finally
+            {
+                _rwlock.ExitReadLock();
+            }
+        }
+
 #pragma warning disable MEN003
         internal void Append(
             Block<T> block,
@@ -1085,146 +1249,6 @@ namespace Libplanet.Blockchain
                     "Failed to find a branchpoint locator [{LocatorHead}, ...].",
                     locator.FirstOrDefault());
                 return null;
-            }
-            finally
-            {
-                _rwlock.ExitReadLock();
-            }
-        }
-
-        internal Tuple<long?, IReadOnlyList<BlockHash>> FindNextHashes(
-            BlockLocator locator,
-            BlockHash? stop = null,
-            int count = 500)
-        {
-            DateTimeOffset startTime = DateTimeOffset.Now;
-
-            // FIXME Theoretically, we don't accept empty chain. so `tip` can't be null on this
-            // assumption. but during some test case(e.g. GetDemandBlockHashesDuringReorg),
-            // it had been occurred.
-            // We should find a reason for that and fix it before remote this early return.
-            BlockHash? tip = Store.IndexBlockHash(Id, -1);
-            if (tip is null)
-            {
-                return new Tuple<long?, IReadOnlyList<BlockHash>>(null, new BlockHash[0]);
-            }
-
-            BlockHash? branchpoint = FindBranchpoint(locator);
-            var branchpointIndex = branchpoint is { } h ? (int)Store.GetBlockIndex(h)! : 0;
-
-            // FIXME: Currently, increasing count by one to satisfy
-            // the number defined by FindNextHashesChunkSize variable
-            // when branchPointIndex didn't indicate genesis block.
-            // Since branchPointIndex is same as the latest block of
-            // requesting peer.
-            if (branchpointIndex > 0)
-            {
-                count++;
-            }
-
-            var result = new List<BlockHash>();
-            foreach (BlockHash hash in Store.IterateIndexes(Id, branchpointIndex, count))
-            {
-                if (count == 0)
-                {
-                    break;
-                }
-
-                result.Add(hash);
-
-                if (hash.Equals(stop))
-                {
-                    break;
-                }
-
-                count--;
-            }
-
-            TimeSpan duration = DateTimeOffset.Now - startTime;
-            _logger
-                .ForContext("Tag", "Metric")
-                .ForContext("Subtag", "FindHashesDuration")
-                .Debug(
-                    "Found {HashCount} hashes from storage with {ChainIdCount} chain ids " +
-                    "in {DurationMs:F0}ms.",
-                    result.Count,
-                    Store.ListChainIds().Count(),
-                    duration.TotalMilliseconds);
-
-            return new Tuple<long?, IReadOnlyList<BlockHash>>(branchpointIndex, result);
-        }
-
-        internal BlockChain<T> Fork(BlockHash point, bool inheritRenderers = true)
-        {
-            if (!ContainsBlock(point))
-            {
-                throw new ArgumentException(
-                    $"The block [{point}] doesn't exist.",
-                    nameof(point));
-            }
-
-            Block<T> pointBlock = this[point];
-
-            if (!point.Equals(this[pointBlock.Index].Hash))
-            {
-                throw new ArgumentException(
-                    $"The block [{point}] doesn't exist in the chain index.",
-                    nameof(point));
-            }
-
-            IEnumerable<IRenderer<T>> renderers = inheritRenderers
-                ? Renderers
-                : Enumerable.Empty<IRenderer<T>>();
-            var forked = new BlockChain<T>(
-                Policy, StagePolicy, Store, StateStore, Guid.NewGuid(), Genesis, true, renderers);
-            Guid forkedId = forked.Id;
-            _logger.Debug(
-                "Trying to fork chain at {branchPoint}" +
-                "(prevId: {prevChainId}) (forkedId: {forkedChainId})",
-                point,
-                Id,
-                forkedId);
-            try
-            {
-                _rwlock.EnterReadLock();
-
-                Store.ForkBlockIndexes(Id, forkedId, point);
-                Store.ForkTxNonces(Id, forked.Id);
-
-                for (Block<T> block = Tip;
-                     block.PreviousHash is { } hash && !block.Hash.Equals(point);
-                     block = _blocks[hash])
-                {
-                    IEnumerable<(Address, int)> signers = block
-                        .Transactions
-                        .GroupBy(tx => tx.Signer)
-                        .Select(g => (g.Key, g.Count()));
-
-                    foreach ((Address address, int txCount) in signers)
-                    {
-                        Store.IncreaseTxNonce(forked.Id, address, -txCount);
-                    }
-                }
-            }
-            finally
-            {
-                _rwlock.ExitReadLock();
-            }
-
-            return forked;
-        }
-
-        internal BlockLocator GetBlockLocator(int threshold = 10)
-        {
-            try
-            {
-                _rwlock.EnterReadLock();
-
-                return new BlockLocator(
-                    indexBlockHash: idx => Store.IndexBlockHash(Id, idx),
-                    indexByBlockHash: hash => _blocks[hash].Index,
-                    sampleAfter: threshold
-                );
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -5,10 +5,23 @@ using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain
 {
-    internal class BlockLocator : IEnumerable<BlockHash>
+    /// <summary>
+    /// A class that contains the hashes for a series of blocks.
+    /// </summary>
+    public class BlockLocator : IEnumerable<BlockHash>
     {
         private readonly IEnumerable<BlockHash> _impl;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="BlockLocator"/> with a set of indexer
+        /// functions, sampling after <paramref name="sampleAfter"/> number of blocks.
+        /// </summary>
+        /// <param name="indexBlockHash">A function that converts an index to a
+        /// <see cref="BlockHash"/>.</param>
+        /// <param name="indexByBlockHash">A function that converts a <see cref="BlockHash"/> to its
+        /// index.</param>
+        /// <param name="sampleAfter">The number of consequent blocks to include before sampling.
+        /// </param>
         public BlockLocator(
             Func<long, BlockHash?> indexBlockHash,
             Func<BlockHash, long> indexByBlockHash,
@@ -40,11 +53,19 @@ namespace Libplanet.Blockchain
             _impl = hashes;
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="BlockLocator"/> from <paramref name="hashes"/>.
+        /// </summary>
+        /// <param name="hashes">Enumerable of <see cref="BlockHash"/>es to convert from.</param>
         public BlockLocator(IEnumerable<BlockHash> hashes)
         {
             _impl = hashes;
         }
 
+        /// <summary>
+        /// Gets the enumerator.
+        /// </summary>
+        /// <returns>The enumerator.</returns>
         public IEnumerator<BlockHash> GetEnumerator()
         {
             return _impl.GetEnumerator();


### PR DESCRIPTION
(Partially?) Implements #1762.
This PR does not completely decouple Libplanet.Net from Libplanet, but it exposes few APIs required to remove `[assembly: InternalsVisibleTo("Libplanet.Net")]` to the public. The exposed APIs are those of which does not seem to introduce severe side effects.