### PR TITLE
Support chain migration from PoW-based blockchain to PBFT-based blockchain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@ To be released.
     [[#PBFT]]
  -  Added `Crypto.BlsSignature` class.  [[#PBFT]]
  -  Added static `PublicKeyGetter` class.  [[#PBFT]]
+ -  Added `BlockMetadata.PoWProtocolVersion` constant of value 3.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]
@@ -120,6 +121,15 @@ To be released.
  -  (Libplanet.Net) Parameter type `PrivateKey privateKey` in
     `NetMQMessageCodec.Encode(Message, PrivateKey, AppProtocolVersion, Peer,
     DateTimeOffset)` is now `IPrivateKey`.  [[#PBFT]]
+ -  `BlockSet` element getter became not to verify hash for blocks
+    with `ProtocolVersion` less than `BlockMetadata.PoWProtocolVersion`.
+    [[#PBFT]]
+ -  `Block()` constructor became not to verify hash for blocks
+    with `ProtocolVersion` less than `BlockMetadata.PoWProtocolVersion`.
+    [[#PBFT]]
+ -  `BlockHeader()` constructor became not to verify hash and signature for
+    blocks with `ProtocolVersion` less than `BlockMetadata.PoWProtocolVersion`.
+    [[#PBFT]]
 
 ### Bug fixes
 

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -52,14 +52,27 @@ namespace Libplanet.Blocks
         /// <paramref name="header"/> has an invalid
         /// <see cref="IPreEvaluationBlockHeader.PreEvaluationHash"/>.</exception>
         public Block(IBlockHeader header, IEnumerable<Transaction<T>> transactions)
-            : this(
-                new PreEvaluationBlock<T>(
-                    new BlockContent<T>(header, transactions),
-                    header.PreEvaluationHash),
-                header.StateRootHash,
-                header.Signature
-            )
         {
+            _preEvaluationBlock = new PreEvaluationBlock<T>(
+                new BlockContent<T>(header, transactions),
+                header.PreEvaluationHash);
+            if (((IBlockMetadata)header).ProtocolVersion <= BlockMetadata.PoWProtocolVersion)
+            {
+                // Skip hash check for PoW blocks due to change of the block structure.
+                // If verification is required, use older version of LibPlanet(<0.43).
+                Header = new BlockHeader(
+                    _preEvaluationBlock,
+                    header.StateRootHash,
+                    header.Signature,
+                    header.Hash);
+            }
+            else
+            {
+                Header = new BlockHeader(
+                    _preEvaluationBlock,
+                    header.StateRootHash,
+                    header.Signature);
+            }
         }
 
         /// <summary>

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -28,6 +28,11 @@ namespace Libplanet.Blocks
         /// </summary>
         public const int CurrentProtocolVersion = 4;
 
+        /// <summary>
+        /// The latest PoW protocol version.
+        /// </summary>
+        public const int PoWProtocolVersion = 3;
+
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();
 

--- a/Libplanet/Store/BlockSet.cs
+++ b/Libplanet/Store/BlockSet.cs
@@ -44,7 +44,12 @@ namespace Libplanet.Store
                     );
                 }
 
-                if (!block.Hash.Equals(key))
+                if (block.ProtocolVersion <= BlockMetadata.PoWProtocolVersion)
+                {
+                    // Skip verifying BlockHash of PoW blocks due to change of the block structure.
+                    // If verification is required, use older version of LibPlanet(<0.43).
+                }
+                else if (!block.Hash.Equals(key))
                 {
                     throw new InvalidBlockHashException(
                         $"The given hash[{key}] was not equal to actual[{block.Hash}].");


### PR DESCRIPTION
Migration is done by ignoring verification for `Hash` and `Signature` for PoW-based blocks.

Closes #2203.