### PR TITLE
♻️ Refactor `NetMQTransport`'s initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ To be released.
 
 ### Deprecated APIs
 
+ -  (Libplanet.Net) Removed `NetMQTransport()` constructor.  Use
+    `NetMQTransport.Create()` instead.  [[#2215]]
  -  Unused `TcpMessageCodec` class removed.  [[#2216]]
  -  (Libplanet.Stun) Removed `TurnClient.IsConnectable()` method.  [[#2219]]
  -  (Libplanet.Stun) Removed `TurnClient.BindProxies()` method.
@@ -112,7 +114,8 @@ To be released.
         instance.
  -  (Libplanet.Net) `NetMQTransport`'s general behavior has changed.  [[#2215]]
      -  `NetMQTransport` is now able to send requests and receive
-        replies as soon as it is created.
+        replies as soon as it is created through `NetMQTransport.Create()`
+        factory method.
      -  `NetMQTransport.StartAsync()` enables a `NetMQTransport` instance
         to recieve requests and send replies.
      -  `NetMQTransport.StopAsync()` only disables a `NetMQTransport` instance

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,8 @@ To be released.
     TotalSupplyStateCompleter<T>` method which gets the total supply of
     a `Currency` in `FungibleAssetValue` from the state, and if not found,
     returns null.  [[#915], [#2200]]
+ -  (Libplanet.Net) `ITransport.AsPeer` and `Swarm<T>.AsPeer` type changed from
+    `Peer` to `BoundPeer`.  [[#2215]]
 
 ### Backward-incompatible network protocol changes
 
@@ -108,6 +110,13 @@ To be released.
         throws `SupplyOverflowException` if the sum of current total supply and
         the value to be minted exceeds the maximum supply of the `Currency`
         instance.
+ -  (Libplanet.Net) `NetMQTransport`'s general behavior has changed.  [[#2215]]
+     -  `NetMQTransport` is now able to send requests and receive
+        replies as soon as it is created.
+     -  `NetMQTransport.StartAsync()` enables a `NetMQTransport` instance
+        to recieve requests and send replies.
+     -  `NetMQTransport.StopAsync()` only disables a `NetMQTransport` instance
+        to stop recieving requests and sending replies.
 
 ### Bug fixes
 
@@ -117,6 +126,7 @@ To be released.
 
 [#915]: https://github.com/planetarium/libplanet/issues/915
 [#2200]: https://github.com/planetarium/libplanet/pull/2200
+[#2215]: https://github.com/planetarium/libplanet/pull/2215
 [#2216]: https://github.com/planetarium/libplanet/pull/2216
 [#2219]: https://github.com/planetarium/libplanet/pull/2219
 

--- a/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
+++ b/Libplanet.Net.Tests/Protocols/ProtocolTest.cs
@@ -530,7 +530,7 @@ namespace Libplanet.Net.Tests.Protocols
                 foreach (var t in transports)
                 {
                     transport.Table.AddPeer(
-                        (BoundPeer)t.AsPeer,
+                        t.AsPeer,
                         DateTimeOffset.UtcNow - TimeSpan.FromMinutes(2));
                 }
 

--- a/Libplanet.Net.Tests/Protocols/TestTransport.cs
+++ b/Libplanet.Net.Tests/Protocols/TestTransport.cs
@@ -74,7 +74,7 @@ namespace Libplanet.Net.Tests.Protocols
 
         public Address Address => _privateKey.ToAddress();
 
-        public Peer AsPeer => new BoundPeer(
+        public BoundPeer AsPeer => new BoundPeer(
             _privateKey.PublicKey,
             new DnsEndPoint("localhost", 1234));
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -72,7 +72,8 @@ namespace Libplanet.Net.Tests
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                Assert.Equal(swarmA.AsPeer, swarmB.AsPeer);
+                Assert.Equal(swarmA.AsPeer.Address, swarmB.AsPeer.Address);
+                Assert.Equal(swarmA.AsPeer.PublicIPAddress, swarmB.AsPeer.PublicIPAddress);
 
                 await swarmA.AddPeersAsync(new[] { seed.AsPeer }, null);
                 await StopAsync(swarmA);
@@ -503,8 +504,8 @@ namespace Libplanet.Net.Tests
                 chainA.UnstageTransaction(tx2);
                 Assert.Equal(1, chainA.GetNextTxNonce(privateKey.ToAddress()));
 
-                swarmA.RoutingTable.RemovePeer((BoundPeer)swarmB.AsPeer);
-                swarmB.RoutingTable.RemovePeer((BoundPeer)swarmA.AsPeer);
+                swarmA.RoutingTable.RemovePeer(swarmB.AsPeer);
+                swarmB.RoutingTable.RemovePeer(swarmA.AsPeer);
                 Assert.Empty(swarmA.Peers);
                 Assert.Empty(swarmB.Peers);
 
@@ -949,7 +950,7 @@ namespace Libplanet.Net.Tests
                 var transport = swarm1.Transport;
                 var msg = new GetTxsMsg(new[] { tx1.Id, tx2.Id, tx3.Id, tx4.Id });
                 var replies = (await transport.SendMessageAsync(
-                    (BoundPeer)swarm2.AsPeer,
+                    swarm2.AsPeer,
                     msg,
                     TimeSpan.FromSeconds(1),
                     4,

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -187,7 +187,7 @@ namespace Libplanet.Net.Tests
                     {
                         EstimatedTotalBlockHashCount = 10,
                         ReceivedBlockHashCount = 1,
-                        SourcePeer = minerSwarm.AsPeer as BoundPeer,
+                        SourcePeer = minerSwarm.AsPeer,
                     };
                     expectedStates.Add(state);
                 }
@@ -200,7 +200,7 @@ namespace Libplanet.Net.Tests
                         ReceivedBlockHash = b.Hash,
                         TotalBlockCount = i == 9 || i == 10 ? 11 : 10,
                         ReceivedBlockCount = i,
-                        SourcePeer = minerSwarm.AsPeer as BoundPeer,
+                        SourcePeer = minerSwarm.AsPeer,
                     };
                     expectedStates.Add(state);
                 }
@@ -439,7 +439,7 @@ namespace Libplanet.Net.Tests
                     {
                         EstimatedTotalBlockHashCount = 10,
                         ReceivedBlockHashCount = i,
-                        SourcePeer = nominerSwarm1.AsPeer as BoundPeer,
+                        SourcePeer = nominerSwarm1.AsPeer,
                     };
                     expectedStates.Add(state);
                 }
@@ -451,7 +451,7 @@ namespace Libplanet.Net.Tests
                         ReceivedBlockHash = minerChain[i].Hash,
                         TotalBlockCount = 10,
                         ReceivedBlockCount = i,
-                        SourcePeer = nominerSwarm1.AsPeer as BoundPeer,
+                        SourcePeer = nominerSwarm1.AsPeer,
                     };
                     expectedStates.Add(state);
                 }
@@ -665,7 +665,7 @@ namespace Libplanet.Net.Tests
 
             (BoundPeer, IBlockExcerpt)[] peersWithExcerpt =
             {
-                ((BoundPeer)minerSwarm.AsPeer, minerChain.Tip.Header),
+                (minerSwarm.AsPeer, minerChain.Tip.Header),
             };
 
             (long, BlockHash)[] demands = await receiverSwarm.GetDemandBlockHashes(
@@ -757,7 +757,7 @@ namespace Libplanet.Net.Tests
 
             (BoundPeer, IBlockExcerpt)[] peersWithBlockExcerpt =
             {
-                ((BoundPeer)minerSwarm.AsPeer, minerChain.Tip.Header),
+                (minerSwarm.AsPeer, minerChain.Tip.Header),
             };
 
             long receivedCount = 0;

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -251,7 +251,7 @@ namespace Libplanet.Net.Tests
                 await StartAsync(swarmD);
 
                 var bootstrappedAt = DateTimeOffset.UtcNow;
-                swarmC.RoutingTable.AddPeer((BoundPeer)swarmD.AsPeer);
+                swarmC.RoutingTable.AddPeer(swarmD.AsPeer);
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
                 await BootstrapAsync(swarmC, swarmA.AsPeer);
 
@@ -298,8 +298,8 @@ namespace Libplanet.Net.Tests
                 {
                     StaticPeers = new[]
                     {
-                        (BoundPeer)swarmA.AsPeer,
-                        (BoundPeer)swarmB.AsPeer,
+                        swarmA.AsPeer,
+                        swarmB.AsPeer,
                         // Unreachable peer:
                         new BoundPeer(
                             new PrivateKey().PublicKey,
@@ -390,7 +390,7 @@ namespace Libplanet.Net.Tests
 
                 (long, BlockHash)[] inventories1 = (
                     await swarmB.GetBlockHashes(
-                        swarmA.AsPeer as BoundPeer,
+                        swarmA.AsPeer,
                         new BlockLocator(new[] { genesis.Hash }),
                         null
                     ).ToArrayAsync()
@@ -406,7 +406,7 @@ namespace Libplanet.Net.Tests
 
                 (long, BlockHash)[] inventories2 = (
                     await swarmB.GetBlockHashes(
-                        swarmA.AsPeer as BoundPeer,
+                        swarmA.AsPeer,
                         new BlockLocator(new[] { genesis.Hash }),
                         block1.Hash
                     ).ToArrayAsync()
@@ -417,7 +417,7 @@ namespace Libplanet.Net.Tests
 
                 Block<DumbAction>[] receivedBlocks =
                     await swarmB.GetBlocksAsync(
-                        swarmA.AsPeer as BoundPeer,
+                        swarmA.AsPeer,
                         inventories1.Select(pair => pair.Item2),
                         cancellationToken: default
                     ).ToArrayAsync();
@@ -452,7 +452,7 @@ namespace Libplanet.Net.Tests
                 await StartAsync(swarmA);
                 await StartAsync(swarmB);
 
-                var peer = swarmA.AsPeer as BoundPeer;
+                var peer = swarmA.AsPeer;
 
                 await swarmB.AddPeersAsync(new[] { peer }, null);
 
@@ -466,7 +466,7 @@ namespace Libplanet.Net.Tests
 
                 var request = new GetBlocksMsg(hashes.Select(pair => pair.Item2), 2);
                 Message[] responses = (await transport.SendMessageAsync(
-                    (BoundPeer)swarmA.AsPeer,
+                    swarmA.AsPeer,
                     request,
                     null,
                     2,
@@ -518,7 +518,7 @@ namespace Libplanet.Net.Tests
 
                 List<Transaction<DumbAction>> txs =
                     await swarmA.GetTxsAsync(
-                        swarmB.AsPeer as BoundPeer,
+                        swarmB.AsPeer,
                         new[] { tx.Id },
                         cancellationToken: default
                     ).ToListAsync();
@@ -567,7 +567,7 @@ namespace Libplanet.Net.Tests
             using (Swarm<DumbAction> s = CreateSwarm(host: "1.2.3.4", listenPort: 5678))
             {
                 Assert.Equal(expected, s.EndPoint);
-                Assert.Equal(expected, (s.AsPeer as BoundPeer)?.EndPoint);
+                Assert.Equal(expected, s.AsPeer?.EndPoint);
             }
         }
 
@@ -622,15 +622,15 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     new HashSet<BoundPeer>
                     {
-                        swarmA.AsPeer as BoundPeer,
-                        swarmB.AsPeer as BoundPeer,
+                        swarmA.AsPeer,
+                        swarmB.AsPeer,
                     },
                     seed.Peers.ToHashSet());
                 Assert.Equal(
-                    new HashSet<BoundPeer> { seed.AsPeer as BoundPeer, swarmB.AsPeer as BoundPeer },
+                    new HashSet<BoundPeer> { seed.AsPeer, swarmB.AsPeer },
                     swarmA.Peers.ToHashSet());
                 Assert.Equal(
-                    new HashSet<BoundPeer> { seed.AsPeer as BoundPeer, swarmA.AsPeer as BoundPeer },
+                    new HashSet<BoundPeer> { seed.AsPeer, swarmA.AsPeer },
                     swarmB.Peers.ToHashSet());
             }
             finally
@@ -1682,7 +1682,7 @@ namespace Libplanet.Net.Tests
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(
-                    new PeerChainState((BoundPeer)swarm2.AsPeer, 0, 0),
+                    new PeerChainState(swarm2.AsPeer, 0, 0),
                     peerChainState.First()
                 );
 
@@ -1690,7 +1690,7 @@ namespace Libplanet.Net.Tests
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(
-                    new PeerChainState((BoundPeer)swarm2.AsPeer, 1, 1024),
+                    new PeerChainState(swarm2.AsPeer, 1, 1024),
                     peerChainState.First()
                 );
 
@@ -1700,8 +1700,8 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     new[]
                     {
-                        new PeerChainState((BoundPeer)swarm2.AsPeer, 1, 1024),
-                        new PeerChainState((BoundPeer)swarm3.AsPeer, 0, 0),
+                        new PeerChainState(swarm2.AsPeer, 1, 1024),
+                        new PeerChainState(swarm3.AsPeer, 0, 0),
                     }.ToHashSet(),
                     peerChainState.ToHashSet()
                 );

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -318,6 +318,7 @@ namespace Libplanet.Net.Tests
 
                 _logger.Debug("Address of swarmA: {Address}", swarmA.Address);
                 await StopAsync(swarmA);
+                swarmA.Dispose();
                 await Task.Delay(100);
                 await swarm.PeerDiscovery.RefreshTableAsync(
                     TimeSpan.Zero,
@@ -338,7 +339,6 @@ namespace Libplanet.Net.Tests
             }
             finally
             {
-                await StopAsync(swarmA);
                 await StopAsync(swarmB);
                 await StopAsync(swarmC);
             }

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -68,9 +68,9 @@ namespace Libplanet.Net.Tests.Transports
         {
             privateKey = privateKey ?? new PrivateKey();
             host = host ?? IPAddress.Loopback.ToString();
-            iceServers = iceServers ?? new IceServer[] { };
+            iceServers = iceServers ?? new List<IceServer>();
 
-            return new NetMQTransport(
+            return NetMQTransport.Create(
                 privateKey,
                 appProtocolVersion,
                 trustedAppProtocolVersionSigners,
@@ -79,7 +79,7 @@ namespace Libplanet.Net.Tests.Transports
                 listenPort,
                 iceServers,
                 differentAppProtocolVersionEncountered,
-                messageTimestampBuffer);
+                messageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }
 }

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -58,10 +58,6 @@ namespace Libplanet.Net.Tests.Transports
                 Assert.True(transport.Running);
                 await transport.StopAsync(TimeSpan.Zero);
                 Assert.False(transport.Running);
-                if (transport is NetMQTransport)
-                {
-                    NetMQConfig.Cleanup(false);
-                }
 
                 await InitializeAsync(transport);
                 Assert.True(transport.Running);
@@ -69,6 +65,10 @@ namespace Libplanet.Net.Tests.Transports
             finally
             {
                 transport.Dispose();
+                if (transport is NetMQTransport)
+                {
+                    NetMQConfig.Cleanup(false);
+                }
             }
         }
 

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -147,7 +147,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(boundTransport);
                 peer = boundTransport.AsPeer;
                 Assert.IsType<BoundPeer>(peer);
-                var boundPeer = (BoundPeer)peer;
+                var boundPeer = peer;
                 Assert.Equal(boundPrivateKey.ToAddress(), boundPeer.Address);
                 Assert.Equal(listenPort, boundPeer.EndPoint.Port);
                 Assert.Equal(host, boundPeer.EndPoint.Host);
@@ -185,7 +185,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportB);
 
                 Message reply = await transportA.SendMessageAsync(
-                    (BoundPeer)transportB.AsPeer,
+                    transportB.AsPeer,
                     new PingMsg(),
                     TimeSpan.FromSeconds(3),
                     CancellationToken.None);
@@ -214,7 +214,7 @@ namespace Libplanet.Net.Tests.Transports
                 cts.CancelAfter(TimeSpan.FromSeconds(1));
                 await Assert.ThrowsAsync<TaskCanceledException>(
                     async () => await transportA.SendMessageAsync(
-                        (BoundPeer)transportB.AsPeer,
+                        transportB.AsPeer,
                         new PingMsg(),
                         null,
                         cts.Token));
@@ -258,7 +258,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportB);
 
                 var replies = (await transportA.SendMessageAsync(
-                    (BoundPeer)transportB.AsPeer,
+                    transportB.AsPeer,
                     new PingMsg(),
                     TimeSpan.FromSeconds(3),
                     2,
@@ -289,7 +289,7 @@ namespace Libplanet.Net.Tests.Transports
 
                 var e = await Assert.ThrowsAsync<CommunicationFailException>(
                     async () => await transportA.SendMessageAsync(
-                        (BoundPeer)transportB.AsPeer,
+                        transportB.AsPeer,
                         new PingMsg(),
                         TimeSpan.FromSeconds(3),
                         CancellationToken.None));
@@ -348,7 +348,7 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportB);
 
                 Task t = transportA.SendMessageAsync(
-                        (BoundPeer)transportB.AsPeer,
+                        transportB.AsPeer,
                         new PingMsg(),
                         null,
                         CancellationToken.None);
@@ -408,9 +408,9 @@ namespace Libplanet.Net.Tests.Transports
                 await InitializeAsync(transportD);
 
                 var table = new RoutingTable(address, bucketSize: 1);
-                table.AddPeer(transportB.AsPeer as BoundPeer);
-                table.AddPeer(transportC.AsPeer as BoundPeer);
-                table.AddPeer(transportD.AsPeer as BoundPeer);
+                table.AddPeer(transportB.AsPeer);
+                table.AddPeer(transportC.AsPeer);
+                table.AddPeer(transportD.AsPeer);
 
                 transportA = CreateTransport();
                 await InitializeAsync(transportA);

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -134,8 +134,8 @@ namespace Libplanet.Net.Tests.Transports
             try
             {
                 var peer = transport.AsPeer;
-                Assert.IsType<Peer>(peer);
-                Assert.IsNotType<BoundPeer>(peer);
+                Assert.IsNotType<Peer>(peer);
+                Assert.IsType<BoundPeer>(peer);
                 Assert.Equal(privateKey.ToAddress(), peer.Address);
 
                 await InitializeAsync(transport);

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -168,7 +168,7 @@ namespace Libplanet.Net
 
         public Address Address => _privateKey.ToAddress();
 
-        public Peer AsPeer => Transport?.AsPeer;
+        public BoundPeer AsPeer => Transport?.AsPeer;
 
         /// <summary>
         /// The last time when any message was arrived.

--- a/Libplanet.Net/Transports/ITransport.cs
+++ b/Libplanet.Net/Transports/ITransport.cs
@@ -41,24 +41,22 @@ namespace Libplanet.Net.Transports
         bool Running { get; }
 
         /// <summary>
-        /// Initiates and runs transport layer.
+        /// Starts running a transport layer.
         /// </summary>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.</param>
-        /// <returns>An awaitable task without value.</returns>
-        /// <exception cref="ObjectDisposedException">
-        /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>
+        /// <param name="cancellationToken">The cancellation token used to propagate a notification
+        /// that this operation should be canceled.</param>
+        /// <returns>An awaitable <see cref="Task"/> without a value.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the <see cref="ITransport"/>
+        /// instance is already disposed.</exception>
         Task StartAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Stops running transport layer.
+        /// Stops running a transport layer.
         /// </summary>
         /// <param name="waitFor">The <see cref="TimeSpan"/> of delay
         /// before actual stopping.</param>
-        /// <param name="cancellationToken">
-        /// A cancellation token used to propagate notification that this
-        /// operation should be canceled.</param>
+        /// <param name="cancellationToken">The cancellation token used to propagate a notification
+        /// that this operation should be canceled.</param>
         /// <returns>An awaitable task without value.</returns>
         /// <exception cref="ObjectDisposedException">
         /// Thrown when <see cref="ITransport"/> instance is already disposed.</exception>

--- a/Libplanet.Net/Transports/ITransport.cs
+++ b/Libplanet.Net/Transports/ITransport.cs
@@ -22,10 +22,10 @@ namespace Libplanet.Net.Transports
         AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <summary>
-        /// <see cref="Peer"/> representation of <see cref="ITransport"/>.
+        /// <see cref="BoundPeer"/> representation of <see cref="ITransport"/>.
         /// </summary>
         [Pure]
-        Peer AsPeer { get; }
+        BoundPeer AsPeer { get; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> of the last message was received.

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -462,7 +462,7 @@ namespace Libplanet.Net.Transports
             _replyCompletionSources.TryRemove(identityHex, out _);
         }
 
-        internal async Task Initialize(CancellationToken cancellationToken = default)
+        private async Task Initialize(CancellationToken cancellationToken = default)
         {
             _router = new RouterSocket();
             _router.Options.RouterHandover = true;

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -172,9 +172,7 @@ namespace Libplanet.Net.Transports
         public AsyncDelegate<Message> ProcessMessageHandler { get; }
 
         /// <inheritdoc/>
-        public Peer AsPeer => EndPoint is null
-            ? new Peer(_privateKey.PublicKey, PublicIPAddress)
-            : new BoundPeer(_privateKey.PublicKey, EndPoint, PublicIPAddress);
+        public BoundPeer AsPeer => new BoundPeer(_privateKey.PublicKey, EndPoint, PublicIPAddress);
 
         /// <inheritdoc/>
         public DateTimeOffset? LastMessageTimestamp { get; private set; }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -51,8 +51,6 @@ namespace Libplanet.Net.Transports
         // Used only for logging.
         private long _requestCount;
         private long _socketCount;
-
-        private bool _initialized = false;
         private bool _disposed = false;
 
         static NetMQTransport()
@@ -166,6 +164,8 @@ namespace Libplanet.Net.Transports
             ProcessMessageHandler = new AsyncDelegate<Message>();
             _replyCompletionSources =
                 new ConcurrentDictionary<string, TaskCompletionSource<object>>();
+
+            Initialize(default).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
@@ -212,12 +212,6 @@ namespace Libplanet.Net.Transports
             if (Running)
             {
                 throw new TransportException("Transport is already running.");
-            }
-
-            if (!_initialized)
-            {
-                await Initialize(cancellationToken);
-                _initialized = true;
             }
 
             _runtimeCancellationTokenSource =


### PR DESCRIPTION
Related to #1612, #1934.
Some preparatory work to streamline uses of `ITransport` and `Swarm<T>`.

This is mostly to move up `ITransport`'s binding phase more in line with the rest of the `Libplanet.Net`'s (seemingly) intended design. 🙄

There are some problematic uses of `async` and `CancellationToken` handling here and there, which should be dealt with shortly. 😐

Hopefully with this, we might be ready to combine `Peer` and `BoundPeer` into a single class.