### PR TITLE
Upgrade Ubuntu 18.04 image to latest in GitHub Actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
         - macos-latest
-        - ubuntu-18.04
+        - ubuntu-latest
         - windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -14,7 +14,7 @@ name: check-build
 jobs:
   build:
     name: check-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
       if: github.event_name != 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     if: github.event_name != 'schedule' || github.repository == 'planetarium/libplanet'
     name: dist
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
       if: github.event_name != 'pull_request'
@@ -86,7 +86,7 @@ jobs:
   docs:
     if: github.event_name != 'schedule' || github.repository == 'planetarium/libplanet'
     name: docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
       if: github.event_name != 'pull_request'
@@ -125,7 +125,7 @@ jobs:
   bundle:
     name: bundle
     needs: [build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - run: sudo apt-get install nuget
     - uses: actions/checkout@main


### PR DESCRIPTION
The GitHub Blog said, they will deprecate Ubuntu 18.04 runner image since 2022.12.01. So this pull request upgrades the runner image to the latest runner image.

See also https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/.