### PR TITLE
Introduce `IAccountStateView`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ To be released.
    - Added `BlockChain<T>.GetBlockLocator(int)` method.
  -  Added `IActionContext.GenesisHash` property.  [[#1972], [#2179]]
  -  Added `ActionEvaluator<T>.GenesisHash` property.  [[#1972], [#2179]]
+ -  Added `IAccountStateView` interface.  [[#2183]]
+ -  `IAccountStateDelta` now inherits `IAccountStateView` interface.
+    [[#2183]]
 
 ### Behavioral changes
 
@@ -52,6 +55,7 @@ To be released.
 [#2162]: https://github.com/planetarium/libplanet/issues/2162
 [#2171]: https://github.com/planetarium/libplanet/pull/2171
 [#2179]: https://github.com/planetarium/libplanet/pull/2179
+[#2183]: https://github.com/planetarium/libplanet/pull/2183
 
 
 Version 0.39.0

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -71,14 +71,14 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
-        IValue? IAccountStateDelta.GetState(Address address) =>
+        IValue? IAccountStateView.GetState(Address address) =>
             UpdatedStates.TryGetValue(address, out IValue? value)
                 ? value
                 : StateGetter(new[] { address })[0];
 
-        /// <inheritdoc cref="IAccountStateDelta.GetStates(IReadOnlyList{Address})"/>
+        /// <inheritdoc cref="IAccountStateView.GetStates(IReadOnlyList{Address})"/>
         [Pure]
-        IReadOnlyList<IValue?> IAccountStateDelta.GetStates(IReadOnlyList<Address> addresses)
+        IReadOnlyList<IValue?> IAccountStateView.GetStates(IReadOnlyList<Address> addresses)
         {
             int length = addresses.Count;
             IValue?[] values = new IValue?[length];

--- a/Libplanet/Action/IAccountStateDelta.cs
+++ b/Libplanet/Action/IAccountStateDelta.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Action
     /// method does not manipulate the instance, but returns a new
     /// <see cref="IAccountStateDelta"/> instance with updated states.
     /// </remarks>
-    public interface IAccountStateDelta
+    public interface IAccountStateDelta : IAccountStateView
     {
         /// <summary>
         /// <seealso cref="Address"/>es of the accounts that have
@@ -64,30 +64,6 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// Gets the account state of the given <paramref name="address"/>.
-        /// </summary>
-        /// <param name="address">The <see cref="Address"/> referring
-        /// the account to get its state.</param>
-        /// <returns>The account state of the given <paramref name="address"/>.
-        /// If it has never been set to any state it returns <c>null</c>
-        /// instead.</returns>
-        [Pure]
-        IValue? GetState(Address address);
-
-        /// <summary>
-        /// Gets multiple account states associated with the specified <paramref name="addresses"/>
-        /// at once.
-        /// </summary>
-        /// <param name="addresses">The <see cref="Address"/>es associated with states to get.
-        /// </param>
-        /// <returns>The states associated to the specified <paramref name="addresses"/>.
-        /// Associated values are ordered in the same way to the corresponding
-        /// <paramref name="addresses"/>.  Absent states are represented as <see langword="null"/>.
-        /// </returns>
-        [Pure]
-        IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses);
-
-        /// <summary>
         /// Gets a new instance that the account state of the given
         /// <paramref name="address"/> is set to the given
         /// <paramref name="state"/>.
@@ -105,17 +81,6 @@ namespace Libplanet.Action
         /// </remarks>
         [Pure]
         IAccountStateDelta SetState(Address address, IValue state);
-
-        /// <summary>
-        /// Queries <paramref name="address"/>'s balance of the <paramref name="currency"/>.
-        /// </summary>
-        /// <param name="address">The owner address to query.</param>
-        /// <param name="currency">The currency type to query.</param>
-        /// <returns>
-        /// The <paramref name="address"/>'s balance of the <paramref name="currency"/>.
-        /// </returns>
-        [Pure]
-        FungibleAssetValue GetBalance(Address address, Currency currency);
 
         /// <summary>
         /// Mints the fungible asset <paramref name="value"/> (i.e., in-game monetary),

--- a/Libplanet/Action/IAccountStateView.cs
+++ b/Libplanet/Action/IAccountStateView.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Bencodex.Types;
+using Libplanet.Assets;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// An interface to fetch account states.
+    /// <para>It is like a readonly map which is virtually initialized such
+    /// that every possible <see cref="Address"/> exists and
+    /// is mapped to <c>null</c>.  That means that:</para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>it does not have length,</description>
+    /// </item>
+    /// <item>
+    /// <description>its index getter never throws
+    /// <see cref="KeyNotFoundException"/>,
+    /// but returns <c>null</c> instead, and</description>
+    /// </item>
+    /// <item>
+    /// <description>filling an <see cref="Address"/> with
+    /// <c>null</c> state cannot be distinguished from
+    /// the <see cref="Address"/> having never been set to
+    /// any state.</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public interface IAccountStateView
+    {
+        /// <summary>
+        /// Gets the account state of the given <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> referring
+        /// the account to get its state.</param>
+        /// <returns>The account state of the given <paramref name="address"/>.
+        /// If it has never been set to any state it returns <c>null</c>
+        /// instead.</returns>
+        [Pure]
+        IValue? GetState(Address address);
+
+        /// <summary>
+        /// Gets multiple account states associated with the specified <paramref name="addresses"/>
+        /// at once.
+        /// </summary>
+        /// <param name="addresses">The <see cref="Address"/>es associated with states to get.
+        /// </param>
+        /// <returns>The states associated to the specified <paramref name="addresses"/>.
+        /// Associated values are ordered in the same way to the corresponding
+        /// <paramref name="addresses"/>.  Absent states are represented as <see langword="null"/>.
+        /// </returns>
+        [Pure]
+        IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses);
+
+        /// <summary>
+        /// Queries <paramref name="address"/>'s balance of the <paramref name="currency"/>.
+        /// </summary>
+        /// <param name="address">The owner address to query.</param>
+        /// <param name="currency">The currency type to query.</param>
+        /// <returns>
+        /// The <paramref name="address"/>'s balance of the <paramref name="currency"/>.
+        /// </returns>
+        [Pure]
+        FungibleAssetValue GetBalance(Address address, Currency currency);
+    }
+}

--- a/Libplanet/Action/IAccountStateView.cs
+++ b/Libplanet/Action/IAccountStateView.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Action
     /// An interface to fetch account states.
     /// <para>It is like a readonly map which is virtually initialized such
     /// that every possible <see cref="Address"/> exists and
-    /// is mapped to <c>null</c>.  That means that:</para>
+    /// is mapped to <see langword="null"/>.  That means that:</para>
     /// <list type="bullet">
     /// <item>
     /// <description>it does not have length,</description>
@@ -17,7 +17,7 @@ namespace Libplanet.Action
     /// <item>
     /// <description>its index getter never throws
     /// <see cref="KeyNotFoundException"/>,
-    /// but returns <c>null</c> instead, and</description>
+    /// but returns <see langword="null"/> instead, and</description>
     /// </item>
     /// <item>
     /// <description>filling an <see cref="Address"/> with


### PR DESCRIPTION
This pull request introduces a new interface named `IAccountStateDeltaView`, a part of `IAccountStateDelta` but read-only. For example, in nine-chronicles, it implements `IAccounStateDeltaExtensions`, utils to fetch typed many states over the raw API. In the case, it uses only read-only methods (e.g. `GetState`, `GetStates`, `GetBalance`). For cases like the extensions, its modification permission is too excessive so I hope it has a read-only view. (Of course, I think side-effects or mistakes will not occur though it has permission because it is immutable.)

If its labels are not fit this issue, please re-label for this issue 🙏🏻 