### PR TITLE
Let `Address` and `TxId` implement `IEquatable<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ To be released.
 
 ### Added APIs
 
+ -  `Address` now implements `IEquatable<Address>` interface. [[#2320]]
  -  Added `BlockChain<T>.MakeTransaction(PrivateKey, IAction,
     IImmutableSet<Address>, DateTimeOffset?)` overloaded method.
     [[#2151], [#2273]]
@@ -60,6 +61,7 @@ To be released.
 [#2290]: https://github.com/planetarium/libplanet/issues/2290
 [#2291]: https://github.com/planetarium/libplanet/pull/2291
 [#2298]: https://github.com/planetarium/libplanet/pull/2298
+[#2320]: https://github.com/planetarium/libplanet/pull/2320
 [Bencodex 0.5.0]: https://www.nuget.org/packages/Bencodex/0.5.0
 [Bencodex 0.6.0]: https://www.nuget.org/packages/Bencodex/0.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ To be released.
 ### Added APIs
 
  -  `Address` now implements `IEquatable<Address>` interface. [[#2320]]
+ -  `TxId` now implements `IEquatable<TxId>` interface.  [[#2320]]
  -  Added `BlockChain<T>.MakeTransaction(PrivateKey, IAction,
     IImmutableSet<Address>, DateTimeOffset?)` overloaded method.
     [[#2151], [#2273]]

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -39,7 +39,8 @@ namespace Libplanet
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
     [Serializable]
-    public readonly struct Address : ISerializable, IComparable<Address>, IComparable
+    public readonly struct Address
+        : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="Address"/> takes.

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tx
     /// </summary>
     /// <seealso cref="Transaction{T}.Id"/>
     [Serializable]
-    public struct TxId : ISerializable, IComparable<TxId>, IComparable
+    public struct TxId : ISerializable, IEquatable<TxId>, IComparable<TxId>, IComparable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="TxId"/> takes.


### PR DESCRIPTION
It's shocking that they haven't implemented `IEquatable<T>`.  Note that they've already had `Equals(T)` which could satisfy the interface anyway…