### PR TITLE
Implement different extra callbacks and ignore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,8 @@ a system action, its features will be added more in the future.
         of their `PlainValue` with `type_id` field.  [[#2294]]
  -  System actions' `GetHashCode()` and `Equals(object)` methods now check
     value equality (rather than reference equality).  [[#2294]]
+ -  A `ValidateAppProtocolVersion` became allow validation of different extra.
+    [[#2380]]
 
 ### Bug fixes
 

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -59,6 +59,7 @@ namespace Libplanet.Net.Tests.Messages
             var extra2 = new Bencodex.Types.Integer(17);
             var trustedApv1 = AppProtocolVersion.Sign(trustedSigner, version1, extra1);
             var trustedApv2 = AppProtocolVersion.Sign(trustedSigner, version2, extra2);
+            var trustedApv3 = AppProtocolVersion.Sign(trustedSigner, version1, extra2);
             var unknownApv1 = AppProtocolVersion.Sign(unknownSigner, version1, extra1);
             var unknownApv2 = AppProtocolVersion.Sign(unknownSigner, version1, extra2);
             ImmutableHashSet<PublicKey>? trustedApvSigners1 =
@@ -70,6 +71,7 @@ namespace Libplanet.Net.Tests.Messages
             var peer = new BoundPeer(trustedSigner.PublicKey, new DnsEndPoint("0.0.0.0", 0));
             var trustedPing1 = new PingMsg() { Remote = peer, Version = trustedApv1 };
             var trustedPing2 = new PingMsg() { Remote = peer, Version = trustedApv2 };
+            var trustedPing3 = new PingMsg() { Remote = peer, Version = trustedApv3 };
             var unknownPing1 = new PingMsg() { Remote = peer, Version = unknownApv1 };
             var unknownPing2 = new PingMsg() { Remote = peer, Version = unknownApv2 };
 
@@ -90,6 +92,9 @@ namespace Libplanet.Net.Tests.Messages
             exception = Assert.Throws<DifferentAppProtocolVersionException>(
                 () => messageValidator.ValidateAppProtocolVersion(trustedPing2));
             Assert.True(exception.Trusted);
+            Assert.True(called);
+            called = false;
+            messageValidator.ValidateAppProtocolVersion(trustedPing3);
             Assert.True(called);
             called = false;
             exception = Assert.Throws<DifferentAppProtocolVersionException>(
@@ -124,9 +129,8 @@ namespace Libplanet.Net.Tests.Messages
                 messageTimestampBuffer: null,
                 differentAppProtocolVersionEncountered: callback);
             messageValidator.ValidateAppProtocolVersion(trustedPing1);
-            exception = Assert.Throws<DifferentAppProtocolVersionException>(
-                () => messageValidator.ValidateAppProtocolVersion(unknownPing1));
-            Assert.True(exception.Trusted);
+            Assert.False(called);
+            messageValidator.ValidateAppProtocolVersion(unknownPing1);
             Assert.True(called);
             called = false;
             exception = Assert.Throws<DifferentAppProtocolVersionException>(
@@ -134,9 +138,10 @@ namespace Libplanet.Net.Tests.Messages
             Assert.True(exception.Trusted);
             Assert.True(called);
             called = false;
-            exception = Assert.Throws<DifferentAppProtocolVersionException>(
-                () => messageValidator.ValidateAppProtocolVersion(unknownPing2));
-            Assert.True(exception.Trusted);
+            messageValidator.ValidateAppProtocolVersion(trustedPing3);
+            Assert.True(called);
+            called = false;
+            messageValidator.ValidateAppProtocolVersion(unknownPing2);
             Assert.True(called);
         }
     }

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -154,7 +154,7 @@ namespace Libplanet.Net.Messages
                     dapve(peer, message.Version, appProtocolVersion);
                 }
 
-                if (!message.Version.Version.Equals(appProtocolVersion.Version) || !trusted)
+                if (!trusted || !message.Version.Version.Equals(appProtocolVersion.Version))
                 {
                     throw new DifferentAppProtocolVersionException(
                         $"The APV of a received message is invalid:\n" +

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -154,18 +154,21 @@ namespace Libplanet.Net.Messages
                     dapve(peer, message.Version, appProtocolVersion);
                 }
 
-                throw new DifferentAppProtocolVersionException(
-                    $"The APV of a received message is invalid:\n" +
-                    $"Expected: APV {appProtocolVersion} with " +
-                    $"signature {ByteUtil.Hex(appProtocolVersion.Signature)} by " +
-                    $"signer {appProtocolVersion.Signer}\n" +
-                    $"Actual: APV {message.Version} with " +
-                    $"signature: {ByteUtil.Hex(message.Version.Signature)} by " +
-                    $"signer: {message.Version.Signer}\n" +
-                    $"Signed by a trusted signer: {trusted}",
-                    appProtocolVersion,
-                    message.Version,
-                    trusted);
+                if (!message.Version.Version.Equals(appProtocolVersion.Version) || !trusted)
+                {
+                    throw new DifferentAppProtocolVersionException(
+                        $"The APV of a received message is invalid:\n" +
+                        $"Expected: APV {appProtocolVersion} with " +
+                        $"signature {ByteUtil.Hex(appProtocolVersion.Signature)} by " +
+                        $"signer {appProtocolVersion.Signer}\n" +
+                        $"Actual: APV {message.Version} with " +
+                        $"signature: {ByteUtil.Hex(message.Version.Signature)} by " +
+                        $"signer: {message.Version.Signer}\n" +
+                        $"Signed by a trusted signer: {trusted}",
+                        appProtocolVersion,
+                        message.Version,
+                        trusted);
+                }
             }
             else
             {


### PR DESCRIPTION
Solved https://github.com/planetarium/libplanet/issues/2377

I add `!message.Version.Version.Equals(appProtocolVersion.Version) || !trusted` condition above `DifferentAppProtocolVersionException`
it only checks apv version and accepts trusted signer