### PR TITLE
Serialize/deserialize better with `System.Text.Json.JsonSerializer`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,7 @@ commands:
             "Libplanet.Net.Tests.Protocols.ProtocolTest"
             "Libplanet.Net.Tests.SwarmTest"
             "Libplanet.Net.Tests.Transports.NetMQTransportTest"
+            "Libplanet.Node.Tests.SwarmConfigTest"
           )
           args=(
             "--hang-seconds=60"
@@ -358,8 +359,10 @@ commands:
           done
           for project in *.Tests; do
             if [[
-              $project !=  *"Explorer"*
-              && $project != *"RocksDBStore"*
+              $project != Libplanet.Explorer.Tests
+              && $project != Libplanet.Extensions.Cocona.Tests
+              && $project != Libplanet.RocksDBStore.Tests
+              && $project != Libplanet.Tools.Tests
             ]]
             then
               args+=("$PWD/$project/bin/Release/net47/$project.dll")

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
 
      -  An `Address` became represented as a single hexadecimal string in JSON.
      -  A `BlockHash` became represented as a single hexadecimal string in JSON.
+     -  A `HashDigest` became represented as a single hexadecimal string in
+        JSON.
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ To be released.
      -  A `BlockHash` became represented as a single hexadecimal string in JSON.
      -  A `HashDigest` became represented as a single hexadecimal string in
         JSON.
+     -  A `TxId` became represented as a single hexadecimal string in JSON.
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Extensions.Cocona) The return type of
+    `Utils.DeserializeHumanReadable<T>()` static method became `T?` (was `T`).
+    [[#2322]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -18,11 +22,26 @@ To be released.
 
 ### Behavioral changes
 
+ -  Many types became serialized and deserialized better with
+    [`System.Text.Json.JsonSerializer`] as they now have their own
+    [custom converters].  [[#2322]]
+
+     -  An `Address` became represented as a single hexadecimal string in JSON.
+
 ### Bug fixes
 
 ### Dependencies
 
+ -  Upgrade *System.Text.Json* from [4.7.2][System.Text.Json 4.7.2] to
+    [6.0.0][System.Text.Json 6.0.0].  [[#2322]]
+
 ### CLI tools
+
+[#2322]: https://github.com/planetarium/libplanet/pull/2322
+[`System.Text.Json.JsonSerializer`]: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer
+[custom converters]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to
+[System.Text.Json 4.7.2]: https://www.nuget.org/packages/System.Text.Json/4.7.2
+[System.Text.Json 6.0.0]: https://www.nuget.org/packages/System.Text.Json/6.0.0
 
 
 Version 0.42.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,8 @@ To be released.
 
  -  Many types became serialized and deserialized better with
     [`System.Text.Json.JsonSerializer`] as they now have their own
-    [custom converters].  [[#2322]]
+    [custom converters].  Note that these serializations are unavailable
+    on Unity due to its incomplete reflection support.  [[#2322]]
 
      -  An `Address` became represented as a single hexadecimal string in JSON.
      -  A `BlockHash` became represented as a single hexadecimal string in JSON.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,7 @@ To be released.
 ### Dependencies
 
  -  Upgrade *System.Text.Json* from [4.7.2][System.Text.Json 4.7.2] to
-    [6.0.0][System.Text.Json 6.0.0].  [[#2322]]
+    [6.0.6][System.Text.Json 6.0.6].  [[#2322]]
 
 ### CLI tools
 
@@ -51,7 +51,7 @@ To be released.
 [`System.Text.Json.JsonSerializer`]: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer
 [custom converters]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to
 [System.Text.Json 4.7.2]: https://www.nuget.org/packages/System.Text.Json/4.7.2
-[System.Text.Json 6.0.0]: https://www.nuget.org/packages/System.Text.Json/6.0.0
+[System.Text.Json 6.0.6]: https://www.nuget.org/packages/System.Text.Json/6.0.6
 
 
 Version 0.42.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ To be released.
     [custom converters].  [[#2322]]
 
      -  An `Address` became represented as a single hexadecimal string in JSON.
+     -  A `BlockHash` became represented as a single hexadecimal string in JSON.
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@ To be released.
 
      -  An `Address` became represented as a single hexadecimal string in JSON.
      -  A `BlockHash` became represented as a single hexadecimal string in JSON.
+     -  A `Currency` became represented as an object with values in JSON.
+        Note that it contains its `Hash` and it throws `JsonException`
+        if a JSON object to deserialize has an inconsistent `Hash` with
+        other field values.
      -  A `HashDigest` became represented as a single hexadecimal string in
         JSON.
      -  A `TxId` became represented as a single hexadecimal string in JSON.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@ To be released.
         Note that it contains its `Hash` and it throws `JsonException`
         if a JSON object to deserialize has an inconsistent `Hash` with
         other field values.
+     -  A `FungibleAssetValue` became represented as an object with
+        its `Currency` object and `Quantity` string.
      -  A `HashDigest` became represented as a single hexadecimal string in
         JSON.
      -  A `TxId` became represented as a single hexadecimal string in JSON.

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -40,7 +40,7 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
@@ -40,7 +40,7 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -147,15 +147,19 @@ namespace Libplanet.Extensions.Cocona
                 }
             );
 
-        public static T DeserializeHumanReadable<T>(string target) => JsonSerializer.Deserialize<T>(
-            target, new JsonSerializerOptions
-            {
-                Converters =
+        public static T? DeserializeHumanReadable<T>(string target)
+            where T : notnull
+        =>
+            JsonSerializer.Deserialize<T>(
+                target, new JsonSerializerOptions
                 {
-                    new ByteArrayStringJsonConverter(),
-                    new DateTimeOffsetJsonConverter(),
-                },
-            });
+                    Converters =
+                    {
+                        new ByteArrayStringJsonConverter(),
+                        new DateTimeOffsetJsonConverter(),
+                    },
+                }
+            );
 
         private static void PrintTable(object[] header, IEnumerable<object[]> rows)
         {
@@ -239,7 +243,7 @@ namespace Libplanet.Extensions.Cocona
                 Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                var hexString = reader.GetString();
+                var hexString = reader.GetString() ?? throw new JsonException("Expected a string.");
                 return ImmutableArray.Create(ByteUtil.ParseHex(hexString));
             }
 
@@ -257,7 +261,8 @@ namespace Libplanet.Extensions.Cocona
                 Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                var jsonString = reader.GetString();
+                var jsonString = reader.GetString()
+                    ?? throw new JsonException("Expected a string.");
                 return DateTimeOffset.ParseExact(
                     jsonString,
                     DateTimeOffsetFormat,

--- a/Libplanet.Node.Tests/Libplanet.Node.Tests.csproj
+++ b/Libplanet.Node.Tests/Libplanet.Node.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />

--- a/Libplanet.Node/SwarmConfig.cs
+++ b/Libplanet.Node/SwarmConfig.cs
@@ -53,9 +53,20 @@ namespace Libplanet.Node
         /// <param name="jsonString">The json <see cref="string"/> to parse.</param>
         /// <returns>The <see cref="SwarmConfig"/> instance parsed from
         /// <paramref name="jsonString"/>.</returns>
+        /// <exception cref="JsonException">Thrown when the input <paramref name="jsonString"/>
+        /// is invalid.</exception>
         public static SwarmConfig FromJson(string jsonString)
         {
-            return JsonSerializer.Deserialize<SwarmConfig>(jsonString, _jsonSerializerOptions);
+            SwarmConfig? config =
+                JsonSerializer.Deserialize<SwarmConfig>(jsonString, _jsonSerializerOptions);
+            if (config is { } cfg)
+            {
+                return cfg;
+            }
+
+            // JsonSerializer.Deserialize() can return null if the root JSON node is null.
+            // https://github.com/dotnet/runtime/discussions/60195#discussioncomment-1649740
+            throw new JsonException("A null is disallowed for the root of the input JSON tree.");
         }
 
         /// <summary>
@@ -134,7 +145,9 @@ namespace Libplanet.Node
                 Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                return BoundPeer.ParsePeer(reader.GetString());
+                return BoundPeer.ParsePeer(
+                    reader.GetString() ?? throw new JsonException("Expected a string.")
+                );
             }
 
             public override void Write(

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -329,7 +329,7 @@ namespace Libplanet.Tests
             );
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
             var address = new Address("0123456789ABcdefABcdEfABcdEFabcDEFabCDEF");

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests
 {
@@ -133,7 +134,7 @@ namespace Libplanet.Tests
                     continue;
                 }
 
-                byte[] addressBytes = TestUtils.GetRandomBytes(size);
+                byte[] addressBytes = GetRandomBytes(size);
                 Assert.Throws<ArgumentException>(() =>
                     new Address(addressBytes)
                 );
@@ -162,7 +163,7 @@ namespace Libplanet.Tests
         [Fact]
         public void ToByteArray()
         {
-            byte[] addressBytes = TestUtils.GetRandomBytes(20);
+            byte[] addressBytes = GetRandomBytes(20);
             var address = new Address(addressBytes);
             Assert.Equal(addressBytes, address.ToByteArray());
         }
@@ -325,6 +326,16 @@ namespace Libplanet.Tests
         {
             Assert.Throws<ArgumentException>(() =>
                  new Address("0X0123456789ABcdefABcdEfABcdEFabcDEFabCDEF")
+            );
+        }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+            var address = new Address("0123456789ABcdefABcdEfABcdEFabcDEFabCDEF");
+            AssertJsonSerializable(
+                address,
+                "\"0123456789ABcdefABcdEfABcdEFabcDEFabCDEF\""
             );
         }
     }

--- a/Libplanet.Tests/Assets/CurrencyTest.cs
+++ b/Libplanet.Tests/Assets/CurrencyTest.cs
@@ -255,5 +255,39 @@ namespace Libplanet.Tests.Assets
 
             Assert.Equal(bar, new Currency(bar.Serialize()));
         }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+#pragma warning disable CS0618  // must test obsoleted Currency.Legacy() for backwards compatibility
+            var foo = Currency.Legacy("FOO", 2, null);
+#pragma warning restore CS0618  // must test obsoleted Currency.Legacy() for backwards compatibility
+            AssertJsonSerializable(foo, @"
+                {
+                    ""hash"": ""8db87f973776e2218113202e00e09e185fff8971"",
+                    ""ticker"": ""FOO"",
+                    ""decimalPlaces"": 2,
+                    ""minters"": null,
+                    ""maximumSupply"": null,
+                    ""totalSupplyTrackable"": false,
+                }
+            ");
+
+            var bar =
+                Currency.Capped("BAR", 0, (100, 0), ImmutableHashSet.Create(AddressA, AddressB));
+            AssertJsonSerializable(bar, @"
+                {
+                    ""hash"": ""e4ee30562819a9e74be40098c76f84209d05da5e"",
+                    ""ticker"": ""BAR"",
+                    ""decimalPlaces"": 0,
+                    ""minters"": [
+                        ""5003712B63baAB98094aD678EA2B24BcE445D076"",
+                        ""D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"",
+                    ],
+                    ""maximumSupply"": ""100.0"",
+                    ""totalSupplyTrackable"": true,
+                }
+            ");
+        }
     }
 }

--- a/Libplanet.Tests/Assets/CurrencyTest.cs
+++ b/Libplanet.Tests/Assets/CurrencyTest.cs
@@ -256,7 +256,7 @@ namespace Libplanet.Tests.Assets
             Assert.Equal(bar, new Currency(bar.Serialize()));
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
 #pragma warning disable CS0618  // must test obsoleted Currency.Legacy() for backwards compatibility

--- a/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
+++ b/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
@@ -533,7 +533,7 @@ namespace Libplanet.Tests.Assets
             Assert.Equal(new FungibleAssetValue(FOO, -12, 0), FungibleAssetValue.Parse(FOO, "-12"));
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
             var v = new FungibleAssetValue(FOO, 123, 45);

--- a/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
+++ b/Libplanet.Tests/Assets/FungibleAssetValueTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Assets;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Assets
 {
@@ -530,6 +531,40 @@ namespace Libplanet.Tests.Assets
             Assert.Equal(new FungibleAssetValue(FOO, 123, 0), FungibleAssetValue.Parse(FOO, "123"));
             Assert.Equal(new FungibleAssetValue(FOO, 12, 0), FungibleAssetValue.Parse(FOO, "+12"));
             Assert.Equal(new FungibleAssetValue(FOO, -12, 0), FungibleAssetValue.Parse(FOO, "-12"));
+        }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+            var v = new FungibleAssetValue(FOO, 123, 45);
+            AssertJsonSerializable(v, @"
+                {
+                    ""quantity"": ""123.45"",
+                    ""currency"": {
+                        ""hash"": ""946ea39b6f49926c0ed3df2a3aa0d2aba0f0fc25"",
+                        ""ticker"": ""FOO"",
+                        ""decimalPlaces"": 2,
+                        ""minters"": null,
+                        ""maximumSupply"": null,
+                        ""totalSupplyTrackable"": true,
+                    }
+                }
+            ");
+
+            v = new FungibleAssetValue(FOO, -456, 0);
+            AssertJsonSerializable(v, @"
+                {
+                    ""quantity"": ""-456"",
+                    ""currency"": {
+                        ""hash"": ""946ea39b6f49926c0ed3df2a3aa0d2aba0f0fc25"",
+                        ""ticker"": ""FOO"",
+                        ""decimalPlaces"": 2,
+                        ""minters"": null,
+                        ""maximumSupply"": null,
+                        ""totalSupplyTrackable"": true,
+                    }
+                }
+            ");
         }
     }
 }

--- a/Libplanet.Tests/Blocks/BlockHashTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHashTest.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Blocks
 {
@@ -14,8 +15,8 @@ namespace Libplanet.Tests.Blocks
         public void DefaultConstructor()
         {
             BlockHash def = default;
-            TestUtils.AssertBytesEqual(new byte[32].ToImmutableArray(), def.ByteArray);
-            TestUtils.AssertBytesEqual(new byte[32], def.ToByteArray());
+            AssertBytesEqual(new byte[32].ToImmutableArray(), def.ByteArray);
+            AssertBytesEqual(new byte[32], def.ToByteArray());
         }
 
         [Fact]
@@ -88,12 +89,12 @@ namespace Libplanet.Tests.Blocks
         public void DeriveFrom()
         {
             byte[] foo = { 0x66, 0x6f, 0x6f }, bar = { 0x62, 0x61, 0x72 };
-            TestUtils.AssertBytesEqual(
+            AssertBytesEqual(
                 BlockHash.FromString(
                     "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"),
                 BlockHash.DeriveFrom(foo)
             );
-            TestUtils.AssertBytesEqual(
+            AssertBytesEqual(
                 BlockHash.FromString(
                     "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"),
                 BlockHash.DeriveFrom(bar)
@@ -137,6 +138,17 @@ namespace Libplanet.Tests.Blocks
             }
 
             Assert.Equal(deserialized, expected);
+        }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+            BlockHash hash = BlockHash.FromString(
+                "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae");
+            AssertJsonSerializable(
+                hash,
+                "\"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\""
+            );
         }
     }
 }

--- a/Libplanet.Tests/Blocks/BlockHashTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHashTest.cs
@@ -140,7 +140,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(deserialized, expected);
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
             BlockHash hash = BlockHash.FromString(

--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests
 {
@@ -172,6 +173,17 @@ namespace Libplanet.Tests
             }
 
             Assert.Equal(deserializedHashDigest, expectedHashDigest);
+        }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+            HashDigest<SHA1> digest =
+                HashDigest<SHA1>.FromString("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
+            AssertJsonSerializable(
+                digest,
+                "\"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33\""
+            );
         }
     }
 }

--- a/Libplanet.Tests/HashDigestTest.cs
+++ b/Libplanet.Tests/HashDigestTest.cs
@@ -175,7 +175,7 @@ namespace Libplanet.Tests
             Assert.Equal(deserializedHashDigest, expectedHashDigest);
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
             HashDigest<SHA1> digest =

--- a/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/Libplanet.Tests/Libplanet.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
@@ -40,6 +40,7 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
+    <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="1.3.0"/>
     <PackageReference Include="xRetry" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -553,10 +553,20 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             var buffer = new MemoryStream();
             JsonSerializer.Serialize(buffer, obj);
             buffer.Seek(0L, SeekOrigin.Begin);
-            JsonNode actual = JsonSerializer.SerializeToNode(obj);
-            JsonNode expected = JsonNode.Parse(expectedJson);
+            var options = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            JsonNode actual = JsonSerializer.SerializeToNode(obj, options);
+            JsonNode expected = JsonNode.Parse(expectedJson, null, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip,
+            });
             JsonAssert.Equal(expected, actual, true);
-            var deserialized = JsonSerializer.Deserialize<T>(expectedJson);
+            var deserialized = JsonSerializer.Deserialize<T>(expectedJson, options);
             Assert.Equal(obj, deserialized);
         }
     }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.JsonDiffPatch.Xunit;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using DiffPlex.DiffBuilder;
@@ -542,5 +546,18 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 output,
                 conditionLabel
             );
+
+        public static void AssertJsonSerializable<T>(T obj, string expectedJson)
+            where T : IEquatable<T>
+        {
+            var buffer = new MemoryStream();
+            JsonSerializer.Serialize(buffer, obj);
+            buffer.Seek(0L, SeekOrigin.Begin);
+            JsonNode actual = JsonSerializer.SerializeToNode(obj);
+            JsonNode expected = JsonNode.Parse(expectedJson);
+            JsonAssert.Equal(expected, actual, true);
+            var deserialized = JsonSerializer.Deserialize<T>(expectedJson);
+            Assert.Equal(obj, deserialized);
+        }
     }
 }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -550,6 +550,11 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         public static void AssertJsonSerializable<T>(T obj, string expectedJson)
             where T : IEquatable<T>
         {
+            Skip.IfNot(
+                Type.GetType("Mono.Runtime") is null,
+                "System.Text.Json 6.0.0+ does not work well with Unity/Mono."
+            );
+
             var buffer = new MemoryStream();
             JsonSerializer.Serialize(buffer, obj);
             buffer.Seek(0L, SeekOrigin.Begin);

--- a/Libplanet.Tests/Tx/TxIdTest.cs
+++ b/Libplanet.Tests/Tx/TxIdTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Tx;
 using Xunit;
+using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Tx
 {
@@ -25,7 +26,7 @@ namespace Libplanet.Tests.Tx
                     continue;
                 }
 
-                byte[] bytes = TestUtils.GetRandomBytes(size);
+                byte[] bytes = GetRandomBytes(size);
                 Assert.Throws<ArgumentOutOfRangeException>(
                     "txid",
                     () => new TxId(bytes)
@@ -71,7 +72,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void ToByteArray()
         {
-            var bytes = TestUtils.GetRandomBytes(32);
+            var bytes = GetRandomBytes(32);
             var txId = new TxId(bytes);
 
             Assert.Equal(bytes, txId.ToByteArray());
@@ -225,6 +226,17 @@ namespace Libplanet.Tests.Tx
             );
             Assert.Throws<ArgumentException>(() =>
                 txIds[0].CompareTo("invalid")
+            );
+        }
+
+        [Fact]
+        public void JsonSerialization()
+        {
+            TxId txid = TxId.FromHex(
+                "45a22187e2d8850bb357886958bc3e8560929ccc886958bc3e8560929ccc9ccc");
+            AssertJsonSerializable(
+                txid,
+                "\"45a22187e2d8850bb357886958bc3e8560929ccc886958bc3e8560929ccc9ccc\""
             );
         }
     }

--- a/Libplanet.Tests/Tx/TxIdTest.cs
+++ b/Libplanet.Tests/Tx/TxIdTest.cs
@@ -229,7 +229,7 @@ namespace Libplanet.Tests.Tx
             );
         }
 
-        [Fact]
+        [SkippableFact]
         public void JsonSerialization()
         {
             TxId txid = TxId.FromHex(

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
@@ -38,6 +41,7 @@ namespace Libplanet
     /// </summary>
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
+    [JsonConverter(typeof(AddressJsonConverter))]
     [Serializable]
     public readonly struct Address
         : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable
@@ -359,5 +363,37 @@ namespace Libplanet
                 );
             }
         }
+    }
+
+    [SuppressMessage(
+        "StyleCop.CSharp.MaintainabilityRules",
+        "SA1402:FileMayOnlyContainASingleClass",
+        Justification = "It's okay to have non-public classes together in a single file."
+    )]
+    internal class AddressJsonConverter : JsonConverter<Address>
+    {
+        public override Address Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            string? hex = reader.GetString();
+            try
+            {
+                return new Address(hex!);
+            }
+            catch (ArgumentException e)
+            {
+                throw new JsonException(e.Message);
+            }
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            Address value,
+            JsonSerializerOptions options
+        ) =>
+            writer.WriteStringValue(value.ToHex());
     }
 }

--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -50,6 +53,7 @@ namespace Libplanet.Assets
         /// <summary>
         /// The ticker symbol, e.g., <c>&quot;USD&quot;</c>.
         /// </summary>
+        [JsonInclude]
         public readonly string Ticker;
 
         /// <summary>
@@ -57,6 +61,7 @@ namespace Libplanet.Assets
         /// href="https://w.wiki/ZXv#Treatment_of_minor_currency_units_(the_%22exponent%22)">minor
         /// units (i.e., exponent)</a>.
         /// </summary>
+        [JsonInclude]
         public readonly byte DecimalPlaces;
 
         /// <summary>
@@ -67,16 +72,19 @@ namespace Libplanet.Assets
         /// Unlike <c>null</c>, an empty set means <em>no one</em> can mint the currency.
         /// </remarks>
         /// <seealso cref="IAccountStateDelta.MintAsset"/>
+        [JsonInclude]
         public readonly IImmutableSet<Address>? Minters;
 
         /// <summary>
         /// The deterministic hash derived from other fields.
         /// </summary>
+        [JsonInclude]
         public readonly HashDigest<SHA1> Hash;
 
         /// <summary>
         /// Whether the total supply of this instance of <see cref="Currency"/> is trackable.
         /// </summary>
+        [JsonInclude]
         public readonly bool TotalSupplyTrackable;
 
         private readonly (BigInteger Major, BigInteger Minor)? _maximumSupply;
@@ -226,6 +234,48 @@ namespace Libplanet.Assets
             Hash = GetHash();
         }
 
+        /// <summary>
+        /// An internal constructor for JSON deserialization.  Do not use this directly.
+        /// </summary>
+        [JsonConstructor]
+        [Obsolete]
+#pragma warning disable SA1611
+        public Currency(
+            HashDigest<SHA1> hash,
+            string ticker,
+            byte decimalPlaces,
+            IImmutableSet<Address>? minters,
+            bool totalSupplyTrackable,
+            FungibleAssetValue? maximumSupply
+        )
+#pragma warning restore SA1611
+#pragma warning disable SA1118
+            : this(
+                ticker,
+                decimalPlaces,
+                maximumSupply is { } v
+                    ? (v.MajorUnit, v.MinorUnit)
+                    : ((BigInteger, BigInteger)?)null,
+                minters
+            )
+#pragma warning restore SA1118
+        {
+            TotalSupplyTrackable = totalSupplyTrackable;
+            HashDigest<SHA1> expectedHash = GetHash();
+            if (!expectedHash.Equals(hash))
+            {
+                var msg = $"Invalid currency hash; expected {expectedHash}, but got {hash}. " +
+                      "This probably means the given data is inconsistent with the given hash.\n" +
+                      $"  ticker: {Ticker}\n  decimalPlaces: {decimalPlaces}\n" +
+                      $"  minters: {(Minters is { } m ? string.Join(", ", m) : "N/A")}\n" +
+                      $"  totalSupplyTrackable: {TotalSupplyTrackable}\n" +
+                      $"  maximumSupply: {MaximumSupply?.ToString() ?? "N/A"}";
+                throw new JsonException(msg);
+            }
+
+            Hash = hash;
+        }
+
         private Currency(SerializationInfo info, StreamingContext context)
         {
             Ticker = info.GetValue<string>(nameof(Ticker));
@@ -291,7 +341,8 @@ namespace Libplanet.Assets
         }
 
         /// <summary>
-        /// Private implementation to create a capped instance of <see cref="Currency"/>.
+        /// Private implementation to create a capped instance of <see cref="Currency"/> or
+        /// a deserialized instance.
         /// </summary>
         /// <param name="ticker">The ticker symbol, e.g., <c>&quot;USD&quot;</c>.</param>
         /// <param name="decimalPlaces">The number of digits to treat as <a
@@ -311,7 +362,7 @@ namespace Libplanet.Assets
         private Currency(
             string ticker,
             byte decimalPlaces,
-            (BigInteger Major, BigInteger Minor) maximumSupply,
+            (BigInteger Major, BigInteger Minor)? maximumSupply,
             IImmutableSet<Address>? minters)
             : this(ticker, decimalPlaces, minters, true)
         {
@@ -330,9 +381,10 @@ namespace Libplanet.Assets
                               + $" big for the given decimal places {decimalPlaces}.";
                     throw new ArgumentException(msg, nameof(minor));
                 }
+
+                _maximumSupply = maximumSupply;
             }
 
-            _maximumSupply = maximumSupply;
             Hash = GetHash();
         }
 
@@ -378,6 +430,7 @@ namespace Libplanet.Assets
         /// The uppermost quantity of currency allowed to exist.
         /// <c>null</c> means unlimited supply.
         /// </summary>
+        [JsonConverter(typeof(MaximumSupplyJsonConverter))]
         public FungibleAssetValue? MaximumSupply =>
             _maximumSupply.HasValue
                 ? new FungibleAssetValue(
@@ -654,5 +707,40 @@ namespace Libplanet.Assets
             stream.FlushFinalBlock();
             return new HashDigest<SHA1>(sha1.Hash);
         }
+    }
+
+    [SuppressMessage(
+        "StyleCop.CSharp.MaintainabilityRules",
+        "SA1402:FileMayOnlyContainASingleClass",
+        Justification = "It's okay to have non-public classes together in a single file."
+    )]
+    internal class MaximumSupplyJsonConverter : JsonConverter<FungibleAssetValue>
+    {
+        public override FungibleAssetValue Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            string? quantityString = reader.GetString();
+            if (!(quantityString is { } qs))
+            {
+                throw new JsonException("MaximumSupply must be a string.");
+            }
+
+            int periodPos = qs.IndexOf('.');
+            byte decimalPlaces = periodPos < 0 ? (byte)0 : (byte)(qs.Length - periodPos - 1);
+            var fakeCurrency = Currency.Uncapped("FAKE", decimalPlaces, null);
+            return FungibleAssetValue.Parse(fakeCurrency, qs);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            FungibleAssetValue value,
+            JsonSerializerOptions options
+        ) =>
+            writer.WriteStringValue(
+                value.GetQuantityString() + (value.MinorUnit.IsZero ? ".0" : string.Empty)
+            );
     }
 }

--- a/Libplanet/Assets/FungibleAssetValue.cs
+++ b/Libplanet/Assets/FungibleAssetValue.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Libplanet.Serialization;
 
 namespace Libplanet.Assets
@@ -16,6 +19,7 @@ namespace Libplanet.Assets
     /// to handle its remainder; use <see cref="DivRem(FungibleAssetValue)"/> and <see
     /// cref="DivRem(BigInteger)"/> methods instead.
     /// </remarks>
+    [JsonConverter(typeof(FungibleAssetValueJsonConverter))]
     [Serializable]
     public readonly struct FungibleAssetValue :
         IEquatable<FungibleAssetValue>,
@@ -625,5 +629,119 @@ namespace Libplanet.Assets
         [Pure]
         public override string ToString() =>
             $"{GetQuantityString()} {Currency.Ticker}";
+    }
+
+    [SuppressMessage(
+        "StyleCop.CSharp.MaintainabilityRules",
+        "SA1402:FileMayOnlyContainASingleClass",
+        Justification = "It's okay to have non-public classes together in a single file."
+    )]
+    internal class FungibleAssetValueJsonConverter : JsonConverter<FungibleAssetValue>
+    {
+        public override FungibleAssetValue Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException(
+                    $"Expected an object representation of {nameof(FungibleAssetValue)}."
+                );
+            }
+
+            reader.Read();
+
+            string quantityFieldName =
+                options.PropertyNamingPolicy?.ConvertName("Quantity") ?? "Quantity";
+            string currencyFieldName =
+                options.PropertyNamingPolicy?.ConvertName("Currency") ?? "Currency";
+            string? quantityString = null;
+            Currency? currency = null;
+
+            while (reader.TokenType != JsonTokenType.EndObject &&
+                   (quantityString is null || currency is null))
+            {
+                if (quantityString is { } && currency is { })
+                {
+                    throw new JsonException($"Unexpected token: {reader.TokenType}.");
+                }
+
+                if (!(reader.GetString() is { } propName))
+                {
+                    throw new JsonException("Expected a field name.");
+                }
+
+                reader.Read();
+                switch (propName.ToLowerInvariant())
+                {
+                    case "quantity":
+                        if (options.PropertyNameCaseInsensitive || propName == quantityFieldName)
+                        {
+                            quantityString = reader.GetString();
+                            reader.Read();
+                            if (quantityString is null)
+                            {
+                                throw new JsonException("Expected a string value.");
+                            }
+                        }
+
+                        break;
+
+                    case "currency":
+                        if (options.PropertyNameCaseInsensitive || propName == currencyFieldName)
+                        {
+                            currency = JsonSerializer.Deserialize<Currency>(ref reader, options);
+                            if (currency is null)
+                            {
+                                throw new JsonException(
+                                    $"Expected an object representation of {nameof(Currency)}.");
+                            }
+                        }
+
+                        break;
+
+                    default:
+                        throw new JsonException($"Unexpected field name: {propName}.");
+                }
+            }
+
+            if (reader.TokenType != JsonTokenType.EndObject)
+            {
+                throw new JsonException($"Unexpected token: {reader.TokenType}.");
+            }
+
+            reader.Read();
+
+            if (!(quantityString is { } q))
+            {
+                throw new JsonException($"Missing field: \"{quantityFieldName}\".");
+            }
+
+            if (!(currency is { } c))
+            {
+                throw new JsonException($"Missing field: \"{currencyFieldName}\".");
+            }
+
+            return FungibleAssetValue.Parse(c, q);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            FungibleAssetValue value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStartObject();
+            writer.WriteString(
+                options.PropertyNamingPolicy?.ConvertName("Quantity") ?? "Quantity",
+                value.GetQuantityString()
+            );
+            writer.WritePropertyName(
+                options.PropertyNamingPolicy?.ConvertName("Currency") ?? "Currency");
+            JsonSerializer.Serialize(writer, value.Currency, options);
+            writer.WriteEndObject();
+        }
     }
 }

--- a/Libplanet/HashDigest.cs
+++ b/Libplanet/HashDigest.cs
@@ -336,9 +336,20 @@ namespace Libplanet
     )]
     internal class HashDigestJsonConverter : JsonConverter<object>
     {
-        public override bool CanConvert(Type typeToConvert) =>
-            typeToConvert.IsConstructedGenericType &&
-            typeToConvert.GetGenericTypeDefinition() == typeof(HashDigest<>);
+        private Type? _queriedType;
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert.IsConstructedGenericType &&
+                typeToConvert.GetGenericTypeDefinition() == typeof(HashDigest<>))
+            {
+                _queriedType = typeToConvert;
+                return true;
+            }
+
+            _queriedType = null;
+            return false;
+        }
 
         public override object Read(
             ref Utf8JsonReader reader,
@@ -346,6 +357,11 @@ namespace Libplanet
             JsonSerializerOptions options
         )
         {
+            if (typeToConvert == typeof(object) && _queriedType is { } t)
+            {
+                typeToConvert = t;
+            }
+
             MethodInfo fromString = typeToConvert.GetMethod(
                 "FromString",
                 BindingFlags.Public | BindingFlags.Static

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -90,7 +90,7 @@ https://docs.libplanet.io/</Description>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="System.Linq.Async" Version="4.0.*" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" />
     <PackageReference Include="Zio" Version="0.7.4" />
   </ItemGroup>
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -90,7 +90,7 @@ https://docs.libplanet.io/</Description>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="System.Linq.Async" Version="4.0.*" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Zio" Version="0.7.4" />
   </ItemGroup>
 

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -1,9 +1,12 @@
 #nullable disable
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Libplanet.Serialization;
 
 namespace Libplanet.Tx
@@ -17,6 +20,7 @@ namespace Libplanet.Tx
     /// (See also <see cref="Size"/> constant.)</para>
     /// </summary>
     /// <seealso cref="Transaction{T}.Id"/>
+    [JsonConverter(typeof(TxIdJsonConverter))]
     [Serializable]
     public struct TxId : ISerializable, IEquatable<TxId>, IComparable<TxId>, IComparable
     {
@@ -198,5 +202,38 @@ namespace Libplanet.Tx
         {
             info.AddValue("tx_id", _byteArray.ToArray());
         }
+    }
+
+#nullable enable
+    [SuppressMessage(
+        "StyleCop.CSharp.MaintainabilityRules",
+        "SA1402:FileMayOnlyContainASingleClass",
+        Justification = "It's okay to have non-public classes together in a single file."
+    )]
+    internal class TxIdJsonConverter : JsonConverter<TxId>
+    {
+        public override TxId Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            string? hex = reader.GetString();
+            try
+            {
+                return TxId.FromHex(hex);
+            }
+            catch (ArgumentException e)
+            {
+                throw new JsonException(e.Message);
+            }
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            TxId value,
+            JsonSerializerOptions options
+        ) =>
+            writer.WriteStringValue(value.ToHex());
     }
 }


### PR DESCRIPTION
I implemented several [custom JSON converters] for types so that they are serialized better with [`System.Text.Json.JsonSerializer`].

[custom JSON converters]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to
[`System.Text.Json.JsonSerializer`]: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer