### PR TITLE
Slightly improve CI/CD experience

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,8 @@ commands:
               LC_ALL: "<<parameters.locale>>"
               LANG: "<<parameters.locale>>"
               LANGUAGE: "<<parameters.locale>>"
+        - store_test_results:
+            path: /tmp/junit
 
   macos_netcore_test_base:
     parameters:

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,11 +2,12 @@ addReviewers: true
 addAssignees: author
 
 reviewers:
+- colibrishin
 - dahlia
-- longfin
-- limebell
-- riemannulus
 - greymistcube
-#- kfangw
+- limebell
+- longfin
+- OnedgeLee
+- riemannulus
 
 numberOfReviewers: 0

--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -34,6 +34,7 @@ package_version="$(cat obj/package_version.txt)"
 for project in "${projects[@]}"; do
   dotnet-nuget push \
     "./$project/bin/$configuration/$project.$package_version.nupkg" \
+    --skip-duplicate \
     --api-key "$NUGET_API_KEY" \
     --source https://api.nuget.org/v3/index.json
 done


### PR DESCRIPTION
- `dotnet nuget push` had been failed when we re-run a job triggered by a tag push (due to its flakiness).  Now such failure would not happen as it ignores NuGet packages of already uploaded versions.
- Test report XMLs hadn't been collected for tests without code coverage.  (I omitted it by mistake.)  It's now fixed.
- @colibrishin & @OnedgeLee are added to the auto-assign list.