### PR TITLE
Added constraints to `BlockCommit`

### DIFF
--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -126,7 +126,7 @@ public class TransactionQueryTest
         var lastCommit = new BlockCommit(
                 height: 1,
                 round: 0,
-                hash: block.Hash,
+                blockHash: block.Hash,
                 votes: ImmutableArray<Vote>.Empty
                     .Add(new VoteMetadata(1, 0, block.Hash, DateTimeOffset.UtcNow,
                     _source.Validator.PublicKey, VoteFlag.PreCommit).Sign(_source.Validator)));

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -191,7 +191,7 @@ namespace Libplanet.Explorer.Store
         }
 
         /// <inheritdoc />
-        public BlockCommit? GetLastCommit(long height)
+        public BlockCommit GetLastCommit(long height)
         {
             return _store.GetLastCommit(height);
         }

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -159,7 +159,7 @@ namespace Libplanet.Explorer.Store
         }
 
         /// <inheritdoc />
-        public BlockCommit? GetLastCommit(long height)
+        public BlockCommit GetLastCommit(long height)
         {
             return _store.GetLastCommit(height);
         }

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -277,7 +277,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             VoteSet roundVoteSet = context.VoteSet(0);
             Assert.Equal(1, roundVoteSet.Height);
             Assert.Equal(0, roundVoteSet.Round);
-            Assert.Equal(VoteFlag.PreVote, roundVoteSet.Votes[0].Flag);
+            Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[0].Flag);
             Assert.Equal(VoteFlag.PreCommit, roundVoteSet.Votes[1].Flag);
             Assert.Equal(VoteFlag.PreCommit, roundVoteSet.Votes[2].Flag);
             Assert.Equal(VoteFlag.Null, roundVoteSet.Votes[3].Flag);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -199,7 +199,7 @@ namespace Libplanet.Net.Consensus
                     _logger.Debug(
                         "Caching LastCommit of Height {Height}...",
                         height - 1);
-                    _blockChain.Store.PutLastCommit(lastCommit.Value);
+                    _blockChain.Store.PutLastCommit(lastCommit);
                 }
                 else
                 {
@@ -210,8 +210,8 @@ namespace Libplanet.Net.Consensus
                         _logger.Debug(
                             "Found cached LastCommit of Height #{Height} " +
                             "and Round #{Round}",
-                            lastCommit.Value.Height,
-                            lastCommit.Value.Round);
+                            lastCommit.Height,
+                            lastCommit.Round);
                     }
                 }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -233,7 +233,6 @@ namespace Libplanet.Net.Consensus
                 ? new VoteSet(Height, round, b.Hash, _validators)
                 : throw new NullReferenceException(
                     $"Cannot create a {nameof(Libplanet.Consensus.VoteSet)} for a null block");
-            _messageLog.GetVotes(round).ForEach(vote => voteSet.Add(vote.ProposeVote));
             _messageLog.GetCommits(round).ForEach(commit => voteSet.Add(commit.CommitVote));
             return voteSet;
         }

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1221,7 +1221,7 @@ namespace Libplanet.RocksDBStore
         }
 
         /// <inheritdoc />
-        public override BlockCommit? GetLastCommit(long height)
+        public override BlockCommit GetLastCommit(long height)
         {
             _rwLastCommitLock.EnterReadLock();
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -597,7 +597,7 @@ namespace Libplanet.Tests.Blockchain
                 lastCommit: blockCommit);
 
             Assert.NotNull(block.LastCommit);
-            AssertBytesEqual(block.LastCommit.Value.ByteArray, blockCommit.ByteArray);
+            AssertBytesEqual(block.LastCommit.ByteArray, blockCommit.ByteArray);
         }
 
         [Fact]

--- a/Libplanet.Tests/Blocks/BlockCommitExtensionsTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitExtensionsTest.cs
@@ -20,10 +20,10 @@ namespace Libplanet.Tests.Blocks
         public void HasTwoThirdCommits()
         {
             var hash = new BlockHash(TestUtils.GetRandomBytes(32));
-            BlockCommit? allCommits = TestUtils.CreateLastCommit(hash, 2, 0);
+            BlockCommit allCommits = TestUtils.CreateLastCommit(hash, 2, 0);
             Assert.True(allCommits?.HasTwoThirdCommits(TestUtils.ConsensusValidators));
 
-            BlockCommit? noCommits = TestUtils.CreateLastCommit(hash, 2, 0, VoteFlag.PreVote);
+            BlockCommit noCommits = TestUtils.CreateLastCommit(hash, 2, 0, VoteFlag.PreVote);
             Assert.False(noCommits?.HasTwoThirdCommits(TestUtils.ConsensusValidators));
 
             VoteSet voteSet = new VoteSet(2, 0, hash, TestUtils.ConsensusValidators);
@@ -45,7 +45,7 @@ namespace Libplanet.Tests.Blocks
         public void HasSameValidators()
         {
             var hash = new BlockHash(TestUtils.GetRandomBytes(32));
-            BlockCommit? allCommits = TestUtils.CreateLastCommit(hash, 2, 0);
+            BlockCommit allCommits = TestUtils.CreateLastCommit(hash, 2, 0);
             Assert.True(allCommits?.HasSameValidators(TestUtils.ConsensusValidators));
             Assert.False(
                 allCommits?.HasSameValidators(TestUtils.ConsensusValidators.Skip(1).Take(3)));

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Tests.Blocks
                 lastCommit: new BlockCommit(
                     height: Next.Index,
                     round: 0,
-                    hash: Next.Hash,
+                    blockHash: Next.Hash,
                     votes: new[]
                     {
                         new VoteMetadata(

--- a/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
@@ -99,7 +99,7 @@ namespace Libplanet.Tests
                     _fx.HasTx.Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                 .Add(PublicKeyKey, _fx.HasTx.PublicKey.Format(true))
                 .Add(TxHashKey, _fx.HasTx.TxHash.Value.ByteArray)
-                .Add(LastCommitKey, _fx.HasTx.LastCommit.Value.ByteArray);
+                .Add(LastCommitKey, _fx.HasTx.LastCommit.ByteArray);
             var expectedHasTxHeader = _marshaledHasTxMetadata
                 .Add(PreEvaluationHashKey, _fx.HasTx.PreEvaluationHash.ByteArray)
                 .Add(StateRootHashKey, _fx.HasTx.StateRootHash.ByteArray)

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -301,7 +301,6 @@ namespace Libplanet.Tests.Blocks
                 txHash: null,
                 lastCommit: invalidBlockHashLastCommit));
 
-            // Signature can be null for null or unknown votes.
             var validLastCommit = new BlockCommit(
                 1,
                 0,
@@ -322,7 +321,7 @@ namespace Libplanet.Tests.Blocks
                         blockHash,
                         timestamp,
                         validatorC.PublicKey,
-                        VoteFlag.Unknown).Sign(null),
+                        VoteFlag.PreCommit).Sign(validatorC),
                 }.ToImmutableArray());
             var validMetadata = new BlockMetadata(
                 protocolVersion: BlockMetadata.CurrentProtocolVersion,

--- a/Libplanet.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetTest.cs
@@ -27,8 +27,6 @@ namespace Libplanet.Tests.Consensus
 
              var now = DateTimeOffset.UtcNow;
 
-             Assert.False(voteSet.HasTwoThirdAny());
-             Assert.False(voteSet.HasTwoThirdPrevote());
              Assert.False(voteSet.HasTwoThirdCommit());
 
              for (int i = 0; i < 3; i++)
@@ -43,8 +41,6 @@ namespace Libplanet.Tests.Consensus
                 voteSet.Add(vote);
              }
 
-             Assert.True(voteSet.HasTwoThirdAny());
-             Assert.True(voteSet.HasTwoThirdPrevote());
              Assert.False(voteSet.HasTwoThirdCommit());
 
              voteSet = new VoteSet(
@@ -65,8 +61,6 @@ namespace Libplanet.Tests.Consensus
                  voteSet.Add(vote);
              }
 
-             Assert.True(voteSet.HasTwoThirdAny());
-             Assert.False(voteSet.HasTwoThirdPrevote());
              Assert.True(voteSet.HasTwoThirdCommit());
          }
 
@@ -86,8 +80,6 @@ namespace Libplanet.Tests.Consensus
 
              var now = DateTimeOffset.UtcNow;
 
-             Assert.False(voteSet.HasTwoThirdAny());
-             Assert.False(voteSet.HasTwoThirdPrevote());
              Assert.False(voteSet.HasTwoThirdCommit());
 
              for (int i = 0; i < 3; i++)
@@ -102,8 +94,6 @@ namespace Libplanet.Tests.Consensus
                  voteSet.Add(vote);
              }
 
-             Assert.False(voteSet.HasTwoThirdAny());
-             Assert.False(voteSet.HasTwoThirdPrevote());
              Assert.False(voteSet.HasTwoThirdCommit());
          }
     }

--- a/Libplanet.Tests/Store/ProxyStore.cs
+++ b/Libplanet.Tests/Store/ProxyStore.cs
@@ -196,7 +196,7 @@ namespace Libplanet.Tests.Store
             Store.PruneOutdatedChains(noopWithoutCanon);
 
         /// <inheritdoc />
-        public BlockCommit? GetLastCommit(long height) =>
+        public BlockCommit GetLastCommit(long height) =>
             Store.GetLastCommit(height);
 
         /// <inheritdoc />

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1102,7 +1102,7 @@ namespace Libplanet.Tests.Store
                 BlockCommit blockCommit = new BlockCommit(voteSet, fx.Block2.Hash);
 
                 fx.Store.PutLastCommit(blockCommit);
-                BlockCommit? storedCommitVotes =
+                BlockCommit storedCommitVotes =
                     fx.Store.GetLastCommit(blockCommit.Height);
 
                 Assert.Equal(blockCommit, storedCommitVotes);
@@ -1161,7 +1161,7 @@ namespace Libplanet.Tests.Store
                             .Add(new VoteMetadata(
                                 0,
                                 0,
-                                null,
+                                Fx.GenesisBlock.Hash,
                                 DateTimeOffset.UtcNow,
                                 validatorPrivateKey.PublicKey,
                                 VoteFlag.PreCommit).Sign(validatorPrivateKey)));

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -216,7 +216,7 @@ namespace Libplanet.Tests.Store
             _store.PruneOutdatedChains();
         }
 
-        public BlockCommit? GetLastCommit(long height)
+        public BlockCommit GetLastCommit(long height)
         {
             Log(nameof(GetLastCommit), height);
             return _store.GetLastCommit(height);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -348,7 +348,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return bytes;
         }
 
-        public static BlockCommit? CreateLastCommit(
+        public static BlockCommit CreateLastCommit(
             BlockHash blockHash,
             long height,
             int round,
@@ -497,7 +497,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             PublicKey miner = null,
             TimeSpan? blockInterval = null,
             int protocolVersion = Block<T>.CurrentProtocolVersion,
-            BlockCommit? lastCommit = null
+            BlockCommit lastCommit = null
         )
             where T : IAction, new()
         {
@@ -529,7 +529,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             TimeSpan? blockInterval = null,
             int protocolVersion = Block<T>.CurrentProtocolVersion,
             HashDigest<SHA256> stateRootHash = default,
-            BlockCommit? lastCommit = null
+            BlockCommit lastCommit = null
         )
             where T : IAction, new()
         {

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Blockchain
             int? maxTransactions = null,
             int? maxTransactionsPerSigner = null,
             IComparer<Transaction<T>> txPriority = null,
-            BlockCommit? lastCommit = null) =>
+            BlockCommit lastCommit = null) =>
 #pragma warning disable SA1118
             ProposeBlock(
                 proposer: proposer,
@@ -93,7 +93,7 @@ namespace Libplanet.Blockchain
             int maxTransactions,
             int maxTransactionsPerSigner,
             IComparer<Transaction<T>> txPriority = null,
-            BlockCommit? lastCommit = null)
+            BlockCommit lastCommit = null)
         {
             long index = Count;
             long difficulty = 1L;

--- a/Libplanet/Blocks/BlockCommitExtensions.cs
+++ b/Libplanet/Blocks/BlockCommitExtensions.cs
@@ -63,14 +63,5 @@ namespace Libplanet.Blocks
             commit.Votes.All(
                 vote => vote.Flag == VoteFlag.Null || vote.Flag == VoteFlag.Unknown ||
                         vote.Verify());
-
-        /// <summary>
-        /// Checks whether <see cref="BlockCommit"/> has same height for every votes.
-        /// </summary>
-        /// <param name="commit">A <see cref="BlockCommit"/> to check.</param>
-        /// <returns>Returns <see langword="true"/> if <see cref="BlockCommit.Votes"/> have same
-        /// height, otherwise returns <see langword="false"/>.</returns>
-        public static bool HasVotesSameHeight(this BlockCommit commit) =>
-            commit.Votes.All(vote => vote.Height == commit.Height);
     }
 }

--- a/Libplanet/Consensus/VoteSet.cs
+++ b/Libplanet/Consensus/VoteSet.cs
@@ -96,29 +96,6 @@ namespace Libplanet.Consensus
         }
 
         /// <summary>
-        /// Check if the validators voted has more than +2/3 voting power.
-        /// </summary>
-        /// <returns><c>true</c> if +2/3 of voting power in the <see cref="ValidatorSet"/> voted.
-        /// <c>false</c> otherwise.</returns>
-        public bool HasTwoThirdAny()
-        {
-            var twoThird = ValidatorSet.Length * 2.0 / 3.0;
-            return _votes.Count(x => !x.Value.Signature.IsDefaultOrEmpty) > twoThird;
-        }
-
-        /// <summary>
-        /// Check if the validators who voted about PreVote state have more than +2/3 voting power.
-        /// </summary>
-        /// <returns><c>true</c> if +2/3 of the voting power in the <see cref="ValidatorSet"/>
-        /// voted about <see cref="VoteFlag.PreVote"/>, <c>false</c> otherwise.</returns>
-        public bool HasTwoThirdPrevote()
-        {
-            var twoThird = ValidatorSet.Length * 2.0 / 3.0;
-            return _votes.Count(x =>
-                !x.Value.Signature.IsDefaultOrEmpty && x.Value.Flag == VoteFlag.PreVote) > twoThird;
-        }
-
-        /// <summary>
         /// Check if the validators who voted about PreCommit state have more than +2/3 voting
         /// power.
         /// </summary>
@@ -135,10 +112,10 @@ namespace Libplanet.Consensus
         private bool IsVoteValid(Vote vote)
         {
             return ValidatorSet.Contains(vote.Validator) &&
-                vote.Verify() &&
                 vote.Height == Height &&
                 vote.Round == Round &&
-                _votes[vote.Validator].Flag <= vote.Flag;
+                vote.Flag == VoteFlag.PreCommit &&
+                _votes[vote.Validator].Flag == VoteFlag.Null;
         }
     }
 }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -183,7 +183,7 @@ namespace Libplanet.Store
         public abstract void PruneOutdatedChains(bool noopWithoutCanon = false);
 
         /// <inheritdoc/>
-        public abstract BlockCommit? GetLastCommit(long height);
+        public abstract BlockCommit GetLastCommit(long height);
 
         /// <inheritdoc/>
         public abstract void PutLastCommit(BlockCommit lastCommit);

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -665,7 +665,7 @@ namespace Libplanet.Store
         }
 
         /// <inheritdoc />
-        public override BlockCommit? GetLastCommit(long height)
+        public override BlockCommit GetLastCommit(long height)
         {
             UPath path = LastCommitPath(height);
             if (!_lastCommits.FileExists(path))

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -353,7 +353,7 @@ namespace Libplanet.Store
         /// <param name="height">A height to get.</param>
         /// <returns>Returns <see cref="BlockCommit"/> if given height is stored and available,
         /// otherwise returns <see langword="null"/>.</returns>
-        BlockCommit? GetLastCommit(long height);
+        BlockCommit GetLastCommit(long height);
 
         /// <summary>
         /// Puts a <see cref="BlockCommit"/> to the store.

--- a/Libplanet/Store/MemoryStore.cs
+++ b/Libplanet/Store/MemoryStore.cs
@@ -284,7 +284,7 @@ namespace Libplanet.Store
             }
         }
 
-        public BlockCommit? GetLastCommit(long height)
+        public BlockCommit GetLastCommit(long height)
         {
             if (!_lastCommits.ContainsKey(height))
             {


### PR DESCRIPTION
Notable changes:
- `Vote`'s in `BlockCommit` must be either `Null` or `PreCommit` votes.
- `BlockCommit` is now a `class`.