### PR TITLE
Open RocksDB in read-only mode when opening past epochs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@ Released on November 2, 2022.
 ### Behavioral changes
 
  - Optimized `ByteUtil.CalculateHash()` method.  [[#2437], [#2459]]
+ - (Libplanet.RocksDBStore) `GetBlockDigest`, `GetTranaction` methods open
+   RocksDB in read-only mode when opening past epochs.  [[#2443]]
 
 ### Bug fixes
 

--- a/Libplanet.RocksDBStore/RocksDBUtils.cs
+++ b/Libplanet.RocksDBStore/RocksDBUtils.cs
@@ -6,11 +6,22 @@ namespace Libplanet.RocksDBStore
     internal static class RocksDBUtils
     {
         internal static RocksDb OpenRocksDb(
-            DbOptions options, string dbPath, ColumnFamilies? columnFamilies = null)
+            DbOptions options,
+            string dbPath,
+            ColumnFamilies? columnFamilies = null,
+            bool readOnly = false
+        )
         {
             if (!Directory.Exists(dbPath))
             {
                 Directory.CreateDirectory(dbPath);
+            }
+
+            if (readOnly)
+            {
+                return columnFamilies is null
+                    ? RocksDb.OpenReadOnly(options, dbPath, false)
+                    : RocksDb.OpenReadOnly(options, dbPath, columnFamilies, false);
             }
 
             return columnFamilies is null


### PR DESCRIPTION
Resolves #2443

To open RocksDB store in read-only mode, pass readOnly param.
This change allows multiple clients to access the same store at the same time.