### PR TITLE
Use default `Nonce` for pbft `Block<T>`s

### DIFF
--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -365,12 +365,7 @@ namespace Libplanet.Blockchain
             var blockContent = new BlockContent<T>(metadata) { Transactions = transactionsToMine };
             PreEvaluationBlock<T> preEval;
 
-            if (!(prevHash is { } ph))
-            {
-                throw new InvalidBlockPreviousHashException("Need PreviousHash.");
-            }
-
-            preEval = blockContent.Propose(ph.ByteArray);
+            preEval = blockContent.Propose();
 
             (Block<T> block, IReadOnlyList<ActionEvaluation> actionEvaluations) =
                 preEval.EvaluateActions(proposer, this);

--- a/Libplanet/Blocks/BlockContent.cs
+++ b/Libplanet/Blocks/BlockContent.cs
@@ -224,11 +224,7 @@ namespace Libplanet.Blocks
         public PreEvaluationBlock<T> Mine(CancellationToken cancellationToken = default) =>
             new PreEvaluationBlock<T>(this, MineNonce(cancellationToken));
 
-        public PreEvaluationBlock<T> Propose(
-            ImmutableArray<byte> preEvaluationHash) =>
-            new PreEvaluationBlock<T>(
-                this,
-                (default, preEvaluationHash));
+        public PreEvaluationBlock<T> Propose() => new PreEvaluationBlock<T>(this, default(Nonce));
 
         /// <summary>
         /// Derives <see cref="TxHash"/> from the given <paramref name="transactions"/>.


### PR DESCRIPTION
Follows #2252.

Keeping `PreEvaluationHash` as a separate entity from `PreviousHash` might be useful. Further discussion may be needed.