### PR TITLE
Make `bindSignature()` can take tx w/ a system action & release 0.40.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.40.3
 --------------
 
-To be released.
+Released on September 29, 2022.
 
  -  (Libplanet.Explorer) Fixed a bug of `TransactionQuery<T>` that
     `bindSignature()` had errored if `unsignedTransaction` has a system
@@ -18,8 +18,8 @@ Version 0.40.2
 
 Released on September 23, 2022.
 
--  Fixed a bug where `Transaction<T>.ToBencodex(bool)` method had incorrectly
-   serialized `SystemAction`.  [[#2339]]
+ -  Fixed a bug where `Transaction<T>.ToBencodex(bool)` method had incorrectly
+    serialized `SystemAction`.  [[#2339]]
 
 [#2339]: https://github.com/planetarium/libplanet/pull/2339
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.40.3
 
 To be released.
 
+ -  (Libplanet.Explorer) Fixed a bug of `TransactionQuery<T>` that
+    `bindSignature()` had errored if `unsignedTransaction` has a system
+    action.  [[#2358]]
+
+[#2358]: https://github.com/planetarium/libplanet/pull/2358
+
 
 Version 0.40.2
 --------------

--- a/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
+++ b/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
@@ -2,6 +2,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
+using Libplanet.Store;
+using Libplanet.Explorer.GraphTypes;
+using Libplanet.Action;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Libplanet.Explorer.Tests
 {
@@ -13,17 +18,55 @@ namespace Libplanet.Explorer.Tests
             object source = null)
             where TObjectGraphType : IObjectGraphType, new()
         {
+            return ExecuteQueryAsync(
+                query,
+                new TObjectGraphType(),
+                userContext,
+                source
+            );
+        }
+
+        public static Task<ExecutionResult> ExecuteQueryAsync(
+            string query,
+            IObjectGraphType queryGraphType,
+            IDictionary<string, object> userContext = null,
+            object source = null
+        )
+        {
             var documentExecutor = new DocumentExecuter();
-            return documentExecutor.ExecuteAsync(new ExecutionOptions
-            {
-                Query = query,
-                Schema = new Schema
+
+            // FIXME these codes are temporarly fix and should be replaced with unified provider.
+            // see also: https://github.com/planetarium/libplanet/discussions/2230
+            var services = new ServiceCollection();
+            services.AddSingleton<BlockType<NullAction>>();
+            services.AddSingleton<IStore>(_ => new MemoryStore());
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var failSafeServiceProvider = new FuncServiceProvider(type =>
                 {
-                    Query = new TObjectGraphType(),
-                },
-                UserContext = userContext,
-                Root = source,
-            });
+                    try
+                    {
+                        return serviceProvider.GetRequiredService(type);
+                    }
+                    catch
+                    {
+                        // mimics previous way. (call parameterless constructor)
+                        return Activator.CreateInstance(type);
+                    }
+                }
+            );
+
+            return documentExecutor.ExecuteAsync(
+                new ExecutionOptions
+                {
+                    Query = query,
+                    Schema = new Schema(failSafeServiceProvider)
+                    {
+                        Query = queryGraphType,
+                    },
+                    UserContext = userContext,
+                    Root = source,
+                }
+            );
         }
     }
 }

--- a/Libplanet.Explorer.Tests/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/TransactionQueryTest.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Execution;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Explorer.Interfaces;
+using Libplanet.Explorer.Queries;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tx;
+using Xunit;
+using static Libplanet.ByteUtil;
+using static Libplanet.Explorer.Tests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class TransactionQueryTest
+{
+    private MockBlockChainContext<NullAction> _source;
+    private TransactionQuery<NullAction> _queryGraph;
+
+    public TransactionQueryTest()
+    {
+        _source = new MockBlockChainContext<NullAction>();
+        _queryGraph = new TransactionQuery<NullAction>(_source);
+    }
+
+    [Fact]
+    public async Task BindSignatureWithCustomActions()
+    {
+        var tx = Transaction<NullAction>.Create(
+            0L,
+            new PrivateKey(),
+            _source.BlockChain.Genesis.Hash,
+            Enumerable.Empty<NullAction>()
+        );
+        ExecutionResult result = await ExecuteQueryAsync(@$"
+        {{
+            bindSignature(
+                unsignedTransaction: ""{Hex(tx.Serialize(false))}"",
+                signature: ""{Hex(tx.Signature)}""
+            )
+         }}
+         ", _queryGraph, source: _source);
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        Assert.Equal(tx.Serialize(true), ParseHex((string)resultDict["bindSignature"]));
+    }
+
+    private class MockBlockChainContext<T> : IBlockChainContext<T>
+        where T : IAction, new()
+    {
+        public bool Preloaded => true;
+        public BlockChain<T> BlockChain { get; }
+        public IStore Store { get; }
+
+        public MockBlockChainContext()
+        {
+            Store = new MemoryStore();
+            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            var minerKey = new PrivateKey();
+            var genesisContent = new BlockContent<T> { PublicKey = minerKey.PublicKey };
+            Block<T> genesis = genesisContent.Mine().Evaluate(
+                minerKey,
+                null,
+                _ => true,
+                stateStore
+            );
+            BlockChain = new BlockChain<T>(
+                new BlockPolicy<T>(),
+                new VolatileStagePolicy<T>(),
+                Store,
+                stateStore,
+                genesis
+            );
+        }
+    }
+}

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -199,12 +199,17 @@ namespace Libplanet.Explorer.Queries
                             ),
                             false
                         );
-                    var signedTransaction = new Transaction<T>(
-                        metadata: unsignedTransaction,
-                        customActions: unsignedTransaction.CustomActions,
-                        signature: signature
-                    );
-
+                    var signedTransaction = unsignedTransaction.SystemAction is { } sysAction
+                        ? new Transaction<T>(
+                            metadata: unsignedTransaction,
+                            systemAction: sysAction,
+                            signature: signature
+                        )
+                        : new Transaction<T>(
+                            metadata: unsignedTransaction,
+                            customActions: unsignedTransaction.CustomActions,
+                            signature: signature
+                        );
                     return ByteUtil.Hex(signedTransaction.Serialize(true));
                 }
             );


### PR DESCRIPTION
See also the changelog.

Note that I cherry-picked a part of 83f665e60949b59e0594003a5e7d77d8e8fe5bf7 (see also #2186).