### PR TITLE
Added pluggable validators policy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ To be released.
  -  Added `BlockCommit` class.  [[#PBFT]]
  -  Added `BlockChain.ProposeGenesisBlock()` static method.  [[#PBFT]]
  -  Added `BlockChain.ProposeBlock()` method.  [[#PBFT]]
+ -  Added `IBlockPolicy.GetValidators()` method.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -427,7 +427,7 @@ If omitted (default) explorer only the local blockchain store.")]
             public int GetMaxTransactionsPerSignerPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerSignerPerBlock(index);
 
-            public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
+            public IEnumerable<PublicKey> GetValidators(long index) => new List<PublicKey>();
         }
 
         internal class Startup : IBlockChainContext<NullAction>

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         private readonly ILogger _logger;
 
         public ConsensusContextTest(ITestOutputHelper output)
-            : base(output, PrivateKeyPeer1, Validators)
+            : base(output, PrivateKeyPeer1, index => Validators)
         {
             const string outputTemplate =
                 "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTestBase.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         public ConsensusContextTestBase(
             ITestOutputHelper output,
             PrivateKey? privateKey = null,
-            List<PublicKey>? validators = null)
+            Func<long, IEnumerable<PublicKey>>? getValidators = null)
         {
             const string outputTemplate =
                 "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
@@ -42,7 +42,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             Fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
 
             privateKey ??= TestUtils.Peer1Priv;
-            validators ??= TestUtils.Validators;
+            getValidators ??= TestUtils.Policy.GetValidators;
 
             void BroadcastMessage(ConsensusMessage message) =>
                 Task.Run(() =>
@@ -59,8 +59,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 BlockChain,
                 BlockChain.Tip.Index + 1,
                 privateKey,
-                validators,
-                NewHeightDelay);
+                NewHeightDelay,
+                getValidators);
         }
 
         protected event EventHandler<ConsensusMessage>? ConsensusMessageSent;

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTestBase.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net.Tests.Consensus
 
         private const int Port = 6100;
         private readonly StoreFixture _fx;
-        private readonly PrivateKey[] _privateKey;
+        private readonly List<PrivateKey> _privateKeys;
         private readonly IStore[] _stores;
 
         private ILogger _logger;
@@ -54,7 +54,7 @@ namespace Libplanet.Net.Tests.Consensus
 
             CancellationTokenSource = new CancellationTokenSource();
 
-            _privateKey = new PrivateKey[Count];
+            _privateKeys = TestUtils.PrivateKeys;
             ConsensusReactors = new ConsensusReactor<DumbAction>[Count];
             ValidatorPeers = new List<BoundPeer>();
             _stores = new IStore[Count];
@@ -62,10 +62,9 @@ namespace Libplanet.Net.Tests.Consensus
 
             for (var i = 0; i < Count; i++)
             {
-                _privateKey[i] = new PrivateKey();
                 ValidatorPeers.Add(
                     new BoundPeer(
-                        _privateKey[i].PublicKey,
+                        _privateKeys[i].PublicKey,
                         new DnsEndPoint("localhost", Port + i)));
                 _stores[i] = new MemoryStore();
                 BlockChains[i] = new BlockChain<DumbAction>(
@@ -80,7 +79,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 ConsensusReactors[i] = (ConsensusReactor<DumbAction>)CreateReactor(
                     blockChain: BlockChains[i],
-                    key: _privateKey[i],
+                    key: _privateKeys[i],
                     consensusPort: Port + i,
                     validatorPeers: ValidatorPeers,
                     newHeightDelayMilliseconds: PropagationDelay * 2);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTestBase.cs
@@ -56,8 +56,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 BlockChain,
                 height,
                 privateKey: TestUtils.PrivateKeys[(int)nodeId],
-                validators: TestUtils.Validators,
-                _newHeightDelay);
+                _newHeightDelay,
+                BlockChain.Policy.GetValidators);
 
             Context = new Context<DumbAction>(
                 _consensusContext,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -90,7 +90,8 @@ namespace Libplanet.Net.Tests
 
         public static IBlockPolicy<DumbAction> Policy = new BlockPolicy<DumbAction>(
             blockAction: new MinerReward(1),
-            getMaxTransactionsBytes: _ => 50 * 1024);
+            getMaxTransactionsBytes: _ => 50 * 1024,
+            getValidators: _ => Validators);
 
         public delegate void DelegateWatchConsensusMessage(ConsensusMessage message);
 
@@ -221,8 +222,8 @@ namespace Libplanet.Net.Tests
                 blockChain,
                 height,
                 privateKey,
-                validators,
-                newHeightDelay: newHeightDelay);
+                newHeightDelay: newHeightDelay,
+                getValidators: _ => validators);
 
             async Task DummyHandle(Message message)
             {

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,8 +69,8 @@ namespace Libplanet.Net.Consensus
                 blockChain,
                 blockChain.Tip.Index,
                 privateKey,
-                validatorPeers.Select(x => x.PublicKey).ToList(),
-                newHeightDelay);
+                newHeightDelay,
+                blockChain.Policy.GetValidators);
 
             _logger = Log
                 .ForContext("Tag", "Consensus")

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -110,20 +110,20 @@ namespace Libplanet.Blockchain
                 difficulty,
                 prevHash);
 
-            var transactionsToMine = GatherTransactionsToPropose(
+            var transactionsToPropose = GatherTransactionsToPropose(
                 maxTransactionsBytes: maxTransactionsBytes,
                 maxTransactions: maxTransactions,
                 maxTransactionsPerSigner: maxTransactionsPerSigner,
                 txPriority: txPriority
             );
 
-            if (transactionsToMine.Count < Policy.GetMinTransactionsPerBlock(index))
+            if (transactionsToPropose.Count < Policy.GetMinTransactionsPerBlock(index))
             {
                 throw new OperationCanceledException(
                     $"Proposal operation canceled due to insufficient number of " +
                     $"gathered transactions to mine for the requirement of " +
                     $"{Policy.GetMinTransactionsPerBlock(index)} " +
-                    $"given by the policy: {transactionsToMine.Count}");
+                    $"given by the policy: {transactionsToPropose.Count}");
             }
 
             _logger.Verbose(
@@ -132,7 +132,7 @@ namespace Libplanet.Blockchain
                 sessionId,
                 processId,
                 index,
-                transactionsToMine.Count);
+                transactionsToPropose.Count);
 
             var blockContent = new BlockContent<T>
             {
@@ -140,7 +140,7 @@ namespace Libplanet.Blockchain
                 PublicKey = proposer.PublicKey,
                 PreviousHash = prevHash,
                 Timestamp = timestamp,
-                Transactions = transactionsToMine,
+                Transactions = transactionsToPropose,
                 LastCommit = lastCommit,
             };
             PreEvaluationBlock<T> preEval;

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -31,6 +31,7 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerSignerPerBlock;
+        private readonly Func<long, IEnumerable<PublicKey>> _getValidators;
 
         /// <summary>
         /// <para>
@@ -72,6 +73,8 @@ namespace Libplanet.Blockchain.Policies
         /// a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s index.
         /// Goes to <see cref="GetMaxTransactionsPerSignerPerBlock"/>.  Set to
         /// <see cref="GetMaxTransactionsPerBlock"/> by default.</param>
+        /// <param name="getValidators">The function determining the set of validators
+        /// for a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s index.</param>
         /// <param name="nativeTokens">A fixed set of <see cref="Currency"/> objects that are
         /// supported by the blockchain as first-class citizens.  Empty by default.</param>
         public BlockPolicy(
@@ -85,6 +88,7 @@ namespace Libplanet.Blockchain.Policies
             Func<long, int>? getMinTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null,
+            Func<long, IEnumerable<PublicKey>>? getValidators = null,
             IImmutableSet<Currency>? nativeTokens = null)
         {
             BlockAction = blockAction;
@@ -95,6 +99,7 @@ namespace Libplanet.Blockchain.Policies
             _getMaxTransactionsPerBlock = getMaxTransactionsPerBlock ?? (_ => 100);
             _getMaxTransactionsPerSignerPerBlock = getMaxTransactionsPerSignerPerBlock
                 ?? GetMaxTransactionsPerBlock;
+            _getValidators = getValidators ?? (_ => ImmutableList<PublicKey>.Empty);
 
             _validateNextBlockTx = validateNextBlockTx ?? ((_, __) => null);
             if (validateNextBlock is { } vnb)
@@ -208,6 +213,6 @@ namespace Libplanet.Blockchain.Policies
 
         /// <inheritdoc/>
         [Pure]
-        public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
+        public IEnumerable<PublicKey> GetValidators(long index) => _getValidators(index);
     }
 }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -129,8 +129,10 @@ namespace Libplanet.Blockchain.Policies
         /// <summary>
         /// Gets <see cref="IEnumerable{T}"/> of validator.
         /// </summary>
+        /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
+        /// for which this constraint should apply.</param>
         /// <returns><see cref="IEnumerable{T}"/> of validator.</returns>
         [Pure]
-        IEnumerable<PublicKey> GetValidators();
+        IEnumerable<PublicKey> GetValidators(long index);
     }
 }

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -57,6 +57,6 @@ namespace Libplanet.Blockchain.Policies
         public int GetMaxTransactionsPerSignerPerBlock(long index) =>
             GetMaxTransactionsPerBlock(index);
 
-        public IEnumerable<PublicKey> GetValidators() => new List<PublicKey>();
+        public IEnumerable<PublicKey> GetValidators(long index) => new List<PublicKey>();
     }
 }


### PR DESCRIPTION
Adds `IBlockPolicy.GetValidators()` method to retrieve a set of validators tied to an index.