### PR TITLE
Discover indexes sequentially

### DIFF
--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -118,6 +118,10 @@ namespace Libplanet.Tests.Store
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
             Block3 = TestUtils.MineNextBlock(Block2, miner: Miner);
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
+            Block4 = TestUtils.MineNextBlock(Block3, miner: Miner);
+            stateRootHashes[Block4.Hash] = Block4.StateRootHash;
+            Block5 = TestUtils.MineNextBlock(Block4, miner: Miner);
+            stateRootHashes[Block5.Hash] = Block5.StateRootHash;
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
             Transaction2 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);
@@ -161,6 +165,10 @@ namespace Libplanet.Tests.Store
         public Block<DumbAction> Block2 { get; }
 
         public Block<DumbAction> Block3 { get; }
+
+        public Block<DumbAction> Block4 { get; }
+
+        public Block<DumbAction> Block5 { get; }
 
         public Transaction<DumbAction> Transaction1 { get; }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -892,6 +892,7 @@ namespace Libplanet.Tests.Store
             store.AppendIndex(chainA, Fx.Block1.Hash);
             store.ForkBlockIndexes(chainA, chainB, Fx.Block1.Hash);
             store.AppendIndex(chainB, Fx.Block2.Hash);
+            store.AppendIndex(chainB, Fx.Block3.Hash);
 
             Assert.Equal(
                 new[]
@@ -907,12 +908,14 @@ namespace Libplanet.Tests.Store
                     Fx.GenesisBlock.Hash,
                     Fx.Block1.Hash,
                     Fx.Block2.Hash,
+                    Fx.Block3.Hash,
                 },
                 store.IterateIndexes(chainB)
             );
 
-            store.ForkBlockIndexes(chainB, chainC, Fx.Block2.Hash);
-            store.AppendIndex(chainC, Fx.Block3.Hash);
+            store.ForkBlockIndexes(chainB, chainC, Fx.Block3.Hash);
+            store.AppendIndex(chainC, Fx.Block4.Hash);
+            store.AppendIndex(chainC, Fx.Block5.Hash);
 
             Assert.Equal(
                 new[]
@@ -928,6 +931,7 @@ namespace Libplanet.Tests.Store
                     Fx.GenesisBlock.Hash,
                     Fx.Block1.Hash,
                     Fx.Block2.Hash,
+                    Fx.Block3.Hash,
                 },
                 store.IterateIndexes(chainB)
             );
@@ -938,8 +942,65 @@ namespace Libplanet.Tests.Store
                     Fx.Block1.Hash,
                     Fx.Block2.Hash,
                     Fx.Block3.Hash,
+                    Fx.Block4.Hash,
+                    Fx.Block5.Hash,
                 },
                 store.IterateIndexes(chainC)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block1.Hash,
+                    Fx.Block2.Hash,
+                    Fx.Block3.Hash,
+                    Fx.Block4.Hash,
+                    Fx.Block5.Hash,
+                },
+                store.IterateIndexes(chainC, offset: 1)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block2.Hash,
+                    Fx.Block3.Hash,
+                    Fx.Block4.Hash,
+                    Fx.Block5.Hash,
+                },
+                store.IterateIndexes(chainC, offset: 2)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block3.Hash,
+                    Fx.Block4.Hash,
+                    Fx.Block5.Hash,
+                },
+                store.IterateIndexes(chainC, offset: 3)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block4.Hash,
+                    Fx.Block5.Hash,
+                },
+                store.IterateIndexes(chainC, offset: 4)
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    Fx.Block5.Hash,
+                },
+                store.IterateIndexes(chainC, offset: 5)
+            );
+
+            Assert.Equal(
+                Array.Empty<BlockHash>(),
+                store.IterateIndexes(chainC, offset: 6)
             );
 
             Assert.Equal(Fx.Block1.Hash, store.IndexBlockHash(chainA, 1));
@@ -947,7 +1008,10 @@ namespace Libplanet.Tests.Store
             Assert.Equal(Fx.Block1.Hash, store.IndexBlockHash(chainC, 1));
             Assert.Equal(Fx.Block2.Hash, store.IndexBlockHash(chainB, 2));
             Assert.Equal(Fx.Block2.Hash, store.IndexBlockHash(chainC, 2));
+            Assert.Equal(Fx.Block3.Hash, store.IndexBlockHash(chainB, 3));
             Assert.Equal(Fx.Block3.Hash, store.IndexBlockHash(chainC, 3));
+            Assert.Equal(Fx.Block4.Hash, store.IndexBlockHash(chainC, 4));
+            Assert.Equal(Fx.Block5.Hash, store.IndexBlockHash(chainC, 5));
         }
 
         [SkippableFact]


### PR DESCRIPTION
This pull request tries to resolve #2338.

## Overview

Since https://github.com/planetarium/libplanet/pull/1606, the blockchain node has been forking chain while syncing blocks. So there are too many forked chain ids. And they occur very deep recursion depth (stack overflow).

So this pull request makes `RocksDBStore.IterateIndexes` discover indexes sequentially without recursion. Fetch chain ids and store it as stack, iterate them.

- [x] Add more test cases.