### PR TITLE
Refactor `IceServer.CreateTurnClient()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@ To be released.
 ### Deprecated APIs
 
  -  Unused `TcpMessageCodec` class removed.  [[#2216]]
+ -  (Libplanet.Stun) Removed `TurnClient.IsConnectable()` method.  [[#2219]]
+ -  (Libplanet.Stun) Removed `TurnClient.BindProxies()` method.
+    [[#2219]]
+ -  (Libplanet.Stun) Removed `TurnClient()` constructor.
+    Use `TurnClient.Create()` instead.  [[#2219]]
 
 ### Backward-incompatible API changes
 
@@ -74,6 +79,8 @@ To be released.
  -  Added `TotalSupplyStateCompleters<T>` static class.  [[#915], [#2200]]
  -  Added `StateCompleterSet<T>.TotalSupplyStateCompleter` property.
     [[#915], [#2200]]
+ -  (Libplanet.Stun) Added `IIceServer` interface.  [[#2219]]
+ -  (Libplanet.Stun) Added `TurnClient.Create()` static method.  [[#2219]]
 
 ### Behavioral changes
 
@@ -109,8 +116,9 @@ To be released.
 ### CLI tools
 
 [#915]: https://github.com/planetarium/libplanet/issues/915
-[#2216]: https://github.com/planetarium/libplanet/pull/2216
 [#2200]: https://github.com/planetarium/libplanet/pull/2200
+[#2216]: https://github.com/planetarium/libplanet/pull/2216
+[#2219]: https://github.com/planetarium/libplanet/pull/2219
 
 
 Version 0.40.0

--- a/Libplanet.Net.Tests/IceServerTest.cs
+++ b/Libplanet.Net.Tests/IceServerTest.cs
@@ -62,20 +62,15 @@ namespace Libplanet.Net.Tests
             var turnUri = FactOnlyTurnAvailableAttribute.GetTurnUri();
             var userInfo = turnUri.UserInfo.Split(':');
             await Assert.ThrowsAsync<ArgumentException>(
-                async () =>
-                {
-                    await IceServer.CreateTurnClient(
-                       new[] { new IceServer("stun://stun.l.google.com:19302") }
-                    );
-                }
-            );
+                async () => await TurnClient.Create(
+                    new[] { new IceServer("stun://stun.l.google.com:19302") }));
             var servers = new List<IceServer>()
             {
                 new IceServer("turn://turn.does-not-exists.org"),
             };
 
             await Assert.ThrowsAsync<IceServerException>(
-                async () => { await IceServer.CreateTurnClient(servers); });
+                async () => await TurnClient.Create(servers));
 
             servers.Add(new IceServer(turnUri));
             for (int i = 3; i > 0; i--)
@@ -83,7 +78,7 @@ namespace Libplanet.Net.Tests
                 TurnClient turnClient;
                 try
                 {
-                    turnClient = await IceServer.CreateTurnClient(servers);
+                    turnClient = await TurnClient.Create(servers);
                 }
                 catch (IceServerException)
                 {

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -482,7 +482,7 @@ namespace Libplanet.Net.Transports
             }
             else if (_iceServers is { } iceServers)
             {
-                _turnClient = await IceServer.CreateTurnClient(_iceServers);
+                _turnClient = await TurnClient.Create(_iceServers);
                 await _turnClient.StartAsync(_listenPort, cancellationToken);
                 if (!_turnClient.BehindNAT)
                 {

--- a/Libplanet.Stun/IIceServer.cs
+++ b/Libplanet.Stun/IIceServer.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Libplanet.Stun
+{
+    public interface IIceServer
+    {
+        public Uri Url { get; }
+
+        public string Username { get; }
+
+        public string Credential { get; }
+    }
+}

--- a/Libplanet.Stun/IceServerException.cs
+++ b/Libplanet.Stun/IceServerException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Libplanet.Net
+namespace Libplanet.Stun
 {
     [Serializable]
     public class IceServerException : Exception


### PR DESCRIPTION
Related to #2218.

Two points:
 - Not sure if `ProbeConnectableLength` is appropriate.
 - ~Still wondering if there is a more elegant way of calling `async` from `sync`.~ 🙄

~P.S. I know forcefully calling `async` from `sync` is bad practice, but IMO this is still better than `async` code spreading uncontrollably without proper design support.~ 😐