### PR TITLE
Upgrade StyleCop analyzer to 1.2.0-beta.435

### DIFF
--- a/Libplanet.Explorer/GraphTypes/BencodexValueType.cs
+++ b/Libplanet.Explorer/GraphTypes/BencodexValueType.cs
@@ -7,7 +7,7 @@ namespace Libplanet.Explorer.GraphTypes
 {
     public class BencodexValueType : StringGraphType
     {
-        private static readonly Codec _codec = new ();
+        private static readonly Codec _codec = new();
 
         public BencodexValueType()
         {

--- a/Libplanet.Explorer/GraphTypes/ByteStringType.cs
+++ b/Libplanet.Explorer/GraphTypes/ByteStringType.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Explorer.GraphTypes
             {
                 byte[] b => ByteUtil.Hex(b),
                 string s => s,
-                _ => null
+                _ => null,
             };
         }
 

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="SqlKata" Version="2.2.0" />
     <PackageReference Include="SqlKata.Execution" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -265,7 +265,7 @@ namespace Libplanet.Explorer.Queries
                                 #pragma warning disable format
                                 $"{nameof(execution)} is not expected concrete class."
                                 #pragma warning restore format
-                            )
+                            ),
                         };
                     }
                     catch (Exception)

--- a/Libplanet.Explorer/Store/IRichStore.cs
+++ b/Libplanet.Explorer/Store/IRichStore.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Explorer.Store
     {
         void StoreTxReferences(TxId txId, in BlockHash blockHash, long blockIndex);
 
-        IEnumerable<ValueTuple<TxId, BlockHash>> IterateTxReferences(
+        IEnumerable<(TxId, BlockHash)> IterateTxReferences(
             TxId? txId = null,
             bool desc = false,
             int offset = 0,

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -318,7 +318,7 @@ namespace Libplanet.Explorer.Store
             collection.EnsureIndex(nameof(TxRefDoc.BlockIndex));
         }
 
-        public IEnumerable<ValueTuple<TxId, BlockHash>> IterateTxReferences(
+        public IEnumerable<(TxId, BlockHash)> IterateTxReferences(
             TxId? txId = null,
             bool desc = false,
             int offset = 0,

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -281,7 +281,7 @@ namespace Libplanet.Explorer.Store
             });
         }
 
-        public IEnumerable<ValueTuple<TxId, BlockHash>> IterateTxReferences(
+        public IEnumerable<(TxId, BlockHash)> IterateTxReferences(
             TxId? txId = null,
             bool desc = false,
             int offset = 0,
@@ -296,7 +296,7 @@ namespace Libplanet.Explorer.Store
 
             query = desc ? query.OrderByDesc("tx_nonce") : query.OrderBy("tx_nonce");
             query = query.Offset(offset).Limit(limit);
-            return db.GetDictionary(query).Select(dict => new ValueTuple<TxId, BlockHash>(
+            return db.GetDictionary(query).Select(dict => (
                 new TxId((byte[])dict["tx_id"]),
                 new BlockHash((byte[])dict["block_hash"])));
         }


### PR DESCRIPTION
This pull request bumps `StyleCop.Analyzer` to `1.2.0-beta.435`, the latest version.

I was working for #2353 and used `record` syntax but the current `StyleCop.Analyzer` doesn't support it. So I opened this pull request.

---

I don't know why this pull request cannot pass the `linux-unity-test` job 😭 