### PR TITLE
Run `ConsensusReactor` if `consensusOption` is given

### DIFF
--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -74,6 +74,41 @@ namespace Libplanet.Net.Tests
             return (blocks[1].Transactions.First().CustomActions.First().TargetAddress, blocks);
         }
 
+        private Swarm<DumbAction> CreateConsensusSwarm(
+            PrivateKey privateKey = null,
+            AppProtocolVersion? appProtocolVersion = null,
+            string host = null,
+            int? listenPort = null,
+            IEnumerable<IceServer> iceServers = null,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
+            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
+            SwarmOptions options = null,
+            IBlockPolicy<DumbAction> policy = null,
+            Block<DumbAction> genesis = null,
+            ConsensusReactorOption? consensusReactorOption = null)
+        {
+            return CreateSwarm(
+                privateKey,
+                appProtocolVersion,
+                host,
+                listenPort,
+                iceServers,
+                differentAppProtocolVersionEncountered,
+                trustedAppProtocolVersionSigners,
+                options,
+                policy,
+                genesis,
+                consensusReactorOption ?? new ConsensusReactorOption
+            {
+                SeedPeers = ImmutableList<BoundPeer>.Empty,
+                ConsensusPeers = ImmutableList<BoundPeer>.Empty,
+                ConsensusPort = 0,
+                ConsensusPrivateKey = new PrivateKey(),
+                ConsensusWorkers = 100,
+                TargetBlockInterval = TimeSpan.FromSeconds(10),
+            });
+        }
+
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
             AppProtocolVersion? appProtocolVersion = null,
@@ -143,15 +178,7 @@ namespace Libplanet.Net.Tests
                 differentAppProtocolVersionEncountered: differentAppProtocolVersionEncountered,
                 trustedAppProtocolVersionSigners: trustedAppProtocolVersionSigners,
                 options: options,
-                consensusOption: consensusReactorOption ?? new ConsensusReactorOption
-                {
-                    SeedPeers = ImmutableList<BoundPeer>.Empty,
-                    ConsensusPeers = ImmutableList<BoundPeer>.Empty,
-                    ConsensusPort = 0,
-                    ConsensusPrivateKey = new PrivateKey(),
-                    ConsensusWorkers = 100,
-                    TargetBlockInterval = TimeSpan.FromSeconds(10),
-                });
+                consensusOption: consensusReactorOption);
             _finalizers.Add(async () =>
             {
                 try

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -125,6 +125,24 @@ namespace Libplanet.Net.Tests
         }
 
         [Fact(Timeout = Timeout)]
+        public async Task RunConsensusReactorIfOptionGiven()
+        {
+            Swarm<DumbAction> swarmA = CreateSwarm();
+            Swarm<DumbAction> swarmB = CreateConsensusSwarm();
+
+            await StartAsync(swarmA);
+            await StartAsync(swarmB);
+
+            Assert.True(swarmA.Running);
+            Assert.True(swarmB.Running);
+            Assert.False(swarmA.ConsensusRunning);
+            Assert.True(swarmB.ConsensusRunning);
+
+            await StopAsync(swarmA);
+            await StopAsync(swarmB);
+        }
+
+        [Fact(Timeout = Timeout)]
         public async Task StopAsyncTest()
         {
             Swarm<DumbAction> swarm = CreateSwarm();

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -93,6 +93,9 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         public bool Running => _gossip.Running;
 
+        /// <inheritdoc cref="ConsensusContext{T}.Height"/>
+        public long Height => _consensusContext.Height;
+
         /// <summary>
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         /// </summary>

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -415,7 +415,11 @@ namespace Libplanet.Net
                         _cancellationToken
                     )
                 );
-                tasks.Add(_consensusReactor.StartAsync(_cancellationToken));
+                if (_consensusReactor is { })
+                {
+                    tasks.Add(_consensusReactor.StartAsync(_cancellationToken));
+                }
+
                 _logger.Debug("Swarm started.");
 
                 await await Task.WhenAny(tasks);

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -207,6 +207,8 @@ namespace Libplanet.Net
 
         public bool Running => Transport?.Running ?? false;
 
+        public bool ConsensusRunning => _consensusReactor?.Running ?? false;
+
         public DnsEndPoint EndPoint => AsPeer is BoundPeer boundPeer ? boundPeer.EndPoint : null;
 
         public Address Address => _privateKey.ToAddress();


### PR DESCRIPTION
This PR resolves a possible problematic initialization path of `ConsensusReactor` that is `null` when the `consensusOption` is not given.
https://github.com/planetarium/libplanet/blob/845b423f35c477060227866f16eefd676997bf31/Libplanet.Net/Swarm.cs#L129-L157