### PR TITLE
Add `PeerString` property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,7 @@ To be released.
  -  Added `TotalSupplyStateCompleters<T>` static class.  [[#915], [#2200]]
  -  Added `StateCompleterSet<T>.TotalSupplyStateCompleter` property.
     [[#915], [#2200]]
+ -  (Libplanet.Net) Added `BoundPeer.PeerString` property.  [[#2187]]
  -  (Libplanet.Stun) Added `IIceServer` interface.  [[#2219]]
  -  (Libplanet.Stun) Added `TurnClient.Create()` static method.  [[#2219]]
 
@@ -134,11 +135,13 @@ To be released.
 
 [#915]: https://github.com/planetarium/libplanet/issues/915
 [#1538]: https://github.com/planetarium/libplanet/issues/1538
+[#2187]:https://github.com/planetarium/libplanet/issues/2187
 [#2200]: https://github.com/planetarium/libplanet/pull/2200
 [#2201]: https://github.com/planetarium/libplanet/pull/2201
 [#2215]: https://github.com/planetarium/libplanet/pull/2215
 [#2216]: https://github.com/planetarium/libplanet/pull/2216
 [#2219]: https://github.com/planetarium/libplanet/pull/2219
+[#2232]: https://github.com/planetarium/libplanet/pull/2231
 
 
 Version 0.40.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,7 +88,7 @@ To be released.
  -  Added `TotalSupplyStateCompleters<T>` static class.  [[#915], [#2200]]
  -  Added `StateCompleterSet<T>.TotalSupplyStateCompleter` property.
     [[#915], [#2200]]
- -  (Libplanet.Net) Added `BoundPeer.PeerString` property.  [[#2187]]
+ -  (Libplanet.Net) Added `BoundPeer.PeerString` property.  [[#2187], [#2232]]
  -  (Libplanet.Stun) Added `IIceServer` interface.  [[#2219]]
  -  (Libplanet.Stun) Added `TurnClient.Create()` static method.  [[#2219]]
 

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -70,6 +70,19 @@ namespace Libplanet.Net.Tests
         }
 
         [Fact]
+        public void PeerString()
+        {
+#pragma warning disable MEN002 // Line is too long
+            var expected = "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,3333";
+            var boundPeer = new BoundPeer(
+                new PublicKey(ByteUtil.ParseHex("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233")),
+                new DnsEndPoint("192.168.0.1", 3333)
+            );
+#pragma warning restore MEN002 // Line is too long
+            Assert.Equal(expected, boundPeer.PeerString);
+        }
+
+        [Fact]
         public void ParsePeerException()
         {
             Assert.Throws<ArgumentNullException>(() => { BoundPeer.ParsePeer(null); });

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -61,8 +61,7 @@ namespace Libplanet.Net
         [Pure]
         public DnsEndPoint EndPoint { get; }
 
-        public string PeerString =>
-            $"{PublicKey},{EndPoint.Host},{EndPoint.Port}";
+        public string PeerString => $"{PublicKey},{EndPoint.Host},{EndPoint.Port}";
 
         public static bool operator ==(BoundPeer left, BoundPeer right) => left.Equals(right);
 

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -61,6 +61,9 @@ namespace Libplanet.Net
         [Pure]
         public DnsEndPoint EndPoint { get; }
 
+        public string PeerString =>
+            $"{PublicKey},{EndPoint.Host},{EndPoint.Port}";
+
         public static bool operator ==(BoundPeer left, BoundPeer right) => left.Equals(right);
 
         public static bool operator !=(BoundPeer left, BoundPeer right) => !left.Equals(right);


### PR DESCRIPTION
Add `PeerString` property to get a `BoundPeer`'s peer string.

resolved: #2187 