### PR TITLE
Workaround for `dotnet test --list-tests` omitting newlines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,10 @@ commands:
           fi
           dotnet test --no-restore --no-build -c Release --list-tests \
           > .dotnet-list-tests.txt
-          grep -E '^    ' .dotnet-list-tests.txt \
+          grep '    ' .dotnet-list-tests.txt \
+          | sed 's/    /\n    /g' \
+          | sed '/^$/d' \
+          | grep '^    ' \
           | sed -E 's/^    |\(.*?\)$//g' \
           | uniq \
           | /usr/bin/sort -R --random-source=CHANGES.md \


### PR DESCRIPTION
Resolves #1598.

First we grep by four spaces (`    `) to find lines containing test cases, then replace with `\n    `. Then, we remove the consecutive multiple newlines, followed by another grep by four spaces to isolate only test cases.