### PR TITLE
Subscribing all `Context` EventHandler

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -152,6 +152,36 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             }
 
+            consensusContext.StateChanged += (sender, state) =>
+            {
+                if (state.Height == 2)
+                {
+                    if (state.Step == Step.PreVote)
+                    {
+                        heightTwoStepChangedToPreVote.Set();
+                    }
+                    else if (state.Step == Step.PreCommit)
+                    {
+                        heightTwoStepChangedToPreCommit.Set();
+                    }
+                    else if (state.Step == Step.EndCommit)
+                    {
+                        heightTwoStepChangedToEndCommit.Set();
+                    }
+                }
+                else if (state.Height == 3)
+                {
+                    if (state.Step == Step.Propose)
+                    {
+                        heightThreeStepChangedToPropose.Set();
+                    }
+                    else if (state.Step == Step.PreVote)
+                    {
+                        heightThreeStepChangedToPreVote.Set();
+                    }
+                }
+            };
+
             blockChain.Append(blockChain.ProposeBlock(TestUtils.Peer1Priv));
 
             blockChain.Store.PutLastCommit(TestUtils.CreateLastCommit(
@@ -168,25 +198,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 throw new NullException(propose);
             }
 
-            // FIXME: Waiting for PreVote is not triggered and block the whole test.
-            consensusContext.Contexts[2].StateChanged += (sender, state) =>
-            {
-                if (state.Step == Step.PreVote)
-                {
-                    heightTwoStepChangedToPreVote.Set();
-                }
-                else if (state.Step == Step.PreCommit)
-                {
-                    heightTwoStepChangedToPreCommit.Set();
-                }
-                else if (state.Step == Step.EndCommit)
-                {
-                    heightTwoStepChangedToEndCommit.Set();
-                }
-            };
-
             foreach ((PrivateKey privateKey, BoundPeer peer)
-                in TestUtils.PrivateKeys.Zip(TestUtils.Peers, (first, second) => (first, second)))
+                     in TestUtils.PrivateKeys.Zip(
+                         TestUtils.Peers,
+                         (first, second) => (first, second)))
             {
                 if (privateKey == TestUtils.Peer2Priv)
                 {
@@ -252,18 +267,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     codec.Encode(blockHeightThree.MarshalBlock()),
                     -1));
 
-            consensusContext.Contexts[3].StateChanged += (sender, state) =>
-            {
-                if (state.Step == Step.Propose)
-                {
-                    heightThreeStepChangedToPropose.Set();
-                }
-                else if (state.Step == Step.PreVote)
-                {
-                    heightThreeStepChangedToPreVote.Set();
-                }
-            };
-
             // Commit ends.
             await heightTwoStepChangedToEndCommit.WaitAsync();
             var heightTwoEndTimestamp = DateTime.UtcNow;
@@ -295,24 +298,33 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.Policy,
                 TestUtils.Peer2Priv);
 
-            // Do a consensus for height #1. (Genesis doesn't have last commit.)
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].StateChanged +=
+            consensusContext.StateChanged +=
                 (sender, tuple) =>
                 {
-                    if (tuple.Step == Step.EndCommit)
+                    if (tuple.Height == 1 && tuple.Step == Step.EndCommit)
                     {
                         heightOneEnded.Set();
                     }
                 };
-            consensusContext.Contexts[blockChain.Tip.Index + 1].MessageConsumed +=
+            consensusContext.MessageConsumed +=
                 (sender, message) =>
                 {
-                    if (message is ConsensusPropose propose)
+                    if (message.Height == 1 && message.Message is ConsensusPropose)
                     {
                         heightOneProposeSent.Set();
                     }
+
+                    if (message.Height == 2 &&
+                        message.Message is ConsensusPropose propose)
+                    {
+                        proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
+                            (Dictionary)codec.Decode(propose!.Payload));
+                        heightTwoProposeSent.Set();
+                    }
                 };
+
+            // Do a consensus for height #1. (Genesis doesn't have last commit.)
+            consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
             var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             consensusContext.HandleMessage(
@@ -345,16 +357,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             // Restart consensus from height #2
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].MessageConsumed +=
-                (sender, message) =>
-                {
-                    if (message is ConsensusPropose propose)
-                    {
-                        proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(propose!.Payload));
-                        heightTwoProposeSent.Set();
-                    }
-                };
             await heightTwoProposeSent.WaitAsync();
 
             if (proposedBlock == null)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -36,12 +36,16 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var timeoutProcessed = new AsyncAutoResetEvent();
 
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].TimeoutProcessed +=
-                (sender, message) =>
+            consensusContext.TimeoutProcessed +=
+                (sender, tuple) =>
                 {
-                    timeoutProcessed.Set();
+                    if (tuple.Height == 1)
+                    {
+                        timeoutProcessed.Set();
+                    }
                 };
+
+            consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
             // Wait for block to be proposed.
             Assert.Equal(1, consensusContext.Height);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -55,14 +55,15 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             Assert.Throws<InvalidHeightIncreasingException>(
                 () => consensusContext.NewHeight(blockChain.Tip.Index + 2));
 
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].StateChanged += (sender, state) =>
+            consensusContext.StateChanged += (sender, state) =>
             {
-                if (state.Step == Step.EndCommit)
+                if (state.Height == 1 && state.Step == Step.EndCommit)
                 {
                     stepChangedToEndCommit.Set();
                 }
             };
+
+            consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
             // FIXME: StartAsync inside NewHeight makes it unreliable to try to await for
             // early events.
@@ -210,16 +211,38 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             }
 
-            // Do a consensus for height to #2 consecutively.
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].StateChanged +=
+            consensusContext.StateChanged +=
                 (sender, tuple) =>
                 {
-                    if (tuple.Step == Step.EndCommit)
+                    if (tuple.Height == 1 && tuple.Step == Step.EndCommit)
                     {
                         heightOneEnded.Set();
                     }
+
+                    if (tuple.Height == 2 && tuple.Step == Step.EndCommit)
+                    {
+                        heightTwoEnded.Set();
+                    }
+
+                    if (tuple.Height == 3 && tuple.Step == Step.PreVote)
+                    {
+                        heightThreePreVote.Set();
+                    }
                 };
+
+            consensusContext.MessageConsumed +=
+                (sender, message) =>
+                {
+                    if (message.Height == 2 && message.Message is ConsensusPropose propose)
+                    {
+                        proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
+                            (Dictionary)codec.Decode(propose!.Payload));
+                        heightTwoProposeSent.Set();
+                    }
+                };
+
+            // Do a consensus for height to #2 consecutively.
+            consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
             await heightOneProposeSent.WaitAsync();
 
@@ -247,18 +270,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             // Starts NewHeight manually.
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].StateChanged +=
-                (sender, tuple) =>
-                {
-                    if (tuple.Step == Step.EndCommit)
-                    {
-                        heightTwoEnded.Set();
-                    }
-                };
             consensusContext.Contexts[blockChain.Tip.Index + 1].MessageConsumed +=
-                (sender, message) =>
+                (sender, hm) =>
                 {
-                    if (message is ConsensusPropose propose)
+                    if (hm.Message is ConsensusPropose propose)
                     {
                         proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
                             (Dictionary)codec.Decode(propose!.Payload));
@@ -300,16 +315,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // Starts round 3, Waits PreVote timeout
             // Checks previous LastCommit and see if it's available.
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
-            consensusContext.Contexts[blockChain.Tip.Index + 1].StateChanged +=
-                (sender, tuple) =>
-                {
-                    if (tuple.Step == Step.PreVote)
-                    {
-                        heightThreePreVote.Set();
-                    }
-                };
-
             await heightThreePreVote.WaitAsync();
+
             Assert.NotNull(blockChain.Store.GetLastCommit(blockChain.Tip.Index));
             Assert.Null(blockChain.Store.GetLastCommit(blockChain.Tip.Index - 1));
         }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -127,9 +127,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
-            context.ExceptionOccurred += (sender, e) =>
+            context.ExceptionOccurred += (sender, he) =>
             {
-                exceptionThrown = e;
+                exceptionThrown = he.Exception;
                 exceptionOccurred.Set();
             };
 
@@ -151,9 +151,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
-            context.ExceptionOccurred += (sender, e) =>
+            context.ExceptionOccurred += (sender, he) =>
             {
-                exceptionThrown = e;
+                exceptionThrown = he.Exception;
                 exceptionOccurred.Set();
             };
 
@@ -176,9 +176,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
-            context.ExceptionOccurred += (sender, e) =>
+            context.ExceptionOccurred += (sender, he) =>
             {
-                exceptionThrown = e;
+                exceptionThrown = he.Exception;
                 exceptionOccurred.Set();
             };
 
@@ -224,9 +224,9 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
-            context.ExceptionOccurred += (sender, e) =>
+            context.ExceptionOccurred += (sender, he) =>
             {
-                exceptionThrown = e;
+                exceptionThrown = he.Exception;
                 exceptionOccurred.Set();
             };
 

--- a/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -1,0 +1,54 @@
+using System;
+using Libplanet.Action;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    public partial class ConsensusContext<T>
+        where T : IAction, new()
+    {
+        /// <inheritdoc cref="Context{T}.ExceptionOccurred"/>
+        internal event EventHandler<(long Height, Exception)>? ExceptionOccurred;
+
+        /// <inheritdoc cref="Context{T}.TimeoutOccurred"/>
+        internal event EventHandler<
+                (long Height, int Round, Step Step, TimeSpan TimeSpan)>?
+            TimeoutOccurred;
+
+        /// <inheritdoc cref="Context{T}.TimeoutProcessed"/>
+        internal event EventHandler<(long Height, int Round)>? TimeoutProcessed;
+
+        /// <inheritdoc cref="Context{T}.StateChanged"/>
+        internal event EventHandler<
+                (long Height, int MessageLogSize, int Round, Step Step)>?
+            StateChanged;
+
+        /// <inheritdoc cref="Context{T}.MessageConsumed"/>
+        internal event EventHandler<(long Height, ConsensusMessage Message)>?
+            MessageConsumed;
+
+        /// <inheritdoc cref="Context{T}.MutationConsumed"/>
+        internal event EventHandler<(long Height, System.Action)>? MutationConsumed;
+
+        private void AttachEventHandlers(Context<T> context)
+        {
+            context.ExceptionOccurred += (sender, exception) =>
+                ExceptionOccurred?.Invoke(this, exception);
+
+            context.TimeoutOccurred += (sender, timeoutWait) =>
+                TimeoutOccurred?.Invoke(this, timeoutWait);
+
+            context.TimeoutProcessed += (sender, timeoutStart) =>
+                TimeoutProcessed?.Invoke(this, timeoutStart);
+
+            context.StateChanged += (sender, state) =>
+                StateChanged?.Invoke(this, state);
+
+            context.MessageConsumed += (sender, message) =>
+                MessageConsumed?.Invoke(this, message);
+
+            context.MutationConsumed += (sender, action) =>
+                MutationConsumed?.Invoke(this, action);
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Net.Consensus
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type of <see cref="BlockChain{T}"/>.
     /// </typeparam>
-    public class ConsensusContext<T> : IDisposable
+    public partial class ConsensusContext<T> : IDisposable
         where T : IAction, new()
     {
         private readonly ContextTimeoutOption _contextTimeoutOption;
@@ -209,6 +209,8 @@ namespace Libplanet.Net.Consensus
                     _getValidators(height).ToList(),
                     Step.Default,
                     contextTimeoutOptions: _contextTimeoutOption);
+
+                AttachEventHandlers(_contexts[height]);
             }
 
             _contexts[height].Start(lastCommit);
@@ -258,6 +260,8 @@ namespace Libplanet.Net.Consensus
                     _privateKey,
                     _getValidators(height).ToList(),
                     _contextTimeoutOption);
+
+                AttachEventHandlers(_contexts[height]);
             }
 
             _contexts[height].ProduceMessage(consensusMessage);

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Net.Consensus
                 catch (TaskCanceledException tce)
                 {
                     _logger.Debug(tce, "Cancellation was requested");
-                    ExceptionOccurred?.Invoke(this, tce);
+                    ExceptionOccurred?.Invoke(this, (Height, tce));
                     throw;
                 }
                 catch (Exception e)
@@ -49,7 +49,7 @@ namespace Libplanet.Net.Consensus
                         e,
                         "Unexpected exception occurred during {FName}",
                         nameof(ConsumeMessage));
-                    ExceptionOccurred?.Invoke(this, e);
+                    ExceptionOccurred?.Invoke(this, (Height, e));
                     throw;
                 }
             }
@@ -72,7 +72,7 @@ namespace Libplanet.Net.Consensus
                 catch (TaskCanceledException tce)
                 {
                     _logger.Debug(tce, "Cancellation was requested");
-                    ExceptionOccurred?.Invoke(this, tce);
+                    ExceptionOccurred?.Invoke(this, (Height, tce));
                     throw;
                 }
                 catch (Exception e)
@@ -81,7 +81,7 @@ namespace Libplanet.Net.Consensus
                         e,
                         "Unexpected exception occurred during {FName}",
                         nameof(ConsumeMutation));
-                    ExceptionOccurred?.Invoke(this, e);
+                    ExceptionOccurred?.Invoke(this, (Height, e));
                     throw;
                 }
             }
@@ -118,7 +118,7 @@ namespace Libplanet.Net.Consensus
                     ProcessHeightOrRoundUponRules(message);
                 }
             });
-            MessageConsumed?.Invoke(this, message);
+            MessageConsumed?.Invoke(this, (Height, message));
         }
 
         private async Task ConsumeMutation(CancellationToken cancellationToken)
@@ -142,12 +142,12 @@ namespace Libplanet.Net.Consensus
                     nextState.Round,
                     nextState.Step.ToString());
                 StateChanged?.Invoke(
-                    this, (nextState.MessageLogSize, nextState.Round, nextState.Step));
+                    this, (Height, nextState.MessageLogSize, nextState.Round, nextState.Step));
 
                 ProduceMutation(() => ProcessGenericUponRules());
             }
 
-            MutationConsumed?.Invoke(this, mutation);
+            MutationConsumed?.Invoke(this, (Height, mutation));
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Libplanet.Net.Consensus
                 "TimeoutPropose has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());
-            TimeoutOccurred?.Invoke(this, (Step.Propose, timeout));
+            TimeoutOccurred?.Invoke(this, (Height, round, Step.Propose, timeout));
             ProduceMutation(() => ProcessTimeoutPropose(round));
         }
 
@@ -180,7 +180,7 @@ namespace Libplanet.Net.Consensus
                 "TimeoutPreVote has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());
-            TimeoutOccurred?.Invoke(this, (Step.PreVote, timeout));
+            TimeoutOccurred?.Invoke(this, (Height, round, Step.PreVote, timeout));
             ProduceMutation(() => ProcessTimeoutPreVote(round));
         }
 
@@ -197,7 +197,7 @@ namespace Libplanet.Net.Consensus
                 "TimeoutPreCommit has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());
-            TimeoutOccurred?.Invoke(this, (Step.PreCommit, timeout));
+            TimeoutOccurred?.Invoke(this, (Height, round, Step.PreCommit, timeout));
             ProduceMutation(() => ProcessTimeoutPreCommit(round));
         }
     }

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -8,34 +8,36 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// An event that is invoked when an exception is thrown.
         /// </summary>
-        internal event EventHandler<Exception>? ExceptionOccurred;
+        internal event EventHandler<(long Height, Exception Exception)>? ExceptionOccurred;
 
         /// <summary>
         /// An event that invoked when any timeout occurs.
         /// </summary>
-        internal event EventHandler<(Step Step, TimeSpan TimeSpan)>? TimeoutOccurred;
+        internal event EventHandler<(long Height, int Round, Step Step, TimeSpan TimeSpan)>?
+            TimeoutOccurred;
 
         /// <summary>
         /// An event that invoked when any timeout triggered mutation is processed.
         /// This is conditionally triggered, i.e. when certain conditions are met
         /// after <see cref="TimeoutOccurred"/> is triggered.
         /// </summary>
-        internal event EventHandler<int>? TimeoutProcessed;
+        internal event EventHandler<(long Height, int Round)>? TimeoutProcessed;
 
         /// <summary>
         /// An event that is invoked when the message log size, <see cref="Round"/>,
         /// and/or <see cref="Step"/> is changed.
         /// </summary>
-        internal event EventHandler<(int MessageLogSize, int Round, Step Step)>? StateChanged;
+        internal event EventHandler<(long Height, int MessageLogSize, int Round, Step Step)>?
+            StateChanged;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMessage"/> is consumed.
         /// </summary>
-        internal event EventHandler<ConsensusMessage>? MessageConsumed;
+        internal event EventHandler<(long Height, ConsensusMessage Message)>? MessageConsumed;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="System.Action"/> is consumed.
         /// </summary>
-        internal event EventHandler<System.Action>? MutationConsumed;
+        internal event EventHandler<(long Height, System.Action Action)>? MutationConsumed;
     }
 }

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -157,7 +157,7 @@ namespace Libplanet.Net.Consensus
                     ime,
                     "Failed to add invalid message {Message}.",
                     message);
-                ExceptionOccurred?.Invoke(this, ime);
+                ExceptionOccurred?.Invoke(this, (Height, ime));
             }
         }
 
@@ -339,7 +339,7 @@ namespace Libplanet.Net.Consensus
                 BroadcastMessage(
                     new ConsensusVote(MakeVote(Round, null, VoteFlag.Absent)));
                 Step = Step.PreVote;
-                TimeoutProcessed?.Invoke(this, round);
+                TimeoutProcessed?.Invoke(this, (Height, round));
             }
         }
 
@@ -356,7 +356,7 @@ namespace Libplanet.Net.Consensus
                 BroadcastMessage(
                     new ConsensusCommit(MakeVote(Round, null, VoteFlag.Commit)));
                 Step = Step.PreCommit;
-                TimeoutProcessed?.Invoke(this, round);
+                TimeoutProcessed?.Invoke(this, (Height, round));
             }
         }
 
@@ -371,7 +371,7 @@ namespace Libplanet.Net.Consensus
             if (round == Round && Step < Step.EndCommit)
             {
                 StartRound(Round + 1);
-                TimeoutProcessed?.Invoke(this, round);
+                TimeoutProcessed?.Invoke(this, (Height, round));
             }
         }
     }


### PR DESCRIPTION
This PR adds `EventHandler`s in `ConsensusContext<T>` which are listening to their designated `EventHandler` from multiple `Context<T>`.

Solves after-attaching (Subscribe method to `EventHandler` after the `Context<T>` has started) problem.

## Changes
`ConsensusContext` has now its `EventHandler`s which are the same type as `Context<T>`'s. These will be attached to `Context<T>` when it is initialized (By `NewHeight()` or `HandleMessage`.)

## Failing tests
This PR is one of fixing flakiness in the PBFT test, but the groundwork for subscribing `EventHandler` before the `Context` starts.

- `HandleMessageFromHigherHeight` fails due to time check. target time was 1 sec, actual time delta was ~= 0.99 sec, 1.5sec in the worst case.
- Some of the tests have a long duration. Most tests are timeout, so the shortened timeout value is needed.

These reasons are out of the scope of this PR so the remaining failed test is fixed in https://github.com/planetarium/libplanet/pull/2373.