### PR TITLE
Default `ConsensusContext.Height` value

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -145,9 +145,9 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.Peer1Priv,
                 validators);
 
-            Assert.Equal(0, consensusContext.Height);
+            Assert.Equal(-1, consensusContext.Height);
             blockChain.Append(blockChain.ProposeBlock(new PrivateKey()));
-            Assert.Equal(0, consensusContext.Height);
+            Assert.Equal(-1, consensusContext.Height);
             await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
             Assert.Equal(2, consensusContext.Height);
         }
@@ -160,13 +160,13 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.Peer0Priv.PublicKey, TestUtils.Peer1Priv.PublicKey,
             };
 
-            var (fx, _, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (fx, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.Peer1Priv,
-                validators,
-                height: 1);
+                validators);
 
+            consensusContext.NewHeight(blockChain.Tip.Index + 1);
             Assert.True(consensusContext.Height == 1);
             Assert.Throws<InvalidHeightMessageException>(
                 () => consensusContext.HandleMessage(

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -216,8 +216,7 @@ namespace Libplanet.Net.Tests
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
                 EventHandler<ConsensusMessage>? consensusMessageSent = null,
                 long lastCommitClearThreshold = 30,
-                ContextTimeoutOption? contextTimeoutOptions = null,
-                long height = 0)
+                ContextTimeoutOption? contextTimeoutOptions = null)
         {
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
@@ -244,7 +243,6 @@ namespace Libplanet.Net.Tests
             consensusContext = new ConsensusContext<DumbAction>(
                 broadcastMessage,
                 blockChain,
-                height,
                 privateKey,
                 newHeightDelay,
                 _ => validators,

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -43,9 +43,6 @@ namespace Libplanet.Net.Consensus
         /// <param name="blockChain">A blockchain that will be committed, which
         /// will be voted by consensus, and used for proposing a block.
         /// </param>
-        /// <param name="height">The current height of consensus. this value should be same as the
-        /// index of <see cref="BlockChain{T}.Tip"/> + 1.
-        /// </param>
         /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
         /// </param>
         /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
@@ -61,7 +58,6 @@ namespace Libplanet.Net.Consensus
         public ConsensusContext(
             DelegateBroadcastMessage broadcastMessage,
             BlockChain<T> blockChain,
-            long height,
             PrivateKey privateKey,
             TimeSpan newHeightDelay,
             Func<long, IEnumerable<PublicKey>> getValidators,
@@ -71,7 +67,7 @@ namespace Libplanet.Net.Consensus
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
             _privateKey = privateKey;
-            Height = height;
+            Height = -1;
             _newHeightDelay = newHeightDelay;
             _getValidators = getValidators;
             LastCommitClearThreshold = lastCommitClearThreshold;
@@ -101,12 +97,12 @@ namespace Libplanet.Net.Consensus
         public DelegateBroadcastMessage BroadcastMessage { get; }
 
         /// <summary>
-        /// Index of the block that is now under consensus. After a consensus starts, the value
-        /// should be same as the index of <see cref="BlockChain{T}.Tip"/> + 1.
-        /// <seealso cref="NewHeight"/>
-        /// <remarks>The initial value is the index of <see cref="BlockChain{T}.Tip"/>.
-        /// </remarks>
+        /// The index of block that <see cref="ConsensusContext{T}"/> is watching. The value can be
+        /// changed by starting a consensus or appending a block.
         /// </summary>
+        /// <seealso cref="NewHeight"/>  <seealso cref="OnBlockChainTipChanged"/>
+        /// <returns>If <see cref="NewHeight"/> or <see cref="OnBlockChainTipChanged"/> is called
+        /// before, returns current working height, otherwise returns <c>-1</c>.</returns>
         public long Height { get; private set; }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -75,7 +75,6 @@ namespace Libplanet.Net.Consensus
             _consensusContext = new ConsensusContext<T>(
                 AddMessage,
                 blockChain,
-                blockChain.Tip.Index,
                 privateKey,
                 newHeightDelay,
                 blockChain.Policy.GetValidators,


### PR DESCRIPTION
This resolves #2423

Current `ConsensusContext` set `Height` value from parameter. This is hidden from a constructor, and set value -1 as default. The `Height` value changes only if `NewHeight()` is called or `OnBlockChainTipChanged()`.