### PR TITLE
Check marshaled transactions size instead of entire block size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,10 @@ To be released.
 
 ### Behavioral changes
 
+ -  `IBlockPolicy.GetMaxBlockBytes()` is used as an upper limit for the
+    encoded size of `Block<T>.Transactions` instead of `Block<T>`.
+    [[#2290], [#2291]]
+
 ### Bug fixes
 
 ### Dependencies
@@ -43,6 +47,8 @@ To be released.
 [#2273]: https://github.com/planetarium/libplanet/pull/2273
 [#2283]: https://github.com/planetarium/libplanet/pull/2283
 [#2189]: https://github.com/planetarium/libplanet/pull/2189
+[#2290]: https://github.com/planetarium/libplanet/issues/2290
+[#2291]: https://github.com/planetarium/libplanet/pull/2291
 [Bencodex 0.5.0]: https://www.nuget.org/packages/Bencodex/0.5.0
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,18 @@ To be released.
  -  Renamed `BlockChain<T>.MakeTransaction(PrivateKey, IEnumerable<T>,
     IImmutableSet<Address>, DateTimeOffset?)` method's `actions` parameter to
     `customActions`.  [[#2151], [#2273]]
+ -  Changed `IBlockPolicy.GetMaxBlockBytes()` to
+    `IBlockPolicy.GetMaxTransactionBytes()`.  Behaviourally, this is now used
+    as an upper limit for the encoded size of `Block<T>.Transactions`
+    instead of `Block<T>`.  [[#2290], [#2291]]
+     -  (Libplanet.Explorer) Changed `Options.MaxBlockBytes` to
+        `Options.MaxTransactionsBytes` and `Options.MaxGenesisBytes` to
+        `Options.MaxGenesisTransactionsBytes`.
+     -  (Libplanet.Explorer) Changed executable argument `max-block-bytes`
+        to `max-transactions-bytes` and `max-genesis-bytes` to
+        `max-genesis-transactions-bytes`.
+     -  All public method parameter names `maxBlockBytes` changed to
+        `maxTransactionsBytes`.
 
 ### Backward-incompatible network protocol changes
 
@@ -28,10 +40,6 @@ To be released.
     [[#2065], [#2198]]
 
 ### Behavioral changes
-
- -  `IBlockPolicy.GetMaxBlockBytes()` is used as an upper limit for the
-    encoded size of `Block<T>.Transactions` instead of `Block<T>`.
-    [[#2290], [#2291]]
 
 ### Bug fixes
 

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -30,8 +30,8 @@ namespace Libplanet.Explorer.Executable
             string mysqlPassword,
             string mysqlDatabase,
             int maxTransactionsPerBlock,
-            int maxBlockBytes,
-            int maxGenesisBytes,
+            int maxTransactionsBytes,
+            int maxGenesisTransactionsBytes,
             IEnumerable<string> seedStrings,
             string iceServerUrl,
             string storePath,
@@ -53,8 +53,8 @@ namespace Libplanet.Explorer.Executable
             MySQLPassword = mysqlPassword;
             MySQLDatabase = mysqlDatabase;
             MaxTransactionsPerBlock = maxTransactionsPerBlock;
-            MaxBlockBytes = maxBlockBytes;
-            MaxGenesisBytes = maxGenesisBytes;
+            MaxTransactionsBytes = maxTransactionsBytes;
+            MaxGenesisTransactionsBytes = maxGenesisTransactionsBytes;
             SeedStrings = seedStrings;
             IceServerUrl = iceServerUrl;
             StorePath = storePath;
@@ -90,9 +90,9 @@ namespace Libplanet.Explorer.Executable
 
         public int MaxTransactionsPerBlock { get; set; }
 
-        public int MaxBlockBytes { get; set; }
+        public int MaxTransactionsBytes { get; set; }
 
-        public int MaxGenesisBytes { get; set; }
+        public int MaxGenesisTransactionsBytes { get; set; }
 
         public IEnumerable<string> SeedStrings
         {

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -121,14 +121,15 @@ consecutive blocks.")]
 in a block.")]
             int maxTransactionsPerBlock = 100,
             [Option(
-                "max-block-bytes",
-                Description = @"The number of maximum bytes size of blocks except
-for genesis block.")]
-            int maxBlockBytes = 100 * 1024,
+                "max-transactions-bytes",
+                Description = @"The number of maximum bytes size of all transactions in a block
+except for genesis block.")]
+            int maxTransactionsBytes = 100 * 1024,
             [Option(
-                "max-genesis-bytes",
-                Description = "The number of maximum bytes size of the genesis block.")]
-            int maxGenesisBytes = 1024 * 1024,
+                "max-genesis-transactions-bytes",
+                Description = @"The number of maximum bytes size of all transactions
+in the genesis block.")]
+            int maxGenesisTransactionsBytes = 1024 * 1024,
             [Option(
                 "seed",
                 new[] { 's' },
@@ -159,8 +160,8 @@ If omitted (default) explorer only the local blockchain store.")]
                 mysqlPassword,
                 mysqlDatabase,
                 maxTransactionsPerBlock,
-                maxBlockBytes,
-                maxGenesisBytes,
+                maxTransactionsBytes,
+                maxGenesisTransactionsBytes,
                 seedStrings,
                 iceServerUrl,
                 storePath,
@@ -355,7 +356,9 @@ If omitted (default) explorer only the local blockchain store.")]
                 blockInterval: TimeSpan.FromMilliseconds(options.BlockIntervalMilliseconds),
                 difficultyStability: options.DifficultyBoundDivisor,
                 minimumDifficulty: options.MinimumDifficulty,
-                getMaxBlockBytes: i => i > 0 ? options.MaxBlockBytes : options.MaxGenesisBytes,
+                getMaxTransactionsBytes: i => i > 0
+                    ? options.MaxTransactionsBytes
+                    : options.MaxGenesisTransactionsBytes,
                 getMaxTransactionsPerBlock: _ => options.MaxTransactionsPerBlock);
         }
 
@@ -410,8 +413,8 @@ If omitted (default) explorer only the local blockchain store.")]
             public int GetMaxTransactionsPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerBlock(index);
 
-            public long GetMaxBlockBytes(long index) =>
-                _impl.GetMaxBlockBytes(index);
+            public long GetMaxTransactionsBytes(long index) =>
+                _impl.GetMaxTransactionsBytes(index);
 
             public long GetNextBlockDifficulty(BlockChain<NullAction> blocks)
             {

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Action
             _output = output;
             _policy = new BlockPolicy<DumbAction>(
                 blockAction: new MinerReward(1),
-                getMaxBlockBytes: _ => 50 * 1024);
+                getMaxTransactionsBytes: _ => 50 * 1024);
             _storeFx = new MemoryStoreFixture(_policy.BlockAction);
             _txFx = new TxFixture(null);
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -325,7 +325,7 @@ namespace Libplanet.Tests.Blockchain
                 difficulty: _blockChain.Policy.GetNextBlockDifficulty(_blockChain),
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(miner, _blockChain);
-            long maxBytes = _blockChain.Policy.GetMaxBlockBytes(block.Index);
+            long maxBytes = _blockChain.Policy.GetMaxTransactionsBytes(block.Index);
             Assert.True(block.MarshalBlock().EncodingLength > maxBytes);
 
             var e = Assert.Throws<InvalidBlockBytesLengthException>(() =>

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -727,8 +727,7 @@ namespace Libplanet.Tests.Blockchain
 
             // Test if minTransactions and minTransactionsPerSigner work:
             ImmutableList<Transaction<DumbAction>> gathered =
-                _blockChain.GatherTransactionsToMine(
-                    new BlockMetadata(), 1024 * 1024, 5, 3);
+                _blockChain.GatherTransactionsToMine(1024 * 1024, 5, 3);
             Assert.Equal(5, gathered.Count);
             var expectedNonces = new Dictionary<Address, long> { [a] = 0, [b] = 0, [c] = 0 };
             foreach (Transaction<DumbAction> tx in gathered)
@@ -747,8 +746,7 @@ namespace Libplanet.Tests.Blockchain
                     int rank2 = tx2.Signer.Equals(a) ? 0 : (tx2.Signer.Equals(b) ? 1 : 2);
                     return rank1.CompareTo(rank2);
                 });
-            gathered = _blockChain.GatherTransactionsToMine(
-                new BlockMetadata(), 1024 * 1024, 8, 3, txPriority);
+            gathered = _blockChain.GatherTransactionsToMine(1024 * 1024, 8, 3, txPriority);
             Assert.Equal(
                 txsA.Concat(txsB.Take(3)).Concat(txsC).Select(tx => tx.Id).ToArray(),
                 gathered.Select(tx => tx.Id).ToArray()

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Tests.Blockchain
                     privateKey: signingKey);
             _blockChainMinTx.StageTransaction(lightTx);
 
-            Func<long, long> getMaxBlockBytes = _blockChain.Policy.GetMaxBlockBytes;
+            Func<long, long> getMaxTransactionsBytes = _blockChain.Policy.GetMaxTransactionsBytes;
             Assert.Equal(1, _blockChain.Count);
             AssertBencodexEqual((Text)$"{GenesisMiner.ToAddress()}", _blockChain.GetState(default));
 
@@ -45,7 +45,8 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block = await _blockChain.MineBlock(minerA);
             Assert.True(_blockChain.ContainsBlock(block.Hash));
             Assert.Equal(2, _blockChain.Count);
-            Assert.True(block.MarshalBlock().EncodingLength <= getMaxBlockBytes(block.Index));
+            Assert.True(
+                block.MarshalBlock().EncodingLength <= getMaxTransactionsBytes(block.Index));
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()}",
                 _blockChain.GetState(default)
@@ -56,8 +57,8 @@ namespace Libplanet.Tests.Blockchain
             Assert.True(_blockChain.ContainsBlock(anotherBlock.Hash));
             Assert.Equal(3, _blockChain.Count);
             Assert.True(
-                anotherBlock.MarshalBlock().EncodingLength <= getMaxBlockBytes(anotherBlock.Index)
-            );
+                anotherBlock.MarshalBlock().EncodingLength <=
+                    getMaxTransactionsBytes(anotherBlock.Index));
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",
                 _blockChain.GetState(default)
@@ -67,7 +68,8 @@ namespace Libplanet.Tests.Blockchain
                 await _blockChain.MineBlock(new PrivateKey(), append: false);
             Assert.False(_blockChain.ContainsBlock(block3.Hash));
             Assert.Equal(3, _blockChain.Count);
-            Assert.True(block3.MarshalBlock().EncodingLength <= getMaxBlockBytes(block3.Index));
+            Assert.True(
+                block3.MarshalBlock().EncodingLength <= getMaxTransactionsBytes(block3.Index));
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",
                 _blockChain.GetState(default)
@@ -102,10 +104,11 @@ namespace Libplanet.Tests.Blockchain
                 block4.MarshalBlock().EncodingLength
             );
             _logger.Debug(
-                $"{nameof(getMaxBlockBytes)}({nameof(block4)}.{nameof(block4.Index)}) = {0}",
-                getMaxBlockBytes(block4.Index)
+                $"{nameof(getMaxTransactionsBytes)}({nameof(block4)}.{nameof(block4.Index)}) = {0}",
+                getMaxTransactionsBytes(block4.Index)
             );
-            Assert.True(block4.MarshalBlock().EncodingLength <= getMaxBlockBytes(block4.Index));
+            Assert.True(
+                block4.MarshalBlock().EncodingLength <= getMaxTransactionsBytes(block4.Index));
             Assert.Equal(3, block4.Transactions.Count());
             AssertBencodexEqual(
                 (Text)$"{GenesisMiner.ToAddress()},{minerA.ToAddress()},{minerB.ToAddress()}",
@@ -696,7 +699,7 @@ namespace Libplanet.Tests.Blockchain
         public void GatherTransactionsToMine()
         {
             // TODO: We test more properties of GatherTransactionsToMine() method:
-            //       - if transactions are cut off if they exceed GetMaxBlockBytes()
+            //       - if transactions are cut off if they exceed GetMaxTransactionsBytes()
             //       - if transactions with already consumed nonces are excluded
             //       - if transactions with greater nonces than unconsumed nonces are excluded
             //       - if transactions are cut off if the process exceeds the timeout (4 sec)

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -61,10 +61,10 @@ namespace Libplanet.Tests.Blockchain
 
             _policy = new BlockPolicy<DumbAction>(
                 blockAction: new MinerReward(1),
-                getMaxBlockBytes: _ => 50 * 1024);
+                getMaxTransactionsBytes: _ => 50 * 1024);
             _policyMinTx = new BlockPolicy<DumbAction>(
                 blockAction: new MinerReward(1),
-                getMaxBlockBytes: _ => 50 * 1024,
+                getMaxTransactionsBytes: _ => 50 * 1024,
                 getMinTransactionsPerBlock: _ => 1);
             _stagePolicy = new VolatileStagePolicy<DumbAction>();
             _fx = getStoreFixture(_policy.BlockAction);

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -30,8 +30,8 @@ namespace Libplanet.Blockchain
         /// <param name="miner">The miner's <see cref="PublicKey"/> that mines the block.</param>
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> when mining started.</param>
         /// <param name="append">Whether to append the mined block immediately after mining.</param>
-        /// <param name="maxBlockBytes">The maximum number of bytes a block can have.
-        /// See also <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>.</param>
+        /// <param name="maxTransactionsBytes">The maximum number of bytes a block can have.
+        /// See also <see cref="IBlockPolicy{T}.GetMaxTransactionsBytes(long)"/>.</param>
         /// <param name="maxTransactions">The maximum number of transactions that a block can
         /// accept.  See also <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>.
         /// </param>
@@ -49,7 +49,7 @@ namespace Libplanet.Blockchain
             PrivateKey miner,
             DateTimeOffset? timestamp = null,
             bool? append = null,
-            long? maxBlockBytes = null,
+            long? maxTransactionsBytes = null,
             int? maxTransactions = null,
             int? maxTransactionsPerSigner = null,
             IComparer<Transaction<T>> txPriority = null,
@@ -59,8 +59,8 @@ namespace Libplanet.Blockchain
                     miner: miner,
                     timestamp: timestamp ?? DateTimeOffset.UtcNow,
                     append: append ?? true,
-                    maxBlockBytes: maxBlockBytes
-                        ?? Policy.GetMaxBlockBytes(Count),
+                    maxTransactionsBytes: maxTransactionsBytes
+                        ?? Policy.GetMaxTransactionsBytes(Count),
                     maxTransactions: maxTransactions
                         ?? Policy.GetMaxTransactionsPerBlock(Count),
                     maxTransactionsPerSigner: maxTransactionsPerSigner
@@ -75,8 +75,8 @@ namespace Libplanet.Blockchain
         /// <param name="miner">The miner's <see cref="PublicKey"/> that mines the block.</param>
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> when mining started.</param>
         /// <param name="append">Whether to append the mined block immediately after mining.</param>
-        /// <param name="maxBlockBytes">The maximum number of bytes a block can have.
-        /// See also <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>.</param>
+        /// <param name="maxTransactionsBytes">The maximum number of bytes a block can have.
+        /// See also <see cref="IBlockPolicy{T}.GetMaxTransactionsBytes(long)"/>.</param>
         /// <param name="maxTransactions">The maximum number of transactions that a block can
         /// accept.  See also <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>.
         /// </param>
@@ -94,7 +94,7 @@ namespace Libplanet.Blockchain
             PrivateKey miner,
             DateTimeOffset timestamp,
             bool append,
-            long maxBlockBytes,
+            long maxTransactionsBytes,
             int maxTransactions,
             int maxTransactionsPerSigner,
             IComparer<Transaction<T>> txPriority = null,
@@ -132,7 +132,7 @@ namespace Libplanet.Blockchain
                 prevHash);
 
             var transactionsToMine = GatherTransactionsToMine(
-                maxBlockBytes: maxBlockBytes,
+                maxTransactionsBytes: maxTransactionsBytes,
                 maxTransactions: maxTransactions,
                 maxTransactionsPerSigner: maxTransactionsPerSigner,
                 txPriority: txPriority
@@ -223,7 +223,7 @@ namespace Libplanet.Blockchain
         /// Gathers <see cref="Transaction{T}"/>s for mining a next block
         /// from the current set of staged <see cref="Transaction{T}"/>s.
         /// </summary>
-        /// <param name="maxBlockBytes">The maximum number of bytes a block can have.</param>
+        /// <param name="maxTransactionsBytes">The maximum number of bytes a block can have.</param>
         /// <param name="maxTransactions">The maximum number of <see cref="Transaction{T}"/>s
         /// allowed.</param>
         /// <param name="maxTransactionsPerSigner">The maximum number of
@@ -235,7 +235,7 @@ namespace Libplanet.Blockchain
         /// <see cref="Transaction{T}"/>s in the list for each signer not exceeding
         /// <paramref name="maxTransactionsPerSigner"/>.</returns>
         internal ImmutableList<Transaction<T>> GatherTransactionsToMine(
-            long maxBlockBytes,
+            long maxTransactionsBytes,
             int maxTransactions,
             int maxTransactionsPerSigner,
             IComparer<Transaction<T>> txPriority = null
@@ -307,7 +307,7 @@ namespace Libplanet.Blockchain
 
                     List txAddedEncoding = estimatedEncoding.Add(
                         BlockMarshaler.MarshalTransaction(tx));
-                    if (txAddedEncoding.EncodingLength > maxBlockBytes)
+                    if (txAddedEncoding.EncodingLength > maxTransactionsBytes)
                     {
                         _logger.Debug(
                             "Ignoring tx {Iter}/{Total} {TxId} due to the maximum size allowed " +
@@ -316,7 +316,7 @@ namespace Libplanet.Blockchain
                             stagedTransactions.Count,
                             tx.Id,
                             txAddedEncoding.EncodingLength,
-                            maxBlockBytes);
+                            maxTransactionsBytes);
                         continue;
                     }
                     else if (toMineCounts[tx.Signer] >= maxTransactionsPerSigner)

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -63,7 +63,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
         /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
         /// <param name="getMaxBlockBytes">The function determining the maximum size of
-        /// a <see cref="Block{T}"/> in number of <c>byte</c>s given
+        /// <see cref="Block{T}.Transactions"/> in number of <c>byte</c>s given
         /// its <see cref="Block{T}.Index"/>.  Goes to <see cref="GetMaxBlockBytes"/>.
         /// Set to a constant size of <c>100</c>KiB, i.e. <c>100 * 1024</c>, by default.</param>
         /// <param name="getMinTransactionsPerBlock">The function determining the minimum number of
@@ -129,7 +129,8 @@ namespace Libplanet.Blockchain.Policies
                     int maxTransactionsPerSignerPerBlock =
                         GetMaxTransactionsPerSignerPerBlock(block.Index);
 
-                    long blockBytes = block.MarshalBlock().EncodingLength;
+                    long blockBytes = BlockMarshaler.MarshalTransactions<T>(block.Transactions)
+                        .EncodingLength;
                     if (blockBytes > maxBlockBytes)
                     {
                         return new InvalidBlockBytesLengthException(

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<BlockChain<T>, Block<T>, BlockPolicyViolationException?>
             _validateNextBlock;
 
-        private readonly Func<long, long> _getMaxBlockBytes;
+        private readonly Func<long, long> _getMaxTransactionsBytes;
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerSignerPerBlock;
@@ -62,9 +62,9 @@ namespace Libplanet.Blockchain.Policies
         /// </param>
         /// <param name="canonicalChainComparer">The custom rule to determine which is the canonical
         /// chain.  If omitted, <see cref="TotalDifficultyComparer"/> is used by default.</param>
-        /// <param name="getMaxBlockBytes">The function determining the maximum size of
+        /// <param name="getMaxTransactionsBytes">The function determining the maximum size of
         /// <see cref="Block{T}.Transactions"/> in number of <c>byte</c>s given
-        /// its <see cref="Block{T}.Index"/>.  Goes to <see cref="GetMaxBlockBytes"/>.
+        /// its <see cref="Block{T}.Index"/>.  Goes to <see cref="GetMaxTransactionsBytes"/>.
         /// Set to a constant size of <c>100</c>KiB, i.e. <c>100 * 1024</c>, by default.</param>
         /// <param name="getMinTransactionsPerBlock">The function determining the minimum number of
         /// <see cref="Transaction{T}"/>s that must be included in a <see cref="Block{T}"/>.
@@ -91,7 +91,7 @@ namespace Libplanet.Blockchain.Policies
             Func<BlockChain<T>, Block<T>, BlockPolicyViolationException?>?
                 validateNextBlock = null,
             IComparer<IBlockExcerpt>? canonicalChainComparer = null,
-            Func<long, long>? getMaxBlockBytes = null,
+            Func<long, long>? getMaxTransactionsBytes = null,
             Func<long, int>? getMinTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null,
@@ -106,7 +106,7 @@ namespace Libplanet.Blockchain.Policies
                 ?? DifficultyAdjustment<T>.DefaultMinimumDifficulty;
             CanonicalChainComparer = canonicalChainComparer ?? new TotalDifficultyComparer();
             NativeTokens = nativeTokens ?? ImmutableHashSet<Currency>.Empty;
-            _getMaxBlockBytes = getMaxBlockBytes ?? (_ => 100L * 1024L);
+            _getMaxTransactionsBytes = getMaxTransactionsBytes ?? (_ => 100L * 1024L);
             _getMinTransactionsPerBlock = getMinTransactionsPerBlock ?? (_ => 0);
             _getMaxTransactionsPerBlock = getMaxTransactionsPerBlock ?? (_ => 100);
             _getMaxTransactionsPerSignerPerBlock = getMaxTransactionsPerSignerPerBlock
@@ -123,7 +123,7 @@ namespace Libplanet.Blockchain.Policies
             {
                 _validateNextBlock = (blockchain, block) =>
                 {
-                    long maxBlockBytes = GetMaxBlockBytes(block.Index);
+                    long maxTransactionsBytes = GetMaxTransactionsBytes(block.Index);
                     int minTransactionsPerBlock = GetMinTransactionsPerBlock(block.Index);
                     int maxTransactionsPerBlock = GetMaxTransactionsPerBlock(block.Index);
                     int maxTransactionsPerSignerPerBlock =
@@ -131,11 +131,11 @@ namespace Libplanet.Blockchain.Policies
 
                     long blockBytes = BlockMarshaler.MarshalTransactions<T>(block.Transactions)
                         .EncodingLength;
-                    if (blockBytes > maxBlockBytes)
+                    if (blockBytes > maxTransactionsBytes)
                     {
                         return new InvalidBlockBytesLengthException(
-                            $"The size of block #{block.Index} {block.Hash} is too large " +
-                            $"where the maximum number of bytes allowed is {maxBlockBytes}: " +
+                            $"The size of block #{block.Index} {block.Hash} is too large where " +
+                            $"the maximum number of bytes allowed is {maxTransactionsBytes}: " +
                             $"{blockBytes}.",
                             blockBytes
                         );
@@ -232,7 +232,7 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         [Pure]
-        public long GetMaxBlockBytes(long index) => _getMaxBlockBytes(index);
+        public long GetMaxTransactionsBytes(long index) => _getMaxTransactionsBytes(index);
 
         /// <inheritdoc/>
         [Pure]

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -109,7 +109,7 @@ namespace Libplanet.Blockchain.Policies
         /// for which this constraint should apply.</param>
         /// <returns>The maximum length of <see cref="Block{T}.Transactions"/> in bytes
         /// to accept.</returns>
-        long GetMaxBlockBytes(long index);
+        long GetMaxTransactionsBytes(long index);
 
         /// <summary>
         /// Gets the minimum number of <see cref="Transaction{T}"/>s allowed for

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -103,11 +103,12 @@ namespace Libplanet.Blockchain.Policies
         long GetNextBlockDifficulty(BlockChain<T> blockChain);
 
         /// <summary>
-        /// Gets the maximum length of a <see cref="Block{T}"/> in bytes.
+        /// Gets the maximum length of <see cref="Block{T}.Transactions"/> in bytes.
         /// </summary>
         /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
         /// for which this constraint should apply.</param>
-        /// <returns>The maximum length of a <see cref="Block{T}"/> in bytes to accept.</returns>
+        /// <returns>The maximum length of <see cref="Block{T}.Transactions"/> in bytes
+        /// to accept.</returns>
         long GetMaxBlockBytes(long index);
 
         /// <summary>

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -57,7 +57,7 @@ namespace Libplanet.Blockchain.Policies
                 : null;
         }
 
-        public long GetMaxBlockBytes(long index) => 1024 * 1024;
+        public long GetMaxTransactionsBytes(long index) => 1024 * 1024;
 
         public int GetMaxTransactionsPerSignerPerBlock(long index) =>
             GetMaxTransactionsPerBlock(index);

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -125,7 +125,10 @@ namespace Libplanet.Blocks
         public static List MarshalTransactions<T>(this IReadOnlyList<Transaction<T>> txs)
             where T : IAction, new()
         =>
-            new List(txs.Select(tx => new Binary(tx.Serialize(true))).Cast<IValue>());
+            new List(txs.Select(tx => MarshalTransaction<T>(tx)).Cast<IValue>());
+
+        public static Binary MarshalTransaction<T>(this Transaction<T> tx)
+            where T : IAction, new() => new Binary(tx.Serialize(true));
 
         public static Dictionary MarshalBlock(
             Dictionary marshaledBlockHeader,
@@ -149,26 +152,6 @@ namespace Libplanet.Blocks
                 MarshalBlockHeader(block.Header),
                 MarshalTransactions(block.Transactions)
             );
-
-        public static Dictionary AppendTxToMarshaledBlock<T>(
-            Dictionary marshaledBlock,
-            Transaction<T> tx
-        )
-            where T : IAction, new()
-        {
-            List marshaledTxs;
-            try
-            {
-                marshaledTxs = (List)marshaledBlock[TransactionsKey];
-            }
-            catch (KeyNotFoundException)
-            {
-                marshaledTxs = List.Empty;
-            }
-
-            marshaledTxs = marshaledTxs.Add(tx.ToBencodex(true));
-            return marshaledBlock.SetItem(TransactionsKey, (IValue)marshaledTxs);
-        }
 
         public static long UnmarshalBlockMetadataIndex(Dictionary marshaledMetadata) =>
             marshaledMetadata.GetValue<Integer>(IndexKey);

--- a/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
+++ b/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
@@ -6,7 +6,7 @@ namespace Libplanet.Blocks
 {
     /// <summary>
     /// An exception thrown when the encoded bytes of <see cref="Block{T}.Transactions"/> exceeds
-    /// <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>.
+    /// <see cref="IBlockPolicy{T}.GetMaxTransactionsBytes(long)"/>.
     /// </summary>
     [Serializable]
     public sealed class InvalidBlockBytesLengthException : BlockPolicyViolationException

--- a/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
+++ b/Libplanet/Blocks/InvalidBlockBytesLengthException.cs
@@ -5,7 +5,7 @@ using Libplanet.Blockchain.Policies;
 namespace Libplanet.Blocks
 {
     /// <summary>
-    /// An exception thrown when a <see cref="Block{T}"/>'s encoded bytes exceeds
+    /// An exception thrown when the encoded bytes of <see cref="Block{T}.Transactions"/> exceeds
     /// <see cref="IBlockPolicy{T}.GetMaxBlockBytes(long)"/>.
     /// </summary>
     [Serializable]
@@ -15,8 +15,8 @@ namespace Libplanet.Blocks
         /// Initializes a new instance of <see cref="InvalidBlockBytesLengthException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        /// <param name="bytesLength">The actual length of the <see cref="Block{T}"/>'s encoded
-        /// bytes.</param>
+        /// <param name="bytesLength">The actual encoded length of
+        /// <see cref="Block{T}.Transactions"/> as bytes.</param>
         public InvalidBlockBytesLengthException(string message, long bytesLength)
             : base(message)
         {
@@ -30,7 +30,7 @@ namespace Libplanet.Blocks
         }
 
         /// <summary>
-        /// The actual length of the <see cref="Block{T}"/>'s encoded bytes.
+        /// The actual encoded length of <see cref="Block{T}.Transactions"/> as bytes.
         /// </summary>
         public long BytesLength { get; private set; }
 


### PR DESCRIPTION
Closes #2290.

To be frank, this is only tangentially related to what I'm supposed to be working on. 😗

~~It's a bit of a stretch, but the name `GetMaxBlockBytes()` is kept intact so the API doesn't have to change.~~
See the discussion below.