### PR TITLE
Removed policy controlled parameters from `MineBlock`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,17 @@ To be released.
 
 ### Deprecated APIs
 
+ -  Removed `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset, bool, long,
+    int, int, IComparer<Transaction<T>>, CancellationToken?)` by making
+    it `internal`.  [[#2529]]
+
 ### Backward-incompatible API changes
+
+ -  Changed `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset?, bool?, long?,
+    int?, int?, IComparer<Transaction<T>>, CancellationToken?)` to
+    `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset?, bool?,
+    IComparer<Transaction<T>>, CancellationToken?)` by removing policy
+    controlled parameters.  [[#2529]]
 
 ### Backward-incompatible network protocol changes
 
@@ -35,6 +45,7 @@ To be released.
 
 [#2518]: https://github.com/planetarium/libplanet/issues/2518
 [#2520]: https://github.com/planetarium/libplanet/pull/2520
+[#2529]: https://github.com/planetarium/libplanet/pull/2529
 
 
 Version 0.44.1

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -35,9 +35,7 @@ namespace Libplanet.Tests.Blockchain
         private readonly ILogger _logger;
         private StoreFixture _fx;
         private BlockPolicy<DumbAction> _policy;
-        private BlockPolicy<DumbAction> _policyMinTx;
         private BlockChain<DumbAction> _blockChain;
-        private BlockChain<DumbAction> _blockChainMinTx;
         private ValidatingActionRenderer<DumbAction> _renderer;
         private Block<DumbAction> _validNext;
         private List<Transaction<DumbAction>> _emptyTransactions;
@@ -62,23 +60,11 @@ namespace Libplanet.Tests.Blockchain
             _policy = new BlockPolicy<DumbAction>(
                 blockAction: new MinerReward(1),
                 getMaxTransactionsBytes: _ => 50 * 1024);
-            _policyMinTx = new BlockPolicy<DumbAction>(
-                blockAction: new MinerReward(1),
-                getMaxTransactionsBytes: _ => 50 * 1024,
-                getMinTransactionsPerBlock: _ => 1);
             _stagePolicy = new VolatileStagePolicy<DumbAction>();
             _fx = getStoreFixture(_policy.BlockAction);
             _renderer = new ValidatingActionRenderer<DumbAction>();
             _blockChain = new BlockChain<DumbAction>(
                 _policy,
-                _stagePolicy,
-                _fx.Store,
-                _fx.StateStore,
-                _fx.GenesisBlock,
-                renderers: new[] { new LoggedActionRenderer<DumbAction>(_renderer, Log.Logger) }
-            );
-            _blockChainMinTx = new BlockChain<DumbAction>(
-                _policyMinTx,
                 _stagePolicy,
                 _fx.Store,
                 _fx.StateStore,
@@ -153,7 +139,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void CanFindBlockByIndex()
+        public async Task CanFindBlockByIndex()
         {
             var genesis = _blockChain.Genesis;
             Assert.Equal(genesis, _blockChain[0]);
@@ -163,7 +149,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void CanonicalId()
+        public async Task CanonicalId()
         {
             var x = _blockChain;
             var key = new PrivateKey();
@@ -186,7 +172,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void BlockHashes()
+        public async Task BlockHashes()
         {
             var key = new PrivateKey();
             var genesis = _blockChain.Genesis;
@@ -210,7 +196,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void ProcessActions()
+        public async Task ProcessActions()
         {
             Block<PolymorphicAction<BaseAction>> genesisBlock =
                 BlockChain<PolymorphicAction<BaseAction>>.MakeGenesisBlock();
@@ -469,7 +455,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void FindNextHashes()
+        public async Task FindNextHashes()
         {
             var key = new PrivateKey();
             long? offsetIndex;
@@ -505,7 +491,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void FindNextHashesAfterFork()
+        public async Task FindNextHashesAfterFork()
         {
             var key = new PrivateKey();
 
@@ -525,7 +511,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void Fork()
+        public async Task Fork()
         {
             var key = new PrivateKey();
 
@@ -785,7 +771,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void GetBlockLocator()
+        public async Task GetBlockLocator()
         {
             var key = new PrivateKey();
             List<Block<DumbAction>> blocks = new List<Block<DumbAction>>();
@@ -1240,7 +1226,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void GetStateReturnsValidStateAfterFork()
+        public async Task GetStateReturnsValidStateAfterFork()
         {
             Block<DumbAction> genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock(
                 new[] { new DumbAction(_fx.Address1, "item0.0", idempotent: true) }
@@ -1334,7 +1320,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void GetStateReturnsLatestStatesWhenMultipleAddresses()
+        public async Task GetStateReturnsLatestStatesWhenMultipleAddresses()
         {
             var privateKeys = Enumerable.Range(1, 10).Select(_ => new PrivateKey()).ToList();
             var addresses = privateKeys.Select(AddressExtensions.ToAddress).ToList();
@@ -1375,7 +1361,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void FindBranchPoint()
+        public async Task FindBranchPoint()
         {
             var key = new PrivateKey();
             Block<DumbAction> b1 = await _blockChain.MineBlock(key);
@@ -1663,7 +1649,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        public async void BlockActionWithMultipleAddress()
+        public async Task BlockActionWithMultipleAddress()
         {
             var miner0 = _blockChain.Genesis.Miner;
             var miner1 = new PrivateKey();
@@ -1922,7 +1908,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        private async void TipChanged()
+        private async Task TipChanged()
         {
             var genesis = _blockChain.Genesis;
 
@@ -1948,7 +1934,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
-        private async void Reorged()
+        private async Task Reorged()
         {
             _renderer.ResetRecords();
             var branchpoint = _blockChain.Tip;

--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -31,14 +31,6 @@ namespace Libplanet.Blockchain
         /// <param name="miner">The miner's <see cref="PublicKey"/> that mines the block.</param>
         /// <param name="timestamp">The <see cref="DateTimeOffset"/> when mining started.</param>
         /// <param name="append">Whether to append the mined block immediately after mining.</param>
-        /// <param name="maxTransactionsBytes">The maximum number of bytes a block can have.
-        /// See also <see cref="IBlockPolicy{T}.GetMaxTransactionsBytes(long)"/>.</param>
-        /// <param name="maxTransactions">The maximum number of transactions that a block can
-        /// accept.  See also <see cref="IBlockPolicy{T}.GetMaxTransactionsPerBlock(long)"/>.
-        /// </param>
-        /// <param name="maxTransactionsPerSigner">The maximum number of transactions
-        /// that a block can accept per signer.  See also
-        /// <see cref="IBlockPolicy{T}.GetMaxTransactionsPerSignerPerBlock(long)"/>.</param>
         /// <param name="txPriority">An optional comparer for give certain transactions to
         /// priority to belong to the block.  No certain priority by default.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification
@@ -50,25 +42,17 @@ namespace Libplanet.Blockchain
             PrivateKey miner,
             DateTimeOffset? timestamp = null,
             bool? append = null,
-            long? maxTransactionsBytes = null,
-            int? maxTransactions = null,
-            int? maxTransactionsPerSigner = null,
             IComparer<Transaction<T>> txPriority = null,
             CancellationToken? cancellationToken = null) =>
-#pragma warning disable SA1118
                 await MineBlock(
                     miner: miner,
                     timestamp: timestamp ?? DateTimeOffset.UtcNow,
                     append: append ?? true,
-                    maxTransactionsBytes: maxTransactionsBytes
-                        ?? Policy.GetMaxTransactionsBytes(Count),
-                    maxTransactions: maxTransactions
-                        ?? Policy.GetMaxTransactionsPerBlock(Count),
-                    maxTransactionsPerSigner: maxTransactionsPerSigner
-                        ?? Policy.GetMaxTransactionsPerSignerPerBlock(Count),
+                    maxTransactionsBytes: Policy.GetMaxTransactionsBytes(Count),
+                    maxTransactions: Policy.GetMaxTransactionsPerBlock(Count),
+                    maxTransactionsPerSigner: Policy.GetMaxTransactionsPerSignerPerBlock(Count),
                     txPriority: txPriority,
                     cancellationToken: cancellationToken ?? default);
-#pragma warning restore SA1118
 
         /// <summary>
         /// Mines a next <see cref="Block{T}"/> using staged <see cref="Transaction{T}"/>s.
@@ -91,7 +75,7 @@ namespace Libplanet.Blockchain
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is mined.</returns>
         /// <exception cref="OperationCanceledException">Thrown when
         /// <see cref="BlockChain{T}.Tip"/> is changed while mining.</exception>
-        public async Task<Block<T>> MineBlock(
+        internal async Task<Block<T>> MineBlock(
             PrivateKey miner,
             DateTimeOffset timestamp,
             bool append,


### PR DESCRIPTION
Tried removing policy controlled parameters from `MineBlock()` as these aren't really being used. As far as I know, even [Lib9c] and [9c-headless] aren't affected by this.

[lib9c]: https://github.com/planetarium/lib9c
[9c-headless]: https://github.com/planetarium/NineChronicles.Headless