### PR TITLE
Added `BlockCommit` hash consistency check

### DIFF
--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -328,44 +328,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void ValidateNextBlockLastCommitDifferentBlockHash()
-        {
-            Block<DumbAction> block1 = new BlockContent<DumbAction>(
-                new BlockMetadata(
-                    index: 1L,
-                    timestamp: DateTimeOffset.UtcNow,
-                    publicKey: _fx.Miner.PublicKey,
-                    previousHash: _fx.GenesisBlock.Hash,
-                    txHash: null,
-                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
-
-            var voteSet = new VoteSet(
-                1,
-                0,
-                _fx.Hash1,
-                TestUtils.ConsensusValidators);
-
-            voteSet = TestUtils.AddVotesToVoteSet(
-                voteSet,
-                _fx.Hash1,
-                VoteFlag.Commit,
-                TestUtils.ConsensusPrivateKeys);
-
-            var blockCommit = new BlockCommit(voteSet, block1.Hash);
-
-            Block<DumbAction> block2 = new BlockContent<DumbAction>(
-                new BlockMetadata(
-                    index: 2,
-                    timestamp: DateTimeOffset.UtcNow,
-                    publicKey: _fx.Miner.PublicKey,
-                    previousHash: block1.Hash,
-                    txHash: null,
-                    lastCommit: blockCommit)).Propose().Evaluate(_fx.Miner, _blockChain);
-            Assert.Throws<InvalidBlockLastCommitException>(() => _blockChain.Append(block2));
-        }
-
-        [Fact]
         public void ValidateNextBlockLastCommitFailsUnexpectedValidator()
         {
             Block<DumbAction> block1 = new BlockContent<DumbAction>(

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -114,6 +114,31 @@ namespace Libplanet.Tests.Blocks
          }
 
         [Fact]
+        public void AllVotesShouldHaveMatchingHash()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+            var badHash = new BlockHash(TestUtils.GetRandomBytes(32));
+
+            var votes = ImmutableArray<Vote>.Empty
+                .Add(new VoteMetadata(
+                    2,
+                    0,
+                    hash,
+                    DateTimeOffset.UtcNow,
+                    TestUtils.ConsensusPeer0PrivateKey.PublicKey,
+                    VoteFlag.Commit).Sign(TestUtils.ConsensusPeer0PrivateKey))
+                .Add(new VoteMetadata(
+                    2,
+                    0,
+                    badHash,
+                    DateTimeOffset.UtcNow,
+                    TestUtils.ConsensusPeer1PrivateKey.PublicKey,
+                    VoteFlag.Commit).Sign(TestUtils.ConsensusPeer1PrivateKey));
+
+            Assert.Throws<ArgumentException>(() => new BlockCommit(2, 0, hash, votes));
+        }
+
+        [Fact]
         public void DecodeFailsNegativeHeight()
         {
             var fx = new MemoryStoreFixture();

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1123,7 +1123,7 @@ namespace Libplanet.Tests.Store
                 var voteSetTwo = new VoteSet(
                     2,
                     0,
-                    fx.Block1.Hash,
+                    fx.Block2.Hash,
                     new List<PublicKey>() { fx.Miner.PublicKey });
 
                 BlockCommit[] blockCommits =

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -36,8 +36,16 @@ namespace Libplanet.Blocks
         /// </description></item>
         /// <item><description>
         ///     Any one of <see cref="Vote"/> of <paramref name="votes"/> has a different
-        ///     <see cref="Vote.Height"/> from <paramref name="height"/> or a different
+        ///     <see cref="Vote.Height"/> from <paramref name="height"/>.
+        /// </description></item>
+        /// <item><description>
+        ///     Any one of <see cref="Vote"/> of <paramref name="votes"/> has a different
         ///     <see cref="Vote.Round"/> from <paramref name="round"/>.
+        /// </description></item>
+        /// <item><description>
+        ///     Any one of <see cref="Vote"/> of <paramref name="votes"/> has a different
+        ///     <see cref="Vote.BlockHash"/> from <paramref name="round"/> that is not
+        ///     <see langword="null"/>.
         /// </description></item>
         /// </list>
         /// </exception>
@@ -63,10 +71,14 @@ namespace Libplanet.Blocks
             {
                 throw new ArgumentException("Empty set of votes is not allowed.", nameof(votes));
             }
-            else if (votes.Any(vote => vote.Height != height || vote.Round != round))
+            else if (votes.Any(vote =>
+                vote.Height != height ||
+                vote.Round != round ||
+                (vote.BlockHash is { } h && !h.Equals(hash))))
             {
                 throw new ArgumentException(
-                    $"All votes must have the same height as {height} and round as {round}",
+                    $"Every vote must have the same height as {height}, the same round " +
+                    $"as {round}, and either null hash or the same hash as {hash}.",
                     nameof(votes));
             }
 

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -221,21 +221,11 @@ namespace Libplanet.Blocks
                         $"The lastcommit height {commit.Height} of block #{index} " +
                         $"should match the previous block's index {index - 1}.");
                 }
-
-                if (!commit.BlockHash.Equals(previousHash))
+                else if (!commit.BlockHash.Equals(previousHash))
                 {
                     throw new InvalidBlockLastCommitException(
                         $"The lastcommit blockhash {commit.BlockHash} of block #{index} " +
                         $"should match the previous block's hash {previousHash}.");
-                }
-
-                // FIXME: This should be checked by blockcommit instance
-                if (!commit.HasVotesSameHeight())
-                {
-                    // The height of all votes are same with the lastcommit's height.
-                    throw new InvalidBlockLastCommitException(
-                        $"All votes in the lastcommit of block #{index} " +
-                        $"should match the previous block's index {index - 1}.");
                 }
             }
 


### PR DESCRIPTION
In addition to having to have same height and rounds, this also requires `BlockCommit`'s `Vote`s to have the same hash when not `null`.