### PR TITLE
Moved vote signature validity check to constructor

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -168,53 +168,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task ThrowInvalidValidatorVote()
-        {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
-                startStep: Step.Default);
-
-            var block = blockChain.ProposeBlock(TestUtils.Peer1Priv);
-            Exception? exceptionThrown = null;
-            var exceptionOccurred = new AsyncAutoResetEvent();
-            context.ExceptionOccurred += (sender, he) =>
-            {
-                exceptionThrown = he.Exception;
-                exceptionOccurred.Set();
-            };
-
-            _ = context.MessageConsumerTask(default);
-            _ = context.MutationConsumerTask(default);
-
-            // Vote's signature does not match with remote
-            context.ProduceMessage(
-                new ConsensusVote(
-                    new VoteMetadata(
-                        context.Height,
-                        context.Round,
-                        block.Hash,
-                        DateTimeOffset.UtcNow,
-                        TestUtils.Validators[0],
-                        VoteFlag.PreVote).Sign(TestUtils.Peer1Priv)));
-            await exceptionOccurred.WaitAsync();
-            Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
-
-            // Reset exception thrown.
-            exceptionThrown = null;
-
-            context.ProduceMessage(
-                new ConsensusVote(
-                    new VoteMetadata(
-                        context.Height,
-                        context.Round,
-                        block.Hash,
-                        DateTimeOffset.UtcNow,
-                        TestUtils.Validators[0],
-                        VoteFlag.PreVote).Sign(TestUtils.Peer1Priv)));
-            await exceptionOccurred.WaitAsync();
-            Assert.True(exceptionThrown is InvalidValidatorVoteMessageException);
-        }
-
-        [Fact(Timeout = Timeout)]
         public async Task ThrowDifferentHeight()
         {
             var (_, blockChain, context) = TestUtils.CreateDummyContext(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -587,8 +587,7 @@ namespace Libplanet.Tests.Blockchain
                         blockHash: vote.BlockHash,
                         timestamp: vote.Timestamp,
                         validator: vote.Validator,
-                        flag: vote.Flag
-                    ).Sign(keys[i]));
+                        flag: VoteFlag.PreCommit).Sign(keys[i]));
             }
 
             var blockCommit = new BlockCommit(voteSet, _blockChain.Tip.Hash);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -265,69 +265,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public void ValidateNextBlockLastCommitInvalidSignature()
-        {
-            Block<DumbAction> block1 = new BlockContent<DumbAction>(
-                new BlockMetadata(
-                    index: 1L,
-                    timestamp: DateTimeOffset.UtcNow,
-                    publicKey: _fx.Miner.PublicKey,
-                    previousHash: _fx.GenesisBlock.Hash,
-                    txHash: null,
-                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
-
-            Vote voteA = new VoteMetadata(
-                1,
-                0,
-                block1.Hash,
-                DateTimeOffset.UtcNow,
-                TestUtils.ConsensusPeer0PrivateKey.PublicKey,
-                VoteFlag.PreCommit).Sign(TestUtils.ConsensusPeer0PrivateKey);
-
-            // Invalid Signature
-            Vote voteB = new VoteMetadata(
-                1,
-                0,
-                block1.Hash,
-                DateTimeOffset.UtcNow,
-                TestUtils.ConsensusPeer1PrivateKey.PublicKey,
-                VoteFlag.PreCommit).Sign(new PrivateKey());
-
-            Vote voteC = new VoteMetadata(
-                1,
-                0,
-                block1.Hash,
-                DateTimeOffset.UtcNow,
-                TestUtils.ConsensusPeer2PrivateKey.PublicKey,
-                VoteFlag.PreCommit).Sign(TestUtils.ConsensusPeer2PrivateKey);
-
-            Vote voteD = new VoteMetadata(
-                1,
-                0,
-                block1.Hash,
-                DateTimeOffset.UtcNow,
-                TestUtils.ConsensusPeer3PrivateKey.PublicKey,
-                VoteFlag.PreCommit).Sign(TestUtils.ConsensusPeer3PrivateKey);
-
-            var blockCommit = new BlockCommit(
-                1,
-                0,
-                block1.Hash,
-                new[] { voteA, voteB, voteC, voteD }.ToImmutableArray());
-
-            Block<DumbAction> block2 = new BlockContent<DumbAction>(
-                new BlockMetadata(
-                    index: 2L,
-                    timestamp: DateTimeOffset.UtcNow,
-                    publicKey: _fx.Miner.PublicKey,
-                    previousHash: block1.Hash,
-                    txHash: null,
-                    lastCommit: blockCommit)).Propose().Evaluate(_fx.Miner, _blockChain);
-            Assert.Throws<InvalidBlockLastCommitException>(() => _blockChain.Append(block2));
-        }
-
-        [Fact]
         public void ValidateNextBlockLastCommitFailsUnexpectedValidator()
         {
             Block<DumbAction> block1 = new BlockContent<DumbAction>(

--- a/Libplanet.Tests/Blocks/BlockCommitExtensionsTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitExtensionsTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Immutable;
 using System.Linq;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
@@ -60,40 +58,6 @@ namespace Libplanet.Tests.Blocks
                 Enumerable.Range(0, TestUtils.ConsensusValidators.Count)
                     .Select(x => new PrivateKey().PublicKey)
                     .ToArray()));
-        }
-
-        [Fact]
-        public void HasValidVotes()
-        {
-            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
-            BlockCommit? allValidVotes = TestUtils.CreateLastCommit(hash, 2, 0);
-            Assert.True(allValidVotes?.HasValidVotes());
-
-            VoteSet threeVoteSet = new VoteSet(2, 0, hash, TestUtils.ConsensusValidators);
-            TestUtils.AddVotesToVoteSet(
-                threeVoteSet,
-                hash,
-                VoteFlag.PreCommit,
-                TestUtils.ConsensusPrivateKeys.Take(3));
-            BlockCommit threeValidVotes = new BlockCommit(threeVoteSet, hash);
-            Assert.True(threeValidVotes.HasValidVotes());
-
-            var invalidValidator = new PrivateKey();
-            var invalidSignatureCommit = new BlockCommit(
-                2,
-                0,
-                hash,
-                new[]
-                {
-                    new VoteMetadata(
-                        2,
-                        0,
-                        hash,
-                        DateTimeOffset.UtcNow,
-                        new PrivateKey().PublicKey,
-                        VoteFlag.PreCommit).Sign(invalidValidator),
-                }.ToImmutableArray());
-            Assert.False(invalidSignatureCommit.HasValidVotes());
         }
     }
 }

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     privateKey.PublicKey,
-                    VoteFlag.Null).Sign(privateKey));
+                    VoteFlag.Null).Sign(null));
             Assert.Throws<ArgumentException>(() =>
                 new BlockCommit(1, 1, hash, ImmutableArray<Vote>.Empty));
             Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Immutable;
+using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
-using Libplanet.Tests.Store;
 using Xunit;
 
 namespace Libplanet.Tests.Consensus
@@ -11,14 +12,13 @@ namespace Libplanet.Tests.Consensus
         [Fact]
         public void MarshalVote()
         {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
             var key = new PrivateKey();
-            var fx = new MemoryStoreFixture();
-            var now = DateTimeOffset.UtcNow;
             var vote = new VoteMetadata(
                 1,
                 2,
-                fx.Hash1,
-                now,
+                hash,
+                DateTimeOffset.UtcNow,
                 key.PublicKey,
                 VoteFlag.PreCommit).Sign(key);
             byte[] marshaled = vote.ByteArray;
@@ -29,18 +29,110 @@ namespace Libplanet.Tests.Consensus
         [Fact]
         public void Sign()
         {
-            var fx = new MemoryStoreFixture();
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
             var privateKey = new PrivateKey();
             var voteMetadata = new VoteMetadata(
                 1,
                 2,
-                fx.Hash1,
+                hash,
                 DateTimeOffset.UtcNow,
                 privateKey.PublicKey,
                 VoteFlag.PreCommit);
             Vote vote = voteMetadata.Sign(privateKey);
             Assert.True(
                 privateKey.PublicKey.Verify(voteMetadata.ByteArray, vote.Signature));
+        }
+
+        [Fact]
+        public void CannotSignWithWrongPrivateKey()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+            var validator = new PrivateKey().PublicKey;
+            var key = new PrivateKey();
+            var voteMetadata = new VoteMetadata(
+                height: 2,
+                round: 3,
+                blockHash: hash,
+                timestamp: DateTimeOffset.UtcNow,
+                validator: validator,
+                flag: VoteFlag.PreCommit);
+
+            // Cannot sign with Sign method
+            Assert.Throws<ArgumentException>(() => voteMetadata.Sign(key));
+
+            // Cannot bypass by attaching signature
+            Assert.Throws<ArgumentException>(() =>
+                new Vote(
+                    voteMetadata,
+                    key.Sign(voteMetadata.ByteArray).ToImmutableArray()));
+        }
+
+        [Fact]
+        public void EmptySignatureNotAllowedForPreVoteAndPreCommit()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+            var key = new PrivateKey();
+            var preVoteMetadata = new VoteMetadata(
+                height: 2,
+                round: 3,
+                blockHash: hash,
+                timestamp: DateTimeOffset.UtcNow,
+                validator: key.PublicKey,
+                flag: VoteFlag.PreVote);
+            var preCommitMetadata = new VoteMetadata(
+                height: 2,
+                round: 3,
+                blockHash: hash,
+                timestamp: DateTimeOffset.UtcNow,
+                validator: key.PublicKey,
+                flag: VoteFlag.PreCommit);
+
+            // Works fine.
+            _ = preVoteMetadata.Sign(key);
+            _ = preCommitMetadata.Sign(key);
+
+            Assert.Throws<ArgumentException>(() => preVoteMetadata.Sign(null));
+            Assert.Throws<ArgumentException>(() =>
+                new Vote(preVoteMetadata, ImmutableArray<byte>.Empty));
+            Assert.Throws<ArgumentException>(() => preCommitMetadata.Sign(null));
+            Assert.Throws<ArgumentException>(() =>
+                new Vote(preCommitMetadata, ImmutableArray<byte>.Empty));
+        }
+
+        [Fact]
+        public void SignatureNotAllowedForNullAndUnknown()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+            var key = new PrivateKey();
+            var nullMetadata = new VoteMetadata(
+                height: 2,
+                round: 3,
+                blockHash: hash,
+                timestamp: DateTimeOffset.UtcNow,
+                validator: key.PublicKey,
+                flag: VoteFlag.Null);
+            var unknownMetadata = new VoteMetadata(
+                height: 2,
+                round: 3,
+                blockHash: hash,
+                timestamp: DateTimeOffset.UtcNow,
+                validator: key.PublicKey,
+                flag: VoteFlag.Unknown);
+
+            // Works fine.
+            _ = nullMetadata.Sign(null);
+            _ = unknownMetadata.Sign(null);
+
+            Assert.Throws<ArgumentException>(() => nullMetadata.Sign(key));
+            Assert.Throws<ArgumentException>(() =>
+                new Vote(
+                    nullMetadata,
+                    key.Sign(nullMetadata.ByteArray).ToImmutableArray()));
+            Assert.Throws<ArgumentException>(() => unknownMetadata.Sign(key));
+            Assert.Throws<ArgumentException>(() =>
+                new Vote(
+                    unknownMetadata,
+                    key.Sign(unknownMetadata.ByteArray).ToImmutableArray()));
         }
 
         [Fact]

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -11,6 +11,7 @@ namespace Libplanet.Tests.Consensus
         [Fact]
         public void MarshalVote()
         {
+            var key = new PrivateKey();
             var fx = new MemoryStoreFixture();
             var now = DateTimeOffset.UtcNow;
             var vote = new VoteMetadata(
@@ -18,8 +19,8 @@ namespace Libplanet.Tests.Consensus
                 2,
                 fx.Hash1,
                 now,
-                new PrivateKey().PublicKey,
-                VoteFlag.PreCommit).Sign(new PrivateKey());
+                key.PublicKey,
+                VoteFlag.PreCommit).Sign(key);
             byte[] marshaled = vote.ByteArray;
             var unMarshaled = new Vote(marshaled);
             Assert.Equal(vote, unMarshaled);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1164,7 +1164,7 @@ namespace Libplanet.Tests.Store
                                 null,
                                 DateTimeOffset.UtcNow,
                                 validatorPrivateKey.PublicKey,
-                                VoteFlag.Null).Sign(validatorPrivateKey)));
+                                VoteFlag.PreCommit).Sign(validatorPrivateKey)));
 
                 fx.Store.PutLastCommit(blockCommit);
                 Assert.NotNull(fx.Store.GetLastCommit(blockCommit.Height));

--- a/Libplanet/Consensus/Vote.cs
+++ b/Libplanet/Consensus/Vote.cs
@@ -27,8 +27,32 @@ namespace Libplanet.Consensus
             if (signature.IsDefault)
             {
                 throw new ArgumentException(
-                    $"{nameof(signature)} should not be set to default; use an empty array " +
-                    $"to represent a lack of signature for a {nameof(Vote)}.",
+                    $"Given {nameof(signature)} should not be set to default; use " +
+                    $"an empty array to represent a lack of signature for a {nameof(Vote)}.",
+                    nameof(signature));
+            }
+            else if (!signature.IsEmpty)
+            {
+                if (metadata.Flag != VoteFlag.PreVote && metadata.Flag != VoteFlag.PreCommit)
+                {
+                    throw new ArgumentException(
+                        $"If {nameof(signature)} is not empty, {metadata.Flag} should be either " +
+                        $"{VoteFlag.PreVote} or {VoteFlag.PreCommit}",
+                        nameof(signature));
+                }
+                else if (!metadata.Validator.Verify(metadata.ByteArray, signature))
+                {
+                    throw new ArgumentException(
+                        $"Given {nameof(signature)} is invalid.",
+                        nameof(signature));
+                }
+            }
+            else if (signature.IsEmpty &&
+                (metadata.Flag != VoteFlag.Null && metadata.Flag != VoteFlag.Unknown))
+            {
+                throw new ArgumentException(
+                    $"If {nameof(signature)} is empty, {metadata.Flag} should be either " +
+                    $"{VoteFlag.Null} or {VoteFlag.Unknown}",
                     nameof(signature));
             }
 


### PR DESCRIPTION
Prevents creating a `Vote` object with an invalid signature through "normal" operation.
Several tests are removed for now. As evidence collection is currently not under consideration, malformed messages are not allowed to be interpreted. Once structural validity of objects, all the way up to `Block<T>`, is enforced, we need a mechanism to handle "undecipherable" messages. This is currently not an issue at this testing phase as we are more concerned about correct behaviors among honest nodes.