### PR TITLE
Test cleanup

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -47,23 +47,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     stateChangedToRoundOnePreVote.Set();
                 }
             };
+
             context.Start();
-
-            context.ProduceMessage(
-                TestUtils.CreateConsensusPropose(
-                    block, TestUtils.Peer1Priv, round: 0));
-
             context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
                     block, TestUtils.Peer2Priv, round: 1));
-
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 1, hash: block.Hash, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer2,
-                });
+                        TestUtils.Peer2Priv, 1, 1, hash: block.Hash, flag: VoteFlag.PreVote)));
 
             // Wait for round 1 prevote step.
             await stateChangedToRoundOnePreVote.WaitAsync();
@@ -109,26 +101,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer1,
-                });
-
+                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: block.Hash, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer2,
-                });
-
+                        TestUtils.Peer2Priv, 1, 0, hash: block.Hash, VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peers[3],
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.PreVote)));
 
             await Task.WhenAll(commitSent.WaitAsync(), stepChangedToPreCommit.WaitAsync());
             Assert.Equal(Step.PreCommit, context.Step);
@@ -183,30 +164,18 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.Start();
             context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(invalidBlock, TestUtils.Peer1Priv));
-
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer1Priv, 1, 0, hash: null, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer1,
-                });
-
+                        TestUtils.Peer1Priv, 1, 0, hash: null, VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer2,
-                });
-
+                        TestUtils.Peer2Priv, 1, 0, hash: null, VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peers[3],
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, VoteFlag.PreVote)));
 
             await Task.WhenAll(commitSent.WaitAsync(), stepChangedToPreCommit.WaitAsync());
             Assert.Equal(Step.PreCommit, context.Step);
@@ -289,18 +258,13 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
                     block, TestUtils.Peer1Priv, round: 0));
-
             context.ProduceMessage(
                 TestUtils.CreateConsensusPropose(
                     block, TestUtils.Peer2Priv, round: 1));
-
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 1, hash: null, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer2,
-                });
+                        TestUtils.Peer2Priv, 1, 1, hash: null, flag: VoteFlag.PreVote)));
 
             await stepChangedToRoundOnePreVote.WaitAsync();
             Assert.Equal(Step.PreVote, context.Step);
@@ -373,33 +337,21 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer1,
-                });
+                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer1,
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreVote)));
 
             // Two additional votes should be enough to trigger precommit timeout timer.
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreCommit))
-                {
-                    Remote = TestUtils.Peer1,
-                });
+                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreCommit))
-                {
-                    Remote = TestUtils.Peer1,
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreCommit)));
 
             context.Start();
 
@@ -434,26 +386,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer1,
-                });
-
+                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peer2,
-                });
-
+                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreVote))
-                {
-                    Remote = TestUtils.Peers[3],
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreVote)));
 
             // Wait for timeout.
             await timeoutProcessed.WaitAsync();
@@ -481,26 +422,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, flag: VoteFlag.PreCommit))
-                {
-                    Remote = TestUtils.Peer1,
-                });
-
+                        TestUtils.Peer1Priv, 1, 0, hash: block.Hash, flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreCommit))
-                {
-                    Remote = TestUtils.Peer2,
-                });
-
+                        TestUtils.Peer2Priv, 1, 0, hash: null, flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreCommit))
-                {
-                    Remote = TestUtils.Peers[3],
-                });
+                        TestUtils.PrivateKeys[3], 1, 0, hash: null, flag: VoteFlag.PreCommit)));
 
             // Wait for timeout.
             await timeoutProcessed.WaitAsync();

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -257,14 +257,12 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> BlockChain,
             Context<DumbAction> Context)
             CreateDummyContext(
-            long height = 1,
-            int round = 0,
-            IBlockPolicy<DumbAction>? policy = null,
-            PrivateKey? privateKey = null,
-            List<PublicKey>? validators = null,
-            EventHandler<ConsensusMsg>? consensusMessageSent = null,
-            Step startStep = Step.Default,
-            ContextTimeoutOption? contextTimeoutOptions = null)
+                long height = 1,
+                IBlockPolicy<DumbAction>? policy = null,
+                PrivateKey? privateKey = null,
+                List<PublicKey>? validators = null,
+                EventHandler<ConsensusMsg>? consensusMessageSent = null,
+                ContextTimeoutOption? contextTimeoutOptions = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= Peer1Priv;
@@ -295,8 +293,6 @@ namespace Libplanet.Net.Tests
                 height,
                 privateKey,
                 validators,
-                startStep,
-                round,
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (fx, blockChain, context);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -226,7 +226,6 @@ namespace Libplanet.Net.Consensus
                             height,
                             _privateKey,
                             _getValidators(height).ToList(),
-                            Step.Default,
                             contextTimeoutOptions: _contextTimeoutOption);
 
                         AttachEventHandlers(_contexts[height]);

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Net.Consensus
             if (Proposer(Round) == _privateKey.PublicKey)
             {
                 _logger.Debug(
-                    "Starting round {NewRound} and is a proposer. (context: {Context})",
+                    "Starting round {NewRound} and is a proposer.",
                     round,
                     ToString());
                 if ((_validValue ?? GetValue()) is Block<T> proposal)

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -141,7 +141,7 @@ namespace Libplanet.Net.Consensus
         {
         }
 
-        internal Context(
+        private Context(
             ConsensusContext<T> consensusContext,
             BlockChain<T> blockChain,
             long height,


### PR DESCRIPTION
This mainly deals with removing custom `Context` initial state setup.

As `Context` is a rather complex structure in and of itself, it is **extremely hard** to know all the side-effects of simply setting its round and step to a desired value. Under normal operations, any state of a non-zero round and a step implies either that particular step has been reached by multiple iterations of timeouts and/or failure to form a consensus on a network where numerous messages have been received (even if the progression is made by purely timeouts, **there will be messages received** from the node itself, meaning it is never a clean slate).

This results in test codes not being clear as to whether tested methods are in fact being tested under right circumstances.