### PR TITLE
WIP: Allow providing updatedAddresses for UnsignedTransaction in Libplanet.Explorer

### DIFF
--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -1,0 +1,6 @@
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class TransactionQueryTest
+{
+    
+}

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Immutable;
 using Bencodex;
 using Bencodex.Types;
 using GraphQL;
@@ -139,6 +140,12 @@ namespace Libplanet.Explorer.Queries
                     {
                         Name = "nonce",
                         Description = "The nonce for Transaction.",
+                    },
+                    new QueryArgument<ListGraphType<NonNullGraphType<StringGraphType>>>
+                    {
+                        Name = "updatedAddresses",
+                        Description = "Addresses with their state transitioned by Actions included"
+                                      + " in this Transaction.",
                     }
                 ),
                 resolve: context =>
@@ -155,12 +162,15 @@ namespace Libplanet.Explorer.Queries
                     Address signer = publicKey.ToAddress();
                     long nonce = context.GetArgument<long?>("nonce") ??
                         chain.GetNextTxNonce(signer);
+                    var updatedAddresses =
+                        context.GetArgument<IImmutableSet<Address>>("updatedAddresses");
                     Transaction<T> unsignedTransaction =
                         Transaction<T>.CreateUnsigned(
                             nonce,
                             publicKey,
                             chain.Genesis.Hash,
-                            new[] { action }
+                            new[] { action },
+                            updatedAddresses
                         );
                     return unsignedTransaction.Serialize(false);
                 }


### PR DESCRIPTION
Related: planetarium/pn-chrono#11, planetarium/pnscan-cloud#6

Currently, updatedAddresses cannot be provided for UnsignedTransaction Query. This implies that external applications that connect to nodes via RPC and sign locally cannot populate the updatedAddresses field, which means block explorers like planetarium/pnscan-cloud that use the updatedAddresses field for finding involved addresses in a tx can't do so in a transaction created in external applications. This PR provides the needed facility.