### PR TITLE
Fix hangs on .SendMessageAsync() & Release v0.43.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.43.3
 
 To be released.
 
+ - (Libplanet.Net) Fixed a bug where `NetMQTransport.SendMessageAsnyc()` had
+   hung forever when given peer information isn't valid.  [[#2424], [#2521]]
+
+[#2424]: https://github.com/planetarium/libplanet/issues/2424
+[#2521]: https://github.com/planetarium/libplanet/pulls/2521
+
 
 Version 0.43.2
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.43.3
 --------------
 
-To be released.
+Released on November 7, 2022.
 
  - (Libplanet.Net) Fixed a bug where `NetMQTransport.SendMessageAsnyc()` had
    hung forever when given peer information isn't valid.  [[#2424], [#2521]]


### PR DESCRIPTION
This PR fixes freezing on `NetMQTransport.SendMessageAsync()`. (had been reported as #2424)