### PR TITLE
♻️ `Proposal` and `ProposalMetadata`

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -161,7 +161,6 @@ namespace Libplanet.Net.Tests.Consensus.Context
                         1,
                         0,
                         codec.Encode(mockBlock),
-                        fx.Block1.Timestamp,
                         TestUtils.Peer1Priv.PublicKey,
                         -1).Sign(TestUtils.Peer1Priv)));
 

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -6,7 +6,6 @@ using Bencodex;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
-using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
 using Libplanet.Tests.Common.Action;

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -164,7 +164,6 @@ namespace Libplanet.Net.Tests.Messages
                 1,
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
-                fx.Block1.Timestamp,
                 key.PublicKey,
                 -1).Sign(key);
 

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -153,7 +153,6 @@ namespace Libplanet.Net.Tests
                     height,
                     round,
                     codec.Encode(block.MarshalBlock()),
-                    block.Timestamp,
                     privateKey.PublicKey,
                     validRound).Sign(privateKey))
             {

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -36,7 +36,6 @@ namespace Libplanet.Net.Consensus
                         Height,
                         Round,
                         _codec.Encode(proposalValue.MarshalBlock()),
-                        proposalValue.Timestamp,
                         _privateKey.PublicKey,
                         _validRound
                     ).Sign(_privateKey);

--- a/Libplanet.Net/Messages/ConsensusProposeMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusProposeMsg.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 

--- a/Libplanet.Tests/Consensus/ProposalMetaDataTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalMetaDataTest.cs
@@ -1,13 +1,14 @@
 using System;
 using Bencodex;
 using Libplanet.Blocks;
-using Libplanet.Net.Consensus;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
 using Libplanet.Tests.Store;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Net.Tests.Consensus
+namespace Libplanet.Tests.Consensus
 {
     public class ProposalMetaDataTest
     {
@@ -37,7 +38,7 @@ namespace Libplanet.Net.Tests.Consensus
                     0,
                     codec.Encode(fx.Block1.MarshalBlock()),
                     fx.Block1.Timestamp,
-                    TestUtils.Peer1Priv.PublicKey,
+                    new PrivateKey().PublicKey,
                     -1));
 
             Assert.Throws<ArgumentOutOfRangeException>(() => new ProposalMetaData(
@@ -45,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus
                 -1,
                 codec.Encode(fx.Block1.MarshalBlock()),
                 fx.Block1.Timestamp,
-                TestUtils.Peer1Priv.PublicKey,
+                new PrivateKey().PublicKey,
                 -1));
 
             Assert.Throws<ArgumentOutOfRangeException>(() => new ProposalMetaData(
@@ -53,7 +54,7 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
                 fx.Block1.Timestamp,
-                TestUtils.Peer1Priv.PublicKey,
+                new PrivateKey().PublicKey,
                 -2));
         }
     }

--- a/Libplanet.Tests/Consensus/ProposalMetaDataTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalMetaDataTest.cs
@@ -37,7 +37,6 @@ namespace Libplanet.Tests.Consensus
                     -1,
                     0,
                     codec.Encode(fx.Block1.MarshalBlock()),
-                    fx.Block1.Timestamp,
                     new PrivateKey().PublicKey,
                     -1));
 
@@ -45,7 +44,6 @@ namespace Libplanet.Tests.Consensus
                 1,
                 -1,
                 codec.Encode(fx.Block1.MarshalBlock()),
-                fx.Block1.Timestamp,
                 new PrivateKey().PublicKey,
                 -1));
 
@@ -53,7 +51,6 @@ namespace Libplanet.Tests.Consensus
                 1,
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
-                fx.Block1.Timestamp,
                 new PrivateKey().PublicKey,
                 -2));
         }

--- a/Libplanet.Tests/Consensus/ProposalTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalTest.cs
@@ -37,7 +37,6 @@ namespace Libplanet.Tests.Consensus
                 1,
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
-                fx.Block1.Timestamp,
                 new PrivateKey().PublicKey,
                 -1);
 
@@ -63,7 +62,6 @@ namespace Libplanet.Tests.Consensus
                 1,
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
-                fx.Block1.Timestamp,
                 key.PublicKey,
                 -1);
             Proposal proposal = metaData.Sign(key);

--- a/Libplanet.Tests/Consensus/ProposalTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalTest.cs
@@ -1,13 +1,14 @@
 using System;
 using Bencodex;
 using Libplanet.Blocks;
-using Libplanet.Net.Consensus;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
 using Libplanet.Tests.Store;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Net.Tests.Consensus
+namespace Libplanet.Tests.Consensus
 {
     public class ProposalTest
     {
@@ -37,7 +38,7 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
                 fx.Block1.Timestamp,
-                TestUtils.Peer1Priv.PublicKey,
+                new PrivateKey().PublicKey,
                 -1);
 
             // Empty Signature
@@ -47,7 +48,7 @@ namespace Libplanet.Net.Tests.Consensus
             // Invalid Signature
             var invSigBencodex = metaData.Encoded.Add(
                 Proposal.SignatureKey,
-                TestUtils.Peer1Priv.Sign(codec.Encode(fx.Block2.MarshalBlock())));
+                new PrivateKey().Sign(codec.Encode(fx.Block2.MarshalBlock())));
             Assert.Throws<ArgumentException>(() => new Proposal(invSigBencodex));
         }
 
@@ -56,20 +57,19 @@ namespace Libplanet.Net.Tests.Consensus
         {
             MemoryStoreFixture fx = new MemoryStoreFixture();
             var codec = new Codec();
+            var key = new PrivateKey();
 
             ProposalMetaData metaData = new ProposalMetaData(
                 1,
                 0,
                 codec.Encode(fx.Block1.MarshalBlock()),
                 fx.Block1.Timestamp,
-                TestUtils.Peer1Priv.PublicKey,
+                key.PublicKey,
                 -1);
+            Proposal proposal = metaData.Sign(key);
 
-            Proposal proposal = metaData.Sign(TestUtils.Peer1Priv);
-
-            Assert.Equal(proposal.Signature, TestUtils.Peer1Priv.Sign(metaData.ByteArray));
-            Assert.True(
-                TestUtils.Peer1Priv.PublicKey.Verify(metaData.ByteArray, proposal.Signature));
+            Assert.Equal(proposal.Signature, key.Sign(metaData.ByteArray));
+            Assert.True(key.PublicKey.Verify(metaData.ByteArray, proposal.Signature));
         }
     }
 }

--- a/Libplanet/Consensus/Proposal.cs
+++ b/Libplanet/Consensus/Proposal.cs
@@ -5,13 +5,12 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using Bencodex;
 using Bencodex.Types;
-using Libplanet.Consensus;
 using Libplanet.Crypto;
 
-namespace Libplanet.Net.Consensus
+namespace Libplanet.Consensus
 {
     /// <summary>
-    /// A class for a proposal information for used in <see cref="Context{T}"/>. It contains an
+    /// Represents a <see cref="Proposal"/> from a validator for consensus.  It contains an
     /// essential information <see cref="ProposalMetaData"/> to propose a block for a consensus
     /// in a height and a round, and its signature to verify. The signature is verified in
     /// constructor, so the instance of <see cref="Proposal"/> should be valid.
@@ -73,8 +72,8 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="ProposalMetaData.Round"/>
         public int Round => _proposalMetaData.Round;
 
-        /// <inheritdoc cref="ProposalMetaData.BlockMarshaled"/>
-        public byte[] BlockMarshaled => _proposalMetaData.BlockMarshaled;
+        /// <inheritdoc cref="ProposalMetaData.MarshaledBlock"/>
+        public byte[] BlockMarshaled => _proposalMetaData.MarshaledBlock;
 
         /// <inheritdoc cref="ProposalMetaData.Timestamp"/>
         public DateTimeOffset Timestamp => _proposalMetaData.Timestamp;
@@ -131,7 +130,7 @@ namespace Libplanet.Net.Consensus
         [Pure]
         public override bool Equals(object? obj)
         {
-            return obj is Vote other && Equals(other);
+            return obj is Proposal other && Equals(other);
         }
 
         /// <inheritdoc/>

--- a/Libplanet/Consensus/Proposal.cs
+++ b/Libplanet/Consensus/Proposal.cs
@@ -75,9 +75,6 @@ namespace Libplanet.Consensus
         /// <inheritdoc cref="ProposalMetaData.MarshaledBlock"/>
         public byte[] BlockMarshaled => _proposalMetaData.MarshaledBlock;
 
-        /// <inheritdoc cref="ProposalMetaData.Timestamp"/>
-        public DateTimeOffset Timestamp => _proposalMetaData.Timestamp;
-
         /// <inheritdoc cref="ProposalMetaData.Validator"/>
         public PublicKey Validator => _proposalMetaData.Validator;
 
@@ -137,7 +134,9 @@ namespace Libplanet.Consensus
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.Combine(_proposalMetaData.GetHashCode(), Signature);
+            return HashCode.Combine(
+                _proposalMetaData.GetHashCode(),
+                ByteUtil.CalculateHashCode(Signature.ToArray()));
         }
     }
 }

--- a/Libplanet/Consensus/ProposalMetaData.cs
+++ b/Libplanet/Consensus/ProposalMetaData.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Text.Json.Serialization;
 using Bencodex;
 using Bencodex.Types;
@@ -19,7 +18,6 @@ namespace Libplanet.Consensus
         private const string HeightKey = "height";
         private const string RoundKey = "round";
         private const string BlockKey = "block";
-        private const string TimestampKey = "timestamp";
         private const string ValidatorKey = "validator";
         private const string ValidRoundKey = "validRound";
 
@@ -32,7 +30,6 @@ namespace Libplanet.Consensus
         /// <param name="round">a round of given proposal values.</param>
         /// <param name="marshaledBlock">a marshaled bencodex-encoded <see cref="byte"/> array of
         /// block.</param>
-        /// <param name="timestamp">the proposed time of given block.</param>
         /// <param name="validator">a <see cref="PublicKey"/> of proposing validator.</param>
         /// <param name="validRound">a latest valid round at the moment of given proposal.</param>
         /// <exception cref="ArgumentOutOfRangeException">This can be thrown in following reasons:
@@ -52,7 +49,6 @@ namespace Libplanet.Consensus
             long height,
             int round,
             byte[] marshaledBlock,
-            DateTimeOffset timestamp,
             PublicKey validator,
             int validRound)
         {
@@ -78,7 +74,6 @@ namespace Libplanet.Consensus
             Height = height;
             Round = round;
             MarshaledBlock = marshaledBlock;
-            Timestamp = timestamp;
             Validator = validator;
             ValidRound = validRound;
         }
@@ -89,10 +84,6 @@ namespace Libplanet.Consensus
                 height: encoded.GetValue<Integer>(HeightKey),
                 round: encoded.GetValue<Integer>(RoundKey),
                 marshaledBlock: encoded.GetValue<Binary>(BlockKey),
-                timestamp: DateTimeOffset.ParseExact(
-                    encoded.GetValue<Text>(TimestampKey),
-                    TimestampFormat,
-                    CultureInfo.InvariantCulture),
                 validator: new PublicKey(encoded.GetValue<Binary>(ValidatorKey).ByteArray),
                 validRound: encoded.GetValue<Integer>(ValidRoundKey))
         {
@@ -113,11 +104,6 @@ namespace Libplanet.Consensus
         /// A marshaled bencodex-encoded <see cref="byte"/> array of block.
         /// </summary>
         public byte[] MarshaledBlock { get; }
-
-        /// <summary>
-        /// The proposed time of given block.
-        /// </summary>
-        public DateTimeOffset Timestamp { get; }
 
         /// <summary>
         /// A <see cref="PublicKey"/> of proposing validator.
@@ -141,9 +127,6 @@ namespace Libplanet.Consensus
                     .Add(HeightKey, Height)
                     .Add(RoundKey, Round)
                     .Add(BlockKey, MarshaledBlock)
-                    .Add(
-                        TimestampKey,
-                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                     .Add(ValidatorKey, Validator.Format(compress: true))
                     .Add(ValidRoundKey, ValidRound);
 
@@ -168,9 +151,9 @@ namespace Libplanet.Consensus
             return HashCode.Combine(
                 Height,
                 Round,
-                MarshaledBlock,
-                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
-                Validator);
+                ByteUtil.CalculateHashCode(MarshaledBlock),
+                Validator,
+                ValidRound);
         }
     }
 }

--- a/Libplanet/Consensus/ProposalMetaData.cs
+++ b/Libplanet/Consensus/ProposalMetaData.cs
@@ -6,7 +6,7 @@ using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
 
-namespace Libplanet.Net.Consensus
+namespace Libplanet.Consensus
 {
     /// <summary>
     /// A class for constructing <see cref="Proposal"/>. This class contains proposal information
@@ -30,7 +30,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="height">a height of given proposal values.</param>
         /// <param name="round">a round of given proposal values.</param>
-        /// <param name="blockMarshaled">a marshaled bencodex-encoded <see cref="byte"/> array of
+        /// <param name="marshaledBlock">a marshaled bencodex-encoded <see cref="byte"/> array of
         /// block.</param>
         /// <param name="timestamp">the proposed time of given block.</param>
         /// <param name="validator">a <see cref="PublicKey"/> of proposing validator.</param>
@@ -51,11 +51,10 @@ namespace Libplanet.Net.Consensus
         public ProposalMetaData(
             long height,
             int round,
-            byte[] blockMarshaled,
+            byte[] marshaledBlock,
             DateTimeOffset timestamp,
             PublicKey validator,
-            int validRound
-        )
+            int validRound)
         {
             if (height < 0)
             {
@@ -78,7 +77,7 @@ namespace Libplanet.Net.Consensus
 
             Height = height;
             Round = round;
-            BlockMarshaled = blockMarshaled;
+            MarshaledBlock = marshaledBlock;
             Timestamp = timestamp;
             Validator = validator;
             ValidRound = validRound;
@@ -89,7 +88,7 @@ namespace Libplanet.Net.Consensus
             : this(
                 height: encoded.GetValue<Integer>(HeightKey),
                 round: encoded.GetValue<Integer>(RoundKey),
-                blockMarshaled: encoded.GetValue<Binary>(BlockKey),
+                marshaledBlock: encoded.GetValue<Binary>(BlockKey),
                 timestamp: DateTimeOffset.ParseExact(
                     encoded.GetValue<Text>(TimestampKey),
                     TimestampFormat,
@@ -113,7 +112,7 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// A marshaled bencodex-encoded <see cref="byte"/> array of block.
         /// </summary>
-        public byte[] BlockMarshaled { get; }
+        public byte[] MarshaledBlock { get; }
 
         /// <summary>
         /// The proposed time of given block.
@@ -141,7 +140,7 @@ namespace Libplanet.Net.Consensus
                 Dictionary encoded = Bencodex.Types.Dictionary.Empty
                     .Add(HeightKey, Height)
                     .Add(RoundKey, Round)
-                    .Add(BlockKey, BlockMarshaled)
+                    .Add(BlockKey, MarshaledBlock)
                     .Add(
                         TimestampKey,
                         Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
@@ -169,7 +168,7 @@ namespace Libplanet.Net.Consensus
             return HashCode.Combine(
                 Height,
                 Round,
-                BlockMarshaled,
+                MarshaledBlock,
                 Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
                 Validator);
         }


### PR DESCRIPTION
Changes:
- `Proposal` and `ProposalMetadata` moved from `Libplanet.Net.Consensus` to `Libplanet.Consensus`
- Removed `Timestamp` from `Proposal`.
- Fixed `GetHashCode()`