### PR TITLE
Remove old contexts

### DIFF
--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -216,9 +216,9 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
+            _cancellationTokenSource.Cancel();
             _messageRequests.Writer.TryComplete();
             _mutationRequests.Writer.TryComplete();
-            _cancellationTokenSource.Cancel();
         }
 
         /// <summary>


### PR DESCRIPTION
There were cases where `ConsensusContext` did not dispose `Context` instances correctly, and this PR fixed it by iterating the dictionary and removing it correctly.

Skips the changelog because PBFT has not been released yet.