### PR TITLE
Add `json` field to `ActionType` GraphQL type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,11 +14,16 @@ To be released.
 
 ### Added APIs
 
+ -  (Libplanet.Explorer) Added `json` field to `ActionType` GraphQL type.
+    [[#2418]]
+
 ### Behavioral changes
 
 ### Bug fixes
 
 ### CLI tools
+
+[#2418]: https://github.com/planetarium/libplanet/pull/2418
 
 
 Version 0.43.1

--- a/Libplanet.Explorer/GraphTypes/ActionType.cs
+++ b/Libplanet.Explorer/GraphTypes/ActionType.cs
@@ -1,7 +1,11 @@
 #nullable disable
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
 using Bencodex;
 using Bencodex.Types;
 using GraphQL;
@@ -51,6 +55,19 @@ namespace Libplanet.Explorer.GraphTypes
                 name: "Inspection",
                 description: "A readable representation for debugging.",
                 resolve: ctx => ctx.Source.PlainValue.Inspect(loadAll: true)
+            );
+
+            Field<NonNullGraphType<StringGraphType>>(
+                name: "json",
+                description: "A JSON representaion of action data",
+                resolve: ctx =>
+                {
+                    var converter = new Bencodex.Json.BencodexJsonConverter();
+                    var buffer = new MemoryStream();
+                    var writer = new Utf8JsonWriter(buffer);
+                    converter.Write(writer, ctx.Source.PlainValue, new JsonSerializerOptions());
+                    return Encoding.UTF8.GetString(buffer.ToArray());
+                }
             );
 
             Name = "Action";

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -9,7 +9,7 @@
     <Authors>Planetarium</Authors>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <NoWarn>NU1701;SA1118</NoWarn>
+    <NoWarn>NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
@@ -58,6 +58,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <PackageReference Include="Bencodex.Json" Version="0.7.0-dev.20220923062845" />
     <!-- FIXME: We should specify the version range when the following NuGet
     issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
   </ItemGroup>


### PR DESCRIPTION
This pull request resolves #2416 

The execution result seems like below screenshot:

![image](https://user-images.githubusercontent.com/26626194/196619091-92aa612a-b55d-44cd-a48a-aca5e09195a9.png)

This pull request introduces `ActionType.json` field to represent action's json format.


----


I requested a review for SDK team but please adjust reviewers if it's other's part.
