### PR TITLE
Refactor test fixture

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var tipChanged = new AsyncAutoResetEvent();
             ConsensusProposalMsg? proposal = null;
             var heightTwoProposalSent = new AsyncAutoResetEvent();
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[2]);
@@ -126,7 +126,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var proposalSent = new AsyncAutoResetEvent();
             var newHeightDelay = TimeSpan.FromSeconds(1);
 
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[2]);
@@ -262,7 +262,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var heightTwoProposalSent = new AsyncAutoResetEvent();
             Block<DumbAction>? proposedBlock = null;
 
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[2]);
@@ -304,7 +304,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var timeError = 500;
             var heightOneEndCommit = new AsyncAutoResetEvent();
             var heightTwoProposalSent = new AsyncAutoResetEvent();
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[2]);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         [Fact(Timeout = Timeout)]
         public async void IncreaseRoundWhenTimeout()
         {
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1]);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
@@ -41,7 +42,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             });
             ConsensusProposalMsg? proposal = null;
             var proposalMessageSent = new AsyncAutoResetEvent();
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -97,7 +98,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.PrivateKeys[0].PublicKey, TestUtils.PrivateKeys[1].PublicKey,
             });
 
-            var (_, _, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (_, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -116,7 +117,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.PrivateKeys[0].PublicKey, TestUtils.PrivateKeys[1].PublicKey,
             });
 
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -137,7 +138,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.PrivateKeys[0].PublicKey, TestUtils.PrivateKeys[1].PublicKey,
             });
 
-            var (fx, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -166,7 +167,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var heightTwoEnded = new AsyncAutoResetEvent();
             var heightThreePropose = new AsyncAutoResetEvent();
 
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -272,7 +273,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         [Fact(Timeout = Timeout)]
         public void RemoveOldContexts()
         {
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1],
@@ -319,7 +320,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var heightOneEndCommit = new AsyncAutoResetEvent();
             var votes = new List<Vote>();
 
-            var (fx, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1]);
@@ -349,7 +350,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 TestUtils.PrivateKeys[0],
                 1,
                 0,
-                fx.Block1.Hash,
+                new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
                 VoteFlag.PreCommit));
             votes.AddRange(Enumerable.Range(1, 3).Select(x => TestUtils.CreateVote(
                 TestUtils.PrivateKeys[x],
@@ -387,7 +388,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             var stepChangedToEndCommit = new AsyncAutoResetEvent();
 
-            var (_, blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1]);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
+using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
@@ -35,7 +36,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async Task EnterPreVoteBlockOneThird()
         {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
 
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
@@ -70,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             ConsensusPreCommitMsg? preCommit = null;
             var preCommitSent = new AsyncAutoResetEvent();
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
 
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
@@ -130,17 +131,18 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var stepChangedToPreCommit = new AsyncAutoResetEvent();
             var preCommitSent = new AsyncAutoResetEvent();
 
-            var (fx, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
 
+            var key = new PrivateKey();
             var invalidBlock = new BlockContent<DumbAction>(
                 new BlockMetadata(
                     index: blockChain.Tip.Index + 1,
                     timestamp: DateTimeOffset.UtcNow,
-                    publicKey: fx.Miner.PublicKey,
+                    publicKey: key.PublicKey,
                     previousHash: blockChain.Tip.Hash,
                     txHash: null,
-                    lastCommit: null)).Propose().Evaluate(fx.Miner, blockChain);
+                    lastCommit: null)).Propose().Evaluate(key, blockChain);
 
             context.StateChanged += (_, eventArgs) =>
             {
@@ -186,7 +188,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var timeoutProcessed = false;
             var nilPreVoteSent = new AsyncAutoResetEvent();
 
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
             context.StateChanged += (_, evnetArgs) =>
             {
@@ -234,7 +236,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async Task EnterPreVoteNilOneThird()
         {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
 
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
@@ -271,7 +273,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var stepChangedToPreVote = new AsyncAutoResetEvent();
             var preVoteSent = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext(
+            var (_, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0],
                 contextTimeoutOptions: new ContextTimeoutOption(proposeSecondBase: 1));
 
@@ -300,7 +302,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async Task UponRulesCheckAfterTimeout()
         {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0],
                 contextTimeoutOptions: new ContextTimeoutOption(
                     preVoteSecondBase: 1,
@@ -362,7 +364,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async Task TimeoutPreVote()
         {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0],
                 contextTimeoutOptions: new ContextTimeoutOption(preVoteSecondBase: 1));
 
@@ -398,7 +400,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact(Timeout = Timeout)]
         public async Task TimeoutPreCommit()
         {
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0],
                 contextTimeoutOptions: new ContextTimeoutOption(preCommitSecondBase: 1));
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             ConsensusPreCommitMsg? preCommit = null;
             var preCommitSent = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Step == Step.PreCommit)
@@ -81,7 +81,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             ConsensusPreCommitMsg? preCommit = null;
             var preCommitSent = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Step == Step.PreCommit)
@@ -140,7 +140,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             var roundChangedToOne = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Round == 1)
@@ -177,7 +177,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             ConsensusProposalMsg? proposal = null;
             var proposalSent = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Step == Step.PreCommit)
@@ -229,7 +229,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             var stepChangedToPreVote = new AsyncAutoResetEvent();
             var nilPreVoteSent = new AsyncAutoResetEvent();
-            var (_, _, context) = TestUtils.CreateDummyContext(
+            var (_, context) = TestUtils.CreateDummyContext(
                 height: 5); // Peer1 should be a proposer
 
             context.StateChanged += (_, eventArgs) =>
@@ -262,7 +262,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             ConsensusPreVoteMsg? preVote = null;
             var preVoteSent = new AsyncAutoResetEvent();
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
 
             context.StateChanged += (_, eventArgs) =>
             {
@@ -302,7 +302,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var privateKey = new PrivateKey();
             var exceptionOccurred = new AsyncAutoResetEvent();
             Exception? exception = null;
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[2],
                 height: 2);
             context.ExceptionOccurred += (sender, e) =>

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
+using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
 using Libplanet.Tests.Common.Action;
@@ -40,7 +41,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var stateChangedToRoundTwoPropose = new AsyncAutoResetEvent();
             bool timeoutProcessed = false;
 
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Round == 2 && eventArgs.Step == Step.Propose)
@@ -122,7 +123,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var stateChangedToRoundThreePropose = new AsyncAutoResetEvent();
             var roundThreeNilPreVoteSent = new AsyncAutoResetEvent();
             bool timeoutProcessed = false;
-            var (fx, blockChain, context) = TestUtils.CreateDummyContext();
+            var (blockChain, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Round == 2 && eventArgs.Step == Step.Propose)
@@ -158,17 +159,18 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 }
             };
 
+            var key = new PrivateKey();
             var differentBlock = new BlockContent<DumbAction>(
                 new BlockMetadata(
                     protocolVersion: BlockMetadata.CurrentProtocolVersion,
                     index: blockChain.Tip.Index + 1,
                     timestamp: blockChain.Tip.Timestamp.Add(TimeSpan.FromSeconds(1)),
-                    miner: fx.Miner.PublicKey.ToAddress(),
-                    publicKey: fx.Miner.PublicKey,
+                    miner: key.PublicKey.ToAddress(),
+                    publicKey: key.PublicKey,
                     previousHash: blockChain.Tip.Hash,
                     txHash: null,
                     lastCommit: null))
-                .Propose().Evaluate(fx.Miner, blockChain);
+                .Propose().Evaluate(key, blockChain);
 
             context.Start();
             await proposalSent.WaitAsync();

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             var proposalSent = new AsyncAutoResetEvent();
             var stepChangedToPreVote = new AsyncAutoResetEvent();
-            var (_, _, context) = TestUtils.CreateDummyContext();
+            var (_, context) = TestUtils.CreateDummyContext();
             context.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Step == Step.PreVote)
@@ -71,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             // Assumed that height 1 is already committed.  It will catch a propose to check
             // whether the lastCommit of height 1 is used for propose.  Note that Peer2
             // is the proposer for height 2.
-            var (_, blockChain, context) = TestUtils.CreateDummyContext(
+            var (blockChain, context) = TestUtils.CreateDummyContext(
                 height: 2,
                 privateKey: TestUtils.PrivateKeys[2]);
 
@@ -114,7 +114,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
 
-            var (_, blockChain, context) = TestUtils.CreateDummyContext();
+            var (blockChain, context) = TestUtils.CreateDummyContext();
             context.ExceptionOccurred += (_, e) =>
             {
                 exceptionThrown = e;
@@ -135,7 +135,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();
 
-            var (_, blockChain, context) = TestUtils.CreateDummyContext();
+            var (blockChain, context) = TestUtils.CreateDummyContext();
             context.ExceptionOccurred += (_, e) =>
             {
                 exceptionThrown = e;

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -240,7 +240,6 @@ namespace Libplanet.Net.Tests
                 TimeSpan newHeightDelay,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
-                ValidatorSet? validators = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
                 long lastCommitClearThreshold = 30,
                 ContextTimeoutOption? contextTimeoutOptions = null)
@@ -251,7 +250,6 @@ namespace Libplanet.Net.Tests
             ConsensusContext<DumbAction>? consensusContext = null;
 
             privateKey ??= PrivateKeys[1];
-            validators ??= ValidatorSet;
 
             void BroadcastMessage(ConsensusMsg message) =>
                 Task.Run(() =>
@@ -271,7 +269,7 @@ namespace Libplanet.Net.Tests
                 blockChain,
                 privateKey,
                 newHeightDelay,
-                _ => validators,
+                policy.GetValidatorSet,
                 lastCommitClearThreshold,
                 contextTimeoutOptions ?? new ContextTimeoutOption());
 
@@ -285,13 +283,11 @@ namespace Libplanet.Net.Tests
                 long height = 1,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
-                ValidatorSet? validators = null,
                 ContextTimeoutOption? contextTimeoutOptions = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= PrivateKeys[1];
             policy ??= Policy;
-            validators ??= ValidatorSet;
 
             void BroadcastMessage(ConsensusMsg message) =>
                 Task.Run(() =>
@@ -306,7 +302,6 @@ namespace Libplanet.Net.Tests
                 TimeSpan.FromSeconds(1),
                 policy,
                 PrivateKeys[1],
-                validators,
                 broadcastMessage: BroadcastMessage);
 
             context = new Context<DumbAction>(
@@ -314,7 +309,7 @@ namespace Libplanet.Net.Tests
                 blockChain,
                 height,
                 privateKey,
-                validators,
+                policy.GetValidatorSet(height),
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, context);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -234,7 +234,6 @@ namespace Libplanet.Net.Tests
         }
 
         public static (
-            StoreFixture Fx,
             BlockChain<DumbAction> BlockChain,
             ConsensusContext<DumbAction> ConsensusContext)
             CreateDummyConsensusContext(
@@ -276,11 +275,10 @@ namespace Libplanet.Net.Tests
                 lastCommitClearThreshold,
                 contextTimeoutOptions ?? new ContextTimeoutOption());
 
-            return (fx, blockChain, consensusContext);
+            return (blockChain, consensusContext);
         }
 
         public static (
-            StoreFixture Fx,
             BlockChain<DumbAction> BlockChain,
             Context<DumbAction> Context)
             CreateDummyContext(
@@ -304,7 +302,7 @@ namespace Libplanet.Net.Tests
                     context!.ProduceMessage(message);
                 });
 
-            var (fx, blockChain, consensusContext) = CreateDummyConsensusContext(
+            var (blockChain, consensusContext) = CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 policy,
                 PrivateKeys[1],
@@ -319,7 +317,7 @@ namespace Libplanet.Net.Tests
                 validators,
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
-            return (fx, blockChain, context);
+            return (blockChain, context);
         }
 
         public static ConsensusReactor<DumbAction> CreateDummyConsensusReactor(


### PR DESCRIPTION
Two points.
- Unless necessary, when testing `Context` and/or `ConsensusContext`, there should be no need to access underlying fixtures.
- `ValidatorSet` should be controlled by `BlockPolicy<T>`. Providing additional `ValidatorSet` creates an internally inconsistent structure.