### PR TITLE
🧹  Unnecessary code removed

### DIFF
--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -117,7 +117,6 @@ namespace Libplanet.Net.Consensus
 
                 if (message is ConsensusPreVoteMsg vote &&
                     (!vote.Validator.Equals(vote.PreVote.Validator) ||
-                    !vote.PreVote.Verify() ||
                     !_validators.Contains(vote.Validator)))
                 {
                     throw new InvalidValidatorVoteMessageException(
@@ -127,7 +126,6 @@ namespace Libplanet.Net.Consensus
 
                 if (message is ConsensusPreCommitMsg commit &&
                     (!commit.Validator.Equals(commit.PreCommit.Validator) ||
-                    !commit.PreCommit.Verify() ||
                     !_validators.Contains(commit.Validator)))
                 {
                     throw new InvalidValidatorVoteMessageException(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1522,7 +1522,7 @@ namespace Libplanet.Blockchain
 
             if (block.ProtocolVersion > BlockMetadata.PoWProtocolVersion)
             {
-                if ((block.Index == 0 || block.Index == 1) && block.LastCommit is { })
+                if (block.Index <= 1 && block.LastCommit is { })
                 {
                     return new InvalidBlockLastCommitException(
                         "The genesis block and the next block should not have lastCommit");
@@ -1535,21 +1535,13 @@ namespace Libplanet.Blockchain
                         $"have lastCommit.");
                 }
 
-                if (block.Index > 1 && block.LastCommit is { Votes: var votes } commit)
+                if (block.Index > 1 &&
+                    block.LastCommit is { } commit &&
+                    !commit.HasSameValidators(Policy.GetValidators(commit.Height)))
                 {
-                    if (!commit.HasSameValidators(Policy.GetValidators(block.Index - 1)))
-                    {
-                        return new InvalidBlockLastCommitException(
-                            "The validator set of block lastCommit is not matching " +
-                            "with known validator set in policy.");
-                    }
-
-                    if (!commit.HasValidVotes())
-                    {
-                        return new InvalidBlockLastCommitException(
-                            $"Some of the block #{block.Index}'s lastcommit's votes' " +
-                            "are not valid.");
-                    }
+                    return new InvalidBlockLastCommitException(
+                        "The validator set of block lastCommit is not matching " +
+                        "with known validator set in policy.");
                 }
             }
 

--- a/Libplanet/Blocks/BlockCommitExtensions.cs
+++ b/Libplanet/Blocks/BlockCommitExtensions.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Libplanet.Consensus;
 using Libplanet.Crypto;
 
 namespace Libplanet.Blocks
@@ -34,18 +33,5 @@ namespace Libplanet.Blocks
             return iaVoteToHashSetList.Count == publicKeys.Count() &&
                    voteValidators.SetEquals(previousValidators);
         }
-
-        /// <summary>
-        /// Checks whether <see cref="BlockCommit"/> has valid signatures for every votes.
-        /// </summary>
-        /// <param name="commit">A <see cref="BlockCommit"/> to check.</param>
-        /// <returns>Returns <see langword="true"/> if <see cref="BlockCommit.Votes"/> has valid
-        /// signatures, otherwise return <see langword="false"/>.</returns>
-        /// <remarks>A vote with <see cref="VoteFlag.Null"/> or <see cref="VoteFlag.Unknown"/> is
-        /// excluded from target, so these case returns <see langword="true"/>.</remarks>
-        public static bool HasValidVotes(this BlockCommit commit) =>
-            commit.Votes.All(
-                vote => vote.Flag == VoteFlag.Null || vote.Flag == VoteFlag.Unknown ||
-                        vote.Verify());
     }
 }


### PR DESCRIPTION
🧹 As `Vote` instances are verified on instantiation, there is no need to double check from outside context.