### PR TITLE
Native tokens & system actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Added `IBlockPolicy<T>.NativeTokens` property.  [[#2149], [#2150], [#2175]]
+ -  Added option `IImmutableSet<Currency>? nativeTokens` to `BlockPolicy<T>()`
+    constructor as its last parameter.  [[#2149], [#2150], [#2175]]
  -  Removed `ChainIdNotFoundException` class. [[#2047], [#2156]]
  -  Added `IStore.GetCanonicalGenesisBlock(HashAlgorithmGetter)` method.
     [[#2162], [#2171]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,22 @@ To be released.
  -  Added `IBlockPolicy<T>.NativeTokens` property.  [[#2149], [#2150], [#2175]]
  -  Added option `IImmutableSet<Currency>? nativeTokens` to `BlockPolicy<T>()`
     constructor as its last parameter.  [[#2149], [#2150], [#2175]]
+ -  Added `IActionContext.IsNativeToken(Currency)` method.
+    [[#2149], [#2150], [#2175]]
+ -  Added parameter `Predicate<Currency> nativeTokenPredicate` to
+    all `PreEvaluationBlock<T>.Evaluate()` method as its second parameter
+    (parameter `IStateStore stateStore` remains at the last).
+    [[#2149], [#2150], [#2175]]
+ -  Added parameter `Predicate<Currency> nativeTokenPredicate` to
+    all `PreEvaluationBlock<T>.DetermineStateRootHash()` overloads as their
+    second parameter (existing second and rest parameters were shifted).
+    [[#2149], [#2150], [#2175]]
+ -  Added parameter `Predicate<Currency> nativeTokenPredicate` to
+    `BlockChain<T>.MakeGenesisBlock()` method as its last parameter.
+    [[#2149], [#2150], [#2175]]
+ -  Added parameter `Predicate<Currency> nativeTokenPredicate` to
+    `ActionEvaluator<T>()` constructor as its last parameter.
+    [[#2149], [#2150], [#2175]]
  -  Removed `ChainIdNotFoundException` class. [[#2047], [#2156]]
  -  Added `IStore.GetCanonicalGenesisBlock(HashAlgorithmGetter)` method.
     [[#2162], [#2171]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Added `IBlockPolicy<T>.NativeTokens` property.  [[#2149], [#2150], [#2175]]
  -  Removed `ChainIdNotFoundException` class. [[#2047], [#2156]]
  -  Added `IStore.GetCanonicalGenesisBlock(HashAlgorithmGetter)` method.
     [[#2162], [#2171]]
@@ -53,12 +54,15 @@ To be released.
 [#1972]: https://github.com/planetarium/libplanet/issues/1972
 [#2047]: https://github.com/planetarium/libplanet/issues/2047
 [#2140]: https://github.com/planetarium/libplanet/pull/2140
+[#2149]: https://github.com/planetarium/libplanet/issues/2149
+[#2150]: https://github.com/planetarium/libplanet/issues/2150
 [#2155]: https://github.com/planetarium/libplanet/issues/2155
 [#2156]: https://github.com/planetarium/libplanet/pull/2156
 [#2159]: https://github.com/planetarium/libplanet/pull/2159
 [#2162]: https://github.com/planetarium/libplanet/issues/2162
 [#2171]: https://github.com/planetarium/libplanet/pull/2171
 [#2173]: https://github.com/planetarium/libplanet/pull/2173
+[#2175]: https://github.com/planetarium/libplanet/issues/2175
 [#2179]: https://github.com/planetarium/libplanet/pull/2179
 [#2183]: https://github.com/planetarium/libplanet/pull/2183
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,12 +42,13 @@ To be released.
  -  (Libplanet.Explorer) Added `unsignedTransaction`, `bindSignature` and
     `transactionResult` GraphQL fields to `TransactionQuery<T>`.  [[#2130]]
 
- - Added `BlockLocator` class. [[#1762], [#2140]]
- - Added methods required for decoupling `Libplanet.Net` from
-   `Libplanet`. [[#1762], [#2140]]
-   - Added `BlockChain<T>.FindNextHashes(BlockLocator, BlockHash?, int)` method.
-   - Added `BlockChain<T>.Fork(BlockHash, bool)` method.
-   - Added `BlockChain<T>.GetBlockLocator(int)` method.
+ -  Added `BlockLocator` class. [[#1762], [#2140]]
+ -  Added methods required for decoupling *Libplanet.Net* from
+    *Libplanet*. [[#1762], [#2140]]
+     -  Added `BlockChain<T>.FindNextHashes(BlockLocator, BlockHash?, int)`
+        method.
+     -  Added `BlockChain<T>.Fork(BlockHash, bool)` method.
+     -  Added `BlockChain<T>.GetBlockLocator(int)` method.
  -  Added `IActionContext.GenesisHash` property.  [[#1972], [#2179]]
  -  Added `ActionEvaluator<T>.GenesisHash` property.  [[#1972], [#2179]]
  -  Added `IAccountStateView` interface.  [[#2183]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,8 @@ To be released.
         method.
      -  Added `TxMetadata.ToBencodex(IValue, ImmutableArray<byte>?)` overloaded
         method.
+ -  Introduced new system built-in actions.  [[#2149], [#2150], [#2175]]
+     -  Added `Transfer` class.
  -  Added `NonNativeTokenException` class.  [[#2149], [#2150], [#2175]]
  -  Added `BlockLocator` class. [[#1762], [#2140]]
  -  Added methods required for decoupling *Libplanet.Net* from

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,36 @@ To be released.
 
 ### Deprecated APIs
 
+ -  `Transaction<T>(long, Address, PublicKey, BlockHash?,
+    IImmutableSet<Address>, DateTimeOffset, IEnumerable<T>, byte[])` constructor
+    is now deprecated.  Use `Transaction<T>(ITxMetadata, IEnumerable<T>,
+    byte[])` constructor or `Transaction<T>.Create()` static method instead.
+    [[#2175]]
+ -  `Transaction<T>.Actions` property is now deprecated.  Use
+    `Transaction<T>.SystemAction` property or `Transaction<T>.CustomActions`
+    property instead.  [[#2149], [#2151], [#2175]]
+
 ### Backward-incompatible API changes
 
+ -  The type of `Transaction<T>.Actions` property became
+    `IImmutableList<IAction>` (was `IImmutableList<T>` where `T : IAction,
+    new()`).  [[#2149], [#2151], [#2175]]
+ -  Renamed parameters named `actions` of many methods to `customActions`.
+    [[#2149], [#2151], [#2175]]
+     -  Renamed `Transaction<T>(ITxMetadata, IEnumerable<T>, byte[])`
+        constructor's parameter `actions` to `customActions`.
+     -  Renamed `Transaction<T>(long, Address, PublicKey, BlockHash?,
+        IImmutableSet<Address>, DateTimeOffset, IEnumerable<T>, byte[])`
+        constructor's parameter `actions` to `customActions`.
+     -  Renamed `Transaction<T>.Create(long, PrivateKey, BlockHash?,
+        IEnumerable<T>, IImmutableSet<Address>?, DateTimeOffset?)` static
+        method's parameter `actions` to `customActions`.
+     -  Renamed `Transaction<T>.CreateUnsigned(long, PrivateKey, BlockHash?,
+        IEnumerable<T>, IImmutableSet<Address>?, DateTimeOffset?)` static
+        method's parameter `actions` to `customActions`.
+     -  Renamed `TxMetadata.ToBencodex(IEnumerable<IValue>,
+        IImmutableArray<byte>?)` method's parameter `actions` to
+        `customActions`.
  -  Added `IBlockPolicy<T>.NativeTokens` property.  [[#2149], [#2150], [#2175]]
  -  Added option `IImmutableSet<Currency>? nativeTokens` to `BlockPolicy<T>()`
     constructor as its last parameter.  [[#2149], [#2150], [#2175]]
@@ -42,6 +70,19 @@ To be released.
  -  (Libplanet.Explorer) Added `unsignedTransaction`, `bindSignature` and
     `transactionResult` GraphQL fields to `TransactionQuery<T>`.  [[#2130]]
 
+ -  Added `Transaction<T>.SystemAction` property.  [[#2149], [#2151], [#2175]]
+ -  Added `Transaction<T>.CustomActions` property.  [[#2149], [#2151], [#2175]]
+ -  Added overloads to take `systemAction` besides the existing constructors and
+    methods taking `customActions`.  [[#2149], [#2151], [#2175]]
+     -  Added `Transaction<T>(ITxMetadata, IAction, byte[])` overloaded
+        constructor.
+     -  Added `Transaction<T>.Create(long, PrivateKey, BlockHash?, IAction,
+        IImmutableSet<Address>?, DateTimeOffset?)` overloaded static method.
+     -  Added `Transaction<T>.CreateUnsigned(long, PrivateKey, BlockHash?,
+        IAction, IImmutableSet<Address>?, DateTimeOffset?)` overloaded static
+        method.
+     -  Added `TxMetadata.ToBencodex(IValue, ImmutableArray<byte>?)` overloaded
+        method.
  -  Added `NonNativeTokenException` class.  [[#2149], [#2150], [#2175]]
  -  Added `BlockLocator` class. [[#1762], [#2140]]
  -  Added methods required for decoupling *Libplanet.Net* from
@@ -76,6 +117,7 @@ To be released.
 [#2140]: https://github.com/planetarium/libplanet/pull/2140
 [#2149]: https://github.com/planetarium/libplanet/issues/2149
 [#2150]: https://github.com/planetarium/libplanet/issues/2150
+[#2151]: https://github.com/planetarium/libplanet/issues/2151
 [#2155]: https://github.com/planetarium/libplanet/issues/2155
 [#2156]: https://github.com/planetarium/libplanet/pull/2156
 [#2159]: https://github.com/planetarium/libplanet/pull/2159

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@ To be released.
      -  Added `TxMetadata.ToBencodex(IValue, ImmutableArray<byte>?)` overloaded
         method.
  -  Introduced new system built-in actions.  [[#2149], [#2150], [#2175]]
+     -  Added `Mint` class.
      -  Added `Transfer` class.
  -  Added `NonNativeTokenException` class.  [[#2149], [#2150], [#2175]]
  -  Added `BlockLocator` class. [[#1762], [#2140]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@ To be released.
  -  (Libplanet.Explorer) Added `unsignedTransaction`, `bindSignature` and
     `transactionResult` GraphQL fields to `TransactionQuery<T>`.  [[#2130]]
 
+ -  Added `NonNativeTokenException` class.  [[#2149], [#2150], [#2175]]
  -  Added `BlockLocator` class. [[#1762], [#2140]]
  -  Added methods required for decoupling *Libplanet.Net* from
     *Libplanet*. [[#1762], [#2140]]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Bencodex.Types;
 using Cocona;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -396,6 +397,9 @@ If omitted (default) explorer only the local blockchain store.")]
             }
 
             public IAction BlockAction => _impl.BlockAction;
+
+            /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
+            public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
 
             public IComparer<IBlockExcerpt> CanonicalChainComparer =>
                 _impl.CanonicalChainComparer;

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -200,14 +200,10 @@ namespace Libplanet.Explorer.Queries
                             false
                         );
                     var signedTransaction = new Transaction<T>(
-                        unsignedTransaction.Nonce,
-                        unsignedTransaction.Signer,
-                        unsignedTransaction.PublicKey,
-                        unsignedTransaction.GenesisHash,
-                        unsignedTransaction.UpdatedAddresses,
-                        unsignedTransaction.Timestamp,
-                        unsignedTransaction.Actions,
-                        signature);
+                        metadata: unsignedTransaction,
+                        customActions: unsignedTransaction.CustomActions,
+                        signature: signature
+                    );
 
                     return ByteUtil.Hex(signedTransaction.Serialize(true));
                 }

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -128,7 +128,11 @@ namespace Libplanet.Net.Tests
                 Timestamp = DateTimeOffset.MinValue,
             }
                 .Mine(policy.GetHashAlgorithm(0))
-                .Evaluate(receiverKey, policy.BlockAction, seedStateStore);
+                .Evaluate(
+                    privateKey: receiverKey,
+                    blockAction: policy.BlockAction,
+                    nativeTokenPredicate: policy.NativeTokens.Contains,
+                    stateStore: seedStateStore);
             BlockChain<DumbAction> seedChain = MakeBlockChain(
                 policy,
                 new MemoryStore(),

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -64,7 +64,7 @@ namespace Libplanet.Net.Tests
                 }
             }
 
-            return (blocks[1].Transactions.First().Actions.First().TargetAddress, blocks);
+            return (blocks[1].Transactions.First().CustomActions.First().TargetAddress, blocks);
         }
 
         private Swarm<DumbAction> CreateSwarm(

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -891,7 +891,11 @@ namespace Libplanet.Net.Tests
                     policy,
                     new MemoryStore(),
                     stateStore,
-                    genesisBlock: genesisBlock.Evaluate(minerKey, policy.BlockAction, stateStore)
+                    genesisBlock: genesisBlock.Evaluate(
+                        privateKey: minerKey,
+                        blockAction: policy.BlockAction,
+                        nativeTokenPredicate: policy.NativeTokens.Contains,
+                        stateStore: stateStore)
                 );
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -953,7 +953,7 @@ namespace Libplanet.Net.Tests
                         0,
                         new PrivateKey(),
                         miner1.BlockChain.Genesis.Hash,
-                        actions: new[] { new Sleep() }
+                        customActions: new[] { new Sleep() }
                     )
                 );
                 var b = await miner1.BlockChain.MineBlock(key1);

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -694,7 +694,7 @@ namespace Libplanet.Net
                     transactions = block.Transactions.ToImmutableArray();
                 txsCount += transactions.Count();
                 actionsCount +=
-                    transactions.Sum(tx => tx.Actions.Count);
+                    transactions.Sum(tx => tx.CustomActions is { } ca ? ca.Count : 1L);
 
                 _logger.Debug(
                     "Executed actions in block #{Index} {Hash}.",

--- a/Libplanet.Node.Tests/UntypedBlockTest.cs
+++ b/Libplanet.Node.Tests/UntypedBlockTest.cs
@@ -36,14 +36,14 @@ namespace Libplanet.Node.Tests
                 nonce: 0L,
                 privateKey: _signerKey,
                 genesisHash: null,
-                actions: Enumerable.Empty<NullAction>(),
+                customActions: Enumerable.Empty<NullAction>(),
                 timestamp: new DateTimeOffset(2022, 5, 24, 0, 0, 0, TimeSpan.Zero)
             );
             var txB = Transaction<NullAction>.Create(
                 nonce: 1L,
                 privateKey: _signerKey,
                 genesisHash: null,
-                actions: new[]
+                customActions: new[]
                 {
                     new NullAction(),
                     new NullAction(),
@@ -112,7 +112,7 @@ namespace Libplanet.Node.Tests
             var untypedTxs = _txs.Select(tx =>
                 new UntypedTransaction(
                     tx,
-                    tx.Actions.Select(a => a.PlainValue),
+                    tx.CustomActions.Select(a => a.PlainValue),
                     tx.Signature.ToImmutableArray()));
             var untyped = new UntypedBlock(_block, untypedTxs);
             Assert.Equal(_block.MarshalBlock(), untyped.ToBencodex());

--- a/Libplanet.Node.Tests/UntypedBlockTest.cs
+++ b/Libplanet.Node.Tests/UntypedBlockTest.cs
@@ -72,9 +72,10 @@ namespace Libplanet.Node.Tests
             var proof = (nonce, preEvalHash);
             _preEval = new PreEvaluationBlock<NullAction>(_content, Sha256, proof);
             _block = _preEval.Evaluate(
-                _minerKey,
-                null,
-                new TrieStateStore(new MemoryKeyValueStore())
+                privateKey: _minerKey,
+                blockAction: null,
+                nativeTokenPredicate: _ => true,
+                stateStore: new TrieStateStore(new MemoryKeyValueStore())
             );
         }
 

--- a/Libplanet.Node.Tests/UntypedTransactionTest.cs
+++ b/Libplanet.Node.Tests/UntypedTransactionTest.cs
@@ -105,7 +105,8 @@ namespace Libplanet.Node.Tests
                 e.TxId
             );
 
-            var invalidActionsDict = signedDict.SetItem(TxMetadata.ActionsKey, (IValue)new List());
+            var invalidActionsDict =
+                signedDict.SetItem(TxMetadata.CustomActionsKey, (IValue)new List());
             e = Assert.Throws<InvalidTxSignatureException>(
                 () => new UntypedTransaction(invalidActionsDict)
             );

--- a/Libplanet.Node/NodeUtils.cs
+++ b/Libplanet.Node/NodeUtils.cs
@@ -70,9 +70,10 @@ namespace Libplanet.Node
                 })
                 .Mine(blockPolicy.GetHashAlgorithm(0L))
                 .Evaluate(
-                    privateKey,
-                    blockPolicy.BlockAction,
-                    new TrieStateStore(new MemoryKeyValueStore()));
+                    privateKey: privateKey,
+                    blockAction: blockPolicy.BlockAction,
+                    nativeTokenPredicate: blockPolicy.NativeTokens.Contains,
+                    stateStore: new TrieStateStore(new MemoryKeyValueStore()));
         }
 
         /// <summary>

--- a/Libplanet.Node/UntypedTransaction.cs
+++ b/Libplanet.Node/UntypedTransaction.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Node
         public UntypedTransaction(Bencodex.Types.Dictionary dictionary)
             : this(
                 new TxMetadata(dictionary),
-                dictionary.GetValue<List>(TxMetadata.ActionsKey),
+                dictionary.GetValue<List>(TxMetadata.CustomActionsKey),
                 dictionary.GetValue<Binary>(TxMetadata.SignatureKey).ByteArray)
         {
         }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -79,13 +79,14 @@ namespace Libplanet.Tests.Action
                 transactions: txs
             );
             Block<RandomAction> stateRootBlock =
-                noStateRootBlock.Evaluate(GenesisMiner, null, stateStore);
+                noStateRootBlock.Evaluate(GenesisMiner, null, _ => true, stateStore);
             var actionEvaluator =
                 new ActionEvaluator<RandomAction>(
                     policyBlockAction: null,
                     blockChainStates: NullChainStates<RandomAction>.Instance,
                     trieGetter: null,
-                    genesisHash: null);
+                    genesisHash: null,
+                    nativeTokenPredicate: _ => true);
             var generatedRandomNumbers = new List<int>();
 
             AssertPreEvaluationBlocksEqual(stateRootBlock, noStateRootBlock);
@@ -281,7 +282,9 @@ namespace Libplanet.Tests.Action
                 policyBlockAction: null,
                 blockChainStates: NullChainStates<DumbAction>.Instance,
                 trieGetter: null,
-                genesisHash: null);
+                genesisHash: null,
+                nativeTokenPredicate: _ => true
+            );
             IAccountStateDelta previousStates = genesis.ProtocolVersion > 0
                 ? new AccountStateDeltaImpl(
                     ActionEvaluator<DumbAction>.NullAccountStateGetter,
@@ -584,7 +587,8 @@ namespace Libplanet.Tests.Action
                 policyBlockAction: null,
                 blockChainStates: NullChainStates<DumbAction>.Instance,
                 trieGetter: null,
-                genesisHash: tx.GenesisHash);
+                genesisHash: tx.GenesisHash,
+                nativeTokenPredicate: _ => true);
 
             foreach (bool rehearsal in new[] { false, true })
             {
@@ -712,7 +716,9 @@ namespace Libplanet.Tests.Action
                 policyBlockAction: null,
                 blockChainStates: NullChainStates<ThrowException>.Instance,
                 trieGetter: null,
-                genesisHash: tx.GenesisHash);
+                genesisHash: tx.GenesisHash,
+                nativeTokenPredicate: _ => true
+            );
             var block = new BlockContent<ThrowException>
             {
                 Index = 123,
@@ -761,7 +767,9 @@ namespace Libplanet.Tests.Action
                 actions: txA.Actions.ToImmutableArray<IAction>(),
                 rehearsal: rehearsal,
                 previousBlockStatesTrie: fx.GetTrie(blockA.PreviousHash),
-                blockAction: false).ToArray();
+                blockAction: false,
+                nativeTokenPredicate: _ => true
+            ).ToArray();
 
             Assert.Equal(evalsA.Length, deltaA.Count - 1);
             for (int i = 0; i < evalsA.Length; i++)
@@ -811,7 +819,9 @@ namespace Libplanet.Tests.Action
                 actions: txB.Actions.ToImmutableArray<IAction>(),
                 rehearsal: rehearsal,
                 previousBlockStatesTrie: fx.GetTrie(blockB.PreviousHash),
-                blockAction: false).ToArray();
+                blockAction: false,
+                nativeTokenPredicate: _ => true
+            ).ToArray();
 
             Assert.Equal(evalsB.Length, deltaB.Count - 1);
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Tests.Action
                     nonce: 0,
                     privateKey: signer,
                     genesisHash: null,
-                    actions: new[] { new RandomAction(txAddress), }),
+                    customActions: new[] { new RandomAction(txAddress), }),
             };
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             HashAlgorithmGetter hashAlgorithmGetter = _ => HashAlgorithmType.Of<SHA256>();
@@ -130,7 +130,7 @@ namespace Libplanet.Tests.Action
                 nonce: 0,
                 privateKey: privateKey,
                 genesisHash: chain.Genesis.Hash,
-                actions: new[] { action });
+                customActions: new[] { action });
 
             chain.StageTransaction(tx);
             var miner = new PrivateKey();
@@ -167,7 +167,7 @@ namespace Libplanet.Tests.Action
                 nonce: 0,
                 privateKey: privateKey,
                 genesisHash: chain.Genesis.Hash,
-                actions: new[] { action });
+                customActions: new[] { action });
 
             chain.StageTransaction(tx);
             await chain.MineBlock(new PrivateKey());
@@ -210,7 +210,7 @@ namespace Libplanet.Tests.Action
                 nonce: 0,
                 privateKey: privateKey,
                 genesisHash: genesis.Hash,
-                actions: new[] { action });
+                customActions: new[] { action });
             PreEvaluationBlock<ThrowException> block = new BlockContent<ThrowException>
             {
                 Index = 1,
@@ -305,7 +305,7 @@ namespace Libplanet.Tests.Action
                     nonce: 0,
                     privateKey: _txFx.PrivateKey1,
                     genesisHash: genesis.Hash,
-                    actions: new[]
+                    customActions: new[]
                     {
                         MakeAction(addresses[0], 'A', addresses[1]),
                         MakeAction(addresses[1], 'B', addresses[2]),
@@ -315,13 +315,13 @@ namespace Libplanet.Tests.Action
                     nonce: 0,
                     privateKey: _txFx.PrivateKey2,
                     genesisHash: genesis.Hash,
-                    actions: new[] { MakeAction(addresses[2], 'C', addresses[3]) },
+                    customActions: new[] { MakeAction(addresses[2], 'C', addresses[3]) },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(4)),
                 Transaction<DumbAction>.Create(
                     nonce: 0,
                     privateKey: _txFx.PrivateKey3,
                     genesisHash: genesis.Hash,
-                    actions: new DumbAction[0],
+                    customActions: new DumbAction[0],
                     timestamp: DateTimeOffset.MinValue.AddSeconds(7)),
             };
             foreach ((var tx, var i) in block1Txs.Zip(
@@ -360,7 +360,7 @@ namespace Libplanet.Tests.Action
             foreach (var (expect, eval) in expectations.Zip(evals, (x, y) => (x, y)))
             {
                 Assert.Equal(block1Txs[expect.TxIdx].Id, eval.InputContext.TxId);
-                Assert.Equal(block1Txs[expect.TxIdx].Actions[expect.ActionIdx], eval.Action);
+                Assert.Equal(block1Txs[expect.TxIdx].CustomActions[expect.ActionIdx], eval.Action);
                 Assert.Equal(expect.Signer, eval.InputContext.Signer);
                 Assert.Equal(GenesisMiner.ToAddress(), eval.InputContext.Miner);
                 Assert.Equal(block1.Index, eval.InputContext.BlockIndex);
@@ -494,7 +494,7 @@ namespace Libplanet.Tests.Action
             foreach (var (expect, eval) in expectations.Zip(evals, (x, y) => (x, y)))
             {
                 Assert.Equal(block2Txs[expect.TxIdx].Id, eval.InputContext.TxId);
-                Assert.Equal(block2Txs[expect.TxIdx].Actions[expect.Item2], eval.Action);
+                Assert.Equal(block2Txs[expect.TxIdx].CustomActions[expect.Item2], eval.Action);
                 Assert.Equal(expect.Signer, eval.InputContext.Signer);
                 Assert.Equal(GenesisMiner.ToAddress(), eval.InputContext.Miner);
                 Assert.Equal(block2.Index, eval.InputContext.BlockIndex);
@@ -764,7 +764,7 @@ namespace Libplanet.Tests.Action
                 miner: blockA.Miner,
                 signer: txA.Signer,
                 signature: txA.Signature,
-                actions: txA.Actions.ToImmutableArray<IAction>(),
+                actions: txA.CustomActions.ToImmutableArray<IAction>(),
                 rehearsal: rehearsal,
                 previousBlockStatesTrie: fx.GetTrie(blockA.PreviousHash),
                 blockAction: false,
@@ -779,9 +779,9 @@ namespace Libplanet.Tests.Action
                 IAccountStateDelta prevStates = context.PreviousStates;
                 IAccountStateDelta outputStates = eval.OutputStates;
                 _logger.Debug("evalsA[{0}] = {1}", i, eval);
-                _logger.Debug("txA.Actions[{0}] = {1}", i, txA.Actions[i]);
+                _logger.Debug("txA.CustomActions[{0}] = {1}", i, txA.CustomActions[i]);
 
-                Assert.Equal(txA.Actions[i], eval.Action);
+                Assert.Equal(txA.CustomActions[i], eval.Action);
                 Assert.Equal(txA.Id, context.TxId);
                 Assert.Equal(blockA.Miner, context.Miner);
                 Assert.Equal(blockA.Index, context.BlockIndex);
@@ -816,7 +816,7 @@ namespace Libplanet.Tests.Action
                 miner: blockB.Miner,
                 signer: txB.Signer,
                 signature: txB.Signature,
-                actions: txB.Actions.ToImmutableArray<IAction>(),
+                actions: txB.CustomActions.ToImmutableArray<IAction>(),
                 rehearsal: rehearsal,
                 previousBlockStatesTrie: fx.GetTrie(blockB.PreviousHash),
                 blockAction: false,
@@ -833,9 +833,9 @@ namespace Libplanet.Tests.Action
                 IAccountStateDelta outputStates = eval.OutputStates;
 
                 _logger.Debug("evalsB[{0}] = {@1}", i, eval);
-                _logger.Debug("txB.Actions[{0}] = {@1}", i, txB.Actions[i]);
+                _logger.Debug("txB.CustomActions[{0}] = {@1}", i, txB.CustomActions[i]);
 
-                Assert.Equal(txB.Actions[i], eval.Action);
+                Assert.Equal(txB.CustomActions[i], eval.Action);
                 Assert.Equal(txB.Id, context.TxId);
                 Assert.Equal(blockB.Miner, context.Miner);
                 Assert.Equal(blockB.Index, context.BlockIndex);
@@ -996,7 +996,8 @@ namespace Libplanet.Tests.Action
                         nonce: signerNoncePair.nonce,
                         privateKey: signerNoncePair.signer,
                         genesisHash: null,
-                        actions: new[] { new RandomAction(signerNoncePair.signer.ToAddress()) },
+                        customActions:
+                            new[] { new RandomAction(signerNoncePair.signer.ToAddress()) },
                         timestamp: epoch)).ToImmutableArray();
             // Rearrange transactions so that transactions are not grouped by signers
             // while keeping the hard coded mixed order nonces above.
@@ -1100,7 +1101,7 @@ namespace Libplanet.Tests.Action
                 nonce: 0,
                 privateKey: privateKey,
                 genesisHash: chain.Genesis.Hash,
-                actions: new[] { action });
+                customActions: new[] { action });
             chain.StageTransaction(tx);
             var miner = new PrivateKey();
             await chain.MineBlock(miner);

--- a/Libplanet.Tests/Action/Sys/MintTest.cs
+++ b/Libplanet.Tests/Action/Sys/MintTest.cs
@@ -1,0 +1,109 @@
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Action.Sys;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+using Random = System.Random;
+
+namespace Libplanet.Tests.Action.Sys
+{
+    public class MintTest
+    {
+        // ReSharper disable once InconsistentNaming
+        private static readonly Currency FOO = new Currency("FOO", 2, minter: null);
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly Currency BAR = new Currency("BAR", 0, minter: null);
+
+        [Fact]
+        public void Constructor()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            FungibleAssetValue amount = FOO * 125;
+            var action = new Mint(recipient, amount);
+            AssertBytesEqual(recipient, action.Recipient);
+            Assert.Equal(FOO * 125, action.Amount);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            FungibleAssetValue amount = FOO * 125;
+            var action = new Mint(recipient, amount);
+            AssertBencodexEqual(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("recipient", recipient.ByteArray)
+                    .Add("amount", 12500)
+                    .Add("currency", FOO.Serialize()),
+                action.PlainValue
+            );
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            IValue serialized = Bencodex.Types.Dictionary.Empty
+                .Add("recipient", recipient.ByteArray)
+                .Add("amount", 12500)
+                .Add("currency", FOO.Serialize());
+            var action = new Mint();
+            action.LoadPlainValue(serialized);
+            AssertBytesEqual(recipient, action.Recipient);
+            Assert.Equal(FOO * 125, action.Amount);
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var random = new Random();
+            Address signer = random.NextAddress();
+            Currency bazCurrency = new Currency("BAZ", 0, minter: random.NextAddress());
+            var prevStates = new AccountStateDeltaImpl(
+                accountStateGetter: addr => new IValue[addr.Count],
+                accountBalanceGetter: (addr, c) => c * 0,
+                signer: signer
+            );
+            BlockHash genesisHash = random.NextBlockHash();
+            var context = new ActionContext(
+                signer: signer,
+                txid: random.NextTxId(),
+                miner: random.NextAddress(),
+                blockIndex: 123L,
+                previousStates: prevStates,
+                randomSeed: 123,
+                rehearsal: false,
+                previousBlockStatesTrie: null,
+                blockAction: false,
+                genesisHash: genesisHash,
+                nativeTokenPredicate: c => c.Equals(FOO) || c.Equals(bazCurrency)
+            );
+            Address recipient = random.NextAddress();
+            var mintFoo = new Mint(recipient, FOO * 123456);
+            var nextStates = mintFoo.Execute(context);
+            Assert.Equal(FOO * 0, nextStates.GetBalance(signer, FOO));
+            Assert.Equal(BAR * 0, nextStates.GetBalance(signer, BAR));
+            Assert.Equal(FOO * 123456, nextStates.GetBalance(recipient, FOO));
+            Assert.Equal(BAR * 0, nextStates.GetBalance(recipient, BAR));
+
+            var mintBar = new Mint(recipient, BAR * 10);
+            NonNativeTokenException exc = Assert.Throws<NonNativeTokenException>(
+                () => mintBar.Execute(context)
+            );
+            Assert.Equal(BAR, exc.NonNativeToken);
+
+            var mintDisallowedCurrency = new Mint(signer, bazCurrency * 1000);
+            CurrencyPermissionException exc2 = Assert.Throws<CurrencyPermissionException>(
+                () => mintDisallowedCurrency.Execute(context)
+            );
+            Assert.Equal(signer, exc2.TransactionSigner);
+            Assert.Equal(bazCurrency, exc2.Currency);
+        }
+    }
+}

--- a/Libplanet.Tests/Action/Sys/RegistryTest.cs
+++ b/Libplanet.Tests/Action/Sys/RegistryTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Action.Sys
             var random = new Random();
             Address addr = random.NextAddress();
             Bencodex.Types.Dictionary dict = Dictionary.Empty
-                .Add("type_id", 0)
+                .Add("type_id", 1)
                 .Add(
                     "values",
                     Dictionary.Empty
@@ -70,7 +70,7 @@ namespace Libplanet.Tests.Action.Sys
             Bencodex.Types.Dictionary actual =
                 Registry.Serialize(new Transfer(addr, FooCurrency * 123));
             Bencodex.Types.Dictionary expected = Dictionary.Empty
-                .Add("type_id", 0)
+                .Add("type_id", 1)
                 .Add(
                     "values",
                     Dictionary.Empty

--- a/Libplanet.Tests/Action/Sys/RegistryTest.cs
+++ b/Libplanet.Tests/Action/Sys/RegistryTest.cs
@@ -1,0 +1,66 @@
+using System;
+using Bencodex.Types;
+using Libplanet.Action.Sys;
+using Libplanet.Assets;
+using Libplanet.Tests.Common.Action;
+using Xunit;
+using Random = System.Random;
+
+namespace Libplanet.Tests.Action.Sys
+{
+    public class RegistryTest
+    {
+        private static readonly Currency FooCurrency = new Currency("FOO", 2, minters: null);
+
+        [Fact]
+        public void Deserialize()
+        {
+            var random = new Random();
+            Address addr = random.NextAddress();
+            Bencodex.Types.Dictionary dict = Dictionary.Empty
+                .Add("type_id", 0)
+                .Add("values", Dictionary.Empty);
+
+            ArgumentException e;
+            e = Assert.Throws<ArgumentException>(
+                () => Registry.Deserialize((Dictionary)dict.Remove(new Text("type_id")))
+            );
+            Assert.Equal("serialized", e.ParamName);
+            Assert.Contains("type_id", e.Message);
+
+            e = Assert.Throws<ArgumentException>(
+                () => Registry.Deserialize((Dictionary)dict.Remove(new Text("values")))
+            );
+            Assert.Equal("serialized", e.ParamName);
+            Assert.Contains("values", e.Message);
+
+            e = Assert.Throws<ArgumentException>(
+                () => Registry.Deserialize(dict.SetItem("type_id", "non-integer"))
+            );
+            Assert.Equal("serialized", e.ParamName);
+            Assert.Contains("type_id", e.Message);
+
+            e = Assert.Throws<ArgumentOutOfRangeException>(
+                () => Registry.Deserialize(dict.SetItem("type_id", short.MaxValue))
+            );
+            Assert.Contains(
+                "unknown system type id",
+                e.Message,
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var random = new Random();
+            Address addr = random.NextAddress();
+            ArgumentException e = Assert.Throws<ArgumentException>(
+                () => Registry.Serialize(new DumbAction(addr, "foo"))
+            );
+            Assert.Contains(
+                "unknown system action type",
+                e.Message,
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/Libplanet.Tests/Action/Sys/TransferTest.cs
+++ b/Libplanet.Tests/Action/Sys/TransferTest.cs
@@ -1,0 +1,108 @@
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Action.Sys;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+using Random = System.Random;
+
+namespace Libplanet.Tests.Action.Sys
+{
+    public class TransferTest
+    {
+        // ReSharper disable once InconsistentNaming
+        private static readonly Currency FOO = new Currency("FOO", 2, minter: null);
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly Currency BAR = new Currency("BAR", 0, minter: null);
+
+        [Fact]
+        public void Constructor()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            FungibleAssetValue amount = FOO * 125;
+            var action = new Transfer(recipient, amount);
+            AssertBytesEqual(recipient, action.Recipient);
+            Assert.Equal(FOO * 125, action.Amount);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            FungibleAssetValue amount = FOO * 125;
+            var action = new Transfer(recipient, amount);
+            AssertBencodexEqual(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("recipient", recipient.ByteArray)
+                    .Add("amount", 12500)
+                    .Add("currency", FOO.Serialize()),
+                action.PlainValue
+            );
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var random = new Random();
+            Address recipient = random.NextAddress();
+            IValue serialized = Bencodex.Types.Dictionary.Empty
+                .Add("recipient", recipient.ByteArray)
+                .Add("amount", 12500)
+                .Add("currency", FOO.Serialize());
+            var action = new Transfer();
+            action.LoadPlainValue(serialized);
+            AssertBytesEqual(recipient, action.Recipient);
+            Assert.Equal(FOO * 125, action.Amount);
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var random = new Random();
+            Address signer = random.NextAddress();
+            var prevStates = new AccountStateDeltaImpl(
+                accountStateGetter: addr => new IValue[addr.Count],
+                accountBalanceGetter: (addr, c) => c * (addr == signer ? 500 : 0),
+                signer: signer
+            );
+            BlockHash genesisHash = random.NextBlockHash();
+            var context = new ActionContext(
+                signer: signer,
+                txid: random.NextTxId(),
+                miner: random.NextAddress(),
+                blockIndex: 123L,
+                previousStates: prevStates,
+                randomSeed: 123,
+                rehearsal: false,
+                previousBlockStatesTrie: null,
+                blockAction: false,
+                genesisHash: genesisHash,
+                nativeTokenPredicate: FOO.Equals
+            );
+            Address recipient = random.NextAddress();
+            var transferFoo = new Transfer(recipient, FOO * 125);
+            var nextStates = transferFoo.Execute(context);
+            Assert.Equal(FOO * 375, nextStates.GetBalance(signer, FOO));
+            Assert.Equal(BAR * 500, nextStates.GetBalance(signer, BAR));
+            Assert.Equal(FOO * 125, nextStates.GetBalance(recipient, FOO));
+            Assert.Equal(BAR * 0, nextStates.GetBalance(recipient, BAR));
+
+            var transferBar = new Transfer(recipient, BAR * 10);
+            NonNativeTokenException exc = Assert.Throws<NonNativeTokenException>(
+                () => transferBar.Execute(context)
+            );
+            Assert.Equal(BAR, exc.NonNativeToken);
+
+            var transferFromUnsufficientBalance = new Transfer(signer, FOO * 1000);
+            InsufficientBalanceException exc2 = Assert.Throws<InsufficientBalanceException>(
+                () => transferFromUnsufficientBalance.Execute(context)
+            );
+            Assert.Equal(signer, exc2.Address);
+            Assert.Equal(FOO * 500, exc2.Balance);
+        }
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -204,7 +204,12 @@ namespace Libplanet.Tests.Blockchain
             var genesisBlock = TestUtils.MineGenesis<DumbAction>(
                 policy.GetHashAlgorithm,
                 TestUtils.GenesisMiner.PublicKey
-            ).Evaluate(TestUtils.GenesisMiner, policy.BlockAction, stateStore);
+            ).Evaluate(
+                TestUtils.GenesisMiner,
+                policy.BlockAction,
+                policy.NativeTokens.Contains,
+                stateStore
+            );
             store.PutBlock(genesisBlock);
             Assert.NotNull(store.GetStateRootHash(genesisBlock.Hash));
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -849,7 +849,7 @@ namespace Libplanet.Tests.Blockchain
 
             Transaction<DumbAction>[][] txsA =
             {
-                new[]
+                new[] // block #2
                 {
                     _fx.MakeTransaction(
                         new[]
@@ -868,7 +868,7 @@ namespace Libplanet.Tests.Blockchain
                         nonce: 3,
                         privateKey: privateKey),
                 },
-                new[]
+                new[] // block #3
                 {
                     _fx.MakeTransaction(
                         new[]
@@ -957,9 +957,9 @@ namespace Libplanet.Tests.Blockchain
             DumbAction[] actions = actionRenders.Select(r => (DumbAction)r.Action).ToArray();
 
             int actionsCountA = txsA.Sum(
-                a => a.Sum(tx => tx.Actions.Count)
+                a => a.Sum(tx => tx.CustomActions.Count)
             );
-            int actionsCountB = txsB.Sum(tx => tx.Actions.Count);
+            int actionsCountB = txsB.Sum(tx => tx.CustomActions.Count);
 
             int totalBlockCount = (int)_blockChain[-1].Index + 1;
             int unRenderBlockCount = 2;
@@ -1613,12 +1613,12 @@ namespace Libplanet.Tests.Blockchain
             var transaction = txs[0];
             Assert.Equal(0, transaction.Nonce);
             Assert.Equal(address, transaction.Signer);
-            Assert.Equal(actions, transaction.Actions);
+            Assert.Equal(actions, transaction.CustomActions);
 
             transaction = txs[1];
             Assert.Equal(1, transaction.Nonce);
             Assert.Equal(address, transaction.Signer);
-            Assert.Equal(actions, transaction.Actions);
+            Assert.Equal(actions, transaction.CustomActions);
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -634,7 +634,12 @@ namespace Libplanet.Tests.Blockchain
                     _policy.GetHashAlgorithm,
                     GenesisMiner.PublicKey,
                     transactions: new[] { _fx.MakeTransaction(new[] { action }) }
-                ).Evaluate(GenesisMiner, _policy.BlockAction, stateStore);
+                ).Evaluate(
+                    privateKey: GenesisMiner,
+                    blockAction: _policy.BlockAction,
+                    nativeTokenPredicate: _policy.NativeTokens.Contains,
+                    stateStore: stateStore
+                );
                 store.PutBlock(genesis);
                 var renderer = new RecordingActionRenderer<DumbAction>();
                 var blockChain = new BlockChain<DumbAction>(
@@ -1067,7 +1072,12 @@ namespace Libplanet.Tests.Blockchain
                     _policy.GetHashAlgorithm,
                     timestamp: DateTimeOffset.UtcNow,
                     miner: GenesisMiner.PublicKey
-                ).Evaluate(GenesisMiner, _policy.BlockAction, fx2.StateStore);
+                ).Evaluate(
+                    GenesisMiner,
+                    _policy.BlockAction,
+                    _policy.NativeTokens.Contains,
+                    fx2.StateStore
+                );
                 var chain2 = new BlockChain<DumbAction>(
                     _policy,
                     _stagePolicy,
@@ -1126,7 +1136,12 @@ namespace Libplanet.Tests.Blockchain
                         Array.Empty<DumbAction>()
                     ),
                 }
-            ).Evaluate(GenesisMiner, policy.BlockAction, stateStore);
+            ).Evaluate(
+                privateKey: GenesisMiner,
+                blockAction: policy.BlockAction,
+                nativeTokenPredicate: policy.NativeTokens.Contains,
+                stateStore: stateStore
+            );
             var chain = new BlockChain<DumbAction>(
                 policy,
                 new VolatileStagePolicy<DumbAction>(),
@@ -1709,7 +1724,12 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> genesisBlock = MineGenesis<DumbAction>(
                 blockPolicy.GetHashAlgorithm,
                 GenesisMiner.PublicKey
-            ).Evaluate(GenesisMiner, blockPolicy.BlockAction, stateStore);
+            ).Evaluate(
+                privateKey: GenesisMiner,
+                blockAction: blockPolicy.BlockAction,
+                nativeTokenPredicate: blockPolicy.NativeTokens.Contains,
+                stateStore: stateStore
+            );
             var chain = new BlockChain<DumbAction>(
                 blockPolicy,
                 new VolatileStagePolicy<DumbAction>(),
@@ -2039,7 +2059,12 @@ namespace Libplanet.Tests.Blockchain
                         Array.Empty<DumbAction>()
                     ),
                 }
-            ).Evaluate(GenesisMiner, policy.BlockAction, stateStore);
+            ).Evaluate(
+                privateKey: GenesisMiner,
+                blockAction: policy.BlockAction,
+                nativeTokenPredicate: policy.NativeTokens.Contains,
+                stateStore: stateStore
+            );
 
             Assert.Throws<TxPolicyViolationException>(() =>
             {

--- a/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
@@ -50,17 +50,17 @@ namespace Libplanet.Tests.Blockchain.Renderers
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[0], r.Action);
+                Assert.Equal(_successTx.CustomActions[0], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[1], r.Action);
+                Assert.Equal(_successTx.CustomActions[1], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[2], r.Action);
+                Assert.Equal(_successTx.CustomActions[2], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[4], r => Assert.True(r.End));
         }
@@ -78,17 +78,17 @@ namespace Libplanet.Tests.Blockchain.Renderers
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[2], r.Action);
+                Assert.Equal(_successTx.CustomActions[2], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[1], r.Action);
+                Assert.Equal(_successTx.CustomActions[1], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.Actions[0], r.Action);
+                Assert.Equal(_successTx.CustomActions[0], r.Action);
             });
             AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[4], r => Assert.True(r.Begin));
             AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[5], r => Assert.True(r.End));

--- a/Libplanet.Tests/Blocks/BlockContentTest.cs
+++ b/Libplanet.Tests/Blocks/BlockContentTest.cs
@@ -81,13 +81,13 @@ namespace Libplanet.Tests.Blocks
                 "ea0493b0ed67fc97b2e5e85a1d145adea294112f09df15398cb10f2ed5ad1a83"
             );
             var tx2 = new Transaction<Arithmetic>(
-                nonce: 0L,
-                signer: key.ToAddress(),
-                publicKey: key.PublicKey,
-                genesisHash: GenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty,
-                timestamp: new DateTimeOffset(2021, 9, 7, 10, 23, 12, 345, TimeSpan.FromHours(9)),
-                actions: Array.Empty<Arithmetic>(),
+                metadata: new TxMetadata(key.PublicKey)
+                {
+                    GenesisHash = GenesisHash,
+                    Timestamp = new DateTimeOffset(
+                        2021, 9, 7, 10, 23, 12, 345, TimeSpan.FromHours(9)),
+                },
+                customActions: Array.Empty<Arithmetic>(),
                 signature: ByteUtil.ParseHex(
                     "304402202a8324c83390b1fe0fdd4014056a049bc02ca059369ef62145fe574cb31224f" +
                     "d022073bf8a48403cf46f5fa63f26f3e8ef4db8ef1d841684856da63d9b7eeb91759a"
@@ -104,13 +104,14 @@ namespace Libplanet.Tests.Blocks
         public void TransactionsWithDuplicateNonce()
         {
             var dupTx1 = new Transaction<Arithmetic>(
-                nonce: 1L,
-                signer: Tx1InBlock1.Signer,
-                publicKey: Tx1InBlock1.PublicKey,
-                genesisHash: GenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty.Add(Tx1InBlock1.Signer),
-                timestamp: Tx1InBlock1.Timestamp,
-                actions: Array.Empty<Arithmetic>(),
+                metadata: new TxMetadata(Tx1InBlock1.PublicKey)
+                {
+                    Nonce = 1L,
+                    GenesisHash = GenesisHash,
+                    UpdatedAddresses = ImmutableHashSet.Create(Tx1InBlock1.Signer),
+                    Timestamp = Tx1InBlock1.Timestamp,
+                },
+                customActions: Array.Empty<Arithmetic>(),
                 signature: ByteUtil.ParseHex(
                     "304502210099e580e8599acf0b26ad0a80315f2d488703ffde01e9449b4bf399593b8cc" +
                     "e63022002feb21bf0e4d76d25d17c8c1c4fbb3dfbda986e0693f984fbb302183ab7ece1"
@@ -130,13 +131,14 @@ namespace Libplanet.Tests.Blocks
         public void TransactionsWithMissingNonce()
         {
             var dupTx1 = new Transaction<Arithmetic>(
-                nonce: 3L,
-                signer: Tx1InBlock1.Signer,
-                publicKey: Tx1InBlock1.PublicKey,
-                genesisHash: GenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty.Add(Tx1InBlock1.Signer),
-                timestamp: Tx1InBlock1.Timestamp,
-                actions: Array.Empty<Arithmetic>(),
+                metadata: new TxMetadata(Tx1InBlock1.PublicKey)
+                {
+                    Nonce = 3L,
+                    GenesisHash = GenesisHash,
+                    UpdatedAddresses = ImmutableHashSet.Create(Tx1InBlock1.Signer),
+                    Timestamp = Tx1InBlock1.Timestamp,
+                },
+                customActions: Array.Empty<Arithmetic>(),
                 signature: ByteUtil.ParseHex(
                     "3045022100bfdf79427028efea9449ad46fbf46d5a806694aa5bbab1a01f4c76b21acd" +
                     "cb16022057c851a01dd74797121385ccfc81e7b33842941189154b4d46d05e891a28e3eb"
@@ -162,13 +164,14 @@ namespace Libplanet.Tests.Blocks
                 "76942b42f99c28da02ed916ebd2fadb189415e8288a4bd87f9ae3594127b79e6"
             );
             var txWithDifferentGenesis = new Transaction<Arithmetic>(
-                nonce: 0L,
-                signer: key.ToAddress(),
-                publicKey: key.PublicKey,
-                genesisHash: differentGenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty,
-                timestamp: new DateTimeOffset(2021, 9, 7, 12, 1, 12, 345, TimeSpan.FromHours(9)),
-                actions: Array.Empty<Arithmetic>(),
+                metadata: new TxMetadata(key.PublicKey)
+                {
+                    Nonce = 0L,
+                    GenesisHash = differentGenesisHash,
+                    Timestamp = new DateTimeOffset(
+                        2021, 9, 7, 12, 1, 12, 345, TimeSpan.FromHours(9)),
+                },
+                customActions: Array.Empty<Arithmetic>(),
                 signature: ByteUtil.ParseHex(
                     "304402202027a31e4298c685daaa944b1d120b4e6894f3bfffa13563331c0a7071a04b" +
                     "310220167507575e982d47d7c6753b782a5f1beb6415af96e7db3ccaf83b516d5133d1"

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -249,8 +249,12 @@ namespace Libplanet.Tests.Blocks
 
             using (var fx = new MemoryStoreFixture())
             {
-                Block<Arithmetic> genesis =
-                    preEvalGenesis.Evaluate(_contents.GenesisKey, blockAction, fx.StateStore);
+                Block<Arithmetic> genesis = preEvalGenesis.Evaluate(
+                    privateKey: _contents.GenesisKey,
+                    blockAction: blockAction,
+                    nativeTokenPredicate: _ => true,
+                    stateStore: fx.StateStore
+                );
                 AssertPreEvaluationBlocksEqual(preEvalGenesis, genesis);
                 _output.WriteLine("#1: {0}", genesis);
 
@@ -304,8 +308,11 @@ namespace Libplanet.Tests.Blocks
 
             using (var fx = new MemoryStoreFixture())
             {
-                HashDigest<SHA256> genesisStateRootHash =
-                    preEvalGenesis.DetermineStateRootHash(blockAction, fx.StateStore);
+                HashDigest<SHA256> genesisStateRootHash = preEvalGenesis.DetermineStateRootHash(
+                    blockAction: blockAction,
+                    nativeTokenPredicate: _ => true,
+                    stateStore: fx.StateStore
+                );
                 _output.WriteLine("#0 StateRootHash: {0}", genesisStateRootHash);
                 Block<Arithmetic> genesis =
                     preEvalGenesis.Sign(_contents.GenesisKey, genesisStateRootHash);

--- a/Libplanet.Tests/Fixtures/BlockContentFixture.cs
+++ b/Libplanet.Tests/Fixtures/BlockContentFixture.cs
@@ -68,13 +68,14 @@ namespace Libplanet.Tests.Fixtures
                 "2d5c20079bc4b2e6eab9ecbb405da8ba6590c436edfb07b7d4466563d7dac096"
             );
             Tx0InBlock1 = new Transaction<Arithmetic>(
-                nonce: 0L,
-                signer: block1Tx0Key.ToAddress(),
-                publicKey: block1Tx0Key.PublicKey,
-                genesisHash: GenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty.Add(block1Tx0Key.ToAddress()),
-                timestamp: new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, kst),
-                actions: new[]
+                metadata: new TxMetadata(block1Tx0Key.PublicKey)
+                {
+                    Nonce = 0L,
+                    GenesisHash = GenesisHash,
+                    UpdatedAddresses = ImmutableHashSet.Create(block1Tx0Key.ToAddress()),
+                    Timestamp = new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, kst),
+                },
+                customActions: new[]
                 {
                     Arithmetic.Add(10), Arithmetic.Add(50), Arithmetic.Sub(25),
                 },
@@ -88,13 +89,14 @@ namespace Libplanet.Tests.Fixtures
                 "105341c78dfb0dd313b961081630444c2586a1f01fb0c625368ffdc9136cfa30"
             );
             Tx1InBlock1 = new Transaction<Arithmetic>(
-                nonce: 1L,
-                signer: block1Tx1Key.ToAddress(),
-                publicKey: block1Tx1Key.PublicKey,
-                genesisHash: GenesisHash,
-                updatedAddresses: ImmutableHashSet<Address>.Empty.Add(block1Tx1Key.ToAddress()),
-                timestamp: new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, kst),
-                actions: new[] { Arithmetic.Add(30) },
+                metadata: new TxMetadata(block1Tx1Key.PublicKey)
+                {
+                    Nonce = 1L,
+                    GenesisHash = GenesisHash,
+                    UpdatedAddresses = ImmutableHashSet.Create(block1Tx1Key.ToAddress()),
+                    Timestamp = new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, kst),
+                },
+                customActions: new[] { Arithmetic.Add(30) },
                 signature: ByteUtil.ParseHex(
                     "3045022100abe3caabf2a46a297f2e4496f2c46d7e2f723e75fc42025d19f3ed7fce382" +
                     "d4e02200ffd36f7bef759b6c7ab43bc0f8959a0c463f88fd0f1faeaa209a8661506c4f0"

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -69,7 +69,12 @@ namespace Libplanet.Tests.Fixtures
                 PublicKey = Miner.PublicKey,
                 Timestamp = DateTimeOffset.UtcNow,
                 Transactions = Txs,
-            }.Mine(policy.GetHashAlgorithm(0)).Evaluate(Miner, policy.BlockAction, StateStore);
+            }.Mine(policy.GetHashAlgorithm(0)).Evaluate(
+                privateKey: Miner,
+                blockAction: policy.BlockAction,
+                nativeTokenPredicate: policy.NativeTokens.Contains,
+                stateStore: StateStore
+            );
             Chain = new BlockChain<Arithmetic>(
                 policy,
                 new VolatileStagePolicy<Arithmetic>(),

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -109,7 +109,7 @@ namespace Libplanet.Tests.Fixtures
             (BigInteger, HashDigest<SHA256>) stagedStates = Chain.ListStagedTransactions()
                 .Where(t => t.Signer.Equals(signerAddress))
                 .OrderBy(t => t.Nonce)
-                .SelectMany(t => t.Actions)
+                .SelectMany(t => t.CustomActions)
                 .TakeWhile(a => a.Error is null)
                 .Aggregate(prevPair, (prev, act) =>
                 {
@@ -121,8 +121,8 @@ namespace Libplanet.Tests.Fixtures
                     return (nextState, nextRootHash);
                 });
             Chain.StageTransaction(tx);
-            ImmutableArray<(BigInteger, HashDigest<SHA256>)> expectedDelta = tx.Actions
-                .Take(tx.Actions.TakeWhile(a => a.Error is null).Count() + 1)
+            ImmutableArray<(BigInteger, HashDigest<SHA256>)> expectedDelta = tx.CustomActions
+                .Take(tx.CustomActions.TakeWhile(a => a.Error is null).Count() + 1)
                 .Aggregate(
                     ImmutableArray.Create(stagedStates),
                     (delta, act) =>

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Store;
@@ -14,7 +15,10 @@ namespace Libplanet.Tests.Store
 {
     public abstract class StoreFixture : IDisposable
     {
-        protected StoreFixture(IAction blockAction = null)
+        protected StoreFixture(
+            IAction blockAction = null,
+            IImmutableSet<Currency> nativeTokens = null
+        )
         {
             Path = null;
 
@@ -100,7 +104,14 @@ namespace Libplanet.Tests.Store
             GenesisBlock = TestUtils.MineGenesis<DumbAction>(
                 GetHashAlgorithm,
                 Miner.PublicKey
-            ).Evaluate(Miner, blockAction, stateStore);
+            ).Evaluate(
+                privateKey: Miner,
+                blockAction: blockAction,
+                nativeTokenPredicate: nativeTokens is null
+                    ? _ => true
+                    : (Predicate<Currency>)nativeTokens.Contains,
+                stateStore: stateStore
+            );
             stateRootHashes[GenesisBlock.Hash] = GenesisBlock.StateRootHash;
             Block1 = TestUtils.MineNextBlock(GenesisBlock, GetHashAlgorithm, miner: Miner);
             stateRootHashes[Block1.Hash] = Block1.StateRootHash;

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -906,8 +906,8 @@ namespace Libplanet.Tests.Store
             {
                 var tx = Fx.Store.GetTransaction<AtomicityTestAction>(txid);
                 tx.Validate();
-                Assert.Single(tx.Actions);
-                AtomicityTestAction action = tx.Actions[0];
+                Assert.Single(tx.CustomActions);
+                AtomicityTestAction action = tx.CustomActions[0];
                 Assert.Equal(
                     md5Hasher.ComputeHash(action.ArbitraryBytes.ToArray()),
                     action.Md5Digest.ToArray()

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1067,8 +1067,14 @@ namespace Libplanet.Tests.Store
                     new VolatileStagePolicy<DumbAction>(),
                     s1,
                     fx.StateStore,
-                    MineGenesis<DumbAction>(policy.GetHashAlgorithm, GenesisMiner.PublicKey)
-                        .Evaluate(GenesisMiner, policy.BlockAction, fx.StateStore)
+                    MineGenesis<DumbAction>(
+                            hashAlgorithmGetter: policy.GetHashAlgorithm,
+                            miner: GenesisMiner.PublicKey)
+                        .Evaluate(
+                            privateKey: GenesisMiner,
+                            blockAction: policy.BlockAction,
+                            nativeTokenPredicate: policy.NativeTokens.Contains,
+                            stateStore: fx.StateStore)
                 );
 
                 // FIXME: Need to add more complex blocks/transactions.

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -465,11 +465,18 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                     new Nonce(new byte[] { 0x01, 0x00, 0x00, 0x00 })
                 );
                 genesisBlock = protocolVersion < 2
-                 ? new Block<T>(
-                     preEval,
-                     preEval.DetermineStateRootHash(policy.BlockAction, stateStore),
-                     signature: null)
-                 : preEval.Evaluate(GenesisMiner, policy.BlockAction, stateStore);
+                    ? new Block<T>(
+                         preEval,
+                         preEval.DetermineStateRootHash(
+                             blockAction: policy.BlockAction,
+                             nativeTokenPredicate: policy.NativeTokens.Contains,
+                             stateStore: stateStore),
+                         signature: null)
+                    : preEval.Evaluate(
+                         privateKey: GenesisMiner,
+                         blockAction: policy.BlockAction,
+                         nativeTokenPredicate: policy.NativeTokens.Contains,
+                         stateStore: stateStore);
             }
 
             ValidatingActionRenderer<T> validator = null;

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
@@ -10,7 +12,7 @@ namespace Libplanet.Action
     {
         private readonly int _randomSeed;
         private readonly ITrie? _previousBlockStatesTrie;
-
+        private readonly Predicate<Currency>? _nativeTokenPredicate;
         private HashDigest<SHA256>? _previousStateRootHash;
 
         public ActionContext(
@@ -23,8 +25,8 @@ namespace Libplanet.Action
             int randomSeed,
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null,
-            bool blockAction = false
-        )
+            bool blockAction = false,
+            Predicate<Currency>? nativeTokenPredicate = null)
         {
             GenesisHash = genesisHash;
             Signer = signer;
@@ -37,6 +39,7 @@ namespace Libplanet.Action
             _randomSeed = randomSeed;
             _previousBlockStatesTrie = previousBlockStatesTrie;
             BlockAction = blockAction;
+            _nativeTokenPredicate = nativeTokenPredicate;
         }
 
         public BlockHash? GenesisHash { get; }
@@ -68,6 +71,9 @@ namespace Libplanet.Action
 
         public bool BlockAction { get; }
 
+        public bool IsNativeToken(Currency currency) =>
+            _nativeTokenPredicate is { } && _nativeTokenPredicate(currency);
+
         [Pure]
         public IActionContext GetUnconsumedContext() =>
             new ActionContext(
@@ -80,6 +86,7 @@ namespace Libplanet.Action
                 _randomSeed,
                 Rehearsal,
                 _previousBlockStatesTrie,
-                BlockAction);
+                BlockAction,
+                _nativeTokenPredicate);
     }
 }

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -30,6 +30,7 @@ namespace Libplanet.Action
         private readonly IAction? _policyBlockAction;
         private readonly IBlockChainStates<T> _blockChainStates;
         private readonly Func<BlockHash, ITrie>? _trieGetter;
+        private readonly Predicate<Currency> _nativeTokenPredicate;
 
         /// <summary>
         /// Creates a new <see cref="ActionEvaluator{T}"/>.
@@ -43,17 +44,22 @@ namespace Libplanet.Action
         /// a provided <see cref="BlockHash"/>.</param>
         /// <param name="genesisHash"> A <see cref="BlockHash"/> value of the genesis block.
         /// </param>
+        /// <param name="nativeTokenPredicate">A predicate function to determine whether
+        /// the specified <see cref="Currency"/> is a native token defined by chain's
+        /// <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/> or not.</param>
         public ActionEvaluator(
             IAction? policyBlockAction,
             IBlockChainStates<T> blockChainStates,
             Func<BlockHash, ITrie>? trieGetter,
-            BlockHash? genesisHash)
+            BlockHash? genesisHash,
+            Predicate<Currency> nativeTokenPredicate)
         {
             _logger = Log.ForContext<ActionEvaluator<T>>();
             _policyBlockAction = policyBlockAction;
             _blockChainStates = blockChainStates;
             _trieGetter = trieGetter;
             _genesisHash = genesisHash;
+            _nativeTokenPredicate = nativeTokenPredicate;
         }
 
         /// <summary>
@@ -174,7 +180,8 @@ namespace Libplanet.Action
                 signature: tx.Signature,
                 actions: tx.Actions.Cast<IAction>().ToImmutableList(),
                 rehearsal: true,
-                previousBlockStatesTrie: null);
+                previousBlockStatesTrie: null,
+                nativeTokenPredicate: _ => true);
 
             if (evaluations.Any())
             {
@@ -207,6 +214,9 @@ namespace Libplanet.Action
         /// <param name="signature"><see cref="Transaction{T}"/> signature used to generate random
         /// seeds.</param>
         /// <param name="actions">Actions to evaluate.</param>
+        /// <param name="nativeTokenPredicate">A predicate function to determine whether
+        /// the specified <see cref="Currency"/> is a native token defined by chain's
+        /// <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/> or not.</param>
         /// <param name="rehearsal">Pass <c>true</c> if it is intended
         /// to be dry-run (i.e., the returned result will be never used).
         /// The default value is <c>false</c>.</param>
@@ -246,6 +256,7 @@ namespace Libplanet.Action
             Address signer,
             byte[] signature,
             IImmutableList<IAction> actions,
+            Predicate<Currency> nativeTokenPredicate,
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null,
             bool blockAction = false,
@@ -263,7 +274,8 @@ namespace Libplanet.Action
                     randomSeed: randomSeed,
                     rehearsal: rehearsal,
                     previousBlockStatesTrie: previousBlockStatesTrie,
-                    blockAction: blockAction);
+                    blockAction: blockAction,
+                    nativeTokenPredicate: nativeTokenPredicate);
             }
 
             byte[] hashedSignature;
@@ -547,7 +559,8 @@ namespace Libplanet.Action
                 signature: tx.Signature,
                 actions: tx.Actions.Cast<IAction>().ToImmutableList(),
                 rehearsal: rehearsal,
-                previousBlockStatesTrie: previousBlockStatesTrie);
+                previousBlockStatesTrie: previousBlockStatesTrie,
+                nativeTokenPredicate: _nativeTokenPredicate);
 
         /// <summary>
         /// Evaluates <see cref="Transaction{T}.Actions"/> of a given
@@ -631,7 +644,9 @@ namespace Libplanet.Action
                 actions: new[] { _policyBlockAction }.ToImmutableList(),
                 rehearsal: false,
                 previousBlockStatesTrie: previousBlockStatesTrie,
-                blockAction: true).Single();
+                blockAction: true,
+                nativeTokenPredicate: _nativeTokenPredicate
+            ).Single();
         }
 
         [Pure]

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -50,7 +50,6 @@ namespace Libplanet.Action
         /// &#x201c;rehearsal mode&#x201d;, that there is nothing
         /// in <see cref="PreviousStates"/>.
         /// </summary>
-        /// <seealso cref="Libplanet.Tx.Transaction{T}.Create"/>
         [Pure]
         bool Rehearsal { get; }
 

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 
@@ -90,6 +91,17 @@ namespace Libplanet.Action
         /// </summary>
         [Pure]
         bool BlockAction { get; }
+
+        /// <summary>
+        /// Checks whether the specified <paramref name="currency"/> is a native token defined by
+        /// chain's <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/>.
+        /// </summary>
+        /// <param name="currency">A token currency to check.</param>
+        /// <returns><see langword="true"/> if the specified <paramref name="currency"/> is a native
+        /// token, otherwise <see langword="false"/>.</returns>
+        /// <seealso cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/>
+        [Pure]
+        bool IsNativeToken(Currency currency);
 
         /// <summary>
         /// Returns a clone of this context, except that its <see cref="Random"/> has the unconsumed

--- a/Libplanet/Action/Sys/Mint.cs
+++ b/Libplanet/Action/Sys/Mint.cs
@@ -1,0 +1,71 @@
+using Bencodex.Types;
+using Libplanet.Assets;
+
+namespace Libplanet.Action.Sys
+{
+    /// <summary>
+    /// A system action that mints specified <see cref="Amount"/> of tokens to a given
+    /// <see cref="Recipient"/>.
+    /// </summary>
+    /// <remarks>Only native tokens can be minted.</remarks>
+    public sealed class Mint : IAction
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="Mint"/> action.
+        /// </summary>
+        /// <param name="recipient">The address of the recipient to receive the minted tokens.
+        /// </param>
+        /// <param name="amount">The amount of the asset to be minted.</param>
+        public Mint(Address recipient, FungibleAssetValue amount)
+        {
+            Recipient = recipient;
+            Amount = amount;
+        }
+
+        internal Mint()
+        {
+            // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
+        }
+
+        /// <summary>
+        /// The address of the recipient to receive the minted tokens.
+        /// </summary>
+        public Address Recipient { get; private set; }
+
+        /// <summary>
+        /// The amount of the asset to be minted.
+        /// </summary>
+        public FungibleAssetValue Amount { get; private set; }
+
+        /// <inheritdoc cref="IAction.PlainValue"/>
+        public IValue PlainValue => Bencodex.Types.Dictionary.Empty
+            .Add("recipient", Recipient.ByteArray)
+            .Add("currency", Amount.Currency.Serialize())
+            .Add("amount", (IValue)new Bencodex.Types.Integer(Amount.RawValue));
+
+        /// <inheritdoc cref="IAction.LoadPlainValue(IValue)"/>
+        public void LoadPlainValue(IValue plainValue)
+        {
+            var dict = (Bencodex.Types.Dictionary)plainValue;
+            Recipient = new Address(dict.GetValue<Binary>("recipient"));
+            Amount = new FungibleAssetValue(
+                new Currency(dict["currency"]),
+                dict.GetValue<Bencodex.Types.Integer>("amount")
+            );
+        }
+
+        /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
+        public IAccountStateDelta Execute(IActionContext context)
+        {
+            if (!context.IsNativeToken(Amount.Currency))
+            {
+                var message =
+                    $"System action {nameof(Mint)} only accepts native tokens, " +
+                    $"but {Amount.Currency} is not native.";
+                throw new NonNativeTokenException(Amount.Currency, message);
+            }
+
+            return context.PreviousStates.MintAsset(Recipient, Amount);
+        }
+    }
+}

--- a/Libplanet/Action/Sys/Registry.cs
+++ b/Libplanet/Action/Sys/Registry.cs
@@ -7,7 +7,8 @@ namespace Libplanet.Action.Sys
     {
         private enum TypeId : short
         {
-            Transfer = 0,
+            Mint = 0,
+            Transfer = 1,
         }
 
         public static IAction Deserialize(Bencodex.Types.Dictionary serialized)
@@ -44,6 +45,7 @@ namespace Libplanet.Action.Sys
         private static IAction Instantiate(TypeId typeId) =>
             typeId switch
             {
+                TypeId.Mint => new Mint(),
                 TypeId.Transfer => new Transfer(),
                 _ => throw new ArgumentOutOfRangeException(
                     nameof(typeId),
@@ -55,6 +57,7 @@ namespace Libplanet.Action.Sys
         private static TypeId GetTypeId(IAction action) =>
             action switch
             {
+                Mint _ => TypeId.Mint,
                 Transfer _ => TypeId.Transfer,
                 _ => throw new ArgumentException("Unknown system action type.", nameof(action)),
             };

--- a/Libplanet/Action/Sys/Registry.cs
+++ b/Libplanet/Action/Sys/Registry.cs
@@ -1,0 +1,59 @@
+using System;
+using Bencodex.Types;
+
+namespace Libplanet.Action.Sys
+{
+    internal static class Registry
+    {
+        private enum TypeId : short
+        {
+        }
+
+        public static IAction Deserialize(Bencodex.Types.Dictionary serialized)
+        {
+            if (!serialized.TryGetValue((Text)"type_id", out IValue typeIdValue))
+            {
+                throw new ArgumentException("No type_id field found.", nameof(serialized));
+            }
+
+            if (!serialized.TryGetValue((Text)"values", out IValue values))
+            {
+                throw new ArgumentException("No values field found.", nameof(serialized));
+            }
+
+            if (!(typeIdValue is Bencodex.Types.Integer typeIdInt))
+            {
+                throw new ArgumentException(
+                    "type_id field is not an integer.",
+                    nameof(serialized)
+                );
+            }
+
+            var typeId = (TypeId)(short)typeIdInt;
+            IAction action = Instantiate(typeId);
+            action.LoadPlainValue(values);
+            return action;
+        }
+
+        public static Bencodex.Types.Dictionary Serialize(IAction action) =>
+            Bencodex.Types.Dictionary.Empty
+                .Add("type_id", (short)GetTypeId(action))
+                .Add("values", action.PlainValue);
+
+        private static IAction Instantiate(TypeId typeId) =>
+            typeId switch
+            {
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(typeId),
+                    typeId,
+                    "Unknown system type ID."
+                ),
+            };
+
+        private static TypeId GetTypeId(IAction action) =>
+            action switch
+            {
+                _ => throw new ArgumentException("Unknown system action type.", nameof(action)),
+            };
+    }
+}

--- a/Libplanet/Action/Sys/Registry.cs
+++ b/Libplanet/Action/Sys/Registry.cs
@@ -7,6 +7,7 @@ namespace Libplanet.Action.Sys
     {
         private enum TypeId : short
         {
+            Transfer = 0,
         }
 
         public static IAction Deserialize(Bencodex.Types.Dictionary serialized)
@@ -43,6 +44,7 @@ namespace Libplanet.Action.Sys
         private static IAction Instantiate(TypeId typeId) =>
             typeId switch
             {
+                TypeId.Transfer => new Transfer(),
                 _ => throw new ArgumentOutOfRangeException(
                     nameof(typeId),
                     typeId,
@@ -53,6 +55,7 @@ namespace Libplanet.Action.Sys
         private static TypeId GetTypeId(IAction action) =>
             action switch
             {
+                Transfer _ => TypeId.Transfer,
                 _ => throw new ArgumentException("Unknown system action type.", nameof(action)),
             };
     }

--- a/Libplanet/Action/Sys/Transfer.cs
+++ b/Libplanet/Action/Sys/Transfer.cs
@@ -1,0 +1,75 @@
+using Bencodex.Types;
+using Libplanet.Assets;
+
+namespace Libplanet.Action.Sys
+{
+    /// <summary>
+    /// A system action that transfers the ownership of specified <see cref="Amount"/> of tokens to
+    /// another account.
+    /// </summary>
+    /// <remarks>Only native tokens can be transferred.</remarks>
+    public sealed class Transfer : IAction
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="Transfer"/> action.
+        /// </summary>
+        /// <param name="recipient">The address of the recipient.</param>
+        /// <param name="amount">The amount of the asset to be transferred.</param>
+        public Transfer(Address recipient, FungibleAssetValue amount)
+        {
+            Recipient = recipient;
+            Amount = amount;
+        }
+
+        internal Transfer()
+        {
+            // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
+        }
+
+        /// <summary>
+        /// The address of the recipient.
+        /// </summary>
+        public Address Recipient { get; private set; }
+
+        /// <summary>
+        /// The amount of the asset to be transferred.
+        /// </summary>
+        public FungibleAssetValue Amount { get; private set; }
+
+        /// <inheritdoc cref="IAction.PlainValue"/>
+        public IValue PlainValue => Bencodex.Types.Dictionary.Empty
+            .Add("recipient", Recipient.ByteArray)
+            .Add("currency", Amount.Currency.Serialize())
+            .Add("amount", (IValue)new Bencodex.Types.Integer(Amount.RawValue));
+
+        /// <inheritdoc cref="IAction.LoadPlainValue(IValue)"/>
+        public void LoadPlainValue(IValue plainValue)
+        {
+            var dict = (Bencodex.Types.Dictionary)plainValue;
+            Recipient = new Address(dict.GetValue<Binary>("recipient"));
+            Amount = new FungibleAssetValue(
+                new Currency(dict["currency"]),
+                dict.GetValue<Bencodex.Types.Integer>("amount")
+            );
+        }
+
+        /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
+        public IAccountStateDelta Execute(IActionContext context)
+        {
+            if (!context.IsNativeToken(Amount.Currency))
+            {
+                var message =
+                    $"System action {nameof(Transfer)} only accepts native tokens, " +
+                    $"but {Amount.Currency} is not native.";
+                throw new NonNativeTokenException(Amount.Currency, message);
+            }
+
+            return context.PreviousStates.TransferAsset(
+                context.Signer,
+                Recipient,
+                Amount,
+                allowNegativeBalance: false
+            );
+        }
+    }
+}

--- a/Libplanet/Assets/FungibleAssetValue.cs
+++ b/Libplanet/Assets/FungibleAssetValue.cs
@@ -153,7 +153,7 @@ namespace Libplanet.Assets
         /// </summary>
         /// <param name="currency">The currency to create a value.</param>
         /// <param name="rawValue">The raw quantity of the value to create.</param>
-        private FungibleAssetValue(Currency currency, BigInteger rawValue)
+        internal FungibleAssetValue(Currency currency, BigInteger rawValue)
         {
             Currency = currency;
             RawValue = rawValue;

--- a/Libplanet/Assets/NonNativeTokenException.cs
+++ b/Libplanet/Assets/NonNativeTokenException.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.Serialization;
+using Libplanet.Serialization;
+
+namespace Libplanet.Assets
+{
+    /// <summary>
+    /// The exception that is thrown when a non-native asset is tried to be used for system actions.
+    /// </summary>
+    [Serializable]
+    public sealed class NonNativeTokenException : Exception
+    {
+        /// <summary>
+        /// Creates a new <see cref="NonNativeTokenException"/> instance.
+        /// </summary>
+        /// <param name="nonNativeToken">The non-native token which caused this exception.</param>
+        /// <param name="message">Specifies a <see cref="Exception.Message"/>.</param>
+        public NonNativeTokenException(Currency nonNativeToken, string? message = null)
+            : base(message)
+        {
+            NonNativeToken = nonNativeToken;
+        }
+
+        private NonNativeTokenException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            NonNativeToken = info.GetValue<Currency>(nameof(NonNativeToken));
+        }
+
+        /// <summary>
+        /// The non-native token which caused this exception.
+        /// </summary>
+        public Currency NonNativeToken { get; }
+
+        /// <inheritdoc cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(NonNativeToken), NonNativeToken);
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -739,7 +739,6 @@ namespace Libplanet.Blockchain
         /// signed.</param>
         /// <returns>A created new <see cref="Transaction{T}"/> signed by the given
         /// <paramref name="privateKey"/>.</returns>
-        /// <seealso cref="Transaction{T}.Create" />
         public Transaction<T> MakeTransaction(
             PrivateKey privateKey,
             IEnumerable<T> actions,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -167,7 +167,8 @@ namespace Libplanet.Blockchain
                 Policy.BlockAction,
                 blockChainStates: this,
                 trieGetter: hash => StateStore.GetStateRoot(_blocks[hash].StateRootHash),
-                genesisBlock.Hash
+                genesisHash: genesisBlock.Hash,
+                nativeTokenPredicate: Policy.NativeTokens.Contains
             );
 
             if (Count == 0)
@@ -359,13 +360,18 @@ namespace Libplanet.Blockchain
         /// <param name="blockAction">A block action to execute and be rendered for every block.
         /// It must match to <see cref="BlockPolicy{T}.BlockAction"/> of <see cref="Policy"/>.
         /// </param>
+        /// <param name="nativeTokenPredicate">A predicate function to determine whether
+        /// the specified <see cref="Currency"/> is a native token defined by chain's
+        /// <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/> or not.
+        /// Treat no <see cref="Currency"/> as native token if the argument omitted.</param>
         /// <returns>The genesis block mined with parameters.</returns>
         public static Block<T> MakeGenesisBlock(
             HashAlgorithmType hashAlgorithm,
             IEnumerable<T> actions = null,
             PrivateKey privateKey = null,
             DateTimeOffset? timestamp = null,
-            IAction blockAction = null)
+            IAction blockAction = null,
+            Predicate<Currency> nativeTokenPredicate = null)
         {
             privateKey ??= new PrivateKey();
             actions ??= ImmutableArray<T>.Empty;
@@ -385,6 +391,7 @@ namespace Libplanet.Blockchain
             return preEval.Evaluate(
                 privateKey,
                 blockAction,
+                nativeTokenPredicate,
                 new TrieStateStore(new DefaultKeyValueStore(null))
             );
         }

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 
@@ -190,6 +192,10 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         public IAction? BlockAction { get; }
+
+        /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
+        // TODO: This should be configurable through the constructor.
+        public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
 
         /// <summary>
         /// Targeted time interval between two consecutive <see cref="Block{T}"/>s.

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -83,6 +83,8 @@ namespace Libplanet.Blockchain.Policies
         /// a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s index.
         /// Goes to <see cref="GetMaxTransactionsPerSignerPerBlock"/>.  Set to
         /// <see cref="GetMaxTransactionsPerBlock"/> by default.</param>
+        /// <param name="nativeTokens">A fixed set of <see cref="Currency"/> objects that are
+        /// supported by the blockchain as first-class citizens.  Empty by default.</param>
         public BlockPolicy(
             IAction? blockAction = null,
             TimeSpan? blockInterval = null,
@@ -97,7 +99,8 @@ namespace Libplanet.Blockchain.Policies
             Func<long, long>? getMaxBlockBytes = null,
             Func<long, int>? getMinTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerBlock = null,
-            Func<long, int>? getMaxTransactionsPerSignerPerBlock = null)
+            Func<long, int>? getMaxTransactionsPerSignerPerBlock = null,
+            IImmutableSet<Currency>? nativeTokens = null)
         {
             BlockAction = blockAction;
             BlockInterval = blockInterval
@@ -107,6 +110,7 @@ namespace Libplanet.Blockchain.Policies
             MinimumDifficulty = minimumDifficulty
                 ?? DifficultyAdjustment<T>.DefaultMinimumDifficulty;
             CanonicalChainComparer = canonicalChainComparer ?? new TotalDifficultyComparer();
+            NativeTokens = nativeTokens ?? ImmutableHashSet<Currency>.Empty;
             _hashAlgorithmGetter = hashAlgorithmGetter ?? (_ => HashAlgorithmType.Of<SHA256>());
             _getMaxBlockBytes = getMaxBlockBytes ?? (_ => 100L * 1024L);
             _getMinTransactionsPerBlock = getMinTransactionsPerBlock ?? (_ => 0);
@@ -195,7 +199,7 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
         // TODO: This should be configurable through the constructor.
-        public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
+        public IImmutableSet<Currency> NativeTokens { get; }
 
         /// <summary>
         /// Targeted time interval between two consecutive <see cref="Block{T}"/>s.

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 
@@ -33,6 +35,13 @@ namespace Libplanet.Blockchain.Policies
         /// An <see cref="IAction"/> to execute and be rendered for every block, if any.
         /// </summary>
         IAction? BlockAction { get; }
+
+        /// <summary>
+        /// A fixed set of <see cref="Currency"/> objects that are supported by the blockchain
+        /// as first-class citizens.
+        /// </summary>
+        [Pure]
+        IImmutableSet<Currency> NativeTokens { get; }
 
         /// <summary>
         /// Checks if a <see cref="Transaction{T}"/> can be included in a yet to be mined

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -1,7 +1,9 @@
 #nullable disable
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 
@@ -26,6 +28,9 @@ namespace Libplanet.Blockchain.Policies
             new TotalDifficultyComparer();
 
         public IAction BlockAction => null;
+
+        /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
+        public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
 
         public int GetMinTransactionsPerBlock(long index) => 0;
 

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -162,7 +162,10 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 );
 
                 expectedUnrenderedActions.AddRange(
-                    transactions.SelectMany(t => t.Actions).Cast<IAction>().Reverse());
+                    transactions.SelectMany(t =>
+                        t.SystemAction is { } sa ? new[] { sa } : t.CustomActions!.Cast<IAction>()
+                    ).Reverse()
+                );
 
                 BlockDigest prevDigest = store.GetBlockDigest(
                     header.PreviousHash ?? throw heterogeneousGenesisError
@@ -182,8 +185,9 @@ namespace Libplanet.Blockchain.Renderers.Debug
                     transactions,
                     header.PreEvaluationHash
                 );
-                IEnumerable<IAction> actions =
-                    transactions.SelectMany(t => t.Actions).Cast<IAction>();
+                IEnumerable<IAction> actions = transactions.SelectMany(t =>
+                    t.SystemAction is { } sa ? new[] { sa } : t.CustomActions!.Cast<IAction>()
+                );
                 if (policy.BlockAction is IAction blockAction)
                 {
 #if NET472 || NET471 || NET47 || NET462 || NET461

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -632,15 +632,5 @@ namespace Libplanet.Tx
             action.LoadPlainValue(value);
             return action;
         }
-
-        private readonly struct TransactionSerializationContext
-        {
-            internal TransactionSerializationContext(bool includeSignature)
-            {
-                IncludeSignature = includeSignature;
-            }
-
-            internal bool IncludeSignature { get; }
-        }
     }
 }


### PR DESCRIPTION
*Addresses #2149, #2150, and #2151.*

It adds chain-native tokens, which means these tokens are capable of minting, burning[^1], and transfer whether custom actions support them or not.

Native tokens are configured by `IBlockPolicy.NativeTokens`, which means it's a part of consensus.  However, it does not mean non-native tokens cannot be used in the blockchain.  Non-native tokens can be used within custom actions.  If a non-native token is tried to used with system actions `NonNativeTokenException` is thrown.

Now there are two types of actions: system built-in actions and user-defined custom actions.  The former one is introduced in this patch, and the latter one is what we've used so far and represented by a generic parameter `T : IAction, new()`.  System actions could be used for several scenarios, but this patch focuses on providing primitive actions for native tokens: `Mint` and `Transfer`.[^1]  The set of system actions are deliberately hard-coded in `Libplanet.Action.Sys.Registry` and unable to be extended by users.  `Registry` is even a non-public class.

A transaction may have either a system action or user-defined custom actions, but these fields are mutually exclusive.  At type-level, `Transaction<T>.SystemAction` and `CustomActions` properties are both nullable, but at runtime, one must be `null` and other one must not be `null`.[^2]  Note that `Transaction<T>.Actions` became to include system actions as well, and its type is now `IImmutableList<IAction>`.  It's deprecated though.  You should use `SystemAction` or `CustomActions` instead.

[^1]: In this patch, `Burn` is not implemented.  Before implementing it, we need to discuss on who should be allowed to burn and whose tokens should be burnable.

[^2]: It's like the below table:

    | Property                   | `SystemAction` | `CustomActions` |
    |----------------------------|----------------|-----------------|
    | :x: Disallowed             | `null`         | `null`          |
    | :white_check_mark: Allowed | `null`         | non-`null`      |
    | :white_check_mark: Allowed | non-`null`     | `null`          |
    | :x: Disallowed             | non-`null`     | non-`null`      |