### PR TITLE
`BlockChain<T>.MakeTransaction()` for system actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,19 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Renamed `BlockChain<T>.MakeTransaction(PrivateKey, IEnumerable<T>,
+    IImmutableSet<Address>, DateTimeOffset?)` method's `actions` parameter to
+    `customActions`.  [[##2151], [#2273]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  Added `BlockChain<T>.MakeTransaction(PrivateKey, IAction,
+    IImmutableSet<Address>, DateTimeOffset?)` overloaded method.
+    [[#2151], [#2273]]
 
 ### Behavioral changes
 
@@ -23,6 +31,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#2273]: https://github.com/planetarium/libplanet/pull/2273
 
 
 Version 0.41.1

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -485,10 +485,10 @@ namespace Libplanet.Net.Tests
             {
                 var tx1 = swarmA.BlockChain.MakeTransaction(
                     privateKey: privateKey,
-                    actions: new DumbAction[] { });
+                    customActions: new DumbAction[] { });
                 var tx2 = swarmA.BlockChain.MakeTransaction(
                     privateKey: privateKey,
-                    actions: new DumbAction[] { });
+                    customActions: new DumbAction[] { });
                 Assert.Equal(0, tx1.Nonce);
                 Assert.Equal(1, tx2.Nonce);
 
@@ -513,10 +513,10 @@ namespace Libplanet.Net.Tests
 
                 var tx3 = chainA.MakeTransaction(
                     privateKey: privateKey,
-                    actions: new DumbAction[] { });
+                    customActions: new DumbAction[] { });
                 var tx4 = chainA.MakeTransaction(
                     privateKey: privateKey,
-                    actions: new DumbAction[] { });
+                    customActions: new DumbAction[] { });
                 Assert.Equal(1, tx3.Nonce);
                 Assert.Equal(2, tx4.Nonce);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Action.Sys;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -1573,7 +1574,36 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void MakeTransaction()
+        public void MakeTransactionWithSystemAction()
+        {
+            var foo = Currency.Uncapped("FOO", 2, minters: null);
+            var privateKey = new PrivateKey();
+            Address address = privateKey.ToAddress();
+            var action = new Transfer(address, foo * 10);
+
+            _blockChain.MakeTransaction(privateKey, systemAction: action);
+            _blockChain.MakeTransaction(privateKey, systemAction: action);
+
+            List<Transaction<DumbAction>> txs = _stagePolicy
+                .Iterate(_blockChain)
+                .OrderBy(tx => tx.Nonce)
+                .ToList();
+
+            Assert.Equal(2, txs.Count);
+
+            var transaction = txs[0];
+            Assert.Equal(0, transaction.Nonce);
+            Assert.Equal(address, transaction.Signer);
+            Assert.Equal(action, transaction.SystemAction);
+
+            transaction = txs[1];
+            Assert.Equal(1, transaction.Nonce);
+            Assert.Equal(address, transaction.Signer);
+            Assert.Equal(action, transaction.SystemAction);
+        }
+
+        [Fact]
+        public void MakeTransactionWithCustomActions()
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.ToAddress();


### PR DESCRIPTION
This method would've been implemented together in #2175, but I omitted it.