### PR TITLE
Add signable consensus Proposal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,8 @@ Version PBFT
     `InvalidValidatorVoteMessageException` class.  [[#PBFT]]
  -  (Libplanet.Net) Added `Message.Id` property.  [[#PBFT]]
  -  (Libplanet.Net) Added `Gossip` class.  [[#PBFT]]
+ -  (Libplanet.Net) Added `Proposal` class.  [[#PBFT]]
+ -  (Libplaent.Net) Added `ProposalMetaData` class.  [[#PBFT]]
 
 ### Behavioral changes
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -172,13 +172,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             Assert.True(consensusContext.Height == 1);
             Assert.Throws<InvalidHeightMessageException>(
                 () => consensusContext.HandleMessage(
-                    new ConsensusProposeMsg(
-                        new PrivateKey().PublicKey,
-                        0,
-                        0,
-                        fx.Block1.Hash,
-                        new byte[] { },
-                        -1)));
+                    TestUtils.CreateConsensusPropose(
+                        blockChain.ProposeBlock(TestUtils.Peer0Priv),
+                        TestUtils.Peer0Priv,
+                        0)));
         }
 
         [Fact(Timeout = Timeout)]
@@ -207,7 +204,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 {
                     proposedBlock =
                         BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(propose.Payload));
+                            (Dictionary)codec.Decode(propose.Proposal.BlockMarshaled));
                     heightOneProposeSent.Set();
                 }
             }
@@ -247,7 +244,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     if (message.Height == 2 && message.Message is ConsensusProposeMsg propose)
                     {
                         proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(propose!.Payload));
+                            (Dictionary)codec.Decode(propose!.Proposal.BlockMarshaled));
                         heightTwoProposeSent.Set();
                     }
                 };
@@ -279,7 +276,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     if (hm.Message is ConsensusProposeMsg propose)
                     {
                         proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(propose!.Payload));
+                            (Dictionary)codec.Decode(propose!.Proposal.BlockMarshaled));
                         heightTwoProposeSent.Set();
                     }
                 };
@@ -330,8 +327,11 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             consensusContext.NewHeight(1);
             // Create context of index 2.
             consensusContext.HandleMessage(
-                new ConsensusProposeMsg(
-                    TestUtils.Validators[1], 2, 1, fx.Hash1, new byte[] { }, -1));
+                TestUtils.CreateConsensusPropose(
+                    blockChain.ProposeBlock(TestUtils.Peer2Priv),
+                    TestUtils.Peer2Priv,
+                    2,
+                    1));
 
             blockChain.Append(blockChain.ProposeBlock(new PrivateKey()));
             blockChain.Append(
@@ -373,7 +373,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     if (msg is ConsensusProposeMsg proposeMsg)
                     {
                         proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(proposeMsg.Payload));
+                            (Dictionary)codec.Decode(proposeMsg.Proposal.BlockMarshaled));
                         heightOneProposeSent.Set();
                     }
                 });

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -56,7 +56,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 if (message is ConsensusProposeMsg propose)
                 {
                     proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                        (Bencodex.Types.Dictionary)_codec.Decode(propose.Payload));
+                        (Bencodex.Types.Dictionary)_codec.Decode(propose.Proposal.BlockMarshaled));
                     proposeSent.Set();
                 }
                 else if (message is ConsensusPreVoteMsg prevote &&
@@ -74,7 +74,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             // Force round change.
             context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                proposedBlock, TestUtils.Peer3Priv, round: 2, validRound: 1));
+                proposedBlock!, TestUtils.Peer3Priv, round: 2, validRound: 1));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.Peer0Priv,
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 if (message is ConsensusProposeMsg propose)
                 {
                     proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                        (Bencodex.Types.Dictionary)_codec.Decode(propose.Payload));
+                        (Bencodex.Types.Dictionary)_codec.Decode(propose.Proposal.BlockMarshaled));
                     proposeSent.Set();
                 }
                 else if (message is ConsensusPreVoteMsg prevote &&
@@ -179,7 +179,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             // Force round change to 2.
             context.ProduceMessage(TestUtils.CreateConsensusPropose(
-                proposedBlock, TestUtils.Peer3Priv, round: 2, validRound: -1));
+                proposedBlock!, TestUtils.Peer3Priv, round: 2, validRound: -1));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.Peer0Priv,

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -105,7 +105,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Assert.Equal(Step.PreVote, context.Step);
             Assert.NotNull(proposedMessage);
             Block<DumbAction> proposed = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                (Dictionary)new Codec().Decode(proposedMessage!.Payload));
+                (Dictionary)new Codec().Decode(proposedMessage!.Proposal.BlockMarshaled));
             Assert.NotNull(proposed.LastCommit);
             Assert.Equal(lastCommit, proposed.LastCommit);
         }
@@ -134,7 +134,13 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async void ThrowNilPropose()
         {
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var codec = new Codec();
+            var (fx, _, context) = TestUtils.CreateDummyContext();
+            Binary blockHash = default(BlockHash).ByteArray;
+
+            // FIXME: for null-hashed block, the mocked bencodex is used for testing.
+            Dictionary mockBlockHeader = Dictionary.Empty.Add(new byte[] { 0x68 }, blockHash);
+            var mockBlock = Dictionary.Empty.Add(new byte[] { 0x48 }, mockBlockHeader);
 
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
@@ -146,7 +152,19 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             context.Start();
             context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(default, TestUtils.Peer1Priv));
+                new ConsensusProposeMsg(
+                    TestUtils.Peer1Priv.PublicKey,
+                    1,
+                    0,
+                    default,
+                    new ProposalMetaData(
+                        1,
+                        0,
+                        codec.Encode(mockBlock),
+                        fx.Block1.Timestamp,
+                        TestUtils.Peer1Priv.PublicKey,
+                        -1).Sign(TestUtils.Peer1Priv)));
+
             await exceptionOccurred.WaitAsync();
             Assert.True(exceptionThrown is InvalidBlockProposeMessageException);
         }
@@ -218,7 +236,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     if (msg is ConsensusProposeMsg proposeMsg)
                     {
                         proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(proposeMsg.Payload));
+                            (Dictionary)codec.Decode(proposeMsg.Proposal.BlockMarshaled));
                         proposeSent.Set();
                     }
                 });
@@ -302,7 +320,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 {
                     proposedBlock =
                         BlockMarshaler.UnmarshalBlock<DumbAction>(
-                            (Dictionary)codec.Decode(proposeMsg.Payload));
+                            (Dictionary)codec.Decode(proposeMsg.Proposal.BlockMarshaled));
                     proposeSent.Set();
                 }
             }

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -6,6 +6,7 @@ using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
+using Libplanet.Tests.Store;
 using NetMQ;
 using Nito.AsyncEx;
 using Serilog;
@@ -41,6 +42,7 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact(Timeout = Timeout)]
         public async void AddMessage()
         {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
             bool received1 = false;
             bool received2 = false;
             var key1 = new PrivateKey();
@@ -76,13 +78,7 @@ namespace Libplanet.Net.Tests.Consensus
                 await gossip1.WaitForRunningAsync();
                 await gossip2.WaitForRunningAsync();
                 gossip1.AddMessage(
-                    new ConsensusProposeMsg(
-                        new PrivateKey().PublicKey,
-                        0,
-                        0,
-                        TestUtils.BlockHash0,
-                        new byte[] { },
-                        0));
+                    TestUtils.CreateConsensusPropose(fx.Block1, new PrivateKey(), 0));
                 await receivedEvent.WaitAsync();
                 Assert.True(received1);
                 Assert.True(received2);
@@ -99,6 +95,7 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact(Timeout = Timeout)]
         public async void AddMessages()
         {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
             int received1 = 0;
             int received2 = 0;
             var key1 = new PrivateKey();
@@ -137,14 +134,14 @@ namespace Libplanet.Net.Tests.Consensus
                 _ = gossip2.StartAsync(default);
                 await gossip1.WaitForRunningAsync();
                 await gossip2.WaitForRunningAsync();
-                PublicKey key = new PrivateKey().PublicKey;
+                PrivateKey key = new PrivateKey();
                 gossip1.AddMessages(
                     new[]
                     {
-                        new ConsensusProposeMsg(key, 0, 0, TestUtils.BlockHash0, new byte[] { }, 0),
-                        new ConsensusProposeMsg(key, 1, 0, TestUtils.BlockHash0, new byte[] { }, 0),
-                        new ConsensusProposeMsg(key, 2, 0, TestUtils.BlockHash0, new byte[] { }, 0),
-                        new ConsensusProposeMsg(key, 3, 0, TestUtils.BlockHash0, new byte[] { }, 0),
+                        TestUtils.CreateConsensusPropose(fx.Block1, key, 0),
+                        TestUtils.CreateConsensusPropose(fx.Block1, key, 1),
+                        TestUtils.CreateConsensusPropose(fx.Block1, key, 2),
+                        TestUtils.CreateConsensusPropose(fx.Block1, key, 3),
                     });
 
                 await receivedEvent.WaitAsync();

--- a/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
+++ b/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
+using Libplanet.Tests.Store;
 using Xunit;
 
 namespace Libplanet.Net.Tests.Consensus
@@ -43,11 +44,12 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void GetGossipIds_Shift()
         {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
             var cache = new MessageCache(2, 1);
-            var key = new PrivateKey().PublicKey;
-            var msg0 = new ConsensusProposeMsg(key, 0, 0, TestUtils.BlockHash0, new byte[] { }, -1);
-            var msg1 = new ConsensusProposeMsg(key, 0, 1, TestUtils.BlockHash0, new byte[] { }, -1);
-            var msg2 = new ConsensusProposeMsg(key, 0, 2, TestUtils.BlockHash0, new byte[] { }, -1);
+            var key = new PrivateKey();
+            var msg0 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 0);
+            var msg1 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 1);
+            var msg2 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 2);
             cache.Put(msg0);
             cache.Put(msg1);
             var ids = cache.GetGossipIds();

--- a/Libplanet.Net.Tests/Consensus/ProposalMetaDataTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ProposalMetaDataTest.cs
@@ -1,0 +1,60 @@
+using System;
+using Bencodex;
+using Libplanet.Blocks;
+using Libplanet.Net.Consensus;
+using Libplanet.Tests.Store;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Net.Tests.Consensus
+{
+    public class ProposalMetaDataTest
+    {
+        private ILogger _logger;
+
+        public ProposalMetaDataTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ProposalMetaDataTest>();
+
+            _logger = Log.ForContext<ProposalMetaDataTest>();
+        }
+
+        [Fact]
+        public void InvalidValues()
+        {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
+            var codec = new Codec();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ProposalMetaData(
+                    -1,
+                    0,
+                    codec.Encode(fx.Block1.MarshalBlock()),
+                    fx.Block1.Timestamp,
+                    TestUtils.Peer1Priv.PublicKey,
+                    -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ProposalMetaData(
+                1,
+                -1,
+                codec.Encode(fx.Block1.MarshalBlock()),
+                fx.Block1.Timestamp,
+                TestUtils.Peer1Priv.PublicKey,
+                -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ProposalMetaData(
+                1,
+                0,
+                codec.Encode(fx.Block1.MarshalBlock()),
+                fx.Block1.Timestamp,
+                TestUtils.Peer1Priv.PublicKey,
+                -2));
+        }
+    }
+}

--- a/Libplanet.Net.Tests/Consensus/ProposalTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ProposalTest.cs
@@ -1,0 +1,75 @@
+using System;
+using Bencodex;
+using Libplanet.Blocks;
+using Libplanet.Net.Consensus;
+using Libplanet.Tests.Store;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Net.Tests.Consensus
+{
+    public class ProposalTest
+    {
+        private ILogger _logger;
+
+        public ProposalTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ProposalTest>();
+
+            _logger = Log.ForContext<ProposalTest>();
+        }
+
+        [Fact]
+        public void InvalidSignature()
+        {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
+            var codec = new Codec();
+
+            ProposalMetaData metaData = new ProposalMetaData(
+                1,
+                0,
+                codec.Encode(fx.Block1.MarshalBlock()),
+                fx.Block1.Timestamp,
+                TestUtils.Peer1Priv.PublicKey,
+                -1);
+
+            // Empty Signature
+            var emptySigBencodex = metaData.Encoded.Add(Proposal.SignatureKey, Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>(() => new Proposal(emptySigBencodex));
+
+            // Invalid Signature
+            var invSigBencodex = metaData.Encoded.Add(
+                Proposal.SignatureKey,
+                TestUtils.Peer1Priv.Sign(codec.Encode(fx.Block2.MarshalBlock())));
+            Assert.Throws<ArgumentException>(() => new Proposal(invSigBencodex));
+        }
+
+        [Fact]
+        public void Sign()
+        {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
+            var codec = new Codec();
+
+            ProposalMetaData metaData = new ProposalMetaData(
+                1,
+                0,
+                codec.Encode(fx.Block1.MarshalBlock()),
+                fx.Block1.Timestamp,
+                TestUtils.Peer1Priv.PublicKey,
+                -1);
+
+            Proposal proposal = metaData.Sign(TestUtils.Peer1Priv);
+
+            Assert.Equal(proposal.Signature, TestUtils.Peer1Priv.Sign(metaData.ByteArray));
+            Assert.True(
+                TestUtils.Peer1Priv.PublicKey.Verify(metaData.ByteArray, proposal.Signature));
+        }
+    }
+}

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -137,7 +137,7 @@ namespace Libplanet.Net.Tests
         }
 
         public static ConsensusProposeMsg CreateConsensusPropose(
-            Block<DumbAction>? block,
+            Block<DumbAction> block,
             PrivateKey privateKey,
             long height = 1,
             int round = 0,
@@ -148,9 +148,14 @@ namespace Libplanet.Net.Tests
                 privateKey.PublicKey,
                 height,
                 round,
-                block?.Hash ?? default,
-                block is null ? Array.Empty<byte>() : codec.Encode(block.MarshalBlock()),
-                validRound)
+                block.Hash,
+                new ProposalMetaData(
+                    height,
+                    round,
+                    codec.Encode(block.MarshalBlock()),
+                    block.Timestamp,
+                    privateKey.PublicKey,
+                    validRound).Sign(privateKey))
             {
                 Remote = new BoundPeer(privateKey.PublicKey, new DnsEndPoint("1.2.3.4", 1234)),
             };

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -30,16 +30,24 @@ namespace Libplanet.Net.Consensus
                     "Starting round {NewRound} and is a proposer.",
                     round,
                     ToString());
-                if ((_validValue ?? GetValue()) is Block<T> proposal)
+                if ((_validValue ?? GetValue()) is Block<T> proposalValue)
                 {
+                    Proposal proposal = new ProposalMetaData(
+                        Height,
+                        Round,
+                        _codec.Encode(proposalValue.MarshalBlock()),
+                        proposalValue.Timestamp,
+                        _privateKey.PublicKey,
+                        _validRound
+                    ).Sign(_privateKey);
+
                     BroadcastMessage(
                         new ConsensusProposeMsg(
                             _privateKey.PublicKey,
                             Height,
                             Round,
-                            proposal.Hash,
-                            _codec.Encode(proposal.MarshalBlock()),
-                            _validRound));
+                            proposalValue.Hash,
+                            proposal));
                 }
                 else
                 {

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -429,8 +429,8 @@ namespace Libplanet.Net.Consensus
                 // FIXME: Probably should not blindly pick the first one.
                 ConsensusProposeMsg propose = proposes[0];
                 var block = BlockMarshaler.UnmarshalBlock<T>(
-                    (Dictionary)_codec.Decode(propose.Payload));
-                return (block, propose.ValidRound);
+                    (Dictionary)_codec.Decode(propose.Proposal.BlockMarshaled));
+                return (block, propose.Proposal.ValidRound);
             }
 
             return null;

--- a/Libplanet.Net/Consensus/Proposal.cs
+++ b/Libplanet.Net/Consensus/Proposal.cs
@@ -10,6 +10,12 @@ using Libplanet.Crypto;
 
 namespace Libplanet.Net.Consensus
 {
+    /// <summary>
+    /// A class for a proposal information for used in <see cref="Context{T}"/>. It contains an
+    /// essential information <see cref="ProposalMetaData"/> to propose a block for a consensus
+    /// in a height and a round, and its signature to verify. The signature is verified in
+    /// constructor, so the instance of <see cref="Proposal"/> should be valid.
+    /// </summary>
     public class Proposal : IEquatable<Proposal>
     {
         internal const string SignatureKey = "signature";
@@ -17,6 +23,17 @@ namespace Libplanet.Net.Consensus
 
         private readonly ProposalMetaData _proposalMetaData;
 
+        /// <summary>
+        /// Instantiates a <see cref="Proposal"/> with given <paramref name="proposalMetaData"/>
+        /// and its <paramref name="signature"/>.
+        /// </summary>
+        /// <param name="proposalMetaData">A <see cref="ProposalMetaData"/> to propose.</param>
+        /// <param name="signature">A signature signed with <paramref name="proposalMetaData"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="signature"/> is
+        /// empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="signature"/> is
+        /// invalid and cannot be verified with <paramref name="proposalMetaData"/>.</exception>
         public Proposal(ProposalMetaData proposalMetaData, ImmutableArray<byte> signature)
         {
             _proposalMetaData = proposalMetaData;
@@ -50,20 +67,32 @@ namespace Libplanet.Net.Consensus
         }
 #pragma warning restore SA1118
 
+        /// <inheritdoc cref="ProposalMetaData.Height"/>
         public long Height => _proposalMetaData.Height;
 
+        /// <inheritdoc cref="ProposalMetaData.Round"/>
         public int Round => _proposalMetaData.Round;
 
+        /// <inheritdoc cref="ProposalMetaData.BlockMarshaled"/>
         public byte[] BlockMarshaled => _proposalMetaData.BlockMarshaled;
 
+        /// <inheritdoc cref="ProposalMetaData.Timestamp"/>
         public DateTimeOffset Timestamp => _proposalMetaData.Timestamp;
 
+        /// <inheritdoc cref="ProposalMetaData.Validator"/>
         public PublicKey Validator => _proposalMetaData.Validator;
 
+        /// <inheritdoc cref="ProposalMetaData.ValidRound"/>
         public int ValidRound => _proposalMetaData.ValidRound;
 
+        /// <summary>
+        /// A signature that signed with <see cref="ProposalMetaData"/>.
+        /// </summary>
         public ImmutableArray<byte> Signature { get; }
 
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="Proposal"/>.
+        /// </summary>
         [JsonIgnore]
         public Dictionary Encoded =>
             !Signature.IsEmpty
@@ -71,13 +100,13 @@ namespace Libplanet.Net.Consensus
                 : _proposalMetaData.Encoded;
 
         /// <summary>
-        /// <see cref="byte"/> encoded <see cref="Vote"/> data.
+        /// <see cref="byte"/> encoded <see cref="Proposal"/> data.
         /// </summary>
         [JsonIgnore]
         public byte[] ByteArray => _codec.Encode(Encoded);
 
         /// <summary>
-        /// Verifies whether the <see cref="Vote"/>'s payload is properly signed by
+        /// Verifies whether the <see cref="ProposalMetaData"/> is properly signed by
         /// <see cref="Validator"/>.
         /// </summary>
         /// <returns><c>true</c> if the <see cref="Signature"/> is not empty

--- a/Libplanet.Net/Consensus/Proposal.cs
+++ b/Libplanet.Net/Consensus/Proposal.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+
+namespace Libplanet.Net.Consensus
+{
+    public class Proposal : IEquatable<Proposal>
+    {
+        internal const string SignatureKey = "signature";
+        private static Codec _codec = new Codec();
+
+        private readonly ProposalMetaData _proposalMetaData;
+
+        public Proposal(ProposalMetaData proposalMetaData, ImmutableArray<byte> signature)
+        {
+            _proposalMetaData = proposalMetaData;
+            Signature = signature;
+
+            if (signature.IsDefaultOrEmpty)
+            {
+                throw new ArgumentNullException(
+                    nameof(signature),
+                    "Signature cannot be null or empty.");
+            }
+            else if (!Verify())
+            {
+                throw new ArgumentException("Signature is invalid.", nameof(signature));
+            }
+        }
+
+        public Proposal(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
+        {
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public Proposal(Dictionary encoded)
+            : this(
+                new ProposalMetaData(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        public long Height => _proposalMetaData.Height;
+
+        public int Round => _proposalMetaData.Round;
+
+        public byte[] BlockMarshaled => _proposalMetaData.BlockMarshaled;
+
+        public DateTimeOffset Timestamp => _proposalMetaData.Timestamp;
+
+        public PublicKey Validator => _proposalMetaData.Validator;
+
+        public int ValidRound => _proposalMetaData.ValidRound;
+
+        public ImmutableArray<byte> Signature { get; }
+
+        [JsonIgnore]
+        public Dictionary Encoded =>
+            !Signature.IsEmpty
+                ? _proposalMetaData.Encoded.Add(SignatureKey, Signature)
+                : _proposalMetaData.Encoded;
+
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="Vote"/> data.
+        /// </summary>
+        [JsonIgnore]
+        public byte[] ByteArray => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Verifies whether the <see cref="Vote"/>'s payload is properly signed by
+        /// <see cref="Validator"/>.
+        /// </summary>
+        /// <returns><c>true</c> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
+        [Pure]
+        public bool Verify() =>
+            !Signature.IsDefaultOrEmpty &&
+            Validator.Verify(
+                _proposalMetaData.ByteArray.ToImmutableArray(),
+                Signature);
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(Proposal? other)
+        {
+            return other is Proposal proposal &&
+                   _proposalMetaData.Equals(proposal._proposalMetaData) &&
+                   Signature.SequenceEqual(proposal.Signature);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool Equals(object? obj)
+        {
+            return obj is Vote other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_proposalMetaData.GetHashCode(), Signature);
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/ProposalMetaData.cs
+++ b/Libplanet.Net/Consensus/ProposalMetaData.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+
+namespace Libplanet.Net.Consensus
+{
+    public class ProposalMetaData
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private const string HeightKey = "height";
+        private const string RoundKey = "round";
+        private const string BlockKey = "block";
+        private const string TimestampKey = "timestamp";
+        private const string ValidatorKey = "validator";
+        private const string ValidRoundKey = "validRound";
+
+        private static Codec _codec = new Codec();
+
+        public ProposalMetaData(
+            long height,
+            int round,
+            byte[] blockMarshaled,
+            DateTimeOffset timestamp,
+            PublicKey validator,
+            int validRound
+        )
+        {
+            if (height < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(height),
+                    "Height must be greater than or equal to 0.");
+            }
+            else if (round < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(round),
+                    "Round must be greater than or equal to 0.");
+            }
+            else if (validRound < -1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(validRound),
+                    "ValidRound must be greater than or equal to -1.");
+            }
+
+            Height = height;
+            Round = round;
+            BlockMarshaled = blockMarshaled;
+            Timestamp = timestamp;
+            Validator = validator;
+            ValidRound = validRound;
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public ProposalMetaData(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                blockMarshaled: encoded.GetValue<Binary>(BlockKey),
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validator: new PublicKey(encoded.GetValue<Binary>(ValidatorKey).ByteArray),
+                validRound: encoded.GetValue<Integer>(ValidRoundKey))
+        {
+        }
+#pragma warning restore SA1118
+
+        public long Height { get; }
+
+        public int Round { get; }
+
+        public byte[] BlockMarshaled { get; }
+
+        public DateTimeOffset Timestamp { get; }
+
+        public PublicKey Validator { get; }
+
+        public int ValidRound { get; }
+
+        [JsonIgnore]
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(BlockKey, BlockMarshaled)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorKey, Validator.Format(compress: true))
+                    .Add(ValidRoundKey, ValidRound);
+
+                return encoded;
+            }
+        }
+
+        [JsonIgnore]
+        public byte[] ByteArray => _codec.Encode(Encoded);
+
+        public Proposal Sign(PrivateKey signer)
+        {
+            return signer is PrivateKey key
+                ? new Proposal(this, key.Sign(ByteArray).ToImmutableArray())
+                : new Proposal(this, ImmutableArray<byte>.Empty);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                BlockMarshaled,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                Validator);
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/ProposalMetaData.cs
+++ b/Libplanet.Net/Consensus/ProposalMetaData.cs
@@ -8,6 +8,11 @@ using Libplanet.Crypto;
 
 namespace Libplanet.Net.Consensus
 {
+    /// <summary>
+    /// A class for constructing <see cref="Proposal"/>. This class contains proposal information
+    /// in consensus of a height and a round. Use <see cref="Sign"/> to create a
+    /// <see cref="Proposal"/>.
+    /// </summary>
     public class ProposalMetaData
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
@@ -20,6 +25,29 @@ namespace Libplanet.Net.Consensus
 
         private static Codec _codec = new Codec();
 
+        /// <summary>
+        /// Instantiates <see cref="ProposalMetaData"/> with given parameters.
+        /// </summary>
+        /// <param name="height">a height of given proposal values.</param>
+        /// <param name="round">a round of given proposal values.</param>
+        /// <param name="blockMarshaled">a marshaled bencodex-encoded <see cref="byte"/> array of
+        /// block.</param>
+        /// <param name="timestamp">the proposed time of given block.</param>
+        /// <param name="validator">a <see cref="PublicKey"/> of proposing validator.</param>
+        /// <param name="validRound">a latest valid round at the moment of given proposal.</param>
+        /// <exception cref="ArgumentOutOfRangeException">This can be thrown in following reasons:
+        /// <list type="bullet">
+        /// <item><description>
+        ///     Given <paramref name="height"/> is less than 0.
+        /// </description></item>
+        /// <item><description>
+        ///     Given <paramref name="round"/> is less than 0.
+        /// </description></item>
+        /// <item><description>
+        ///     Given <paramref name="validRound"/> is less than -1.
+        /// </description></item>
+        /// </list>
+        /// </exception>
         public ProposalMetaData(
             long height,
             int round,
@@ -72,18 +100,39 @@ namespace Libplanet.Net.Consensus
         }
 #pragma warning restore SA1118
 
+        /// <summary>
+        /// A height of given proposal values.
+        /// </summary>
         public long Height { get; }
 
+        /// <summary>
+        /// A round of given proposal values.
+        /// </summary>
         public int Round { get; }
 
+        /// <summary>
+        /// A marshaled bencodex-encoded <see cref="byte"/> array of block.
+        /// </summary>
         public byte[] BlockMarshaled { get; }
 
+        /// <summary>
+        /// The proposed time of given block.
+        /// </summary>
         public DateTimeOffset Timestamp { get; }
 
+        /// <summary>
+        /// A <see cref="PublicKey"/> of proposing validator.
+        /// </summary>
         public PublicKey Validator { get; }
 
+        /// <summary>
+        /// a latest valid round at the moment of given proposal.
+        /// </summary>
         public int ValidRound { get; }
 
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="ProposalMetaData"/>.
+        /// </summary>
         [JsonIgnore]
         public Dictionary Encoded
         {
@@ -106,13 +155,15 @@ namespace Libplanet.Net.Consensus
         [JsonIgnore]
         public byte[] ByteArray => _codec.Encode(Encoded);
 
-        public Proposal Sign(PrivateKey signer)
-        {
-            return signer is PrivateKey key
-                ? new Proposal(this, key.Sign(ByteArray).ToImmutableArray())
-                : new Proposal(this, ImmutableArray<byte>.Empty);
-        }
+        /// <summary>
+        /// Signs given <see cref="ProposalMetaData"/> with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">A <see cref="PrivateKey"/> to sign.</param>
+        /// <returns>Returns a signed <see cref="Proposal"/>.</returns>
+        public Proposal Sign(PrivateKey signer) =>
+            new Proposal(this, signer.Sign(ByteArray).ToImmutableArray());
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return HashCode.Combine(


### PR DESCRIPTION
This PR introduces the new classes, `Proposal` and `ProposalMetaData`. These are for replacing sending raw `ConsensusProposeMsg` without a signature of its propose.

## Role
The `Proposal` is a signable class that contains the proposal information of consensus in a height and a round. The previous method, sending a raw proposal in `ConsensusProposeMsg`, can be manipulated easily by replacing the payload of its message. 

By adding a signature to the proposal, the attacker cannot manipulate the proposal until the attacker has no access to the target victim's private key.