### PR TITLE
Unexpected vote created with arbitrary `VoteFlag`

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -334,14 +334,14 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreVote))
+                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreCommit))
                 {
                     Remote = TestUtils.Peer1,
                 });
             context.ProduceMessage(
                 new ConsensusCommit(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreVote))
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreCommit))
                 {
                     Remote = TestUtils.Peer1,
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -212,7 +212,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             exceptionThrown = null;
 
             context.ProduceMessage(
-                new ConsensusCommit(
+                new ConsensusVote(
                     TestUtils.CreateVote(
                         TestUtils.Peer2Priv,
                         2,

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
@@ -120,6 +121,34 @@ namespace Libplanet.Net.Tests.Messages
                 new MessageId(ByteUtil.ParseHex(
                     "dae1eaa93fd023279c4d0eb73000d66fdbf196c1239a4cee3d1d84f28d49ece6")),
                 message.Id);
+        }
+
+        [Fact]
+        public void InvalidVoteFlagConsensus()
+        {
+            var blockHash = new BlockHash(TestUtils.GetRandomBytes(32));
+
+            var preVote = TestUtils.CreateVote(
+                TestUtils.Peer0Priv,
+                1,
+                0,
+                blockHash,
+                VoteFlag.PreVote);
+
+            var preCommit = TestUtils.CreateVote(
+                TestUtils.Peer0Priv,
+                1,
+                0,
+                blockHash,
+                VoteFlag.PreCommit);
+
+            // Valid message cases
+            _ = new ConsensusVote(preVote);
+            _ = new ConsensusCommit(preCommit);
+
+            // Invalid message cases
+            Assert.Throws<InvalidMessageException>(() => new ConsensusVote(preCommit));
+            Assert.Throws<InvalidMessageException>(() => new ConsensusCommit(preVote));
         }
     }
 }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -18,6 +18,7 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
+using Random = System.Random;
 
 namespace Libplanet.Net.Tests
 {
@@ -92,6 +93,8 @@ namespace Libplanet.Net.Tests
             "1/54684Ac4ee5B933e72144C4968BEa26056880d71/MEQCICGonYW" +
             ".X8y4JpPIyccPYWGrsCXWA95sBfextucz3lOyAiBUoY5t8aYNPT0lwYwC0MSkK3HT7T" +
             ".lGJJW13dJi+06nw==");
+
+        private static readonly Random Random = new Random();
 
         public static Vote CreateVote(
             PrivateKey privateKey,
@@ -331,6 +334,14 @@ namespace Libplanet.Net.Tests
                 TimeSpan.FromMilliseconds(newHeightDelayMilliseconds),
                 30,
                 contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
+        }
+
+        public static byte[] GetRandomBytes(int size)
+        {
+            var bytes = new byte[size];
+            Random.NextBytes(bytes);
+
+            return bytes;
         }
     }
 }

--- a/Libplanet.Net/Messages/ConsensusCommit.cs
+++ b/Libplanet.Net/Messages/ConsensusCommit.cs
@@ -17,6 +17,11 @@ namespace Libplanet.Net.Messages
         public ConsensusCommit(Vote vote)
             : base(vote.Validator, vote.Height, vote.Round, vote.BlockHash)
         {
+            if (vote.Flag != VoteFlag.PreCommit)
+            {
+                throw new InvalidMessageException("Vote flag must be PreCommit.", this);
+            }
+
             CommitVote = vote;
         }
 

--- a/Libplanet.Net/Messages/ConsensusVote.cs
+++ b/Libplanet.Net/Messages/ConsensusVote.cs
@@ -17,6 +17,11 @@ namespace Libplanet.Net.Messages
         public ConsensusVote(Vote vote)
             : base(vote.Validator, vote.Height, vote.Round, vote.BlockHash)
         {
+            if (vote.Flag != VoteFlag.PreVote)
+            {
+                throw new InvalidMessageException("Vote flag must be PreVote.", this);
+            }
+
             ProposeVote = vote;
         }
 


### PR DESCRIPTION
There is a case in which a forged vote can be created with an arbitrary `VoteFlag` for `ConsensusVote/Commit` (e.g., `VoteFlag.PreVote` + `ConsensusCommit`.) These could lead to an unexpected state change of `Context<T>`.

## `Context`
The current `GetVotes()` and `GetCommits()` behaviour could count different `VoteFlag`. For example, If a `ConsensusVote` with a vote contains `VoteFlag.PreCommit` can be counted as a PreVote message.

https://github.com/planetarium/libplanet/blob/b580d379a2f092a9054504990e2b0812194144fc/Libplanet.Net/Consensus/MessageLog.cs#L52-L80

The methods are used in state change condition methods, `HasTwoThirdsPreVote()` and `HasTwoThirdsPreCommit()`, which do not also check `VoteFlag`.

https://github.com/planetarium/libplanet/blob/b580d379a2f092a9054504990e2b0812194144fc/Libplanet.Net/Consensus/Context.cs#L402-L438

This behavior also has an impact on `VoteSet` because `GetVotes()` and `GetCommits()` are used.

https://github.com/planetarium/libplanet/blob/b580d379a2f092a9054504990e2b0812194144fc/Libplanet.Net/Consensus/Context.cs#L224-L236

## Changes
In the constructor of `ConsensusVote` and `ConsensusCommit`, the sanity of `VoteFlag` is checked.