### PR TITLE
Fix flakiness in PBFT `ConsensusContext` test

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         public ConsensusContextNonProposerTest(ITestOutputHelper output)
         {
             const string outputTemplate =
-                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.TestOutput(output, outputTemplate: outputTemplate)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -17,7 +17,6 @@ using Xunit.Sdk;
 
 namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 {
-    [Collection("NetMQConfiguration")]
     public class ConsensusContextNonProposerTest
     {
         private const int Timeout = 30000;

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -267,8 +267,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     codec.Encode(blockHeightThree.MarshalBlock()),
                     -1));
 
-            // Commit ends.
-            await heightTwoStepChangedToEndCommit.WaitAsync();
             // New height started.
             await heightThreeStepChangedToPropose.WaitAsync();
             // Propose -> PreVote (message consumed)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         public ConsensusContextProposerTest(ITestOutputHelper output)
         {
             const string outputTemplate =
-                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.TestOutput(output, outputTemplate: outputTemplate)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -66,8 +66,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
-            // FIXME: StartAsync inside NewHeight makes it unreliable to try to await for
-            // early events.
             BlockHash blockHash;
             while (true)
             {

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         public ConsensusContextTest(ITestOutputHelper output)
         {
             const string outputTemplate =
-                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.TestOutput(output, outputTemplate: outputTemplate)

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Net.Tests.Consensus
     [Collection("NetMQConfiguration")]
     public class ConsensusReactorTest : IDisposable
     {
-        private const int PropagationDelay = 30_000;
+        private const int PropagationDelay = 25_000;
         private const int Timeout = 60 * 1000;
         private ILogger _logger;
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -22,14 +22,14 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public ContextNonProposerTest(ITestOutputHelper output)
         {
             const string outputTemplate =
-                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
                 .CreateLogger()
-                .ForContext<ContextTest>();
+                .ForContext<ContextNonProposerTest>();
 
-            _logger = Log.ForContext<ContextTest>();
+            _logger = Log.ForContext<ContextNonProposerTest>();
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -261,7 +261,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             var (_, _, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.Peer0Priv,
-                consensusMessageSent: CheckVote);
+                consensusMessageSent: CheckVote,
+                contextTimeoutOptions: new ContextTimeoutOption(proposeSecondBase: 1));
 
             context.StateChanged += (sender, state) =>
             {
@@ -289,7 +290,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public async Task UponRulesCheckAfterTimeout()
         {
             var (_, blockChain, context) = TestUtils.CreateDummyContext(
-                privateKey: TestUtils.Peer0Priv);
+                privateKey: TestUtils.Peer0Priv,
+                contextTimeoutOptions: new ContextTimeoutOption(
+                    preVoteSecondBase: 1,
+                    preCommitSecondBase: 1));
 
             var block1 = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             var block2 = blockChain.ProposeBlock(TestUtils.Peer2Priv);
@@ -360,7 +364,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public async Task TimeoutPreVote()
         {
             var (_, blockChain, context) = TestUtils.CreateDummyContext(
-                privateKey: TestUtils.Peer0Priv);
+                privateKey: TestUtils.Peer0Priv,
+                contextTimeoutOptions: new ContextTimeoutOption(preVoteSecondBase: 1));
 
             var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             var timeoutProcessed = new AsyncAutoResetEvent();
@@ -406,7 +411,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public async Task TimeoutPreCommit()
         {
             var (_, blockChain, context) = TestUtils.CreateDummyContext(
-                privateKey: TestUtils.Peer0Priv);
+                privateKey: TestUtils.Peer0Priv,
+                contextTimeoutOptions: new ContextTimeoutOption(preCommitSecondBase: 1));
 
             var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             var timeoutProcessed = new AsyncAutoResetEvent();

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -6,6 +6,7 @@ using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
 using Nito.AsyncEx;
+using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,9 +15,19 @@ namespace Libplanet.Net.Tests.Consensus.Context
     public class ContextProposerTest
     {
         private const int Timeout = 30000;
+        private readonly ILogger _logger;
 
         public ContextProposerTest(ITestOutputHelper output)
         {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ContextProposerTest>();
+
+            _logger = Log.ForContext<ContextProposerTest>();
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -147,7 +147,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public async void EnterNewRoundNil()
         {
             var (_, blockChain, context) = TestUtils.CreateDummyContext(
-                startStep: Step.Propose);
+                startStep: Step.Propose,
+                contextTimeoutOptions: new ContextTimeoutOption(preCommitSecondBase: 1));
 
             var roundChangedToOne = new AsyncAutoResetEvent();
             context.StateChanged += (sender, state) =>

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -6,6 +6,7 @@ using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
 using Nito.AsyncEx;
+using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,9 +15,19 @@ namespace Libplanet.Net.Tests.Consensus.Context
     public class ContextProposerValidRoundTest
     {
         private const int Timeout = 30000;
+        private readonly ILogger _logger;
 
         public ContextProposerValidRoundTest(ITestOutputHelper output)
         {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ContextProposerValidRoundTest>();
+
+            _logger = Log.ForContext<ContextProposerValidRoundTest>();
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -278,7 +278,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             // FIXME: Pretty lousy testing method.
             var (_, _, context) = TestUtils.CreateDummyContext(
-                startStep: Step.Default);
+                startStep: Step.Default,
+                contextTimeoutOptions: new ContextTimeoutOption(preVoteSecondBase: 1));
 
             BlockHash? blockHash = null;
             var stepChangedToPreCommit = new AsyncAutoResetEvent();


### PR DESCRIPTION
This fixes the flakiness of the `ConsensusContext` test. 

## Reasons
- The flakiness occurred when the asynchronous `Context` starts and receives messages before any `EventHandler` is attached and catching.
- Some of the PBFT timeout tests run long.

## Changes
- Expose timeout parameters from `Context` and `ConsensusContext` and set 1 second for every timeout test.
- Remove unnecessary `NetMQConfiguration` collection from the test.
- `HandleMessageFromHigherHeight` covers two cases. separated as `NewHeightDelay`.
- Removed two duplicated WaitHandle in `HandleMessageFromHigherHeight` which blocks the test.
- Simplified `UseLastCommitCacheIfHeightContextIsEmpty`.
- Shortened `StartAsync`'s PropagationDelay that triggers timeout in the CI test.

## Related PR

https://github.com/planetarium/libplanet/pull/2383 - This change fixes the after-attaching, for lack of a better term, EventHandler problem.
https://github.com/planetarium/libplanet/pull/2382 - This change is a ground work of fixing timeout in CI failure because of test duration.