### PR TITLE
Refactor `Context` for thread safety and covering additional edge cases

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -17,7 +17,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 {
     public class ConsensusContextNonProposerTest : ConsensusContextTestBase
     {
-        private const int Timeout = 60_000;
         private readonly ILogger _logger;
 
         public ConsensusContextNonProposerTest(ITestOutputHelper output)
@@ -241,8 +240,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             await heightThreeStepChanged.WaitAsync();
             // Commit ends
             await heightTwoStepChanged.WaitAsync();
-            // GST, PreVote -> Propose (NewHeight and NewRound started)
-            await NewHeightDelayAssert(3);
             // Propose -> PreVote (message consumed)
             await heightThreeStepChanged.WaitAsync();
             Assert.Equal(3, ConsensusContext.Height);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -31,15 +31,9 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         [Fact(Timeout = Timeout)]
         public async void IncreaseRoundWhenTimeout()
         {
-            var messageProcessed = new AsyncAutoResetEvent();
             var timeoutOccurred = new AsyncAutoResetEvent();
 
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
-            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].MessageProcessed +=
-                (sender, message) =>
-                {
-                    messageProcessed.Set();
-                };
             ConsensusContext.Contexts[BlockChain.Tip.Index + 1].TimeoutOccurred +=
                 (sender, message) =>
                 {

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -10,8 +10,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
     [Collection("NetMQConfiguration")]
     public class ConsensusContextProposerTest : ConsensusContextTestBase
     {
-        private const int Timeout = 60_000;
-
         private readonly ILogger _logger;
 
         public ConsensusContextProposerTest(ITestOutputHelper output)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -29,13 +29,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         [Fact(Timeout = Timeout)]
         public async void IncreaseRoundWhenTimeout()
         {
-            var timeoutOccurred = new AsyncAutoResetEvent();
+            var timeoutProcessed = new AsyncAutoResetEvent();
 
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
-            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].TimeoutOccurred +=
+            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].TimeoutProcessed +=
                 (sender, message) =>
                 {
-                    timeoutOccurred.Set();
+                    timeoutProcessed.Set();
                 };
 
             // Wait for block to be proposed.
@@ -65,7 +65,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     Remote = TestUtils.Peer3,
                 });
 
-            await timeoutOccurred.WaitAsync();
+            await timeoutProcessed.WaitAsync();
 
             ConsensusContext.HandleMessage(
                 new ConsensusCommit(
@@ -89,13 +89,9 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     Remote = TestUtils.Peer3,
                 });
 
-            await timeoutOccurred.WaitAsync();
-
+            await timeoutProcessed.WaitAsync();
             Assert.Equal(1, ConsensusContext.Height);
-            await Libplanet.Tests.TestUtils.AssertThatEventually(
-                () => ConsensusContext.Round == 1,
-                5_000,
-                conditionLabel: "Round does not changed.");
+            Assert.Equal(1, ConsensusContext.Round);
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -35,7 +35,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var timeoutOccurred = new AsyncAutoResetEvent();
 
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
-
             ConsensusContext.Contexts[BlockChain.Tip.Index + 1].MessageProcessed +=
                 (sender, message) =>
                 {
@@ -48,7 +47,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 };
 
             // Wait for block to be proposed.
-            await messageProcessed.WaitAsync();
             Assert.Equal(1, ConsensusContext.Height);
             Assert.Equal(0, ConsensusContext.Round);
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // NewHeight also covers Commit() due to calling the method from Context<T>
             AutoResetEvent waitingCommit = new AutoResetEvent(false);
             AutoResetEvent stepChanged = new AutoResetEvent(false);
-            AutoResetEvent messageProcessed = new AutoResetEvent(false);
+            AutoResetEvent messageConsumed = new AutoResetEvent(false);
 
             Assert.Throws<InvalidHeightIncreasingException>(
                 () => ConsensusContext.NewHeight(BlockChain.Tip.Index));
@@ -70,10 +70,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
             // PreVote is sent and handled due to node is the proposer.
             ConsensusContext.Contexts[BlockChain.Tip.Index + 1].StepChanged += CheckPreVote;
-            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].MessageProcessed +=
-                    (sender, message) => messageProcessed.Set();
+            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].MessageConsumed +=
+                    (sender, message) => messageConsumed.Set();
 
-            messageProcessed.WaitOne();
+            messageConsumed.WaitOne();
             VoteSet voteSet = ConsensusContext.Contexts[BlockChain.Tip.Index + 1].VoteSet(0);
             BlockHash blockHash = voteSet.Votes[0].BlockHash!.Value;
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -56,20 +56,24 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             // FIXME: StartAsync inside NewHeight makes it unreliable to try to await for
             // early events.
-            VoteSet? voteSet = null;
+            BlockHash blockHash;
             while (true)
             {
                 try
                 {
-                    voteSet = ConsensusContext.Contexts[BlockChain.Tip.Index + 1].VoteSet(0);
-                    break;
+                    var voteSet = ConsensusContext.Contexts[BlockChain.Tip.Index + 1].VoteSet(0);
+                    if (voteSet.Votes[0].BlockHash is BlockHash hash)
+                    {
+                        blockHash = hash;
+                        break;
+                    }
                 }
                 catch (Exception)
                 {
                 }
-            }
 
-            BlockHash blockHash = voteSet!.Votes[0].BlockHash!.Value;
+                await Task.Delay(100);
+            }
 
             ConsensusContext.HandleMessage(
                 new ConsensusVote(

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -46,9 +46,9 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 () => ConsensusContext.NewHeight(BlockChain.Tip.Index + 2));
 
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
-            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].StepChanged += (sender, step) =>
+            ConsensusContext.Contexts[BlockChain.Tip.Index + 1].StateChanged += (sender, state) =>
             {
-                if (step == Step.EndCommit)
+                if (state.Step == Step.EndCommit)
                 {
                     stepChangedToEndCommit.Set();
                 }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
@@ -21,8 +21,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         protected readonly ConsensusContext<DumbAction> ConsensusContext;
         protected readonly TimeSpan NewHeightDelay = TimeSpan.FromSeconds(1);
 
-        protected TestUtils.DelegateWatchConsensusMessage? watchConsensusMessage;
-
         private const int Port = 19283;
         private readonly ILogger _logger;
 
@@ -48,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             void BroadcastMessage(ConsensusMessage message) =>
                 Task.Run(() =>
                 {
-                    watchConsensusMessage?.Invoke(message);
+                    ConsensusMessageSent?.Invoke(this, message);
                     message.Remote = new Peer(privateKey.PublicKey);
                     ConsensusContext!.HandleMessage(message);
                 });
@@ -62,6 +60,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 validators,
                 NewHeightDelay);
         }
+
+        protected event EventHandler<ConsensusMessage>? ConsensusMessageSent;
 
         public void Dispose()
         {

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
@@ -14,6 +14,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 {
     public class ConsensusContextTestBase : IDisposable
     {
+        protected const int Timeout = 30_000;
+
         protected readonly StoreFixture Fx;
         protected readonly BlockChain<DumbAction> BlockChain;
         protected readonly ConsensusContext<DumbAction> ConsensusContext;
@@ -65,13 +67,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         {
             Fx.Dispose();
             ConsensusContext.Dispose();
-        }
-
-        protected async Task NewHeightDelayAssert(long height)
-        {
-            await Libplanet.Tests.TestUtils.AssertThatEventually(
-                () => ConsensusContext.Height == height,
-                NewHeightDelay.Duration().Milliseconds + 3_000);
         }
     }
 }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -45,6 +45,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await messageProcessed.WaitAsync();
+            await messageProcessed.WaitAsync();
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
@@ -205,6 +206,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await messageProcessed.WaitAsync();
+            await messageProcessed.WaitAsync();
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);
@@ -229,7 +231,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.TimeoutOccurred += (sender, tuple) => timeoutOccurred.Set();
             AsyncAutoResetEvent messageProcessed = WatchMessageProcessed();
 
-            await Context.StartAsync();
+            Context.StartAsync();
 
             Context.StepChanged += (sender, step) => stepChanged.Set();
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -206,7 +206,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await messageProcessed.WaitAsync();
-            await messageProcessed.WaitAsync();
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -194,15 +194,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void EnterPreVoteNilOneThird()
         {
-            var stepChangedToRoundZeroPreVote = new AsyncAutoResetEvent();
             var stepChangedToRoundOnePreVote = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, stage) =>
             {
-                if (stage.Round == 0 && stage.Step == Step.PreVote)
-                {
-                    stepChangedToRoundZeroPreVote.Set();
-                }
-                else if (stage.Round == 1 && stage.Step == Step.PreVote)
+                if (stage.Round == 1 && stage.Step == Step.PreVote)
                 {
                     stepChangedToRoundOnePreVote.Set();
                 }
@@ -228,9 +223,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
 
-            await Task.WhenAll(
-                stepChangedToRoundZeroPreVote.WaitAsync(),
-                stepChangedToRoundOnePreVote.WaitAsync());
+            await stepChangedToRoundOnePreVote.WaitAsync();
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -31,7 +31,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     stateChangedToRoundOnePreVote.Set();
                 }
             };
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
@@ -78,7 +78,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     commitSent.Set();
                 }
             };
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
@@ -143,7 +143,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     commitSent.Set();
                 }
             };
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
@@ -190,7 +190,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     stepChangedToRoundOnePreVote.Set();
                 }
             };
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
@@ -233,7 +233,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     voteSent.Set();
                 }
             };
-            Context.StartAsync();
+            Context.Start();
 
             await Task.WhenAll(voteSent.WaitAsync(), stepChangedToPreVote.WaitAsync());
             Assert.Equal(Step.PreVote, Context.Step);
@@ -247,7 +247,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
             var timeoutProcessed = new AsyncAutoResetEvent();
             Context.TimeoutProcessed += (sender, message) => timeoutProcessed.Set();
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
@@ -290,7 +290,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
             var timeoutProcessed = new AsyncAutoResetEvent();
             Context.TimeoutProcessed += (sender, message) => timeoutProcessed.Set();
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -171,7 +171,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await roundChangedToOne.WaitAsync();
-            await NewRoundSendMessageAssert();
             Assert.Equal(Step.Propose, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(1, Context.Round);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Block<DumbAction> block =
                 await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
-            await Context.StartAsync();
+            Context.StartAsync();
 
             Context.HandleMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[NodeId]));
@@ -102,7 +102,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Block<DumbAction> block =
                 await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
             targetHash = block.Hash;
-            await Context.StartAsync();
+            Context.StartAsync();
 
             Context.HandleMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -182,7 +182,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await timeoutOccurred.WaitAsync();
-            await roundStarted.WaitAsync();
+            await Context.ConsumeMutation(default);
             // Node id 1 is not next proposer, and wait for SendMessageAfter() and broadcast
             // messages.
             await NewRoundSendMessageAssert();

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             watchConsensusMessage = IsVoteSent;
 
-            Context.HandleMessage(
+            Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
                     1,
@@ -56,8 +56,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
+            await Context.ConsumeMessage();
 
-            Context.HandleMessage(new
+            Context.ProduceMessage(new
                 ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
                     1,
@@ -67,10 +68,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
+            await Context.ConsumeMessage();
 
-            AsyncAutoResetEvent messageProcessed = WatchMessageProcessed();
-
-            Context.HandleMessage(
+            Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
                     1,
@@ -80,9 +80,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
+            await Context.ConsumeMessage();
 
             await messageReceived.WaitAsync();
-            await messageProcessed.WaitAsync();
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(2, Context.Round);
@@ -113,7 +113,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.AddMessage(TestUtils.CreateConsensusPropose(
                 invalidBlock, TestUtils.PrivateKeys[3], round: 2, validRound: 1));
 
-            Context.HandleMessage(
+            Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
                     1,
@@ -123,8 +123,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[0]),
                 });
+            await Context.ConsumeMessage();
 
-            Context.HandleMessage(new
+            Context.ProduceMessage(new
                 ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
                     1,
@@ -134,10 +135,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[2]),
                 });
+            await Context.ConsumeMessage();
 
-            AsyncAutoResetEvent messageProcessed = WatchMessageProcessed();
-
-            Context.HandleMessage(
+            Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
                     1,
@@ -147,9 +147,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     Remote = new Peer(TestUtils.Validators[3]),
                 });
+            await Context.ConsumeMessage();
 
             await messageReceived.WaitAsync();
-            await messageProcessed.WaitAsync();
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
             Assert.Equal(2, Context.Round);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -242,6 +242,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 });
 
             await stepChangedToPreCommit.WaitAsync();
+            // Wait for the vote to change from Absent to Commit to avoid flakiness.
+            await Libplanet.Tests.TestUtils.AssertThatEventually(
+                () => Context.VoteSet(0).Votes[1].Flag == VoteFlag.Commit,
+                3_000);
             VoteSet roundVoteSet = Context.VoteSet(0);
             Assert.Equal(1, roundVoteSet.Height);
             Assert.Equal(0, roundVoteSet.Round);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -207,8 +207,11 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             BlockHash? blockHash = null;
             AsyncAutoResetEvent stepChanged = new AsyncAutoResetEvent();
+            AsyncAutoResetEvent mutationConsumed = new AsyncAutoResetEvent();
+            Context.MutationConsumed += (sender, message) => mutationConsumed.Set();
 
             Context.StartAsync();
+            await mutationConsumed.WaitAsync();
 
             void WatchPropose(ConsensusMessage message)
             {

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 }
             };
 
-            Context.StartAsync();
+            Context.Start();
             await Task.WhenAll(proposeSent.WaitAsync(), stepChangedToPreVote.WaitAsync());
 
             Assert.Equal(Step.PreVote, Context.Step);
@@ -76,7 +76,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var voteSet = new VoteSet(0, 0, BlockChain.Tip.Hash, TestUtils.Validators);
             var lastCommit = new BlockCommit(voteSet, BlockChain.Tip.Hash);
 
-            Context.StartAsync(lastCommit);
+            Context.Start(lastCommit);
             await Task.WhenAll(proposeSent.WaitAsync(), stepChangedToPreVote.WaitAsync());
 
             Assert.Equal(Step.PreVote, Context.Step);
@@ -201,7 +201,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 }
             };
 
-            Context.StartAsync();
+            Context.Start();
 
             Context.ProduceMessage(
                 new ConsensusVote(

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -251,10 +251,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             // Wait for all messages to be cleared.
             await messageConsumed.WaitAsync();
-            await messageConsumed.WaitAsync();
             roundVoteSet = Context.VoteSet(0);
             Assert.Equal(VoteFlag.Absent, roundVoteSet.Votes[0].Flag);
-            Assert.Equal(VoteFlag.Commit, roundVoteSet.Votes[1].Flag);
+            Assert.Equal(VoteFlag.Absent, roundVoteSet.Votes[1].Flag);
             Assert.Equal(VoteFlag.Absent, roundVoteSet.Votes[2].Flag);
             Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[3].Flag);
 
@@ -272,7 +271,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(1, roundVoteSet.Height);
             Assert.Equal(0, roundVoteSet.Round);
             Assert.Equal(VoteFlag.Absent, roundVoteSet.Votes[0].Flag);
-            Assert.Equal(VoteFlag.Commit, roundVoteSet.Votes[1].Flag);
+            Assert.Equal(VoteFlag.Absent, roundVoteSet.Votes[1].Flag);
             Assert.Equal(VoteFlag.Commit, roundVoteSet.Votes[2].Flag);
             Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[3].Flag);
         }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void StartAsync()
         {
-            var stepChanged = new AsyncAutoResetEvent();
+            var stepChangedToPreVote = new AsyncAutoResetEvent();
             var messageReceived = new AsyncAutoResetEvent();
 
             void IsProposeSent(ConsensusMessage message)
@@ -41,13 +41,13 @@ namespace Libplanet.Net.Tests.Consensus.Context
             {
                 if (step == Step.PreVote)
                 {
-                    stepChanged.Set();
+                    stepChangedToPreVote.Set();
                 }
             };
 
             Context.StartAsync();
             await messageReceived.WaitAsync();
-            await stepChanged.WaitAsync();
+            await stepChangedToPreVote.WaitAsync();
 
             Assert.Equal(Step.PreVote, Context.Step);
             Assert.Equal(1, Context.Height);
@@ -57,7 +57,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void StartAsyncWithLastCommit()
         {
-            var stepChanged = new AsyncAutoResetEvent();
+            var stepChangedToPreVote = new AsyncAutoResetEvent();
             var messageReceived = new AsyncAutoResetEvent();
             ConsensusPropose? received = null;
 
@@ -76,7 +76,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             {
                 if (step == Step.PreVote)
                 {
-                    stepChanged.Set();
+                    stepChangedToPreVote.Set();
                 }
             };
 
@@ -85,7 +85,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.StartAsync(lastCommit);
             await messageReceived.WaitAsync();
-            await stepChanged.WaitAsync();
+            await stepChangedToPreVote.WaitAsync();
 
             Assert.Equal(Step.PreVote, Context.Step);
             // Looks dirty, but compiler throws error without if statement.

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 }
             };
 
-            await Context.StartAsync();
+            Context.StartAsync();
             await messageReceived.WaitAsync();
             await stepChanged.WaitAsync();
 
@@ -83,7 +83,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var voteSet = new VoteSet(0, 0, BlockChain.Tip.Hash, TestUtils.Validators);
             var lastCommit = new BlockCommit(voteSet, BlockChain.Tip.Hash);
 
-            await Context.StartAsync(lastCommit);
+            Context.StartAsync(lastCommit);
             await messageReceived.WaitAsync();
             await stepChanged.WaitAsync();
 
@@ -208,7 +208,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             BlockHash? blockHash = null;
             AsyncAutoResetEvent stepChanged = new AsyncAutoResetEvent();
 
-            await Context.StartAsync();
+            Context.StartAsync();
 
             void WatchPropose(ConsensusMessage message)
             {

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -46,12 +46,11 @@ namespace Libplanet.Net.Tests.Consensus.Context
             BlockChain = TestUtils.CreateDummyBlockChain((MemoryStoreFixture)_fx);
 
             void BroadcastMessage(ConsensusMessage message) =>
-                Task.Run(async () =>
+                Task.Run(() =>
                 {
                     watchConsensusMessage?.Invoke(message);
                     message.Remote = new Peer(TestUtils.PrivateKeys[(int)nodeId].PublicKey);
                     Context!.ProduceMessage(message);
-                    await Context!.ConsumeMessage();
                 });
 
             _consensusContext = new ConsensusContext<DumbAction>(

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -19,8 +19,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
         protected readonly Context<DumbAction> Context;
         protected readonly BlockChain<DumbAction> BlockChain;
 
-        protected TestUtils.DelegateWatchConsensusMessage? watchConsensusMessage = null;
-
         private readonly StoreFixture _fx;
         private readonly ILogger _logger;
         private readonly TimeSpan _newHeightDelay = TimeSpan.FromSeconds(4);
@@ -48,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             void BroadcastMessage(ConsensusMessage message) =>
                 Task.Run(() =>
                 {
-                    watchConsensusMessage?.Invoke(message);
+                    ConsensusMessageSent?.Invoke(this, message);
                     message.Remote = new Peer(TestUtils.PrivateKeys[(int)nodeId].PublicKey);
                     Context!.ProduceMessage(message);
                 });
@@ -70,6 +68,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 step,
                 round);
         }
+
+        protected event EventHandler<ConsensusMessage>? ConsensusMessageSent;
 
         public void Dispose()
         {

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 {
     public class ContextTestBase : IDisposable
     {
-        protected const int Timeout = 60_000;
+        protected const int Timeout = 30_000;
         protected readonly Context<DumbAction> Context;
         protected readonly BlockChain<DumbAction> BlockChain;
 
@@ -89,12 +89,5 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 Timestamp = BlockChain.Tip.Timestamp.Subtract(TimeSpan.FromSeconds(1)),
                 Transactions = new List<Transaction<DumbAction>>(),
             }.Mine(_fx.GetHashAlgorithm(2)).Evaluate(_fx.Miner, BlockChain);
-
-        protected async Task NewRoundSendMessageAssert()
-        {
-            await Libplanet.Tests.TestUtils.AssertThatEventually(
-                () => Context.Step == Step.Propose,
-                1_000);
-        }
     }
 }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -182,8 +182,7 @@ namespace Libplanet.Net.Tests
             };
         }
 
-        public static ConsensusContext<DumbAction>
-            CreateStandaloneConsensusContext(
+        public static ConsensusContext<DumbAction> CreateStandaloneConsensusContext(
             BlockChain<DumbAction> blockChain,
             ITransport transport,
             TimeSpan newHeightDelay,

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -171,7 +171,7 @@ namespace Libplanet.Net.Consensus
                     _validators);
             }
 
-            _contexts[height].StartAsync(lastCommit);
+            _contexts[height].Start(lastCommit);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -171,7 +171,7 @@ namespace Libplanet.Net.Consensus
                     _validators);
             }
 
-            _ = _contexts[height].StartAsync(lastCommit);
+            _contexts[height].StartAsync(lastCommit);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -14,13 +14,10 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="lastCommit">A <see cref="Block{T}.LastCommit"/> from previous block.
         /// </param>
-        /// <returns>An awaitable task without value. This task
-        /// awaits <see cref="StartRound"/> and starts <see cref="MessageConsumerTask"/>.
-        /// </returns>
-        public async Task StartAsync(BlockCommit? lastCommit = null)
+        public void StartAsync(BlockCommit? lastCommit = null)
         {
             _lastCommit = lastCommit;
-            await StartRound(0);
+            StartRound(0);
             if (Proposer(0) != _privateKey.PublicKey &&
                 _messagesInRound.ContainsKey(0) &&
                 _messagesInRound[0].FirstOrDefault(msg => msg is ConsensusPropose) is

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -97,7 +97,6 @@ namespace Libplanet.Net.Consensus
                         nameof(AddMessage));
                 }
             });
-            ProduceMutation(() => ProcessGenericUponRules());
             ProduceMutation(() => ProcessHeightOrRoundUponRules(message));
             MessageConsumed?.Invoke(this, message);
         }
@@ -127,6 +126,13 @@ namespace Libplanet.Net.Consensus
                     nextRound,
                     nextStep.ToString());
                 StateChanged?.Invoke(this, (nextMessageLogSize, nextRound, nextStep));
+
+                // FIXME: This is to avoid an exception.
+                // Methods accessing message log should be changed instead.
+                if (_messagesInRound.ContainsKey(Round))
+                {
+                    ProduceMutation(() => ProcessGenericUponRules());
+                }
             }
 
             MutationConsumed?.Invoke(this, mutation);

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -63,8 +63,8 @@ namespace Libplanet.Net.Consensus
                     message.BlockHash,
                     _messagesInRound[Round].Count,
                     ToString());
-                ProcessGenericUponRules();
-                ProcessHeightOrRoundUponRules(message);
+                ProduceMutation(() => ProcessGenericUponRules());
+                ProduceMutation(() => ProcessHeightOrRoundUponRules(message));
                 MessageConsumed?.Invoke(this, message);
             }
             catch (Exception e)

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
@@ -18,13 +17,6 @@ namespace Libplanet.Net.Consensus
         {
             _lastCommit = lastCommit;
             StartRound(0);
-            if (Proposer(0) != _privateKey.PublicKey &&
-                _messagesInRound.ContainsKey(0) &&
-                _messagesInRound[0].FirstOrDefault(msg => msg is ConsensusPropose) is
-                    ConsensusPropose propose)
-            {
-                ProcessUponRules(propose);
-            }
 
             _ = MessageConsumerTask(_cancellationTokenSource.Token);
         }

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Net.Consensus
         public void StartAsync(BlockCommit? lastCommit = null)
         {
             _lastCommit = lastCommit;
-            StartRound(0);
+            ProduceMutation(() => StartRound(0));
 
             // FIXME: Exceptions inside tasks should be handled properly.
             _ = MessageConsumerTask(_cancellationTokenSource.Token);

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -102,7 +102,31 @@ namespace Libplanet.Net.Consensus
         private async Task ConsumeMutation(CancellationToken cancellationToken)
         {
             System.Action mutation = await _mutationRequests.Reader.ReadAsync(cancellationToken);
+            int prevRound = Round;
+            Step prevStep = Step;
             mutation();
+            int nextRound = Round;
+            Step nextStep = Step;
+            if (prevStep != nextStep)
+            {
+                _logger.Debug(
+                    "Step changed from {PrevStep} to {NextStep}. {Info}",
+                    prevStep.ToString(),
+                    nextStep.ToString(),
+                    ToString());
+                StepChanged?.Invoke(this, nextStep);
+            }
+
+            if (prevRound != nextRound)
+            {
+                _logger.Debug(
+                    "Round changed from {PrevRound} to {NextRound}. {Info}",
+                    prevRound,
+                    nextRound,
+                    ToString());
+                RoundChanged?.Invoke(this, Round);
+            }
+
             MutationConsumed?.Invoke(this, mutation);
         }
 

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -108,7 +108,7 @@ namespace Libplanet.Net.Consensus
                 timeout,
                 ToString());
             TimeoutOccurred?.Invoke(this, (Step.Propose, TimeoutPropose(round)));
-            ProcessTimeoutPropose(height, round);
+            ProduceMutation(() => ProcessTimeoutPropose(height, round));
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Libplanet.Net.Consensus
                 timeout,
                 ToString());
             TimeoutOccurred?.Invoke(this, (Step.PreVote, TimeoutPreVote(round)));
-            ProcessTimeoutPreVote(height, round);
+            ProduceMutation(() => ProcessTimeoutPreVote(height, round));
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Libplanet.Net.Consensus
                 timeout,
                 ToString());
             TimeoutOccurred?.Invoke(this, (Step.PreCommit, TimeoutPreCommit(round)));
-            ProcessTimeoutPreCommit(height, round);
+            ProduceMutation(() => ProcessTimeoutPreCommit(height, round));
         }
     }
 }

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public partial class Context<T>
+    {
+        /// <summary>
+        /// Starts the round #0 of consensus for <see cref="Height"/>.
+        /// </summary>
+        /// <param name="lastCommit">A <see cref="Block{T}.LastCommit"/> from previous block.
+        /// </param>
+        /// <returns>An awaitable task without value. This task
+        /// awaits <see cref="StartRound"/> and starts <see cref="MessageConsumerTask"/>.
+        /// </returns>
+        public async Task StartAsync(BlockCommit? lastCommit = null)
+        {
+            _lastCommit = lastCommit;
+            await StartRound(0);
+            if (Proposer(0) != _privateKey.PublicKey &&
+                _messagesInRound.ContainsKey(0) &&
+                _messagesInRound[0].FirstOrDefault(msg => msg is ConsensusPropose) is
+                    ConsensusPropose propose)
+            {
+                ProcessMessage(propose);
+            }
+
+            _ = MessageConsumerTask(_cancellationTokenSource.Token);
+        }
+
+        /// <summary>
+        /// Consumes the every <see cref="ConsensusMessage"/> in the message queue.
+        /// </summary>
+        /// <param name="ctx">A cancellation token for reading message from message queue.</param>
+        private async Task MessageConsumerTask(CancellationToken ctx)
+        {
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET
+            await foreach (ConsensusMessage message in _messageRequests.Reader.ReadAllAsync(ctx))
+            {
+#else
+            while (!ctx.IsCancellationRequested)
+            {
+                ConsensusMessage message = await _messageRequests.Reader.ReadAsync(ctx);
+#endif
+                try
+                {
+                    HandleMessage(message);
+                }
+                catch (Exception e)
+                {
+                    _logger.Error(
+                        e,
+                        "Unexpected exception occurred during {FName}. {E}",
+                        nameof(HandleMessage),
+                        e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A timeout task for a round if no <see cref="ConsensusPropose"/> is received in
+        /// <see cref="TimeoutPropose"/> and <see cref="Libplanet.Net.Consensus.Step.Propose"/>
+        /// step.
+        /// </summary>
+        /// <param name="height">A height that the timeout task is scheduled for.</param>
+        /// <param name="round">A round that the timeout task is scheduled for.</param>
+        private async Task OnTimeoutPropose(long height, int round)
+        {
+            TimeSpan timeout = TimeoutPropose(round);
+            await Task.Delay(timeout, _cancellationTokenSource.Token);
+            if (height == Height && round == Round && Step == Step.Propose)
+            {
+                _logger.Debug(
+                    "TimeoutPropose has occurred in {Timeout}. {Info}",
+                    timeout,
+                    ToString());
+                TimeoutOccurred?.Invoke(this, (Step.Propose, TimeoutPropose(round)));
+                BroadcastMessage(
+                    new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                SetStep(Step.PreVote);
+            }
+        }
+
+        /// <summary>
+        /// A timeout task for a round if <see cref="ConsensusVote"/> is received +2/3 any but has
+        /// no majority neither Block nor NIL in
+        /// <see cref="TimeoutPreVote"/> and <see cref="Libplanet.Net.Consensus.Step.PreVote"/>
+        /// step.
+        /// </summary>
+        /// <param name="height">A height that the timeout task is scheduled for.</param>
+        /// <param name="round">A round that the timeout task is scheduled for.</param>
+        private async Task OnTimeoutPreVote(long height, int round)
+        {
+            TimeSpan timeout = TimeoutPreVote(round);
+            await Task.Delay(timeout, _cancellationTokenSource.Token);
+            if (height == Height && round == Round && Step == Step.PreVote)
+            {
+                _logger.Debug(
+                    "TimeoutPreVote has occurred in {Timeout}. {Info}",
+                    timeout,
+                    ToString());
+                TimeoutOccurred?.Invoke(this, (Step.PreVote, TimeoutPreVote(round)));
+                BroadcastMessage(
+                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
+                SetStep(Step.PreCommit);
+            }
+        }
+
+        /// <summary>
+        /// A timeout task for a round if <see cref="ConsensusCommit"/> is received +2/3 any but has
+        /// no majority neither Block or NIL in
+        /// <see cref="TimeoutPreCommit"/> and <see cref="Libplanet.Net.Consensus.Step.PreCommit"/>
+        /// step.
+        /// </summary>
+        /// <param name="height">A height that the timeout task is scheduled for.</param>
+        /// <param name="round">A round that the timeout task is scheduled for.</param>
+        private async Task OnTimeoutPreCommit(long height, int round)
+        {
+            TimeSpan timeout = TimeoutPreCommit(round);
+            await Task.Delay(timeout, _cancellationTokenSource.Token);
+            if (height == Height && round == Round && Step < Step.EndCommit)
+            {
+                _logger.Debug(
+                    "TimeoutPreCommit has occurred in {Timeout}. {Info}",
+                    timeout,
+                    ToString());
+                TimeoutOccurred?.Invoke(this, (Step.PreCommit, TimeoutPreCommit(round)));
+                _ = StartRound(Round + 1);
+            }
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -1,0 +1,38 @@
+using System;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public partial class Context<T>
+    {
+        /// <summary>
+        /// An event that invoked when any timeout occurs.
+        /// </summary>
+        internal event EventHandler<(Step, TimeSpan)>? TimeoutOccurred;
+
+        /// <summary>
+        /// An event that invoked when any timeout triggered event is processed.
+        /// </summary>
+        internal event EventHandler<(long, int)>? TimeoutProcessed;
+
+        /// <summary>
+        /// An event that is invoked when <see cref="Round"/> is changed.
+        /// </summary>
+        internal event EventHandler<int>? RoundChanged;
+
+        /// <summary>
+        /// An event that is invoked when <see cref="Step"/> is changed.
+        /// </summary>
+        internal event EventHandler<Step>? StepChanged;
+
+        /// <summary>
+        /// An event that is invoked when a queued <see cref="ConsensusMessage"/> is consumed.
+        /// </summary>
+        internal event EventHandler<ConsensusMessage>? MessageConsumed;
+
+        /// <summary>
+        /// An event that is invoked when a queued <see cref="System.Action"/> is consumed.
+        /// </summary>
+        internal event EventHandler<System.Action>? MutationConsumed;
+    }
+}

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -22,14 +22,10 @@ namespace Libplanet.Net.Consensus
         internal event EventHandler<Block<T>>? BlockProposed;
 
         /// <summary>
-        /// An event that is invoked when <see cref="Round"/> is changed.
+        /// An event that is invoked when the message log size, <see cref="Round"/>,
+        /// and/or <see cref="Step"/> is changed.
         /// </summary>
-        internal event EventHandler<int>? RoundChanged;
-
-        /// <summary>
-        /// An event that is invoked when <see cref="Step"/> is changed.
-        /// </summary>
-        internal event EventHandler<Step>? StepChanged;
+        internal event EventHandler<(int MessageLogSize, int Round, Step Step)>? StateChanged;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMessage"/> is consumed.

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -1,5 +1,4 @@
 using System;
-using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -9,17 +8,14 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// An event that invoked when any timeout occurs.
         /// </summary>
-        internal event EventHandler<(Step, TimeSpan)>? TimeoutOccurred;
+        internal event EventHandler<(Step Step, TimeSpan TimeSpan)>? TimeoutOccurred;
 
         /// <summary>
-        /// An event that invoked when any timeout triggered event is processed.
+        /// An event that invoked when any timeout triggered mutation is processed.
+        /// This is conditionally triggered, i.e. when certain conditions are met
+        /// after <see cref="TimeoutOccurred"/> is triggered.
         /// </summary>
-        internal event EventHandler<(long, int)>? TimeoutProcessed;
-
-        /// <summary>
-        /// An event that invoked when block is proposed.
-        /// </summary>
-        internal event EventHandler<Block<T>>? BlockProposed;
+        internal event EventHandler<int>? TimeoutProcessed;
 
         /// <summary>
         /// An event that is invoked when the message log size, <see cref="Round"/>,

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -1,4 +1,5 @@
 using System;
+using Libplanet.Blocks;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -14,6 +15,11 @@ namespace Libplanet.Net.Consensus
         /// An event that invoked when any timeout triggered event is processed.
         /// </summary>
         internal event EventHandler<(long, int)>? TimeoutProcessed;
+
+        /// <summary>
+        /// An event that invoked when block is proposed.
+        /// </summary>
+        internal event EventHandler<Block<T>>? BlockProposed;
 
         /// <summary>
         /// An event that is invoked when <see cref="Round"/> is changed.

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Messages;
@@ -127,6 +128,19 @@ namespace Libplanet.Net.Consensus
 
                 // TODO: Prevent duplicated messages adding.
                 _messagesInRound[message.Round].Add(message);
+                _logger.Debug(
+                    "{FName}: Message: {Message} => Height: {Height}, Round: {Round}, " +
+                    "Validator Address: {VAddress}, Remote Address: {RAddress}, " +
+                    "Hash: {BlockHash}, MessageCount: {Count}. (context: {Context})",
+                    nameof(AddMessage),
+                    message,
+                    message.Height,
+                    message.Round,
+                    message.Validator.ToAddress(),
+                    message.Remote!.Address,
+                    message.BlockHash,
+                    _messagesInRound.Sum(x => x.Value.Count),
+                    ToString());
             }
         }
 

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -12,8 +12,7 @@ namespace Libplanet.Net.Consensus
         /// Start a new round.
         /// </summary>
         /// <param name="round">A round to start.</param>
-        /// <returns>An awaitable task without value.</returns>
-        internal async Task StartRound(int round)
+        internal void StartRound(int round)
         {
             RoundStarted?.Invoke(this, round);
             _logger.Debug(
@@ -29,15 +28,7 @@ namespace Libplanet.Net.Consensus
                     "Starting round {NewRound} and is a proposer. (context: {Context})",
                     round,
                     ToString());
-                Block<T> proposal;
-                if (_validValue is null)
-                {
-                    proposal = await GetValue();
-                }
-                else
-                {
-                    proposal = _validValue;
-                }
+                Block<T> proposal = _validValue ?? GetValue();
 
                 BroadcastMessage(
                     new ConsensusPropose(
@@ -301,7 +292,7 @@ namespace Libplanet.Net.Consensus
                     message.Round,
                     Round,
                     ToString());
-                _ = StartRound(message.Round);
+                Task.Run(() => StartRound(message.Round));
             }
 
             MessageProcessed?.Invoke(this, message);
@@ -354,7 +345,7 @@ namespace Libplanet.Net.Consensus
         {
             if (height == Height && round == Round && Step < Step.EndCommit)
             {
-                _ = StartRound(Round + 1);
+                StartRound(Round + 1);
             }
         }
     }

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Net.Consensus
                 Round,
                 ToString());
             Round = round;
-            SetStep(Step.Propose);
+            Step = Step.Propose;
             if (Proposer(Round) == _privateKey.PublicKey)
             {
                 _logger.Debug(
@@ -45,8 +45,6 @@ namespace Libplanet.Net.Consensus
                     ToString());
                 _ = OnTimeoutPropose(Height, Round);
             }
-
-            RoundChanged?.Invoke(this, Round);
         }
 
         /// <summary>
@@ -149,7 +147,7 @@ namespace Libplanet.Net.Consensus
                     "Entering PreVote step due to proposal message with " +
                     "valid round -1. (context: {Context})",
                     ToString());
-                SetStep(Step.PreVote);
+                Step = Step.PreVote;
 
                 if (IsValid(block1) && (_lockedRound == -1 || _lockedValue == block1))
                 {
@@ -174,7 +172,7 @@ namespace Libplanet.Net.Consensus
                     "2/3+ PreVote for valid round {ValidRound}. (context: {Context})",
                     validRound2,
                     ToString());
-                SetStep(Step.PreVote);
+                Step = Step.PreVote;
 
                 if (IsValid(block2) && (_lockedRound <= validRound2 || _lockedValue == block2))
                 {
@@ -220,7 +218,7 @@ namespace Libplanet.Net.Consensus
                         "2/3+ PreVote for current round {Round}. (context: {Context})",
                         Round,
                         ToString());
-                    SetStep(Step.PreCommit);
+                    Step = Step.PreCommit;
                     _lockedValue = block3;
                     _lockedRound = Round;
                     BroadcastMessage(
@@ -238,7 +236,7 @@ namespace Libplanet.Net.Consensus
                     "(context: {Context})",
                     Round,
                     ToString());
-                SetStep(Step.PreCommit);
+                Step = Step.PreCommit;
                 BroadcastMessage(
                     new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
             }
@@ -270,7 +268,7 @@ namespace Libplanet.Net.Consensus
                 Step != Step.EndCommit &&
                 IsValid(block4))
             {
-                SetStep(Step.EndCommit);
+                Step = Step.EndCommit;
                 CommittedRound = round;
                 _logger.Debug(
                     "Committed block in round {Round}. (context: {Context})",
@@ -309,7 +307,7 @@ namespace Libplanet.Net.Consensus
             {
                 BroadcastMessage(
                     new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
-                SetStep(Step.PreVote);
+                Step = Step.PreVote;
                 TimeoutProcessed?.Invoke(this, (height, round));
             }
         }
@@ -328,7 +326,7 @@ namespace Libplanet.Net.Consensus
             {
                 BroadcastMessage(
                     new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
-                SetStep(Step.PreCommit);
+                Step = Step.PreCommit;
                 TimeoutProcessed?.Invoke(this, (height, round));
             }
         }

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -294,8 +294,6 @@ namespace Libplanet.Net.Consensus
                     ToString());
                 Task.Run(() => StartRound(message.Round));
             }
-
-            MessageProcessed?.Invoke(this, message);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -27,6 +27,7 @@ namespace Libplanet.Net.Consensus
                     round,
                     ToString());
                 Block<T> proposal = _validValue ?? GetValue();
+                BlockProposed?.Invoke(this, proposal);
 
                 BroadcastMessage(
                     new ConsensusPropose(

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -1,0 +1,309 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public partial class Context<T>
+    {
+        /// <summary>
+        /// Start a new round.
+        /// </summary>
+        /// <param name="round">A round to start.</param>
+        internal async Task StartRound(int round)
+        {
+            RoundStarted?.Invoke(this, round);
+            _logger.Debug(
+                "Starting round {NewRound} (was {PrevRound}). (context: {Context})",
+                round,
+                Round,
+                ToString());
+            Round = round;
+            SetStep(Step.Propose);
+            if (Proposer(Round) == _privateKey.PublicKey)
+            {
+                _logger.Debug(
+                    "Starting round {NewRound} and is a proposer. (context: {Context})",
+                    round,
+                    ToString());
+                Block<T> proposal;
+                if (_validValue is null)
+                {
+                    proposal = await GetValue();
+                }
+                else
+                {
+                    proposal = _validValue;
+                }
+
+                BroadcastMessage(
+                    new ConsensusPropose(
+                        Height,
+                        Round,
+                        proposal.Hash,
+                        _codec.Encode(proposal.MarshalBlock()),
+                        _validRound));
+            }
+            else
+            {
+                _logger.Debug(
+                    "Starting round {NewRound} and is not a proposer. (context: {Context})",
+                    round,
+                    ToString());
+                _ = OnTimeoutPropose(Height, Round);
+            }
+        }
+
+        /// <summary>
+        /// Validates the given <paramref name="message"/> and add into the message queue.
+        /// </summary>
+        /// <param name="message">A <see cref="ConsensusMessage"/> to be added.
+        /// </param>
+        /// <exception cref="InvalidHeightMessageException">Thrown when the Height of message and
+        /// context height does not match.
+        /// </exception>
+        /// <exception cref="InvalidProposerProposeMessageException">Thrown when the
+        /// <see cref="ConsensusPropose"/> message has proposer that is not proposer of the current
+        /// round.
+        /// </exception>
+        /// <exception cref="InvalidBlockProposeMessageException">Thrown when the
+        /// <see cref="ConsensusPropose"/> message has invalid blockHash (i.e., NIL).
+        /// </exception>
+        /// <exception cref="InvalidValidatorVoteMessageException">Thrown when the signature of
+        /// <see cref="Vote"/> is invalid or the <see cref="Vote"/> is not signed by any validator
+        /// of this context.
+        /// </exception>
+        internal void AddMessage(ConsensusMessage message)
+        {
+            if (message.Height != Height)
+            {
+                throw new InvalidHeightMessageException(
+                    "Height of message differs with working height.  " +
+                    $"(expected: {Height}, actual: {message.Height})",
+                    message);
+            }
+
+            if (message is ConsensusPropose propose)
+            {
+                if (!propose.Remote!.PublicKey.Equals(Proposer(message.Round)))
+                {
+                    throw new InvalidProposerProposeMessageException(
+                        "Proposer for the height " +
+                        $"{message.Height} and round {message.Round} is invalid.  " +
+                        $"(expected: Height: {message.Height}, Round: {message.Round}, " +
+                        $"Proposer: {message.Remote!.PublicKey} / " +
+                        $"actual: Height: {Height}, Round: {Round}, " +
+                        $"Proposer: {Proposer(message.Round)})",
+                        message);
+                }
+
+                if (message.BlockHash.Equals(default(BlockHash)))
+                {
+                    throw new InvalidBlockProposeMessageException(
+                        "Cannot propose a null block.",
+                        message);
+                }
+            }
+
+            if (message is ConsensusVote vote &&
+                (!vote.ProposeVote.Verify(vote.Remote!.PublicKey) ||
+                 !_validators.Contains(vote.ProposeVote.Validator)))
+            {
+                throw new InvalidValidatorVoteMessageException(
+                    "Received ConsensusVote message is made by invalid validator.",
+                    vote);
+            }
+
+            if (message is ConsensusCommit commit &&
+                (!commit.CommitVote.Verify(commit.Remote!.PublicKey) ||
+                 !_validators.Contains(commit.CommitVote.Validator)))
+            {
+                throw new InvalidValidatorVoteMessageException(
+                    "Received ConsensusCommit message is made by invalid validator.",
+                    commit);
+            }
+
+            if (!_messagesInRound.ContainsKey(message.Round))
+            {
+                _messagesInRound.TryAdd(message.Round, new HashSet<ConsensusMessage>());
+            }
+
+            // TODO: Prevent duplicated messages adding.
+            _messagesInRound[message.Round].Add(message);
+        }
+
+        /// <summary>
+        /// Processes a message and translate the <see cref="Step"/> or <see cref="Round"/>.
+        /// </summary>
+        /// <param name="message">A <see cref="ConsensusMessage"/> to be processed.</param>
+        private void ProcessMessage(ConsensusMessage message)
+        {
+            _logger.Debug(
+                "{FName}: Message: {Message} => " +
+                "Height: {Height}, Round: {Round}, Address: {Address}, Hash: {BlockHash}. " +
+                "MessageCount: {Count}. (context: {Context})",
+                nameof(ProcessMessage),
+                message,
+                message.Height,
+                message.Round,
+                message.Remote!.Address,
+                message.BlockHash,
+                _messagesInRound[Round].Count,
+                ToString());
+            if (Step == Step.Default || Step == Step.EndCommit)
+            {
+                _logger.Debug("Operation will not run in {State} state.", Step.ToString());
+                return;
+            }
+
+            if (GetPropose(Round) is (Block<T> block1, int validRound1) &&
+                validRound1 == -1 &&
+                Step == Step.Propose)
+            {
+                _logger.Debug(
+                    "Entering PreVote step due to proposal message with " +
+                    "valid round -1. (context: {Context})",
+                    ToString());
+                SetStep(Step.PreVote);
+
+                if (IsValid(block1) && (_lockedRound == -1 || _lockedValue == block1))
+                {
+                    BroadcastMessage(
+                        new ConsensusVote(Voting(Round, block1.Hash, VoteFlag.Absent)));
+                }
+                else
+                {
+                    BroadcastMessage(
+                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                }
+            }
+
+            if (GetPropose(Round) is (Block<T> block2, int validRound2) &&
+                validRound2 >= 0 &&
+                validRound2 < Round &&
+                HasTwoThirdsPreVote(validRound2, block2.Hash) &&
+                Step == Step.Propose)
+            {
+                _logger.Debug(
+                    "Entering PreVote step due to proposal message and have collected " +
+                    "2/3+ PreVote for valid round {ValidRound}. (context: {Context})",
+                    validRound2,
+                    ToString());
+                SetStep(Step.PreVote);
+
+                if (IsValid(block2) && (_lockedRound <= validRound2 || _lockedValue == block2))
+                {
+                    BroadcastMessage(
+                        new ConsensusVote(Voting(Round, block2.Hash, VoteFlag.Absent)));
+                }
+                else
+                {
+                    BroadcastMessage(
+                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                }
+            }
+
+            if (HasTwoThirdsPreVote(Round, null, true) &&
+                Step == Step.PreVote &&
+                !_preVoteFlags.Contains(Round))
+            {
+                _logger.Debug(
+                    "PreVote step in round {Round} is scheduled to be timed out because " +
+                    "2/3+ PreVotes are collected for the round. (context: {Context})",
+                    Round,
+                    ToString());
+                _preVoteFlags.Add(Round);
+                _ = OnTimeoutPreVote(Height, Round);
+            }
+
+            if (GetPropose(Round) is (Block<T> block3, _) &&
+                HasTwoThirdsPreVote(Round, block3.Hash) &&
+                IsValid(block3) &&
+                Step >= Step.PreVote &&
+                !_hasTwoThirdsPreVoteFlags.Contains(Round))
+            {
+                _logger.Debug(
+                    "2/3+ PreVotes for the current round {Round} have collected. " +
+                    "(context: {Context})",
+                    Round,
+                    ToString());
+                _hasTwoThirdsPreVoteFlags.Add(Round);
+                if (Step == Step.PreVote)
+                {
+                    _logger.Debug(
+                        "Entering PreCommit step due to proposal message and have collected " +
+                        "2/3+ PreVote for current round {Round}. (context: {Context})",
+                        Round,
+                        ToString());
+                    SetStep(Step.PreCommit);
+                    _lockedValue = block3;
+                    _lockedRound = Round;
+                    BroadcastMessage(
+                        new ConsensusCommit(Voting(Round, block3.Hash, VoteFlag.Commit)));
+                }
+
+                _validValue = block3;
+                _validRound = Round;
+            }
+
+            if (HasTwoThirdsPreVote(Round, null) && Step == Step.PreVote)
+            {
+                _logger.Debug(
+                    "PreCommit nil for the round {Round} because 2/3+ PreVotes were collected. " +
+                    "(context: {Context})",
+                    Round,
+                    ToString());
+                SetStep(Step.PreCommit);
+                BroadcastMessage(
+                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
+            }
+
+            if (HasTwoThirdsPreCommit(Round, null, true) && !_preCommitFlags.Contains(Round))
+            {
+                _logger.Debug(
+                    "PreCommit step in round {Round} is scheduled to be timed out because " +
+                    "2/3+ PreCommits are collected for the round. (context: {Context})",
+                    Round,
+                    ToString());
+                _preCommitFlags.Add(Round);
+                _ = OnTimeoutPreCommit(Height, Round);
+            }
+
+            if (message is ConsensusPropose || message is ConsensusCommit)
+            {
+                int round = message.Round;
+                if (GetPropose(round) is (Block<T> block4, _) &&
+                    HasTwoThirdsPreCommit(round, block4.Hash) &&
+                    Step != Step.EndCommit &&
+                    IsValid(block4))
+                {
+                    SetStep(Step.EndCommit);
+                    CommittedRound = round;
+                    _logger.Debug(
+                        "Committed block in round {Round}. (context: {Context})",
+                        Round,
+                        ToString());
+
+                    ConsensusContext.Commit(block4);
+                }
+            }
+
+            // FIXME: _messagesInRound should not contain any duplicated messages for this.
+            if (message.Round > Round &&
+                _messagesInRound[message.Round].Count > TotalValidators / 3)
+            {
+                _logger.Debug(
+                    "1/3+ messages from the round {Round} > current round {CurrentRound}. " +
+                    "(context: {Context})",
+                    message.Round,
+                    Round,
+                    ToString());
+                _ = StartRound(message.Round);
+            }
+
+            MessageProcessed?.Invoke(this, message);
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -118,13 +118,16 @@ namespace Libplanet.Net.Consensus
                     commit);
             }
 
-            if (!_messagesInRound.ContainsKey(message.Round))
+            lock (_messagesInRoundLock)
             {
-                _messagesInRound.TryAdd(message.Round, new HashSet<ConsensusMessage>());
-            }
+                if (!_messagesInRound.ContainsKey(message.Round))
+                {
+                    _messagesInRound.TryAdd(message.Round, new HashSet<ConsensusMessage>());
+                }
 
-            // TODO: Prevent duplicated messages adding.
-            _messagesInRound[message.Round].Add(message);
+                // TODO: Prevent duplicated messages adding.
+                _messagesInRound[message.Round].Add(message);
+            }
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -127,23 +127,10 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Processes a message and translate the <see cref="Step"/> or <see cref="Round"/>.
+        /// Checks the current state to mutate <see cref="Step"/> or schedule timeouts.
         /// </summary>
-        /// <param name="message">A <see cref="ConsensusMessage"/> to be processed.</param>
-        private void ProcessUponRules(ConsensusMessage message)
+        private void ProcessGenericUponRules()
         {
-            _logger.Debug(
-                "{FName}: Message: {Message} => " +
-                "Height: {Height}, Round: {Round}, Address: {Address}, Hash: {BlockHash}. " +
-                "MessageCount: {Count}. (context: {Context})",
-                nameof(ProcessUponRules),
-                message,
-                message.Height,
-                message.Round,
-                message.Remote!.Address,
-                message.BlockHash,
-                _messagesInRound[Round].Count,
-                ToString());
             if (Step == Step.Default || Step == Step.EndCommit)
             {
                 _logger.Debug("Operation will not run in {State} state.", Step.ToString());
@@ -262,7 +249,16 @@ namespace Libplanet.Net.Consensus
                 _preCommitFlags.Add(Round);
                 _ = OnTimeoutPreCommit(Height, Round);
             }
+        }
 
+        /// <summary>
+        /// Checks the current state to mutate <see cref="Round"/> or terminate
+        /// by setting <see cref="Step"/> to <see cref="Step.EndCommit"/>.
+        /// </summary>
+        /// <param name="message">The <see cref="ConsensusMessage"/> to process.
+        /// Although this is not strictly needed, this is used for optimization.</param>
+        private void ProcessHeightOrRoundUponRules(ConsensusMessage message)
+        {
             if (message is ConsensusPropose || message is ConsensusCommit)
             {
                 int round = message.Round;

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -119,7 +119,9 @@ namespace Libplanet.Net.Consensus
         /// <param name="height">A target <see cref="Context{T}.Height"/> of the consensus state.
         /// </param>
         /// <param name="privateKey">A private key for signing a block and message.
-        /// <seealso cref="GetValue"/><seealso cref="ProcessUponRules"/><seealso cref="Voting"/>
+        /// <seealso cref="GetValue"/>
+        /// <seealso cref="ProcessGenericUponRules"/>
+        /// <seealso cref="Voting"/>
         /// </param>
         /// <param name="validators">A list of <see cref="PublicKey"/> of validators.</param>
         public Context(
@@ -351,7 +353,20 @@ namespace Libplanet.Net.Consensus
                 throw;
             }
 
-            ProcessUponRules(message);
+            _logger.Debug(
+                "{FName}: Message: {Message} => " +
+                "Height: {Height}, Round: {Round}, Address: {Address}, Hash: {BlockHash}. " +
+                "MessageCount: {Count}. (context: {Context})",
+                nameof(ProcessGenericUponRules),
+                message,
+                message.Height,
+                message.Round,
+                message.Remote!.Address,
+                message.BlockHash,
+                _messagesInRound[Round].Count,
+                ToString());
+            ProcessGenericUponRules();
+            ProcessHeightOrRoundUponRules(message);
             MessageProcessed?.Invoke(this, message);
         }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -256,7 +256,7 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Add received message to the message queue.
+        /// Adds <paramref name="message"/> to the message queue.
         /// </summary>
         /// <param name="message">A <see cref="ConsensusMessage"/> to be processed.</param>
         public void ProduceMessage(ConsensusMessage message)
@@ -282,7 +282,7 @@ namespace Libplanet.Net.Consensus
             var dict = new Dictionary<string, object>
             {
                 { "node_id", _privateKey.ToAddress().ToString() },
-                { "number_of_validator", _validators!.Count },
+                { "number_of_validator", _validators.Count },
                 { "height", Height },
                 { "round", Round },
                 { "step", Step.ToString() },
@@ -300,7 +300,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="round">A round to get the timeout.</param>
         /// <returns>A duration in <see cref="TimeSpan"/>.</returns>
-        internal static TimeSpan TimeoutPreVote(long round)
+        private static TimeSpan TimeoutPreVote(long round)
         {
             return TimeSpan.FromSeconds(TimeoutPreVoteBase + round + TimeoutPreVoteMultiplier);
         }
@@ -311,7 +311,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="round">A round to get the timeout.</param>
         /// <returns>A duration in <see cref="TimeSpan"/>.</returns>
-        internal static TimeSpan TimeoutPreCommit(long round)
+        private static TimeSpan TimeoutPreCommit(long round)
         {
             return TimeSpan.FromSeconds(TimeoutPreCommitBase + round + TimeoutPreCommitMultiplier);
         }
@@ -322,7 +322,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="round">A round to get the timeout.</param>
         /// <returns>A duration in <see cref="TimeSpan"/>.</returns>
-        internal static TimeSpan TimeoutPropose(long round)
+        private static TimeSpan TimeoutPropose(long round)
         {
             return TimeSpan.FromSeconds(TimeoutProposeBase + round * TimeoutProposeMultiplier);
         }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Net.Consensus
         /// <param name="height">A target <see cref="Context{T}.Height"/> of the consensus state.
         /// </param>
         /// <param name="privateKey">A private key for signing a block and message.
-        /// <seealso cref="GetValue"/><seealso cref="ProcessMessage"/><seealso cref="Voting"/>
+        /// <seealso cref="GetValue"/><seealso cref="ProcessUponRules"/><seealso cref="Voting"/>
         /// </param>
         /// <param name="validators">A list of <see cref="PublicKey"/> of validators.</param>
         public Context(
@@ -352,7 +352,7 @@ namespace Libplanet.Net.Consensus
                 throw;
             }
 
-            ProcessMessage(message);
+            ProcessUponRules(message);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -77,7 +77,7 @@ namespace Libplanet.Net.Consensus
     /// A <see cref="Context{T}"/> represents a consensus of a single height and its multiple
     /// rounds.
     /// </remarks>
-    public class Context<T> : IDisposable
+    public partial class Context<T> : IDisposable
         where T : IAction, new()
     {
         private const int TimeoutProposeBase = 5;
@@ -91,13 +91,12 @@ namespace Libplanet.Net.Consensus
         private readonly Codec _codec;
         private readonly List<PublicKey> _validators;
         private readonly Channel<ConsensusMessage> _messageRequests;
-        private readonly ConcurrentDictionary<int, ConcurrentBag<ConsensusMessage>>
-            _messagesInRound;
+        private readonly ConcurrentDictionary<int, HashSet<ConsensusMessage>> _messagesInRound;
 
         private readonly PrivateKey _privateKey;
-        private readonly ConcurrentBag<int> _preVoteFlags;
-        private readonly ConcurrentBag<int> _hasTwoThirdsPreVoteFlags;
-        private readonly ConcurrentBag<int> _preCommitFlags;
+        private readonly HashSet<int> _preVoteFlags;
+        private readonly HashSet<int> _hasTwoThirdsPreVoteFlags;
+        private readonly HashSet<int> _preCommitFlags;
 
         private readonly CancellationTokenSource _cancellationTokenSource;
 
@@ -109,7 +108,6 @@ namespace Libplanet.Net.Consensus
         private Block<T>? _validValue;
         private int _validRound;
         private BlockCommit? _lastCommit;
-        private int _requestCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Context{T}"/> class.
@@ -163,10 +161,10 @@ namespace Libplanet.Net.Consensus
             _blockChain = blockChain;
             _codec = new Codec();
             _messageRequests = Channel.CreateUnbounded<ConsensusMessage>();
-            _messagesInRound = new ConcurrentDictionary<int, ConcurrentBag<ConsensusMessage>>();
-            _preVoteFlags = new ConcurrentBag<int>();
-            _hasTwoThirdsPreVoteFlags = new ConcurrentBag<int>();
-            _preCommitFlags = new ConcurrentBag<int>();
+            _messagesInRound = new ConcurrentDictionary<int, HashSet<ConsensusMessage>>();
+            _preVoteFlags = new HashSet<int>();
+            _hasTwoThirdsPreVoteFlags = new HashSet<int>();
+            _preCommitFlags = new HashSet<int>();
             _validators = validators;
             _cancellationTokenSource = new CancellationTokenSource();
             ConsensusContext = consensusContext;
@@ -231,29 +229,6 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         private int TotalValidators => _validators.Count;
 
-        /// <summary>
-        /// Starts the round #0 of consensus for <see cref="Height"/>.
-        /// </summary>
-        /// <param name="lastCommit">A <see cref="Block{T}.LastCommit"/> from previous block.
-        /// </param>
-        /// <returns>An awaitable task without value. This task
-        /// awaits <see cref="StartRound"/> and starts <see cref="MessageConsumerTask"/>.
-        /// </returns>
-        public async Task StartAsync(BlockCommit? lastCommit = null)
-        {
-            _lastCommit = lastCommit;
-            await StartRound(0);
-            if (Proposer(0) != _privateKey.PublicKey &&
-                _messagesInRound.ContainsKey(0) &&
-                _messagesInRound[0].FirstOrDefault(msg => msg is ConsensusPropose) is
-                    ConsensusPropose propose)
-            {
-                ProcessMessage(propose);
-            }
-
-            _ = MessageConsumerTask(_cancellationTokenSource.Token);
-        }
-
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
@@ -298,7 +273,6 @@ namespace Libplanet.Net.Consensus
         /// <param name="message">A <see cref="ConsensusMessage"/> to be processed.</param>
         public void ProduceMessage(ConsensusMessage message)
         {
-            Interlocked.Increment(ref _requestCount);
             _messageRequests.Writer.WriteAsync(message);
         }
 
@@ -382,260 +356,6 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Validates the given <paramref name="message"/> and add into the message queue.
-        /// </summary>
-        /// <param name="message">A <see cref="ConsensusMessage"/> to be added.
-        /// </param>
-        /// <exception cref="InvalidHeightMessageException">Thrown when the Height of message and
-        /// context height does not match.
-        /// </exception>
-        /// <exception cref="InvalidProposerProposeMessageException">Thrown when the
-        /// <see cref="ConsensusPropose"/> message has proposer that is not proposer of the current
-        /// round.
-        /// </exception>
-        /// <exception cref="InvalidBlockProposeMessageException">Thrown when the
-        /// <see cref="ConsensusPropose"/> message has invalid blockHash (i.e., NIL).
-        /// </exception>
-        /// <exception cref="InvalidValidatorVoteMessageException">Thrown when the signature of
-        /// <see cref="Vote"/> is invalid or the <see cref="Vote"/> is not signed by any validator
-        /// of this context.
-        /// </exception>
-        internal void AddMessage(ConsensusMessage message)
-        {
-            if (message.Height != Height)
-            {
-                throw new InvalidHeightMessageException(
-                    "Height of message differs with working height.  " +
-                    $"(expected: {Height}, actual: {message.Height})",
-                    message);
-            }
-
-            if (message is ConsensusPropose propose)
-            {
-                if (!propose.Validator.Equals(Proposer(message.Round)))
-                {
-                    throw new InvalidProposerProposeMessageException(
-                        "Proposer for the height " +
-                        $"{message.Height} and round {message.Round} is invalid.  " +
-                        $"(expected: Height: {message.Height}, Round: {message.Round}, " +
-                        $"Proposer: {propose.Validator} / " +
-                        $"actual: Height: {Height}, Round: {Round}, " +
-                        $"Proposer: {Proposer(message.Round)})",
-                        message);
-                }
-
-                if (message.BlockHash.Equals(default(BlockHash)))
-                {
-                    throw new InvalidBlockProposeMessageException(
-                        "Cannot propose a null block.",
-                        message);
-                }
-            }
-
-            if (message is ConsensusVote vote &&
-                (!vote.Validator.Equals(vote.ProposeVote.Validator) ||
-                 !vote.ProposeVote.Verify(vote.Validator) ||
-                 !_validators.Contains(vote.Validator)))
-            {
-                throw new InvalidValidatorVoteMessageException(
-                    "Received ConsensusVote message is made by invalid validator.",
-                    vote);
-            }
-
-            if (message is ConsensusCommit commit &&
-                (!commit.Validator.Equals(commit.CommitVote.Validator) ||
-                 !commit.CommitVote.Verify(commit.Validator) ||
-                 !_validators.Contains(commit.Validator)))
-            {
-                throw new InvalidValidatorVoteMessageException(
-                    "Received ConsensusCommit message is made by invalid validator.",
-                    commit);
-            }
-
-            if (!_messagesInRound.ContainsKey(message.Round))
-            {
-                _messagesInRound.TryAdd(message.Round, new ConcurrentBag<ConsensusMessage>());
-            }
-
-            // TODO: Prevent duplicated messages adding.
-            _messagesInRound[message.Round].Add(message);
-        }
-
-        /// <summary>
-        /// Processes a message and translate the <see cref="Step"/> or <see cref="Round"/>.
-        /// </summary>
-        /// <param name="message">A <see cref="ConsensusMessage"/> to be processed.</param>
-        private void ProcessMessage(ConsensusMessage message)
-        {
-            _logger.Debug(
-                "{FName}: Message: {Message} => " +
-                "Height: {Height}, Round: {Round}, ValidatorAddress: {VAddress}, " +
-                "RemoteAddress: {RAddress}, Hash: {BlockHash}. " +
-                "MessageCount: {Count}. (context: {Context})",
-                nameof(ProcessMessage),
-                message,
-                message.Height,
-                message.Round,
-                message.Validator.ToAddress(),
-                message.Remote!.Address,
-                message.BlockHash,
-                _messagesInRound[Round].Count,
-                ToString());
-            if (Step == Step.Default || Step == Step.EndCommit)
-            {
-                _logger.Debug("Operation will not run in {State} state.", Step.ToString());
-                return;
-            }
-
-            if (GetPropose(Round) is (Block<T> block1, int validRound1) &&
-                validRound1 == -1 &&
-                Step == Step.Propose)
-            {
-                _logger.Debug(
-                    "Entering PreVote step due to proposal message with " +
-                    "valid round -1. (context: {Context})",
-                    ToString());
-                SetStep(Step.PreVote);
-
-                if (IsValid(block1) && (_lockedRound == -1 || _lockedValue == block1))
-                {
-                    BroadcastMessage(
-                        new ConsensusVote(Voting(Round, block1.Hash, VoteFlag.Absent)));
-                }
-                else
-                {
-                    BroadcastMessage(
-                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
-                }
-            }
-
-            if (GetPropose(Round) is (Block<T> block2, int validRound2) &&
-                validRound2 >= 0 &&
-                validRound2 < Round &&
-                HasTwoThirdsPreVote(validRound2, block2.Hash) &&
-                Step == Step.Propose)
-            {
-                _logger.Debug(
-                    "Entering PreVote step due to proposal message and have collected " +
-                    "2/3+ PreVote for valid round {ValidRound}. (context: {Context})",
-                    validRound2,
-                    ToString());
-                SetStep(Step.PreVote);
-
-                if (IsValid(block2) && (_lockedRound <= validRound2 || _lockedValue == block2))
-                {
-                    BroadcastMessage(
-                        new ConsensusVote(Voting(Round, block2.Hash, VoteFlag.Absent)));
-                }
-                else
-                {
-                    BroadcastMessage(
-                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
-                }
-            }
-
-            if (HasTwoThirdsPreVote(Round, null, true) &&
-                Step == Step.PreVote &&
-                !_preVoteFlags.Contains(Round))
-            {
-                _logger.Debug(
-                    "PreVote step in round {Round} is scheduled to be timed out because " +
-                    "2/3+ PreVotes are collected for the round. (context: {Context})",
-                    Round,
-                    ToString());
-                _preVoteFlags.Add(Round);
-                _ = OnTimeoutPreVote(Height, Round);
-            }
-
-            if (GetPropose(Round) is (Block<T> block3, _) &&
-                HasTwoThirdsPreVote(Round, block3.Hash) &&
-                IsValid(block3) &&
-                Step >= Step.PreVote &&
-                !_hasTwoThirdsPreVoteFlags.Contains(Round))
-            {
-                _logger.Debug(
-                    "2/3+ PreVotes for the current round {Round} have collected. " +
-                    "(context: {Context})",
-                    Round,
-                    ToString());
-                _hasTwoThirdsPreVoteFlags.Add(Round);
-                if (Step == Step.PreVote)
-                {
-                    _logger.Debug(
-                        "Entering PreCommit step due to proposal message and have collected " +
-                        "2/3+ PreVote for current round {Round}. (context: {Context})",
-                        Round,
-                        ToString());
-                    SetStep(Step.PreCommit);
-                    _lockedValue = block3;
-                    _lockedRound = Round;
-                    BroadcastMessage(
-                        new ConsensusCommit(Voting(Round, block3.Hash, VoteFlag.Commit)));
-                }
-
-                _validValue = block3;
-                _validRound = Round;
-            }
-
-            if (HasTwoThirdsPreVote(Round, null) && Step == Step.PreVote)
-            {
-                _logger.Debug(
-                    "PreCommit nil for the round {Round} because 2/3+ PreVotes were collected. " +
-                    "(context: {Context})",
-                    Round,
-                    ToString());
-                SetStep(Step.PreCommit);
-                BroadcastMessage(
-                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
-            }
-
-            if (HasTwoThirdsPreCommit(Round, null, true) && !_preCommitFlags.Contains(Round))
-            {
-                _logger.Debug(
-                    "PreCommit step in round {Round} is scheduled to be timed out because " +
-                    "2/3+ PreCommits are collected for the round. (context: {Context})",
-                    Round,
-                    ToString());
-                _preCommitFlags.Add(Round);
-                _ = OnTimeoutPreCommit(Height, Round);
-            }
-
-            if (message is ConsensusPropose || message is ConsensusCommit)
-            {
-                int round = message.Round;
-                if (GetPropose(round) is (Block<T> block4, _) &&
-                    HasTwoThirdsPreCommit(round, block4.Hash) &&
-                    Step != Step.EndCommit &&
-                    IsValid(block4))
-                {
-                    SetStep(Step.EndCommit);
-                    CommittedRound = round;
-                    _logger.Debug(
-                        "Committed block in round {Round}. (context: {Context})",
-                        Round,
-                        ToString());
-
-                    ConsensusContext.Commit(block4);
-                }
-            }
-
-            // FIXME: _messagesInRound should not contain any duplicated messages for this.
-            if (message.Round > Round &&
-                _messagesInRound[message.Round].Count > TotalValidators / 3)
-            {
-                _logger.Debug(
-                    "1/3+ messages from the round {Round} > current round {CurrentRound}. " +
-                    "(context: {Context})",
-                    message.Round,
-                    Round,
-                    ToString());
-                _ = StartRound(message.Round);
-            }
-
-            MessageProcessed?.Invoke(this, message);
-        }
-
-        /// <summary>
         /// Creates a new <see cref="Block{T}"/> to propose.
         /// </summary>
         /// <returns>A new <see cref="Block{T}"/>.</returns>
@@ -660,55 +380,6 @@ namespace Libplanet.Net.Consensus
         {
             // return designated proposer for the height round pair.
             return _validators[(int)((Height + round) % TotalValidators)];
-        }
-
-        /// <summary>
-        /// Start a new round.
-        /// </summary>
-        /// <param name="round">A round to start.</param>
-        private async Task StartRound(int round)
-        {
-            RoundStarted?.Invoke(this, round);
-            _logger.Debug(
-                "Starting round {NewRound} (was {PrevRound}). (context: {Context})",
-                round,
-                Round,
-                ToString());
-            Round = round;
-            SetStep(Step.Propose);
-            if (Proposer(Round) == _privateKey.PublicKey)
-            {
-                _logger.Debug(
-                    "Starting round {NewRound} and is a proposer. (context: {Context})",
-                    round,
-                    ToString());
-                Block<T> proposal;
-                if (_validValue is null)
-                {
-                    proposal = await GetValue();
-                }
-                else
-                {
-                    proposal = _validValue;
-                }
-
-                BroadcastMessage(
-                    new ConsensusPropose(
-                        _privateKey.PublicKey,
-                        Height,
-                        Round,
-                        proposal.Hash,
-                        _codec.Encode(proposal.MarshalBlock()),
-                        _validRound));
-            }
-            else
-            {
-                _logger.Debug(
-                    "Starting round {NewRound} and is not a proposer. (context: {Context})",
-                    round,
-                    ToString());
-                _ = OnTimeoutPropose(Height, Round);
-            }
         }
 
         /// <summary>
@@ -780,36 +451,6 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Consumes the every <see cref="ConsensusMessage"/> in the message queue.
-        /// </summary>
-        /// <param name="ctx">A cancellation token for reading message from message queue.</param>
-        private async Task MessageConsumerTask(CancellationToken ctx)
-        {
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET
-            await foreach (ConsensusMessage message in _messageRequests.Reader.ReadAllAsync(ctx))
-            {
-#else
-            while (!ctx.IsCancellationRequested)
-            {
-                ConsensusMessage message = await _messageRequests.Reader.ReadAsync(ctx);
-#endif
-                long left = Interlocked.Decrement(ref _requestCount);
-                try
-                {
-                    HandleMessage(message);
-                }
-                catch (Exception e)
-                {
-                    _logger.Error(
-                        e,
-                        "Unexpected exception occurred during {FName}. {E}",
-                        nameof(HandleMessage),
-                        e);
-                }
-            }
-        }
-
-        /// <summary>
         /// Gets the proposed block and valid round of the given round.
         /// </summary>
         /// <param name="round">A round to get.</param>
@@ -819,8 +460,7 @@ namespace Libplanet.Net.Consensus
         private (Block<T>?, int?) GetPropose(int round)
         {
             ConsensusMessage? msg = _messagesInRound[round].FirstOrDefault(
-                msg =>
-                    msg is ConsensusPropose);
+                msg => msg is ConsensusPropose);
 
             if (msg is ConsensusPropose propose)
             {
@@ -871,78 +511,6 @@ namespace Libplanet.Net.Consensus
                 msg => msg is ConsensusCommit preCommit &&
                        (any || preCommit.BlockHash.Equals(hash)));
             return count > TotalValidators * 2 / 3;
-        }
-
-        /// <summary>
-        /// A timeout task for a round if no <see cref="ConsensusPropose"/> is received in
-        /// <see cref="TimeoutPropose"/> and <see cref="Libplanet.Net.Consensus.Step.Propose"/>
-        /// step.
-        /// </summary>
-        /// <param name="height">A height that the timeout task is scheduled for.</param>
-        /// <param name="round">A round that the timeout task is scheduled for.</param>
-        private async Task OnTimeoutPropose(long height, int round)
-        {
-            TimeSpan timeout = TimeoutPropose(round);
-            await Task.Delay(timeout, _cancellationTokenSource.Token);
-            if (height == Height && round == Round && Step == Step.Propose)
-            {
-                _logger.Debug(
-                    "TimeoutPropose has occurred in {Timeout}. {Info}",
-                    timeout,
-                    ToString());
-                TimeoutOccurred?.Invoke(this, (Step.Propose, TimeoutPropose(round)));
-                BroadcastMessage(
-                    new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
-                SetStep(Step.PreVote);
-            }
-        }
-
-        /// <summary>
-        /// A timeout task for a round if <see cref="ConsensusVote"/> is received +2/3 any but has
-        /// no majority neither Block nor NIL in
-        /// <see cref="TimeoutPreVote"/> and <see cref="Libplanet.Net.Consensus.Step.PreVote"/>
-        /// step.
-        /// </summary>
-        /// <param name="height">A height that the timeout task is scheduled for.</param>
-        /// <param name="round">A round that the timeout task is scheduled for.</param>
-        private async Task OnTimeoutPreVote(long height, int round)
-        {
-            TimeSpan timeout = TimeoutPreVote(round);
-            await Task.Delay(timeout, _cancellationTokenSource.Token);
-            if (height == Height && round == Round && Step == Step.PreVote)
-            {
-                _logger.Debug(
-                    "TimeoutPreVote has occurred in {Timeout}. {Info}",
-                    timeout,
-                    ToString());
-                TimeoutOccurred?.Invoke(this, (Step.PreVote, TimeoutPreVote(round)));
-                BroadcastMessage(
-                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
-                SetStep(Step.PreCommit);
-            }
-        }
-
-        /// <summary>
-        /// A timeout task for a round if <see cref="ConsensusCommit"/> is received +2/3 any but has
-        /// no majority neither Block or NIL in
-        /// <see cref="TimeoutPreCommit"/> and <see cref="Libplanet.Net.Consensus.Step.PreCommit"/>
-        /// step.
-        /// </summary>
-        /// <param name="height">A height that the timeout task is scheduled for.</param>
-        /// <param name="round">A round that the timeout task is scheduled for.</param>
-        private async Task OnTimeoutPreCommit(long height, int round)
-        {
-            TimeSpan timeout = TimeoutPreCommit(round);
-            await Task.Delay(timeout, _cancellationTokenSource.Token);
-            if (height == Height && round == Round && Step < Step.EndCommit)
-            {
-                _logger.Debug(
-                    "TimeoutPreCommit has occurred in {Timeout}. {Info}",
-                    timeout,
-                    ToString());
-                TimeoutOccurred?.Invoke(this, (Step.PreCommit, TimeoutPreCommit(round)));
-                _ = StartRound(Round + 1);
-            }
         }
     }
 }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
 using Caching;
@@ -359,12 +358,9 @@ namespace Libplanet.Net.Consensus
         /// Creates a new <see cref="Block{T}"/> to propose.
         /// </summary>
         /// <returns>A new <see cref="Block{T}"/>.</returns>
-        private async Task<Block<T>> GetValue()
+        private Block<T> GetValue()
         {
-            Block<T> block = await _blockChain.ProposeBlock(
-                _privateKey,
-                lastCommit: _lastCommit,
-                cancellationToken: _cancellationTokenSource.Token);
+            Block<T> block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
             _blockChain.Store.PutBlock(block);
             return block;
         }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -448,8 +448,8 @@ namespace Libplanet.Net.Consensus
             lock (_messagesInRoundLock)
             {
                 count = _messagesInRound[round].Count(
-                msg => msg is ConsensusVote preVote &&
-                       (any || preVote.BlockHash.Equals(hash)));
+                    msg => msg is ConsensusVote preVote &&
+                    (any || preVote.BlockHash.Equals(hash)));
             }
 
             return count > TotalValidators * 2 / 3;
@@ -474,7 +474,7 @@ namespace Libplanet.Net.Consensus
             {
                 count = _messagesInRound[round].Count(
                     msg => msg is ConsensusCommit preCommit &&
-                        (any || preCommit.BlockHash.Equals(hash)));
+                    (any || preCommit.BlockHash.Equals(hash)));
             }
 
             return count > TotalValidators * 2 / 3;

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -405,21 +405,6 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Changes the step of the consensus.
-        /// </summary>
-        /// <param name="step">A new step to set.</param>
-        private void SetStep(Step step)
-        {
-            _logger.Debug(
-                "Translate step from {Before} to {After}. {Info}",
-                Step.ToString(),
-                step.ToString(),
-                ToString());
-            Step = step;
-            StepChanged?.Invoke(this, step);
-        }
-
-        /// <summary>
         /// Gets the proposed block and valid round of the given round.
         /// </summary>
         /// <param name="round">A round to get.</param>

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -317,7 +317,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="round">A round to get the timeout.</param>
         /// <returns>A duration in <see cref="TimeSpan"/>.</returns>
-        internal TimeSpan TimeoutPropose(long round)
+        internal static TimeSpan TimeoutPropose(long round)
         {
             return TimeSpan.FromSeconds(TimeoutProposeBase + round * TimeoutProposeMultiplier);
         }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -352,6 +352,7 @@ namespace Libplanet.Net.Consensus
             }
 
             ProcessUponRules(message);
+            MessageProcessed?.Invoke(this, message);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #2193.

Refactors `Context.cs`.

## Overview
Largely tries to achieve the following two points:
- Better thread safety.
- Cover more cases.

### Thread Safety
While message consumption was single threaded, spawning side tasks for timeout events were problematic. As triggered timeout tasks needed to access the message log as a side task, race condition could happen as the main message consuming task could add messages to the message log while a timeout task was accessing the message log. Use of `Concurrency` type itself does not ensure concurrency, especially when conditional checks on the collection in question and `LINQ` expressions are involved.

## Edge Cases
The original intent was to additionally trigger processing tasks (i.e. apply upon rules) when timeout events occur, but as mentioned above, as timeout events are side tasks, simply calling the processing method, previously named `ProcessMessage()`, is even more dangerous as it would've meant processing methods running in parallel. So in order to
have additional calls to `ProcessMessage()`, calls were needed to be managed somehow.

## Approach
The gist of it is to have a separate long running task called `MutationConsumerTask()` that runs any process that **might potentially mutate** the state of the `Context` object. Note that adding a `ConsensusMessage` to the `MessageLog`[^1] is **mutating** the `Context` in question. Hence, it is important that `MessageConsumerTask()` **does not directly add** an incoming message to the `MessageLog`. Instead it queues up a process that adds the message to the `MessageLog` which `MutationConsumerTask()` can run.

Similarly, timeout events occurring outside the main thread, i.e. the long running `MutationConsumerTask()`, also do not call methods processing state changes directly, but simply queue them for `MutationConsumerTask()` to consume at some point.

Handling of edge cases are covered my spawning additional processes when `MutationConsumerTask()` consumes a mutation and observes a state change.

[^1]: There is no such exposed property called `MessageLog` for `Context`, but this term is used to simply assist in the understanding of the schematics described above.