### PR TITLE
Make all `TxResultType`'s internal types public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.43.1
 
 To be released.
 
+### Added APIs
+
+ -  (Libplanet.Explorer) Added `TxResultType.UpdatedStateType` and
+    `TxResultType.FungibleAssetBalancesType` GraphQL types.  [[#2405]]
+
+[#2405]: https://github.com/planetarium/libplanet/pull/2405
+
 
 Version 0.43.0
 --------------

--- a/Libplanet.Explorer/GraphTypes/TxResultType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResultType.cs
@@ -58,9 +58,9 @@ namespace Libplanet.Explorer.GraphTypes
             );
         }
 
-        private record UpdatedState(Address Address, Bencodex.Types.IValue? State);
+        public record UpdatedState(Address Address, Bencodex.Types.IValue? State);
 
-        private class UpdatedStateType : ObjectGraphType<UpdatedState>
+        public class UpdatedStateType : ObjectGraphType<UpdatedState>
         {
             public UpdatedStateType()
             {
@@ -75,10 +75,10 @@ namespace Libplanet.Explorer.GraphTypes
             }
         }
 
-        private record FungibleAssetBalances(
+        public record FungibleAssetBalances(
             Address Address, IEnumerable<FungibleAssetValue> FungibleAssetValues);
 
-        private class FungibleAssetBalancesType : ObjectGraphType<FungibleAssetBalances>
+        public class FungibleAssetBalancesType : ObjectGraphType<FungibleAssetBalances>
         {
             public FungibleAssetBalancesType()
             {


### PR DESCRIPTION
This pull request makes `TxResultType`'s all internal classes public:

- `UpdatedStateType`
- `FungibleAssetBalancesType`

because it should be opened when other application wants to use `TxResultType`.