### PR TITLE
Add `PreviousMiner` property on `IBlockMetadata`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,14 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  Added property `LastCommit` to `IActionContext`.  [[#2297]]
+ -  Added property `LastCommit` on `IActionContext`.  [[#2297]]
  -  Replace property `NativeTokenPredicate` with `NativeTokens` on
     `IActionContext`.  [[#2316]]
  -  Replace parameter `nativeTokenPredicate` with `nativeTokens` on
     `ActionEvaluator`.  [[#2316]]
+ -  Added property `PreviousMiner` on `IBlockMetadata`.  [[#2332]]
+ -  Added property `PreviousMiner` on `IActionContext`.  [[#2332]]
+ -  Bumped `BlockMetadata.CurrentProtocolVersion` to 5.  [[#2332]]
 
 ### Backward-incompatible network protocol changes
 
@@ -78,6 +81,7 @@ To be released.
 [#2287]: https://github.com/planetarium/libplanet/pull/2287
 [#2297]: https://github.com/planetarium/libplanet/pull/2297
 [#2316]: https://github.com/planetarium/libplanet/pull/2316
+[#2332]: https://github.com/planetarium/libplanet/pull/2332
 
 
 Version PBFT

--- a/Libplanet.Node/UntypedBlock.cs
+++ b/Libplanet.Node/UntypedBlock.cs
@@ -97,6 +97,9 @@ namespace Libplanet.Node
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _header.TxHash;
 
+        /// <inheritdoc cref="IBlockMetadata.PreviousMiner"/>
+        public Address? PreviousMiner => _header.PreviousMiner;
+
         /// <inheritdoc cref="IBlockMetadata.LastCommit"/>
         public BlockCommit? LastCommit => _header.LastCommit;
 

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -45,6 +45,7 @@ namespace Libplanet.Tests.Action
                     ),
                     123,
                     null,
+                    null,
                     false
                 ),
                 new AccountStateDeltaImpl(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -20,6 +20,7 @@ namespace Libplanet.Tests.Blockchain
                 Index = 1,
                 PublicKey = _fx.Miner.PublicKey,
                 PreviousHash = _fx.GenesisBlock.Hash,
+                PreviousMiner = _fx.GenesisBlock.Miner,
                 Timestamp = _fx.GenesisBlock.Timestamp.AddDays(1),
                 Transactions = _emptyTransaction,
             }.Propose().Evaluate(_fx.Miner, _blockChain);
@@ -35,6 +36,7 @@ namespace Libplanet.Tests.Blockchain
                 Index = 1,
                 PublicKey = _fx.Miner.PublicKey,
                 PreviousHash = _fx.GenesisBlock.Hash,
+                PreviousMiner = _fx.GenesisBlock.Miner,
                 Timestamp = _fx.GenesisBlock.Timestamp.AddDays(1),
                 Transactions = _emptyTransaction,
                 ProtocolVersion = _blockChain.Tip.ProtocolVersion,
@@ -47,6 +49,7 @@ namespace Libplanet.Tests.Blockchain
                 PublicKey = _fx.Miner.PublicKey,
                 Miner = _fx.Miner.ToAddress(),
                 PreviousHash = block1.Hash,
+                PreviousMiner = block1.Miner,
                 Timestamp = _fx.GenesisBlock.Timestamp.AddDays(1),
                 Transactions = _emptyTransaction,
                 ProtocolVersion = _blockChain.Tip.ProtocolVersion - 1,
@@ -61,6 +64,7 @@ namespace Libplanet.Tests.Blockchain
                     Index = 2,
                     PublicKey = _fx.Miner.PublicKey,
                     PreviousHash = block1.Hash,
+                    PreviousMiner = block1.Miner,
                     Timestamp = _fx.GenesisBlock.Timestamp.AddDays(1),
                     Transactions = _emptyTransaction,
                     ProtocolVersion = BlockMetadata.CurrentProtocolVersion + 1,
@@ -80,6 +84,7 @@ namespace Libplanet.Tests.Blockchain
                 PublicKey = _fx.Miner.PublicKey,
                 // Wrong PreviousHash for test; it should be _validNext.Hash:
                 PreviousHash = _validNext.PreviousHash,
+                PreviousMiner = _validNext.Miner,
                 Timestamp = _validNext.Timestamp.AddDays(1),
                 Transactions = _emptyTransaction,
             }.Propose().Evaluate(_fx.Miner, _blockChain);
@@ -97,6 +102,7 @@ namespace Libplanet.Tests.Blockchain
                 Index = 2,
                 PublicKey = _fx.Miner.PublicKey,
                 PreviousHash = _validNext.Hash,
+                PreviousMiner = _validNext.Miner,
                 Timestamp = _validNext.Timestamp.AddSeconds(-1),
                 Transactions = _emptyTransaction,
             }.Propose().Evaluate(_fx.Miner, _blockChain);
@@ -138,6 +144,7 @@ namespace Libplanet.Tests.Blockchain
                 Index = 1,
                 PublicKey = TestUtils.GenesisMiner.PublicKey,
                 PreviousHash = genesisBlock.Hash,
+                PreviousMiner = genesisBlock.Miner,
                 Timestamp = genesisBlock.Timestamp.AddSeconds(1),
                 Transactions = _emptyTransaction,
             }.Propose().Evaluate(TestUtils.GenesisMiner, chain1);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -94,6 +94,7 @@ namespace Libplanet.Tests.Blockchain
                 Index = 1,
                 PublicKey = _fx.Miner.PublicKey,
                 PreviousHash = _fx.GenesisBlock.Hash,
+                PreviousMiner = _fx.GenesisBlock.Miner,
                 Timestamp = _fx.GenesisBlock.Timestamp.AddSeconds(1),
                 Transactions = _emptyTransaction,
             }.Propose().Evaluate(_fx.Miner, _blockChain);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -76,7 +76,16 @@ namespace Libplanet.Tests.Blockchain.Renderers
             LogEvent firstLog = null;
             IActionContext actionContext =
                 new ActionContext(
-                    default, default, default, default, 123, _stateDelta, default, null, rehearsal
+                    default,
+                    default,
+                    default,
+                    default,
+                    123,
+                    _stateDelta,
+                    default,
+                    null,
+                    null,
+                    rehearsal
                 );
             Exception actionError = new Exception();
             IActionRenderer<DumbAction> actionRenderer;

--- a/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
@@ -32,6 +32,7 @@ namespace Libplanet.Tests
         private static readonly byte[] StateRootHashKey = { 0x73 }; // 's'
         private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
         private static readonly byte[] PreEvaluationHashKey = { 0x63 }; // 'c'
+        private static readonly byte[] PreviousMinerKey = { 0x4D }; // 'M'
         private static readonly byte[] LastCommitKey = { 0x43 }; // 'C'
 
         // Block fields:
@@ -81,6 +82,7 @@ namespace Libplanet.Tests
                     TimestampKey,
                     _fx.Next.Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                 .Add(PublicKeyKey, _fx.Next.PublicKey.Format(compress: true))
+                .Add(PreviousMinerKey, _fx.Next.PreviousMiner.Value.ByteArray)
                 .Add(LastCommitKey, _fx.Next.LastCommit.Value.ByteArray);
             var expectedNextHeader = _marshaledNextMetadata
                 .Add(PreEvaluationHashKey, _fx.Next.PreEvaluationHash.ByteArray)
@@ -99,6 +101,7 @@ namespace Libplanet.Tests
                     _fx.HasTx.Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                 .Add(PublicKeyKey, _fx.HasTx.PublicKey.Format(true))
                 .Add(TxHashKey, _fx.HasTx.TxHash.Value.ByteArray)
+                .Add(PreviousMinerKey, _fx.HasTx.PreviousMiner.Value.ByteArray)
                 .Add(LastCommitKey, _fx.HasTx.LastCommit.Value.ByteArray);
             var expectedHasTxHeader = _marshaledHasTxMetadata
                 .Add(PreEvaluationHashKey, _fx.HasTx.PreEvaluationHash.ByteArray)

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -63,6 +63,7 @@ namespace Libplanet.Tests.Blocks
 
                 BlockContent<Arithmetic> content1 = _contents.Block1;
                 content1.PreviousHash = genesis.Hash;
+                content1.PreviousMiner = genesis.Miner;
                 content1.Transactions = new[] { _contents.Tx0InBlock1 };
                 PreEvaluationBlock<Arithmetic> preEval1 = content1.Propose();
 
@@ -120,6 +121,7 @@ namespace Libplanet.Tests.Blocks
 
                 BlockContent<Arithmetic> content1 = _contents.Block1;
                 content1.PreviousHash = genesis.Hash;
+                content1.PreviousMiner = genesis.Miner;
                 content1.Transactions = new[] { _contents.Tx0InBlock1 };
                 PreEvaluationBlock<Arithmetic> preEval1 = content1.Propose();
 

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -419,6 +419,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 Timestamp = previousBlock.Timestamp.Add(blockInterval ?? TimeSpan.FromSeconds(15)),
                 Transactions = txs ?? Array.Empty<Transaction<T>>(),
                 ProtocolVersion = protocolVersion,
+                PreviousMiner = previousBlock.Miner,
                 LastCommit = lastCommit,
             };
 

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -22,6 +22,7 @@ namespace Libplanet.Action
             long blockIndex,
             IAccountStateDelta previousStates,
             int randomSeed,
+            Address? previousMiner = null,
             BlockCommit? lastCommit = null,
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null,
@@ -33,6 +34,7 @@ namespace Libplanet.Action
             TxId = txid;
             Miner = miner;
             BlockIndex = blockIndex;
+            PreviousMiner = previousMiner;
             LastCommit = lastCommit;
             Rehearsal = rehearsal;
             PreviousStates = previousStates;
@@ -52,6 +54,8 @@ namespace Libplanet.Action
         public Address Miner { get; }
 
         public long BlockIndex { get; }
+
+        public Address? PreviousMiner { get; }
 
         public BlockCommit? LastCommit { get; }
 
@@ -86,6 +90,7 @@ namespace Libplanet.Action
                 BlockIndex,
                 PreviousStates,
                 _randomSeed,
+                PreviousMiner,
                 LastCommit,
                 Rehearsal,
                 _previousBlockStatesTrie,

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -212,6 +212,7 @@ namespace Libplanet.Action
                 signer: tx.Signer,
                 signature: tx.Signature,
                 actions: actions,
+                previousMiner: null,
                 lastCommit: null,
                 rehearsal: true,
                 previousBlockStatesTrie: null,
@@ -250,6 +251,9 @@ namespace Libplanet.Action
         /// <param name="actions">Actions to evaluate.</param>
         /// <param name="nativeTokens">A set of <see cref="Currency"/>s defined as native tokens by
         /// chain's <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/>.
+        /// </param>
+        /// <param name="previousMiner">
+        /// <see cref="Address"/> of a block miner account on last <see cref="Block{T}"/>.
         /// </param>
         /// <param name="lastCommit"><see cref="BlockCommit"/> of last <see cref="Block{T}"/>.
         /// </param>
@@ -293,6 +297,7 @@ namespace Libplanet.Action
             byte[] signature,
             IImmutableList<IAction> actions,
             IImmutableSet<Currency>? nativeTokens = null,
+            Address? previousMiner = null,
             BlockCommit? lastCommit = null,
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null,
@@ -309,6 +314,7 @@ namespace Libplanet.Action
                     blockIndex: blockIndex,
                     previousStates: prevStates,
                     randomSeed: randomSeed,
+                    previousMiner: previousMiner,
                     lastCommit: lastCommit,
                     rehearsal: rehearsal,
                     previousBlockStatesTrie: previousBlockStatesTrie,
@@ -618,6 +624,7 @@ namespace Libplanet.Action
                 signer: tx.Signer,
                 signature: tx.Signature,
                 actions: actions,
+                previousMiner: block.PreviousMiner,
                 lastCommit: block.LastCommit,
                 rehearsal: rehearsal,
                 previousBlockStatesTrie: previousBlockStatesTrie,
@@ -687,6 +694,8 @@ namespace Libplanet.Action
                 signer: block.Miner,
                 signature: Array.Empty<byte>(),
                 actions: new[] { _policyUpdateValidatorAction }.ToImmutableList(),
+                previousMiner: block.PreviousMiner,
+                lastCommit: block.LastCommit,
                 rehearsal: false,
                 previousBlockStatesTrie: previousBlockStatesTrie,
                 blockAction: true,
@@ -735,6 +744,7 @@ namespace Libplanet.Action
                 signer: block.Miner,
                 signature: Array.Empty<byte>(),
                 actions: new[] { _policyBlockAction }.ToImmutableList(),
+                previousMiner: block.PreviousMiner,
                 lastCommit: block.LastCommit,
                 rehearsal: false,
                 previousBlockStatesTrie: previousBlockStatesTrie,

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -47,6 +47,12 @@ namespace Libplanet.Action
         long BlockIndex { get; }
 
         /// <summary>
+        /// <see cref="Address"/> of a block miner account on last <see cref="Block{T}"/>.
+        /// </summary>
+        [Pure]
+        Address? PreviousMiner { get; }
+
+        /// <summary>
         /// <see cref="BlockCommit"/> of last <see cref="Block{T}"/>.
         /// </summary>
         [Pure]

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -100,6 +100,15 @@ namespace Libplanet.Blockchain
             long index = Count;
             long difficulty = 1L;
             BlockHash? prevHash = index > 0 ? Store.IndexBlockHash(Id, index - 1) : null;
+            Address? prevMiner;
+            if (prevHash is { } hash && index > 0)
+            {
+                prevMiner = Store.GetBlock<T>(hash).Miner;
+            }
+            else
+            {
+                prevMiner = null;
+            }
 
             int sessionId = new System.Random().Next();
             int processId = Process.GetCurrentProcess().Id;
@@ -119,6 +128,7 @@ namespace Libplanet.Blockchain
                 PublicKey = proposer.PublicKey,
                 PreviousHash = prevHash,
                 Timestamp = timestamp,
+                PreviousMiner = prevMiner,
                 LastCommit = lastCommit,
             };
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1464,6 +1464,7 @@ namespace Libplanet.Blockchain
             Block<T> lastBlock = index >= 1 ? this[index - 1] : null;
             BlockHash? prevHash = lastBlock?.Hash;
             DateTimeOffset? prevTimestamp = lastBlock?.Timestamp;
+            Address? prevMiner = lastBlock?.Miner;
 
             if (!block.PreviousHash.Equals(prevHash))
             {
@@ -1488,6 +1489,21 @@ namespace Libplanet.Blockchain
                     $"The block #{index} {block.Hash}'s timestamp " +
                     $"({block.Timestamp}) is earlier than " +
                     $"the block #{index - 1}'s ({prevTimestamp}).");
+            }
+
+            if (!block.PreviousMiner.Equals(prevMiner) && actualProtocolVersion >= 5)
+            {
+                if (prevMiner is null)
+                {
+                    return new InvalidBlockPreviousHashException(
+                        $"The genesis block {block.Hash} should not have previous miner, " +
+                        $"but its value is {block.PreviousMiner}.");
+                }
+
+                return new InvalidBlockPreviousMinerException(
+                    $"The block #{index} {block.Hash}'s miner " +
+                    $"({block.PreviousMiner}) is different from " +
+                    $"the block #{index - 1}'s miner ({prevMiner}).");
             }
 
             return null;

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -116,6 +116,9 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _preEvaluationBlock.TxHash;
 
+        /// <inheritdoc cref="IBlockMetadata.PreviousMiner"/>
+        public Address? PreviousMiner => _preEvaluationBlock.PreviousMiner;
+
         /// <inheritdoc cref="IBlockMetadata.LastCommit"/>
         public BlockCommit? LastCommit => _preEvaluationBlock.LastCommit;
 

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -137,6 +137,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _preEvaluationBlockHeader.TxHash;
 
+        public Address? PreviousMiner => _preEvaluationBlockHeader.PreviousMiner;
+
         public BlockCommit? LastCommit => _preEvaluationBlockHeader.LastCommit;
 
         /// <inheritdoc cref="IBlockHeader.Signature"/>

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -37,6 +37,7 @@ namespace Libplanet.Blocks
         private static readonly byte[] StateRootHashKey = { 0x73 }; // 's'
         private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
         private static readonly byte[] PreEvaluationHashKey = { 0x63 }; // 'c'
+        private static readonly byte[] PreviousMinerKey = { 0x4D }; // 'M'
         private static readonly byte[] LastCommitKey = { 0x43 }; // 'C'
 
         public static Dictionary MarshalBlockMetadata(IBlockMetadata metadata)
@@ -65,6 +66,11 @@ namespace Libplanet.Blocks
             dict = metadata.PublicKey is { } pubKey
                 ? dict.Add(PublicKeyKey, pubKey.Format(compress: true))
                 : dict.Add(MinerKey, metadata.Miner.ByteArray);
+
+            if (metadata.PreviousMiner is { } miner)
+            {
+                dict = dict.Add(PreviousMinerKey, miner.ByteArray);
+            }
 
             if (metadata.LastCommit is { } commit)
             {
@@ -195,6 +201,9 @@ namespace Libplanet.Blocks
                     ? new HashDigest<SHA256>(
                         marshaled.GetValue<Binary>(TxHashKey).ByteArray)
                     : (HashDigest<SHA256>?)null,
+                PreviousMiner = marshaled.ContainsKey(PreviousMinerKey)
+                ? new Address(marshaled.GetValue<Binary>(PreviousMinerKey).ByteArray)
+                : (Address?)null,
                 LastCommit = marshaled.ContainsKey(LastCommitKey)
                 ? new BlockCommit(marshaled.GetValue<Binary>(LastCommitKey).ByteArray.ToArray())
                 : (BlockCommit?)null,

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -53,6 +53,7 @@ namespace Libplanet.Blocks
         /// has a negative <see cref="IBlockMetadata.Index"/>.</exception>
         public BlockMetadata(IBlockMetadata metadata)
         {
+            PreviousMiner = metadata.PreviousMiner;
             LastCommit = metadata.LastCommit;
             ProtocolVersion = metadata.ProtocolVersion;
             Index = metadata.Index;
@@ -165,6 +166,8 @@ namespace Libplanet.Blocks
             get => _txHash;
             set => _txHash = value;
         }
+
+        public Address? PreviousMiner { get; set; }
 
         public BlockCommit? LastCommit { get; set; }
 

--- a/Libplanet/Blocks/IBlockMetadata.cs
+++ b/Libplanet/Blocks/IBlockMetadata.cs
@@ -54,6 +54,11 @@ namespace Libplanet.Blocks
         HashDigest<SHA256>? TxHash { get; }
 
         /// <summary>
+        /// The address of the miner on previous block.
+        /// </summary>
+        Address? PreviousMiner { get; }
+
+        /// <summary>
         /// The <see cref="BlockCommit"/> about previous block's vote information.
         /// </summary>
         BlockCommit? LastCommit { get; }

--- a/Libplanet/Blocks/InvalidBlockPreviousMinerException.cs
+++ b/Libplanet/Blocks/InvalidBlockPreviousMinerException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Libplanet.Blocks
+{
+    [Serializable]
+    public class InvalidBlockPreviousMinerException : InvalidBlockException
+    {
+        public InvalidBlockPreviousMinerException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Libplanet/Blocks/PreEvaluationBlockHeader.cs
+++ b/Libplanet/Blocks/PreEvaluationBlockHeader.cs
@@ -220,6 +220,8 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => Metadata.TxHash;
 
+        public Address? PreviousMiner => Metadata.PreviousMiner;
+
         public BlockCommit? LastCommit => Metadata.LastCommit;
 
         /// <inheritdoc cref="IPreEvaluationBlockHeader.PreEvaluationHash"/>

--- a/Libplanet/PoS/Action/PoSAction.cs
+++ b/Libplanet/PoS/Action/PoSAction.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Action
             states = ValidatorSetCtrl.Update(states, ctx.BlockIndex);
 
             states = AllocateReward.Execute(
-                states, ctx.NativeTokens, ctx.LastCommit?.Votes, ctx.Miner, ctx.BlockIndex);
+                states, ctx.NativeTokens, ctx.LastCommit?.Votes, ctx.PreviousMiner, ctx.BlockIndex);
             return states;
         }
     }

--- a/Libplanet/PoS/Misc/Asset.cs
+++ b/Libplanet/PoS/Misc/Asset.cs
@@ -2,10 +2,12 @@ using Libplanet.Assets;
 
 namespace Libplanet.PoS
 {
-    internal struct Asset
+    public struct Asset
     {
         public static readonly Currency GovernanceToken =
+#pragma warning disable CS0618
             Currency.Uncapped("GovernanceToken", 18, minters: null);
+#pragma warning restore CS0618
 
         public static readonly Currency ConsensusToken =
             Currency.Uncapped("ConsensusToken", 18, minters: null);

--- a/Libplanet/Store/BlockDigest.cs
+++ b/Libplanet/Store/BlockDigest.cs
@@ -83,6 +83,9 @@ namespace Libplanet.Store
         /// <inheritdoc cref="IBlockMetadata.TxHash"/>
         public HashDigest<SHA256>? TxHash => _metadata.TxHash;
 
+        /// <inheritdoc cref="IBlockMetadata.PreviousMiner"/>
+        public Address? PreviousMiner => _metadata.PreviousMiner;
+
         /// <inheritdoc cref="IBlockMetadata.LastCommit"/>
         public BlockCommit? LastCommit => _metadata.LastCommit;
 


### PR DESCRIPTION
`AllocationReward` was misimplemented to calculate proposer reward with "current proposer" and "previous validators".
To fix it, additional information`PreviousMiner` is required, so added this information to `IBlockMetadata` and `IActionContext`.