### PR TITLE
Longer propagation delay for test

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Tests.Consensus
     public class ConsensusReactorTestBase : IDisposable, IAsyncLifetime
     {
         protected const int Count = 4;
-        protected const int PropagationDelay = 10_000;
+        protected const int PropagationDelay = 30_000;
 
         protected readonly ConsensusReactor<DumbAction>[] ConsensusReactors;
         protected readonly BlockChain<DumbAction>[] BlockChains;

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -502,12 +502,12 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     new HashSet<TxId> { tx1.Id, tx2.Id },
                     chainB.GetStagedTransactionIds().ToHashSet());
+                swarmA.RoutingTable.RemovePeer(swarmB.AsPeer);
+                swarmB.RoutingTable.RemovePeer(swarmA.AsPeer);
 
                 chainA.UnstageTransaction(tx2);
                 Assert.Equal(1, chainA.GetNextTxNonce(privateKey.ToAddress()));
 
-                swarmA.RoutingTable.RemovePeer(swarmB.AsPeer);
-                swarmB.RoutingTable.RemovePeer(swarmA.AsPeer);
                 Assert.Empty(swarmA.Peers);
                 Assert.Empty(swarmB.Peers);
 


### PR DESCRIPTION
Makes it overall less flaky. macos-netcore-test is still problematic.