### PR TITLE
Streamline `Bencodex` serialization for `Transaction<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,17 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed all `TxMetadata.ToBencodex()` overload methods with parameters.
+    Use newly introduced parameterless `TxMetadata.ToBencodex()` instead.
+    [[#2457]]
+ -  (Libplanet.Node) Changed `UntypedTransaction(ITxMetadata,
+    IEnumerable<IValue>, ImmutableArray<byte>)` to `UntypedTransaction(
+    ITxMetadata, IValue?, IValue?, ImmutableArray<byte>`) to support
+    `Transaction<T>.SystemAction`.  [[#2456], [#2457]]
+ -  (Libplanet.Node) Renamed `UntypedTransaction.ActionValues` to
+    `UntypedTransaction.CustomActionsValue` and changed its type from
+    `IReadOnlyList<IValue>` to `IValue?`.  [[#2456], [#2457]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -16,6 +27,8 @@ To be released.
 
  -  (Libplanet.Explorer) Added `json` field to `ActionType` GraphQL type.
     [[#2418]]
+ -  (Libplanet.Node) Added `IValue? SystemActionValue` property to
+    `UntypedTransaction`.  [[#2456], [#2457]]
 
 ### Behavioral changes
 
@@ -36,6 +49,8 @@ To be released.
 [#2418]: https://github.com/planetarium/libplanet/pull/2418
 [#2437]: https://github.com/planetarium/libplanet/issues/2437
 [#2459]: https://github.com/planetarium/libplanet/pull/2459
+[#2456]: https://github.com/planetarium/libplanet/issues/2456
+[#2457]: https://github.com/planetarium/libplanet/pull/2457
 
 
 Version 0.43.1

--- a/Libplanet.Node.Tests/UntypedBlockTest.cs
+++ b/Libplanet.Node.Tests/UntypedBlockTest.cs
@@ -111,6 +111,7 @@ namespace Libplanet.Node.Tests
             var untypedTxs = _txs.Select(tx =>
                 new UntypedTransaction(
                     tx,
+                    null,
                     tx.CustomActions.Select(a => a.PlainValue),
                     tx.Signature.ToImmutableArray()));
             var untyped = new UntypedBlock(_block, untypedTxs);

--- a/Libplanet.Node.Tests/UntypedBlockTest.cs
+++ b/Libplanet.Node.Tests/UntypedBlockTest.cs
@@ -112,7 +112,7 @@ namespace Libplanet.Node.Tests
                 new UntypedTransaction(
                     tx,
                     null,
-                    tx.CustomActions.Select(a => a.PlainValue),
+                    new Bencodex.Types.List(tx.CustomActions.Select(a => a.PlainValue)),
                     tx.Signature.ToImmutableArray()));
             var untyped = new UntypedBlock(_block, untypedTxs);
             Assert.Equal(_block.MarshalBlock(), untyped.ToBencodex());

--- a/Libplanet.Node.Tests/UntypedTransactionTest.cs
+++ b/Libplanet.Node.Tests/UntypedTransactionTest.cs
@@ -45,7 +45,8 @@ namespace Libplanet.Node.Tests
                     "83915317ebdbf870c567b263dd2e61ec9dca7fb381c592d80993291b6ffe5ad5"),
             };
             _actionValues = new IValue[] { new Integer(123), new Integer(456) };
-            Bencodex.Types.Dictionary unsignedDict = _meta.ToBencodex(_actionValues);
+            Bencodex.Types.Dictionary unsignedDict = _meta.ToBencodex()
+                .Add(TxMetadata.CustomActionsKey, new Bencodex.Types.List(_actionValues));
             var codec = new Codec();
             _sig = ImmutableArray.Create(_key2.Sign(codec.Encode(unsignedDict)));
         }
@@ -85,7 +86,8 @@ namespace Libplanet.Node.Tests
         public void Deserialize()
         {
             Bencodex.Types.Dictionary signedDict = _meta
-                .ToBencodex(_actionValues)
+                .ToBencodex()
+                .Add(TxMetadata.CustomActionsKey, new Bencodex.Types.List(_actionValues))
                 .Add(TxMetadata.SignatureKey, _sig);
             var untyped = new UntypedTransaction(signedDict);
             Assert.Equal(_meta.Nonce, untyped.Nonce);
@@ -123,7 +125,11 @@ namespace Libplanet.Node.Tests
         {
             Bencodex.Types.Dictionary dict =
                 new UntypedTransaction(_meta, null, _actionValues, _sig).ToBencodex();
-            Assert.Equal(_meta.ToBencodex(_actionValues).Add(TxMetadata.SignatureKey, _sig), dict);
+            Assert.Equal(
+                _meta.ToBencodex()
+                    .Add(TxMetadata.CustomActionsKey, new Bencodex.Types.List(_actionValues))
+                    .Add(TxMetadata.SignatureKey, _sig),
+                dict);
 
             var deserialized = new UntypedTransaction(dict);
             Assert.Equal(_meta.Nonce, deserialized.Nonce);

--- a/Libplanet.Node.Tests/UntypedTransactionTest.cs
+++ b/Libplanet.Node.Tests/UntypedTransactionTest.cs
@@ -84,7 +84,9 @@ namespace Libplanet.Node.Tests
         [Fact]
         public void Deserialize()
         {
-            Bencodex.Types.Dictionary signedDict = _meta.ToBencodex(_actionValues, _sig);
+            Bencodex.Types.Dictionary signedDict = _meta
+                .ToBencodex(_actionValues)
+                .Add(TxMetadata.SignatureKey, _sig);
             var untyped = new UntypedTransaction(signedDict);
             Assert.Equal(_meta.Nonce, untyped.Nonce);
             Assert.Equal(_meta.Signer, untyped.Signer);
@@ -121,7 +123,7 @@ namespace Libplanet.Node.Tests
         {
             Bencodex.Types.Dictionary dict =
                 new UntypedTransaction(_meta, _actionValues, _sig).ToBencodex();
-            Assert.Equal(_meta.ToBencodex(_actionValues, _sig), dict);
+            Assert.Equal(_meta.ToBencodex(_actionValues).Add(TxMetadata.SignatureKey, _sig), dict);
 
             var deserialized = new UntypedTransaction(dict);
             Assert.Equal(_meta.Nonce, deserialized.Nonce);

--- a/Libplanet.Node.Tests/UntypedTransactionTest.cs
+++ b/Libplanet.Node.Tests/UntypedTransactionTest.cs
@@ -60,7 +60,8 @@ namespace Libplanet.Node.Tests
         [Fact]
         public void Constructor()
         {
-            var untyped = new UntypedTransaction(_meta, _systemActionValue, null, _withCustomActionsSignature);
+            var untyped = new UntypedTransaction(
+                _meta, _systemActionValue, null, _withSystemActionSignature);
             Assert.Equal(_meta.Nonce, untyped.Nonce);
             Assert.Equal(_meta.Signer, untyped.Signer);
             Assert.Equal(_meta.UpdatedAddresses, untyped.UpdatedAddresses);
@@ -71,7 +72,8 @@ namespace Libplanet.Node.Tests
             Assert.Null(untyped.CustomActionsValue);
             Assert.Equal(_withSystemActionSignature, untyped.Signature);
 
-            untyped = new UntypedTransaction(_meta, null, _customActionsValue, _withCustomActionsSignature);
+            untyped = new UntypedTransaction(
+                _meta, null, _customActionsValue, _withCustomActionsSignature);
             Assert.Equal(_meta.Nonce, untyped.Nonce);
             Assert.Equal(_meta.Signer, untyped.Signer);
             Assert.Equal(_meta.UpdatedAddresses, untyped.UpdatedAddresses);

--- a/Libplanet.Node.Tests/UntypedTransactionTest.cs
+++ b/Libplanet.Node.Tests/UntypedTransactionTest.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Node.Tests
         [Fact]
         public void Constructor()
         {
-            var untyped = new UntypedTransaction(_meta, _actionValues, _sig);
+            var untyped = new UntypedTransaction(_meta, null, _actionValues, _sig);
             Assert.Equal(_meta.Nonce, untyped.Nonce);
             Assert.Equal(_meta.Signer, untyped.Signer);
             Assert.Equal(_meta.UpdatedAddresses, untyped.UpdatedAddresses);
@@ -65,7 +65,7 @@ namespace Libplanet.Node.Tests
 
             InvalidTxSignatureException e;
             e = Assert.Throws<InvalidTxSignatureException>(
-                () => new UntypedTransaction(_meta, _actionValues, default)
+                () => new UntypedTransaction(_meta, null, _actionValues, default)
             );
             Assert.Equal(
                 TxId.FromHex("ea601351c27c3c6291c4352ec060f06650b81c02ded4a4d22858da756098fd4e"),
@@ -73,7 +73,7 @@ namespace Libplanet.Node.Tests
             );
 
             e = Assert.Throws<InvalidTxSignatureException>(
-                () => new UntypedTransaction(_meta, Enumerable.Empty<IValue>(), _sig)
+                () => new UntypedTransaction(_meta, null, Enumerable.Empty<IValue>(), _sig)
             );
             Assert.Equal(
                 TxId.FromHex("f91abd37cad6962cb206a9c29faffddede8bce47751f3e5e4b0e1c8f714a4a82"),
@@ -122,7 +122,7 @@ namespace Libplanet.Node.Tests
         public void ToBencodex()
         {
             Bencodex.Types.Dictionary dict =
-                new UntypedTransaction(_meta, _actionValues, _sig).ToBencodex();
+                new UntypedTransaction(_meta, null, _actionValues, _sig).ToBencodex();
             Assert.Equal(_meta.ToBencodex(_actionValues).Add(TxMetadata.SignatureKey, _sig), dict);
 
             var deserialized = new UntypedTransaction(dict);

--- a/Libplanet.Node/UntypedTransaction.cs
+++ b/Libplanet.Node/UntypedTransaction.cs
@@ -56,14 +56,9 @@ namespace Libplanet.Node
             Signature = signature;
 
             Dictionary dict = _metadata.ToBencodex();
-            if (SystemActionValue is { } sav)
-            {
-                dict = dict.Add(TxMetadata.SystemActionKey, sav);
-            }
-            else
-            {
-                dict = dict.Add(TxMetadata.CustomActionsKey, CustomActionsValue!);
-            }
+            dict = SystemActionValue is { } sav
+                ? dict.Add(TxMetadata.SystemActionKey, sav)
+                : dict.Add(TxMetadata.CustomActionsKey, CustomActionsValue!);
 
             byte[] encoded = Codec.Encode(dict);
 

--- a/Libplanet.Node/UntypedTransaction.cs
+++ b/Libplanet.Node/UntypedTransaction.cs
@@ -133,6 +133,6 @@ namespace Libplanet.Node
         /// <seealso cref="Transaction{T}(Bencodex.Types.Dictionary)"/>
         [Pure]
         public Bencodex.Types.Dictionary ToBencodex() =>
-            _metadata.ToBencodex(ActionValues, Signature);
+            _metadata.ToBencodex(ActionValues).Add(TxMetadata.SignatureKey, Signature);
     }
 }

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -316,32 +316,6 @@ namespace Libplanet.Tests.Tx
                 0x09, 0xf4, 0x50, 0x9f, 0xb1, 0xb1, 0x1e, 0xab, 0x11, 0x4b,
                 0x3f,
             };
-
-            // The customActions parameter cannot be null.
-            Assert.Throws<ArgumentNullException>(() =>
-                new Transaction<DumbAction>(
-                    metadata: new TxMetadata(privateKey.PublicKey)
-                    {
-                        Nonce = 0L,
-                        Timestamp = timestamp,
-                    },
-                    customActions: null,
-                    signature: signature
-                )
-            );
-
-            // The signature parameter cannot be null.
-            Assert.Throws<ArgumentNullException>(() =>
-                new Transaction<DumbAction>(
-                    metadata: new TxMetadata(privateKey.PublicKey)
-                    {
-                        Nonce = 0L,
-                        Timestamp = timestamp,
-                    },
-                    customActions: new DumbAction[0],
-                    signature: null
-                )
-            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TxMetadataTest.cs
+++ b/Libplanet.Tests/Tx/TxMetadataTest.cs
@@ -111,7 +111,6 @@ namespace Libplanet.Tests.Tx
                         .Add(_key2.ToAddress().ToByteArray()))
                 .Add(new byte[] { 0x74 }, "2022-01-12T04:56:07.890000Z")
                 .Add(new byte[] { 0x70 }, _key2.PublicKey.ToImmutableArray(compress: false))
-                .Add(new byte[] { 0x61 }, new List())
                 .Add(
                     new byte[] { 0x67 },
                     ByteUtil.ParseHex(
@@ -146,18 +145,10 @@ namespace Libplanet.Tests.Tx
                 .Add(new byte[] { 0x73 }, _key1.ToAddress().ByteArray)
                 .Add(new byte[] { 0x75 }, new List())
                 .Add(new byte[] { 0x74 }, "2022-05-23T10:02:00.000000Z")
-                .Add(new byte[] { 0x70 }, _key1.PublicKey.ToImmutableArray(compress: false))
-                .Add(new byte[] { 0x61 }, new List());
+                .Add(new byte[] { 0x70 }, _key1.PublicKey.ToImmutableArray(compress: false));
             AssertBencodexEqual(
                 expected1,
-                meta1.ToBencodex(Array.Empty<IValue>())
-            );
-
-            IValue[] actions = { new Integer(123), new Integer(456) };
-            AssertBencodexEqual(
-                expected1.SetItem(new byte[] { 0x61 }, new List(actions)),
-                meta1.ToBencodex(actions)
-            );
+                meta1.ToBencodex());
 
             var meta2 = new TxMetadata(_key2.PublicKey)
             {
@@ -181,20 +172,13 @@ namespace Libplanet.Tests.Tx
                         .Add(_key2.ToAddress().ToByteArray()))
                 .Add(new byte[] { 0x74 }, "2022-01-12T04:56:07.890000Z")
                 .Add(new byte[] { 0x70 }, _key2.PublicKey.ToImmutableArray(compress: false))
-                .Add(new byte[] { 0x61 }, new List())
                 .Add(
                     new byte[] { 0x67 },
                     ByteUtil.ParseHex(
                         "83915317ebdbf870c567b263dd2e61ec9dca7fb381c592d80993291b6ffe5ad5"));
             AssertBencodexEqual(
                 expected2,
-                meta2.ToBencodex(Array.Empty<IValue>())
-            );
-
-            AssertBencodexEqual(
-                expected2.SetItem(new byte[] { 0x61 }, new List(actions)),
-                meta2.ToBencodex(actions)
-            );
+                meta2.ToBencodex());
         }
     }
 }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -52,14 +52,11 @@ namespace Libplanet.Tx
         /// <see cref="Transaction{T}"/>.  This has to be signed by <paramref name="metadata"/>'s
         /// <see cref="ITxMetadata.PublicKey"/>. This is copied and then assigned to
         /// the <see cref="Signature"/> property.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <see langword="null"/> is passed to
-        /// <paramref name="signature"/> or <paramref name="systemAction"/>.</exception>
         public Transaction(ITxMetadata metadata, IAction systemAction, byte[] signature)
         {
             _metadata = new TxMetadata(metadata);
-            SystemAction = systemAction ?? throw new ArgumentNullException(nameof(systemAction));
-            _signature =
-                new byte[(signature ?? throw new ArgumentNullException(nameof(signature))).Length];
+            SystemAction = systemAction;
+            _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
         }
 
@@ -75,15 +72,11 @@ namespace Libplanet.Tx
         /// <see cref="Transaction{T}"/>.  This has to be signed by <paramref name="metadata"/>'s
         /// <see cref="ITxMetadata.PublicKey"/>. This is copied and then assigned to
         /// the <see cref="Signature"/> property.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <see langword="null"/> is passed to
-        /// <paramref name="signature"/> or <paramref name="customActions"/>.</exception>
         public Transaction(ITxMetadata metadata, IEnumerable<T> customActions, byte[] signature)
         {
             _metadata = new TxMetadata(metadata);
-            CustomActions = customActions?.ToImmutableList()
-                ?? throw new ArgumentNullException(nameof(customActions));
-            _signature =
-                new byte[(signature ?? throw new ArgumentNullException(nameof(signature))).Length];
+            CustomActions = customActions.ToImmutableList();
+            _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
         }
 
@@ -128,9 +121,6 @@ namespace Libplanet.Tx
         /// or it will throw <see cref="InvalidTxSignatureException"/>.
         /// This is copied and then assigned to the <see cref="Signature"/>
         /// property.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <see langword="null"/>
-        /// is passed to <paramref name="signature"/> or <paramref name="customActions"/>.
-        /// </exception>
         [Obsolete("Use constructors taking ITxMetadata or static factory methods instead.")]
         public Transaction(
             long nonce,
@@ -144,21 +134,17 @@ namespace Libplanet.Tx
         {
             // TODO: Remove parameter signer in the future.  Apparently no more used.
             // FIXME: This constructor should be removed.
-            _metadata = new TxMetadata(publicKey
-                ?? throw new ArgumentNullException(nameof(publicKey)))
+            _metadata = new TxMetadata(publicKey)
             {
                 Nonce = nonce,
                 GenesisHash = genesisHash,
-                UpdatedAddresses = updatedAddresses
-                    ?? throw new ArgumentNullException(nameof(updatedAddresses)),
+                UpdatedAddresses = updatedAddresses,
                 Timestamp = timestamp,
             };
 
-            _signature =
-                new byte[(signature ?? throw new ArgumentNullException(nameof(signature))).Length];
+            _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
-            CustomActions = customActions?.ToImmutableList()
-                ?? throw new ArgumentNullException(nameof(customActions));
+            CustomActions = customActions.ToImmutableList();
         }
 
         /// <summary>

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -687,8 +687,12 @@ namespace Libplanet.Tx
         public Bencodex.Types.Dictionary ToBencodex(bool sign)
         {
             Dictionary metadataDict = SystemAction is { } sa
-                ? _metadata.ToBencodex(Registry.Serialize(sa))
-                : _metadata.ToBencodex(CustomActions!.Select(a => a.PlainValue));
+                ? _metadata.ToBencodex().Add(
+                    TxMetadata.SystemActionKey,
+                    Registry.Serialize(sa))
+                : _metadata.ToBencodex().Add(
+                    TxMetadata.CustomActionsKey,
+                    new List(CustomActions!.Select(a => a.PlainValue)));
             return sign
                 ? metadataDict.Add(TxMetadata.SignatureKey, ImmutableArray.Create(_signature))
                 : metadataDict;

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -686,12 +686,12 @@ namespace Libplanet.Tx
         /// representation of this <see cref="Transaction{T}"/>.</returns>
         public Bencodex.Types.Dictionary ToBencodex(bool sign)
         {
-            ImmutableArray<byte>? sig = sign
-                ? ImmutableArray.Create(_signature)
-                : (ImmutableArray<byte>?)null;
-            return SystemAction is { } sa
-                ? _metadata.ToBencodex(Registry.Serialize(sa), sig)
-                : _metadata.ToBencodex(CustomActions!.Select(a => a.PlainValue), sig);
+            Dictionary metadataDict = SystemAction is { } sa
+                ? _metadata.ToBencodex(Registry.Serialize(sa))
+                : _metadata.ToBencodex(CustomActions!.Select(a => a.PlainValue));
+            return sign
+                ? metadataDict.Add(TxMetadata.SignatureKey, ImmutableArray.Create(_signature))
+                : metadataDict;
         }
 
         /// <summary>

--- a/Libplanet/Tx/TxMetadata.cs
+++ b/Libplanet/Tx/TxMetadata.cs
@@ -123,25 +123,8 @@ namespace Libplanet.Tx
         public Bencodex.Types.Dictionary ToBencodex(IEnumerable<IValue> customActions) =>
             ToBencodex().Add(CustomActionsKey, new List(customActions));
 
-        /// <inheritdoc cref="object.ToString()"/>
         [Pure]
-        public override string ToString()
-        {
-            return nameof(TxMetadata) + " {\n" +
-                $"  {nameof(Nonce)} = {Nonce},\n" +
-                $"  {nameof(Signer)} = {Signer},\n" +
-                $"  {nameof(UpdatedAddresses)} = ({UpdatedAddresses.Count})" +
-                (UpdatedAddresses.Any()
-                    ? $"\n    {string.Join("\n    ", UpdatedAddresses)};\n"
-                    : ";\n") +
-                $"  {nameof(PublicKey)} = {PublicKey},\n" +
-                $"  {nameof(Timestamp)} = {Timestamp},\n" +
-                $"  {nameof(GenesisHash)} = {GenesisHash?.ToString() ?? "(null)"},\n" +
-                "}";
-        }
-
-        [Pure]
-        private Bencodex.Types.Dictionary ToBencodex()
+        public Bencodex.Types.Dictionary ToBencodex()
         {
             List updatedAddresses = new List(
                 UpdatedAddresses.Select<Address, IValue>(addr => new Binary(addr.ByteArray)));
@@ -160,6 +143,23 @@ namespace Libplanet.Tx
             }
 
             return dict;
+        }
+
+        /// <inheritdoc cref="object.ToString()"/>
+        [Pure]
+        public override string ToString()
+        {
+            return nameof(TxMetadata) + " {\n" +
+                $"  {nameof(Nonce)} = {Nonce},\n" +
+                $"  {nameof(Signer)} = {Signer},\n" +
+                $"  {nameof(UpdatedAddresses)} = ({UpdatedAddresses.Count})" +
+                (UpdatedAddresses.Any()
+                    ? $"\n    {string.Join("\n    ", UpdatedAddresses)};\n"
+                    : ";\n") +
+                $"  {nameof(PublicKey)} = {PublicKey},\n" +
+                $"  {nameof(Timestamp)} = {Timestamp},\n" +
+                $"  {nameof(GenesisHash)} = {GenesisHash?.ToString() ?? "(null)"},\n" +
+                "}";
         }
     }
 }

--- a/Libplanet/Tx/TxMetadata.cs
+++ b/Libplanet/Tx/TxMetadata.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Tx
         /// Creates a <see cref="TxMetadata"/> from a Bencodex <paramref name="dictionary"/>.
         /// </summary>
         /// <param name="dictionary">A Bencodex dictionary made using
-        /// <see cref="ToBencodex(IEnumerable{IValue}, ImmutableArray{byte}?)"/> method.</param>
+        /// <see cref="ToBencodex(IEnumerable{IValue})"/> method.</param>
         /// <exception cref="KeyNotFoundException">Thrown when the given
         /// <paramref name="dictionary"/> lacks some fields.</exception>
         /// <exception cref="InvalidCastException">Thrown when the given
@@ -108,32 +108,20 @@ namespace Libplanet.Tx
         /// </summary>
         /// <param name="systemAction"><see cref="IAction.PlainValue"/> of a system built-in action
         /// to include.</param>
-        /// <param name="signature">Optionally specifies the transaction signature.  It should be
-        /// <see langword="null"/> (which is the default) when you make a signature, and should be
-        /// present when you make a <see cref="TxId"/>.</param>
         /// <returns>A Bencodex dictionary that the transaction turns into.</returns>
         [Pure]
-        public Bencodex.Types.Dictionary ToBencodex(
-            IValue systemAction,
-            ImmutableArray<byte>? signature = null
-        ) =>
-            ToBencodex(signature).Add(SystemActionKey, systemAction);
+        public Bencodex.Types.Dictionary ToBencodex(IValue systemAction) =>
+            ToBencodex().Add(SystemActionKey, systemAction);
 
         /// <summary>
         /// Builds a Bencodex dictionary used for signing and calculating <see cref="TxId"/>.
         /// </summary>
         /// <param name="customActions"><see cref="IAction.PlainValue"/>s of user-defined custom
         /// actions to include.</param>
-        /// <param name="signature">Optionally specifies the transaction signature.  It should be
-        /// <see langword="null"/> (which is the default) when you make a signature, and should be
-        /// present when you make a <see cref="TxId"/>.</param>
         /// <returns>A Bencodex dictionary that the transaction turns into.</returns>
         [Pure]
-        public Bencodex.Types.Dictionary ToBencodex(
-            IEnumerable<IValue> customActions,
-            ImmutableArray<byte>? signature = null
-        ) =>
-            ToBencodex(signature).Add(CustomActionsKey, new List(customActions));
+        public Bencodex.Types.Dictionary ToBencodex(IEnumerable<IValue> customActions) =>
+            ToBencodex().Add(CustomActionsKey, new List(customActions));
 
         /// <inheritdoc cref="object.ToString()"/>
         [Pure]
@@ -153,9 +141,7 @@ namespace Libplanet.Tx
         }
 
         [Pure]
-        private Bencodex.Types.Dictionary ToBencodex(
-            ImmutableArray<byte>? signature = null
-        )
+        private Bencodex.Types.Dictionary ToBencodex()
         {
             List updatedAddresses = new List(
                 UpdatedAddresses.Select<Address, IValue>(addr => new Binary(addr.ByteArray)));
@@ -171,11 +157,6 @@ namespace Libplanet.Tx
             if (GenesisHash is { } genesisHash)
             {
                 dict = dict.Add(GenesisHashKey, genesisHash.ByteArray);
-            }
-
-            if (signature is { } sig)
-            {
-                dict = dict.Add(SignatureKey, sig);
             }
 
             return dict;

--- a/Libplanet/Tx/TxMetadata.cs
+++ b/Libplanet/Tx/TxMetadata.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using Bencodex.Types;
-using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 
@@ -60,7 +59,7 @@ namespace Libplanet.Tx
         /// Creates a <see cref="TxMetadata"/> from a Bencodex <paramref name="dictionary"/>.
         /// </summary>
         /// <param name="dictionary">A Bencodex dictionary made using
-        /// <see cref="ToBencodex(IEnumerable{IValue})"/> method.</param>
+        /// <see cref="ToBencodex()"/> method.</param>
         /// <exception cref="KeyNotFoundException">Thrown when the given
         /// <paramref name="dictionary"/> lacks some fields.</exception>
         /// <exception cref="InvalidCastException">Thrown when the given
@@ -102,26 +101,6 @@ namespace Libplanet.Tx
 
         /// <inheritdoc cref="ITxMetadata.GenesisHash"/>
         public BlockHash? GenesisHash { get; set; }
-
-        /// <summary>
-        /// Builds a Bencodex dictionary used for signing and calculating <see cref="TxId"/>.
-        /// </summary>
-        /// <param name="systemAction"><see cref="IAction.PlainValue"/> of a system built-in action
-        /// to include.</param>
-        /// <returns>A Bencodex dictionary that the transaction turns into.</returns>
-        [Pure]
-        public Bencodex.Types.Dictionary ToBencodex(IValue systemAction) =>
-            ToBencodex().Add(SystemActionKey, systemAction);
-
-        /// <summary>
-        /// Builds a Bencodex dictionary used for signing and calculating <see cref="TxId"/>.
-        /// </summary>
-        /// <param name="customActions"><see cref="IAction.PlainValue"/>s of user-defined custom
-        /// actions to include.</param>
-        /// <returns>A Bencodex dictionary that the transaction turns into.</returns>
-        [Pure]
-        public Bencodex.Types.Dictionary ToBencodex(IEnumerable<IValue> customActions) =>
-            ToBencodex().Add(CustomActionsKey, new List(customActions));
 
         [Pure]
         public Bencodex.Types.Dictionary ToBencodex()


### PR DESCRIPTION
Resolves #2456.

Removed `IAction` and signature serialization handling from `TxMetadata` to have the process more in line with `Block<T>`.