### PR TITLE
Make TxResultType support TxSuccess fully

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ a system action, its features will be added more in the future.
     [[#2046], [#2229]]
  -  Added `ActionEvaluator<T>.GenerateRandomSeed()` static method.
     [[#2131], [#2236]]
+ -  (Libplanet.Explorer) Added `updatedStates`, `updatedFungibleAssets`,
+    `fungibleAssetsDelta` GraphQL fields to `TxResultType`.  [[#2353]]
 
 ### Behavioral changes
 
@@ -90,6 +92,7 @@ a system action, its features will be added more in the future.
 [#2236]: https://github.com/planetarium/libplanet/pull/2236
 [#2294]: https://github.com/planetarium/libplanet/pull/2294
 [#2322]: https://github.com/planetarium/libplanet/pull/2322
+[#2353]: https://github.com/planetarium/libplanet/pull/2353
 [`System.Text.Json.JsonSerializer`]: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer
 [custom converters]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to
 [@planetarium/tx]: https://www.npmjs.com/package/@planetarium/tx

--- a/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GraphQL;
+using GraphQL.Execution;
+using Libplanet.Assets;
+using Libplanet.Explorer.GraphTypes;
+using Libplanet.Store;
+using Xunit;
+using static Libplanet.Explorer.Tests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.Tests.GraphTypes
+{
+    public class TxResultTypeTest
+    {
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async void Query(TxResult txResult, IDictionary<string, object> expected)
+        {
+            var query =
+                @"{
+                    txStatus
+                    blockIndex
+                    blockHash
+                    exceptionName
+                    exceptionMetadata
+                    updatedStates {
+                        address
+                        state
+                    }
+                    updatedFungibleAssets {
+                        address
+                        fungibleAssetValues {
+                            currency {
+                                ticker
+                                decimalPlaces
+                            }
+                            quantity
+                        }
+                    }
+                    fungibleAssetsDelta {
+                        address
+                        fungibleAssetValues {
+                            currency {
+                                ticker
+                                decimalPlaces
+                            }
+                            quantity
+                        }
+                    }
+                }";
+
+            var txResultType = new TxResultType();
+            ExecutionResult result = await ExecuteQueryAsync(
+                query,
+                txResultType,
+                source: txResult
+            );
+            Assert.Null(result.Errors);
+            ExecutionNode executionNode = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+            IDictionary<string, object> dictionary = Assert.IsAssignableFrom<IDictionary<string, object>>(executionNode.ToValue());
+
+            Assert.Equal(expected, dictionary);
+        }
+
+        public static IEnumerable<object[]> TestCases() {
+            Currency KRW = Currency.Uncapped("KRW", 18, null);
+            Address address = new Address("76ca86fa821c8241f9422c22b1386021047faf0d");
+            return new object[][] {
+                new object[] {
+                    new TxResult(
+                        TxStatus.SUCCESS,
+                        0,
+                        "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        null,
+                        null,
+                        ImmutableDictionary<Address, Bencodex.Types.IValue>.Empty,
+                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty,
+                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty
+                    ),
+                    new Dictionary<string, object> {
+                        ["txStatus"] = "SUCCESS",
+                        ["blockIndex"] = 0L,
+                        ["blockHash"] = "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        ["exceptionName"] = null,
+                        ["exceptionMetadata"] = null,
+                        ["updatedStates"] = new object[0],
+                        ["updatedFungibleAssets"] = new object[0],
+                        ["fungibleAssetsDelta"] = new object[0],
+                    }
+                },
+                new object[] {
+                    new TxResult(
+                        TxStatus.SUCCESS,
+                        0,
+                        "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        null,
+                        null,
+                        ImmutableDictionary<Address, Bencodex.Types.IValue>.Empty
+                            .Add(address, Bencodex.Types.Null.Value),
+                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty
+                            .Add(
+                                address,
+                                ImmutableDictionary<Currency, FungibleAssetValue>.Empty
+                                    .Add(KRW, KRW * 10000)
+                            ),
+                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty
+                            .Add(
+                                address,
+                                ImmutableDictionary<Currency, FungibleAssetValue>.Empty
+                                    .Add(KRW, KRW * 20000)
+                            )
+                    ),
+                    new Dictionary<string, object> {
+                        ["txStatus"] = "SUCCESS",
+                        ["blockIndex"] = 0L,
+                        ["blockHash"] = "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        ["exceptionName"] = null,
+                        ["exceptionMetadata"] = null,
+                        ["updatedStates"] = new object[] {
+                            new Dictionary<string, object> {
+                                ["address"] = address.ToString(),
+                                ["state"] = new byte[] { 110, },
+                            },
+                        },
+                        ["updatedFungibleAssets"] = new object[] {
+                            new Dictionary<string, object> {
+                                ["address"] = address.ToString(),
+                                ["fungibleAssetValues"] = new object[] {
+                                    new Dictionary<string, object> {
+                                        ["currency"] = new Dictionary<string, object> {
+                                            ["ticker"] = KRW.Ticker,
+                                            ["decimalPlaces"] = (uint)KRW.DecimalPlaces,
+                                        },
+                                        ["quantity"] = "20000",
+                                    },
+                                },
+                            },
+                        },
+                        ["fungibleAssetsDelta"] = new object[] {
+                            new Dictionary<string, object> {
+                                ["address"] = address.ToString(),
+                                ["fungibleAssetValues"] = new object[] {
+                                    new Dictionary<string, object> {
+                                        ["currency"] = new Dictionary<string, object> {
+                                            ["ticker"] = KRW.Ticker,
+                                            ["decimalPlaces"] = (uint)KRW.DecimalPlaces,
+                                        },
+                                        ["quantity"] = "10000",
+                                    },
+                                },
+                            },
+                        },
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Libplanet.Explorer/GraphTypes/TxResult.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResult.cs
@@ -1,5 +1,9 @@
+using System.Collections.Immutable;
 using Bencodex.Types;
+using Libplanet.Assets;
 using Libplanet.Explorer.GraphTypes;
+
+using FAV = Libplanet.Assets.FungibleAssetValue;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -10,7 +14,11 @@ namespace Libplanet.Explorer.GraphTypes
             long? blockIndex,
             string? blockHash,
             string? exceptionName,
-            IValue? exceptionMetadata
+            IValue? exceptionMetadata,
+            IImmutableDictionary<Address, IValue?>? updatedStates,
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>? fungibleAssetsDelta,
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>?
+                updatedFungibleAssets
         )
         {
             TxStatus = status;
@@ -18,6 +26,9 @@ namespace Libplanet.Explorer.GraphTypes
             BlockHash = blockHash;
             ExceptionName = exceptionName;
             ExceptionMetadata = exceptionMetadata;
+            UpdatedStates = updatedStates;
+            FungibleAssetsDelta = fungibleAssetsDelta;
+            UpdatedFungibleAssets = updatedFungibleAssets;
         }
 
         public TxStatus TxStatus { get; private set; }
@@ -29,5 +40,13 @@ namespace Libplanet.Explorer.GraphTypes
         public string? ExceptionName { get; private set; }
 
         public IValue? ExceptionMetadata { get; private set; }
+
+        public IImmutableDictionary<Address, IValue?>? UpdatedStates { get; }
+
+        public IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>?
+            FungibleAssetsDelta { get; }
+
+        public IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>?
+            UpdatedFungibleAssets { get; }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/TxResultType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResultType.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using GraphQL.Types;
+using Libplanet.Assets;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -35,6 +38,59 @@ namespace Libplanet.Explorer.GraphTypes
                 description: "The hexadecimal string of the exception metadata. (when only failed)",
                 resolve: context => context.Source.ExceptionMetadata
             );
+
+            Field<ListGraphType<NonNullGraphType<UpdatedStateType>>>(
+                nameof(TxResult.UpdatedStates),
+                resolve: context => context.Source.UpdatedStates?
+                    .Select(pair => new UpdatedState(pair.Key, pair.Value))
+            );
+
+            Field<ListGraphType<NonNullGraphType<FungibleAssetBalancesType>>>(
+                nameof(TxResult.UpdatedFungibleAssets),
+                resolve: context => context.Source.UpdatedFungibleAssets?
+                    .Select(pair => new FungibleAssetBalances(pair.Key, pair.Value.Values))
+            );
+
+            Field<ListGraphType<NonNullGraphType<FungibleAssetBalancesType>>>(
+                nameof(TxResult.FungibleAssetsDelta),
+                resolve: context => context.Source.FungibleAssetsDelta?
+                    .Select(pair => new FungibleAssetBalances(pair.Key, pair.Value.Values))
+            );
+        }
+
+        private record UpdatedState(Address Address, Bencodex.Types.IValue? State);
+
+        private class UpdatedStateType : ObjectGraphType<UpdatedState>
+        {
+            public UpdatedStateType()
+            {
+                Field<NonNullGraphType<AddressType>>(
+                    nameof(UpdatedState.Address),
+                    resolve: context => context.Source.Address
+                );
+                Field<BencodexValueType>(
+                    nameof(UpdatedState.State),
+                    resolve: context => context.Source.State
+                );
+            }
+        }
+
+        private record FungibleAssetBalances(
+            Address Address, IEnumerable<FungibleAssetValue> FungibleAssetValues);
+
+        private class FungibleAssetBalancesType : ObjectGraphType<FungibleAssetBalances>
+        {
+            public FungibleAssetBalancesType()
+            {
+                Field<NonNullGraphType<AddressType>>(
+                    nameof(FungibleAssetBalances.Address),
+                    resolve: context => context.Source.Address
+                );
+                Field<NonNullGraphType<ListGraphType<NonNullGraphType<FungibleAssetValueType>>>>(
+                    nameof(FungibleAssetBalances.FungibleAssetValues),
+                    resolve: context => context.Source.FungibleAssetValues
+                );
+            }
         }
     }
 }

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -233,8 +233,24 @@ namespace Libplanet.Explorer.Queries
                     if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
                         return blockChain.GetStagedTransactionIds().Contains(txId)
-                            ? new TxResult(TxStatus.STAGING, null, null, null, null)
-                            : new TxResult(TxStatus.INVALID, null, null, null, null);
+                            ? new TxResult(
+                                TxStatus.STAGING,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null)
+                            : new TxResult(
+                                TxStatus.INVALID,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null);
                     }
 
                     try
@@ -245,6 +261,9 @@ namespace Libplanet.Explorer.Queries
                         );
                         Block<T> txExecutedBlock = blockChain[txExecutedBlockHash];
 
+                        var updatedStates = ((TxSuccess)execution).UpdatedStates;
+                        var updatedFungibleAssets = ((TxSuccess)execution).UpdatedFungibleAssets;
+                        var fungibleAssetsDelta = ((TxSuccess)execution).FungibleAssetsDelta;
                         return execution switch
                         {
                             TxSuccess txSuccess => new TxResult(
@@ -252,14 +271,20 @@ namespace Libplanet.Explorer.Queries
                                 txExecutedBlock.Index,
                                 txExecutedBlock.Hash.ToString(),
                                 null,
-                                null
+                                null,
+                                txSuccess.UpdatedStates,
+                                txSuccess.FungibleAssetsDelta,
+                                txSuccess.UpdatedFungibleAssets
                             ),
                             TxFailure txFailure => new TxResult(
                                 TxStatus.FAILURE,
                                 txExecutedBlock.Index,
                                 txExecutedBlock.Hash.ToString(),
                                 txFailure.ExceptionName,
-                                txFailure.ExceptionMetadata
+                                txFailure.ExceptionMetadata,
+                                null,
+                                null,
+                                null
                             ),
                             _ => throw new NotSupportedException(
                                 #pragma warning disable format
@@ -272,6 +297,9 @@ namespace Libplanet.Explorer.Queries
                     {
                         return new TxResult(
                             TxStatus.INVALID,
+                            null,
+                            null,
+                            null,
                             null,
                             null,
                             null,


### PR DESCRIPTION
Originally, `Libplanet.Tx.TxSuccess` stores `updatedStates`, `updatedFungibleAssets`, `fulgibleAssetsDelta` but GraphQL API doesn't support it. Maybe it was because `NineChronicles` do not store them and it didn't implement the parts. But `Libplanet.Explorer` is *generic* application, not specific for `NineChronicles`, so it should implement them. This pull request implements those.