### PR TITLE
Using BLS Signature in PBFT voting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,10 @@ To be released.
  -  (Libplanet.Net) Parameter type `PublicKey` in `BoundPeer(PublicKey,
     DnsEndPoint)` and `BoundPeer(PublicKey, DnsEndPoint, IPAddress?)` is
     now `IPublicKey`.  [[#PBFT]]
+ -  (Libplanet.Net) Parameters type `PublicKey expected` and `PublicKey actual`
+    in `InvalidCredentialException` is now `IPublicKey`.  [[#PBFT]]
+ -  (Libplanet.Net) Parameter type `PublicKey publicKey` in
+    `InvalidMessageSignatureException` is now `IPublicKey`.  [[#PBFT]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,12 @@ To be released.
     in `InvalidCredentialException` is now `IPublicKey`.  [[#PBFT]]
  -  (Libplanet.Net) Parameter type `PublicKey publicKey` in
     `InvalidMessageSignatureException` is now `IPublicKey`.  [[#PBFT]]
+ -  (Libplanet.Net) Parameter type `PrivateKey privateKey` in
+    `IMessageCodec<T>.Encode(Message, PrivateKey, AppProtocolVersion, Peer,
+    DateTimeOffset)` is now `IPrivatekey`.  [[#PBFT]]
+ -  (Libplanet.Net) Parameter type `PrivateKey privateKey` in
+    `NetMQMessageCodec.Encode(Message, PrivateKey, AppProtocolVersion, Peer,
+    DateTimeOffset)` is now `IPrivateKey`.  [[#PBFT]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,8 +64,6 @@ To be released.
     [[#PBFT]]
  -  Added `Crypto.BlsSignature` class.  [[#PBFT]]
  -  Added static `PublicKeyGetter` class.  [[#PBFT]]
- -  `Crypto.PublicKey` is now inheriting `Crypto.IPrivateKey`.  [[#PBFT]]
- -  `Crypto.PrivateKey` is now inheriting `Crypto.IPublicKey`.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]
@@ -98,6 +96,8 @@ To be released.
  -  `PreEvaluationBlockHeader()` constructor became to throw
     `InvalidBlockLastCommitException` when its metadata's `LastCommit` is
     invalid.  [[#PBFT]]
+ -  `Crypto.PublicKey` is now inheriting `Crypto.IPrivateKey`.  [[#PBFT]]
+ -  `Crypto.PrivateKey` is now inheriting `Crypto.IPublicKey`.  [[#PBFT]]
  -  `Address(PublicKey)` constructor is changed to
     `Address(IPublicKey)`.  [[#PBFT]]
  -  `AddressExtensions.ToAddress(PublicKey)` is changed to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,12 @@ To be released.
  -  `PreEvaluationBlockHeader()` constructor became to throw
     `InvalidBlockLastCommitException` when its metadata's `LastCommit` is
     invalid.  [[#PBFT]]
+ -  `Address(PublicKey)` constructor is changed to
+    `Address(IPublicKey)`.  [[#PBFT]]
+ -  `AddressExtensions.ToAddress(PublicKey)` is changed to
+    `AddressExtensions.ToAddress(IPublicKey)`.  [[#PBFT]]
+ -  `AddressExtensions.ToAddress(PrivateKey)` is changed to
+    `AddressExtensions.ToAddress(IPrivateKey)`  [[#PBFT]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ To be released.
  -  Added `Crypto.IPublicKey` inherited `Crypto.BlsPublicKey` class.
     [[#PBFT]]
  -  Added `Crypto.BlsSignature` class.  [[#PBFT]]
+ -  Added static `PublicKeyGetter` class.  [[#PBFT]]
  -  `Crypto.PublicKey` is now inheriting `Crypto.IPrivateKey`.  [[#PBFT]]
  -  `Crypto.PrivateKey` is now inheriting `Crypto.IPublicKey`.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
@@ -102,7 +103,13 @@ To be released.
  -  `AddressExtensions.ToAddress(PublicKey)` is changed to
     `AddressExtensions.ToAddress(IPublicKey)`.  [[#PBFT]]
  -  `AddressExtensions.ToAddress(PrivateKey)` is changed to
-    `AddressExtensions.ToAddress(IPrivateKey)`  [[#PBFT]]
+    `AddressExtensions.ToAddress(IPrivateKey)`.  [[#PBFT]]
+ -  (Libplanet.Net) Property `BoundPeer.PublicKey` type is now `IPublicKey`. the
+    following constructors `BoundPeer(PublicKey, IPAddress?)` and
+    `BoundPeer(PublicKey)` are also affected by this changes.  [[#PBFT]]
+ -  (Libplanet.Net) Parameter type `PublicKey` in `BoundPeer(PublicKey,
+    DnsEndPoint)` and `BoundPeer(PublicKey, DnsEndPoint, IPAddress?)` is
+    now `IPublicKey`.  [[#PBFT]]
 
 ### Bug fixes
 

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -94,8 +94,9 @@ namespace Libplanet.Explorer.Executable
         {
             get
             {
-                return Seeds?.Select(seed => $"{ByteUtil.Hex(seed.PublicKey.Format(true))}," +
-                                             $"{seed.EndPoint.Host},{seed.EndPoint.Port}");
+                return Seeds?.Select(seed =>
+                    $"{ByteUtil.Hex(seed.PublicKey.CompressedKeyBytes.ToArray())}," +
+                    $"{seed.EndPoint.Host},{seed.EndPoint.Port}");
             }
 
             set

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -222,7 +222,6 @@ If omitted (default) explorer only the local blockchain store.")]
                     Console.Error.WriteLine("Creating Swarm.");
 
                     var privateKey = new PrivateKey();
-                    var consensusPrivateKey = new PrivateKey();
 
                     // FIXME: The appProtocolVersion should be fixed properly.
                     var swarmOptions = new SwarmOptions

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -28,6 +28,19 @@ namespace Libplanet.Net.Tests
                     }),
                     new DnsEndPoint("0.0.0.0", 1234)),
             },
+            new object[]
+            {
+                new BoundPeer(
+                    new BlsPublicKey(new byte[]
+                    {
+                        0x95, 0x0f, 0xfc, 0x59, 0x13, 0x08, 0xf6, 0x77, 0x4a, 0xf6,
+                        0xac, 0x09, 0x0e, 0xa4, 0x1f, 0x9e, 0xdd, 0x45, 0x28, 0xe0,
+                        0xda, 0xc6, 0x22, 0xeb, 0x50, 0xbf, 0xa8, 0x43, 0xa2, 0xb4,
+                        0x37, 0xa9, 0xb6, 0x70, 0xc0, 0x0e, 0x9e, 0xde, 0x07, 0xb4,
+                        0x65, 0xc7, 0xab, 0x41, 0xa7, 0xcc, 0x6a, 0xde,
+                    }),
+                    new DnsEndPoint("0.0.0.0", 1234)),
+            },
         };
 
         [Theory]
@@ -70,16 +83,16 @@ namespace Libplanet.Net.Tests
         }
 
         [Fact]
-        public void PeerString()
+        public void BLSParsePeer()
         {
 #pragma warning disable MEN002 // Line is too long
-            var expected = "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,3333";
-            var boundPeer = new BoundPeer(
-                new PublicKey(ByteUtil.ParseHex("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233")),
+            var peerInfo = "950ffc591308f6774af6ac090ea41f9edd4528e0dac622eb50bfa843a2b437a9b670c00e9ede07b465c7ab41a7cc6ade,192.168.0.1,3333";
+            var expected = new BoundPeer(
+                new BlsPublicKey(ByteUtil.ParseHex("950ffc591308f6774af6ac090ea41f9edd4528e0dac622eb50bfa843a2b437a9b670c00e9ede07b465c7ab41a7cc6ade")),
                 new DnsEndPoint("192.168.0.1", 3333)
             );
 #pragma warning restore MEN002 // Line is too long
-            Assert.Equal(expected, boundPeer.PeerString);
+            Assert.Equal(expected, BoundPeer.ParsePeer(peerInfo));
         }
 
         [Fact]
@@ -91,6 +104,9 @@ namespace Libplanet.Net.Tests
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"));
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1"));
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,999999"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("950ffc591308f6774af6ac090ea41f9edd4528e0dac622eb50bfa843a2b437a9b670c00e9ede07b465c7ab41a7cc6ade"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("950ffc591308f6774af6ac090ea41f9edd4528e0dac622eb50bfa843a2b437a9b670c00e9ede07b465c7ab41a7cc6ade,192.168.0.1"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("950ffc591308f6774af6ac090ea41f9edd4528e0dac622eb50bfa843a2b437a9b670c00e9ede07b465c7ab41a7cc6ade,192.168.0.1,999999"));
 #pragma warning restore MEN002 // Line is too long
         }
     }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv,
+                        TestUtils.Peer2ConsensusPriv,
                         1,
                         hash: null,
                         flag: VoteFlag.Absent))
@@ -57,7 +57,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusVote(
                     vote: TestUtils.CreateVote(
-                        TestUtils.Peer3Priv,
+                        TestUtils.Peer3ConsensusPriv,
                         1,
                         hash: null,
                         flag: VoteFlag.Absent))
@@ -70,7 +70,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv,
+                        TestUtils.Peer2ConsensusPriv,
                         1,
                         hash: null,
                         flag: VoteFlag.Commit))
@@ -81,7 +81,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusCommit(
                     vote: TestUtils.CreateVote(
-                        TestUtils.Peer3Priv,
+                        TestUtils.Peer3ConsensusPriv,
                         1,
                         hash: null,
                         flag: VoteFlag.Commit))

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -15,14 +15,14 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 {
     public class ConsensusContextTest : ConsensusContextTestBase
     {
-        private static readonly PrivateKey PrivateKeyPeer1 = TestUtils.Peer1Priv;
-        private static readonly List<PublicKey> Validators = new List<PublicKey>()
-            { TestUtils.Peer0Priv.PublicKey, PrivateKeyPeer1.PublicKey, };
+        private static readonly BlsPrivateKey PrivateKeyPeer1 = TestUtils.Peer1ConsensusPriv;
+        private static readonly List<BlsPublicKey> Validators = new List<BlsPublicKey>()
+            { TestUtils.Peer0ConsensusPriv.PublicKey, PrivateKeyPeer1.PublicKey, };
 
         private readonly ILogger _logger;
 
         public ConsensusContextTest(ITestOutputHelper output)
-            : base(output, PrivateKeyPeer1, Validators)
+            : base(output, TestUtils.Peer1Priv, PrivateKeyPeer1, Validators)
         {
             const string outputTemplate =
                 "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
@@ -78,7 +78,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.Peer0Priv, 1, hash: blockHash, flag: VoteFlag.Absent))
+                        TestUtils.Peer0ConsensusPriv, 1, hash: blockHash, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[0],
                 });
@@ -86,7 +86,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ConsensusContext.HandleMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.Peer0Priv, 1, hash: blockHash, flag: VoteFlag.Commit))
+                        TestUtils.Peer0ConsensusPriv, 1, hash: blockHash, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[0],
                 });
@@ -123,7 +123,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             Assert.Throws<InvalidHeightMessageException>(
                 () => ConsensusContext.HandleMessage(
                     new ConsensusPropose(
-                        new PrivateKey().PublicKey,
+                        new BlsPrivateKey().PublicKey,
                         0,
                         0,
                         Fx.Block1.Hash,

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
@@ -22,13 +22,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         protected readonly ConsensusContext<DumbAction> ConsensusContext;
         protected readonly TimeSpan NewHeightDelay = TimeSpan.FromSeconds(1);
 
-        private const int Port = 19283;
         private readonly ILogger _logger;
 
         public ConsensusContextTestBase(
             ITestOutputHelper output,
             PrivateKey? privateKey = null,
-            List<PublicKey>? validators = null)
+            BlsPrivateKey? consensusPrivateKey = null,
+            List<BlsPublicKey>? validators = null)
         {
             const string outputTemplate =
                 "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
@@ -41,6 +41,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             _logger = Log.ForContext<ConsensusContextTestBase>();
             Fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
 
+            consensusPrivateKey ??= TestUtils.Peer1ConsensusPriv;
             privateKey ??= TestUtils.Peer1Priv;
             validators ??= TestUtils.Validators;
 
@@ -59,6 +60,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 BlockChain,
                 BlockChain.Tip.Index + 1,
                 privateKey,
+                consensusPrivateKey,
                 validators,
                 NewHeightDelay);
         }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
@@ -35,6 +35,7 @@ namespace Libplanet.Net.Tests.Consensus
         private const int Port = 6100;
         private readonly StoreFixture _fx;
         private readonly PrivateKey[] _privateKey;
+        private readonly BlsPrivateKey[] _consensusPrivateKey;
         private readonly IStore[] _stores;
 
         private ILogger _logger;
@@ -55,6 +56,7 @@ namespace Libplanet.Net.Tests.Consensus
             CancellationTokenSource = new CancellationTokenSource();
 
             _privateKey = new PrivateKey[Count];
+            _consensusPrivateKey = new BlsPrivateKey[Count];
             ConsensusReactors = new ConsensusReactor<DumbAction>[Count];
             ValidatorPeers = new List<BoundPeer>();
             _stores = new IStore[Count];
@@ -63,9 +65,10 @@ namespace Libplanet.Net.Tests.Consensus
             for (var i = 0; i < Count; i++)
             {
                 _privateKey[i] = new PrivateKey();
+                _consensusPrivateKey[i] = new BlsPrivateKey();
                 ValidatorPeers.Add(
                     new BoundPeer(
-                        _privateKey[i].PublicKey,
+                        _consensusPrivateKey[i].PublicKey,
                         new DnsEndPoint("localhost", Port + i)));
                 _stores[i] = new MemoryStore();
                 BlockChains[i] = new BlockChain<DumbAction>(
@@ -81,6 +84,7 @@ namespace Libplanet.Net.Tests.Consensus
                 ConsensusReactors[i] = (ConsensusReactor<DumbAction>)CreateReactor(
                     blockChain: BlockChains[i],
                     key: _privateKey[i],
+                    consensusKey: _consensusPrivateKey[i],
                     consensusPort: Port + i,
                     validatorPeers: ValidatorPeers,
                     newHeightDelayMilliseconds: PropagationDelay * 2);
@@ -105,15 +109,17 @@ namespace Libplanet.Net.Tests.Consensus
         private IReactor CreateReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
+            BlsPrivateKey? consensusKey = null,
             string host = "localhost",
             int consensusPort = 5101,
             List<BoundPeer> validatorPeers = null!,
             int newHeightDelayMilliseconds = 10_000)
         {
             key ??= new PrivateKey();
+            consensusKey ??= new BlsPrivateKey();
 
             var consensusTransport = NetMQTransport.Create(
-                key,
+                consensusKey,
                 TestUtils.AppProtocolVersion,
                 null,
                 8,
@@ -126,6 +132,7 @@ namespace Libplanet.Net.Tests.Consensus
                 consensusTransport,
                 blockChain,
                 key,
+                consensusKey,
                 validatorPeers.ToImmutableList(),
                 TimeSpan.FromMilliseconds(newHeightDelayMilliseconds));
         }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -36,16 +36,20 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], round: 0));
+                    block, TestUtils.ConsensusPrivateKeys[1], round: 0));
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[2], round: 1));
+                    block, TestUtils.ConsensusPrivateKeys[2], round: 1));
 
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 1, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2],
+                        1,
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -82,12 +86,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.Start();
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[1]));
 
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[1], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -95,7 +99,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -103,7 +107,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -148,12 +152,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.Start();
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[1]));
 
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[1], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -161,7 +165,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -169,7 +173,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: null, VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -196,16 +200,16 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], round: 0));
+                    block, TestUtils.ConsensusPrivateKeys[1], round: 0));
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[2], round: 1));
+                    block, TestUtils.ConsensusPrivateKeys[2], round: 1));
 
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 1, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -260,23 +264,23 @@ namespace Libplanet.Net.Tests.Consensus.Context
             // Push round 0 and round 1 proposes.
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block1, TestUtils.PrivateKeys[1], round: 0));
+                    block1, TestUtils.ConsensusPrivateKeys[1], round: 0));
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block2, TestUtils.PrivateKeys[2], round: 1));
+                    block2, TestUtils.ConsensusPrivateKeys[2], round: 1));
 
             // Two additional votes should be enough to trigger prevote timeout timer.
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -285,14 +289,14 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -321,12 +325,16 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], round: 0));
+                    block, TestUtils.ConsensusPrivateKeys[1], round: 0));
 
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[1],
+                        1,
+                        0,
+                        hash: block.Hash,
+                        flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -334,7 +342,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -342,7 +350,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -364,12 +372,16 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    block, TestUtils.PrivateKeys[1], round: 0));
+                    block, TestUtils.ConsensusPrivateKeys[1], round: 0));
 
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[1],
+                        1,
+                        0,
+                        hash: block.Hash,
+                        flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[1],
                 });
@@ -377,7 +389,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[2], 1, 0, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -385,7 +397,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[3],
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -45,23 +45,23 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[NodeId]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[NodeId]));
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0], 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[0], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[0],
                 });
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[2], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 1, hash: null, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[3], 1, hash: null, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -100,25 +100,25 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[1]));
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[0],
                 });
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[2], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 1, hash: block.Hash, flag: VoteFlag.Absent))
+                    TestUtils.ConsensusPrivateKeys[3], 1, hash: block.Hash, flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -148,7 +148,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[0], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[0],
                 });
@@ -156,7 +156,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[2], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -164,7 +164,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, hash: null, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[3], 1, hash: null, flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -194,12 +194,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[NodeId]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[NodeId]));
 
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[0],
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[0],
                 });
@@ -207,7 +210,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[2],
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -215,7 +221,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, hash: block.Hash, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[3],
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[3],
                 });
@@ -253,7 +262,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var invalidBlock = GetInvalidBlock();
             Context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
-                    invalidBlock, TestUtils.PrivateKeys[NodeId]));
+                    invalidBlock, TestUtils.ConsensusPrivateKeys[NodeId]));
 
             await Task.WhenAll(voteSent.WaitAsync(), stepChangedToPreVote.WaitAsync());
             Assert.Equal(Step.PreVote, Context.Step);
@@ -289,7 +298,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[NodeId]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[NodeId]));
 
             await Task.WhenAll(voteSent.WaitAsync(), stepChangedToPreVote.WaitAsync());
             Assert.Equal(Step.PreVote, Context.Step);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -37,17 +37,17 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                block, TestUtils.PrivateKeys[NodeId], round: 0, validRound: -1));
+                block, TestUtils.ConsensusPrivateKeys[NodeId], round: 0, validRound: -1));
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                block, TestUtils.PrivateKeys[2], round: 1, validRound: 0));
+                block, TestUtils.ConsensusPrivateKeys[2], round: 1, validRound: 0));
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                block, TestUtils.PrivateKeys[3], round: 2, validRound: 1));
+                block, TestUtils.ConsensusPrivateKeys[3], round: 2, validRound: 1));
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0],
+                    TestUtils.ConsensusPrivateKeys[0],
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -58,7 +58,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(new
                 ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2],
+                    TestUtils.ConsensusPrivateKeys[2],
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -69,7 +69,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3],
+                    TestUtils.ConsensusPrivateKeys[3],
                     1,
                     round: 1,
                     hash: block.Hash,
@@ -102,17 +102,17 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                invalidBlock, TestUtils.PrivateKeys[NodeId], round: 0, validRound: -1));
+                invalidBlock, TestUtils.ConsensusPrivateKeys[NodeId], round: 0, validRound: -1));
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                invalidBlock, TestUtils.PrivateKeys[2], round: 1, validRound: 0));
+                invalidBlock, TestUtils.ConsensusPrivateKeys[2], round: 1, validRound: 0));
 
             Context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                invalidBlock, TestUtils.PrivateKeys[3], round: 2, validRound: 1));
+                invalidBlock, TestUtils.ConsensusPrivateKeys[3], round: 2, validRound: 1));
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0],
+                    TestUtils.ConsensusPrivateKeys[0],
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,
@@ -123,7 +123,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(new
                 ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2],
+                    TestUtils.ConsensusPrivateKeys[2],
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,
@@ -134,7 +134,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 new ConsensusVote(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3],
+                    TestUtils.ConsensusPrivateKeys[3],
                     1,
                     round: 1,
                     hash: invalidBlock.Hash,

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -105,7 +105,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[0]));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[0]));
             await exceptionOccurred.WaitAsync();
 
             Assert.True(exceptionThrown is InvalidProposerProposeMessageException);
@@ -126,7 +126,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(default, TestUtils.PrivateKeys[NodeId]));
+                TestUtils.CreateConsensusPropose(default, TestUtils.ConsensusPrivateKeys[NodeId]));
             await exceptionOccurred.WaitAsync();
 
             Assert.True(exceptionThrown is InvalidBlockProposeMessageException);
@@ -157,7 +157,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                         DateTimeOffset.UtcNow,
                         TestUtils.Validators[0],
                         VoteFlag.Absent,
-                        null).Sign(TestUtils.PrivateKeys[NodeId])));
+                        null).Sign(TestUtils.ConsensusPrivateKeys[NodeId])));
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
 
@@ -173,7 +173,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                         DateTimeOffset.UtcNow,
                         TestUtils.Validators[0],
                         VoteFlag.Absent,
-                        null).Sign(TestUtils.PrivateKeys[NodeId])));
+                        null).Sign(TestUtils.ConsensusPrivateKeys[NodeId])));
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
         }
@@ -195,7 +195,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             _ = Context.MutationConsumerTask(default);
 
             Context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[2], 2, 2));
+                TestUtils.CreateConsensusPropose(block, TestUtils.ConsensusPrivateKeys[2], 2, 2));
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidHeightMessageException);
 
@@ -205,7 +205,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2],
+                        TestUtils.ConsensusPrivateKeys[2],
                         2,
                         0,
                         block.Hash,
@@ -222,7 +222,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2],
+                        TestUtils.ConsensusPrivateKeys[2],
                         2,
                         0,
                         block.Hash,
@@ -253,7 +253,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 1, hash: blockHash, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[0],
+                        1,
+                        hash: blockHash,
+                        flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[0],
                 });
@@ -261,7 +264,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusVote(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, hash: blockHash, flag: VoteFlag.Absent))
+                        TestUtils.ConsensusPrivateKeys[2],
+                        1,
+                        hash: blockHash,
+                        flag: VoteFlag.Absent))
                 {
                     Remote = TestUtils.Peers[2],
                 });
@@ -269,7 +275,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, hash: blockHash, flag: VoteFlag.Commit))
+                        TestUtils.ConsensusPrivateKeys[2],
+                        1,
+                        hash: blockHash,
+                        flag: VoteFlag.Commit))
                 {
                     Remote = TestUtils.Peers[2],
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -56,6 +56,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 BlockChain,
                 height,
                 privateKey: TestUtils.PrivateKeys[(int)nodeId],
+                consensusPrivateKey: TestUtils.ConsensusPrivateKeys[(int)nodeId],
                 validators: TestUtils.Validators,
                 _newHeightDelay);
 
@@ -64,6 +65,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 BlockChain,
                 height,
                 TestUtils.PrivateKeys[(int)nodeId],
+                TestUtils.ConsensusPrivateKeys[(int)nodeId],
                 TestUtils.Validators,
                 step,
                 round);

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -77,7 +77,7 @@ namespace Libplanet.Net.Tests.Consensus
                 await gossip2.WaitForRunningAsync();
                 gossip1.AddMessage(
                     new ConsensusPropose(
-                        new PrivateKey().PublicKey,
+                        new BlsPrivateKey().PublicKey,
                         0,
                         0,
                         TestUtils.BlockHash0,
@@ -137,7 +137,7 @@ namespace Libplanet.Net.Tests.Consensus
                 _ = gossip2.StartAsync(default);
                 await gossip1.WaitForRunningAsync();
                 await gossip2.WaitForRunningAsync();
-                PublicKey key = new PrivateKey().PublicKey;
+                BlsPublicKey key = new BlsPrivateKey().PublicKey;
                 gossip1.AddMessages(
                     new[]
                     {

--- a/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
+++ b/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Net.Tests.Consensus
         public void GetGossipIds_Shift()
         {
             var cache = new MessageCache(2, 1);
-            var key = new PrivateKey().PublicKey;
+            var key = new BlsPrivateKey().PublicKey;
             var msg0 = new ConsensusPropose(key, 0, 0, TestUtils.BlockHash0, new byte[] { }, -1);
             var msg1 = new ConsensusPropose(key, 0, 1, TestUtils.BlockHash0, new byte[] { }, -1);
             var msg2 = new ConsensusPropose(key, 0, 2, TestUtils.BlockHash0, new byte[] { }, -1);

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -72,7 +72,6 @@ namespace Libplanet.Net.Tests
 
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
-            PrivateKey consensusPrivateKey = null,
             AppProtocolVersion? appProtocolVersion = null,
             string host = null,
             int? listenPort = null,
@@ -142,7 +141,7 @@ namespace Libplanet.Net.Tests
                 {
                     ConsensusPeers = ImmutableList<BoundPeer>.Empty,
                     ConsensusPort = 0,
-                    ConsensusPrivateKey = new PrivateKey(),
+                    ConsensusPrivateKey = new BlsPrivateKey(),
                     ConsensusWorkers = 100,
                     TargetBlockInterval = TimeSpan.FromSeconds(10),
                 });

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -22,7 +22,8 @@ namespace Libplanet.Net.Consensus
     {
         private readonly BlockChain<T> _blockChain;
         private readonly PrivateKey _privateKey;
-        private readonly List<PublicKey> _validators;
+        private readonly BlsPrivateKey _consensusPrivateKey;
+        private readonly List<BlsPublicKey> _validators;
         private readonly TimeSpan _newHeightDelay;
         private readonly ILogger _logger;
         private readonly Dictionary<long, Context<T>> _contexts;
@@ -41,7 +42,9 @@ namespace Libplanet.Net.Consensus
         /// <param name="height">The current height of consensus. this value should be same as the
         /// index of <see cref="BlockChain{T}.Tip"/> + 1.
         /// </param>
-        /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
+        /// <param name="privateKey">A <see cref="PrivateKey"/> for signing a block.
+        /// </param>
+        /// <param name="consensusPrivateKey"> A <see cref="BlsPrivateKey"/> for signing a message.
         /// </param>
         /// <param name="validators">A list of validator's <see cref="PublicKey"/>,
         /// also including self.
@@ -54,12 +57,14 @@ namespace Libplanet.Net.Consensus
             BlockChain<T> blockChain,
             long height,
             PrivateKey privateKey,
-            List<PublicKey> validators,
+            BlsPrivateKey consensusPrivateKey,
+            List<BlsPublicKey> validators,
             TimeSpan newHeightDelay)
         {
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
             _privateKey = privateKey;
+            _consensusPrivateKey = consensusPrivateKey;
             _validators = validators;
             Height = height;
             _newHeightDelay = newHeightDelay;
@@ -168,6 +173,7 @@ namespace Libplanet.Net.Consensus
                     _blockChain,
                     height,
                     _privateKey,
+                    _consensusPrivateKey,
                     _validators);
             }
 
@@ -216,6 +222,7 @@ namespace Libplanet.Net.Consensus
                     _blockChain,
                     height,
                     _privateKey,
+                    _consensusPrivateKey,
                     _validators);
             }
 

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -36,7 +36,9 @@ namespace Libplanet.Net.Consensus
         /// <param name="blockChain">A blockchain that will be committed, which
         /// will be voted by consensus, and used for proposing a block.
         /// </param>
-        /// <param name="privateKey">A <see cref="PrivateKey"/> for using in signing a block,
+        /// <param name="privateKey">A <see cref="PrivateKey"/> for using in signing a block.
+        /// </param>
+        /// <param name="consensusPrivateKey">A <see cref="BlsPrivateKey"/> for using in signing a
         /// message.
         /// </param>
         /// <param name="validatorPeers">A list of validator's <see cref="PublicKey"/>, including
@@ -49,6 +51,7 @@ namespace Libplanet.Net.Consensus
             ITransport consensusTransport,
             BlockChain<T> blockChain,
             PrivateKey privateKey,
+            BlsPrivateKey consensusPrivateKey,
             ImmutableList<BoundPeer> validatorPeers,
             TimeSpan newHeightDelay)
         {
@@ -64,7 +67,8 @@ namespace Libplanet.Net.Consensus
                 blockChain,
                 blockChain.Tip.Index,
                 privateKey,
-                validatorPeers.Select(x => x.PublicKey).ToList(),
+                consensusPrivateKey,
+                validatorPeers.Select(x => (BlsPublicKey)x.PublicKey).ToList(),
                 newHeightDelay);
 
             _logger = Log

--- a/Libplanet.Net/Consensus/ConsensusReactorOption.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactorOption.cs
@@ -22,9 +22,9 @@ namespace Libplanet.Net.Consensus
         public int ConsensusWorkers { get; set; }
 
         /// <summary>
-        /// A <see cref="PrivateKey"/> for signing block and message.
+        /// A <see cref="BlsPrivateKey"/> for signing block and message.
         /// </summary>
-        public PrivateKey ConsensusPrivateKey { get; set; }
+        public BlsPrivateKey ConsensusPrivateKey { get; set; }
 
         /// <summary>
         /// A list of validators.

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net.Consensus
                 ToString());
             Round = round;
             Step = Step.Propose;
-            if (Proposer(Round) == _privateKey.PublicKey)
+            if (Proposer(Round) == _consensusPrivateKey.PublicKey)
             {
                 _logger.Debug(
                     "Starting round {NewRound} and is a proposer. (context: {Context})",
@@ -34,7 +34,7 @@ namespace Libplanet.Net.Consensus
 
                 BroadcastMessage(
                     new ConsensusPropose(
-                        _privateKey.PublicKey,
+                        _consensusPrivateKey.PublicKey,
                         Height,
                         Round,
                         proposal.Hash,

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -247,7 +247,7 @@ namespace Libplanet.Net.Consensus
         {
             var dict = new Dictionary<string, object>
             {
-                { "node_id", _privateKey.ToAddress().ToString() },
+                { "node_id", _consensusPrivateKey.ToAddress().ToString() },
                 { "number_of_validator", _validators.Count },
                 { "height", Height },
                 { "round", Round },

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -87,12 +87,13 @@ namespace Libplanet.Net.Consensus
 
         private readonly BlockChain<T> _blockChain;
         private readonly Codec _codec;
-        private readonly List<PublicKey> _validators;
+        private readonly List<BlsPublicKey> _validators;
         private readonly Channel<ConsensusMessage> _messageRequests;
         private readonly Channel<System.Action> _mutationRequests;
         private readonly MessageLog _messageLog;
 
         private readonly PrivateKey _privateKey;
+        private readonly BlsPrivateKey _consensusPrivateKey;
         private readonly HashSet<int> _preVoteTimeoutFlags;
         private readonly HashSet<int> _hasTwoThirdsPreVoteFlags;
         private readonly HashSet<int> _preCommitTimeoutFlags;
@@ -118,8 +119,10 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="height">A target <see cref="Context{T}.Height"/> of the consensus state.
         /// </param>
-        /// <param name="privateKey">A private key for signing a block and message.
+        /// <param name="privateKey">A private key for signing a block.
         /// <seealso cref="GetValue"/>
+        /// </param>
+        /// <param name="consensusPrivateKey">A private key for signing a message.
         /// <seealso cref="ProcessGenericUponRules"/>
         /// <seealso cref="Voting"/>
         /// </param>
@@ -129,12 +132,14 @@ namespace Libplanet.Net.Consensus
             BlockChain<T> blockChain,
             long height,
             PrivateKey privateKey,
-            List<PublicKey> validators)
+            BlsPrivateKey consensusPrivateKey,
+            List<BlsPublicKey> validators)
             : this(
                 consensusContext,
                 blockChain,
                 height,
                 privateKey,
+                consensusPrivateKey,
                 validators,
                 Step.Default,
                 0)
@@ -146,12 +151,14 @@ namespace Libplanet.Net.Consensus
             BlockChain<T> blockChain,
             long height,
             PrivateKey privateKey,
-            List<PublicKey> validators,
+            BlsPrivateKey consensusPrivateKey,
+            List<BlsPublicKey> validators,
             Step step,
             int round = 0,
             int cacheSize = 128)
         {
             _privateKey = privateKey;
+            _consensusPrivateKey = consensusPrivateKey;
             Height = height;
             Round = round;
             Step = step;
@@ -301,10 +308,10 @@ namespace Libplanet.Net.Consensus
         /// Gets the proposer of the given round.
         /// </summary>
         /// <param name="round">A round to get proposer.</param>
-        /// <returns>Returns designated proposer's <see cref="PublicKey"/> for the
+        /// <returns>Returns designated proposer's <see cref="BlsPublicKey"/> for the
         /// <paramref name="round"/>.
         /// </returns>
-        private PublicKey Proposer(int round)
+        private BlsPublicKey Proposer(int round)
         {
             // return designated proposer for the height round pair.
             return _validators[(int)((Height + round) % TotalValidators)];
@@ -358,9 +365,9 @@ namespace Libplanet.Net.Consensus
                 round,
                 hash,
                 DateTimeOffset.UtcNow,
-                _privateKey.PublicKey,
+                _consensusPrivateKey.PublicKey,
                 flag,
-                null).Sign(_privateKey);
+                null).Sign(_consensusPrivateKey);
         }
 
         /// <summary>

--- a/Libplanet.Net/Messages/ConsensusMessage.cs
+++ b/Libplanet.Net/Messages/ConsensusMessage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
@@ -17,12 +18,12 @@ namespace Libplanet.Net.Messages
         /// Initializes a new instance of the <see cref="ConsensusMessage"/> class.
         /// </summary>
         /// <param name="validator">
-        /// A <see cref="PublicKey"/> of the validator who made this message.</param>
+        /// A <see cref="BlsPublicKey"/> of the validator who made this message.</param>
         /// <param name="height">A <see cref="Context{T}.Height"/> the message is for.</param>
         /// <param name="round">A <see cref="Context{T}.Round"/> the message is written for.</param>
         /// <param name="blockHash">A <see cref="BlockHash"/> the message is written for.</param>
         protected ConsensusMessage(
-            PublicKey validator,
+            BlsPublicKey validator,
             long height,
             int round,
             BlockHash? blockHash)
@@ -40,7 +41,7 @@ namespace Libplanet.Net.Messages
         /// <param name="dataframes">A marshalled message.</param>
         protected ConsensusMessage(byte[][] dataframes)
         {
-            Validator = new PublicKey(dataframes[0]);
+            Validator = new BlsPublicKey(dataframes[0]);
             Height = BitConverter.ToInt64(dataframes[1], 0);
             Round = BitConverter.ToInt32(dataframes[2], 0);
             if (dataframes[3].Length == 1 && dataframes[3][0] == Nil)
@@ -54,9 +55,9 @@ namespace Libplanet.Net.Messages
         }
 
         /// <summary>
-        /// A <see cref="PublicKey"/> of the validator who made this message.
+        /// A <see cref="BlsPublicKey"/> of the validator who made this message.
         /// </summary>
-        public PublicKey Validator { get; }
+        public BlsPublicKey Validator { get; }
 
         /// <summary>
         /// A <see cref="Context{T}.Height"/> the message is written for.
@@ -78,7 +79,7 @@ namespace Libplanet.Net.Messages
         /// </summary>
         public override IEnumerable<byte[]> DataFrames => new[]
         {
-            Validator.Format(true),
+            Validator.KeyBytes.ToArray(),
             BitConverter.GetBytes(Height),
             BitConverter.GetBytes(Round),
             BlockHash is { } blockHash ? blockHash.ToByteArray() : new[] { Nil },

--- a/Libplanet.Net/Messages/ConsensusPropose.cs
+++ b/Libplanet.Net/Messages/ConsensusPropose.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
@@ -15,7 +16,7 @@ namespace Libplanet.Net.Messages
         /// Initializes a new instance of the <see cref="ConsensusPropose"/> class.
         /// </summary>
         /// <param name="validator">
-        /// A <see cref="PublicKey"/> of the validator whe made this message.</param>
+        /// A <see cref="BlsPublicKey"/> of the validator whe made this message.</param>
         /// <param name="height">A <see cref="Context{T}.Height"/> the message is for.</param>
         /// <param name="round">A <see cref="Context{T}.Round"/> the message is written for.</param>
         /// <param name="blockHash">A <see cref="BlockHash"/> the message is written for.</param>
@@ -24,7 +25,7 @@ namespace Libplanet.Net.Messages
         /// <see cref="Libplanet.Net.Consensus.Step.PreVote"/> round.
         /// </param>
         public ConsensusPropose(
-            PublicKey validator,
+            BlsPublicKey validator,
             long height,
             int round,
             BlockHash blockHash,
@@ -65,7 +66,7 @@ namespace Libplanet.Net.Messages
             {
                 var frames = new List<byte[]>
                 {
-                    Validator.Format(true),
+                    Validator.KeyBytes.ToArray(),
                     BitConverter.GetBytes(Height),
                     BitConverter.GetBytes(Round),
                     BlockHash is { } blockHash ? blockHash.ToByteArray() : new[] { Nil },

--- a/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/Libplanet.Net/Messages/IMessageCodec.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Net.Messages
         /// <paramref name="privateKey"/> and <paramref name="peer"/>.
         /// </summary>
         /// <param name="message">The message to encode.</param>
-        /// <param name="privateKey">The <see cref="PrivateKey"/> to sign the encoded message.
+        /// <param name="privateKey">The <see cref="IPrivateKey"/> to sign the encoded message.
         /// </param>
         /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> of
         /// the transport layer.</param>
@@ -27,7 +27,7 @@ namespace Libplanet.Net.Messages
         /// <see cref="PublicKey"/> does not match that of <paramref name="peer"/>.</exception>
         T Encode(
             Message message,
-            PrivateKey privateKey,
+            IPrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
             BoundPeer peer,
             DateTimeOffset timestamp);

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Messages
         /// <inheritdoc/>
         public NetMQMessage Encode(
             Message message,
-            PrivateKey privateKey,
+            IPrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
             BoundPeer peer,
             DateTimeOffset timestamp)

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -137,6 +137,7 @@ namespace Libplanet.Net
                 _consensusReactor = new ConsensusReactor<T>(
                     consensusTransport,
                     BlockChain,
+                    _privateKey,
                     consensusReactorOption.ConsensusPrivateKey,
                     consensusReactorOption.ConsensusPeers,
                     consensusReactorOption.TargetBlockInterval);

--- a/Libplanet.Net/Transports/InvalidCredentialException.cs
+++ b/Libplanet.Net/Transports/InvalidCredentialException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
@@ -15,8 +16,8 @@ namespace Libplanet.Net.Transports
     {
         internal InvalidCredentialException(
             string message,
-            PublicKey expected,
-            PublicKey actual)
+            IPublicKey expected,
+            IPublicKey actual)
             : base(message)
         {
             Expected = expected;
@@ -32,16 +33,16 @@ namespace Libplanet.Net.Transports
             Actual = new PublicKey(info.GetValue<byte[]>(nameof(Actual)));
         }
 
-        public PublicKey Expected { get; private set; }
+        public IPublicKey Expected { get; private set; }
 
-        public PublicKey Actual { get; private set; }
+        public IPublicKey Actual { get; private set; }
 
         public override void GetObjectData(
             SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Expected), Expected.Format(true));
-            info.AddValue(nameof(Actual), Actual.Format(true));
+            info.AddValue(nameof(Expected), Expected.KeyBytes.ToArray());
+            info.AddValue(nameof(Actual), Actual.KeyBytes.ToArray());
         }
     }
 }

--- a/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
+++ b/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
@@ -16,7 +17,7 @@ namespace Libplanet.Net.Transports
         internal InvalidMessageSignatureException(
             string message,
             BoundPeer peer,
-            PublicKey publicKey,
+            IPublicKey publicKey,
             byte[] messageToVerify,
             byte[] signature)
             : base(message)
@@ -40,7 +41,7 @@ namespace Libplanet.Net.Transports
 
         public BoundPeer Peer { get; private set; }
 
-        public PublicKey PublicKey { get; private set; }
+        public IPublicKey PublicKey { get; private set; }
 
         public byte[] MessageToVerify { get; private set; }
 
@@ -51,7 +52,7 @@ namespace Libplanet.Net.Transports
         {
             base.GetObjectData(info, context);
             info.AddValue(nameof(Peer), Peer);
-            info.AddValue(nameof(PublicKey), PublicKey.Format(true));
+            info.AddValue(nameof(PublicKey), PublicKey.KeyBytes.ToArray());
             info.AddValue(nameof(MessageToVerify), MessageToVerify);
             info.AddValue(nameof(Signature), Signature);
         }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Net.Transports
     /// </summary>
     public class NetMQTransport : ITransport
     {
-        private readonly PrivateKey _privateKey;
+        private readonly IPrivateKey _privateKey;
         private readonly string _host;
         private readonly IList<IceServer> _iceServers;
         private readonly ILogger _logger;
@@ -64,7 +64,7 @@ namespace Libplanet.Net.Transports
         /// <summary>
         /// Creates a <see cref="NetMQTransport"/> instance.
         /// </summary>
-        /// <param name="privateKey"><see cref="PrivateKey"/> of the transport layer.</param>
+        /// <param name="privateKey"><see cref="IPrivateKey"/> of the transport layer.</param>
         /// <param name="appProtocolVersion"><see cref="AppProtocolVersion"/>-typed
         /// version of the transport layer.</param>
         /// <param name="trustedAppProtocolVersionSigners"><see cref="PublicKey"/>s of parties
@@ -91,8 +91,8 @@ namespace Libplanet.Net.Transports
         /// If <c>null</c>, any timestamp is accepted.</param>
         /// <exception cref="ArgumentException">Thrown when both <paramref name="host"/> and
         /// <paramref name="iceServers"/> are <c>null</c>.</exception>
-        private NetMQTransport(
-            PrivateKey privateKey,
+        public NetMQTransport(
+            IPrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
             int workers,
@@ -231,7 +231,7 @@ namespace Libplanet.Net.Transports
         /// receive reply <see cref="Message"/>s.
         /// </returns>
         public static async Task<NetMQTransport> Create(
-            PrivateKey privateKey,
+            IPrivateKey privateKey,
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
             int workers,

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -4,7 +4,6 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Crypto;
 using Libplanet.Net;
-using Libplanet.Net.Consensus;
 using Libplanet.Store;
 
 namespace Libplanet.Node
@@ -26,19 +25,11 @@ namespace Libplanet.Node
         private PrivateKey _privateKey;
 
         /// <summary>
-        /// The <see cref="PrivateKey"/> used to sign consensus related messages.
-        /// </summary>
-        private PrivateKey _consensusPrivateKey;
-
-        /// <summary>
         /// Initialize a <see cref="NodeConfig{T}"/> instance.
         /// </summary>
         /// <param name="privateKey">The <see cref="PrivateKey"/> to use to initialize
         /// a <see cref="Swarm{T}"/> instance.  This determines the identity of a node
         /// on the network.</param>
-        /// <param name="consensusPrivateKey">>The <see cref="PrivateKey"/> to use in
-        /// an <see cref="IReactor"/> instance.  This is used to sign consensus related
-        /// messages.</param>
         /// <param name="networkConfig">The <see cref="Node.NetworkConfig{T}"/> to use.</param>
         /// <param name="swarmConfig">The <see cref="Node.SwarmConfig"/> to use.</param>
         /// <param name="store">The <see cref="IStore"/> to use for storing chain data.</param>
@@ -48,7 +39,6 @@ namespace Libplanet.Node
         /// <see cref="BlockChain{T}.Tip"/> changes.</param>
         public NodeConfig(
             PrivateKey privateKey,
-            PrivateKey consensusPrivateKey,
             NetworkConfig<T> networkConfig,
             SwarmConfig swarmConfig,
             IStore store,
@@ -56,7 +46,6 @@ namespace Libplanet.Node
             IEnumerable<IRenderer<T>>? renderers)
         {
             _privateKey = privateKey;
-            _consensusPrivateKey = consensusPrivateKey;
             NetworkConfig = networkConfig;
             SwarmConfig = swarmConfig;
             Store = store;

--- a/Libplanet.Node/SwarmConfig.cs
+++ b/Libplanet.Node/SwarmConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Libplanet.Net;
@@ -141,7 +142,7 @@ namespace Libplanet.Node
                 BoundPeer value,
                 JsonSerializerOptions options)
             {
-                string pubKeyString = ByteUtil.Hex(value.PublicKey.Format(true));
+                string pubKeyString = ByteUtil.Hex(value.PublicKey.CompressedKeyBytes.ToArray());
                 string hostString = value.EndPoint.Host;
                 string portString = value.EndPoint.Port.ToString(CultureInfo.InvariantCulture);
                 writer.WriteStringValue($"{pubKeyString},{hostString},{portString}");

--- a/Libplanet.Tests/AddressExtensionsTest.cs
+++ b/Libplanet.Tests/AddressExtensionsTest.cs
@@ -20,5 +20,15 @@ namespace Libplanet.Tests
             Assert.Equal(expected, privateKey.ToAddress());
             Assert.Equal(expected, privateKey.PublicKey.ToAddress());
         }
+
+        [Fact]
+        public void BLSToAddress()
+        {
+            var privateKey = BlsPrivateKey.FromString(
+                    "228ca2b44ae6e03f29e8e90be5119d0bf763df538d8cdd81b051c9eabce1f1fb");
+            var expected = new Address("71Ad1E774Aa860076A585416f5bbACEd8A237E17");
+            Assert.Equal(expected, privateKey.ToAddress());
+            Assert.Equal(expected, privateKey.PublicKey.ToAddress());
+        }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -552,9 +552,9 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void ProposeBlockWithLastCommit()
         {
-            var keyA = new PrivateKey();
-            var keyB = new PrivateKey();
-            var keyC = new PrivateKey();
+            var keyA = new BlsPrivateKey();
+            var keyB = new BlsPrivateKey();
+            var keyC = new BlsPrivateKey();
 
             var voteSet = new VoteSet(
                 _blockChain.Tip.Index,

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blocks
                                               0,
                                               fx.Hash1,
                                               DateTimeOffset.Now,
-                                              new PrivateKey().PublicKey,
+                                              new BlsPrivateKey().PublicKey,
                                               VoteFlag.Absent,
                                               ImmutableArray<byte>.Empty))
                                           .ToImmutableArray();

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -17,6 +17,7 @@ namespace Libplanet.Tests.Blocks
 
         public BlockFixture()
         {
+            Validator = TestUtils.DummyValidator;
             Miner = TestUtils.GenesisMiner;
             Genesis = TestUtils.ProposeGenesisBlock<PolymorphicAction<BaseAction>>(
                 protocolVersion: ProtocolVersion,
@@ -29,8 +30,6 @@ namespace Libplanet.Tests.Blocks
                 Genesis,
                 miner: Miner,
                 protocolVersion: ProtocolVersion,
-                stateRootHash: HashDigest<SHA256>.FromString(
-                    "6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa"),
                 lastCommit: new BlockCommit(
                     height: Genesis.Index,
                     round: 0,
@@ -42,9 +41,9 @@ namespace Libplanet.Tests.Blocks
                             0,
                             Genesis.Hash,
                             Genesis.Timestamp,
-                            Miner.PublicKey,
+                            Validator.PublicKey,
                             VoteFlag.Commit,
-                            null).Sign(Miner),
+                            null).Sign(Validator),
                     }.ToImmutableArray())
             );
             HasTx = TestUtils.ProposeNextBlock(
@@ -68,9 +67,9 @@ namespace Libplanet.Tests.Blocks
                             0,
                             Next.Hash,
                             Next.Timestamp,
-                            Miner.PublicKey,
+                            Validator.PublicKey,
                             VoteFlag.Commit,
-                            null).Sign(Miner),
+                            null).Sign(Validator),
                     }.ToImmutableArray())
             );
         }
@@ -84,5 +83,7 @@ namespace Libplanet.Tests.Blocks
         internal Block<PolymorphicAction<BaseAction>> Next { get; }
 
         internal Block<PolymorphicAction<BaseAction>> HasTx { get; }
+
+        private BlsPrivateKey Validator { get; }
     }
 }

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -31,6 +31,10 @@ namespace Libplanet.Tests.Blocks
             var validatorB = new PrivateKey();
             var validatorC = new PrivateKey();
             var invalidValidator = new PrivateKey();
+            var validatorAConsensus = new BlsPrivateKey();
+            var validatorBConsensus = new BlsPrivateKey();
+            var validatorCConsensus = new BlsPrivateKey();
+            var invalidValidatorConsensus = new BlsPrivateKey();
             BlockHash blockHash = BlockHash.FromString(
                 "341e8f360597d5bc45ab96aabc5f1b0608063f30af7bd4153556c9536a07693a"
             );
@@ -40,25 +44,25 @@ namespace Libplanet.Tests.Blocks
                 0,
                 blockHash,
                 timestamp,
-                validatorA.PublicKey,
+                validatorAConsensus.PublicKey,
                 VoteFlag.Commit,
-                null).Sign(validatorA);
+                null).Sign(validatorAConsensus);
             var voteB = new Vote(
                 1,
                 0,
                 blockHash,
                 timestamp,
-                validatorB.PublicKey,
+                validatorBConsensus.PublicKey,
                 VoteFlag.Commit,
-                null).Sign(validatorB);
+                null).Sign(validatorBConsensus);
             var voteC = new Vote(
                 1,
                 0,
                 blockHash,
                 timestamp,
-                validatorC.PublicKey,
+                validatorCConsensus.PublicKey,
                 VoteFlag.Commit,
-                null).Sign(validatorC);
+                null).Sign(validatorCConsensus);
 
             // Height of the last commit is invalid.
             var invalidHeightLastCommit = new BlockCommit(
@@ -116,9 +120,9 @@ namespace Libplanet.Tests.Blocks
                         0,
                         blockHash,
                         timestamp,
-                        validatorC.PublicKey,
+                        validatorCConsensus.PublicKey,
                         VoteFlag.Commit,
-                        null).Sign(invalidValidator),
+                        null).Sign(invalidValidatorConsensus),
                 }.ToImmutableArray());
             var invalidVoteSignatureMetadata = new BlockMetadata
             {
@@ -148,9 +152,9 @@ namespace Libplanet.Tests.Blocks
                         0,
                         blockHash,
                         timestamp,
-                        validatorC.PublicKey,
+                        validatorCConsensus.PublicKey,
                         VoteFlag.Commit,
-                        null).Sign(validatorC),
+                        null).Sign(validatorCConsensus),
                 }.ToImmutableArray());
             var invalidVoteHeightMetadata = new BlockMetadata
             {
@@ -179,7 +183,7 @@ namespace Libplanet.Tests.Blocks
                         0,
                         blockHash,
                         timestamp,
-                        validatorB.PublicKey,
+                        validatorBConsensus.PublicKey,
                         VoteFlag.Null,
                         null),
                     new Vote(
@@ -187,7 +191,7 @@ namespace Libplanet.Tests.Blocks
                         0,
                         blockHash,
                         timestamp,
-                        validatorC.PublicKey,
+                        validatorCConsensus.PublicKey,
                         VoteFlag.Unknown,
                         null),
                 }.ToImmutableArray());

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Tests.Consensus
              var fx = new MemoryStoreFixture();
              BlockHash targetBlockHash = fx.Hash1;
              var validators = Enumerable.Range(0, 4)
-                 .Select(x => new PrivateKey())
+                 .Select(x => new BlsPrivateKey())
                  .ToArray();
              var voteSet = new VoteSet(
                  1,
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Consensus
              var fx = new MemoryStoreFixture();
              BlockHash targetBlockHash = fx.Hash1;
              var validators = Enumerable.Range(0, 4)
-                 .Select(x => new PrivateKey())
+                 .Select(x => new BlsPrivateKey())
                  .ToArray();
              var voteSet = new VoteSet(
                  1,

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tests.Consensus
                 2,
                 fx.Hash1,
                 now,
-                new PrivateKey().PublicKey,
+                new BlsPrivateKey().PublicKey,
                 VoteFlag.Commit,
                 null);
             byte[] marshaled = vote.ByteArray;
@@ -31,7 +31,7 @@ namespace Libplanet.Tests.Consensus
         {
             var fx = new MemoryStoreFixture();
             var now = DateTimeOffset.UtcNow;
-            var privateKey = new PrivateKey();
+            var privateKey = new BlsPrivateKey();
             var vote = new Vote(
                 1,
                 2,

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -31,6 +31,9 @@ namespace Libplanet.Tests
         public static readonly PrivateKey GenesisMiner = PrivateKey.FromString(
             "2a15e7deaac09ce631e1faa184efadb175b6b90989cf1faed9dfc321ad1db5ac");
 
+        public static readonly BlsPrivateKey DummyValidator = BlsPrivateKey.FromString(
+            "04ee188b27836eb385f9876107847b5e65cd999204718a62f4c92a94c43ee236");
+
         public static readonly PrivateKey ChainPrivateKey = PrivateKey.FromString(
             "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76");
 

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -95,16 +95,16 @@ namespace Libplanet
 
         /// <summary>
         /// Derives the corresponding <see cref="Address"/> from a <see
-        /// cref="PublicKey"/>.
+        /// cref="IPublicKey"/>.
         /// <para>Note that there is an equivalent extension method
-        /// <see cref="AddressExtensions.ToAddress(PublicKey)"/>, which enables
+        /// <see cref="AddressExtensions.ToAddress(IPublicKey)"/>, which enables
         /// a code like <c>publicKey.ToAddress()</c> instead of
         /// <c>new Address(publicKey)</c>, for convenience.</para>
         /// </summary>
         /// <param name="publicKey">A <see cref="PublicKey"/> to derive
         /// the corresponding <see cref="Address"/> from.</param>
-        /// <seealso cref="AddressExtensions.ToAddress(PublicKey)"/>
-        public Address(PublicKey publicKey)
+        /// <seealso cref="AddressExtensions.ToAddress(IPublicKey)"/>
+        public Address(IPublicKey publicKey)
             : this(DeriveAddress(publicKey))
         {
         }
@@ -305,9 +305,9 @@ namespace Libplanet
             return output;
         }
 
-        private static byte[] DeriveAddress(PublicKey key)
+        private static byte[] DeriveAddress(IPublicKey key)
         {
-            byte[] hashPayload = key.Format(false).Skip(1).ToArray();
+            byte[] hashPayload = key.KeyBytes.Skip(1).ToArray();
             var output = CalculateHash(hashPayload);
 
             return output.Skip(output.Length - Size).ToArray();

--- a/Libplanet/AddressExtensions.cs
+++ b/Libplanet/AddressExtensions.cs
@@ -11,31 +11,31 @@ namespace Libplanet
     {
         /// <summary>
         /// Derives the corresponding <see cref="Address"/> from a <see
-        /// cref="PublicKey"/>.
+        /// cref="IPublicKey"/>.
         /// <para>This enables a code like <c>publicKey.ToAddress()</c> instead
         /// of <c>new Address(publicKey)</c>.</para>
         /// </summary>
-        /// <param name="publicKey">A <see cref="PublicKey"/> to derive
+        /// <param name="publicKey">A <see cref="IPublicKey"/> to derive
         /// the corresponding <see cref="Address"/> from.</param>
         /// <returns>The corresponding <see cref="Address"/> derived from
         /// <paramref name="publicKey"/>.</returns>
-        /// <seealso cref="Address(PublicKey)"/>
-        public static Address ToAddress(this PublicKey publicKey)
+        /// <seealso cref="Address(IPublicKey)"/>
+        public static Address ToAddress(this IPublicKey publicKey)
         {
             return new Address(publicKey);
         }
 
         /// <summary>
         /// Derives the corresponding <see cref="Address"/> from a <see
-        /// cref="PrivateKey"/>.
+        /// cref="IPrivateKey"/>.
         /// <para>This enables a code like <c>privateKey.ToAddress()</c> instead
         /// of <c>new Address(privateKey.PublicKey)</c>.</para>
         /// </summary>
-        /// <param name="privateKey">A <see cref="PrivateKey"/> to derive
+        /// <param name="privateKey">A <see cref="IPrivateKey"/> to derive
         /// the corresponding <see cref="Address"/> from.</param>
         /// <returns>The corresponding <see cref="Address"/> derived from
         /// <paramref name="privateKey"/>.</returns>
-        public static Address ToAddress(this PrivateKey privateKey)
+        public static Address ToAddress(this IPrivateKey privateKey)
         {
             return new Address(privateKey.PublicKey);
         }

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Consensus
     {
         // FIXME: Should separate prevote lock and commit vote lock?
         private readonly object _lock;
-        private Dictionary<PublicKey, Vote> _votes;
+        private Dictionary<BlsPublicKey, Vote> _votes;
 
         /// <summary>
         /// Creates a <see cref="VoteSet"/> instance with its <paramref name="height"/>,
@@ -30,7 +30,7 @@ namespace Libplanet.Consensus
             long height,
             int round,
             BlockHash? blockHash,
-            IEnumerable<PublicKey> validatorSet)
+            IEnumerable<BlsPublicKey> validatorSet)
         {
             Height = height;
             Round = round;
@@ -62,9 +62,9 @@ namespace Libplanet.Consensus
         public int Round { get; }
 
         /// <summary>
-        /// A list of validator's <see cref="PublicKey"/> of <see cref="VoteSet"/>'s target.
+        /// A list of validator's <see cref="BlsPublicKey"/> of <see cref="VoteSet"/>'s target.
         /// </summary>
-        public ImmutableArray<PublicKey> ValidatorSet { get; }
+        public ImmutableArray<BlsPublicKey> ValidatorSet { get; }
 
         /// <summary>
         /// <see cref="Vote"/>s in this VoteSet.

--- a/Libplanet/Crypto/BlsPublicKey.cs
+++ b/Libplanet/Crypto/BlsPublicKey.cs
@@ -63,7 +63,16 @@ namespace Libplanet.Crypto
             _ = CryptoConfig.ConsensusCryptoBackend.ValidateGetNativePublicKey(this);
         }
 
+        /// <summary>
+        /// A <see cref="byte"/> representation of <see cref="BlsPublicKey"/>.
+        /// </summary>
         public ImmutableArray<byte> KeyBytes => ToImmutableArray();
+
+        /// <summary>
+        /// A compressed <see cref="byte"/> representation of <see cref="BlsPublicKey"/>. Currently,
+        /// it has no compressed format, so the return value will be same as <see cref="KeyBytes"/>.
+        /// </summary>
+        public ImmutableArray<byte> CompressedKeyBytes => ToImmutableArray();
 
         public static bool operator ==(BlsPublicKey left, BlsPublicKey right) =>
             left.Equals(right);

--- a/Libplanet/Crypto/BlsPublicKey.cs
+++ b/Libplanet/Crypto/BlsPublicKey.cs
@@ -43,6 +43,12 @@ namespace Libplanet.Crypto
         /// </summary>
         /// <param name="publicKey">A valid <see cref="byte"/> array that
         /// encodes an BLS public key.</param>
+        /// <exception cref="ArgumentNullException">Thrown if given public key array is empty.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the length of given public key
+        /// is not <see cref="KeyBytes"/>.</exception>
+        /// <exception cref="CryptographicException">Thrown if given public key is invalid.
+        /// </exception>
         public BlsPublicKey(IReadOnlyList<byte> publicKey)
         {
             if (publicKey is ImmutableArray<byte> i ? i.IsDefaultOrEmpty : !publicKey.Any())
@@ -97,6 +103,9 @@ namespace Libplanet.Crypto
         /// <param name="proofOfPossession">A proof of possession derived from
         /// <see cref="BlsPrivateKey"/> of this <see cref="BlsPublicKey"/>.</param>
         /// <returns>Returns the proof of possession of <see cref="BlsPublicKey"/>.</returns>
+        /// <exception cref="CryptographicException">Thrown if given
+        /// <paramref name="proofOfPossession"/> is invalid.
+        /// </exception>
         /// <remarks>The infinite public key (e.g., derived from zero private key) cannot be
         /// validated with Proof of possession of its infinite signature and considered invalid,
         /// the infinite public key also can be filtered with proof of possession.
@@ -144,6 +153,12 @@ namespace Libplanet.Crypto
         /// <returns><c>true</c> if the <paramref name="signature"/> proves authenticity of
         /// the <paramref name="message"/> with the corresponding <see cref="BlsPublicKey"/>.
         /// Otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="message"/> or
+        /// <paramref name="signature"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="message"/> or
+        /// <paramref name="signature"/> is empty.</exception>
+        /// <exception cref="CryptographicException">Thrown if given <paramref name="signature"/>
+        /// is invalid.</exception>
         [Pure]
         public bool Verify(IReadOnlyList<byte> message, IReadOnlyList<byte> signature)
         {

--- a/Libplanet/Crypto/IPublicKey.cs
+++ b/Libplanet/Crypto/IPublicKey.cs
@@ -15,6 +15,13 @@ namespace Libplanet.Crypto
         ImmutableArray<byte> KeyBytes { get; }
 
         /// <summary>
+        /// The compressed <see cref="byte"/> representation of public key. Not every key has
+        /// compressed format. If the key does not have compressed format, the value will be
+        /// returned same value as <see cref="KeyBytes"/>.
+        /// </summary>
+        ImmutableArray<byte> CompressedKeyBytes { get; }
+
+        /// <summary>
         /// Verifies message with base public key method. See base verify method for detailed
         /// description about signing and possibly thrown exceptions.
         /// </summary>

--- a/Libplanet/Crypto/PublicKey.cs
+++ b/Libplanet/Crypto/PublicKey.cs
@@ -52,7 +52,15 @@ namespace Libplanet.Crypto
             KeyParam = keyParam;
         }
 
+        /// <summary>
+        /// A <see cref="byte"/> representation of <see cref="PublicKey"/>.
+        /// </summary>
         public ImmutableArray<byte> KeyBytes => Format(false).ToImmutableArray();
+
+        /// <summary>
+        /// A compressed <see cref="byte"/> representation of <see cref="PublicKey"/>.
+        /// </summary>
+        public ImmutableArray<byte> CompressedKeyBytes => Format(true).ToImmutableArray();
 
         internal ECPublicKeyParameters KeyParam { get; }
 

--- a/Libplanet/Crypto/PublicKeyGetter.cs
+++ b/Libplanet/Crypto/PublicKeyGetter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace Libplanet.Crypto
+{
+    /// <summary>
+    /// A static getter class for determine which public key it is by given <see cref="byte"/>
+    /// representation and returns a concrete class type in <see cref="IPublicKey"/>.
+    /// </summary>
+    public static class PublicKeyGetter
+    {
+        /// <summary>
+        /// <p>Gets a concrete class in <see cref="IPublicKey"/> by checking given
+        /// <see cref="byte"/> representation length.</p> The possible return concrete types are:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <see cref="Libplanet.Crypto.PublicKey"/>, if the length of given key is 33 or
+        ///         65 bytes (compressed and not compressed.)
+        ///     </item>
+        ///     <item>
+        ///         <see cref="Libplanet.Crypto.BlsPublicKey"/>, if the length of given key is 48
+        ///         bytes.
+        ///     </item>
+        /// </list>
+        /// See also above concrete classes for possible throwing exceptions.
+        /// </summary>
+        /// <param name="keyBytes">A <see cref="byte"/> representation of a public key.</param>
+        /// <returns>Returns a concrete public key class in <see cref="IPublicKey"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="keyBytes"/> length
+        /// is not matching with known length.</exception>
+        public static IPublicKey Get(IReadOnlyList<byte> keyBytes)
+        {
+            IPublicKey pubKey = keyBytes.Count switch
+            {
+                33 => new PublicKey(keyBytes),
+                48 => new BlsPublicKey(keyBytes),
+                65 => new PublicKey(keyBytes),
+                _ => throw new ArgumentException(nameof(pubKey)),
+            };
+
+            return pubKey;
+        }
+    }
+}


### PR DESCRIPTION
This is the following PR of https://github.com/planetarium/libplanet/pull/2223, the use-case implementation of BLS. 

### Changes
-  `Address`, `AddressExtensions`, and `BoundPeer` are now taking a public key with `IPublicKey` for supporting BLS and pre-existing `PublicKey` secp256k1.
-  `Address` can create an address from BLS. This is not intended to be used in `Transaction` but in `BoundPeer`.
-  For deserialization of public key in `BoundPeer`, static class `PublicKeyGetter` is added and used for determining which public key is given from peer string. The public key is determined by the length of a key.
-  The private key of `Transport` for signing a message is now taking a private key with `IPrivateKey`.
-  `Vote` is now using `BlsPublicKey` and `BlsPrivateKey` for signing and verifying vote messages.
-  Added BLS backend, `BlsCryptoBackend`, which is inherits `ICryptoBackend`, in as `CryptoConfig.BlsCryptoBackend`.

### Notes
-  **In Unity, The Libplanet with BLS** can be built and run but **should be cautiously used depending on IL2CPP**. Using BLS in Unity with IL2CPP[^1] is not available (Using _System.Reflections.Emit_). An action for separating should be done.

### Further discussion
-  This is the out-of-scope of this PR, however, The verification in `BlockCommit` should check whether the **last commit of a block does have +2/3 committed votes**. An arbitrary byzantine could propose a block with full _NULL_ vote last commit and bypass the verification.

[^1]: > Some platforms don’t support AOT compilation, so the IL2CPP backend doesn’t work on every platform. Other platforms support AOT and IL2CPP, but don’t allow JIT compilation, and so can’t support the Mono backend. When a platform can support both backends, Mono is the default. For more information, see [Scripting restrictions](https://docs.unity3d.com/Manual/ScriptingRestrictions.html). ...... An AOT platform cannot implement any of the methods in the System.Reflection.Emit namespace. The rest of System.Reflection is acceptable, as long as the compiler can infer that the code used via reflection needs to exist at runtime.

