### PR TITLE
`Vote` class overhauled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,9 @@ To be released.
 
  -  Added `VoteSet` class.  [[#PBFT]]
  -  Added `VoteFlag` enum.  [[#PBFT]]
- -  Added `Vote` readonly struct.  [[#PBFT]]
+ -  Added `IVoteMetadata` interface.  [[#PBFT]]
+ -  Added `VoteMetadata` class.  [[#PBFT]]
+ -  Added `Vote` class.  [[#PBFT]]
  -  Added `BlockContent.Propose()` method.  [[#PBFT]]
  -  Added `BlockCommit` class.  [[#PBFT]]
  -  Added `BlockChain.ProposeGenesisBlock()` static method.  [[#PBFT]]

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -73,14 +73,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // Enough votes are present to proceed even without Peer3's vote.
             for (int i = 0; i < 2; i++)
             {
-                expectedVotes[i] = new Vote(
+                expectedVotes[i] = new VoteMetadata(
                     1,
                     0,
                     block1.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.Validators[i],
-                    VoteFlag.Absent,
-                    ImmutableArray<byte>.Empty).Sign(TestUtils.PrivateKeys[i]);
+                    VoteFlag.Absent).Sign(TestUtils.PrivateKeys[i]);
                 ConsensusContext.HandleMessage(
                     new ConsensusVote(expectedVotes[i])
                     {
@@ -92,14 +91,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // Enough votes are present to proceed even without Peer3's vote.
             for (int i = 0; i < 2; i++)
             {
-                expectedVotes[i] = new Vote(
+                expectedVotes[i] = new VoteMetadata(
                     1,
                     0,
                     block1.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.Validators[i],
-                    VoteFlag.Commit,
-                    ImmutableArray<byte>.Empty).Sign(TestUtils.PrivateKeys[i]);
+                    VoteFlag.Commit).Sign(TestUtils.PrivateKeys[i]);
                 ConsensusContext.HandleMessage(
                     new ConsensusCommit(expectedVotes[i])
                     {
@@ -184,14 +182,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
                 ConsensusContext.HandleMessage(
                     new ConsensusVote(
-                        new Vote(
+                        new VoteMetadata(
                             2,
                             0,
                             propose.BlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
-                            VoteFlag.Absent,
-                            ImmutableArray<byte>.Empty).Sign(privateKey))
+                            VoteFlag.Absent).Sign(privateKey))
                     {
                         Remote = peer,
                     });
@@ -211,14 +208,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
                 ConsensusContext.HandleMessage(
                     new ConsensusCommit(
-                        new Vote(
+                        new VoteMetadata(
                             2,
                             0,
                             propose.BlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
-                            VoteFlag.Commit,
-                            ImmutableArray<byte>.Empty).Sign(privateKey))
+                            VoteFlag.Commit).Sign(privateKey))
                     {
                         Remote = peer,
                     });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
@@ -151,14 +150,13 @@ namespace Libplanet.Net.Tests.Consensus.Context
             // Vote's signature does not match with remote
             Context.ProduceMessage(
                 new ConsensusVote(
-                    new Vote(
+                    new VoteMetadata(
                         Context.Height,
                         Context.Round,
                         block.Hash,
                         DateTimeOffset.UtcNow,
                         TestUtils.Validators[0],
-                        VoteFlag.Absent,
-                        ImmutableArray<byte>.Empty).Sign(TestUtils.PrivateKeys[NodeId])));
+                        VoteFlag.Absent).Sign(TestUtils.PrivateKeys[NodeId])));
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
 
@@ -167,14 +165,13 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Context.ProduceMessage(
                 new ConsensusVote(
-                    new Vote(
+                    new VoteMetadata(
                         Context.Height,
                         Context.Round,
                         block.Hash,
                         DateTimeOffset.UtcNow,
                         TestUtils.Validators[0],
-                        VoteFlag.Absent,
-                        ImmutableArray<byte>.Empty).Sign(TestUtils.PrivateKeys[NodeId])));
+                        VoteFlag.Absent).Sign(TestUtils.PrivateKeys[NodeId])));
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
         }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using Bencodex;
@@ -99,14 +98,13 @@ namespace Libplanet.Net.Tests
             int round = 0,
             BlockHash? hash = null,
             VoteFlag flag = VoteFlag.Null) =>
-            new Vote(
+            new VoteMetadata(
                 height,
                 round,
                 hash,
                 DateTimeOffset.Now,
                 privateKey.PublicKey,
-                flag,
-                ImmutableArray<byte>.Empty).Sign(privateKey);
+                flag).Sign(privateKey);
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
         {
@@ -169,14 +167,13 @@ namespace Libplanet.Net.Tests
 
                 consensusContext.HandleMessage(
                     new ConsensusCommit(
-                        new Vote(
+                        new VoteMetadata(
                             consensusContext.Height,
                             (int)consensusContext.Round,
                             roundBlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
-                            VoteFlag.Commit,
-                            ImmutableArray<byte>.Empty).Sign(privateKey))
+                            VoteFlag.Commit).Sign(privateKey))
                     {
                         Remote = peer,
                     });

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -117,7 +117,7 @@ namespace Libplanet.Net.Consensus
 
                 if (message is ConsensusVote vote &&
                     (!vote.Validator.Equals(vote.ProposeVote.Validator) ||
-                    !vote.ProposeVote.Verify(vote.Validator) ||
+                    !vote.ProposeVote.Verify() ||
                     !_validators.Contains(vote.Validator)))
                 {
                     throw new InvalidValidatorVoteMessageException(
@@ -127,7 +127,7 @@ namespace Libplanet.Net.Consensus
 
                 if (message is ConsensusCommit commit &&
                     (!commit.Validator.Equals(commit.CommitVote.Validator) ||
-                    !commit.CommitVote.Verify(commit.Validator) ||
+                    !commit.CommitVote.Verify() ||
                     !_validators.Contains(commit.Validator)))
                 {
                     throw new InvalidValidatorVoteMessageException(
@@ -185,12 +185,12 @@ namespace Libplanet.Net.Consensus
                 if (IsValid(block1) && (_lockedRound == -1 || _lockedValue == block1))
                 {
                     BroadcastMessage(
-                        new ConsensusVote(Voting(Round, block1.Hash, VoteFlag.Absent)));
+                        new ConsensusVote(MakeVote(Round, block1.Hash, VoteFlag.Absent)));
                 }
                 else
                 {
                     BroadcastMessage(
-                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                        new ConsensusVote(MakeVote(Round, null, VoteFlag.Absent)));
                 }
             }
 
@@ -210,12 +210,12 @@ namespace Libplanet.Net.Consensus
                 if (IsValid(block2) && (_lockedRound <= validRound2 || _lockedValue == block2))
                 {
                     BroadcastMessage(
-                        new ConsensusVote(Voting(Round, block2.Hash, VoteFlag.Absent)));
+                        new ConsensusVote(MakeVote(Round, block2.Hash, VoteFlag.Absent)));
                 }
                 else
                 {
                     BroadcastMessage(
-                        new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                        new ConsensusVote(MakeVote(Round, null, VoteFlag.Absent)));
                 }
             }
 
@@ -255,7 +255,7 @@ namespace Libplanet.Net.Consensus
                     _lockedValue = block3;
                     _lockedRound = Round;
                     BroadcastMessage(
-                        new ConsensusCommit(Voting(Round, block3.Hash, VoteFlag.Commit)));
+                        new ConsensusCommit(MakeVote(Round, block3.Hash, VoteFlag.Commit)));
                 }
 
                 _validValue = block3;
@@ -271,7 +271,7 @@ namespace Libplanet.Net.Consensus
                     ToString());
                 Step = Step.PreCommit;
                 BroadcastMessage(
-                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
+                    new ConsensusCommit(MakeVote(Round, null, VoteFlag.Commit)));
             }
 
             if (HasTwoThirdsPreCommit(Round, null, true) && !_preCommitTimeoutFlags.Contains(Round))
@@ -337,7 +337,7 @@ namespace Libplanet.Net.Consensus
             if (round == Round && Step == Step.Propose)
             {
                 BroadcastMessage(
-                    new ConsensusVote(Voting(Round, null, VoteFlag.Absent)));
+                    new ConsensusVote(MakeVote(Round, null, VoteFlag.Absent)));
                 Step = Step.PreVote;
                 TimeoutProcessed?.Invoke(this, round);
             }
@@ -354,7 +354,7 @@ namespace Libplanet.Net.Consensus
             if (round == Round && Step == Step.PreVote)
             {
                 BroadcastMessage(
-                    new ConsensusCommit(Voting(Round, null, VoteFlag.Commit)));
+                    new ConsensusCommit(MakeVote(Round, null, VoteFlag.Commit)));
                 Step = Step.PreCommit;
                 TimeoutProcessed?.Invoke(this, round);
             }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -552,18 +552,27 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void ProposeBlockWithLastCommit()
         {
-            var keyA = new PrivateKey();
-            var keyB = new PrivateKey();
-            var keyC = new PrivateKey();
+            var keys = Enumerable.Range(0, 3).Select(_ => new PrivateKey()).ToList();
 
             var voteSet = new VoteSet(
                 _blockChain.Tip.Index,
                 0,
                 _blockChain.Tip.Hash,
-                new[] { keyA.PublicKey, keyB.PublicKey, keyC.PublicKey });
-            voteSet.Add(voteSet.Votes[0].Sign(keyA));
-            voteSet.Add(voteSet.Votes[1].Sign(keyB));
-            voteSet.Add(voteSet.Votes[2].Sign(keyC));
+                keys.Select(key => key.PublicKey));
+            for (int i = 0; i < 3; i++)
+            {
+                var vote = voteSet.Votes[i];
+                voteSet.Add(
+                    new VoteMetadata(
+                        height: vote.Height,
+                        round: vote.Round,
+                        blockHash: vote.BlockHash,
+                        timestamp: vote.Timestamp,
+                        validator: vote.Validator,
+                        flag: vote.Flag
+                    ).Sign(keys[i]));
+            }
+
             var blockCommit = new BlockCommit(voteSet, _blockChain.Tip.Hash);
 
             Block<DumbAction> block = _blockChain.ProposeBlock(

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -24,15 +24,14 @@ namespace Libplanet.Tests.Blocks
          {
              var fx = new MemoryStoreFixture();
              var votes = Enumerable.Range(0, 4)
-                                          .Select(x => new Vote(
-                                              1,
-                                              0,
-                                              fx.Hash1,
-                                              DateTimeOffset.Now,
-                                              new PrivateKey().PublicKey,
-                                              VoteFlag.Absent,
-                                              ImmutableArray<byte>.Empty))
-                                          .ToImmutableArray();
+                .Select(x => new VoteMetadata(
+                    1,
+                    0,
+                    fx.Hash1,
+                    DateTimeOffset.Now,
+                    new PrivateKey().PublicKey,
+                    VoteFlag.Null).Sign(null))
+                .ToImmutableArray();
              var blockCommit = new BlockCommit(1, 0, fx.Hash1, votes);
 
              byte[] marshaled = blockCommit.ByteArray;

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -37,14 +37,13 @@ namespace Libplanet.Tests.Blocks
                     hash: Genesis.Hash,
                     votes: new[]
                     {
-                        new Vote(
+                        new VoteMetadata(
                             Genesis.Index,
                             0,
                             Genesis.Hash,
                             Genesis.Timestamp,
                             Miner.PublicKey,
-                            VoteFlag.Commit,
-                            ImmutableArray<byte>.Empty).Sign(Miner),
+                            VoteFlag.Commit).Sign(Miner),
                     }.ToImmutableArray())
             );
             HasTx = TestUtils.ProposeNextBlock(
@@ -63,14 +62,13 @@ namespace Libplanet.Tests.Blocks
                     hash: Next.Hash,
                     votes: new[]
                     {
-                        new Vote(
+                        new VoteMetadata(
                             Next.Index,
                             0,
                             Next.Hash,
                             Next.Timestamp,
                             Miner.PublicKey,
-                            VoteFlag.Commit,
-                            ImmutableArray<byte>.Empty).Sign(Miner),
+                            VoteFlag.Commit).Sign(Miner),
                     }.ToImmutableArray())
             );
         }

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -35,30 +35,27 @@ namespace Libplanet.Tests.Blocks
                 "341e8f360597d5bc45ab96aabc5f1b0608063f30af7bd4153556c9536a07693a"
             );
             DateTimeOffset timestamp = DateTimeOffset.UtcNow;
-            var voteA = new Vote(
+            var voteA = new VoteMetadata(
                 1,
                 0,
                 blockHash,
                 timestamp,
                 validatorA.PublicKey,
-                VoteFlag.Commit,
-                ImmutableArray<byte>.Empty).Sign(validatorA);
-            var voteB = new Vote(
+                VoteFlag.Commit).Sign(validatorA);
+            var voteB = new VoteMetadata(
                 1,
                 0,
                 blockHash,
                 timestamp,
                 validatorB.PublicKey,
-                VoteFlag.Commit,
-                ImmutableArray<byte>.Empty).Sign(validatorB);
-            var voteC = new Vote(
+                VoteFlag.Commit).Sign(validatorB);
+            var voteC = new VoteMetadata(
                 1,
                 0,
                 blockHash,
                 timestamp,
                 validatorC.PublicKey,
-                VoteFlag.Commit,
-                ImmutableArray<byte>.Empty).Sign(validatorC);
+                VoteFlag.Commit).Sign(validatorC);
 
             // Height of the last commit is invalid.
             var invalidHeightLastCommit = new BlockCommit(
@@ -111,14 +108,13 @@ namespace Libplanet.Tests.Blocks
                 {
                     voteA,
                     voteB,
-                    new Vote(
+                    new VoteMetadata(
                         1,
                         0,
                         blockHash,
                         timestamp,
                         validatorC.PublicKey,
-                        VoteFlag.Commit,
-                        ImmutableArray<byte>.Empty).Sign(invalidValidator),
+                        VoteFlag.Commit).Sign(invalidValidator),
                 }.ToImmutableArray());
             var invalidVoteSignatureMetadata = new BlockMetadata
             {
@@ -143,14 +139,13 @@ namespace Libplanet.Tests.Blocks
                 {
                     voteA,
                     voteB,
-                    new Vote(
+                    new VoteMetadata(
                         2,
                         0,
                         blockHash,
                         timestamp,
                         validatorC.PublicKey,
-                        VoteFlag.Commit,
-                        ImmutableArray<byte>.Empty).Sign(validatorC),
+                        VoteFlag.Commit).Sign(validatorC),
                 }.ToImmutableArray());
             var invalidVoteHeightMetadata = new BlockMetadata
             {
@@ -174,22 +169,20 @@ namespace Libplanet.Tests.Blocks
                 new[]
                 {
                     voteA,
-                    new Vote(
+                    new VoteMetadata(
                         1,
                         0,
                         blockHash,
                         timestamp,
                         validatorB.PublicKey,
-                        VoteFlag.Null,
-                        ImmutableArray<byte>.Empty),
-                    new Vote(
+                        VoteFlag.Null).Sign(null),
+                    new VoteMetadata(
                         1,
                         0,
                         blockHash,
                         timestamp,
                         validatorC.PublicKey,
-                        VoteFlag.Unknown,
-                        ImmutableArray<byte>.Empty),
+                        VoteFlag.Unknown).Sign(null),
                 }.ToImmutableArray());
             var validMetadata = new BlockMetadata
             {

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -33,23 +33,14 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
-                 var voteWithoutSign = new Vote(
-                     1,
-                     2,
-                     targetBlockHash,
-                     now,
-                     validators[i].PublicKey,
-                     VoteFlag.Absent,
-                     ImmutableArray<byte>.Empty);
-                 var vote = new Vote(
-                     1,
-                     2,
-                     targetBlockHash,
-                     now,
-                     validators[i].PublicKey,
-                     VoteFlag.Absent,
-                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
-                 voteSet.Add(vote);
+                var vote = new VoteMetadata(
+                    1,
+                    2,
+                    targetBlockHash,
+                    now,
+                    validators[i].PublicKey,
+                    VoteFlag.Absent).Sign(validators[i]);
+                voteSet.Add(vote);
              }
 
              Assert.True(voteSet.HasTwoThirdAny());
@@ -64,22 +55,13 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
-                 var voteWithoutSign = new Vote(
+                 var vote = new VoteMetadata(
                      1,
                      2,
                      targetBlockHash,
                      now,
                      validators[i].PublicKey,
-                     VoteFlag.Commit,
-                     ImmutableArray<byte>.Empty);
-                 var vote = new Vote(
-                     1,
-                     2,
-                     targetBlockHash,
-                     now,
-                     validators[i].PublicKey,
-                     VoteFlag.Commit,
-                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
+                     VoteFlag.Commit).Sign(validators[i]);
                  voteSet.Add(vote);
              }
 
@@ -110,22 +92,13 @@ namespace Libplanet.Tests.Consensus
 
              for (int i = 0; i < 3; i++)
              {
-                 var voteWithoutSign = new Vote(
+                 var vote = new VoteMetadata(
                      1,
                      1,
                      targetBlockHash,
                      now,
                      validators[i].PublicKey,
-                     VoteFlag.Absent,
-                     ImmutableArray<byte>.Empty);
-                 var vote = new Vote(
-                     1,
-                     1,
-                     targetBlockHash,
-                     now,
-                     validators[i].PublicKey,
-                     VoteFlag.Absent,
-                     validators[i].Sign(voteWithoutSign.ByteArray).ToImmutableArray());
+                     VoteFlag.Absent).Sign(validators[i]);
                  voteSet.Add(vote);
              }
 

--- a/Libplanet/Blocks/PreEvaluationBlockHeader.cs
+++ b/Libplanet/Blocks/PreEvaluationBlockHeader.cs
@@ -154,8 +154,7 @@ namespace Libplanet.Blocks
                     if (!votes.All(
                             vote =>
                             {
-                                if (vote.Signature is { } sign &&
-                                    vote.Validator.Verify(vote.RemoveSignature.ByteArray, sign))
+                                if (vote.Verify())
                                 {
                                     return true;
                                 }

--- a/Libplanet/Consensus/IVoteMetadata.cs
+++ b/Libplanet/Consensus/IVoteMetadata.cs
@@ -1,0 +1,43 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A common <see langword="interface"/> for <see cref="Vote"/>s
+    /// and <see cref="VoteMetadata"/>s.
+    /// </summary>
+    public interface IVoteMetadata
+    {
+        /// <summary>
+        /// Height of the vote target block.
+        /// </summary>
+        long Height { get; }
+
+        /// <summary>
+        /// Round of the vote in given height.
+        /// </summary>
+        int Round { get; }
+
+        /// <summary>
+        /// <see cref="BlockHash"/> of the block in vote. If null, vote nil.
+        /// </summary>
+        BlockHash? BlockHash { get; }
+
+        /// <summary>
+        /// The time at which the voting took place.
+        /// </summary>
+        DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// The <see cref="PublicKey"/> of the validator that voted.
+        /// </summary>
+        PublicKey Validator { get; }
+
+        /// <summary>
+        /// The <see cref="VoteFlag"/> indicating the type of a <see cref="Vote"/>.
+        /// </summary>
+        VoteFlag Flag { get; }
+    }
+}

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Globalization;
 using System.Linq;
 using Bencodex;
 using Bencodex.Types;
@@ -11,226 +10,123 @@ using Libplanet.Crypto;
 namespace Libplanet.Consensus
 {
     /// <summary>
-    /// Represents any vote from validators for consensus.
+    /// Represents a <see cref="Vote"/> from a validator for consensus.
     /// </summary>
-    public readonly struct Vote : IEquatable<Vote>
+    public class Vote : IVoteMetadata, IEquatable<Vote>
     {
-        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private const string HeightKey = "height";
-        private const string RoundKey = "round";
-        private const string BlockHashKey = "block_hash";
-        private const string TimestampKey = "timestamp";
-        private const string ValidatorKey = "validator";
-        private const string FlagKey = "vote_flag";
         private const string SignatureKey = "signature";
 
-        /// <summary>
-        /// Create a vote instance.
-        /// </summary>
-        /// <param name="height">Height of the vote target block.</param>
-        /// <param name="round">Round of the vote in given height.</param>
-        /// <param name="blockHash"><see cref="BlockHash"/> of the block in vote.</param>
-        /// <param name="timestamp">The time at which the voting took place.</param>
-        /// <param name="validator">
-        /// <see cref="PublicKey"/> of the validator made the vote.
-        /// </param>
-        /// <param name="flag">
-        /// <see cref="VoteFlag"/> for the vote's status.</param>
-        /// <param name="signature">Signature of the vote.</param>
+        private static Codec _codec = new Codec();
+        private readonly VoteMetadata _metadata;
+
         public Vote(
-            long height,
-            int round,
-            BlockHash? blockHash,
-            DateTimeOffset timestamp,
-            PublicKey validator,
-            VoteFlag flag,
+            VoteMetadata metadata,
             ImmutableArray<byte> signature)
         {
-            Height = height;
-            Round = round;
-            BlockHash = blockHash;
-            Timestamp = timestamp;
-            Validator = validator;
-            Flag = flag;
+            if (signature.IsDefault)
+            {
+                throw new ArgumentException(
+                    $"{nameof(signature)} should not be set to default; use an empty array " +
+                    $"to represent a lack of signature for a {nameof(Vote)}.",
+                    nameof(signature));
+            }
+
+            _metadata = metadata;
             Signature = signature;
         }
 
         /// <summary>
-        /// Create a vote instance.
+        /// Creates a <see cref="Vote"/> instance.
         /// </summary>
-        /// <param name="marshaled">Marshaled value of the vote. <seealso cref="ByteArray"/></param>
-        /// <exception cref="ArgumentException">
-        /// Thrown when given bytearray cannot be unmarshaled into <see cref="Vote"/>.
-        /// </exception>
+        /// <param name="marshaled">Marshaled value of the <see cref="Vote"/>.
+        /// <seealso cref="ByteArray"/></param>
         public Vote(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
         {
-            var codec = new Codec();
-            try
-            {
-                var dict = (Dictionary)codec.Decode(marshaled);
-                Height = dict.GetValue<Integer>(HeightKey);
-                Round = dict.GetValue<Integer>(RoundKey);
-                BlockHash = dict.ContainsKey(BlockHashKey)
-                    ? new BlockHash(dict.GetValue<Binary>(BlockHashKey).ByteArray)
-                    : (BlockHash?)null;
-                Timestamp = DateTimeOffset.ParseExact(
-                    dict.GetValue<Text>(TimestampKey),
-                    TimestampFormat,
-                    CultureInfo.InvariantCulture);
-                Validator = new PublicKey(dict.GetValue<Binary>(ValidatorKey).ByteArray);
-                Flag = (VoteFlag)(long)dict.GetValue<Integer>(FlagKey);
-                Signature = dict.ContainsKey(SignatureKey)
-                    ? (ImmutableArray<byte>)dict.GetValue<Binary>(SignatureKey)
-                    : ImmutableArray<byte>.Empty;
-            }
-            catch (Exception)
-            {
-                throw new ArgumentException(
-                    "Cannot unmarshal given bytearray into vote.",
-                    nameof(marshaled));
-            }
         }
 
-        /// <summary>
-        /// Height of the vote target block.
-        /// </summary>
-        public long Height { get; }
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public Vote(Dictionary encoded)
+            : this(
+                new VoteMetadata(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc/>
+        public long Height => _metadata.Height;
+
+        /// <inheritdoc/>
+        public int Round => _metadata.Round;
+
+        /// <inheritdoc/>
+        public BlockHash? BlockHash => _metadata.BlockHash;
+
+        /// <inheritdoc/>
+        public DateTimeOffset Timestamp => _metadata.Timestamp;
+
+        /// <inheritdoc/>
+        public PublicKey Validator => _metadata.Validator;
+
+        /// <inheritdoc/>
+        public VoteFlag Flag => _metadata.Flag;
 
         /// <summary>
-        /// Round of the vote in given height.
-        /// </summary>
-        public int Round { get; }
-
-        /// <summary>
-        /// <see cref="BlockHash"/> of the block in vote. If null, vote nil.
-        /// </summary>
-        public BlockHash? BlockHash { get; }
-
-        /// <summary>
-        /// The time at which the voting took place.
-        /// </summary>
-        public DateTimeOffset Timestamp { get; }
-
-        /// <summary>
-        /// <see cref="PublicKey"/> of the validator made the vote.
-        /// </summary>
-        public PublicKey Validator { get; }
-
-        /// <summary>
-        /// <see cref="VoteFlag"/> for the vote's status.
-        /// </summary>
-        public VoteFlag Flag { get; }
-
-        /// <summary>
-        /// Signature of the vote.
+        /// The signature for the <see cref="Vote"/>.  Lack of signature for a <see cref="Vote"/>
+        /// is represented by an empty array <em>not</em> <see langword="default"/>.
         /// </summary>
         public ImmutableArray<byte> Signature { get; }
 
-        /// <summary>
-        /// Marshaled vote data.
-        /// </summary>
-        public byte[] ByteArray
+        public Dictionary Encoded
         {
             get
             {
-                var codec = new Codec();
-                var dict = Bencodex.Types.Dictionary.Empty
-                    .Add(HeightKey, Height)
-                    .Add(RoundKey, Round)
-                    .Add(
-                        TimestampKey,
-                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
-                    .Add(ValidatorKey, Validator.Format(compress: true))
-                    .Add(FlagKey, (long)Flag);
-
-                if (BlockHash is { } blockHash)
-                {
-                    dict = dict.Add(BlockHashKey, blockHash.ByteArray);
-                }
-
-                if (Signature is { } signature)
-                {
-                    dict = dict.Add(SignatureKey, signature);
-                }
-
-                return codec.Encode(dict);
+                return !Signature.IsEmpty
+                    ? _metadata.Encoded.Add(SignatureKey, Signature)
+                    : _metadata.Encoded;
             }
         }
 
-        public Vote RemoveSignature =>
-            new Vote(
-                Height,
-                Round,
-                BlockHash,
-                Timestamp,
-                Validator,
-                Flag,
-                ImmutableArray<byte>.Empty);
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="Vote"/> data.
+        /// </summary>
+        public byte[] ByteArray => _codec.Encode(Encoded);
 
         /// <summary>
-        /// Sign a <see cref="Vote"/> using the given private key.
+        /// Verifies whether the <see cref="Vote"/>'s payload is properly signed by
+        /// <see cref="Validator"/>.
         /// </summary>
-        /// <param name="signer">A private key to sign the claim.</param>
-        /// <returns>A signed vote claim.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="signer"/> is
-        /// <c>null</c>.</exception>
-        public Vote Sign(PrivateKey signer)
-        {
-            Vote voteWithoutSign = RemoveSignature;
-            byte[] sign = signer.Sign(voteWithoutSign.ByteArray);
-            return new Vote(
-                Height,
-                Round,
-                BlockHash,
-                Timestamp,
-                Validator,
-                Flag,
-                sign.ToImmutableArray());
-        }
-
-        /// <summary>
-        /// Verifies whether the claim is certainly signed by the <see cref="Validator"/>.
-        /// </summary>
-        /// <param name="publicKey">A public key of the <see cref="Validator"/>.</param>
-        /// <returns><c>true</c> if and only if the given <paramref name="publicKey"/> is
-        /// <see cref="Validator"/>'s and the <see cref="Signature"/> is certainly signed by
-        /// the <see cref="Validator"/>.</returns>
+        /// <returns><c>true</c> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
         [Pure]
-        public bool Verify(PublicKey publicKey) =>
-            Validator.Equals(publicKey) &&
-            publicKey.Verify(RemoveSignature.ByteArray.ToImmutableArray(), Signature!);
+        public bool Verify() =>
+            !Signature.IsEmpty &&
+            Validator.Verify(_metadata.ByteArray.ToImmutableArray(), Signature);
 
-        public bool Equals(Vote other)
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(Vote? other)
         {
-            return Height == other.Height &&
-                   Round == other.Round &&
-                   Nullable.Equals(BlockHash, other.BlockHash) &&
-                   Timestamp
-                       .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
-                           other.Timestamp.ToString(
-                               TimestampFormat,
-                               CultureInfo.InvariantCulture)) &&
-                   Validator.Equals(other.Validator) &&
-                   Flag == other.Flag &&
-                   Signature.SequenceEqual(other.Signature);
+            return other is Vote vote &&
+                _metadata.Equals(vote._metadata) &&
+                Signature.SequenceEqual(vote.Signature);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
+        [Pure]
         public override bool Equals(object? obj)
         {
             return obj is Vote other && Equals(other);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
+        [Pure]
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Height,
-                Round,
-                BlockHash,
-                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
-                Validator,
-                Signature);
+            return HashCode.Combine(_metadata.GetHashCode(), Signature);
         }
     }
 }

--- a/Libplanet/Consensus/VoteMetadata.cs
+++ b/Libplanet/Consensus/VoteMetadata.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// Represents a vote metadata from a validator for consensus.
+    /// </summary>
+    public class VoteMetadata : IVoteMetadata, IEquatable<VoteMetadata>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private const string HeightKey = "height";
+        private const string RoundKey = "round";
+        private const string BlockHashKey = "block_hash";
+        private const string TimestampKey = "timestamp";
+        private const string ValidatorKey = "validator";
+        private const string FlagKey = "vote_flag";
+
+        private static Codec _codec = new Codec();
+
+        /// <summary>
+        /// Creates a <see cref="VoteMetadata"/> instance.
+        /// </summary>
+        /// <param name="height">Height of the vote target block.</param>
+        /// <param name="round">Round of the vote in given height.</param>
+        /// <param name="blockHash"><see cref="BlockHash"/> of the block in vote.</param>
+        /// <param name="timestamp">The time at which the voting took place.</param>
+        /// <param name="validator">
+        /// <see cref="PublicKey"/> of the validator made the vote.
+        /// </param>
+        /// <param name="flag"><see cref="VoteFlag"/> for the vote's status.</param>
+        public VoteMetadata(
+            long height,
+            int round,
+            BlockHash? blockHash,
+            DateTimeOffset timestamp,
+            PublicKey validator,
+            VoteFlag flag)
+        {
+            // TODO: Check arguments.
+            Height = height;
+            Round = round;
+            BlockHash = blockHash;
+            Timestamp = timestamp;
+            Validator = validator;
+            Flag = flag;
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public VoteMetadata(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                blockHash: encoded.ContainsKey(BlockHashKey)
+                    ? new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray)
+                    : (BlockHash?)null,
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validator: new PublicKey(encoded.GetValue<Binary>(ValidatorKey).ByteArray),
+                flag: (VoteFlag)(long)encoded.GetValue<Integer>(FlagKey))
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc/>
+        public long Height { get; }
+
+        /// <inheritdoc/>
+        public int Round { get; }
+
+        /// <inheritdoc/>
+        public BlockHash? BlockHash { get; }
+
+        /// <inheritdoc/>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <inheritdoc/>
+        public PublicKey Validator { get; }
+
+        /// <inheritdoc/>
+        public VoteFlag Flag { get; }
+
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorKey, Validator.Format(compress: true))
+                    .Add(FlagKey, (long)Flag);
+
+                if (BlockHash is { } blockHash)
+                {
+                    encoded = encoded.Add(BlockHashKey, blockHash.ByteArray);
+                }
+
+                return encoded;
+            }
+        }
+
+        /// <summary>
+        /// Marshaled <see cref="VoteMetadata"/> data.  This is used as a payload for
+        /// signing.
+        /// </summary>
+        public byte[] ByteArray => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Signs a <see cref="VoteMetadata"/> to create a <see cref="Vote"/>
+        /// using given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">The <see cref="PrivateKey"/> to sign the data with.  This can be
+        /// <see langword="null"/> to create an unsigned <see cref="Vote"/> instance.</param>
+        /// <returns>A <see cref="Vote"/> with a (possibly <see langword="null"/>) signature.
+        /// </returns>
+        public Vote Sign(PrivateKey? signer)
+        {
+            return signer is PrivateKey key
+                ? new Vote(this, key.Sign(ByteArray).ToImmutableArray())
+                : new Vote(this, ImmutableArray<byte>.Empty);
+        }
+
+        public bool Equals(VoteMetadata? other)
+        {
+            return other is VoteMetadata metadata &&
+                Height == metadata.Height &&
+                Round == metadata.Round &&
+                BlockHash.Equals(metadata.BlockHash) &&
+                Timestamp
+                    .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                        metadata.Timestamp.ToString(
+                            TimestampFormat,
+                            CultureInfo.InvariantCulture)) &&
+                Validator.Equals(metadata.Validator) &&
+                Flag == metadata.Flag;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is VoteMetadata other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                BlockHash,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                Validator);
+        }
+    }
+}


### PR DESCRIPTION
Makes `Vote`'s design more in line with #2321.

In particular, it is not possible to "normally" generate a `Vote`, i.e. through `VoteMetadata.Sign()`, with one of the following properties:

- A `Vote` with its `Flag` set to `Null` or `Unknown` with a signature.
- A `Vote` with its `Flag` set to `Absent` or `Commit` without a signature.

However, unlike `Block<T>` and `Transaction<T>` in #2321, invalid votes **can** be created through deserialization, as this might be useful for collecting evidences in PoS.