### PR TITLE
Fallback with `SHA1Managed` if the platform doesn't support

### DIFF
--- a/Libplanet/Assets/Currency.cs
+++ b/Libplanet/Assets/Currency.cs
@@ -696,11 +696,23 @@ namespace Libplanet.Assets
             return serialized;
         }
 
+        private static SHA1 GetSHA1()
+        {
+            try
+            {
+                return new SHA1CryptoServiceProvider();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return new SHA1Managed();
+            }
+        }
+
         [Pure]
         private HashDigest<SHA1> GetHash()
         {
             using var buffer = new MemoryStream();
-            using var sha1 = new SHA1CryptoServiceProvider();
+            using var sha1 = GetSHA1();
             using var stream = new CryptoStream(buffer, sha1, CryptoStreamMode.Write);
             var codec = new Codec();
             codec.Encode(Serialize(), stream);


### PR DESCRIPTION
This pull request resolves #2368. I don't have no idea to test this fallback automatically yet. 🤔 

When executing `Libplanet.Assets.Currency.GetHash()` method in WASM environment (Blazor), it throws `PlatformNotSupportedException`. This pull request makes the method use `SHA1Managed` when the exception was thrown.