### PR TITLE
Use `object` instead of `dynamic` for Unity Mono compatibility.

### DIFF
--- a/Libplanet/Store/DataModel.Decode.cs
+++ b/Libplanet/Store/DataModel.Decode.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Store
 {
     public abstract partial class DataModel
     {
-        private static dynamic DecodeFromIValue(BTypes.IValue value, Type type)
+        private static object DecodeFromIValue(BTypes.IValue value, Type type)
         {
             switch (value)
             {
@@ -46,6 +46,7 @@ namespace Libplanet.Store
             }
         }
 
+#pragma warning disable MEN002 // Lines too long.
         private static object DecodeFromListIValue(BTypes.List list, Type type)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ImmutableList<>))
@@ -53,32 +54,30 @@ namespace Libplanet.Store
                 Type[] genericTypes = type.GetGenericArguments();
                 Type genericType = genericTypes[0];
 
-                IEnumerable<dynamic> tempList = list
+                IEnumerable<object> tempList = list
                     .Select(x => DecodeFromIValue(x, genericType));
 
                 switch (tempList)
                 {
-#pragma warning disable MEN002
-                    case IEnumerable<dynamic> listBool when genericType == typeof(bool):
+                    case IEnumerable<object> listBool when genericType == typeof(bool):
                         return listBool.Select(x => (bool)x).ToImmutableList();
-                    case IEnumerable<dynamic> listInt when genericType == typeof(int):
+                    case IEnumerable<object> listInt when genericType == typeof(int):
                         return listInt.Select(x => (int)x).ToImmutableList();
-                    case IEnumerable<dynamic> listLong when genericType == typeof(long):
+                    case IEnumerable<object> listLong when genericType == typeof(long):
                         return listLong.Select(x => (long)x).ToImmutableList();
-                    case IEnumerable<dynamic> listBigInteger when genericType == typeof(BigInteger):
+                    case IEnumerable<object> listBigInteger when genericType == typeof(BigInteger):
                         return listBigInteger.Select(x => (BigInteger)x).ToImmutableList();
-                    case IEnumerable<dynamic> listBytes when genericType == typeof(ImmutableArray<byte>):
+                    case IEnumerable<object> listBytes when genericType == typeof(ImmutableArray<byte>):
                         return listBytes.Select(x => (ImmutableArray<byte>)x).ToImmutableList();
-                    case IEnumerable<dynamic> listGuid when genericType == typeof(Guid):
+                    case IEnumerable<object> listGuid when genericType == typeof(Guid):
                         return listGuid.Select(x => (Guid)x).ToImmutableList();
-                    case IEnumerable<dynamic> listAddress when genericType == typeof(Address):
+                    case IEnumerable<object> listAddress when genericType == typeof(Address):
                         return listAddress.Select(x => (Address)x).ToImmutableList();
-                    case IEnumerable<dynamic> listString when genericType == typeof(string):
+                    case IEnumerable<object> listString when genericType == typeof(string):
                         return listString.Select(x => (string)x).ToImmutableList();
                     default:
                         throw new ArgumentException(
                             $"Invalid generic type {genericType} encountered.");
-#pragma warning restore MEN002
                 }
             }
             else
@@ -87,7 +86,9 @@ namespace Libplanet.Store
                     $"Invalid target property type {type} encountered.");
             }
         }
+#pragma warning restore MEN002
 
+#pragma warning disable MEN002, MEN003 // Lines too long; method too long.
         private static object DecodeFromDictionaryIValue(BTypes.Dictionary dict, Type type)
         {
             if (type.IsGenericType &&
@@ -97,185 +98,215 @@ namespace Libplanet.Store
                 Type keyType = genericTypes[0];
                 Type valueType = genericTypes[1];
 
-                IEnumerable<KeyValuePair<dynamic, dynamic>> tempDict = dict.Select(
-                    kv => new KeyValuePair<dynamic, dynamic>(
+                IEnumerable<KeyValuePair<object, object>> tempDict = dict.Select(
+                    kv => new KeyValuePair<object, object>(
                         DecodeFromIValue(kv.Key, keyType),
                         DecodeFromIValue(kv.Value, valueType)));
 
                 switch (tempDict)
                 {
-#pragma warning disable MEN002
                     // ImmutabeArray<byte> type keys.
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBoolDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesBoolDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(bool):
                         return bytesBoolDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, bool>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, bool>(
+                                (ImmutableArray<byte>)kv.Key, (bool)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesIntDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesIntDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(int):
                         return bytesIntDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, int>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, int>(
+                                (ImmutableArray<byte>)kv.Key, (int)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesLongDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesLongDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(long):
                         return bytesLongDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, long>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, long>(
+                                (ImmutableArray<byte>)kv.Key, (long)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBigIntegerDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesBigIntegerDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(BigInteger):
                         return bytesBigIntegerDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, BigInteger>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, BigInteger>(
+                                (ImmutableArray<byte>)kv.Key, (BigInteger)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesBytesDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesBytesDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(ImmutableArray<byte>):
                         return bytesBytesDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>(
+                                (ImmutableArray<byte>)kv.Key, (ImmutableArray<byte>)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesGuidDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesGuidDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(Guid):
                         return bytesGuidDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Guid>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Guid>(
+                                (ImmutableArray<byte>)kv.Key, (Guid)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesAddressDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesAddressDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(Address):
                         return bytesAddressDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Address>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, Address>(
+                                (ImmutableArray<byte>)kv.Key, (Address)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> bytesStringDict
+                    case IEnumerable<KeyValuePair<object, object>> bytesStringDict
                         when keyType == typeof(ImmutableArray<byte>) && valueType == typeof(string):
                         return bytesStringDict
-                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, string>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<ImmutableArray<byte>, string>(
+                                (ImmutableArray<byte>)kv.Key, (string)kv.Value))
                             .ToImmutableDictionary();
 
                     // Guid type keys.
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBoolDict
+                    case IEnumerable<KeyValuePair<object, object>> guidBoolDict
                         when keyType == typeof(Guid) && valueType == typeof(bool):
                         return guidBoolDict
-                            .Select(kv => new KeyValuePair<Guid, bool>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, bool>(
+                                (Guid)kv.Key, (bool)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidIntDict
+                    case IEnumerable<KeyValuePair<object, object>> guidIntDict
                         when keyType == typeof(Guid) && valueType == typeof(int):
                         return guidIntDict
-                            .Select(kv => new KeyValuePair<Guid, int>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, int>(
+                                (Guid)kv.Key, (int)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidLongDict
+                    case IEnumerable<KeyValuePair<object, object>> guidLongDict
                         when keyType == typeof(Guid) && valueType == typeof(long):
                         return guidLongDict
-                            .Select(kv => new KeyValuePair<Guid, long>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, long>(
+                                (Guid)kv.Key, (long)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBigIntegerDict
+                    case IEnumerable<KeyValuePair<object, object>> guidBigIntegerDict
                         when keyType == typeof(Guid) && valueType == typeof(BigInteger):
                         return guidBigIntegerDict
-                            .Select(kv => new KeyValuePair<Guid, BigInteger>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, BigInteger>(
+                                (Guid)kv.Key, (BigInteger)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidBytesDict
+                    case IEnumerable<KeyValuePair<object, object>> guidBytesDict
                         when keyType == typeof(Guid) && valueType == typeof(ImmutableArray<byte>):
                         return guidBytesDict
-                            .Select(kv => new KeyValuePair<Guid, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, ImmutableArray<byte>>(
+                                (Guid)kv.Key, (ImmutableArray<byte>)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidGuidDict
+                    case IEnumerable<KeyValuePair<object, object>> guidGuidDict
                         when keyType == typeof(Guid) && valueType == typeof(Guid):
                         return guidGuidDict
-                            .Select(kv => new KeyValuePair<Guid, Guid>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, Guid>(
+                                (Guid)kv.Key, (Guid)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidAddressDict
+                    case IEnumerable<KeyValuePair<object, object>> guidAddressDict
                         when keyType == typeof(Guid) && valueType == typeof(Address):
                         return guidAddressDict
-                            .Select(kv => new KeyValuePair<Guid, Address>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, Address>(
+                                (Guid)kv.Key, (Address)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> guidStringDict
+                    case IEnumerable<KeyValuePair<object, object>> guidStringDict
                         when keyType == typeof(Guid) && valueType == typeof(string):
                         return guidStringDict
-                            .Select(kv => new KeyValuePair<Guid, string>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Guid, string>(
+                                (Guid)kv.Key, (string)kv.Value))
                             .ToImmutableDictionary();
 
                     // Address type keys.
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBoolDict
+                    case IEnumerable<KeyValuePair<object, object>> addressBoolDict
                         when keyType == typeof(Address) && valueType == typeof(bool):
                         return addressBoolDict
-                            .Select(kv => new KeyValuePair<Address, bool>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, bool>(
+                                (Address)kv.Key, (bool)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressIntDict
+                    case IEnumerable<KeyValuePair<object, object>> addressIntDict
                         when keyType == typeof(Address) && valueType == typeof(int):
                         return addressIntDict
-                            .Select(kv => new KeyValuePair<Address, int>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, int>(
+                                (Address)kv.Key, (int)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressLongDict
+                    case IEnumerable<KeyValuePair<object, object>> addressLongDict
                         when keyType == typeof(Address) && valueType == typeof(long):
                         return addressLongDict
-                            .Select(kv => new KeyValuePair<Address, long>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, long>(
+                                (Address)kv.Key, (long)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBigIntegerDict
+                    case IEnumerable<KeyValuePair<object, object>> addressBigIntegerDict
                         when keyType == typeof(Address) && valueType == typeof(BigInteger):
                         return addressBigIntegerDict
-                            .Select(kv => new KeyValuePair<Address, BigInteger>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, BigInteger>(
+                                (Address)kv.Key, (BigInteger)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressBytesDict
+                    case IEnumerable<KeyValuePair<object, object>> addressBytesDict
                         when keyType == typeof(Address) && valueType == typeof(ImmutableArray<byte>):
                         return addressBytesDict
-                            .Select(kv => new KeyValuePair<Address, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, ImmutableArray<byte>>(
+                                (Address)kv.Key, (ImmutableArray<byte>)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressGuidDict
+                    case IEnumerable<KeyValuePair<object, object>> addressGuidDict
                         when keyType == typeof(Address) && valueType == typeof(Guid):
                         return addressGuidDict
-                            .Select(kv => new KeyValuePair<Address, Guid>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, Guid>(
+                                (Address)kv.Key, (Guid)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressAddressDict
+                    case IEnumerable<KeyValuePair<object, object>> addressAddressDict
                         when keyType == typeof(Address) && valueType == typeof(Address):
                         return addressAddressDict
-                            .Select(kv => new KeyValuePair<Address, Address>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, Address>(
+                                (Address)kv.Key, (Address)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> addressStringDict
+                    case IEnumerable<KeyValuePair<object, object>> addressStringDict
                         when keyType == typeof(Address) && valueType == typeof(string):
                         return addressStringDict
-                            .Select(kv => new KeyValuePair<Address, string>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<Address, string>(
+                                (Address)kv.Key, (string)kv.Value))
                             .ToImmutableDictionary();
 
                     // string type keys.
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBoolDict
+                    case IEnumerable<KeyValuePair<object, object>> stringBoolDict
                         when keyType == typeof(string) && valueType == typeof(bool):
                         return stringBoolDict
-                            .Select(kv => new KeyValuePair<string, bool>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, bool>(
+                                (string)kv.Key, (bool)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringIntDict
+                    case IEnumerable<KeyValuePair<object, object>> stringIntDict
                         when keyType == typeof(string) && valueType == typeof(int):
                         return stringIntDict
-                            .Select(kv => new KeyValuePair<string, int>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, int>(
+                                (string)kv.Key, (int)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringLongDict
+                    case IEnumerable<KeyValuePair<object, object>> stringLongDict
                         when keyType == typeof(string) && valueType == typeof(long):
                         return stringLongDict
-                            .Select(kv => new KeyValuePair<string, long>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, long>(
+                                (string)kv.Key, (long)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBigIntegerDict
+                    case IEnumerable<KeyValuePair<object, object>> stringBigIntegerDict
                         when keyType == typeof(string) && valueType == typeof(BigInteger):
                         return stringBigIntegerDict
-                            .Select(kv => new KeyValuePair<string, BigInteger>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, BigInteger>(
+                                (string)kv.Key, (BigInteger)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringBytesDict
+                    case IEnumerable<KeyValuePair<object, object>> stringBytesDict
                         when keyType == typeof(string) && valueType == typeof(ImmutableArray<byte>):
                         return stringBytesDict
-                            .Select(kv => new KeyValuePair<string, ImmutableArray<byte>>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, ImmutableArray<byte>>(
+                                (string)kv.Key, (ImmutableArray<byte>)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringGuidDict
+                    case IEnumerable<KeyValuePair<object, object>> stringGuidDict
                         when keyType == typeof(string) && valueType == typeof(Guid):
                         return stringGuidDict
-                            .Select(kv => new KeyValuePair<string, Guid>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, Guid>(
+                                (string)kv.Key, (Guid)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringAddressDict
+                    case IEnumerable<KeyValuePair<object, object>> stringAddressDict
                         when keyType == typeof(string) && valueType == typeof(Address):
                         return stringAddressDict
-                            .Select(kv => new KeyValuePair<string, Address>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, Address>(
+                                (string)kv.Key, (Address)kv.Value))
                             .ToImmutableDictionary();
-                    case IEnumerable<KeyValuePair<dynamic, dynamic>> stringStringDict
+                    case IEnumerable<KeyValuePair<object, object>> stringStringDict
                         when keyType == typeof(string) && valueType == typeof(string):
                         return stringStringDict
-                            .Select(kv => new KeyValuePair<string, string>(kv.Key, kv.Value))
+                            .Select(kv => new KeyValuePair<string, string>(
+                                (string)kv.Key, (string)kv.Value))
                             .ToImmutableDictionary();
                     default:
                         throw new ArgumentException(
                             $"Invalid key {keyType} type and/or value {valueType} type encountered.");
-#pragma warning restore MEN002
                 }
             }
             else
@@ -284,5 +315,6 @@ namespace Libplanet.Store
                     $"Invalid target property type {type} encountered.");
             }
         }
+#pragma warning restore MEN002, MEN003
     }
 }


### PR DESCRIPTION
Closes #2143.

See #2137 for performance comparison.

Seems like we have slightly uglier code with slightly slower decoding. 🙄
Not as slow as I have originally worried.
Need to make sure this passes `linux-unity-test`.

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.413
  [Host]     : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT
  DefaultJob : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT


|             Method |       Mean |     Error |    StdDev |     Median |
|------------------- |-----------:|----------:|----------:|-----------:|
|    EncodeRootModel | 5,556.3 us | 110.62 us | 122.96 us | 5,553.7 us |
|    EncodeLeafModel | 1,662.1 us |  32.46 us |  30.37 us | 1,664.6 us |
| EncodeRawLeafModel | 1,232.2 us |  22.04 us |  22.63 us | 1,241.7 us |
|    DecodeRootModel | 2,988.3 us |  59.27 us | 131.34 us | 2,957.7 us |
|    DecodeLeafModel |   904.1 us |  17.87 us |  20.58 us |   899.8 us |
| DecodeRawLeafModel |   840.1 us |  16.68 us |  46.50 us |   823.3 us |
