### PR TITLE
Fix `NetMQTransport` disposal & Release 0.41.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,13 @@ Libplanet changelog
 Version 0.41.2
 --------------
 
-To be released.
+Released on September 13, 2022.
+
+ -  Fixed a bug where `NetMQTransport` is not correctly disposed of due to
+    `NetMQTransport._router` already being stopped in prior to
+    `_router.Unbind()` call in `NetMQTransport.Dispose()`.  [[#2311]]
+
+[#2311]: https://github.com/planetarium/libplanet/pull/2311
 
 
 Version 0.41.1

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -104,6 +104,11 @@ namespace Libplanet.Net
             Options = options ?? new SwarmOptions();
             TxCompletion = new TxCompletion<BoundPeer, T>(BlockChain, GetTxsAsync, BroadcastTxs);
             RoutingTable = new RoutingTable(Address, Options.TableSize, Options.BucketSize);
+
+            // FIXME: after the initialization of NetMQTransport is fully converted to asynchronous
+            // code, the portion initializing the swarm in Agent.cs in NineChronicles should be
+            // fixed. for context, refer to
+            // https://github.com/planetarium/libplanet/discussions/2303.
             Transport = NetMQTransport.Create(
                 _privateKey,
                 _appProtocolVersion,

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -335,7 +335,6 @@ namespace Libplanet.Net.Transports
 
                 if (_router is { } router && !router.IsDisposed)
                 {
-                    _router.Unbind($"tcp://*:{_listenPort}");
                     _router.Dispose();
                     _turnClient?.Dispose();
                 }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -335,6 +335,8 @@ namespace Libplanet.Net.Transports
 
                 if (_router is { } router && !router.IsDisposed)
                 {
+                    // We omitted _router.Unbind() with intention due to hangs.
+                    // See also: https://github.com/planetarium/libplanet/pull/2311
                     _router.Dispose();
                     _turnClient?.Dispose();
                 }


### PR DESCRIPTION
Fixed a bug where NetMQTransport is not properly disposed of due to NetMQTransport._router being stopped before _router.Unbind() call. Will be released as 0.41.2.