### PR TITLE
Fix `MessageLog.CountVotes(Round)` logic

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -55,7 +55,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 1, hash: block.Hash, flag: VoteFlag.PreVote)));
+                        TestUtils.Peer3Priv, 1, 1, hash: block.Hash, flag: VoteFlag.PreVote)));
 
             // Wait for round 1 prevote step.
             await stateChangedToRoundOnePreVote.WaitAsync();
@@ -264,7 +264,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.Peer2Priv, 1, 1, hash: null, flag: VoteFlag.PreVote)));
+                        TestUtils.Peer3Priv, 1, 1, hash: null, flag: VoteFlag.PreVote)));
 
             await stepChangedToRoundOnePreVote.WaitAsync();
             Assert.Equal(Step.PreVote, context.Step);

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -318,12 +318,11 @@ namespace Libplanet.Net.Consensus
                 return;
             }
 
-            // FIXME: _messagesInRound should not contain any duplicated messages for this.
             if (round > Round &&
-                _messageLog.GetCount(round) > TotalValidators / 3)
+                _messageLog.GetValidatorsCount(round) > TotalValidators / 3)
             {
                 _logger.Debug(
-                    "1/3+ messages from the round {Round} > current round {CurrentRound}. " +
+                    "1/3+ validators from round {Round} > current round {CurrentRound}. " +
                     "(context: {Context})",
                     round,
                     Round,

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -177,8 +177,9 @@ namespace Libplanet.Net.Consensus
                 return;
             }
 
-            if (GetPropose(Round) is (Block<T> block1, int validRound1) &&
-                validRound1 == -1 &&
+            (Block<T> Block, int ValidRound)? propose = GetPropose(Round);
+            if (propose is { } p1 &&
+                p1.ValidRound == -1 &&
                 Step == Step.Propose)
             {
                 _logger.Debug(
@@ -187,10 +188,10 @@ namespace Libplanet.Net.Consensus
                     ToString());
                 Step = Step.PreVote;
 
-                if (IsValid(block1) && (_lockedRound == -1 || _lockedValue == block1))
+                if (IsValid(p1.Block) && (_lockedRound == -1 || _lockedValue == p1.Block))
                 {
                     BroadcastMessage(
-                        new ConsensusPreVoteMsg(MakeVote(Round, block1.Hash, VoteFlag.PreVote)));
+                        new ConsensusPreVoteMsg(MakeVote(Round, p1.Block.Hash, VoteFlag.PreVote)));
                 }
                 else
                 {
@@ -199,23 +200,24 @@ namespace Libplanet.Net.Consensus
                 }
             }
 
-            if (GetPropose(Round) is (Block<T> block2, int validRound2) &&
-                validRound2 >= 0 &&
-                validRound2 < Round &&
-                HasTwoThirdsPreVote(validRound2, block2.Hash) &&
+            if (propose is { } p2 &&
+                p2.ValidRound >= 0 &&
+                p2.ValidRound < Round &&
+                HasTwoThirdsPreVote(p2.ValidRound, p2.Block.Hash) &&
                 Step == Step.Propose)
             {
                 _logger.Debug(
                     "Entering PreVote step due to proposal message and have collected " +
                     "2/3+ PreVote for valid round {ValidRound}. (context: {Context})",
-                    validRound2,
+                    p2.ValidRound,
                     ToString());
                 Step = Step.PreVote;
 
-                if (IsValid(block2) && (_lockedRound <= validRound2 || _lockedValue == block2))
+                if (IsValid(p2.Block) &&
+                    (_lockedRound <= p2.ValidRound || _lockedValue == p2.Block))
                 {
                     BroadcastMessage(
-                        new ConsensusPreVoteMsg(MakeVote(Round, block2.Hash, VoteFlag.PreVote)));
+                        new ConsensusPreVoteMsg(MakeVote(Round, p2.Block.Hash, VoteFlag.PreVote)));
                 }
                 else
                 {
@@ -237,9 +239,9 @@ namespace Libplanet.Net.Consensus
                 _ = OnTimeoutPreVote(Round);
             }
 
-            if (GetPropose(Round) is (Block<T> block3, _) &&
-                HasTwoThirdsPreVote(Round, block3.Hash) &&
-                IsValid(block3) &&
+            if (propose is { } p3 &&
+                HasTwoThirdsPreVote(Round, p3.Block.Hash) &&
+                IsValid(p3.Block) &&
                 Step >= Step.PreVote &&
                 !_hasTwoThirdsPreVoteFlags.Contains(Round))
             {
@@ -257,14 +259,14 @@ namespace Libplanet.Net.Consensus
                         Round,
                         ToString());
                     Step = Step.PreCommit;
-                    _lockedValue = block3;
+                    _lockedValue = p3.Block;
                     _lockedRound = Round;
                     BroadcastMessage(
                         new ConsensusPreCommitMsg(
-                            MakeVote(Round, block3.Hash, VoteFlag.PreCommit)));
+                            MakeVote(Round, p3.Block.Hash, VoteFlag.PreCommit)));
                 }
 
-                _validValue = block3;
+                _validValue = p3.Block;
                 _validRound = Round;
             }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -406,8 +406,11 @@ namespace Libplanet.Net.Consensus
         /// </returns>
         private (Block<T>?, int?) GetPropose(int round)
         {
-            if (_messageLog.GetPropose(round) is ConsensusProposeMsg propose)
+            List<ConsensusProposeMsg> proposes = _messageLog.GetProposes(round);
+            if (proposes.Count > 0)
             {
+                // FIXME: Probably should not blindly pick the first one.
+                ConsensusProposeMsg propose = proposes[0];
                 var block = BlockMarshaler.UnmarshalBlock<T>(
                     (Dictionary)_codec.Decode(propose.Payload));
                 return (block, propose.ValidRound);

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -135,7 +135,7 @@ namespace Libplanet.Net.Consensus
                 privateKey,
                 validators,
                 Step.Default,
-                0,
+                -1,
                 128,
                 contextTimeoutOptions)
         {
@@ -148,7 +148,7 @@ namespace Libplanet.Net.Consensus
             PrivateKey privateKey,
             List<PublicKey> validators,
             Step step,
-            int round = 0,
+            int round = -1,
             int cacheSize = 128,
             ContextTimeoutOption? contextTimeoutOptions = null)
         {
@@ -228,20 +228,25 @@ namespace Libplanet.Net.Consensus
         /// <returns>A <see cref="Libplanet.Consensus.VoteSet"/> of given round.</returns>
         public VoteSet VoteSet(int round)
         {
-            (Block<T>? block, int? _) = GetPropose(round);
-            VoteSet voteSet = block is { } b
-                ? new VoteSet(Height, round, b.Hash, _validators)
-                : throw new NullReferenceException(
-                    $"Cannot create a {nameof(Libplanet.Consensus.VoteSet)} for a null block");
-            _messageLog.GetPreCommits(round)
-                .ForEach(commit =>
-                {
-                    if (commit.PreCommit.BlockHash.Equals(block.Hash))
+            (Block<T> Block, int _)? propose = GetPropose(round);
+            if (propose is { } p)
+            {
+                VoteSet voteSet = new VoteSet(Height, round, p.Block.Hash, _validators);
+                _messageLog.GetPreCommits(round)
+                    .ForEach(commit =>
                     {
-                        voteSet.Add(commit.PreCommit);
-                    }
-                });
-            return voteSet;
+                        if (commit.PreCommit.BlockHash.Equals(p.Block.Hash))
+                        {
+                            voteSet.Add(commit.PreCommit);
+                        }
+                    });
+                return voteSet;
+            }
+            else
+            {
+                throw new NullReferenceException(
+                    $"Cannot create a {nameof(Libplanet.Consensus.VoteSet)} for a null block");
+            }
         }
 
         /// <summary>
@@ -401,10 +406,10 @@ namespace Libplanet.Net.Consensus
         /// Gets the proposed block and valid round of the given round.
         /// </summary>
         /// <param name="round">A round to get.</param>
-        /// <returns>Returns a tuple of proposer and valid round. If proposal for the round does not
-        /// exist returns a tuple of <c>null</c> and <c>null</c>.
+        /// <returns>Returns a tuple of proposer and valid round.  If proposal for the round
+        /// does not exist, returns <see langword="null"/> instead.
         /// </returns>
-        private (Block<T>?, int?) GetPropose(int round)
+        private (Block<T>, int)? GetPropose(int round)
         {
             List<ConsensusProposeMsg> proposes = _messageLog.GetProposes(round);
             if (proposes.Count > 0)
@@ -416,7 +421,7 @@ namespace Libplanet.Net.Consensus
                 return (block, propose.ValidRound);
             }
 
-            return (null, null);
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Not the final spec, but implements few changes:
- As it stands, `MessageLog` is context agnostic (this might have to change later). Just as `GetPreVotes()` and `GetPreCommits()` return all stored prevotes and precommits for `Context` to parse, `GetPropose()` has been changed to `GetProposes()` to let `Context` decided on which one to use.
- One third vote counting logic has been changed.
- As `Round` is fixed for `Context.ProcessGenericUponRules()`, `GetPropose(Round)` is called only once at the beginning.