### PR TITLE
Uncaught exception in `ConsensusContext.NewHeight()`

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -177,20 +177,15 @@ namespace Libplanet.Net.Consensus
                         $"(expected: {_blockChain.Tip.Index + 1}, actual: {height})");
                 }
 
-                BlockCommit? lastCommit = null;
-                if (_contexts.ContainsKey(height - 1))
-                {
-                    lastCommit = _contexts[height - 1].CommittedRound == -1
-                        ? (BlockCommit?)null
-                        : new BlockCommit(
-                            _contexts[height - 1].VoteSet(_contexts[height - 1].CommittedRound),
-                            _blockChain.Tip.Hash);
-                }
+                BlockCommit? lastCommit = _contexts.ContainsKey(height - 1)
+                    ? _contexts[height - 1].GetBlockCommit()
+                    : null;
 
                 RemoveOldContexts(height);
 
                 if (lastCommit == null)
                 {
+                    // Note: Attempting to save a BlockCommit is in Context.Dispose() method.
                     BlockCommit? storedCommit = _blockChain.Store.GetLastCommit(height - 1);
                     if (storedCommit != null)
                     {

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -266,6 +266,20 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
+        /// Returns a <see cref="Libplanet.Blocks.BlockCommit"/> if the context is committed.
+        /// </summary>
+        /// <returns>Returns <see cref="Libplanet.Blocks.BlockCommit"/> if the context is committed
+        /// otherwise returns <see langword="null"/>.
+        /// </returns>
+        /// <remarks>If the <see cref="CommittedRound"/> exists, then the Context guarantees to have
+        /// a valid <see cref="BlockCommit"/> (+2/3 commits.)
+        /// </remarks>
+        public BlockCommit? GetBlockCommit()
+            => CommittedRound == -1
+                ? (BlockCommit?)null
+                : new BlockCommit(VoteSet(CommittedRound), _blockChain.Tip.Hash);
+
+        /// <summary>
         /// Returns the summary of context in JSON-formatted string.
         /// </summary>
         /// <returns>Returns a JSON-formatted string of context state.</returns>

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -216,11 +216,15 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
-            // Save the current height LastCommit before disposing if there was any locked value was
-            // exists.
-            if (_lockedValue is { } lockedValue)
+            // Save the current height LastCommit before disposing.
+            // XXX: The reasons why it is seperated from ConsensusContext.NewHeight() is
+            // that prevents the lost LastCommit while in termination of program. This is the
+            // attempt of saving LastCommit as much as possible.
+            // https://github.com/planetarium/libplanet/pull/2472
+            var currentLastCommit = GetBlockCommit();
+
+            if (currentLastCommit is { })
             {
-                var currentLastCommit = new BlockCommit(VoteSet(Round), lockedValue.Hash);
                 _blockChain.Store.PutLastCommit(currentLastCommit);
                 _logger.Debug(
                     "Saving current height #{Height} and round {Round} LastCommit...",


### PR DESCRIPTION
The `BlockCommit` has the validation of whether +2/3 votes exist. However, while in saving a `BlockCommit` in `Context.Dispose()`, it was trying to save `BlockCommit` even the `CommittedRound` does not exist.[^1]

not null `lockedValue` cases have no +2/3 commit cases.[^2] Due to this, `BlockCommit` constructor threw an exception which causes the `NewHeight` not to work properly.

[^1]: `CommittedRound` indicates the `PreCommit` has collected +2/3 commits.
[^2]: e.g., In step of `PreCommit` where round is not committed due to vote has not collected +2/3 yet.