### PR TITLE
Fix timestamp-related problems in RocksDBStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ To be released.
 
 ### Behavioral changes
 
+ -  `BlockChain<T>.PerceiveBlock()` method now uses millisecond precision for
+    perceive time of newly perceived blocks. [[#2155], [#2159]]
+
 ### Bug fixes
 
 ### Dependencies
@@ -33,6 +36,8 @@ To be released.
 
 [#1762]: https://github.com/planetarium/libplanet/issues/1762
 [#2140]: https://github.com/planetarium/libplanet/pull/2140
+[#2155]: https://github.com/planetarium/libplanet/issues/2155
+[#2159]: https://github.com/planetarium/libplanet/pull/2159
 
 
 Version 0.39.0

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -702,7 +702,7 @@ namespace Libplanet.RocksDBStore
             }
 
             long timestamp = tx.Timestamp.ToUnixTimeSeconds();
-            string txDbName = $"epoch{(int)timestamp / _txEpochUnitSeconds}";
+            string txDbName = $"epoch{timestamp / _txEpochUnitSeconds}";
             _rwTxLock.EnterWriteLock();
             try
             {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -128,7 +128,8 @@ namespace Libplanet.Tests.Blockchain
                 TotalDifficulty = 21584061959429,
             };
 
-            DateTimeOffset timeBMin = DateTimeOffset.UtcNow;
+            DateTimeOffset timeBMin = DateTimeOffset.FromUnixTimeMilliseconds(
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             BlockPerception perceptionB = _blockChain.PerceiveBlock(blockB);
             DateTimeOffset timeBMax = DateTimeOffset.UtcNow;
             Assert.True(blockB.ExcerptEquals(perceptionB));

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -709,7 +709,8 @@ namespace Libplanet.Blockchain
         {
             if (!(Store.GetBlockPerceivedTime(blockExcerpt.Hash) is { } time))
             {
-                time = perceivedTime ?? DateTimeOffset.UtcNow;
+                time = perceivedTime ?? DateTimeOffset.FromUnixTimeMilliseconds(
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                 Store.SetBlockPerceivedTime(blockExcerpt.Hash, time);
             }
 


### PR DESCRIPTION
Resolves #2155.

The overflow was due to trying to cast `timestamp` to `int`, whereas `timestamp` can be anything in the range of `Int64`. Specifically, in `BlockChainTest`, the timestamp used for txs are set to Jan 1st 0, which is well outside `Int32`. `int` cast was removed.

`RocksDBStore` was using `DateTimeOffset.ToUnixMilliseconds` in `PutBlock`, which reduces the precision to at most miliseconds. As such, tests were failing for `PerceivedTime` since the default value for it was derived by `DateTimeOffset.UtcNow` which has more precision. Now, the default value for `PerceivedTime` has millisecond precision.