### PR TITLE
Introduce IActionTypeLoader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,15 @@ To be released.
 - Added `BlockChainStates<T>` class.  [[#2507]]
 - Added new constructors of `BlockChain<T>` takes `IBlockChainStates<T>`
   and `ActionEvaluator<T>` directly.  [[#2507]]
+ -  Added non-generic interfaces.  [[#2539]]
+     -  Added `IPreEvaluationBlock` interface.
+     -  Added `IBlockContent` interface.
+     -  Added `ITransaction` interface.
+ -  Added `IActionTypeLoader` interface.  [[#2539]]
+ -  Added `StaticActionTypeLoader` class.  [[#2539]]
 
 [#2507]: https://github.com/planetarium/libplanet/pull/2507
+[#2539]: https://github.com/planetarium/libplanet/pull/2539
 
 ### Behavioral changes
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -244,13 +244,13 @@ namespace Libplanet.Tests.Action
 
             // ToList() is required for realization.
             chain.ActionEvaluator.EvaluateTx(
-                block: block,
+                blockHeader: block,
                 tx: tx,
                 previousStates: previousStates,
                 rehearsal: true).ToList();
             Assert.Throws<OutOfMemoryException>(
                 () => chain.ActionEvaluator.EvaluateTx(
-                    block: block,
+                    blockHeader: block,
                     tx: tx,
                     previousStates: previousStates,
                     rehearsal: false).ToList());
@@ -315,7 +315,7 @@ namespace Libplanet.Tests.Action
                 ActionEvaluator<DumbAction>.NullTotalSupplyGetter,
                 genesis.Miner);
             Assert.Empty(
-                actionEvaluator.EvaluateTxs(
+                actionEvaluator.EvaluateBlock(
                     block: genesis,
                     previousStates: previousStates));
 
@@ -362,7 +362,7 @@ namespace Libplanet.Tests.Action
                 ActionEvaluator<DumbAction>.NullAccountBalanceGetter,
                 ActionEvaluator<DumbAction>.NullTotalSupplyGetter,
                 block1.Miner);
-            var evals = actionEvaluator.EvaluateTxs(
+            var evals = actionEvaluator.EvaluateBlock(
                 block1,
                 previousStates).ToImmutableArray();
             int randomValue = 0;
@@ -489,7 +489,7 @@ namespace Libplanet.Tests.Action
                 accountBalanceGetter,
                 totalSupplyGetter,
                 block2.Miner);
-            evals = actionEvaluator.EvaluateTxs(
+            evals = actionEvaluator.EvaluateBlock(
                 block2,
                 previousStates).ToImmutableArray();
 
@@ -606,7 +606,7 @@ namespace Libplanet.Tests.Action
                 DumbAction.RehearsalRecords.Value =
                     ImmutableList<(Address, string)>.Empty;
                 var evaluations = actionEvaluator.EvaluateTx(
-                    block: block,
+                    blockHeader: block,
                     tx: tx,
                     previousStates: new AccountStateDeltaImpl(
                         ActionEvaluator<DumbAction>.NullAccountStateGetter,
@@ -685,15 +685,16 @@ namespace Libplanet.Tests.Action
 
                 DumbAction.RehearsalRecords.Value =
                     ImmutableList<(Address, string)>.Empty;
-                IAccountStateDelta delta = actionEvaluator.EvaluateTxResult(
-                    block: block,
+                IAccountStateDelta delta = actionEvaluator.EvaluateTx(
+                    blockHeader: block,
                     tx: tx,
                     previousStates: new AccountStateDeltaImpl(
                         ActionEvaluator<DumbAction>.NullAccountStateGetter,
                         ActionEvaluator<DumbAction>.NullAccountBalanceGetter,
                         ActionEvaluator<DumbAction>.NullTotalSupplyGetter,
                         tx.Signer),
-                    rehearsal: rehearsal);
+                    rehearsal: rehearsal
+                ).Last().OutputStates;
                 Assert.Equal(
                     evaluations[3].OutputStates.GetUpdatedStates(),
                     delta.GetUpdatedStates());
@@ -742,15 +743,16 @@ namespace Libplanet.Tests.Action
                     previousHash: default(BlockHash),
                     txHash: BlockContent<ThrowException>.DeriveTxHash(txs)),
                 transactions: txs).Mine();
-            var nextStates = actionEvaluator.EvaluateTxResult(
-                block: block,
+            var nextStates = actionEvaluator.EvaluateTx(
+                blockHeader: block,
                 tx: tx,
                 previousStates: new AccountStateDeltaImpl(
                     ActionEvaluator<DumbAction>.NullAccountStateGetter,
                     ActionEvaluator<DumbAction>.NullAccountBalanceGetter,
                     ActionEvaluator<DumbAction>.NullTotalSupplyGetter,
                     tx.Signer),
-                rehearsal: false);
+                rehearsal: false
+            ).Last().OutputStates;
 
             Assert.Empty(nextStates.GetUpdatedStates());
         }
@@ -959,7 +961,7 @@ namespace Libplanet.Tests.Action
                 ActionEvaluator<DumbAction>.NullAccountBalanceGetter,
                 ActionEvaluator<DumbAction>.NullTotalSupplyGetter,
                 block.Miner);
-            var txEvaluations = chain.ActionEvaluator.EvaluateTxs(
+            var txEvaluations = chain.ActionEvaluator.EvaluateBlock(
                 block,
                 previousStates).ToList();
             previousStates = txEvaluations.Last().OutputStates;

--- a/Libplanet.Tests/Action/StaticActionTypeLoaderTest.cs
+++ b/Libplanet.Tests/Action/StaticActionTypeLoaderTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Tests.Common.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Action
+{
+    public class StaticActionTypeLoaderTest
+    {
+        [Fact]
+        public void Load()
+        {
+            var actionTypeLoader = new StaticActionTypeLoader(
+                new[] { typeof(Attack).Assembly },
+                typeof(BaseAction)
+            );
+
+            Assert.Equal(
+                new Dictionary<string, Type>
+                {
+                    ["attack"] = typeof(Attack),
+                    ["sleep"] = typeof(Sleep),
+                    ["detect_rehearsal"] = typeof(DetectRehearsal),
+                    ["TextPlainValueAction"] =
+                        Type.GetType("Libplanet.Tests.Action."
+                                     + "PolymorphicActionTest+TextPlainValueAction"),
+                }, actionTypeLoader.Load());
+        }
+
+        [Fact]
+        public void DuplicateIds()
+        {
+            var actionTypeLoader = new StaticActionTypeLoader(
+                new[] { typeof(Attack).Assembly }
+            );
+
+            Assert.Throws<DuplicateActionTypeIdentifierException>(() => actionTypeLoader.Load());
+        }
+    }
+}

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Action
         /// </summary>
         /// <param name="policyBlockAction">The <see cref="IAction"/> provided by
         /// <see cref="IBlockPolicy{T}.BlockAction"/> to evaluate at the end for each
-        /// <see cref="Block{T}"/> that gets evaluated.</param>
+        /// <see cref="IPreEvaluationBlock"/> that gets evaluated.</param>
         /// <param name="blockChainStates">The <see cref="IBlockChainStates{T}"/> to use to retrieve
         /// the states for a provided <see cref="Address"/>.</param>
         /// <param name="trieGetter">The function to retrieve a trie for
@@ -85,7 +85,7 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// The main entry point for evaluating a <see cref="Block{T}"/>.
+        /// The main entry point for evaluating a <see cref="IPreEvaluationBlock"/>.
         /// </summary>
         /// <param name="block">The block to evaluate.</param>
         /// <param name="stateCompleterSet">The <see cref="StateCompleterSet{T}"/> to use.</param>
@@ -94,13 +94,14 @@ namespace Libplanet.Action
         /// <see cref="ActionEvaluation"/>s.</returns>
         /// <remarks>
         /// <para>Publicly exposed for benchmarking.</para>
-        /// <para>First evaluates all <see cref="IAction"/>s in <see cref="Block{T}.Transactions"/>
-        /// of <paramref name="block"/> and appends the evaluation of
-        /// the <see cref="IBlockPolicy{T}.BlockAction"/> held by the instance at the end.</para>
+        /// <para>First evaluates all <see cref="IAction"/>s in
+        /// <see cref="IBlockContent.Transactions"/> of <paramref name="block"/> and appends the
+        /// evaluation of the <see cref="IBlockPolicy{T}.BlockAction"/> held by the instance at
+        /// the end.</para>
         /// </remarks>
         [Pure]
         public IReadOnlyList<ActionEvaluation> Evaluate(
-            IPreEvaluationBlock<T> block,
+            IPreEvaluationBlock block,
             StateCompleterSet<T> stateCompleterSet)
         {
             _logger.Debug(
@@ -236,19 +237,20 @@ namespace Libplanet.Action
         /// </summary>
         /// <param name="genesisHash"> A <see cref="BlockHash"/> value of the genesis block.
         /// </param>
-        /// <param name="preEvaluationHash">The <see cref="Block{T}.PreEvaluationHash"/> of
-        /// the <see cref="Block{T}"/> that <paramref name="actions"/> belong to.</param>
+        /// <param name="preEvaluationHash">The
+        /// <see cref="IPreEvaluationBlockHeader.PreEvaluationHash"/> of
+        /// the <see cref="IPreEvaluationBlock"/> that <paramref name="actions"/> belong to.</param>
         /// <param name="blockIndex">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
         /// that <paramref name="actions"/> belong to.</param>
-        /// <param name="txid">The <see cref="Transaction{T}.Id"/> of the
-        /// <see cref="Transaction{T}"/> that <paramref name="actions"/> belong to.
+        /// <param name="txid">The <see cref="ITxExcerpt.Id"/> of the
+        /// <see cref="ITransaction"/> that <paramref name="actions"/> belong to.
         /// This can be <see langword="null"/> on rehearsal mode or if an <see cref="IAction"/> is a
         /// <see cref="IBlockPolicy{T}.BlockAction"/>.</param>
         /// <param name="previousStates">The states immediately before <paramref name="actions"/>
         /// being executed.</param>
         /// <param name="miner">An address of block miner.</param>
         /// <param name="signer">Signer of the <paramref name="actions"/>.</param>
-        /// <param name="signature"><see cref="Transaction{T}"/> signature used to generate random
+        /// <param name="signature"><see cref="ITransaction"/> signature used to generate random
         /// seeds.</param>
         /// <param name="actions">Actions to evaluate.</param>
         /// <param name="nativeTokenPredicate">A predicate function to determine whether
@@ -432,18 +434,19 @@ namespace Libplanet.Action
         /// Deterministically shuffles <paramref name="txs"/> for evaluation using
         /// <paramref name="preEvaluationHash"/> as a random seed.
         /// </summary>
-        /// <param name="protocolVersion">The <see cref="Block{T}.ProtocolVersion"/> that
-        /// <paramref name="txs"/> belong to.</param>
-        /// <param name="txs">The list of <see cref="Transaction{T}"/>s to shuffle.</param>
-        /// <param name="preEvaluationHash">The <see cref="Block{T}.PreEvaluationHash"/> to use
-        /// as a random seed when shuffling.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Transaction{T}"/>s in evaluation
+        /// <param name="protocolVersion">The <see cref="IBlockMetadata.ProtocolVersion"/>
+        /// that <paramref name="txs"/> belong to.</param>
+        /// <param name="txs">The list of <see cref="ITransaction"/>s to shuffle.</param>
+        /// <param name="preEvaluationHash">The
+        /// <see cref="IPreEvaluationBlockHeader.PreEvaluationHash"/> to use as a random seed when
+        /// shuffling.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ITransaction"/>s in evaluation
         /// order with the following properties:
         /// <list type="bullet">
-        /// <item><see cref="Transaction{T}"/>s with the same <see cref="Transaction{T}.Signer"/>
+        /// <item><see cref="ITransaction"/>s with the same <see cref="ITxMetadata.Signer"/>
         /// value appear consecutive in the list.</item>
-        /// <item><see cref="Transaction{T}"/>s with the same <see cref="Transaction{T}.Signer"/>
-        /// value are ordered by <see cref="Transaction{T}.Nonce"/> value in ascending order.</item>
+        /// <item><see cref="ITransaction"/>s with the same <see cref="ITxMetadata.Signer"/>
+        /// value are ordered by <see cref="ITxMetadata.Nonce"/> value in ascending order.</item>
         /// </list>
         /// </returns>
         /// <remarks>
@@ -461,8 +464,8 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// Evaluates <see cref="IAction"/>s in <see cref="IBlockContent{T}.Transactions"/>
-        /// of a given <see cref="Block{T}"/>.
+        /// Evaluates <see cref="IAction"/>s in <see cref="IBlockContent.Transactions"/>
+        /// of a given <see cref="IPreEvaluationBlock"/>.
         /// </summary>
         /// <param name="block">The block to evaluate.</param>
         /// <param name="previousStates">The states immediately before an execution of any
@@ -474,7 +477,7 @@ namespace Libplanet.Action
         /// </returns>
         [Pure]
         internal IEnumerable<ActionEvaluation> EvaluateBlock(
-            IPreEvaluationBlock<T> block,
+            IPreEvaluationBlock block,
             IAccountStateDelta previousStates,
             ITrie? previousBlockStatesTrie = null)
         {
@@ -566,7 +569,7 @@ namespace Libplanet.Action
         /// <summary>
         /// Evaluates the <see cref="IBlockPolicy{T}.BlockAction"/> set by the policy when
         /// this <see cref="ActionEvaluator{T}"/> was instantiated for a given
-        /// <see cref="Block{T}"/>.
+        /// <see cref="IPreEvaluationBlockHeader"/>.
         /// </summary>
         /// <param name="blockHeader">The header of the block to evaluate.</param>
         /// <param name="previousStates">The states immediately before the evaluation of
@@ -671,23 +674,24 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// Retrieves the last previous states for the previous block of <paramref name="block"/>.
+        /// Retrieves the last previous states for the previous block of
+        /// <paramref name="blockHeader"/>.
         /// </summary>
-        /// <param name="block">The block to reference.</param>
+        /// <param name="blockHeader">The header of block to reference.</param>
         /// <param name="stateCompleterSet">The <see cref="StateCompleterSet{T}"/> to use.</param>
         /// <returns>The last previous <see cref="IAccountStateDelta"/> for the previous
         /// <see cref="Block{T}"/>.
         /// </returns>
         private IAccountStateDelta GetPreviousBlockOutputStates(
-            IPreEvaluationBlockHeader block,
+            IPreEvaluationBlockHeader blockHeader,
             StateCompleterSet<T> stateCompleterSet)
         {
             var (accountStateGetter, accountBalanceGetter, totalSupplyGetter) =
-                InitializeAccountGettersPair(block, stateCompleterSet);
-            Address miner = block.Miner;
+                InitializeAccountGettersPair(blockHeader, stateCompleterSet);
+            Address miner = blockHeader.Miner;
 
             return AccountStateDeltaImpl.ChooseVersion(
-                block.ProtocolVersion,
+                blockHeader.ProtocolVersion,
                 accountStateGetter,
                 accountBalanceGetter,
                 totalSupplyGetter,

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -65,7 +65,8 @@ namespace Libplanet.Action
             new StaticActionTypeLoader(
                 Assembly.GetEntryAssembly() is Assembly entryAssembly
                     ? new[] { typeof(T).Assembly, entryAssembly }
-                    : new[] { typeof(T).Assembly }
+                    : new[] { typeof(T).Assembly },
+                typeof(T)
             )
         )
         {

--- a/Libplanet/Action/IActionTypeLoader.cs
+++ b/Libplanet/Action/IActionTypeLoader.cs
@@ -4,8 +4,17 @@ using Libplanet.Blocks;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// An interface to load action types branched by block index.
+    /// </summary>
     public interface IActionTypeLoader
     {
+        /// <summary>
+        /// Load action types branched by <paramref name="blockHeader"/>.
+        /// </summary>
+        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
+        /// use.</param>
+        /// <returns>A dictionary made of action id to action type pairs.</returns>
         public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader);
     }
 }

--- a/Libplanet/Action/IActionTypeLoader.cs
+++ b/Libplanet/Action/IActionTypeLoader.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Blocks;
+
+namespace Libplanet.Action
+{
+    public interface IActionTypeLoader
+    {
+        public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader);
+    }
+}

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -158,14 +158,9 @@ namespace Libplanet.Action
                 typeof(T)
             );
 
-        private static readonly IDictionary<string, Type> _types;
+        private static IDictionary<string, Type> _types;
 
         private T _innerAction;
-
-        static PolymorphicAction()
-        {
-            _types = _actionTypeLoader.Load();
-        }
 
         /// <summary>
         /// Do not use this constructor.
@@ -241,7 +236,7 @@ namespace Libplanet.Action
         public void LoadPlainValue(Dictionary plainValue)
         {
             var typeStr = (Text)plainValue["type_id"];
-            var innerAction = (T)Activator.CreateInstance(_types[typeStr]);
+            var innerAction = (T)Activator.CreateInstance(GetType(typeStr));
             innerAction.LoadPlainValue(plainValue["values"]);
             InnerAction = innerAction;
         }
@@ -261,6 +256,12 @@ namespace Libplanet.Action
             const string polymorphicActionFullName = nameof(Libplanet) + "." + nameof(Action) +
                                                      "." + nameof(PolymorphicAction<T>);
             return $"{polymorphicActionFullName}<{_innerAction}>";
+        }
+
+        private static Type GetType(string typeId)
+        {
+            _types ??= _actionTypeLoader.Load();
+            return _types[typeId];
         }
     }
 }

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -154,7 +154,8 @@ namespace Libplanet.Action
             new StaticActionTypeLoader(
                 Assembly.GetEntryAssembly() is Assembly entryAssembly
                     ? new[] { typeof(T).Assembly, entryAssembly }
-                    : new[] { typeof(T).Assembly }
+                    : new[] { typeof(T).Assembly },
+                typeof(T)
             );
 
         private static readonly IDictionary<string, Type> _types;

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using Libplanet.Blocks;
+
+namespace Libplanet.Action
+{
+    public class StaticActionTypeLoader : IActionTypeLoader
+    {
+        private readonly Dictionary<string, Type> _types;
+
+        public StaticActionTypeLoader(IEnumerable<Assembly> assemblies)
+        {
+            var assembliesSet = assemblies.ToImmutableHashSet();
+            var actionType = typeof(IAction);
+            _types = new Dictionary<string, Type>();
+            foreach (Assembly asm in assembliesSet)
+            {
+                foreach (Type t in asm.GetTypes())
+                {
+                    if (actionType.IsAssignableFrom(t) &&
+                        ActionTypeAttribute.ValueOf(t) is string actionId)
+                    {
+                        _types[actionId] = t;
+                    }
+                }
+            }
+        }
+
+        public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader) => _types;
+    }
+}

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -29,5 +29,7 @@ namespace Libplanet.Action
         }
 
         public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader) => _types;
+
+        internal IDictionary<string, Type> Load() => _types;
     }
 }

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -27,6 +27,20 @@ namespace Libplanet.Action
                     if (actionType.IsAssignableFrom(t) &&
                         ActionTypeAttribute.ValueOf(t) is string actionId)
                     {
+                        if (_types.TryGetValue(actionId, out Type? existing))
+                        {
+                            if (existing != t)
+                            {
+                                throw new DuplicateActionTypeIdentifierException(
+                                    "Multiple action types are associated with the same type ID.",
+                                    actionId,
+                                    ImmutableHashSet.Create(existing, t)
+                                );
+                            }
+
+                            continue;
+                        }
+
                         _types[actionId] = t;
                     }
                 }

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -6,6 +6,10 @@ using Libplanet.Blocks;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// An <see cref="IActionTypeLoader"/> implementation to load action types
+    /// without branching by block index.
+    /// </summary>
     public class StaticActionTypeLoader : IActionTypeLoader
     {
         private readonly Type? _baseType;
@@ -13,6 +17,11 @@ namespace Libplanet.Action
 
         private IDictionary<string, Type>? _types;
 
+        /// <summary>
+        /// Creates a new <see cref="StaticActionTypeLoader"/> instance.
+        /// </summary>
+        /// <param name="assemblies">The assemblies to load actions from.</param>
+        /// <param name="baseType">The base type of actions to load.</param>
         public StaticActionTypeLoader(IEnumerable<Assembly> assemblies, Type? baseType = null)
         {
             _baseType = baseType;
@@ -20,6 +29,12 @@ namespace Libplanet.Action
             _types = null;
         }
 
+        /// <summary>
+        /// Load action types from assemblies.
+        /// </summary>
+        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
+        /// use. But it isn't used in this implementation.</param>
+        /// <returns>A dictionary made of action id to action type pairs.</returns>
         public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader) => Load();
 
         internal IDictionary<string, Type> Load() =>

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Action
     {
         private readonly Dictionary<string, Type> _types;
 
-        public StaticActionTypeLoader(IEnumerable<Assembly> assemblies)
+        public StaticActionTypeLoader(IEnumerable<Assembly> assemblies, Type? baseType = null)
         {
             var assembliesSet = assemblies.ToImmutableHashSet();
             var actionType = typeof(IAction);
@@ -19,6 +19,11 @@ namespace Libplanet.Action
             {
                 foreach (Type t in asm.GetTypes())
                 {
+                    if (baseType is { } bt && !bt.IsAssignableFrom(t))
+                    {
+                        continue;
+                    }
+
                     if (actionType.IsAssignableFrom(t) &&
                         ActionTypeAttribute.ValueOf(t) is string actionId)
                     {

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -159,7 +159,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                     header.ProtocolVersion,
                     transactions,
                     header.PreEvaluationHash
-                );
+                ).Cast<Transaction<T>>();
 
                 expectedUnrenderedActions.AddRange(
                     transactions.SelectMany(t =>
@@ -184,7 +184,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                     header.ProtocolVersion,
                     transactions,
                     header.PreEvaluationHash
-                );
+                ).Cast<Transaction<T>>();
                 IEnumerable<IAction> actions = transactions.SelectMany(t =>
                     t.SystemAction is { } sa ? new[] { sa } : t.CustomActions!.Cast<IAction>()
                 );

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -15,7 +15,11 @@ namespace Libplanet.Blocks
     /// </summary>
     /// <typeparam name="T">A class implementing <see cref="IAction"/> to include.  This type
     /// parameter is aligned with <see cref="Transaction{T}"/>'s type parameter.</typeparam>
-    public sealed class Block<T> : IPreEvaluationBlock<T>, IBlockHeader, IEquatable<Block<T>>
+    public sealed class Block<T> :
+        IPreEvaluationBlock<T>,
+        IPreEvaluationBlock,
+        IBlockHeader,
+        IEquatable<Block<T>>
         where T : IAction, new()
     {
         /// <summary>
@@ -140,6 +144,10 @@ namespace Libplanet.Blocks
 
         /// <inheritdoc cref="IBlockContent{T}.Transactions"/>
         public IReadOnlyList<Transaction<T>> Transactions => _preEvaluationBlock.Transactions;
+
+        /// <inheritdoc cref="IBlockContent.Transactions"/>
+        IImmutableSet<ITransaction> IBlockContent.Transactions =>
+            ((IPreEvaluationBlock)_preEvaluationBlock).Transactions;
 
         /// <summary>
         /// Equivalent to <see cref="IEquatable{T}.Equals(T)"/>.

--- a/Libplanet/Blocks/IBlockContent.cs
+++ b/Libplanet/Blocks/IBlockContent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Tx;
 
@@ -19,5 +20,13 @@ namespace Libplanet.Blocks
         /// <remarks>This is always ordered by <see cref="Transaction{T}.Id"/>.</remarks>
         // FIXME: Need to change the type to IImmutableSet<Transaction<T>>.
         IReadOnlyList<Transaction<T>> Transactions { get; }
+    }
+
+    public interface IBlockContent : IBlockMetadata
+    {
+        /// <summary>
+        /// Transactions belonging to the block.
+        /// </summary>
+        IImmutableSet<ITransaction> Transactions { get; }
     }
 }

--- a/Libplanet/Blocks/IBlockContent.cs
+++ b/Libplanet/Blocks/IBlockContent.cs
@@ -11,6 +11,7 @@ namespace Libplanet.Blocks
     /// </summary>
     /// <typeparam name="T">A class implementing <see cref="IAction"/> to include.  This type
     /// parameter is aligned with <see cref="Transaction{T}"/>'s type parameter.</typeparam>
+    // This interface will be replaced with `IBlockContent`, non-generic, in the future.
     public interface IBlockContent<T> : IBlockMetadata
         where T : IAction, new()
     {

--- a/Libplanet/Blocks/IBlockContent.cs
+++ b/Libplanet/Blocks/IBlockContent.cs
@@ -22,6 +22,14 @@ namespace Libplanet.Blocks
         IReadOnlyList<Transaction<T>> Transactions { get; }
     }
 
+    /// <summary>
+    /// A common interface for blocks that do not have any proofs, but have their metadata and
+    /// containing <see cref="Transactions"/>.
+    /// </summary>
+    /// <remarks>This is always ordered by <see cref="Transaction{T}.Id"/>.</remarks>
+    /// <remarks>It is similar with <see cref="IBlockContent{T}"/> but
+    /// it is non-generic interface. It means that it doesn't check the action types
+    /// in serialization.</remarks>
     public interface IBlockContent : IBlockMetadata
     {
         /// <summary>

--- a/Libplanet/Blocks/IPreEvaluationBlock.cs
+++ b/Libplanet/Blocks/IPreEvaluationBlock.cs
@@ -15,4 +15,8 @@ namespace Libplanet.Blocks
         where T : IAction, new()
     {
     }
+
+    public interface IPreEvaluationBlock : IBlockContent, IPreEvaluationBlockHeader
+    {
+    }
 }

--- a/Libplanet/Blocks/IPreEvaluationBlock.cs
+++ b/Libplanet/Blocks/IPreEvaluationBlock.cs
@@ -16,6 +16,15 @@ namespace Libplanet.Blocks
     {
     }
 
+    /// <summary>
+    /// A common interface for blocks that have their proof-of-work
+    /// <see cref="IPreEvaluationBlockHeader.Nonce"/>s and
+    /// <see cref="IBlockContent.Transactions"/>, but are not evaluated yet (i.e., their state
+    /// root hashes are not yet determined).
+    /// </summary>
+    /// <remarks>It is similar with <see cref="IPreEvaluationBlock{T}"/> but
+    /// it is non-generic interface. It means that it doesn't check the action types
+    /// in serialization.</remarks>
     public interface IPreEvaluationBlock : IBlockContent, IPreEvaluationBlockHeader
     {
     }

--- a/Libplanet/Blocks/IPreEvaluationBlock.cs
+++ b/Libplanet/Blocks/IPreEvaluationBlock.cs
@@ -11,6 +11,7 @@ namespace Libplanet.Blocks
     /// </summary>
     /// <typeparam name="T">A class implementing <see cref="IAction"/> to include.  This type
     /// parameter is aligned with <see cref="Transaction{T}"/>'s type parameter.</typeparam>
+    // This interface will be replaced with `IPreEvaluationBlock`, non-generic, in the future.
     public interface IPreEvaluationBlock<T> : IBlockContent<T>, IPreEvaluationBlockHeader
         where T : IAction, new()
     {

--- a/Libplanet/Blocks/PreEvaluationBlock.cs
+++ b/Libplanet/Blocks/PreEvaluationBlock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
 using Bencodex.Types;
@@ -26,7 +27,7 @@ namespace Libplanet.Blocks
     /// <remarks>It guarantees that every instance of this type has a valid proof-of-work
     /// <see cref="Nonce"/> which satisfies its <see cref="PreEvaluationBlockHeader.Difficulty"/>.
     /// </remarks>
-    public sealed class PreEvaluationBlock<T> : IPreEvaluationBlock<T>
+    public sealed class PreEvaluationBlock<T> : IPreEvaluationBlock<T>, IPreEvaluationBlock
         where T : IAction, new()
     {
         private BlockContent<T> _content;
@@ -71,6 +72,10 @@ namespace Libplanet.Blocks
 
         /// <inheritdoc cref="IBlockContent{T}.Transactions"/>
         public IReadOnlyList<Transaction<T>> Transactions => _content.Transactions;
+
+        /// <inheritdoc cref="IBlockContent.Transactions" />
+        IImmutableSet<ITransaction> IBlockContent.Transactions =>
+            _content.Transactions.Cast<ITransaction>().ToImmutableHashSet();
 
         /// <inheritdoc cref="IBlockMetadata.ProtocolVersion"/>
         public int ProtocolVersion => _header.ProtocolVersion;

--- a/Libplanet/Tx/ITransaction.cs
+++ b/Libplanet/Tx/ITransaction.cs
@@ -1,0 +1,14 @@
+using System.Collections.Immutable;
+using Bencodex.Types;
+
+namespace Libplanet.Tx
+{
+    public interface ITransaction : ITxExcerpt
+    {
+        public byte[] Signature { get; }
+
+        public Dictionary? SystemAction { get; }
+
+        public IImmutableList<IValue>? CustomActions { get; }
+    }
+}

--- a/Libplanet/Tx/ITransaction.cs
+++ b/Libplanet/Tx/ITransaction.cs
@@ -1,14 +1,35 @@
 using System.Collections.Immutable;
 using Bencodex.Types;
+using Libplanet.Action;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// Similar to <see cref="ITxExcerpt"/> except that it has <see cref="Signature"/>,
+    /// <see cref="SystemAction"/> and <see cref="CustomActions"/> as well.
+    /// </summary>
     public interface ITransaction : ITxExcerpt
     {
+        /// <summary>
+        /// A digital signature of the content of this <see cref="ITransaction"/>.
+        /// </summary>
         public byte[] Signature { get; }
 
+        /// <summary>
+        /// A system action (if any) that this <see cref="ITransaction"/> contains.
+        /// </summary>
+        /// <remarks>It is similar with <see cref="Transaction{T}.SystemAction"/> but
+        /// it is non-generic.  (i.e., it doesn't require to deserialize the system action to
+        /// <see cref="IAction"/> while serialization.</remarks>
         public Dictionary? SystemAction { get; }
 
+        /// <summary>
+        /// Zero or more user-defined custom actions that this <see cref="ITransaction"/>
+        /// contains.
+        /// </summary>
+        /// <remarks>It is similar with <see cref="Transaction{T}.CustomActions"/> but
+        /// it is non-generic.  (i.e., it doesn't require to deserialize the custom actions to
+        /// <see cref="IAction"/> while serialization.</remarks>
         public IImmutableList<IValue>? CustomActions { get; }
     }
 }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Tx
     /// </typeparam>
     /// <seealso cref="IAction"/>
     /// <seealso cref="PolymorphicAction{T}"/>
-    public sealed class Transaction<T> : IEquatable<Transaction<T>>, ITxExcerpt
+    public sealed class Transaction<T> : IEquatable<Transaction<T>>, ITransaction
         where T : IAction, new()
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
@@ -263,6 +263,14 @@ namespace Libplanet.Tx
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(ActionListJsonConverter))]
         public IImmutableList<T>? CustomActions { get; }
+
+        Dictionary? ITransaction.SystemAction => (SystemAction is { } sa)
+            ? (Dictionary)sa.PlainValue
+            : null;
+
+        IImmutableList<IValue>? ITransaction.CustomActions => (CustomActions is { } cs)
+            ? cs.Select(ca => ca.PlainValue).ToImmutableList()
+            : null;
 
         /// <inheritdoc cref="ITxMetadata.Timestamp"/>
         public DateTimeOffset Timestamp => _metadata.Timestamp;

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -36,6 +36,10 @@ namespace Libplanet.Tx
 
         private static readonly Codec Codec = new Codec();
 
+        private readonly IImmutableList<IValue>? _customActions;
+
+        private readonly Dictionary? _systemAction;
+
         private TxId? _id;
         private TxMetadata _metadata;
         private byte[] _signature;
@@ -55,7 +59,7 @@ namespace Libplanet.Tx
         public Transaction(ITxMetadata metadata, IAction systemAction, byte[] signature)
         {
             _metadata = new TxMetadata(metadata);
-            SystemAction = systemAction;
+            _systemAction = Registry.Serialize(systemAction);
             _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
         }
@@ -75,7 +79,7 @@ namespace Libplanet.Tx
         public Transaction(ITxMetadata metadata, IEnumerable<T> customActions, byte[] signature)
         {
             _metadata = new TxMetadata(metadata);
-            CustomActions = customActions.ToImmutableList();
+            _customActions = customActions.Select(ca => ca.PlainValue).ToImmutableList();
             _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
         }
@@ -144,7 +148,8 @@ namespace Libplanet.Tx
 
             _signature = new byte[signature.Length];
             signature.CopyTo(_signature, 0);
-            CustomActions = customActions.ToImmutableList();
+            _customActions = customActions.Select(ca => ca.PlainValue)
+                .ToImmutableList();
         }
 
         /// <summary>
@@ -158,12 +163,11 @@ namespace Libplanet.Tx
             _metadata = new TxMetadata(dict);
             if (dict.TryGetValue(new Binary(TxMetadata.SystemActionKey), out IValue sa))
             {
-                SystemAction = Registry.Deserialize((Dictionary)sa);
+                _systemAction = (Dictionary)sa;
             }
             else
             {
-                CustomActions = dict.GetValue<List>(TxMetadata.CustomActionsKey)
-                    .Select(ToAction)
+                _customActions = dict.GetValue<List>(TxMetadata.CustomActionsKey)
                     .ToImmutableList();
             }
 
@@ -251,7 +255,9 @@ namespace Libplanet.Tx
         /// <see langword="null"/>.</remarks>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(SysActionJsonConverter))]
-        public IAction? SystemAction { get; }
+        public IAction? SystemAction => (_systemAction is { } sa)
+            ? Registry.Deserialize(sa)
+            : null;
 
         /// <summary>
         /// Zero or more user-defined custom actions that this <see cref="Transaction{T}"/>
@@ -262,15 +268,15 @@ namespace Libplanet.Tx
         /// <see langword="null"/>.</remarks>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(ActionListJsonConverter))]
-        public IImmutableList<T>? CustomActions { get; }
+        public IImmutableList<T>? CustomActions => _customActions?
+            .Select(ToAction)
+            .ToImmutableList();
 
-        Dictionary? ITransaction.SystemAction => (SystemAction is { } sa)
-            ? (Dictionary)sa.PlainValue
+        Dictionary? ITransaction.SystemAction => _systemAction is Dictionary dictionary
+            ? dictionary
             : null;
 
-        IImmutableList<IValue>? ITransaction.CustomActions => (CustomActions is { } cs)
-            ? cs.Select(ca => ca.PlainValue).ToImmutableList()
-            : null;
+        IImmutableList<IValue>? ITransaction.CustomActions => _customActions;
 
         /// <inheritdoc cref="ITxMetadata.Timestamp"/>
         public DateTimeOffset Timestamp => _metadata.Timestamp;
@@ -680,13 +686,17 @@ namespace Libplanet.Tx
         /// representation of this <see cref="Transaction{T}"/>.</returns>
         public Bencodex.Types.Dictionary ToBencodex(bool sign)
         {
-            Dictionary metadataDict = SystemAction is { } sa
+            Dictionary metadataDict = _systemAction is { } sa
                 ? _metadata.ToBencodex().Add(
                     TxMetadata.SystemActionKey,
-                    Registry.Serialize(sa))
+                    sa)
                 : _metadata.ToBencodex().Add(
                     TxMetadata.CustomActionsKey,
-                    new List(CustomActions!.Select(a => a.PlainValue)));
+                    new List(
+                        _customActions
+                        ?? throw new InvalidOperationException(
+                            $"Unexpected Transaction<T> state. " +
+                            $"{nameof(_systemAction)} or {nameof(_customActions)} should exist.")));
             return sign
                 ? metadataDict.Add(TxMetadata.SignatureKey, ImmutableArray.Create(_signature))
                 : metadataDict;


### PR DESCRIPTION
(I'll leaving content Korean during drafting, it will be translated later)

# 작업 내용

1. `Transaction<T>`, `Block<T>`에서 T제거 
2. `ActionEvaluator<T>`의 `EvaluateTxs()`, `EvaluateTxResult()` 등의 메소드를 정리
3. `IActionTypeLoader` & `StaticActionTypeLoader` 추가
4. `PolymorphicAction<T>`에 `StaticActionTypeLoader` 적용

# 이 PR에서 남은 일
- [x] csporj 정리
- [x] `ActionEvaluator<T>` 생성자에서 `IActionTypeLoader` 받게끔
- [x] `StaticActionTypeLoader` 테스트 추가
- [x] xmldoc 추가 & 바뀐 부분 반영
- [x] `Transaction<T>`에서 액션 생성 부분 제거 & `StaticActionTypeLoader` 적용 (Lazy CustomActions & SystemAction instantiating)

# 후속 PR로 다룰 일
- `Block<T>` 마샬링에서 T 제거
- `Transaction<T>.Create()` 등에서 `UpdatedAddresses` 자동 계산 해주는 부분 제거 후 직접 입력등으로 대체
  - 정 안되면 `StaticActionTypeLoader()` 쓰게끔
- `ActionEvalutor<T>`에서 T제거
  - Updated Addresses 관련
  - `StateCompleter<T>` 제거 (이건 @planetarium/libplanet 에서 별도 진행 가능할 듯)
- non-`PolymorphicAction` 지원 여부 정하기
  - 지원해야 한다면,  `IActionTypeLoader`에 단일 액션을 위한 인터페이스 추가 해야 함
