### PR TITLE
`ExceptionOccurred` `EventHandler<Exception>` added to `Context`

### DIFF
--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -6,6 +6,11 @@ namespace Libplanet.Net.Consensus
     public partial class Context<T>
     {
         /// <summary>
+        /// An event that is invoked when an exception is thrown.
+        /// </summary>
+        internal event EventHandler<Exception>? ExceptionOccurred;
+
+        /// <summary>
         /// An event that invoked when any timeout occurs.
         /// </summary>
         internal event EventHandler<(Step Step, TimeSpan TimeSpan)>? TimeoutOccurred;


### PR DESCRIPTION
Closes #2196.

There is no real change to the behavior. To iron out the design consistency for `Context`, `AddMessage()` has been made `private`. See the note at the top of `Context.Mutate.cs`.

This only adds an event handler for thrown `Exception`s. If a need arises to react to these `Exception`s, other tasks should subscribe to `ExceptionOccurred` event handler and react accordingly. 😗