### PR TITLE
Thread-safe NewHeight method in `ConsensusContext`

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -185,7 +185,6 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 blockChain[1].Hash,
                 1,
                 0));
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
             await proposeSent.WaitAsync();
 
             Assert.Equal(2, consensusContext.Height);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -57,8 +57,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             };
 
+            // The given height is equal to the consensus context's height.
             Assert.Throws<InvalidHeightIncreasingException>(
                 () => consensusContext.NewHeight(blockChain.Tip.Index));
+            // The given height is not the same tip's index + 1.
             Assert.Throws<InvalidHeightIncreasingException>(
                 () => consensusContext.NewHeight(blockChain.Tip.Index + 2));
 


### PR DESCRIPTION
The `ConsensusContext.NewHeight()` method was not thread-safe and could be invoked multiple times for the same height. No regression test for this because it's a timing problem and hard to reproduce.