### PR TITLE
Change removal `LastCommit` cache target

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -334,6 +334,12 @@ namespace Libplanet.Net.Consensus
                 _newHeightCts.Token);
         }
 
+        /// <summary>
+        /// Removes old last commit (<see cref="BlockCommit"/>) cache in store, if the cache count
+        /// is over <paramref name="maxSize"/>. The removal starts from lowest height cache and
+        /// keep the last commit cache count in <paramref name="maxSize"/>.
+        /// </summary>
+        /// <param name="maxSize">A maximum count value of <see cref="BlockCommit"/> cache.</param>
         private void ClearOldLastCommitCache(long maxSize = 30)
         {
             IEnumerable<long> indices = _blockChain.Store.GetLastCommitIndices().ToArray();

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -192,7 +192,6 @@ namespace Libplanet.Net.Consensus
                 }
 
                 RemoveOldContexts(height);
-                ClearOldLastCommitCache(maxSize: LastCommitClearThreshold);
 
                 if (lastCommit != null)
                 {
@@ -214,6 +213,8 @@ namespace Libplanet.Net.Consensus
                             lastCommit.Round);
                     }
                 }
+
+                ClearOldLastCommitCache(maxSize: LastCommitClearThreshold);
 
                 Height = height;
 
@@ -343,10 +344,10 @@ namespace Libplanet.Net.Consensus
             }
 
             _logger.Debug(
-                "Pruning old LastCommit caches at height {PreviousTip}...",
+                "Removing old LastCommit caches at height {PreviousTip}...",
                 _blockChain.Tip.Index);
 
-            foreach (var height in indices)
+            foreach (var height in indices.OrderBy(x => x).Take((int)(indices.Count() - maxSize)))
             {
                 _blockChain.Store.DeleteLastCommit(height);
             }


### PR DESCRIPTION
## Context
`ClearOldLastCommitCache` removes every `LastCommit` caches if stored count is higher than `maxSize` (`lastCommitClearThreshold`.) This also removes the previous height `LastCommit`.

The problem is, for example, if a node goes down after the `NewHeight()` is called and then restarts, the `LastCommit` for the previous height does not exist in memory and even in the store.

## Changes
- Removes `LastCommit` cache in FIFO manner and it does not remove all `LastCommit` cache now. It keeps the `maxSize` count of `lastCommit` cache.
- Some chores (Add documentation for method, simplifying test.)