### PR TITLE
Feat/enrich explorer query

### DIFF
--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types;
@@ -54,6 +55,14 @@ namespace Libplanet.Explorer.GraphTypes
                 name: "Actions",
                 description: "A list of actions in this transaction."
             );
+            Field<NonNullGraphType<StringGraphType>>(
+                name: "SignedTx",
+                description: "A signed tx in base64 string.",
+                resolve: x =>
+                {
+                    byte[] bytes = x.Source.Serialize(true);
+                    return Convert.ToBase64String(bytes);
+                });
 
             // The block including the transaction. - Only RichStore supports.
             Field<ListGraphType<NonNullGraphType<BlockType<T>>>>(

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -56,8 +56,8 @@ namespace Libplanet.Explorer.GraphTypes
                 description: "A list of actions in this transaction."
             );
             Field<NonNullGraphType<StringGraphType>>(
-                name: "SignedTx",
-                description: "A signed tx in base64 string.",
+                name: "SerializedPayload",
+                description: "A serialized tx payload in base64 string.",
                 resolve: x =>
                 {
                     byte[] bytes = x.Source.Serialize(true);

--- a/Libplanet.Explorer/Queries/ExplorerQuery.cs
+++ b/Libplanet.Explorer/Queries/ExplorerQuery.cs
@@ -54,17 +54,23 @@ namespace Libplanet.Explorer.Queries
             long tipIndex = tip.Index;
             IStore store = ChainContext.Store;
 
-            if (offset < 0)
+            if (desc)
             {
-                offset = tipIndex + offset + 1;
+                if (offset < 0)
+                {
+                    offset = tipIndex + offset + 1;
+                }
+                else
+                {
+                    offset = tipIndex - offset + 1 - (limit ?? 0);
+                }
             }
-            else if (desc && offset == 0)
+            else
             {
-                offset = tipIndex + 1 - (limit ?? 0);
-            }
-            else if (desc && offset > 0)
-            {
-                offset = offset + 1 - (limit ?? 0);
+                if (offset < 0)
+                {
+                    offset = tipIndex + offset + 1;
+                }
             }
 
             var indexList = store.IterateIndexes(


### PR DESCRIPTION
## Changes
1. Add a `SignedTx` field in the `chainquery transaction` data.
- The `SignedTx` field is added to test chain consistency during internal testing (to test whether past txs work in new updates).
- Reference Issue: https://github.com/planetarium/devops/issues/13

2. Use `IterateIndexes` instead of the `GetNextBlock` method when querying blocks.
- This change improves querying speed especially when the `offset` value is far from either 0 or the tip value (the original implementation only worked well for getting blocks close to the genesis or the tip block).