### PR TITLE
Mismatch test fixture of `ConsensusContext` with actual implementation

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -142,9 +142,9 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.Peer1Priv,
                 validators);
 
-            Assert.Equal(1, consensusContext.Height);
+            Assert.Equal(0, consensusContext.Height);
             blockChain.Append(blockChain.ProposeBlock(new PrivateKey()));
-            Assert.Equal(1, consensusContext.Height);
+            Assert.Equal(0, consensusContext.Height);
             await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
             Assert.Equal(2, consensusContext.Height);
         }
@@ -161,9 +161,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.Peer1Priv,
-                validators);
+                validators,
+                height: 1);
 
-            Assert.True(consensusContext.Height > 0);
+            Assert.True(consensusContext.Height == 1);
             Assert.Throws<InvalidHeightMessageException>(
                 () => consensusContext.HandleMessage(
                     new ConsensusPropose(

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -216,7 +216,8 @@ namespace Libplanet.Net.Tests
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
                 EventHandler<ConsensusMessage>? consensusMessageSent = null,
                 long lastCommitClearThreshold = 30,
-                ContextTimeoutOption? contextTimeoutOptions = null)
+                ContextTimeoutOption? contextTimeoutOptions = null,
+                long height = 0)
         {
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
@@ -243,7 +244,7 @@ namespace Libplanet.Net.Tests
             consensusContext = new ConsensusContext<DumbAction>(
                 broadcastMessage,
                 blockChain,
-                blockChain.Tip.Index + 1,
+                height,
                 privateKey,
                 newHeightDelay,
                 _ => validators,

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -99,8 +99,11 @@ namespace Libplanet.Net.Consensus
         public DelegateBroadcastMessage BroadcastMessage { get; }
 
         /// <summary>
-        /// Index of the block that is now under consensus. this value should be same as the index
-        /// of <see cref="BlockChain{T}.Tip"/> + 1.
+        /// Index of the block that is now under consensus. After a consensus starts, the value
+        /// should be same as the index of <see cref="BlockChain{T}.Tip"/> + 1.
+        /// <seealso cref="NewHeight"/>
+        /// <remarks>The initial value is the index of <see cref="BlockChain{T}.Tip"/>.
+        /// </remarks>
         /// </summary>
         public long Height { get; private set; }
 


### PR DESCRIPTION
The `ConsensusReactor` initializes `ConsensusContext` with `BlockChain.Tip.Index`. This results in the initial height of `ConsensusContext` to same as the current Blockchain tip index (e.g., If the genesis block is the tip of Blockchain, then the initial height would be 0.) However, In the test fixture, the `ConsensusContext` is initialized with `BlockChain.Tip.Index + 1`, which is different from the actual implementation.

https://github.com/planetarium/libplanet/blob/c19e5f71195934fdefa5fee12903650c919bf868/Libplanet.Net/Consensus/ConsensusReactor.cs#L75-L83

https://github.com/planetarium/libplanet/blob/c19e5f71195934fdefa5fee12903650c919bf868/Libplanet.Net/Consensus/ConsensusReactor.cs#L112-L116

https://github.com/planetarium/libplanet/blob/c19e5f71195934fdefa5fee12903650c919bf868/Libplanet.Net.Tests/TestUtils.cs#L207-L254