### PR TITLE
Use propose for tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ To be released.
  -  Added `IBlockPolicy.GetValidators()` method.  [[#PBFT]]
  -  (Libplanet.Net) Removed `SwarmOptions.StaticPeers`.  [[#PBFT]]
  -  Bumped `BlockMetadata.CurrentProtocolVersion` to 4.  [[#PBFT]]
+ -  Renamed `BlockChain<T>.MakeGenesisBlock()` to
+    `BlockChain<T>.MineGenesisBlock()`.  [[#PBFT]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +30,7 @@ To be released.
  -  Added `Vote` readonly struct.  [[#PBFT]]
  -  Added `BlockContent.Propose()` method.  [[#PBFT]]
  -  Added `BlockCommit` class.  [[#PBFT]]
+ -  Added `BlockChain.ProposeGenesisBlock()` static method.  [[#PBFT]]
  -  Added `BlockChain.ProposeBlock()` method.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Benchmarks
             var key = new PrivateKey();
             for (var i = 0; i < 500; i++)
             {
-                _blockChain.MineBlock(key).Wait();
+                _blockChain.ProposeBlock(key);
             }
         }
 

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -1,21 +1,19 @@
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 
 namespace Libplanet.Benchmarks
 {
-    public class MineBlock
+    public class ProposeBlock
     {
         private BlockChain<DumbAction> _blockChain;
         private PrivateKey _privateKey;
 
-        public MineBlock()
+        public ProposeBlock()
         {
             var fx = new DefaultStoreFixture();
             _blockChain = new BlockChain<DumbAction>(
@@ -29,24 +27,24 @@ namespace Libplanet.Benchmarks
         }
 
         [Benchmark]
-        public async Task<Block<DumbAction>> MineBlockEmpty()
+        public Block<DumbAction> ProposeBlockEmpty()
         {
-            return await _blockChain.MineBlock(_privateKey);
+            return _blockChain.ProposeBlock(_privateKey);
         }
 
-        [IterationSetup(Target = "MineBlockOneTransactionNoAction")]
+        [IterationSetup(Target = "ProposeBlockOneTransactionNoAction")]
         public void MakeOneTransactionNoAction()
         {
             _blockChain.MakeTransaction(_privateKey, new DumbAction[] { });
         }
 
         [Benchmark]
-        public async Task<Block<DumbAction>> MineBlockOneTransactionNoAction()
+        public Block<DumbAction> ProposeBlockOneTransactionNoAction()
         {
-            return await _blockChain.MineBlock(_privateKey);
+            return _blockChain.ProposeBlock(_privateKey);
         }
 
-        [IterationSetup(Target = "MineBlockTenTransactionsNoAction")]
+        [IterationSetup(Target = "ProposeBlockTenTransactionsNoAction")]
         public void MakeTenTransactionsNoAction()
         {
             for (var i = 0; i < 10; i++)
@@ -56,12 +54,12 @@ namespace Libplanet.Benchmarks
         }
 
         [Benchmark]
-        public async Task<Block<DumbAction>> MineBlockTenTransactionsNoAction()
+        public Block<DumbAction> ProposeBlockTenTransactionsNoAction()
         {
-            return await _blockChain.MineBlock(_privateKey);
+            return _blockChain.ProposeBlock(_privateKey);
         }
 
-        [IterationSetup(Target = "MineBlockOneTransactionWithActions")]
+        [IterationSetup(Target = "ProposeBlockOneTransactionWithActions")]
         public void MakeOneTransactionWithActions()
         {
             var privateKey = new PrivateKey();
@@ -77,12 +75,12 @@ namespace Libplanet.Benchmarks
         }
 
         [Benchmark]
-        public async Task<Block<DumbAction>> MineBlockOneTransactionWithActions()
+        public Block<DumbAction> ProposeBlockOneTransactionWithActions()
         {
-            return await _blockChain.MineBlock(_privateKey);
+            return _blockChain.ProposeBlock(_privateKey);
         }
 
-        [IterationSetup(Target = "MineBlockTenTransactionsWithActions")]
+        [IterationSetup(Target = "ProposeBlockTenTransactionsWithActions")]
         public void MakeTenTransactionsWithActions()
         {
             for (var i = 0; i < 10; i++)
@@ -101,9 +99,9 @@ namespace Libplanet.Benchmarks
         }
 
         [Benchmark]
-        public async Task<Block<DumbAction>> MineBlockTenTransactionsWithActions()
+        public Block<DumbAction> ProposeBlockTenTransactionsWithActions()
         {
-            return await _blockChain.MineBlock(_privateKey);
+            return _blockChain.ProposeBlock(_privateKey);
         }
     }
 }

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Benchmarks
         {
             var blocks = new List<Block<DumbAction>>();
             var txs = new List<Transaction<DumbAction>>();
-            Block<DumbAction> genesis = TestUtils.MineGenesisBlock<DumbAction>(
+            Block<DumbAction> genesis = TestUtils.ProposeGenesisBlock<DumbAction>(
                 TestUtils.GenesisMiner
             );
             blocks.Add(genesis);
@@ -37,7 +37,8 @@ namespace Libplanet.Benchmarks
                 var blockTxs = new List<Transaction<DumbAction>>();
                 for (int j = 0; j < i % 5; j++)
                 {
-                    blockTxs.Add(Transaction<DumbAction>.Create(nonce++, key, genesis.Hash, new DumbAction[0]));
+                    blockTxs.Add(Transaction<DumbAction>.Create(
+                        nonce++, key, genesis.Hash, new DumbAction[0]));
                 }
                 block = TestUtils.ProposeNextBlock(
                     block, TestUtils.GenesisMiner, blockTxs);

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Benchmarks
                 {
                     blockTxs.Add(Transaction<DumbAction>.Create(nonce++, key, genesis.Hash, new DumbAction[0]));
                 }
-                block = TestUtils.MineNextBlock(
+                block = TestUtils.ProposeNextBlock(
                     block, TestUtils.GenesisMiner, blockTxs);
                 blocks.Add(block);
                 txs.AddRange(blockTxs);

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Benchmarks
             _miner = TestUtils.ChainPrivateKey;
             _blocks = new List<Block<DumbAction>>
             {
-                TestUtils.MineGenesisBlock<DumbAction>(_miner),
+                TestUtils.ProposeGenesisBlock<DumbAction>(_miner),
             };
             _appProtocolVersion = AppProtocolVersion.Sign(new PrivateKey(), 1);
             _blocks.Add(TestUtils.ProposeNextBlock(_blocks[0], _miner));

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -59,7 +59,7 @@ namespace Libplanet.Benchmarks
             _blockChains = new BlockChain<DumbAction>[SwarmNumber];
             _swarms = new Swarm<DumbAction>[SwarmNumber];
 
-            var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
+            var genesisBlock = BlockChain<DumbAction>.ProposeGenesisBlock();
             var tasks = new List<Task>();
             for (int i = 0; i < SwarmNumber; i++)
             {

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -44,10 +44,10 @@ namespace Libplanet.Benchmarks
                 TestUtils.MineGenesisBlock<DumbAction>(_miner),
             };
             _appProtocolVersion = AppProtocolVersion.Sign(new PrivateKey(), 1);
-            _blocks.Add(TestUtils.MineNextBlock(_blocks[0], _miner));
-            _blocks.Add(TestUtils.MineNextBlock(_blocks[1], _miner));
-            _blocks.Add(TestUtils.MineNextBlock(_blocks[2], _miner));
-            _blocks.Add(TestUtils.MineNextBlock(_blocks[3], _miner));
+            _blocks.Add(TestUtils.ProposeNextBlock(_blocks[0], _miner));
+            _blocks.Add(TestUtils.ProposeNextBlock(_blocks[1], _miner));
+            _blocks.Add(TestUtils.ProposeNextBlock(_blocks[2], _miner));
+            _blocks.Add(TestUtils.ProposeNextBlock(_blocks[3], _miner));
         }
 
         [IterationSetup(Targets = new[] {"BroadcastBlock", "BroadcastBlockWithoutFill"})]

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -56,15 +56,15 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
             _transaction3 = DummyTransaction();
             _transaction4 = DummyTransaction();
 
-            _block1 = TestUtils.MineNextBlock(
+            _block1 = TestUtils.ProposeNextBlock(
                 _genesisBlock, TestUtils.GenesisMiner, new[] { _transaction1 });
-            _block2 = TestUtils.MineNextBlock(
+            _block2 = TestUtils.ProposeNextBlock(
                 _block1, TestUtils.GenesisMiner, new[] { _transaction2 });
-            _block3 = TestUtils.MineNextBlock(
+            _block3 = TestUtils.ProposeNextBlock(
                 _block2, TestUtils.GenesisMiner, new[] { _transaction3 });
-            _block4 = TestUtils.MineNextBlock(
+            _block4 = TestUtils.ProposeNextBlock(
                 _block3, TestUtils.GenesisMiner, new[] { _transaction3 });
-            _block5 = TestUtils.MineNextBlock(
+            _block5 = TestUtils.ProposeNextBlock(
                 _block4, TestUtils.GenesisMiner);
 
             var guid = Guid.NewGuid();

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -50,7 +50,8 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 throw new SkipException("RocksDB is not available.");
             }
 
-            _genesisBlock = TestUtils.MineGenesisBlock<Utils.DummyAction>(TestUtils.GenesisMiner);
+            _genesisBlock =
+                TestUtils.ProposeGenesisBlock<Utils.DummyAction>(TestUtils.GenesisMiner);
             _transaction1 = DummyTransaction();
             _transaction2 = DummyTransaction();
             _transaction3 = DummyTransaction();

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -293,9 +293,9 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(GenesisMiner),
-                demand = MineNextBlock(genesis, GenesisMiner),
-                wrong = MineNextBlock(genesis, GenesisMiner);
+            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(GenesisMiner);
+            Block<DumbAction> demand = ProposeNextBlock(genesis, GenesisMiner);
+            Block<DumbAction> wrong = ProposeNextBlock(genesis, GenesisMiner);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
             _logger.Debug("Demand:  #{Index} {Hash}", demand.Index, demand.Hash);
             _logger.Debug("Wrong:   #{Index} {Hash}", wrong.Index, wrong.Hash);
@@ -399,14 +399,12 @@ namespace Libplanet.Net.Tests
         {
             if (count >= 1)
             {
-                Block<T> block =
-                    MineGenesisBlock<T>(GenesisMiner);
+                Block<T> block = MineGenesisBlock<T>(GenesisMiner);
                 yield return block;
 
                 for (int i = 1; i < count; i++)
                 {
-                    block =
-                        MineNextBlock(block, GenesisMiner);
+                    block = ProposeNextBlock(block, GenesisMiner);
                     yield return block;
                 }
             }

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -293,7 +293,7 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(GenesisMiner);
+            Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(GenesisMiner);
             Block<DumbAction> demand = ProposeNextBlock(genesis, GenesisMiner);
             Block<DumbAction> wrong = ProposeNextBlock(genesis, GenesisMiner);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
@@ -399,7 +399,7 @@ namespace Libplanet.Net.Tests
         {
             if (count >= 1)
             {
-                Block<T> block = MineGenesisBlock<T>(GenesisMiner);
+                Block<T> block = ProposeGenesisBlock<T>(GenesisMiner);
                 yield return block;
 
                 for (int i = 1; i < count; i++)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -56,7 +56,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             };
 
             ConsensusContext.NewHeight(1);
-            var block1 = await BlockChain.MineBlock(TestUtils.Peer1Priv, append: false);
+            var block1 = BlockChain.ProposeBlock(TestUtils.Peer1Priv);
             ConsensusContext.HandleMessage(
                 new ConsensusPropose(
                     TestUtils.Peer1.PublicKey,
@@ -139,8 +139,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             };
 
-            await BlockChain.MineBlock(TestUtils.Peer1Priv, append: true);
-            var blockHeightThree = await BlockChain.MineBlock(TestUtils.Peer3Priv, append: false);
+            BlockChain.Append(BlockChain.ProposeBlock(TestUtils.Peer1Priv));
+            var blockHeightThree = BlockChain.ProposeBlock(TestUtils.Peer3Priv);
 
             ConsensusContext.NewHeight(BlockChain.Tip.Index + 1);
             await proposeSent.WaitAsync();

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -110,7 +110,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         public async void NewHeightWhenTipChanged()
         {
             Assert.Equal(1, ConsensusContext.Height);
-            await BlockChain.MineBlock(new PrivateKey(), append: true);
+            BlockChain.Append(BlockChain.ProposeBlock(new PrivateKey()));
             Assert.Equal(1, ConsensusContext.Height);
             await Task.Delay(NewHeightDelay + TimeSpan.FromSeconds(1));
             Assert.Equal(2, ConsensusContext.Height);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -21,9 +21,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EnterPreVoteBlockOneThird()
+        public async Task EnterPreVoteBlockOneThird()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var stateChangedToRoundOnePreVote = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, state) =>
             {
@@ -58,9 +58,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EnterPreCommitBlockTwoThird()
+        public async Task EnterPreCommitBlockTwoThird()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var blockHash = block.Hash;
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             var commitSent = new AsyncAutoResetEvent();
@@ -181,9 +181,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EnterPreVoteNilOneThird()
+        public async Task EnterPreVoteNilOneThird()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var stepChangedToRoundOnePreVote = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, stage) =>
             {
@@ -244,10 +244,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void UponRulesCheckAfterTimeout()
+        public async Task UponRulesCheckAfterTimeout()
         {
-            var block1 = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
-            var block2 = await BlockChain.MineBlock(TestUtils.PrivateKeys[2], append: false);
+            var block1 = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+            var block2 = BlockChain.ProposeBlock(TestUtils.PrivateKeys[2]);
             var roundOneStepChangedToPreVote = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, state) =>
             {
@@ -312,9 +312,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void TimeoutPreVote()
+        public async Task TimeoutPreVote()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var timeoutProcessed = new AsyncAutoResetEvent();
             Context.TimeoutProcessed += (sender, message) => timeoutProcessed.Set();
             Context.Start();
@@ -355,9 +355,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void TimeoutPreCommit()
+        public async Task TimeoutPreCommit()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var timeoutProcessed = new AsyncAutoResetEvent();
             Context.TimeoutProcessed += (sender, message) => timeoutProcessed.Set();
             Context.Start();

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -19,9 +19,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EnterPreCommitNil()
+        public async Task EnterPreCommitNil()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[NodeId]);
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             var commitSent = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, state) =>
@@ -75,7 +75,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void EnterPreCommitBlock()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var targetHash = block.Hash;
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             var commitSent = new AsyncAutoResetEvent();
@@ -176,10 +176,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EndCommitBlock()
+        public async Task EndCommitBlock()
         {
             var codec = new Codec();
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[NodeId]);
             var stepChangedToEndCommit = new AsyncAutoResetEvent();
             Context.StateChanged += (sender, state) =>
             {
@@ -264,7 +264,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void EnterPreVoteBlock()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[NodeId]);
             var targetHash = block.Hash;
             var stepChangedToPreVote = new AsyncAutoResetEvent();
             var voteSent = new AsyncAutoResetEvent();

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Consensus;
@@ -19,10 +20,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void EnterValidRoundPreVoteBlock()
+        public async Task EnterValidRoundPreVoteBlock()
         {
-            Block<DumbAction> block =
-                await BlockChain.MineBlock(TestUtils.PrivateKeys[1], append: false);
+            Block<DumbAction> block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var voteSent = new AsyncAutoResetEvent();
             ConsensusMessageSent += (observer, message) =>
             {

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -90,9 +90,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void ThrowInvalidProposer()
+        public async Task ThrowInvalidProposer()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[NodeId]);
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
             Context.ExceptionOccurred += (sender, e) =>
@@ -133,9 +133,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void ThrowInvalidValidatorVote()
+        public async Task ThrowInvalidValidatorVote()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[NodeId], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[NodeId]);
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
             Context.ExceptionOccurred += (sender, e) =>
@@ -179,9 +179,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async void ThrowDifferentHeight()
+        public async Task ThrowDifferentHeight()
         {
-            var block = await BlockChain.MineBlock(TestUtils.PrivateKeys[2], append: false);
+            var block = BlockChain.ProposeBlock(TestUtils.PrivateKeys[2]);
 
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var dateTimeOffset = DateTimeOffset.UtcNow;
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(GenesisMiner);
+            Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(GenesisMiner);
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             var codec = new NetMQMessageCodec();
             NetMQMessage raw =
@@ -110,20 +110,15 @@ namespace Libplanet.Net.Tests.Messages
                 ImmutableArray<byte>.Empty,
                 default(Address));
             var dateTimeOffset = DateTimeOffset.MinValue + TimeSpan.FromHours(6.1234);
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(GenesisMiner);
+            Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(GenesisMiner);
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header)
             {
                 Timestamp = dateTimeOffset,
                 Remote = peer,
             };
             Assert.Equal(
-                new MessageId(new byte[32]
-                {
-                    0xf2, 0xe6, 0x2d, 0xbd, 0x95, 0xd0, 0x0f, 0x5a,
-                    0x54, 0xf2, 0xf2, 0xe3, 0x76, 0xc1, 0x93, 0xb3,
-                    0x21, 0x05, 0x93, 0x75, 0x39, 0xe6, 0x84, 0xc5,
-                    0x55, 0x0a, 0x23, 0x75, 0xbc, 0x38, 0xdc, 0x11,
-                }),
+                new MessageId(ByteUtil.ParseHex(
+                    "f22018338c677240f73b75cbd9bf048d68a49e848ba99a1dcf7a761da6baa87f")),
                 message.Id);
         }
     }

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -671,19 +671,15 @@ namespace Libplanet.Net.Tests
                     privateKey: privateKey),
             };
 
-            Block<DumbAction> block1 = MineNext(
+            Block<DumbAction> block1 = ProposeNext(
                 blockChain.Genesis,
                 new[] { transactions[0] },
-                null,
-                policy.GetNextBlockDifficulty(blockChain),
                 miner: GenesisMiner.PublicKey
             ).Evaluate(GenesisMiner, blockChain);
             blockChain.Append(block1, true, true, false);
-            Block<DumbAction> block2 = MineNext(
+            Block<DumbAction> block2 = ProposeNext(
                 block1,
                 new[] { transactions[1] },
-                null,
-                policy.GetNextBlockDifficulty(blockChain),
                 miner: GenesisMiner.PublicKey
             ).Evaluate(GenesisMiner, blockChain);
             blockChain.Append(block2, true, true, false);

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net.Tests
 
         private readonly List<Func<Task>> _finalizers;
 
-        private static async Task<(Address, Block<DumbAction>[])>
+        private static (Address, Block<DumbAction>[])
             MakeFixtureBlocksForPreloadAsyncCancellationTest()
         {
             Block<DumbAction>[] blocks = _fixtureBlocksForPreloadAsyncCancellationTest;
@@ -49,8 +49,9 @@ namespace Libplanet.Net.Tests
                             );
                         }
 
-                        Block<DumbAction> block = await chain.MineBlock(miner);
+                        Block<DumbAction> block = chain.ProposeBlock(miner);
                         Log.Logger.Information("  #{0,2} {1}", block.Index, block.Hash);
+                        chain.Append(block);
                     }
 
                     var blockList = new List<Block<DumbAction>>();

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -118,10 +118,9 @@ namespace Libplanet.Net.Tests
             var blocks = new List<Block<DumbAction>>();
             foreach (int i in Enumerable.Range(0, 11))
             {
-                Block<DumbAction> block = MineNext(
+                Block<DumbAction> block = ProposeNext(
                     previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
-                    miner: ChainPrivateKey.PublicKey,
-                    difficulty: 1024
+                    miner: ChainPrivateKey.PublicKey
                 ).Evaluate(ChainPrivateKey, minerChain);
                 blocks.Add(block);
                 if (i != 10)
@@ -349,11 +348,10 @@ namespace Libplanet.Net.Tests
                     DateTimeOffset.UtcNow
                 );
 
-                Block<ThrowException> block = MineNext(
+                Block<ThrowException> block = ProposeNext(
                     minerChain.Tip,
                     new[] { tx },
                     miner: ChainPrivateKey.PublicKey,
-                    difficulty: policy.GetNextBlockDifficulty(minerChain),
                     blockInterval: TimeSpan.FromSeconds(1)
                 ).Evaluate(ChainPrivateKey, minerChain);
                 minerSwarm.BlockChain.Append(block, false, true, false);

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await minerChain.MineBlock(minerKey);
+                minerChain.Append(minerChain.ProposeBlock(minerKey));
             }
 
             try
@@ -81,13 +81,13 @@ namespace Libplanet.Net.Tests
                 transfer: Tuple.Create<Address, Address, BigInteger>(address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
-            await minerChain.MineBlock(minerKey);
+            minerChain.Append(minerChain.ProposeBlock(minerKey));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
-            await minerChain.MineBlock(minerKey);
+            minerChain.Append(minerChain.ProposeBlock(minerKey));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
-            await minerChain.MineBlock(minerKey);
+            minerChain.Append(minerChain.ProposeBlock(minerKey));
 
             try
             {
@@ -286,7 +286,7 @@ namespace Libplanet.Net.Tests
             for (var i = 0; i < iteration; i++)
             {
                 sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-                await sender.BlockChain.MineBlock(senderKey);
+                sender.BlockChain.Append(sender.BlockChain.ProposeBlock(senderKey));
             }
 
             renderer1.RenderEventHandler += (_, a) =>
@@ -326,7 +326,7 @@ namespace Libplanet.Net.Tests
 
             foreach (var unused in Enumerable.Range(0, 10))
             {
-                await minerSwarm.BlockChain.MineBlock(minerKey);
+                minerSwarm.BlockChain.Append(minerSwarm.BlockChain.ProposeBlock(minerKey));
             }
 
             try
@@ -396,7 +396,7 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                await minerChain.MineBlock(minerKey);
+                minerChain.Append(minerChain.ProposeBlock(minerKey));
             }
 
             var actualStates = new List<PreloadState>();
@@ -518,7 +518,8 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < blockCount; ++i)
             {
-                var block = await swarm0.BlockChain.MineBlock(key0);
+                var block = swarm0.BlockChain.ProposeBlock(key0);
+                swarm0.BlockChain.Append(block);
                 swarm1.BlockChain.Append(block);
             }
 
@@ -572,7 +573,7 @@ namespace Libplanet.Net.Tests
             Guid receiverChainId = receiverChain.Id;
 
             (Address address, IEnumerable<Block<DumbAction>> blocks) =
-                await MakeFixtureBlocksForPreloadAsyncCancellationTest();
+                MakeFixtureBlocksForPreloadAsyncCancellationTest();
 
             var blockArray = blocks.ToArray();
             foreach (Block<DumbAction> block in blockArray)
@@ -651,7 +652,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             (_, IEnumerable<Block<DumbAction>> blocks) =
-                await MakeFixtureBlocksForPreloadAsyncCancellationTest();
+                MakeFixtureBlocksForPreloadAsyncCancellationTest();
 
             foreach (Block<DumbAction> block in blocks)
             {
@@ -692,21 +693,22 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 25))
             {
-                Block<DumbAction> block = await minerChain.MineBlock(minerKey);
+                Block<DumbAction> block = minerChain.ProposeBlock(minerKey);
+                minerChain.Append(block);
                 receiverChain.Append(block);
             }
 
             var receiverForked = receiverChain.Fork(receiverChain[5].Hash);
             foreach (int i in Enumerable.Range(0, 20))
             {
-                await receiverForked.MineBlock(minerKey);
+                receiverForked.Append(receiverForked.ProposeBlock(minerKey));
             }
 
             receiverChain.Swap(receiverForked, false);
 
             foreach (int i in Enumerable.Range(0, 1))
             {
-                await minerChain.MineBlock(minerKey);
+                minerChain.Append(minerChain.ProposeBlock(minerKey));
             }
 
             minerSwarm.FindNextHashesChunkSize = 1;
@@ -737,7 +739,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Block<DumbAction>[] blocks =
-                (await MakeFixtureBlocksForPreloadAsyncCancellationTest()).Item2;
+                MakeFixtureBlocksForPreloadAsyncCancellationTest().Item2;
 
             foreach (Block<DumbAction> block in blocks)
             {
@@ -747,7 +749,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> forked = minerChain.Fork(minerChain.Genesis.Hash);
             while (forked.Count <= minerChain.Count)
             {
-                await forked.MineBlock(minerKey);
+                forked.Append(forked.ProposeBlock(minerKey));
             }
 
             minerSwarm.FindNextHashesChunkSize = 2;
@@ -787,7 +789,7 @@ namespace Libplanet.Net.Tests
 
             receiverChain = receiverChain.Fork(receiverChain.Genesis.Hash);
             Block<DumbAction>[] blocks =
-                (await MakeFixtureBlocksForPreloadAsyncCancellationTest()).Item2;
+                MakeFixtureBlocksForPreloadAsyncCancellationTest().Item2;
 
             foreach (Block<DumbAction> block in blocks)
             {
@@ -820,15 +822,12 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> minerChain2 = minerSwarm2.BlockChain;
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
-            await minerChain1.MineBlock(minerKey1);
-            await minerChain1.MineBlock(minerKey1);
+            minerChain1.Append(minerChain1.ProposeBlock(minerKey1));
+            minerChain1.Append(minerChain1.ProposeBlock(minerKey1));
 
-            long nextDifficulty = (long)minerChain1.Tip.TotalDifficulty +
-                                  minerChain2.Policy.GetNextBlockDifficulty(minerChain2);
-            Block<DumbAction> block = MineNext(
+            Block<DumbAction> block = ProposeNext(
                 minerChain2.Tip,
-                miner: ChainPrivateKey.PublicKey,
-                difficulty: nextDifficulty
+                miner: ChainPrivateKey.PublicKey
             ).Evaluate(ChainPrivateKey, minerChain2);
             minerChain2.Append(block);
 
@@ -901,12 +900,12 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                await validSeedChain.MineBlock(minerKey);
+                validSeedChain.Append(validSeedChain.ProposeBlock(minerKey));
             }
 
             for (int i = 0; i < 20; i++)
             {
-                await invalidSeedChain.MineBlock(minerKey);
+                invalidSeedChain.Append(invalidSeedChain.ProposeBlock(minerKey));
             }
 
             try
@@ -949,7 +948,8 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                var block = await seedChain.MineBlock(seedKey);
+                var block = seedChain.ProposeBlock(seedKey);
+                seedChain.Append(block);
                 receiverChain.Append(block);
             }
 
@@ -957,7 +957,7 @@ namespace Libplanet.Net.Tests
             seedChain.Swap(forked, false);
             for (int i = 0; i < 10; i++)
             {
-                await seedChain.MineBlock(seedKey);
+                seedChain.Append(seedChain.ProposeBlock(seedKey));
             }
 
             var actionExecutionCount = 0;
@@ -1008,7 +1008,7 @@ namespace Libplanet.Net.Tests
                     {
                         new DumbAction(default, $"Item{i}"),
                     });
-                await seedChain.MineBlock(seedKey);
+                seedChain.Append(seedChain.ProposeBlock(seedKey));
                 transactions.Add(transaction);
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1153,8 +1153,8 @@ namespace Libplanet.Net.Tests
             var actionsA = new[] { new DumbAction(signerAddress, "1") };
             var actionsB = new[] { new DumbAction(signerAddress, "2") };
 
-            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock(actionsA, privateKeyA);
-            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock(actionsB, privateKeyB);
+            var genesisBlockA = BlockChain<DumbAction>.ProposeGenesisBlock(actionsA, privateKeyA);
+            var genesisBlockB = BlockChain<DumbAction>.ProposeGenesisBlock(actionsB, privateKeyB);
 
             BlockChain<DumbAction> MakeGenesisChain(
                 IStore store, IStateStore stateStore, Block<DumbAction> genesisBlock) =>

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1023,6 +1023,7 @@ namespace Libplanet.Net.Tests
             }
         }
 
+        // NOTE: Possibly not a valid test scenario.
         [Fact(Timeout = Timeout)]
         public async Task CreateNewChainWhenBranchPointNotExist()
         {
@@ -1041,30 +1042,25 @@ namespace Libplanet.Net.Tests
             Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(
                 keyC,
                 stateRootHash: MerkleTrie.EmptyRootHash);
-            Block<DumbAction> aBlock1 = MineNextBlock(
+            Block<DumbAction> aBlock1 = ProposeNextBlock(
                 genesis,
                 keyA,
-                difficulty: 10,
                 stateRootHash: MerkleTrie.EmptyRootHash);
-            Block<DumbAction> aBlock2 = MineNextBlock(
+            Block<DumbAction> aBlock2 = ProposeNextBlock(
                 aBlock1,
                 keyA,
-                difficulty: 9,
                 stateRootHash: MerkleTrie.EmptyRootHash);
-            Block<DumbAction> aBlock3 = MineNextBlock(
+            Block<DumbAction> aBlock3 = ProposeNextBlock(
                 aBlock2,
                 keyA,
-                difficulty: 11,
                 stateRootHash: MerkleTrie.EmptyRootHash);
-            Block<DumbAction> bBlock1 = MineNextBlock(
+            Block<DumbAction> bBlock1 = ProposeNextBlock(
                 genesis,
                 keyB,
-                difficulty: 9,
                 stateRootHash: MerkleTrie.EmptyRootHash);
-            Block<DumbAction> bBlock2 = MineNextBlock(
+            Block<DumbAction> bBlock2 = ProposeNextBlock(
                 bBlock1,
                 keyB,
-                difficulty: 11,
                 stateRootHash: MerkleTrie.EmptyRootHash);
 
             policyA.BlockedMiners.Add(keyB.ToAddress());
@@ -1101,6 +1097,7 @@ namespace Libplanet.Net.Tests
                 minerChainB.Append(bBlock1);
 
                 // Broadcast SwarmB's second block.
+                minerChainB.Append(bBlock1);
                 minerChainB.Append(bBlock2);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
@@ -1114,6 +1111,7 @@ namespace Libplanet.Net.Tests
                 minerChainA.Append(aBlock2);
 
                 // Broadcast SwarmA's third block.
+                minerChainA.Append(aBlock2);
                 minerChainA.Append(aBlock3);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
@@ -1370,10 +1368,9 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = MineNext(
+                Block<DumbAction> block = ProposeNext(
                     chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    difficulty: 1024
+                    miner: ChainPrivateKey.PublicKey
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }
@@ -1413,10 +1410,9 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = MineNext(
+                Block<DumbAction> block = ProposeNext(
                     chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    difficulty: 1024
+                    miner: ChainPrivateKey.PublicKey
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }
@@ -1457,10 +1453,9 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = MineNext(
+                Block<DumbAction> block = ProposeNext(
                     chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    difficulty: 1024
+                    miner: ChainPrivateKey.PublicKey
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block);
             }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -11,7 +10,6 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
-using Libplanet.Blockchain.Renderers.Debug;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
@@ -312,19 +310,20 @@ namespace Libplanet.Net.Tests
         public async Task GetBlocks()
         {
             var keyA = new PrivateKey();
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            Block<DumbAction> genesis = BlockChain<DumbAction>.ProposeGenesisBlock(
+                privateKey: new PrivateKey(), blockAction: policy.BlockAction);
 
-            Swarm<DumbAction> swarmA = CreateSwarm(keyA);
-            Swarm<DumbAction> swarmB = CreateSwarm();
+            Swarm<DumbAction> swarmA = CreateSwarm(keyA, genesis: genesis, policy: policy);
+            Swarm<DumbAction> swarmB = CreateSwarm(genesis: genesis, policy: policy);
 
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            // FIXME: Rename the following variables or reuse the real genesis block which
-            // already exists in chainA.  These are misleading as genesis.Index is not 0 but 1.
-            Block<DumbAction> genesis = await chainA.MineBlock(keyA);
-            chainB.Append(genesis); // chainA and chainB shares genesis block.
-            Block<DumbAction> block1 = await chainA.MineBlock(keyA);
-            Block<DumbAction> block2 = await chainA.MineBlock(keyA);
+            Block<DumbAction> block1 = chainA.ProposeBlock(keyA);
+            chainA.Append(block1);
+            Block<DumbAction> block2 = chainA.ProposeBlock(keyA);
+            chainA.Append(block2);
 
             try
             {
@@ -381,16 +380,17 @@ namespace Libplanet.Net.Tests
             var keyA = new PrivateKey();
             var keyB = new PrivateKey();
 
-            Swarm<DumbAction> swarmA = CreateSwarm(keyA);
-            Swarm<DumbAction> swarmB = CreateSwarm(keyB);
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            Block<DumbAction> genesis = BlockChain<DumbAction>.ProposeGenesisBlock(
+                privateKey: new PrivateKey(), blockAction: policy.BlockAction);
+            Swarm<DumbAction> swarmA = CreateSwarm(keyA, genesis: genesis, policy: policy);
+            Swarm<DumbAction> swarmB = CreateSwarm(keyB, genesis: genesis, policy: policy);
 
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            Block<DumbAction> genesis = await chainA.MineBlock(keyA);
-            chainB.Append(genesis); // chainA and chainB shares genesis block.
-            await chainA.MineBlock(keyA);
-            await chainA.MineBlock(keyA);
+            chainA.Append(chainA.ProposeBlock(keyA));
+            chainA.Append(chainA.ProposeBlock(keyA));
 
             try
             {
@@ -440,9 +440,11 @@ namespace Libplanet.Net.Tests
         {
             var keyB = new PrivateKey();
 
-            Swarm<DumbAction> swarmA = CreateSwarm();
-            Swarm<DumbAction> swarmB = CreateSwarm(keyB);
-
+            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            Block<DumbAction> genesis = BlockChain<DumbAction>.ProposeGenesisBlock(
+                privateKey: new PrivateKey(), blockAction: policy.BlockAction);
+            Swarm<DumbAction> swarmA = CreateSwarm(genesis: genesis, policy: policy);
+            Swarm<DumbAction> swarmB = CreateSwarm(keyB, genesis: genesis, policy: policy);
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
@@ -452,7 +454,7 @@ namespace Libplanet.Net.Tests
                 new DumbAction[0]
             );
             chainB.StageTransaction(tx);
-            await chainB.MineBlock(keyB);
+            chainB.Append(chainB.ProposeBlock(keyB));
 
             try
             {
@@ -659,7 +661,8 @@ namespace Libplanet.Net.Tests
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var block = await seed.BlockChain.MineBlock(seedKey);
+                    var block = seed.BlockChain.ProposeBlock(seedKey);
+                    seed.BlockChain.Append(block);
                     seed.BroadcastBlock(block);
                     await Task.Delay(1000, cancellationToken);
                 }
@@ -697,209 +700,6 @@ namespace Libplanet.Net.Tests
 
                 seed.Dispose();
                 swarmA.Dispose();
-            }
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async Task RenderInFork()
-        {
-            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var renderer = new RecordingActionRenderer<DumbAction>();
-            var chain = MakeBlockChain(
-                policy,
-                new MemoryStore(),
-                new TrieStateStore(new MemoryKeyValueStore()),
-                renderers: new[] { renderer }
-            );
-
-            var key1 = new PrivateKey();
-            var key2 = new PrivateKey();
-
-            var miner1 = CreateSwarm(chain, key1);
-            var miner2 = CreateSwarm(
-                MakeBlockChain(
-                    policy,
-                    new MemoryStore(),
-                    new TrieStateStore(new MemoryKeyValueStore())
-                ),
-                key2
-            );
-
-            int renderCount = 0;
-
-            var privKey = new PrivateKey();
-            var addr = miner1.Address;
-            var item = "foo";
-
-            miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-            await miner1.BlockChain.MineBlock(key1);
-
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-            await miner2.BlockChain.MineBlock(key2);
-
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-            var latest = await miner2.BlockChain.MineBlock(key2);
-
-            renderer.RenderEventHandler += (_, a) =>
-                renderCount += a is DumbAction ? 1 : 0;
-
-            await StartAsync(miner1);
-            await StartAsync(miner2);
-
-            await BootstrapAsync(miner2, miner1.AsPeer);
-
-            miner2.BroadcastBlock(latest);
-
-            await miner1.BlockReceived.WaitAsync();
-            await miner1.BlockAppended.WaitAsync();
-
-            Assert.Equal(miner1.BlockChain.Tip, miner2.BlockChain.Tip);
-            Assert.Equal(miner1.BlockChain.Count, miner2.BlockChain.Count);
-            Assert.Equal(2, renderCount);
-        }
-
-        [Fact(Skip = "This should be fixed to work deterministically.")]
-        public async Task HandleReorgInSynchronizing()
-        {
-            var policy = new BlockPolicy<Sleep>(new MinerReward(1));
-
-            Swarm<Sleep> MakeSwarm(PrivateKey key = null) =>
-                CreateSwarm(
-                    MakeBlockChain(
-                        policy,
-                        new MemoryStore(),
-                        new TrieStateStore(new MemoryKeyValueStore())
-                    ),
-                    key
-                );
-
-            var key1 = new PrivateKey();
-            var key2 = new PrivateKey();
-
-            var miner1 = MakeSwarm(key1);
-            var miner2 = MakeSwarm(key2);
-            var receiver = MakeSwarm();
-
-            foreach (var i in Enumerable.Range(0, 8))
-            {
-                miner1.BlockChain.StageTransaction(
-                    Transaction<Sleep>.Create(
-                        0,
-                        new PrivateKey(),
-                        miner1.BlockChain.Genesis.Hash,
-                        customActions: new[] { new Sleep() }
-                    )
-                );
-                var b = await miner1.BlockChain.MineBlock(key1);
-                miner2.BlockChain.Append(b);
-            }
-
-            try
-            {
-                await StartAsync(miner1);
-                await StartAsync(miner2);
-
-                await BootstrapAsync(miner2, miner1.AsPeer);
-                await BootstrapAsync(receiver, miner1.AsPeer);
-
-                var t = receiver.PreloadAsync();
-                await miner1.BlockChain.MineBlock(key1);
-                await miner2.BlockChain.MineBlock(key2);
-                Block<Sleep> latest = await miner2.BlockChain.MineBlock(key2);
-                miner2.BroadcastBlock(latest);
-                await t;
-
-                Assert.Equal(miner1.BlockChain.Tip, miner2.BlockChain.Tip);
-                Assert.Equal(miner1.BlockChain.Count, miner2.BlockChain.Count);
-                Assert.Equal(miner1.BlockChain.Count, receiver.BlockChain.Count);
-                Assert.Equal(miner1.BlockChain.Tip, receiver.BlockChain.Tip);
-            }
-            finally
-            {
-                await StopAsync(miner1);
-                await StopAsync(miner2);
-                miner1.Dispose();
-                miner2.Dispose();
-                receiver.Dispose();
-            }
-        }
-
-        [Theory(Timeout = Timeout)]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async void RestageTransactionsOnceLocallyMinedAfterReorg(bool restage)
-        {
-            var keyA = new PrivateKey();
-            var keyB = new PrivateKey();
-
-            var minerA = CreateSwarm(keyA);
-            var minerB = CreateSwarm(keyB);
-
-            var privateKeyA = new PrivateKey();
-            var privateKeyB = new PrivateKey();
-
-            var targetAddress1 = new PrivateKey().ToAddress();
-            var targetAddress2 = new PrivateKey().ToAddress();
-
-            try
-            {
-                const string dumbItem = "item0.0";
-                var txA = minerA.BlockChain.MakeTransaction(
-                    privateKeyA,
-                    new[] { new DumbAction(targetAddress1, dumbItem), });
-                var txB = minerB.BlockChain.MakeTransaction(
-                    privateKeyB,
-                    new[] { new DumbAction(targetAddress2, dumbItem), });
-
-                if (!restage)
-                {
-                    minerB.BlockChain.StageTransaction(txA);
-                }
-
-                Log.Debug("Make minerB's chain longer than minerA's chain.");
-                Block<DumbAction> blockA = await minerA.BlockChain.MineBlock(keyA);
-                Block<DumbAction> blockB = await minerB.BlockChain.MineBlock(keyB);
-                Block<DumbAction> blockC = await minerB.BlockChain.MineBlock(keyB);
-
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
-                Assert.Equal((Text)dumbItem, minerB.BlockChain.GetState(targetAddress2));
-
-                await StartAsync(minerA);
-                await StartAsync(minerB);
-
-                await BootstrapAsync(minerA, minerB.AsPeer);
-
-                Log.Debug("Reorg occurs.");
-                minerB.BroadcastBlock(blockC);
-                await minerA.BlockAppended.WaitAsync();
-
-                Assert.Equal(minerA.BlockChain.Tip, minerB.BlockChain.Tip);
-                Assert.Equal(3, minerA.BlockChain.Count);
-                Assert.Equal(
-                    restage ? null : (Text?)dumbItem,
-                    minerA.BlockChain.GetState(targetAddress1));
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress2));
-
-                Log.Debug("Check if txs in unrendered blocks staged again.");
-                Assert.Equal(
-                    restage,
-                    minerA.BlockChain.GetStagedTransactionIds().Contains(txA.Id));
-
-                await minerA.BlockChain.MineBlock(keyA);
-                minerA.BroadcastBlock(minerA.BlockChain.Tip);
-                await minerB.BlockAppended.WaitAsync();
-
-                Assert.Equal(minerA.BlockChain.Tip, minerB.BlockChain.Tip);
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
-                Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress2));
-            }
-            finally
-            {
-                await StopAsync(minerA);
-                await StopAsync(minerB);
-
-                minerA.Dispose();
-                minerB.Dispose();
             }
         }
 
@@ -1097,7 +897,6 @@ namespace Libplanet.Net.Tests
                 minerChainB.Append(bBlock1);
 
                 // Broadcast SwarmB's second block.
-                minerChainB.Append(bBlock1);
                 minerChainB.Append(bBlock2);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
@@ -1111,7 +910,6 @@ namespace Libplanet.Net.Tests
                 minerChainA.Append(aBlock2);
 
                 // Broadcast SwarmA's third block.
-                minerChainA.Append(aBlock2);
                 minerChainA.Append(aBlock3);
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
@@ -1190,7 +988,8 @@ namespace Libplanet.Net.Tests
                 await swarmB.AddPeersAsync(new[] { swarmA.AsPeer }, null);
                 await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
 
-                var block = await swarmA.BlockChain.MineBlock(privateKeyA);
+                var block = swarmA.BlockChain.ProposeBlock(privateKeyA);
+                swarmA.BlockChain.Append(block);
 
                 Task.WaitAll(new[]
                 {
@@ -1530,11 +1329,11 @@ namespace Libplanet.Net.Tests
                     peerChainState.First()
                 );
 
-                await swarm2.BlockChain.MineBlock(key2);
+                swarm2.BlockChain.Append(swarm2.BlockChain.ProposeBlock(key2));
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(
-                    new PeerChainState(swarm2.AsPeer, 1, 1024),
+                    new PeerChainState(swarm2.AsPeer, 1, 1),
                     peerChainState.First()
                 );
 
@@ -1544,7 +1343,7 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     new[]
                     {
-                        new PeerChainState(swarm2.AsPeer, 1, 1024),
+                        new PeerChainState(swarm2.AsPeer, 1, 1),
                         new PeerChainState(swarm3.AsPeer, 0, 0),
                     }.ToHashSet(),
                     peerChainState.ToHashSet()

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1039,7 +1039,7 @@ namespace Libplanet.Net.Tests
             var policy = new NullBlockPolicy<DumbAction>();
             var policyA = new NullBlockPolicy<DumbAction>();
             var policyB = new NullBlockPolicy<DumbAction>();
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(
+            Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(
                 keyC,
                 stateRootHash: MerkleTrie.EmptyRootHash);
             Block<DumbAction> aBlock1 = ProposeNextBlock(

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Tests.Action
                 new[] { action }
             );
             chain.Append(
-                TestUtils.MineNext(
+                TestUtils.ProposeNext(
                     chain.Tip,
                     new[] { tx },
                     miner: _keys[1].PublicKey,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            PreEvaluationBlock<DumbAction> preEval = TestUtils.MineNext(
+            PreEvaluationBlock<DumbAction> preEval = TestUtils.ProposeNext(
                 chain.Tip,
                 new[] { tx },
                 miner: _keys[1].PublicKey,

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -231,7 +231,7 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            var preEvalBlock = TestUtils.MineNext(
+            var preEvalBlock = TestUtils.ProposeNext(
                 chain.Tip,
                 new[] { tx },
                 miner: privateKey.PublicKey,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -868,11 +868,10 @@ namespace Libplanet.Tests.Action
                 privateKey: ChainPrivateKey);
             (_, Transaction<DumbAction>[] txs) = MakeFixturesForAppendTests();
             var genesis = chain.Genesis;
-            var block = MineNext(
+            var block = ProposeNext(
                 genesis,
                 txs,
-                miner: GenesisMiner.PublicKey,
-                difficulty: chain.Policy.GetNextBlockDifficulty(chain)
+                miner: GenesisMiner.PublicKey
             ).Evaluate(GenesisMiner, chain);
             var stateCompleterSet = StateCompleterSet<DumbAction>.Recalculate;
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Tests.Action
                     customActions: new[] { new RandomAction(txAddress), }),
             };
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            PreEvaluationBlock<RandomAction> noStateRootBlock = MineGenesis(
+            PreEvaluationBlock<RandomAction> noStateRootBlock = ProposeGenesis(
                 miner: GenesisMiner.PublicKey,
                 timestamp: timestamp,
                 transactions: txs
@@ -283,7 +283,7 @@ namespace Libplanet.Tests.Action
                 _txFx.Address4,
                 _txFx.Address5,
             };
-            Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
             ActionEvaluator<DumbAction> actionEvaluator = new ActionEvaluator<DumbAction>(
                 policyBlockAction: null,
                 blockChainStates: NullChainStates<DumbAction>.Instance,
@@ -476,8 +476,8 @@ namespace Libplanet.Tests.Action
             // have to be updated, since the order may change due to different PreEvaluationHash.
             expectations = new[]
             {
-                (2, 0, new[] { "A", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address3),
-                (0, 0, new[] { "A,D", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address1),
+                (0, 0, new[] { "A,D", "B", "C", null, null }, _txFx.Address1),
+                (2, 0, new[] { "A,D", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address3),
                 (
                     1,
                     0,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -333,12 +333,10 @@ namespace Libplanet.Tests.Action
                 _logger.Debug("{0}[{1}] = {2}", nameof(block1Txs), i, tx.Id);
             }
 
-            Block<DumbAction> block1 = MineNextBlock(
+            Block<DumbAction> block1 = ProposeNextBlock(
                 genesis,
                 GenesisMiner,
-                block1Txs,
-                new byte[] { }
-            );
+                block1Txs);
             previousStates = AccountStateDeltaImpl.ChooseVersion(
                 block1.ProtocolVersion,
                 ActionEvaluator<DumbAction>.NullAccountStateGetter,
@@ -453,12 +451,10 @@ namespace Libplanet.Tests.Action
                 _logger.Debug("{0}[{1}] = {2}", nameof(block2Txs), i, tx.Id);
             }
 
-            Block<DumbAction> block2 = MineNextBlock(
+            Block<DumbAction> block2 = ProposeNextBlock(
                 block1,
                 GenesisMiner,
-                block2Txs,
-                new byte[] { }
-            );
+                block2Txs);
             AccountStateGetter accountStateGetter = addrs =>
                 addrs.Select(dirty1.GetValueOrDefault).ToArray();
             AccountBalanceGetter accountBalanceGetter = (address, currency)

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -392,7 +391,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async Task AppendWhenActionEvaluationFailed()
+        public void AppendWhenActionEvaluationFailed()
         {
             var policy = new NullBlockPolicy<ThrowException>();
             var store = new MemoryStore();
@@ -407,7 +406,7 @@ namespace Libplanet.Tests.Blockchain
             blockChain.MakeTransaction(privateKey, new[] { action });
 
             renderer.ResetRecords();
-            await blockChain.MineBlock(new PrivateKey());
+            blockChain.Append(blockChain.ProposeBlock(new PrivateKey()));
 
             Assert.Equal(2, blockChain.Count);
             Assert.Empty(renderer.ActionSuccessRecords);
@@ -587,7 +586,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async Task AppendWithdrawTxsWithExpiredNoncesFromStage()
+        public void AppendWithdrawTxsWithExpiredNoncesFromStage()
         {
             void AssertTxIdSetEqual(
                 IEnumerable<TxId> setOne,
@@ -606,11 +605,7 @@ namespace Libplanet.Tests.Blockchain
                 txA1 = Transaction<DumbAction>.Create(1, signerA, genesis, emptyActions);
             _blockChain.StageTransaction(txA0);
             _blockChain.StageTransaction(txA1);
-            Block<DumbAction> block = await _blockChain.MineBlock(
-                signerA,
-                DateTimeOffset.UtcNow,
-                append: false
-            );
+            Block<DumbAction> block = _blockChain.ProposeBlock(signerA);
 
             Transaction<DumbAction>
                 txA2 = Transaction<DumbAction>.Create(2, signerA, genesis, emptyActions),

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -41,18 +41,16 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(1, _blockChain.Count);
             Assert.Empty(_renderer.ActionRecords);
             Assert.Empty(_renderer.BlockRecords);
-            var block1 = TestUtils.MineNext(
+            var block1 = TestUtils.ProposeNext(
                 genesis,
                 miner: keys[4].PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(keys[4], _blockChain);
             _blockChain.Append(block1);
-            Block<DumbAction> block2 = TestUtils.MineNext(
+            Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 txs,
                 miner: keys[4].PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(keys[4], _blockChain);
             foreach (Transaction<DumbAction> tx in txs)
@@ -201,11 +199,10 @@ namespace Libplanet.Tests.Blockchain
                 nonce: 2,
                 privateKey: pk
             );
-            Block<DumbAction> block3 = TestUtils.MineNext(
+            Block<DumbAction> block3 = TestUtils.ProposeNext(
                 block2,
                 new[] { tx1Transfer, tx2Error, tx3Transfer },
-                miner: keys[4].PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain)
+                miner: keys[4].PublicKey
             ).Evaluate(keys[4], _blockChain);
             _blockChain.Append(block3);
             var txExecution1 = getTxExecution(block3.Hash, tx1Transfer.Id);
@@ -318,11 +315,10 @@ namespace Libplanet.Tests.Blockchain
             }
 
             var miner = new PrivateKey();
-            var block = TestUtils.MineNext(
+            var block = TestUtils.ProposeNext(
                 _blockChain.Genesis,
                 heavyTxs,
                 miner: miner.PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
             long maxBytes = _blockChain.Policy.GetMaxBlockBytes(block.Index);
@@ -350,11 +346,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.True(manyTxs.Count > maxTxs);
 
             var miner = new PrivateKey();
-            Block<DumbAction> block = TestUtils.MineNext(
+            Block<DumbAction> block = TestUtils.ProposeNext(
                 _blockChain.Genesis,
                 manyTxs,
                 miner: miner.PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
             Assert.Equal(manyTxs.Count, block.Transactions.Count());
@@ -370,10 +365,9 @@ namespace Libplanet.Tests.Blockchain
             var miner = new PrivateKey();
             var genesis = _blockChain.Genesis;
 
-            Block<DumbAction> block = TestUtils.MineNext(
+            Block<DumbAction> block = TestUtils.ProposeNext(
                 genesis,
                 miner: miner.PublicKey,
-                difficulty: 1024,
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
             Assert.Throws<ArgumentException>(() =>
@@ -454,21 +448,19 @@ namespace Libplanet.Tests.Blockchain
 
                 var miner = new PrivateKey();
 
-                Block<DumbAction> block1 = TestUtils.MineNext(
+                Block<DumbAction> block1 = TestUtils.ProposeNext(
                     fx.GenesisBlock,
                     new[] { validTx },
                     miner: miner.PublicKey,
-                    difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
                 ).Evaluate(miner, blockChain);
 
                 blockChain.Append(block1);
 
-                Block<DumbAction> block2 = TestUtils.MineNext(
+                Block<DumbAction> block2 = TestUtils.ProposeNext(
                     block1,
                     new[] { invalidTx },
                     miner: miner.PublicKey,
-                    difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10)
                 ).Evaluate(miner, blockChain);
 
@@ -486,10 +478,9 @@ namespace Libplanet.Tests.Blockchain
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
             // Mining with empty staged.
-            Block<DumbAction> block1 = TestUtils.MineNext(
+            Block<DumbAction> block1 = TestUtils.ProposeNext(
                 genesis,
                 miner: privateKey.PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
             _blockChain.Append(block1);
@@ -499,11 +490,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
             // Tx with nonce 0 is mined.
-            Block<DumbAction> block2 = TestUtils.MineNext(
+            Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
                 miner: privateKey.PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
             _blockChain.Append(block2);
@@ -519,11 +509,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
             // Unmined tx is left intact in the stage.
-            Block<DumbAction> block3 = TestUtils.MineNext(
+            Block<DumbAction> block3 = TestUtils.ProposeNext(
                 block2,
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
                 miner: privateKey.PublicKey,
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
             _blockChain.Append(block3);
@@ -549,11 +538,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, workspace.StagePolicy.Iterate(workspace, filtered: false).Count());
 
             // Mine nonce 0 tx.
-            Block<DumbAction> block1 = TestUtils.MineNext(
+            Block<DumbAction> block1 = TestUtils.ProposeNext(
                 genesis,
                 miner: privateKey.PublicKey,
                 txs: ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
 
@@ -570,11 +558,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.Single(workspace.StagePolicy.Iterate(workspace, filtered: false));
 
             // Mine nonce 1 tx.
-            Block<DumbAction> block2 = TestUtils.MineNext(
+            Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 miner: privateKey.PublicKey,
                 txs: ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
-                difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -103,11 +103,10 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
-            Block<DumbAction> block1 = MineNext(
+            Block<DumbAction> block1 = ProposeNext(
                 genesis,
                 txs,
-                miner: _fx.Miner.PublicKey,
-                difficulty: _policy.GetNextBlockDifficulty(_blockChain)
+                miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
 
             _blockChain.Append(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -1,22 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
-using Libplanet.Blockchain.Renderers.Debug;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
-using xRetry;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 using Random = System.Random;
@@ -552,7 +548,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async Task MineBlockWithLastCommit()
+        public void ProposeBlockWithLastCommit()
         {
             var keyA = new PrivateKey();
             var keyB = new PrivateKey();
@@ -568,104 +564,12 @@ namespace Libplanet.Tests.Blockchain
             voteSet.Add(voteSet.Votes[2].Sign(keyC));
             var blockCommit = new BlockCommit(voteSet, _blockChain.Tip.Hash);
 
-            Block<DumbAction> block = await _blockChain.MineBlock(
+            Block<DumbAction> block = _blockChain.ProposeBlock(
                 new PrivateKey(),
                 lastCommit: blockCommit);
 
             Assert.NotNull(block.LastCommit);
             AssertBytesEqual(block.LastCommit.Value.ByteArray, blockCommit.ByteArray);
-        }
-
-        [RetryFact]
-        public async Task AbortMining()
-        {
-            // Pre-mined genesis 7ae04b6fc0a3410eef40341129b19030ea2e6a0b922e5ae7cc96ab19109495c4:
-            var genesisContent = new BlockContent<DumbAction>
-            {
-                Miner = GenesisMiner.ToAddress(),
-                ProtocolVersion = 2,
-                PublicKey = GenesisMiner.PublicKey,
-                Timestamp = new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero),
-            };
-            var preEvalGenesis = new PreEvaluationBlock<DumbAction>(
-                genesisContent,
-                new Nonce(new byte[] { 0x01, 0, 0, 0 })
-            );
-            var genesis = new Block<DumbAction>(
-                preEvalGenesis,
-                HashDigest<SHA256>.FromString(
-                    "1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"
-                ),
-                ByteUtil.ParseHex(
-                    "30440220453709513c8ca92d3b90f5dd97ecac9c0f1af4b9aa8553ffe4d1b3f7887746" +
-                    "8e02206a484c56b9a7c2b6b7c6b26627714d6e14413dce1f3cc1291d48920d82dacb9f"
-                ).ToImmutableArray()
-            );
-
-            // Pre-mined block #1 ae44df4319711de80cc711668f56bfde9e5d958cc2296b63056c1b9c3df62d51:
-            var block1Content = new BlockContent<DumbAction>
-            {
-                ProtocolVersion = 2,
-                Index = 1,
-                Miner = GenesisMiner.ToAddress(),
-                PublicKey = GenesisMiner.PublicKey,
-                Timestamp = DateTimeOffset.ParseExact(
-                    "2021-10-25T07:54:53.512280Z",
-                    "yyyy-MM-ddTHH:mm:ss.ffffffZ",
-                    CultureInfo.InvariantCulture
-                ),
-                Difficulty = 100_000_000,
-                TotalDifficulty = 100_000_000,
-                PreviousHash = genesis.Hash,
-            };
-            var preEvalBlock1 = new PreEvaluationBlock<DumbAction>(
-                block1Content,
-                new Nonce(new byte[] { 0x0a, 0x24, 0xc6, 0x92, 0xde, 0xfa, 0x5c, 0x64, 0xd0, 0x26 })
-            );
-            var block = new Block<DumbAction>(
-                preEvalBlock1,
-                HashDigest<SHA256>.FromString(
-                    "1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"
-                ),
-                ByteUtil.ParseHex(
-                    "304502210083898c414d6ab45d380ae56d7f5cc63a6c102354a8c59904942e47a7b3fa9" +
-                    "1e2022055ab1c19a11ed980165ce472dac134db580448c5bffb51d0e8dcb4cb5bc71481"
-                ).ToImmutableArray()
-            );
-
-            var renderer = new RecordingActionRenderer<DumbAction>();
-            var policy = new NullBlockPolicy<DumbAction>(difficulty: 100_000_000);
-            StoreFixture fx = new MemoryStoreFixture(policy.BlockAction);
-            using (fx)
-            {
-                var chain = new BlockChain<DumbAction>(
-                    policy,
-                    new VolatileStagePolicy<DumbAction>(),
-                    fx.Store,
-                    fx.StateStore,
-                    genesis,
-                    renderers: new[] { renderer }
-                );
-                renderer.ResetRecords();
-
-                Task miningTask = chain.MineBlock(new PrivateKey());
-
-                // Waits 0.5 seconds for the miningTask to start watching if the tip changes:
-                await Task.Delay(500);
-
-                chain.Append(block);
-
-                IReadOnlyList<RenderRecord<DumbAction>.Block> records = renderer.BlockRecords;
-                Assert.Equal(2, records.Count);
-                foreach (RenderRecord<DumbAction>.Block record in records)
-                {
-                    Assert.Equal(genesis, record.OldTip);
-                    Assert.Equal(block, record.NewTip);
-                }
-
-                // Waits about 10 seconds for the task to receive the cancellation signal:
-                await AssertThatEventually(() => miningTask.IsCanceled, 10_000);
-            }
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
@@ -54,7 +53,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async Task TransactionsWithDuplicatedNonce()
+        public void TransactionsWithDuplicatedNonce()
         {
             var key = new PrivateKey();
 
@@ -85,7 +84,7 @@ namespace Libplanet.Tests.Blockchain
 
             // stage tx_0_0 -> mine tx_0_0 -> stage tx_0_1
             Assert.True(_blockChain.StageTransaction(tx_0_0));
-            await _blockChain.MineBlock(key);
+            _blockChain.Append(_blockChain.ProposeBlock(key));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: false));
@@ -105,7 +104,7 @@ namespace Libplanet.Tests.Blockchain
                 txIds.OrderBy(id => id),
                 _blockChain.GetStagedTransactionIds().OrderBy(id => id)
             );
-            await _blockChain.MineBlock(key);
+            _blockChain.Append(_blockChain.ProposeBlock(key));
             // tx_0_1 and tx_1_x should be still staged, just filtered
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -127,7 +127,7 @@ namespace Libplanet.Tests.Blockchain
             );
             var stateStore = new TrieStateStore(stateKeyValueStore);
             IStore store = new MemoryStore();
-            var genesisBlock = TestUtils.MineGenesis<DumbAction>(
+            var genesisBlock = TestUtils.ProposeGenesis<DumbAction>(
                 TestUtils.GenesisMiner.PublicKey
             ).Evaluate(
                 TestUtils.GenesisMiner,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -209,7 +209,7 @@ namespace Libplanet.Tests.Blockchain
         public async void ProcessActions()
         {
             Block<PolymorphicAction<BaseAction>> genesisBlock =
-                BlockChain<PolymorphicAction<BaseAction>>.MakeGenesisBlock();
+                BlockChain<PolymorphicAction<BaseAction>>.ProposeGenesisBlock();
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var chain = new BlockChain<PolymorphicAction<BaseAction>>(
@@ -1219,7 +1219,7 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public async void GetStateReturnsValidStateAfterFork()
         {
-            Block<DumbAction> genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(
+            Block<DumbAction> genesisBlock = BlockChain<DumbAction>.ProposeGenesisBlock(
                 new[] { new DumbAction(_fx.Address1, "item0.0", idempotent: true) }
             );
             var privateKey = new PrivateKey();
@@ -1368,7 +1368,7 @@ namespace Libplanet.Tests.Blockchain
             using (var emptyFx = new MemoryStoreFixture(_policy.BlockAction))
             using (var forkFx = new MemoryStoreFixture(_policy.BlockAction))
             {
-                var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
+                var genesisBlock = BlockChain<DumbAction>.ProposeGenesisBlock();
                 var emptyChain = new BlockChain<DumbAction>(
                     _blockChain.Policy,
                     new VolatileStagePolicy<DumbAction>(),
@@ -1903,7 +1903,7 @@ namespace Libplanet.Tests.Blockchain
                     new VolatileStagePolicy<DumbAction>(),
                     storeFixture.Store,
                     storeFixture.StateStore,
-                    BlockChain<DumbAction>.MakeGenesisBlock(actions));
+                    BlockChain<DumbAction>.ProposeGenesisBlock(actions));
 
             Assert.Equal(addresses, blockChain.Genesis.Transactions.First().UpdatedAddresses);
 
@@ -1922,8 +1922,8 @@ namespace Libplanet.Tests.Blockchain
             var stagePolicy = new VolatileStagePolicy<DumbAction>();
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            var genesisBlockA = BlockChain<DumbAction>.MakeGenesisBlock();
-            var genesisBlockB = BlockChain<DumbAction>.MakeGenesisBlock();
+            var genesisBlockA = BlockChain<DumbAction>.ProposeGenesisBlock();
+            var genesisBlockB = BlockChain<DumbAction>.ProposeGenesisBlock();
 
             var blockChain = new BlockChain<DumbAction>(
                 policy,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -327,11 +327,10 @@ namespace Libplanet.Tests.Blockchain
                 );
                 var actions = new[] { new DumbAction(miner, "foo") };
                 var tx = chain.MakeTransaction(key, actions);
-                var block = MineNext(
+                var block = ProposeNext(
                     chain.Genesis,
                     new[] { tx },
-                    miner: key.PublicKey,
-                    difficulty: policy.GetNextBlockDifficulty(_blockChain)
+                    miner: key.PublicKey
                 ).Evaluate(key, chain);
                 chain.Append(block);
                 var forked = chain.Fork(chain.Genesis.Hash);
@@ -567,9 +566,8 @@ namespace Libplanet.Tests.Blockchain
                 await _blockChain.MineBlock(key);
             }
 
-            Block<DumbAction> newBlock = MineNext(
+            Block<DumbAction> newBlock = ProposeNext(
                 genesis,
-                difficulty: 1024,
                 miner: key.PublicKey
             ).Evaluate(key, _blockChain);
 
@@ -679,21 +677,17 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey),
             };
 
-            Block<DumbAction> b1 = MineNext(
+            Block<DumbAction> b1 = ProposeNext(
                 genesis,
                 txsA,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
             _blockChain.Append(b1);
 
-            Block<DumbAction> b2 = MineNext(
+            Block<DumbAction> b2 = ProposeNext(
                 b1,
                 txsA,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
@@ -707,11 +701,9 @@ namespace Libplanet.Tests.Blockchain
                     nonce: 1,
                     privateKey: privateKey),
             };
-            b2 = MineNext(
+            b2 = ProposeNext(
                 b1,
                 txsB,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
@@ -742,11 +734,9 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(0, _blockChain.GetNextTxNonce(address));
 
-            Block<DumbAction> b1 = MineNext(
+            Block<DumbAction> b1 = ProposeNext(
                 genesis,
                 txsA,
-                null,
-                _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
@@ -761,11 +751,9 @@ namespace Libplanet.Tests.Blockchain
                     nonce: 1,
                     privateKey: privateKey),
             };
-            Block<DumbAction> b2 = MineNext(
+            Block<DumbAction> b2 = ProposeNext(
                 b1,
                 txsB,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
@@ -817,11 +805,10 @@ namespace Libplanet.Tests.Blockchain
             var miner = new PrivateKey();
             var minerAddress = miner.ToAddress();
 
-            Block<DumbAction> block1 = MineNext(
+            Block<DumbAction> block1 = ProposeNext(
                 genesis,
                 txs1,
                 miner: miner.PublicKey,
-                difficulty: _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
             _blockChain.Append(block1);
@@ -881,11 +868,9 @@ namespace Libplanet.Tests.Blockchain
 
             foreach (Transaction<DumbAction>[] txs in txsA)
             {
-                Block<DumbAction> b = MineNext(
+                Block<DumbAction> b = ProposeNext(
                     _blockChain.Tip,
                     txs,
-                    null,
-                    _policy.GetNextBlockDifficulty(_blockChain),
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: miner.PublicKey
                 ).Evaluate(miner, _blockChain);
@@ -913,11 +898,9 @@ namespace Libplanet.Tests.Blockchain
                     privateKey: privateKey),
             };
 
-            Block<DumbAction> forkTip = MineNext(
+            Block<DumbAction> forkTip = ProposeNext(
                 fork.Tip,
                 txsB,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: miner.PublicKey
             ).Evaluate(miner, fork);
@@ -1173,7 +1156,7 @@ namespace Libplanet.Tests.Blockchain
                 {
                     Transaction<DumbAction>.Create(0, privateKey, chain.Genesis.Hash, actions),
                 };
-                b = MineNext(
+                b = ProposeNext(
                     b,
                     txs,
                     miner: _fx.Miner.PublicKey
@@ -1212,7 +1195,7 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> b = chain.Genesis;
             for (int i = 0; i < 20; ++i)
             {
-                b = MineNext(
+                b = ProposeNext(
                     b,
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: _fx.Miner.PublicKey
@@ -1428,11 +1411,9 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
             };
 
-            Block<DumbAction> b1 = MineNext(
+            Block<DumbAction> b1 = ProposeNext(
                 genesis,
                 txsA,
-                null,
-                _policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey
             ).Evaluate(_fx.Miner, _blockChain);
@@ -1528,14 +1509,13 @@ namespace Libplanet.Tests.Blockchain
 
             var genesis = _blockChain.Genesis;
 
-            Block<DumbAction> MineNext(
+            Block<DumbAction> ProposeNext(
                 Block<DumbAction> block,
                 IReadOnlyList<Transaction<DumbAction>> txs
             ) =>
-                TestUtils.MineNext(
+                TestUtils.ProposeNext(
                     block,
                     txs,
-                    difficulty: 1024,
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: _fx.Miner.PublicKey
                 ).Evaluate(_fx.Miner, _blockChain);
@@ -1545,14 +1525,14 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
             };
-            Block<DumbAction> b1 = MineNext(genesis, txsA);
+            Block<DumbAction> b1 = ProposeNext(genesis, txsA);
             _blockChain.Append(b1);
 
             Transaction<DumbAction>[] txsB =
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 2),
             };
-            Block<DumbAction> b2 = MineNext(b1, txsB);
+            Block<DumbAction> b2 = ProposeNext(b1, txsB);
             _blockChain.Append(b2);
 
             // Invalid if nonce is too low
@@ -1560,7 +1540,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
             };
-            Block<DumbAction> b3a = MineNext(b2, txsC);
+            Block<DumbAction> b3a = ProposeNext(b2, txsC);
             Assert.Throws<InvalidTxNonceException>(() => _blockChain.Append(b3a));
 
             // Invalid if nonce is too high
@@ -1568,7 +1548,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 4),
             };
-            Block<DumbAction> b3b = MineNext(b2, txsD);
+            Block<DumbAction> b3b = ProposeNext(b2, txsD);
             Assert.Throws<InvalidTxNonceException>(() => _blockChain.Append(b3b));
         }
 
@@ -1772,7 +1752,7 @@ namespace Libplanet.Tests.Blockchain
                         chain.Genesis.Hash,
                         new[] { new DumbAction(addresses[j], index.ToString()) }
                     );
-                    b = MineNext(
+                    b = ProposeNext(
                         b,
                         new[] { tx },
                         blockInterval: TimeSpan.FromSeconds(10),

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -625,7 +625,7 @@ namespace Libplanet.Tests.Blockchain
             using (IStore store = new MemoryStore())
             using (var stateStore = new TrieStateStore(new MemoryKeyValueStore()))
             {
-                var genesis = MineGenesis(
+                var genesis = ProposeGenesis(
                     GenesisMiner.PublicKey,
                     transactions: new[] { _fx.MakeTransaction(new[] { action }) }
                 ).Evaluate(
@@ -1039,7 +1039,7 @@ namespace Libplanet.Tests.Blockchain
         {
             using (var fx2 = new MemoryStoreFixture(_policy.BlockAction))
             {
-                Block<DumbAction> genesis2 = MineGenesis<DumbAction>(
+                Block<DumbAction> genesis2 = ProposeGenesis<DumbAction>(
                     timestamp: DateTimeOffset.UtcNow,
                     miner: GenesisMiner.PublicKey
                 ).Evaluate(
@@ -1094,7 +1094,7 @@ namespace Libplanet.Tests.Blockchain
                 });
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            Block<DumbAction> genesisWithTx = MineGenesis(
+            Block<DumbAction> genesisWithTx = ProposeGenesis(
                 GenesisMiner.PublicKey,
                 new[]
                 {
@@ -1680,7 +1680,7 @@ namespace Libplanet.Tests.Blockchain
             IBlockPolicy<DumbAction> blockPolicy = new NullBlockPolicy<DumbAction>();
             store = new StoreTracker(store);
             Guid chainId = Guid.NewGuid();
-            Block<DumbAction> genesisBlock = MineGenesis<DumbAction>(
+            Block<DumbAction> genesisBlock = ProposeGenesis<DumbAction>(
                 GenesisMiner.PublicKey
             ).Evaluate(
                 privateKey: GenesisMiner,
@@ -1991,7 +1991,7 @@ namespace Libplanet.Tests.Blockchain
                 });
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            Block<DumbAction> genesisWithTx = MineGenesis(
+            Block<DumbAction> genesisWithTx = ProposeGenesis(
                 GenesisMiner.PublicKey,
                 new[]
                 {

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
-using Libplanet.Store;
-using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
@@ -44,64 +41,6 @@ namespace Libplanet.Tests.Blockchain.Policies
         public void Dispose()
         {
             _fx.Dispose();
-        }
-
-        [Fact]
-        public void DifficultyAdjustment()
-        {
-            TimeSpan defaultInterval =
-                DifficultyAdjustment<DumbAction>.DefaultTargetBlockInterval;
-            long defaultStability =
-                DifficultyAdjustment<DumbAction>.DefaultDifficultyStability;
-            long defaultMinimum =
-                DifficultyAdjustment<DumbAction>.DefaultMinimumDifficulty;
-
-            // Should work with defaults.
-            DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                defaultInterval,
-                defaultStability,
-                defaultMinimum);
-
-            // Negative block interval.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                    TimeSpan.FromMilliseconds(-5),
-                    defaultStability,
-                    defaultMinimum));
-
-            // Zero block interval.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                    TimeSpan.FromMilliseconds(0),
-                    defaultStability,
-                    defaultMinimum));
-
-            // Invalid stability due to being too low.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                    defaultInterval,
-                    0,
-                    defaultMinimum));
-
-            // Stability being equal to minimum difficulty should be fine.
-            DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                defaultInterval,
-                defaultMinimum,
-                defaultMinimum);
-
-            // Invalid stability in relation to minimum difficulty for stability being too high.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                    defaultInterval,
-                    defaultMinimum + 1,
-                    defaultMinimum));
-
-            // Invalid minimum difficulty for being too low.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                DifficultyAdjustment<DumbAction>.AlgorithmFactory(
-                    defaultInterval,
-                    defaultStability,
-                    0));
         }
 
         [Fact]
@@ -200,56 +139,6 @@ namespace Libplanet.Tests.Blockchain.Policies
             expected = policy.ValidateNextBlockTx(_chain, invalidTx);
             Assert.NotNull(expected);
             Assert.NotNull(expected.InnerException);
-        }
-
-        [Fact]
-        public async Task GetNextBlockDifficulty()
-        {
-            var store = new MemoryStore();
-            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            var dateTimeOffset = FixtureEpoch;
-            var chain =
-                TestUtils.MakeBlockChain(_policy, store, stateStore, timestamp: dateTimeOffset);
-            var miner = new PrivateKey();
-            Assert.Equal(
-                1024,
-                _policy.GetNextBlockDifficulty(chain)
-            );
-            dateTimeOffset = FixtureEpoch + TimeSpan.FromHours(1);
-            await chain.MineBlock(miner, dateTimeOffset);
-
-            Assert.Equal(
-                1032,
-                _policy.GetNextBlockDifficulty(chain)
-            );
-            dateTimeOffset = FixtureEpoch + TimeSpan.FromHours(3);
-            await chain.MineBlock(miner, dateTimeOffset);
-
-            Assert.Equal(
-                1040,
-                _policy.GetNextBlockDifficulty(chain)
-            );
-            dateTimeOffset = FixtureEpoch + TimeSpan.FromHours(7);
-            await chain.MineBlock(miner, dateTimeOffset);
-
-            Assert.Equal(
-                1040,
-                _policy.GetNextBlockDifficulty(chain)
-            );
-            dateTimeOffset = FixtureEpoch + TimeSpan.FromHours(9);
-            await chain.MineBlock(miner, dateTimeOffset);
-
-            Assert.Equal(
-                1048,
-                _policy.GetNextBlockDifficulty(chain)
-            );
-            dateTimeOffset = FixtureEpoch + TimeSpan.FromHours(13);
-            await chain.MineBlock(miner, dateTimeOffset);
-
-            Assert.Equal(
-                1048,
-                _policy.GetNextBlockDifficulty(chain)
-            );
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static Exception _exception = new Exception();
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -23,10 +23,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         [Fact]
         public void ActionRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
     public class AnonymousRendererTest
     {
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -11,10 +11,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         [Fact]
         public void BlockRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blockchain.Renderers.Debug;
@@ -41,9 +40,9 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
-        public async Task Block()
+        public void Block()
         {
-            await _fx.Mine();
+            _fx.Append(_fx.Propose());
             IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
             Assert.Equal(5, records.Count);
             AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[0], r => Assert.True(r.Begin));
@@ -66,10 +65,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
-        public async Task Reorg()
+        public void Reorg()
         {
             BlockChain<Arithmetic> @base = _fx.Chain.Fork(_fx.Genesis.Hash);
-            await _fx.Mine();
+            _fx.Append(_fx.Propose());
             _record.ResetRecords();
             _fx.Chain.Swap(@base, true)();
             IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -12,7 +12,6 @@ using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
 using Serilog.Events;
-using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -154,7 +153,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Equal(0U, unintendedCalls);
         }
 
-        [Fact]
+        [Fact(Skip = "No fork in PBFT.")]
         public override void BlocksBeingAppendedInParallel()
         {
             // FIXME: Eliminate duplication between this and DelayedRendererTest
@@ -435,7 +434,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         // FIXME: This should be properly addressed.
         // https://github.com/planetarium/libplanet/issues/2166
-        [RetryFact]
+        [Fact(Skip = "No fork in PBFT.")]
         public async Task ClearRenderBufferWhenItsInterval()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -507,7 +507,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         }
 
         [Fact]
-        public async Task DelayedRendererInReorg()
+        public void DelayedRendererInReorg()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
             var fx = new MemoryStoreFixture(policy.BlockAction);
@@ -566,7 +566,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var key = new PrivateKey();
 
             var tx1 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#1") });
-            await chain.MineBlock(key);
+            chain.Append(chain.ProposeBlock(key));
 
             Assert.Null(delayedRenderer.Tip);
             Assert.Empty(reorgLogs);
@@ -574,7 +574,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Empty(renderLogs);
 
             var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#2") });
-            await chain.MineBlock(key);
+            chain.Append(chain.ProposeBlock(key));
 
             Assert.Equal(chain[0], delayedRenderer.Tip);
             Assert.Empty(reorgLogs);
@@ -583,7 +583,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var forked = chain.Fork(chain[0].Hash);
             chain.StagePolicy.Stage(chain, tx1);
-            var block = await forked.MineBlock(key, append: false);
+            var block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
@@ -591,7 +591,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     renderActions: false
                 );
             chain.StagePolicy.Stage(chain, tx2);
-            block = await forked.MineBlock(key, append: false);
+            block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
@@ -599,7 +599,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     renderActions: false
                 );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#3") });
-            block = await forked.MineBlock(key, append: false);
+            block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
@@ -607,7 +607,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     renderActions: false
                 );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#4") });
-            block = await forked.MineBlock(key, append: false);
+            block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
@@ -683,7 +683,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var key = new PrivateKey();
 
             var tx1 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#1") });
-            await chain.MineBlock(key);
+            chain.Append(chain.ProposeBlock(key));
 
             Assert.Null(delayedRenderer.Tip);
             Assert.Empty(reorgLogs);
@@ -700,14 +700,14 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var forked = chain.Fork(chain[1].Hash);
             chain.StagePolicy.Stage(chain, tx2);
-            var block = await forked.MineBlock(key, append: false);
+            var block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
                     renderBlocks: false,
                     renderActions: false
                 );
-            block = await forked.MineBlock(key, append: false);
+            block = forked.ProposeBlock(key);
             forked.Append(
                     block,
                     evaluateActions: true,
@@ -722,7 +722,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Equal(new[] { (chain[0], chain[1]) }, blockLogs);
             Assert.Equal(2, renderLogs.Count);
 
-            await chain.MineBlock(key);
+            chain.Append(chain.ProposeBlock(key));
             Assert.Equal(chain[2], delayedRenderer.Tip);
             Assert.Empty(reorgLogs);
             Assert.Equal(new[] { (chain[0], chain[1]), (chain[1], chain[2]) }, blockLogs);

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -25,7 +25,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
         {
             var chainA = new Block<DumbAction>[10];
             var chainB = new Block<DumbAction>[chainA.Length];
-            chainA[0] = chainB[0] = TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            chainA[0] = chainB[0] =
+                TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
             for (int i = 1; i < chainA.Length / 2; i++)
             {
                 _branchpoint = chainA[i] = chainB[i] = TestUtils.ProposeNextBlock(

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -28,31 +28,20 @@ namespace Libplanet.Tests.Blockchain.Renderers
             chainA[0] = chainB[0] = TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
             for (int i = 1; i < chainA.Length / 2; i++)
             {
-                _branchpoint = chainA[i] = chainB[i] = TestUtils.MineNextBlock(
+                _branchpoint = chainA[i] = chainB[i] = TestUtils.ProposeNextBlock(
                     chainA[i - 1],
                     TestUtils.GenesisMiner
                 );
             }
 
-            int extraDifficulty = 1;
             for (int i = chainA.Length / 2; i < chainA.Length; i++)
             {
-                chainA[i] = TestUtils.MineNextBlock(
+                chainA[i] = TestUtils.ProposeNextBlock(
                     chainA[i - 1],
-                    TestUtils.GenesisMiner,
-                    difficulty: 2
-                );
-                chainB[i] = TestUtils.MineNextBlock(
+                    TestUtils.GenesisMiner);
+                chainB[i] = TestUtils.ProposeNextBlock(
                     chainB[i - 1],
-                    TestUtils.GenesisMiner,
-                    difficulty: 2 + extraDifficulty
-                );
-
-                // The block right next the branchpoint in the chainB has 1 more difficulty than
-                // the block with the same index in the chainA, and then rest blocks have the
-                // same difficulty 2.  That means, every block after the branchpoint in the chainB
-                // has exactly 1 more difficulty than a block with the same index in the chainA.
-                extraDifficulty = 0;
+                    TestUtils.GenesisMiner);
             }
 
             _chainA = chainA;
@@ -156,7 +145,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Equal(0U, reorgs);
         }
 
-        [Fact]
+        [Fact(Skip = "No fork in PBFT.")]
         public virtual void BlocksBeingAppendedInParallel()
         {
             var blockLogs = new List<(Block<DumbAction> OldTip, Block<DumbAction> NewTip)>();

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static Exception _exception = new Exception();
 
         private static DumbBlock _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static DumbBlock _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -27,10 +27,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static DumbBlock _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static DumbBlock _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
     public class LoggedRendererTest : IDisposable
     {
         private static DumbBlock _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static DumbBlock _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -19,10 +19,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static DumbBlock _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static DumbBlock _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
@@ -26,10 +26,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         [RetryFact]
         public void Test()

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static Exception _exception = new Exception("EXPECTED");
 
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
@@ -16,10 +16,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.MineNextBlock(_genesis, TestUtils.GenesisMiner);
+            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);
 
         [SuppressMessage(
             "SonarQube",

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
@@ -13,7 +13,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
     public class NonblockRendererTest
     {
         private static Block<DumbAction> _genesis =
-            TestUtils.MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
+            TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
 
         private static Block<DumbAction> _blockA =
             TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisMiner);

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -26,10 +26,9 @@ namespace Libplanet.Tests.Blocks
                     "e2e938f9d8af0a20d16d1c233fc4e8f39157145d003565807e4055ce6b5a0121")
             );
             TxFixture = new TxFixture(Genesis.Hash);
-            Next = TestUtils.MineNextBlock(
+            Next = TestUtils.ProposeNextBlock(
                 Genesis,
                 miner: Miner,
-                nonce: new byte[] { 0x02, 0x00, 0x00, 0x00 },
                 protocolVersion: ProtocolVersion,
                 stateRootHash: HashDigest<SHA256>.FromString(
                     "6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa"),
@@ -49,18 +48,13 @@ namespace Libplanet.Tests.Blocks
                             null).Sign(Miner),
                     }.ToImmutableArray())
             );
-            byte[] hasTxNonce =
-            {
-                0x5c, 0x77, 0x74, 0xc2, 0x39, 0x69, 0x37, 0x51, 0x87, 0xa5,
-            };
-            HasTx = TestUtils.MineNextBlock(
+            HasTx = TestUtils.ProposeNextBlock(
                 Next,
                 miner: Miner,
                 txs: new List<Transaction<PolymorphicAction<BaseAction>>>
                 {
                     TxFixture.TxWithActions,
                 },
-                nonce: hasTxNonce,
                 protocolVersion: ProtocolVersion,
                 stateRootHash: HashDigest<SHA256>.FromString(
                     "aaeda4f1a6a4aee7fc9a29014cff005109176e83a8e5d28876f2d889680e6421"),

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -13,13 +13,12 @@ namespace Libplanet.Tests.Blocks
 {
     public class BlockFixture
     {
-        public const int ProtocolVersion =
-            Block<PolymorphicAction<BaseAction>>.CurrentProtocolVersion;
+        public const int ProtocolVersion = BlockMetadata.CurrentProtocolVersion;
 
         public BlockFixture()
         {
             Miner = TestUtils.GenesisMiner;
-            Genesis = TestUtils.MineGenesisBlock<PolymorphicAction<BaseAction>>(
+            Genesis = TestUtils.ProposeGenesisBlock<PolymorphicAction<BaseAction>>(
                 protocolVersion: ProtocolVersion,
                 miner: Miner,
                 stateRootHash: HashDigest<SHA256>.FromString(

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -87,7 +87,7 @@ namespace Libplanet.Tests.Blocks
                 Array.Empty<byte>()
             );
             Assert.Throws<InvalidTxSignatureException>(() =>
-                MineNext(
+                ProposeNext(
                     MineGenesisBlock<DumbAction>(_fx.Miner),
                     new List<Transaction<DumbAction>> { invalidTx }
                 )

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -68,8 +68,8 @@ namespace Libplanet.Tests.Blocks
                     signer,
                     null,
                     new[] { new RandomAction(signer.ToAddress()) })).ToImmutableArray();
-            var blockA = MineGenesis(timestamp: timestamp, transactions: txs);
-            var blockB = MineGenesis(timestamp: timestamp, transactions: txs);
+            var blockA = ProposeGenesis(timestamp: timestamp, transactions: txs);
+            var blockB = ProposeGenesis(timestamp: timestamp, transactions: txs);
 
             Assert.True(blockA.Transactions.SequenceEqual(blockB.Transactions));
         }
@@ -88,7 +88,7 @@ namespace Libplanet.Tests.Blocks
             );
             Assert.Throws<InvalidTxSignatureException>(() =>
                 ProposeNext(
-                    MineGenesisBlock<DumbAction>(_fx.Miner),
+                    ProposeGenesisBlock<DumbAction>(_fx.Miner),
                     new List<Transaction<DumbAction>> { invalidTx }
                 )
             );

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -4,8 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
-using System.Threading;
-using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -146,12 +144,9 @@ namespace Libplanet.Tests.Fixtures
         public TxWithContext Sign(int signerIndex, params Arithmetic[] actions) =>
             Sign(PrivateKeys[signerIndex], actions);
 
-        public Task<Block<Arithmetic>> Mine(CancellationToken cancellationToken = default) =>
-            Chain.MineBlock(
-                Miner,
-                DateTimeOffset.UtcNow,
-                cancellationToken: cancellationToken
-            );
+        public Block<Arithmetic> Propose() => Chain.ProposeBlock(Miner);
+
+        public void Append(Block<Arithmetic> block) => Chain.Append(block);
 
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)
         {

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -112,11 +112,11 @@ namespace Libplanet.Tests.Store
                 stateStore: stateStore
             );
             stateRootHashes[GenesisBlock.Hash] = GenesisBlock.StateRootHash;
-            Block1 = TestUtils.MineNextBlock(GenesisBlock, miner: Miner);
+            Block1 = TestUtils.ProposeNextBlock(GenesisBlock, miner: Miner);
             stateRootHashes[Block1.Hash] = Block1.StateRootHash;
-            Block2 = TestUtils.MineNextBlock(Block1, miner: Miner);
+            Block2 = TestUtils.ProposeNextBlock(Block1, miner: Miner);
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
-            Block3 = TestUtils.MineNextBlock(Block2, miner: Miner);
+            Block3 = TestUtils.ProposeNextBlock(Block2, miner: Miner);
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -101,7 +101,7 @@ namespace Libplanet.Tests.Store
                     ? rh
                     : (HashDigest<SHA256>?)null;
             Miner = TestUtils.GenesisMiner;
-            GenesisBlock = TestUtils.MineGenesis<DumbAction>(
+            GenesisBlock = TestUtils.ProposeGenesis<DumbAction>(
                 Miner.PublicKey
             ).Evaluate(
                 privateKey: Miner,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Tests.Store
         public void DeleteChainId()
         {
             Block<DumbAction> block1 = ProposeNextBlock(
-                MineGenesisBlock<DumbAction>(GenesisMiner),
+                ProposeGenesisBlock<DumbAction>(GenesisMiner),
                 GenesisMiner,
                 new[] { Fx.Transaction1 });
             Fx.Store.AppendIndex(Fx.StoreChainId, block1.Hash);
@@ -1021,7 +1021,7 @@ namespace Libplanet.Tests.Store
                     new VolatileStagePolicy<DumbAction>(),
                     s1,
                     fx.StateStore,
-                    MineGenesis<DumbAction>(miner: GenesisMiner.PublicKey)
+                    ProposeGenesis<DumbAction>(miner: GenesisMiner.PublicKey)
                         .Evaluate(
                             privateKey: GenesisMiner,
                             blockAction: policy.BlockAction,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -85,7 +85,7 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void DeleteChainId()
         {
-            Block<DumbAction> block1 = MineNextBlock(
+            Block<DumbAction> block1 = ProposeNextBlock(
                 MineGenesisBlock<DumbAction>(GenesisMiner),
                 GenesisMiner,
                 new[] { Fx.Transaction1 });
@@ -959,8 +959,7 @@ namespace Libplanet.Tests.Store
 
             // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
             // actual block...
-            Block<DumbAction> anotherBlock3 =
-                MineNextBlock(Fx.Block2, Fx.Miner);
+            Block<DumbAction> anotherBlock3 = ProposeNextBlock(Fx.Block2, Fx.Miner);
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
             store.PutBlock(Fx.Block2);
@@ -1064,11 +1063,9 @@ namespace Libplanet.Tests.Store
             using (StoreFixture fx = FxConstructor())
             {
                 Block<DumbAction> genesisBlock = fx.GenesisBlock;
-                // NOTE: it depends on that Block<T>.CurrentProtocolVersion is not 0.
-                Block<DumbAction> block = MineNextBlock(
+                Block<DumbAction> block = ProposeNextBlock(
                     genesisBlock,
-                    miner: fx.Miner,
-                    protocolVersion: 0);
+                    miner: fx.Miner);
 
                 fx.Store.PutBlock(block);
                 Block<DumbAction> storedBlock =

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1009,7 +1009,7 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
-        public async Task Copy()
+        public void Copy()
         {
             using (StoreFixture fx = FxConstructor())
             using (StoreFixture fx2 = FxConstructor())
@@ -1031,9 +1031,9 @@ namespace Libplanet.Tests.Store
 
                 // FIXME: Need to add more complex blocks/transactions.
                 var key = new PrivateKey();
-                await blocks.MineBlock(key);
-                await blocks.MineBlock(key);
-                await blocks.MineBlock(key);
+                blocks.Append(blocks.ProposeBlock(key));
+                blocks.Append(blocks.ProposeBlock(key));
+                blocks.Append(blocks.ProposeBlock(key));
 
                 s1.Copy(to: Fx.Store);
                 Fx.Store.Copy(to: s2);

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -124,8 +124,9 @@ namespace Libplanet.Blockchain
                 }
             }
 
+            // FIXME: Some stub difficulty.
+            long difficulty = 5_000L;
             long index = Count;
-            long difficulty = Policy.GetNextBlockDifficulty(this);
             BlockHash? prevHash = index > 0 ? Store.IndexBlockHash(Id, index - 1) : null;
 
             int sessionId = new System.Random().Next();
@@ -311,7 +312,7 @@ namespace Libplanet.Blockchain
             BlockCommit? lastCommit = null)
         {
             long index = Count;
-            long difficulty = 500000;
+            long difficulty = 1L;
             BlockHash? prevHash = index > 0 ? Store.IndexBlockHash(Id, index - 1) : null;
 
             int sessionId = new System.Random().Next();


### PR DESCRIPTION
Follows #2253.

Mostly replaces `chain.MineBlock()` with `chain.Append(chain.ProposeBlock())`.