### PR TITLE
Added constraint on vote metadata

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -115,9 +115,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             ImmutableArray<Vote> votes = proposedBlock!.LastCommit?.Votes is { } vs
                 ? vs
                 : throw new NullReferenceException();
-            Assert.Equal(
-                votes.Count(),
-                votes.Where(vote => vote.BlockHash.Equals(blockChain[1].Hash)).Count());
             Assert.Equal(VoteFlag.PreCommit, votes[0].Flag);
             Assert.Equal(VoteFlag.PreCommit, votes[1].Flag);
             Assert.Equal(VoteFlag.PreCommit, votes[2].Flag);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
-using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
@@ -50,12 +51,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 validators);
 
             AsyncAutoResetEvent stepChangedToEndCommit = new AsyncAutoResetEvent();
-
-            Assert.Throws<InvalidHeightIncreasingException>(
-                () => consensusContext.NewHeight(blockChain.Tip.Index));
-            Assert.Throws<InvalidHeightIncreasingException>(
-                () => consensusContext.NewHeight(blockChain.Tip.Index + 2));
-
             consensusContext.StateChanged += (sender, state) =>
             {
                 if (state.Height == 1 && state.Step == Step.EndCommit)
@@ -64,9 +59,16 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             };
 
+            Assert.Throws<InvalidHeightIncreasingException>(
+                () => consensusContext.NewHeight(blockChain.Tip.Index));
+            Assert.Throws<InvalidHeightIncreasingException>(
+                () => consensusContext.NewHeight(blockChain.Tip.Index + 2));
+
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
             BlockHash blockHash;
+
+            // FIXME: Pretty lousy way to catch the proposed block's hash.
             while (true)
             {
                 try
@@ -104,6 +106,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // Waiting for commit.
             await stepChangedToEndCommit.WaitAsync();
             Assert.Equal(1, blockChain.Tip.Index);
+
             // Next NewHeight is not called yet.
             Assert.Equal(1, consensusContext.Height);
             Assert.Equal(0, consensusContext.Round);

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -229,7 +229,10 @@ namespace Libplanet.Net.Consensus
         public VoteSet VoteSet(int round)
         {
             (Block<T>? block, int? _) = GetPropose(round);
-            VoteSet voteSet = new VoteSet(Height, round, block?.Hash, _validators);
+            VoteSet voteSet = block is { } b
+                ? new VoteSet(Height, round, b.Hash, _validators)
+                : throw new NullReferenceException(
+                    $"Cannot create a {nameof(Libplanet.Consensus.VoteSet)} for a null block");
             _messageLog.GetVotes(round).ForEach(vote => voteSet.Add(vote.ProposeVote));
             _messageLog.GetCommits(round).ForEach(commit => voteSet.Add(commit.CommitVote));
             return voteSet;

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -23,14 +23,15 @@ namespace Libplanet.Tests.Blocks
         public void Marshalling()
         {
             var fx = new MemoryStoreFixture();
-            var votes = Enumerable.Range(0, 4)
-                .Select(x => new VoteMetadata(
+            var keys = Enumerable.Range(0, 4).Select(_ => new PrivateKey()).ToList();
+            var votes = keys.Select(key =>
+                new VoteMetadata(
                     1,
                     0,
                     fx.Hash1,
                     DateTimeOffset.Now,
-                    new PrivateKey().PublicKey,
-                    VoteFlag.Null).Sign(null))
+                    key.PublicKey,
+                    VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
             var blockCommit = new BlockCommit(1, 0, fx.Hash1, votes);
 
@@ -44,15 +45,15 @@ namespace Libplanet.Tests.Blocks
         public void ConstructorInvalidValues()
         {
             var hash = new BlockHash(TestUtils.GetRandomBytes(32));
-            var privateKey = new PrivateKey();
-            var votes = ImmutableArray<Vote>.Empty
-                .Add(new VoteMetadata(
+            var keys = Enumerable.Range(0, 4).Select(_ => new PrivateKey()).ToList();
+            var votes = keys.Select(key =>
+                new VoteMetadata(
                     0,
                     0,
                     hash,
                     DateTimeOffset.UtcNow,
-                    privateKey.PublicKey,
-                    VoteFlag.Null).Sign(null));
+                    key.PublicKey,
+                    VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
             Assert.Throws<ArgumentException>(() =>
                 new BlockCommit(1, 1, hash, ImmutableArray<Vote>.Empty));
             Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/Libplanet.Tests/Consensus/VoteMetadataTest.cs
+++ b/Libplanet.Tests/Consensus/VoteMetadataTest.cs
@@ -1,0 +1,59 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class VoteMetadataTest
+    {
+        private static Bencodex.Codec _codec = new Bencodex.Codec();
+
+        [Fact]
+        public void MarshalVoteMetadata()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+            var key = new PrivateKey();
+            var voteMetadata = new VoteMetadata(
+                1,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                VoteFlag.PreCommit);
+            byte[] marshaled = voteMetadata.ByteArray;
+            var unMarshaled = new VoteMetadata(
+                (Bencodex.Types.Dictionary)_codec.Decode(marshaled));
+            Assert.Equal(voteMetadata, unMarshaled);
+        }
+
+        [Fact]
+        public void NullBlockHashNotAllowedForNullAndUnknown()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(32));
+
+            // Works with some hash value.
+            _ = new VoteMetadata(
+                2, 2, hash, DateTimeOffset.UtcNow, new PrivateKey().PublicKey, VoteFlag.Null);
+            _ = new VoteMetadata(
+                2, 2, hash, DateTimeOffset.UtcNow, new PrivateKey().PublicKey, VoteFlag.Unknown);
+
+            // Null hash is not allowed.
+            Assert.Throws<ArgumentException>(() => new VoteMetadata(
+                2,
+                2,
+                null,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                VoteFlag.Null));
+            Assert.Throws<ArgumentException>(() => new VoteMetadata(
+                2,
+                2,
+                null,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                VoteFlag.Unknown));
+        }
+    }
+}

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -100,7 +100,7 @@ namespace Libplanet.Tests.Consensus
         }
 
         [Fact]
-        public void SignatureNotAllowedForNullAndUnknown()
+        public void NonEmptySignatureNotAllowedForNullAndUnknown()
         {
             var hash = new BlockHash(TestUtils.GetRandomBytes(32));
             var key = new PrivateKey();

--- a/Libplanet/Consensus/VoteMetadata.cs
+++ b/Libplanet/Consensus/VoteMetadata.cs
@@ -35,6 +35,18 @@ namespace Libplanet.Consensus
         /// <see cref="PublicKey"/> of the validator made the vote.
         /// </param>
         /// <param name="flag"><see cref="VoteFlag"/> for the vote's status.</param>
+        /// <exception cref="ArgumentException">Thrown for any of the following reasons:
+        /// <list type="bullet">
+        /// <item><description>
+        ///     Either <paramref name="height"/> or <paramref name="round"/> is negative.
+        /// </description></item>
+        /// <item><description>
+        ///     Given <paramref name="blockHash"/> is <see langword="null"/> when
+        ///     <paramref name="flag"/> is either <see cref="VoteFlag.Null"/>
+        ///     or <see cref="VoteFlag.Unknown"/>.
+        /// </description></item>
+        /// </list>
+        /// </exception>
         public VoteMetadata(
             long height,
             int round,
@@ -43,7 +55,23 @@ namespace Libplanet.Consensus
             PublicKey validator,
             VoteFlag flag)
         {
-            // TODO: Check arguments.
+            if (height < 0)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(height)} cannot be negative: {height}");
+            }
+            else if (round < 0)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(round)} cannot be negative: {round}");
+            }
+            else if (blockHash is null && (flag == VoteFlag.Null || flag == VoteFlag.Unknown))
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(blockHash)} cannot be null if {nameof(flag)} " +
+                    $"is {VoteFlag.Null} or {VoteFlag.Unknown}");
+            }
+
             Height = height;
             Round = round;
             BlockHash = blockHash;

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Consensus
         public VoteSet(
             long height,
             int round,
-            BlockHash? blockHash,
+            BlockHash blockHash,
             IEnumerable<PublicKey> validatorSet)
         {
             Height = height;


### PR DESCRIPTION
~~`Null` and `Unknown` type `Vote`s are no longer allowed to have `BlockHash`.~~
`Null` and `Unknown` type `Vote`s are no longer allowed to have `BlockHash` as `null`.