### PR TITLE
Fix `Transaction<T>.Create()` & release 0.40.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.40.1
 --------------
 
-To be released.
+Released on August 31, 2022.
 
  -  Fixed a bug where `Transaction<T>.Create(long, PrivateKey, BlockHash?,
     IAction, IImmutableSet<Address>?, DateTimeOffset?)` method had thrown
@@ -16,7 +16,7 @@ To be released.
 Version 0.40.0
 --------------
 
-Released on Auguest 12th, 2022.
+Released on August 12, 2022.
 
 ### Deprecated APIs
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.40.1
 
 To be released.
 
+ -  Fixed a bug where `Transaction<T>.Create(long, PrivateKey, BlockHash?,
+    IAction, IImmutableSet<Address>?, DateTimeOffset?)` method had thrown
+    `ArgumentNullException` with valid arguments.  [[#2268]]
+
+[#2268]: https://github.com/planetarium/libplanet/pull/2268
+
 
 Version 0.40.0
 --------------

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -354,7 +354,7 @@ namespace Libplanet.Tx
             byte[] sig = privateKey.Sign(payload);
             return new Transaction<T>(
                 unsignedTransaction._metadata,
-                unsignedTransaction.CustomActions!,
+                unsignedTransaction.SystemAction!,
                 sig
             );
         }


### PR DESCRIPTION
It's a hotfix of `Transaction<T>.Create()` and I'm going to release it as 0.40.1.

See also the changelog and the added regression test.