### PR TITLE
Move `LastCommit` saving to `Commit`

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -381,5 +381,50 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             Assert.Equal(expectedVotes, actualVotesWithoutInvalid);
         }
+
+        [Fact(Timeout = Timeout)]
+        public void Commit()
+        {
+            var stepChangedToPreVote = new AsyncAutoResetEvent();
+            var stepChangedToPreCommit = new AsyncAutoResetEvent();
+            var stepChangedToEndCommit = new AsyncAutoResetEvent();
+
+            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+                TimeSpan.FromSeconds(1),
+                TestUtils.Policy,
+                TestUtils.Peer1Priv);
+
+            consensusContext.StateChanged += (sender, eventArgs) =>
+            {
+                if (eventArgs.Height == 2 && eventArgs.Step == Step.PreVote)
+                {
+                    stepChangedToPreVote.Set();
+                }
+
+                if (eventArgs.Height == 2 && eventArgs.Step == Step.PreCommit)
+                {
+                    stepChangedToPreCommit.Set();
+                }
+
+                if (eventArgs.Height == 2 && eventArgs.Step == Step.EndCommit)
+                {
+                    stepChangedToEndCommit.Set();
+                }
+            };
+
+            // Height 1 does not have lastCommit, so skipping height 1.
+            var block1 = blockChain.ProposeBlock(TestUtils.Peer1Priv, lastCommit: null);
+            blockChain.Append(block1);
+
+            var block2 = blockChain.ProposeBlock(
+                TestUtils.Peer2Priv,
+                lastCommit:
+                TestUtils.CreateLastCommit(blockChain.Tip.Hash, blockChain.Tip.Index, 0));
+            consensusContext.Commit(
+                TestUtils.CreateLastCommit(block2.Hash, block2.Index, 0), block2);
+
+            Assert.Equal(blockChain.Tip, block2);
+            Assert.NotNull(blockChain.Store.GetLastCommit(2));
+        }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -259,18 +259,31 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Committing the block to the <see cref="BlockChain{T}"/>.
+        /// Committing the block to the <see cref="BlockChain{T}"/> and saves
+        /// <see cref="BlockCommit"/> of currently committed height.
         /// </summary>
+        /// <param name="lastCommit">A <see cref="BlockCommit"/> created from committed height.
+        /// </param>
         /// <param name="block">A <see cref="Block{T}"/> to committing to the
         /// <see cref="BlockChain{T}"/>.
         /// </param>
         /// <remarks>the method is called when a block is voted by <see cref="Context{T}"/>
         /// in <see cref="Libplanet.Net.Consensus.Step.EndCommit"/>.
         /// </remarks>
-        public void Commit(Block<T> block)
+        public void Commit(BlockCommit? lastCommit, Block<T> block)
         {
             _logger.Debug("Committing block #{Index} {Block}.", block.Index, block.Hash);
             _blockChain.Append(block);
+            if (lastCommit is null)
+            {
+                return;
+            }
+
+            _logger.Debug(
+                "Saving LastCommit of height #{Height} and round #{Round}.",
+                lastCommit.Height,
+                lastCommit.Round);
+            _blockChain.Store.PutLastCommit(lastCommit);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -272,7 +272,7 @@ namespace Libplanet.Net.Consensus
                     Round,
                     ToString());
 
-                ConsensusContext.Commit(block4);
+                ConsensusContext.Commit(GetBlockCommit(), block4);
                 return;
             }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -213,20 +213,6 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
-            // Save the current height LastCommit before disposing.
-            // XXX: The reasons why it is seperated from ConsensusContext.NewHeight() is
-            // that prevents the lost LastCommit while in termination of program. This is the
-            // attempt of saving LastCommit as much as possible.
-            // https://github.com/planetarium/libplanet/pull/2472
-            if (GetBlockCommit() is BlockCommit currentLastCommit)
-            {
-                _blockChain.Store.PutLastCommit(currentLastCommit);
-                _logger.Debug(
-                    "Saving current height #{Height} and round {Round} LastCommit...",
-                    currentLastCommit.Height,
-                    currentLastCommit.Round);
-            }
-
             _cancellationTokenSource.Cancel();
             _messageRequests.Writer.TryComplete();
             _mutationRequests.Writer.TryComplete();


### PR DESCRIPTION
Saving LastCommit in `Context<T>.Dispose()` was hard to debug. So the LastCommit saving point is moved from `Context<T>.Dispose()` to `Commit`.