### PR TITLE
Fix/app protocol version get hash code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,15 @@ To be released.
 
 ### Bug fixes
 
+ -  (Libplanet.Net) Fixed a bug where `AppProtocolVersion.GetHashCode()`
+    did not work as intended.  [[#2518], [#2520]]
+
 ### Dependencies
 
 ### CLI tools
+
+[#2518]: https://github.com/planetarium/libplanet/issues/2518
+[#2520]: https://github.com/planetarium/libplanet/pull/2520
 
 
 Version 0.44.0

--- a/Libplanet.Net/AppProtocolVersion.cs
+++ b/Libplanet.Net/AppProtocolVersion.cs
@@ -259,7 +259,7 @@ namespace Libplanet.Net
             {
                 hash *= 31 + Version.GetHashCode();
                 hash *= 31 + (Extra is null ? 0 : Extra.GetHashCode());
-                hash *= 31 + Signature.GetHashCode();
+                hash *= 31 + ByteUtil.CalculateHashCode(Signature.ToArray());
                 hash *= 31 + Signer.GetHashCode();
             }
 


### PR DESCRIPTION
Closes #2518.

However, issues remain due to a bug in `Bencodex.Net` implementation. If the `Extra` part is either a `List` or a `Dictionary`, `AppProtocolVersion` will not work as intended.

See https://github.com/planetarium/bencodex.net/issues/72.