### PR TITLE
Change offset and limit parameters in various places to long

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Modified type of parameters `offset`, `limit` from int to long from verious methods. [[#1354], [#2188]]
+   - `BlockChain<T>.IterateBlocks(int, int?)`
+   - `BlockChain<T>.IterateBlockHashes(int, int?)`
+   - `IStore.IterateIndexes(Guid, int, int?)`
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -71,6 +76,7 @@ Released on July 18th, 2022.
  -  (Libplanet.Extensions.Cocona) Removed `DerivationCommand` class.
     [[#2118]]
 
+[#1354]: https://github.com/planetarium/libplanet/issues/1354
 [#1696]: https://github.com/planetarium/libplanet/issues/1696
 [#2058]: https://github.com/planetarium/libplanet/issues/2058
 [#2091]: https://github.com/planetarium/libplanet/pull/2091
@@ -83,6 +89,7 @@ Released on July 18th, 2022.
 [#2136]: https://github.com/planetarium/libplanet/pull/2136
 [#2139]: https://github.com/planetarium/libplanet/pull/2139
 [#2142]: https://github.com/planetarium/libplanet/pull/2142
+[#2188]: https://github.com/planetarium/libplanet/pull/2188
 [Cocona.Lite 2.0.0]: https://www.nuget.org/packages/Cocona.Lite/2.0.0
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  Modified type of parameters `offset`, `limit` from int to long
+ -  Modified type of parameters `offset`, `limit` from `int` to `long`
     from verious methods. [[#1354], [#2188]]
    - `BlockChain<T>.IterateBlocks(int, int?)`
    - `BlockChain<T>.IterateBlockHashes(int, int?)`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  Modified type of parameters `offset`, `limit` from int to long from verious methods. [[#1354], [#2188]]
+ -  Modified type of parameters `offset`, `limit` from int to long
+    from verious methods. [[#1354], [#2188]]
    - `BlockChain<T>.IterateBlocks(int, int?)`
    - `BlockChain<T>.IterateBlockHashes(int, int?)`
    - `IStore.IterateIndexes(Guid, int, int?)`

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -245,11 +245,11 @@ namespace Libplanet.Explorer.Store
             return _store.CountIndex(chainId);
         }
 
-        /// <inheritdoc cref="IStore.IterateIndexes(Guid, int, int?)"/>
+        /// <inheritdoc cref="IStore.IterateIndexes(Guid, long, long?)"/>
         public IEnumerable<BlockHash> IterateIndexes(
             Guid chainId,
-            int offset = 0,
-            int? limit = null)
+            long offset = 0,
+            long? limit = null)
         {
             return _store.IterateIndexes(chainId, offset, limit);
         }

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -206,11 +206,11 @@ namespace Libplanet.Explorer.Store
             return _store.CountIndex(chainId);
         }
 
-        /// <inheritdoc cref="IStore.IterateIndexes(Guid, int, int)"/>
+        /// <inheritdoc cref="IStore.IterateIndexes(Guid, long, long)"/>
         public IEnumerable<BlockHash> IterateIndexes(
             Guid chainId,
-            int offset = 0,
-            int? limit = null
+            long offset = 0,
+            long? limit = null
         ) =>
             _store.IterateIndexes(chainId, offset, limit);
 

--- a/Libplanet.Tests/Store/ProxyStore.cs
+++ b/Libplanet.Tests/Store/ProxyStore.cs
@@ -54,11 +54,11 @@ namespace Libplanet.Tests.Store
         public virtual long CountIndex(Guid chainId) =>
             Store.CountIndex(chainId);
 
-        /// <inheritdoc cref="IStore.IterateIndexes(Guid, int, int?)"/>
+        /// <inheritdoc cref="IStore.IterateIndexes(Guid, long, long?)"/>
         public virtual IEnumerable<BlockHash> IterateIndexes(
             Guid chainId,
-            int offset = 0,
-            int? limit = null
+            long offset = 0,
+            long? limit = null
         ) =>
             Store.IterateIndexes(chainId, offset, limit);
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -650,34 +650,34 @@ namespace Libplanet.Tests.Store
             var indexes = store.IterateIndexes(ns).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndexes(ns, 1).ToArray();
+            indexes = store.IterateIndexes(ns, 1L).ToArray();
             Assert.Equal(new[] { Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndexes(ns, 2).ToArray();
+            indexes = store.IterateIndexes(ns, 2L).ToArray();
             Assert.Equal(new[] { Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndexes(ns, 3).ToArray();
+            indexes = store.IterateIndexes(ns, 3L).ToArray();
             Assert.Equal(new BlockHash[0], indexes);
 
-            indexes = store.IterateIndexes(ns, 4).ToArray();
+            indexes = store.IterateIndexes(ns, 4L).ToArray();
             Assert.Equal(new BlockHash[0], indexes);
 
-            indexes = store.IterateIndexes(ns, limit: 0).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 0L).ToArray();
             Assert.Equal(new BlockHash[0], indexes);
 
-            indexes = store.IterateIndexes(ns, limit: 1).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 1L).ToArray();
             Assert.Equal(new[] { Fx.Hash1 }, indexes);
 
-            indexes = store.IterateIndexes(ns, limit: 2).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 2L).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2 }, indexes);
 
-            indexes = store.IterateIndexes(ns, limit: 3).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 3L).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndexes(ns, limit: 4).ToArray();
+            indexes = store.IterateIndexes(ns, limit: 4L).ToArray();
             Assert.Equal(new[] { Fx.Hash1, Fx.Hash2, Fx.Hash3 }, indexes);
 
-            indexes = store.IterateIndexes(ns, 1, 1).ToArray();
+            indexes = store.IterateIndexes(ns, 1L, 1L).ToArray();
             Assert.Equal(new[] { Fx.Hash2 }, indexes);
         }
 

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -157,7 +157,7 @@ namespace Libplanet.Tests.Store
             return _store.IterateBlockHashes();
         }
 
-        public IEnumerable<BlockHash> IterateIndexes(Guid chainId, int offset, int? limit)
+        public IEnumerable<BlockHash> IterateIndexes(Guid chainId, long offset, long? limit)
         {
              Log(nameof(IterateIndexes), chainId, offset, limit);
              return _store.IterateIndexes(chainId, offset, limit);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1279,7 +1279,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal IEnumerable<Block<T>> IterateBlocks(int offset = 0, int? limit = null)
+        internal IEnumerable<Block<T>> IterateBlocks(long offset = 0, long? limit = null)
         {
             _rwlock.EnterUpgradeableReadLock();
 
@@ -1296,7 +1296,7 @@ namespace Libplanet.Blockchain
             }
         }
 
-        internal IEnumerable<BlockHash> IterateBlockHashes(int offset = 0, int? limit = null)
+        internal IEnumerable<BlockHash> IterateBlockHashes(long offset = 0, long? limit = null)
         {
             _rwlock.EnterUpgradeableReadLock();
 

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -30,8 +30,9 @@ namespace Libplanet.Store
 
         public abstract long CountIndex(Guid chainId);
 
-        /// <inheritdoc cref="IStore.IterateIndexes(Guid, int, int?)"/>
-        public abstract IEnumerable<BlockHash> IterateIndexes(Guid chainId, int offset, int? limit);
+        /// <inheritdoc cref="IStore.IterateIndexes(Guid, long, long?)"/>
+        public abstract IEnumerable<BlockHash>
+        IterateIndexes(Guid chainId, long offset, long? limit);
 
         /// <inheritdoc cref="IStore.IndexBlockHash(Guid, long)"/>
         public abstract BlockHash? IndexBlockHash(Guid chainId, long index);

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -262,11 +262,27 @@ namespace Libplanet.Store
             return IndexCollection(chainId).Count();
         }
 
-        /// <inheritdoc cref="BaseStore.IterateIndexes(Guid, int, int?)"/>
-        public override IEnumerable<BlockHash> IterateIndexes(Guid chainId, int offset, int? limit)
+        /// <inheritdoc cref="BaseStore.IterateIndexes(Guid, long, long?)"/>
+        public override IEnumerable<BlockHash> IterateIndexes(
+            Guid chainId,
+            long offset,
+            long? limit)
         {
+            int iOffSet = (offset < int.MinValue || offset > int.MaxValue)
+                ? throw new ArgumentOutOfRangeException(
+                    nameof(offset),
+                    offset,
+                    "The given value isn't supported on the storage backend.")
+                : (int)offset;
+            int? iLimit = (limit < int.MinValue || limit > int.MaxValue)
+               ? throw new ArgumentOutOfRangeException(
+                   nameof(limit),
+                   limit,
+                   "The given value isn't supported on the storage backend.")
+               : (int?)limit;
+
             return IndexCollection(chainId)
-                .Find(Query.All(), offset, limit ?? int.MaxValue)
+                .Find(Query.All(), iOffSet, iLimit ?? int.MaxValue)
                 .Select(i => i.Hash);
         }
 

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Store
         /// <param name="limit">The maximum number of block hashes to get.</param>
         /// <returns>Block hashes in the index of the <paramref name="chainId"/>, in ascending
         /// order; the genesis block goes first, and the tip block goes last.</returns>
-        IEnumerable<BlockHash> IterateIndexes(Guid chainId, int offset = 0, int? limit = null);
+        IEnumerable<BlockHash> IterateIndexes(Guid chainId, long offset = 0, long? limit = null);
 
         /// <summary>
         /// Determines the block hash by its <paramref name="index"/>.
@@ -86,7 +86,7 @@ namespace Libplanet.Store
         /// <param name="branchpoint">The branchpoint <see cref="Block{T}"/> to fork.</param>
         /// <exception cref="ChainIdNotFoundException">Thrown when the given
         /// <paramref name="sourceChainId"/> does not exist.</exception>
-        /// <seealso cref="IterateIndexes(Guid, int, int?)"/>
+        /// <seealso cref="IterateIndexes(Guid, long, long?)"/>
         /// <seealso cref="AppendIndex(Guid, BlockHash)"/>
         void ForkBlockIndexes(Guid sourceChainId, Guid destinationChainId, BlockHash branchpoint);
 

--- a/Libplanet/Store/MemoryStore.cs
+++ b/Libplanet/Store/MemoryStore.cs
@@ -74,12 +74,12 @@ namespace Libplanet.Store
         long IStore.CountIndex(Guid chainId) =>
             _indices.TryGetValue(chainId, out ImmutableTrieList<BlockHash> index) ? index.Count : 0;
 
-        IEnumerable<BlockHash> IStore.IterateIndexes(Guid chainId, int offset, int? limit)
+        IEnumerable<BlockHash> IStore.IterateIndexes(Guid chainId, long offset, long? limit)
         {
             if (_indices.TryGetValue(chainId, out ImmutableTrieList<BlockHash> list))
             {
-                IEnumerable<BlockHash> index = list.Skip(offset);
-                return limit is { } l ? index.Take(l) : index;
+                IEnumerable<BlockHash> index = list.Skip((int)offset);
+                return limit is { } l ? index.Take((int)l) : index;
             }
 
             return Enumerable.Empty<BlockHash>();


### PR DESCRIPTION
Since `Block<T>.Index` is of type `long`, to remove unnecessary casting, changed offset and limit parameters in various places to long.
- Resolves https://github.com/planetarium/libplanet/issues/1354