### PR TITLE
Change access modifier of `Libplnet.PoS.Asset`

### DIFF
--- a/Libplanet/PoS/Misc/Asset.cs
+++ b/Libplanet/PoS/Misc/Asset.cs
@@ -2,7 +2,7 @@ using Libplanet.Assets;
 
 namespace Libplanet.PoS
 {
-    internal struct Asset
+    public struct Asset
     {
         public static readonly Currency GovernanceToken =
             Currency.Uncapped("GovernanceToken", 18, minters: null);


### PR DESCRIPTION
To access from Lib9c, changed access modifier of `Libplnet.PoS.Asset` to public.