### PR TITLE
Add `BlockHash` unmarshaler from `Block`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Version PBFT
  -  Added `IBlockPolicy.GetValidators()` method.  [[#PBFT]]
  -  Added `BlockCommitExtensions` class.  [[#PBFT]]
  -  Added `ContextTimeoutOption` class.  [[#PBFT]]
+ -  Added `BlockMarshaler.UnmarshalBlockHash()` method. [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]

--- a/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMarshalerTest.cs
@@ -157,6 +157,22 @@ namespace Libplanet.Tests
         }
 
         [Fact]
+        public void UnmarshalBlockHash()
+        {
+            Assert.Equal(
+                _fx.Genesis.Hash,
+                BlockMarshaler.UnmarshalBlockHash(_fx.Genesis.MarshalBlock()));
+
+            Assert.Equal(
+                _fx.Next.Hash,
+                BlockMarshaler.UnmarshalBlockHash(_fx.Next.MarshalBlock()));
+
+            Assert.Equal(
+                _fx.HasTx.Hash,
+                BlockMarshaler.UnmarshalBlockHash(_fx.HasTx.MarshalBlock()));
+        }
+
+        [Fact]
         public void UnmarshalBlock()
         {
             Assert.Equal(

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -207,6 +207,12 @@ namespace Libplanet.Blocks
                     preEvaluationHash: UnmarshalPreEvaluationHash(marshaled));
         }
 
+        public static BlockHash UnmarshalBlockHash(Dictionary marshaledBlock)
+        {
+            Dictionary blockHeader = marshaledBlock.GetValue<Dictionary>(HeaderKey);
+            return UnmarshalBlockHeaderHash(blockHeader);
+        }
+
         public static BlockHash UnmarshalBlockHeaderHash(Dictionary marshaledBlockHeader) =>
             new BlockHash(marshaledBlockHeader.GetValue<Binary>(HashKey).ByteArray);
 


### PR DESCRIPTION
Added new method `UnmarshalBlockHash()` which is unmarshaling the `BlockHash` from `Block<T>`, without unmarshaling the whole `Block<T>` or conversion. 

Note that this `BlockHash` should not be fully trusted and should validate `Block<T>` before being used in action.[^1]


[^1]: For instance, using `BlockHash` as a cross-reference with marshaled `Block<T>`, and later doing `Block<T>` unmarshaling 
 lazy. If the `BlockHash` of `Block<T>` is different with actual `Block<T>` hash, then unmarshaling results fail. See `PreEvaluationBlockHeader`.