### PR TITLE
Refactor `MessageLog`

### DIFF
--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Consensus
                 ToString());
             Round = round;
             Step = Step.Propose;
-            if (Proposer(Round) == _privateKey.PublicKey)
+            if (GetProposer(Round) == _privateKey.PublicKey)
             {
                 _logger.Debug(
                     "Starting round {NewRound} and is a proposer.",
@@ -92,12 +92,12 @@ namespace Libplanet.Net.Consensus
             try
             {
                 if (message is ConsensusProposalMsg propose &&
-                    !propose.Validator.Equals(Proposer(message.Round)))
+                    !propose.Validator.Equals(GetProposer(message.Round)))
                 {
                     throw new InvalidConsensusMessageException(
                         $"Given {nameof(message)}'s proposer {propose.Validator} for height " +
                         $"{message.Height} and round {message.Round} is different from " +
-                        $"the expected proposer, {Proposer(message.Round)}.",
+                        $"the expected proposer, {GetProposer(message.Round)}.",
                         message);
                 }
 
@@ -302,7 +302,7 @@ namespace Libplanet.Net.Consensus
             }
 
             if (round > Round &&
-                _messageLog.GetValidatorsCount(round) > TotalValidators / 3)
+                HasOneThirdValidators(round))
             {
                 _logger.Debug(
                     "1/3+ validators from round {Round} > current round {CurrentRound}. " +

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Consensus
                 ToString());
             Round = round;
             Step = Step.Propose;
-            if (GetProposer(Round) == _privateKey.PublicKey)
+            if (ProposerSelector.GetProposer(_validators, Height, Round) == _privateKey.PublicKey)
             {
                 _logger.Debug(
                     "Starting round {NewRound} and is a proposer.",
@@ -91,13 +91,15 @@ namespace Libplanet.Net.Consensus
         {
             try
             {
+                var expectedProposer = ProposerSelector.GetProposer(
+                    _validators, Height, message.Round);
                 if (message is ConsensusProposalMsg propose &&
-                    !propose.Validator.Equals(GetProposer(message.Round)))
+                    !propose.Validator.Equals(expectedProposer))
                 {
                     throw new InvalidConsensusMessageException(
                         $"Given {nameof(message)}'s proposer {propose.Validator} for height " +
                         $"{message.Height} and round {message.Round} is different from " +
-                        $"the expected proposer, {GetProposer(message.Round)}.",
+                        $"the expected proposer, {expectedProposer}.",
                         message);
                 }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -260,9 +260,9 @@ namespace Libplanet.Net.Consensus
                 { "height", Height },
                 { "round", Round },
                 { "step", Step.ToString() },
-                { "locked_value", _lockedValue?.Hash.ToString() ?? string.Empty },
+                { "locked_value", _lockedValue?.Hash.ToString() ?? "null" },
                 { "locked_round", _lockedRound },
-                { "valid_value", _validValue?.Hash.ToString() ?? string.Empty },
+                { "valid_value", _validValue?.Hash.ToString() ?? "null" },
                 { "valid_round", _validRound },
             };
             return JsonSerializer.Serialize(dict);
@@ -333,7 +333,7 @@ namespace Libplanet.Net.Consensus
         /// <returns>Returns designated proposer's <see cref="PublicKey"/> for the
         /// <paramref name="round"/>.
         /// </returns>
-        private PublicKey Proposer(int round)
+        private PublicKey GetProposer(int round)
         {
             // return designated proposer for the height round pair.
             return _validators[(int)((Height + round) % TotalValidators)];
@@ -449,6 +449,19 @@ namespace Libplanet.Net.Consensus
         {
             int count = _messageLog.GetPreCommits(round).Count(preCommit => predicate(preCommit));
             return count > TotalValidators * 2 / 3;
+        }
+
+        /// <summary>
+        /// Checks whether given <paramref name="round"/> has +1/3 distinct validators
+        /// already participating in it, i.e. has a <see cref="ConsensusMsg"/> in the
+        /// <see cref="MessageLog"/>.
+        /// </summary>
+        /// <param name="round">The round to check.</param>
+        /// <returns><see langword="true"/> if the count is +1/3,
+        /// otherwise <see langword="false"/>.</returns>
+        private bool HasOneThirdValidators(int round)
+        {
+            return _messageLog.GetValidatorsCount(round) > TotalValidators / 3;
         }
     }
 }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -327,19 +327,6 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Gets the proposer of the given round.
-        /// </summary>
-        /// <param name="round">A round to get proposer.</param>
-        /// <returns>Returns designated proposer's <see cref="PublicKey"/> for the
-        /// <paramref name="round"/>.
-        /// </returns>
-        private PublicKey GetProposer(int round)
-        {
-            // return designated proposer for the height round pair.
-            return _validators[(int)((Height + round) % TotalValidators)];
-        }
-
-        /// <summary>
         /// Broadcasts <see cref="ConsensusMsg"/> to validators.
         /// </summary>
         /// <param name="message">A <see cref="ConsensusMsg"/> to broadcast.</param>

--- a/Libplanet/Consensus/ProposerSelector.cs
+++ b/Libplanet/Consensus/ProposerSelector.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    public static class ProposerSelector
+    {
+        /// <summary>
+        /// Gets the proposer for a given context.
+        /// </summary>
+        /// <param name="validators">The list of <see cref="PublicKey"/>s to choose from.</param>
+        /// <param name="height">The height of the context under consideration.</param>
+        /// <param name="round">The round of the context under consideration.</param>
+        /// <returns>A <see cref="PublicKey"/> deterministically chosen from
+        /// <paramref name="validators"/>, <paramref name="height"/>, and <paramref name="round"/>.
+        /// </returns>
+        [Pure]
+        public static PublicKey GetProposer(
+            List<PublicKey> validators, long height, int round)
+        {
+            return validators[(int)((height + round) % validators.Count)];
+        }
+    }
+}


### PR DESCRIPTION
Related to #2473.

Migration of entire `MessageLog` related logic to `MessageLog` from `Context` complete. This should make `MessageLog` only to be in a "valid state" in relation to `Context` (unless there is some lapse in logic somewhere).

Didn't feel like `throw`ing `Exception`s only for the sake of debugging **with stack trace** as opposed to debugging with output logs was worth it, so I've made `MessageLog` exception free again with `bool` returns. 🙄

Also `ProposerSelector` `static` `class` has been added, kinda just stuck it in `Libplanet.Consensus` `namespace`, as I'm still not sure who or what should be responsible for proposer selection logic. 😐