### PR TITLE
Option class for consensus timeout configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@ To be released.
  -  Added `BlockChain.ProposeBlock()` method.  [[#PBFT]]
  -  Added `IBlockPolicy.GetValidators()` method.  [[#PBFT]]
  -  Added `BlockCommitExtensions` class.  [[#PBFT]]
+ -  Added `ContextTimeoutOption` class.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -212,7 +212,8 @@ namespace Libplanet.Net.Tests
                 List<PublicKey>? validators = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
                 EventHandler<ConsensusMessage>? consensusMessageSent = null,
-                long lastCommitClearThreshold = 30)
+                long lastCommitClearThreshold = 30,
+                ContextTimeoutOption? contextTimeoutOptions = null)
         {
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
@@ -243,7 +244,8 @@ namespace Libplanet.Net.Tests
                 privateKey,
                 newHeightDelay,
                 _ => validators,
-                lastCommitClearThreshold);
+                lastCommitClearThreshold,
+                contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (fx, blockChain, consensusContext);
         }
@@ -259,7 +261,8 @@ namespace Libplanet.Net.Tests
             PrivateKey? privateKey = null,
             List<PublicKey>? validators = null,
             EventHandler<ConsensusMessage>? consensusMessageSent = null,
-            Step startStep = Step.Default)
+            Step startStep = Step.Default,
+            ContextTimeoutOption? contextTimeoutOptions = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= Peer1Priv;
@@ -291,7 +294,8 @@ namespace Libplanet.Net.Tests
                 privateKey,
                 validators,
                 startStep,
-                round);
+                round,
+                contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (fx, blockChain, context);
         }
@@ -302,7 +306,8 @@ namespace Libplanet.Net.Tests
             string host = "localhost",
             int consensusPort = 5101,
             List<BoundPeer>? validatorPeers = null,
-            int newHeightDelayMilliseconds = 10_000)
+            int newHeightDelayMilliseconds = 10_000,
+            ContextTimeoutOption? contextTimeoutOptions = null)
         {
             key ??= Peer1Priv;
             validatorPeers ??= Peers;
@@ -324,7 +329,8 @@ namespace Libplanet.Net.Tests
                 validatorPeers.ToImmutableList(),
                 new List<BoundPeer>().ToImmutableList(),
                 TimeSpan.FromMilliseconds(newHeightDelayMilliseconds),
-                30);
+                30,
+                contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
         }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -49,6 +49,8 @@ namespace Libplanet.Net.Consensus
         /// <param name="lastCommitClearThreshold">A cache of <see cref="BlockCommit"/> cleanup
         /// threshold. See <see cref="ConsensusContext{T}.LastCommitClearThreshold"/>.
         /// The value must bigger than <c>0</c>.</param>
+        /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
+        /// configuring a timeout for each <see cref="Step"/>.</param>
         public ConsensusReactor(
             ITransport consensusTransport,
             BlockChain<T> blockChain,
@@ -56,7 +58,8 @@ namespace Libplanet.Net.Consensus
             ImmutableList<BoundPeer> validatorPeers,
             ImmutableList<BoundPeer> seedPeers,
             TimeSpan newHeightDelay,
-            long lastCommitClearThreshold)
+            long lastCommitClearThreshold,
+            ContextTimeoutOption contextTimeoutOption)
         {
             validatorPeers ??= ImmutableList<BoundPeer>.Empty;
             seedPeers ??= ImmutableList<BoundPeer>.Empty;
@@ -76,7 +79,8 @@ namespace Libplanet.Net.Consensus
                 privateKey,
                 newHeightDelay,
                 blockChain.Policy.GetValidators,
-                lastCommitClearThreshold);
+                lastCommitClearThreshold,
+                contextTimeoutOption);
 
             _logger = Log
                 .ForContext("Tag", "Consensus")

--- a/Libplanet.Net/Consensus/ConsensusReactorOption.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactorOption.cs
@@ -50,5 +50,10 @@ namespace Libplanet.Net.Consensus
         /// (e.g., node restarted, joining consensus.)
         /// </summary>
         public long? LastCommitClearThreshold { get; set; }
+
+        /// <summary>
+        /// A timeout second and multiplier value for used in <see cref="Context{T}"/>.
+        /// </summary>
+        public ContextTimeoutOption ContextTimeoutOptions { get; set; }
     }
 }

--- a/Libplanet.Net/Consensus/ContextTimeoutOption.cs
+++ b/Libplanet.Net/Consensus/ContextTimeoutOption.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace Libplanet.Net.Consensus
+{
+    /// <summary>
+    /// A options class to configure <see cref="Context{T}"/> timeout for each <see cref="Step"/>.
+    /// </summary>
+    public class ContextTimeoutOption
+    {
+        public ContextTimeoutOption(
+            int proposeSecondBase = 5,
+            int preVoteSecondBase = 5,
+            int preCommitSecondBase = 5,
+            int proposeMultiplier = 1,
+            int preVoteMultiplier = 1,
+            int preCommitMultiplier = 1)
+        {
+            if (proposeSecondBase <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(proposeSecondBase),
+                    "ProposeSecondBase must be greater than 0.");
+            }
+
+            ProposeSecondBase = proposeSecondBase;
+
+            if (preVoteSecondBase <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(preVoteSecondBase),
+                    "PreVoteSecondBase must be greater than 0.");
+            }
+
+            PreVoteSecondBase = preVoteSecondBase;
+
+            if (preCommitSecondBase <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(preCommitSecondBase),
+                    "PreCommitSecondBase must be greater than 0.");
+            }
+
+            PreCommitSecondBase = preCommitSecondBase;
+
+            if (proposeMultiplier <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(proposeMultiplier),
+                    "ProposeMultiplier must be greater than 0.");
+            }
+
+            ProposeMultiplier = proposeMultiplier;
+
+            if (preVoteMultiplier <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(preVoteMultiplier),
+                    "PreVoteMultiplier must be greater than 0.");
+            }
+
+            PreVoteMultiplier = preVoteMultiplier;
+
+            if (preCommitMultiplier <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(preCommitMultiplier),
+                    "PreCommitMultiplier must be greater than 0.");
+            }
+
+            PreCommitMultiplier = preCommitMultiplier;
+        }
+
+        public int ProposeSecondBase { get; }
+
+        public int PreVoteSecondBase { get; }
+
+        public int PreCommitSecondBase { get; }
+
+        public int ProposeMultiplier { get; }
+
+        public int PreVoteMultiplier { get; }
+
+        public int PreCommitMultiplier { get; }
+    }
+}

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -152,7 +152,8 @@ namespace Libplanet.Net
                     consensusReactorOption.ConsensusPeers,
                     consensusReactorOption.SeedPeers,
                     consensusReactorOption.TargetBlockInterval,
-                    consensusReactorOption.LastCommitClearThreshold ?? 30);
+                    consensusReactorOption.LastCommitClearThreshold ?? 30,
+                    consensusReactorOption.ContextTimeoutOptions);
             }
         }
 


### PR DESCRIPTION
This PR introduces a new class for the option of consensus timeout configuration.

## Base context
- For each step (Propose, PreVote, PreCommit), there are base timeouts and multipliers. Base timeouts are the initial values for timeout, and multipliers are for multiplying factors when a new round is started.
- This class guards from unexpected values (where value <= 0) and lets the values can be configurable.