### PR TITLE
Caching `LastCommit` in `Context` disposing

### DIFF
--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -204,6 +204,90 @@ namespace Libplanet.Net.Tests
             }
         }
 
+        public static void HandleFourPeersPreCommitMessages(
+            Context<DumbAction> context,
+            PrivateKey nodePrivateKey,
+            BlockHash roundBlockHash)
+        {
+            foreach ((PrivateKey privateKey, BoundPeer peer)
+                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            {
+                if (privateKey == nodePrivateKey)
+                {
+                    continue;
+                }
+
+                context.ProduceMessage(
+                    new ConsensusPreCommitMsg(
+                        new VoteMetadata(
+                            context.Height,
+                            context.Round,
+                            roundBlockHash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreCommit).Sign(privateKey))
+                    {
+                        Remote = peer,
+                    });
+            }
+        }
+
+        public static void HandleFourPeersPreVoteMessages(
+            Context<DumbAction> context,
+            PrivateKey nodePrivateKey,
+            BlockHash roundBlockHash)
+        {
+            foreach ((PrivateKey privateKey, BoundPeer peer)
+                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            {
+                if (privateKey == nodePrivateKey)
+                {
+                    continue;
+                }
+
+                context.ProduceMessage(
+                    new ConsensusPreVoteMsg(
+                        new VoteMetadata(
+                            context.Height,
+                            context.Round,
+                            roundBlockHash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreVote).Sign(privateKey))
+                    {
+                        Remote = peer,
+                    });
+            }
+        }
+
+        public static void HandleFourPeersPreVoteMessages(
+            ConsensusContext<DumbAction> consensusContext,
+            PrivateKey nodePrivateKey,
+            BlockHash roundBlockHash)
+        {
+            foreach ((PrivateKey privateKey, BoundPeer peer)
+                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            {
+                if (privateKey == nodePrivateKey)
+                {
+                    continue;
+                }
+
+                consensusContext.HandleMessage(
+                    new ConsensusPreVoteMsg(
+                        new VoteMetadata(
+                            consensusContext.Height,
+                            (int)consensusContext.Round,
+                            roundBlockHash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreVote).Sign(privateKey))
+                    {
+                        Remote = peer,
+                    });
+            }
+        }
+
         public static (
             StoreFixture Fx,
             BlockChain<DumbAction> BlockChain,

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -189,14 +189,7 @@ namespace Libplanet.Net.Consensus
 
                 RemoveOldContexts(height);
 
-                if (lastCommit != null)
-                {
-                    _logger.Debug(
-                        "Caching LastCommit of Height {Height}...",
-                        height - 1);
-                    _blockChain.Store.PutLastCommit(lastCommit);
-                }
-                else
+                if (lastCommit == null)
                 {
                     BlockCommit? storedCommit = _blockChain.Store.GetLastCommit(height - 1);
                     if (storedCommit != null)

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -216,6 +216,18 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
+            // Save the current height LastCommit before disposing if there was any locked value was
+            // exists.
+            if (_lockedValue is { } lockedValue)
+            {
+                var currentLastCommit = new BlockCommit(VoteSet(Round), lockedValue.Hash);
+                _blockChain.Store.PutLastCommit(currentLastCommit);
+                _logger.Debug(
+                    "Saving current height #{Height} and round {Round} LastCommit...",
+                    currentLastCommit.Height,
+                    currentLastCommit.Round);
+            }
+
             _cancellationTokenSource.Cancel();
             _messageRequests.Writer.TryComplete();
             _mutationRequests.Writer.TryComplete();


### PR DESCRIPTION
## Summary
Saving `LastCommit` while disposing `Context` should cover program termination case.

## Flows
```mermaid
graph TD
    A[Consensus Committed]
    B[Consensus Valid]
    C[Consensus Invalid]
    D[Transit to EndCommit]
    F[Program termination]
    G[NewHeight called]
    H[Context.Dispose]
    I[Save LastCommit]
    J[Propose]
    K[PreVote]
    L[PreCommit]
    M[LockedValue is null]
    N[LockedValue is available]
    O[Do not save LastCommit]
    P[Propose]
    Q[PreVote]
    R[PreCommit]
    S{BlockCommit Ctor, +2/3?}
    T[Exception]
    U[Block Synchronization]

    A --> D
    D --> F
    D --> G
    F --> H
    G --> H
    H --> S

    B --> J
    B --> K
    B --> L
    J --> M
    K --> M
    K --> N
    L --> N
    M --> F
    N --> F
    S -->|Yes| I
    S -->|No| T
    T --> O

    C --> P
    C --> Q
    C --> R
    P --> M
    Q --> M
    R --> M
    
    M --> U
    N --> U
    D --> U
    U --> G
    A --> U
```