### PR TITLE
Inject ActionEvaluator and BlockChainStates explicitly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@ To be released.
 
 ### Added APIs
 
+- Added `BlockChainStates<T>` class.  [[#2507]]
+- Added new constructors of `BlockChain<T>` takes `IBlockChainStates<T>`
+  and `ActionEvaluator<T>` directly.  [[#2507]]
+
+[#2507]: https://github.com/planetarium/libplanet/pull/2507
+
 ### Behavioral changes
 
 ### Bug fixes

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -215,9 +215,9 @@ namespace Libplanet.Blockchain
             Store = store;
             _blockChainStates = blockChainStates;
 
-            if (_blockChainStates is BlockChainStates<T> biddableImpl)
+            if (_blockChainStates is BlockChainStates<T> bindableImpl)
             {
-                biddableImpl.Bind(this);
+                bindableImpl.Bind(this);
             }
 
             // It expects store is DefaultStore or RocksDBStore.

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -142,7 +142,7 @@ namespace Libplanet.Blockchain
 
 #pragma warning disable MEN002
 #pragma warning disable CS1573
-        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}})" />
+        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}}, IBlockChainStates{T})" />
         /// <param name="actionEvaluator">The <see cref="ActionEvaluator{T}" /> implementation to calculate next states when append new blocks.</param>
         public BlockChain(
             IBlockPolicy<T> policy,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -23,17 +23,19 @@ using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Blockchain
 {
+#pragma warning disable MEN002
     /// <summary>
     /// A class have <see cref="Block{T}"/>s, <see cref="Transaction{T}"/>s, and the chain
     /// information.
     /// <para>In order to watch its state changes, implement <see cref="IRenderer{T}"/>
-    /// interface and pass it to the <see cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T},
-    /// IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}})"/> constructor.</para>
+    /// interface and pass it to the <see cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}})"/> constructor.</para>
     /// </summary>
     /// <remarks>This object is guaranteed that it has at least one block, since it takes a genesis
     /// block when it's instantiated.</remarks>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
+    ///
+#pragma warning restore MEN002
     public partial class BlockChain<T> : IBlockChainStates<T>
         where T : IAction, new()
     {
@@ -45,6 +47,7 @@ namespace Libplanet.Blockchain
         internal readonly ReaderWriterLockSlim _rwlock;
         private readonly object _txLock;
         private readonly ILogger _logger;
+        private readonly IBlockChainStates<T> _blockChainStates;
 
         /// <summary>
         /// All <see cref="Block{T}"/>s in the <see cref="BlockChain{T}"/>
@@ -94,9 +97,76 @@ namespace Libplanet.Blockchain
                 stagePolicy,
                 store,
                 stateStore,
+                genesisBlock,
+                renderers,
+                new BlockChainStates<T>(store, stateStore)
+            )
+        {
+        }
+
+#pragma warning disable MEN002
+#pragma warning disable CS1573
+        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}})" />
+        /// <param name="blockChainStates">The <see cref="IBlockChainStates{T}"/> implementation to state lookup.</param>
+        public BlockChain(
+            IBlockPolicy<T> policy,
+            IStagePolicy<T> stagePolicy,
+            IStore store,
+            IStateStore stateStore,
+            Block<T> genesisBlock,
+            IEnumerable<IRenderer<T>> renderers,
+            IBlockChainStates<T> blockChainStates
+        )
+#pragma warning restore MEN002
+#pragma warning restore CS1573
+            : this(
+                policy,
+                stagePolicy,
+                store,
+                stateStore,
+                genesisBlock,
+                renderers,
+                blockChainStates,
+                new ActionEvaluator<T>(
+                    policy.BlockAction,
+                    blockChainStates: blockChainStates,
+                    trieGetter: hash => stateStore.GetStateRoot(
+                        store.GetBlockDigest(hash)?.StateRootHash
+                    ),
+                    genesisHash: genesisBlock.Hash,
+                    nativeTokenPredicate: policy.NativeTokens.Contains
+                )
+            )
+        {
+        }
+
+#pragma warning disable MEN002
+#pragma warning disable CS1573
+        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block{T}, IEnumerable{IRenderer{T}})" />
+        /// <param name="actionEvaluator">The <see cref="ActionEvaluator{T}" /> implementation to calculate next states when append new blocks.</param>
+        public BlockChain(
+            IBlockPolicy<T> policy,
+            IStagePolicy<T> stagePolicy,
+            IStore store,
+            IStateStore stateStore,
+            Block<T> genesisBlock,
+            IEnumerable<IRenderer<T>> renderers,
+            IBlockChainStates<T> blockChainStates,
+            ActionEvaluator<T> actionEvaluator
+        )
+#pragma warning restore MEN002
+#pragma warning restore CS1573
+            : this(
+                policy,
+                stagePolicy,
+                store,
+                stateStore,
                 store.GetCanonicalChainId() ?? Guid.NewGuid(),
                 genesisBlock,
-                renderers
+                false,
+                renderers,
+                blockChainStates,
+                actionEvaluator
             )
         {
         }
@@ -108,7 +178,9 @@ namespace Libplanet.Blockchain
             IStateStore stateStore,
             Guid id,
             Block<T> genesisBlock,
-            IEnumerable<IRenderer<T>> renderers
+            IEnumerable<IRenderer<T>> renderers,
+            IBlockChainStates<T> blockChainStates,
+            ActionEvaluator<T> actionEvaluator
         )
             : this(
                 policy,
@@ -118,7 +190,9 @@ namespace Libplanet.Blockchain
                 id,
                 genesisBlock,
                 false,
-                renderers
+                renderers,
+                blockChainStates,
+                actionEvaluator
             )
         {
         }
@@ -131,13 +205,20 @@ namespace Libplanet.Blockchain
             Guid id,
             Block<T> genesisBlock,
             bool inFork,
-            IEnumerable<IRenderer<T>> renderers
-        )
+            IEnumerable<IRenderer<T>> renderers,
+            IBlockChainStates<T> blockChainStates,
+            ActionEvaluator<T> actionEvaluator)
         {
             Id = id;
             Policy = policy;
             StagePolicy = stagePolicy;
             Store = store;
+            _blockChainStates = blockChainStates;
+
+            if (_blockChainStates is BlockChainStates<T> biddableImpl)
+            {
+                biddableImpl.Bind(this);
+            }
 
             // It expects store is DefaultStore or RocksDBStore.
             StateStore = stateStore ?? store as IStateStore;
@@ -163,13 +244,7 @@ namespace Libplanet.Blockchain
                 .ForContext<BlockChain<T>>()
                 .ForContext("Source", nameof(BlockChain<T>))
                 .ForContext("CanonicalChainId", Id);
-            ActionEvaluator = new ActionEvaluator<T>(
-                Policy.BlockAction,
-                blockChainStates: this,
-                trieGetter: hash => StateStore.GetStateRoot(_blocks[hash].StateRootHash),
-                genesisHash: genesisBlock.Hash,
-                nativeTokenPredicate: Policy.NativeTokens.Contains
-            );
+            ActionEvaluator = actionEvaluator;
 
             if (Count == 0)
             {
@@ -524,22 +599,7 @@ namespace Libplanet.Blockchain
             IReadOnlyList<Address> addresses,
             BlockHash offset,
             StateCompleter<T> stateCompleter
-        )
-        {
-            if (Count < 1)
-            {
-                return new IValue[addresses.Count];
-            }
-
-            HashDigest<SHA256>? stateRootHash = Store.GetStateRootHash(offset);
-            if (stateRootHash is { } h && StateStore.ContainsStateRoot(h))
-            {
-                string[] rawKeys = addresses.Select(ToStateKey).ToArray();
-                return StateStore.GetStates(stateRootHash, rawKeys);
-            }
-
-            return stateCompleter(this, offset, addresses);
-        }
+        ) => _blockChainStates.GetStates(addresses, offset, stateCompleter);
 
         /// <summary>
         /// Queries <paramref name="address"/>'s balance of the <paramref name="currency"/> in the
@@ -580,26 +640,7 @@ namespace Libplanet.Blockchain
             Currency currency,
             BlockHash offset,
             FungibleAssetStateCompleter<T> stateCompleter
-        )
-        {
-            if (Count < 1)
-            {
-                return currency * 0;
-            }
-
-            HashDigest<SHA256>? stateRootHash = Store.GetStateRootHash(offset);
-            if (stateRootHash is { } h && StateStore.ContainsStateRoot(h))
-            {
-                string rawKey = ToFungibleAssetKey(address, currency);
-                IReadOnlyList<IValue> values =
-                    StateStore.GetStates(stateRootHash, new[] { rawKey });
-                return values.Count > 0 && values[0] is Bencodex.Types.Integer i
-                    ? FungibleAssetValue.FromRawValue(currency, i)
-                    : currency * 0;
-            }
-
-            return stateCompleter(this, offset, address, currency);
-        }
+        ) => _blockChainStates.GetBalance(address, currency, offset, stateCompleter);
 
         /// <summary>
         /// Gets the total supply of a <paramref name="currency"/> in the
@@ -635,31 +676,7 @@ namespace Libplanet.Blockchain
             Currency currency,
             BlockHash offset,
             TotalSupplyStateCompleter<T> stateCompleter
-        )
-        {
-            if (!currency.TotalSupplyTrackable)
-            {
-                throw TotalSupplyNotTrackableException.WithDefaultMessage(currency);
-            }
-
-            if (Count < 1)
-            {
-                return currency * 0;
-            }
-
-            HashDigest<SHA256>? stateRootHash = Store.GetStateRootHash(offset);
-            if (stateRootHash is { } h && StateStore.ContainsStateRoot(h))
-            {
-                string rawKey = ToTotalSupplyKey(currency);
-                IReadOnlyList<IValue> values =
-                    StateStore.GetStates(stateRootHash, new[] { rawKey });
-                return values.Count > 0 && values[0] is Bencodex.Types.Integer i
-                    ? FungibleAssetValue.FromRawValue(currency, i)
-                    : currency * 0;
-            }
-
-            return stateCompleter(this, offset, currency);
-        }
+        ) => _blockChainStates.GetTotalSupply(currency, offset, stateCompleter);
 
         /// <summary>
         /// Queries the recorded <see cref="TxExecution"/> for a successful or failed
@@ -1049,7 +1066,16 @@ namespace Libplanet.Blockchain
                 ? Renderers
                 : Enumerable.Empty<IRenderer<T>>();
             var forked = new BlockChain<T>(
-                Policy, StagePolicy, Store, StateStore, Guid.NewGuid(), Genesis, true, renderers);
+                Policy,
+                StagePolicy,
+                Store,
+                StateStore,
+                Guid.NewGuid(),
+                Genesis,
+                true,
+                renderers,
+                _blockChainStates,
+                ActionEvaluator);
             Guid forkedId = forked.Id;
             _logger.Debug(
                 "Trying to fork chain at {branchPoint}" +

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using static Libplanet.Blockchain.KeyConverters;
+
+namespace Libplanet.Blockchain
+{
+    /// <summary>
+    /// A default implementation of <see cref="IBlockChainStates{T}" /> interface.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.</typeparam>
+    public class BlockChainStates<T> : IBlockChainStates<T>
+        where T : IAction, new()
+    {
+        private readonly IStore _store;
+        private readonly IStateStore _stateStore;
+
+        // Temporary fields for backward compatibility.
+        // FIXME This field and related codes should be deleted
+        // if we make a decision about StateCompleter deprecation.
+        private BlockChain<T>? _blockChain;
+
+        public BlockChainStates(IStore store, IStateStore stateStore)
+        {
+            _store = store;
+            _stateStore = stateStore;
+        }
+
+        /// <inheritdoc cref="IBlockChainStates{T}.GetStates"/>
+        public IReadOnlyList<IValue?> GetStates(
+            IReadOnlyList<Address> addresses,
+            BlockHash offset,
+            StateCompleter<T> stateCompleter)
+        {
+            HashDigest<SHA256>? stateRootHash = _store.GetStateRootHash(offset);
+            if (stateRootHash is { } h && _stateStore.ContainsStateRoot(h))
+            {
+                string[] rawKeys = addresses.Select(ToStateKey).ToArray();
+                return _stateStore.GetStates(stateRootHash, rawKeys);
+            }
+
+            if (!(_blockChain is null))
+            {
+                return stateCompleter(_blockChain, offset, addresses);
+            }
+
+            throw new IncompleteBlockStatesException(offset);
+        }
+
+        /// <inheritdoc cref="IBlockChainStates{T}.GetBalance"/>
+        public FungibleAssetValue GetBalance(
+            Address address,
+            Currency currency,
+            BlockHash offset,
+            FungibleAssetStateCompleter<T> stateCompleter)
+        {
+            HashDigest<SHA256>? stateRootHash = _store.GetStateRootHash(offset);
+            if (stateRootHash is { } h && _stateStore.ContainsStateRoot(h))
+            {
+                string rawKey = ToFungibleAssetKey(address, currency);
+                IReadOnlyList<IValue?> values =
+                    _stateStore.GetStates(stateRootHash, new[] { rawKey });
+                return values.Count > 0 && values[0] is Bencodex.Types.Integer i
+                    ? FungibleAssetValue.FromRawValue(currency, i)
+                    : currency * 0;
+            }
+
+            if (!(_blockChain is null))
+            {
+                return stateCompleter(_blockChain, offset, address, currency);
+            }
+
+            throw new IncompleteBlockStatesException(offset);
+        }
+
+        /// <inheritdoc cref="IBlockChainStates{T}.GetTotalSupply"/>
+        public FungibleAssetValue GetTotalSupply(
+            Currency currency,
+            BlockHash offset,
+            TotalSupplyStateCompleter<T> stateCompleter)
+        {
+            if (!currency.TotalSupplyTrackable)
+            {
+                throw TotalSupplyNotTrackableException.WithDefaultMessage(currency);
+            }
+
+            HashDigest<SHA256>? stateRootHash = _store.GetStateRootHash(offset);
+            if (stateRootHash is { } h && _stateStore.ContainsStateRoot(h))
+            {
+                string rawKey = ToTotalSupplyKey(currency);
+                IReadOnlyList<IValue?> values =
+                    _stateStore.GetStates(stateRootHash, new[] { rawKey });
+                return values.Count > 0 && values[0] is Bencodex.Types.Integer i
+                    ? FungibleAssetValue.FromRawValue(currency, i)
+                    : currency * 0;
+            }
+
+            if (!(_blockChain is null))
+            {
+                return stateCompleter(_blockChain, offset, currency);
+            }
+
+            throw new IncompleteBlockStatesException(offset);
+        }
+
+        internal void Bind(BlockChain<T> blockChain)
+        {
+            _blockChain = blockChain;
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to extract `ActionEvaluator<T>` creation, from `BlockChain<T>` constructor to outside. to achieve that, we need to solve the dependency chain as below.

1. `ActionEvaluator<T>` depends `BlockChain<T>` as `IBlockChainStates<T>`.
2. To perform as `IBlockChainStates<T>`, `BlockChain<T>` depends `IStore`, `IStateStore`, and itself. (due to state completion).

In other words, if we can implement `IBlockChainState<T>` without the whole `BlockChain<T>`, extracting `ActionEvaluator<T>` creation from `BlockChain<T>` constructor seems possible. 

* At first, I introduced a new `BlockChainStates<T>` implementing `IBlockChainStates<T>`, instead of `BlockChain<T>`.
* Moved `GetBlances()`, `GetStates()` and `GetTotalSupply()` from `BlockChain<T>` to `BlockChainStates<T>`.
  * I think that we have a rough consensus about obsoleting the state completion feature, but it can be another long story. so I deferred it to later PR.
  * To keep current behavior using `StateCompleter<T>`s, I introduced `BlockChainStates<T>.Bind()`. it takes `BlockChain<T>` to support previous methods.