### PR TITLE
Expose `IComparable` and `IComparable<T>` interface methods for `Address`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,6 @@ a system action, its features will be added more in the future.
     [`System.Text.Json.JsonSerializer`] as they now have their own
     [custom converters].  Note that these serializations are unavailable
     on Unity due to its incomplete reflection support.  [[#2294], [#2322]]
-
      -  An `Address` became represented as a single hexadecimal string in JSON.
         [[#2322]]
      -  A `BlockHash` became represented as a single hexadecimal string in JSON.
@@ -65,11 +64,13 @@ a system action, its features will be added more in the future.
         [[#2322]]
      -  System actions became represented as a [Bencodex JSON Representation]
         of their `PlainValue` with `type_id` field.  [[#2294]]
-
  -  System actions' `GetHashCode()` and `Equals(object)` methods now check
     value equality (rather than reference equality).  [[#2294]]
 
 ### Bug fixes
+
+ -  Interface methods `IComparable.CompareTo()` and
+    `IComparable<T>.CompareTo()` for `Address` are now accessible.  [#2384]
 
 ### Dependencies
 
@@ -97,6 +98,7 @@ a system action, its features will be added more in the future.
 [#2353]: https://github.com/planetarium/libplanet/pull/2353
 [#2356]: https://github.com/planetarium/libplanet/issues/2356
 [#2366]: https://github.com/planetarium/libplanet/pull/2366
+[#2384]: https://github.com/planetarium/libplanet/pull/2384
 [`System.Text.Json.JsonSerializer`]: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer
 [custom converters]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to
 [@planetarium/tx]: https://www.npmjs.com/package/@planetarium/tx

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -288,7 +288,7 @@ namespace Libplanet.Tests
             }).ToArray();
             for (int i = 1; i < addresses.Length; i++)
             {
-                IComparable<Address> left = addresses[i - 1];
+                Address left = addresses[i - 1];
                 Address right = addresses[i];
                 string leftString = addresses[i - 1].ToHex().ToLower(),
                        rightString = right.ToHex().ToLower();
@@ -298,16 +298,12 @@ namespace Libplanet.Tests
                 );
                 Assert.Equal(
                     left.CompareTo(right),
-                    (left as IComparable).CompareTo(right)
+                    left.CompareTo(right as object)
                 );
             }
 
-            Assert.Throws<ArgumentNullException>(() =>
-                (addresses[0] as IComparable).CompareTo(null)
-            );
-            Assert.Throws<ArgumentException>(() =>
-                (addresses[0] as IComparable).CompareTo("invalid")
-            );
+            Assert.Throws<ArgumentException>(() => addresses[0].CompareTo(null));
+            Assert.Throws<ArgumentException>(() => addresses[0].CompareTo("invalid"));
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TxIdTest.cs
+++ b/Libplanet.Tests/Tx/TxIdTest.cs
@@ -221,12 +221,8 @@ namespace Libplanet.Tests.Tx
                 );
             }
 
-            Assert.Throws<ArgumentNullException>(() =>
-                txIds[0].CompareTo(null)
-            );
-            Assert.Throws<ArgumentException>(() =>
-                txIds[0].CompareTo("invalid")
-            );
+            Assert.Throws<ArgumentException>(() => txIds[0].CompareTo(null));
+            Assert.Throws<ArgumentException>(() => txIds[0].CompareTo("invalid"));
         }
 
         [SkippableFact]

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -254,7 +254,8 @@ namespace Libplanet
             info.AddValue("address", ToByteArray());
         }
 
-        int IComparable<Address>.CompareTo(Address other)
+        /// <inheritdoc cref="IComparable{T}.CompareTo(T)"/>
+        public int CompareTo(Address other)
         {
             ImmutableArray<byte> self = ByteArray, operand = other.ByteArray;
 
@@ -270,20 +271,11 @@ namespace Libplanet
             return 0;
         }
 
-        int IComparable.CompareTo(object? obj)
-        {
-            if (obj is Address other)
-            {
-                return ((IComparable<Address>)this).CompareTo(other);
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            throw new ArgumentException(nameof(obj));
-        }
+        /// <inheritdoc cref="IComparable.CompareTo(object)"/>
+        public int CompareTo(object? obj) => obj is Address other
+            ? this.CompareTo(other)
+            : throw new ArgumentException(
+                $"Argument {nameof(obj)} is not an ${nameof(Address)}.", nameof(obj));
 
         private static string ToChecksumAddress(string hex)
         {

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -180,20 +180,10 @@ namespace Libplanet.Tx
         }
 
         /// <inheritdoc cref="IComparable.CompareTo(object)"/>
-        public int CompareTo(object obj)
-        {
-            if (obj is TxId other)
-            {
-                return ((IComparable<TxId>)this).CompareTo(other);
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            throw new ArgumentException(nameof(obj));
-        }
+        public int CompareTo(object obj) => obj is TxId other
+            ? this.CompareTo(other)
+            : throw new ArgumentException(
+                $"Argument {nameof(obj)} is not a ${nameof(TxId)}.", nameof(obj));
 
         /// <inheritdoc />
         public void GetObjectData(


### PR DESCRIPTION
Also, `IComaparable.Compare()` is not supposed to throw `ArgumentNullException` according to its interface definition.