### PR TITLE
`Append()` stores `BlockCommit`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@ Version PBFT
  -  Added `BlockCommitExtensions` class.  [[#PBFT]]
  -  Added `ContextTimeoutOption` class.  [[#PBFT]]
  -  Added `BlockMarshaler.UnmarshalBlockHash()` method. [[#PBFT]]
+ -  Added `BlockChain<T>.GetBlockCommit()` method.  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]

--- a/Libplanet.Benchmarks/SwarmBenchmark.cs
+++ b/Libplanet.Benchmarks/SwarmBenchmark.cs
@@ -10,6 +10,7 @@ using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Tests;
@@ -84,10 +85,10 @@ namespace Libplanet.Benchmarks
                     .Wait(WaitTimeout);
             }
 
-            _blockChains[0].Append(_blocks[1]);
-            _blockChains[0].Append(_blocks[2]);
-            _blockChains[0].Append(_blocks[3]);
-            _blockChains[0].Append(_blocks[4]);
+            _blockChains[0].Append(_blocks[1], TestUtils.CreateBlockCommit(_blocks[1]));
+            _blockChains[0].Append(_blocks[2], TestUtils.CreateBlockCommit(_blocks[2]));
+            _blockChains[0].Append(_blocks[3], TestUtils.CreateBlockCommit(_blocks[3]));
+            _blockChains[0].Append(_blocks[4], TestUtils.CreateBlockCommit(_blocks[4]));
         }
 
         [IterationCleanup(Targets = new[] {"BroadcastBlock", "BroadcastBlockWithoutFill"})]

--- a/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -11,12 +11,13 @@
     <ItemGroup>
         <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
+      <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -115,7 +115,9 @@ public class TransactionQueryTest
         _source.BlockChain.MakeTransaction(key1, ImmutableList<NullAction>.Empty.Add(new NullAction()));
         await AssertNextNonce(2, key1.ToAddress());
         var block = _source.BlockChain.ProposeBlock(new PrivateKey());
-        _source.BlockChain.Append(block);
+        _source.BlockChain.Append(
+            block,
+            Libplanet.Tests.TestUtils.CreateBlockCommit(block.Hash, block.Index, 0));
         await AssertNextNonce(2, key1.ToAddress());
 
         var key2 = new PrivateKey();
@@ -131,7 +133,9 @@ public class TransactionQueryTest
                     .Add(new VoteMetadata(1, 0, block.Hash, DateTimeOffset.UtcNow,
                     _source.Validator.PublicKey, VoteFlag.PreCommit).Sign(_source.Validator)));
         block = _source.BlockChain.ProposeBlock(new PrivateKey(), lastCommit: lastCommit);
-        _source.BlockChain.Append(block);
+        _source.BlockChain.Append(
+            block,
+            Libplanet.Tests.TestUtils.CreateBlockCommit(block.Hash, block.Index, 0));
         await AssertNextNonce(1, key2.ToAddress());
         await AssertNextNonce(2, key1.ToAddress());
 

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -115,9 +115,7 @@ public class TransactionQueryTest
         _source.BlockChain.MakeTransaction(key1, ImmutableList<NullAction>.Empty.Add(new NullAction()));
         await AssertNextNonce(2, key1.ToAddress());
         var block = _source.BlockChain.ProposeBlock(new PrivateKey());
-        _source.BlockChain.Append(
-            block,
-            Libplanet.Tests.TestUtils.CreateBlockCommit(block.Hash, block.Index, 0));
+        _source.BlockChain.Append(block, Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         await AssertNextNonce(2, key1.ToAddress());
 
         var key2 = new PrivateKey();
@@ -133,9 +131,7 @@ public class TransactionQueryTest
                     .Add(new VoteMetadata(1, 0, block.Hash, DateTimeOffset.UtcNow,
                     _source.Validator.PublicKey, VoteFlag.PreCommit).Sign(_source.Validator)));
         block = _source.BlockChain.ProposeBlock(new PrivateKey(), lastCommit: lastCommit);
-        _source.BlockChain.Append(
-            block,
-            Libplanet.Tests.TestUtils.CreateBlockCommit(block.Hash, block.Index, 0));
+        _source.BlockChain.Append(block, Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         await AssertNextNonce(1, key2.ToAddress());
         await AssertNextNonce(2, key1.ToAddress());
 

--- a/Libplanet.Explorer.Tests/TestUtils.cs
+++ b/Libplanet.Explorer.Tests/TestUtils.cs
@@ -1,10 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Libplanet.Blocks;
-using Libplanet.Consensus;
-using Libplanet.Crypto;
 
 namespace Libplanet.Explorer.Tests
 {

--- a/Libplanet.Explorer.Tests/TestUtils.cs
+++ b/Libplanet.Explorer.Tests/TestUtils.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
 
 namespace Libplanet.Explorer.Tests
 {

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -65,21 +65,21 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 _block1,
                 TestUtils.GenesisMiner,
                 new[] { _transaction2 },
-                lastCommit: TestUtils.CreateBlockCommit(_block1.Hash, _block1.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block1));
             _block3 = TestUtils.ProposeNextBlock(
                 _block2,
                 TestUtils.GenesisMiner,
                 new[] { _transaction3 },
-                lastCommit: TestUtils.CreateBlockCommit(_block2.Hash, _block2.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block2));
             _block4 = TestUtils.ProposeNextBlock(
                 _block3,
                 TestUtils.GenesisMiner,
                 new[] { _transaction3 },
-                lastCommit: TestUtils.CreateBlockCommit(_block3.Hash, _block3.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block3));
             _block5 = TestUtils.ProposeNextBlock(
                 _block4,
                 TestUtils.GenesisMiner,
-                lastCommit: TestUtils.CreateBlockCommit(_block4.Hash, _block4.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block4));
 
             var guid = Guid.NewGuid();
             foreach (var v in _storeFixtures)

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -65,21 +65,21 @@ namespace Libplanet.Extensions.Cocona.Tests.Commands
                 _block1,
                 TestUtils.GenesisMiner,
                 new[] { _transaction2 },
-                lastCommit: TestUtils.CreateLastCommit(_block1.Hash, _block1.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block1.Hash, _block1.Index, 0));
             _block3 = TestUtils.ProposeNextBlock(
                 _block2,
                 TestUtils.GenesisMiner,
                 new[] { _transaction3 },
-                lastCommit: TestUtils.CreateLastCommit(_block2.Hash, _block2.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block2.Hash, _block2.Index, 0));
             _block4 = TestUtils.ProposeNextBlock(
                 _block3,
                 TestUtils.GenesisMiner,
                 new[] { _transaction3 },
-                lastCommit: TestUtils.CreateLastCommit(_block3.Hash, _block3.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block3.Hash, _block3.Index, 0));
             _block5 = TestUtils.ProposeNextBlock(
                 _block4,
                 TestUtils.GenesisMiner,
-                lastCommit: TestUtils.CreateLastCommit(_block4.Hash, _block4.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(_block4.Hash, _block4.Index, 0));
 
             var guid = Guid.NewGuid();
             foreach (var v in _storeFixtures)

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -407,7 +407,7 @@ namespace Libplanet.Net.Tests
                     block = ProposeNextBlock(
                         block,
                         GenesisMiner,
-                        lastCommit: CreateBlockCommit(block.Hash, block.Index, 0));
+                        lastCommit: CreateBlockCommit(block));
                     yield return block;
                 }
             }

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -407,7 +407,7 @@ namespace Libplanet.Net.Tests
                     block = ProposeNextBlock(
                         block,
                         GenesisMiner,
-                        lastCommit: CreateLastCommit(block.Hash, block.Index, 0));
+                        lastCommit: CreateBlockCommit(block.Hash, block.Index, 0));
                     yield return block;
                 }
             }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -169,7 +169,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 }
             };
 
-            blockChain.Append(blockChain.ProposeBlock(TestUtils.PrivateKeys[1]));
+            Block<DumbAction> block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             blockChain.Store.PutBlockCommit(TestUtils.CreateBlockCommit(
                 blockChain[1].Hash,
@@ -281,8 +282,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             // Do a consensus for height #1. (Genesis doesn't have last commit.)
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
 
-            var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
-            blockChain.Append(block);
+            Block<DumbAction> block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             // Creates a lastCommit of height 1 and put it to the store.
             var createdLastCommit = TestUtils.CreateBlockCommit(block.Hash, 1, 0);

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -172,10 +172,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             Block<DumbAction> block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            blockChain.Store.PutBlockCommit(TestUtils.CreateBlockCommit(
-                blockChain[1].Hash,
-                1,
-                0));
+            blockChain.Store.PutBlockCommit(TestUtils.CreateBlockCommit(blockChain[1]));
             await proposalSent.WaitAsync();
 
             Assert.Equal(2, consensusContext.Height);
@@ -242,7 +239,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     (Dictionary)codec.Decode(proposal.Proposal.MarshaledBlock));
             var blockHeightThree = blockChain.ProposeBlock(
                 TestUtils.PrivateKeys[3],
-                lastCommit: TestUtils.CreateBlockCommit(blockHeightTwo.Hash, 2, 0));
+                lastCommit: TestUtils.CreateBlockCommit(blockHeightTwo));
 
             // Message from higher height
             consensusContext.HandleMessage(
@@ -286,7 +283,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             // Creates a lastCommit of height 1 and put it to the store.
-            var createdLastCommit = TestUtils.CreateBlockCommit(block.Hash, 1, 0);
+            var createdLastCommit = TestUtils.CreateBlockCommit(block);
             blockChain.Store.PutBlockCommit(createdLastCommit);
 
             // Starts height 2. Node 2 is the proposer.

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -222,8 +222,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var block = blockChain.ProposeBlock(
                 TestUtils.PrivateKeys[0],
-                lastCommit:
-                TestUtils.CreateBlockCommit(blockChain.Tip.Hash, blockChain.Tip.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
             consensusContext.HandleMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[2], height: 2));
 
@@ -274,17 +273,11 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: TestUtils.CreateBlockCommit(
-                    blockChain.Tip.Hash,
-                    blockChain.Tip.Index,
-                    0));
+                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Block<DumbAction> block3 = blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: TestUtils.CreateBlockCommit(
-                    blockChain.Tip.Hash,
-                    blockChain.Tip.Index,
-                    0));
+                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
 
             // Create context of index 4, check if the context of 1 and 2 are removed correctly.
@@ -398,11 +391,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var block2 = blockChain.ProposeBlock(
                 TestUtils.PrivateKeys[2],
-                lastCommit:
-                TestUtils.CreateBlockCommit(blockChain.Tip.Hash, blockChain.Tip.Index, 0));
-            consensusContext.Commit(
-                block2,
-                TestUtils.CreateBlockCommit(block2.Hash, block2.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
+            consensusContext.Commit(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(blockChain.Tip, block2);
             Assert.NotNull(blockChain.Store.GetBlockCommit(2));
         }

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -269,16 +269,14 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     2,
                     1));
 
-            Block<DumbAction> block1 = blockChain.ProposeBlock(new PrivateKey());
-            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
-            Block<DumbAction> block2 = blockChain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
-            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
-            Block<DumbAction> block3 = blockChain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
-            blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
+            var block = blockChain.ProposeBlock(new PrivateKey());
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
+            block = blockChain.ProposeBlock(
+                new PrivateKey(), lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
+            block = blockChain.ProposeBlock(
+                new PrivateKey(), lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             // Create context of index 4, check if the context of 1 and 2 are removed correctly.
             consensusContext.NewHeight(4);

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -312,7 +312,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             };
 
             var block = blockChain.ProposeBlock(new PrivateKey(), DateTimeOffset.UtcNow);
-            blockChain.Append(block);
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Equal(
                 TestUtils.PrivateKeys[2].PublicKey, TestUtils.ValidatorSet.GetProposer(2, 0));
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -92,8 +92,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
             };
 
             // It needs a lastCommit to use, so we assume that index #1 block is already committed.
-            var heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
-            blockChain.Append(heightOneBlock);
+            Block<DumbAction> heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+            blockChain.Append(heightOneBlock, TestUtils.CreateBlockCommit(heightOneBlock));
             var lastCommit =
                 TestUtils.CreateBlockCommit(heightOneBlock.Hash, heightOneBlock.Index, 0);
 

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -94,8 +94,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             // It needs a lastCommit to use, so we assume that index #1 block is already committed.
             Block<DumbAction> heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             blockChain.Append(heightOneBlock, TestUtils.CreateBlockCommit(heightOneBlock));
-            var lastCommit =
-                TestUtils.CreateBlockCommit(heightOneBlock.Hash, heightOneBlock.Index, 0);
+            var lastCommit = TestUtils.CreateBlockCommit(heightOneBlock);
 
             context.Start(lastCommit);
             await Task.WhenAll(stepChangedToPreVote.WaitAsync(), proposalSent.WaitAsync());

--- a/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 int.MaxValue,
                 0,
                 0);
-            _lastCommit = TestUtils.CreateBlockCommit(block.Hash, 1, 0);
+            _lastCommit = TestUtils.CreateBlockCommit(block);
             _messageLog = new MessageLog(2, TestUtils.ValidatorSet);
             _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
         }

--- a/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 0);
             _lastCommit = TestUtils.CreateBlockCommit(block.Hash, 1, 0);
             _messageLog = new MessageLog(2, TestUtils.ValidatorSet);
-            _blockChain.Append(block);
+            _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
         }
 
         [Fact]

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -41,8 +41,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    miner,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                    miner, lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -198,8 +197,7 @@ namespace Libplanet.Net.Tests
                         try
                         {
                             var block = chain.ProposeBlock(
-                                miner,
-                                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                                miner, lastCommit: CreateBlockCommit(chain.Tip));
                             chain.Append(block, TestUtils.CreateBlockCommit(block));
 
                             Log.Debug(
@@ -335,7 +333,7 @@ namespace Libplanet.Net.Tests
                     {
                         Block<DumbAction> block = chainC.ProposeBlock(
                             minerC,
-                            lastCommit: CreateBlockCommit(chainC.Tip.Hash, chainC.Tip.Index, 0));
+                            lastCommit: CreateBlockCommit(chainC.Tip));
                         chainC.Append(block, TestUtils.CreateBlockCommit(block));
                     }
                 });
@@ -596,16 +594,14 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = chainA.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
                 Block<DumbAction> block = chainB.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(chainB.Tip.Hash, chainB.Tip.Index, 0));
+                    keyB, lastCommit: CreateBlockCommit(chainB.Tip));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -757,21 +753,18 @@ namespace Libplanet.Net.Tests
                 await StartAsync(swarmB);
 
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
-                Block<DumbAction> block1 = chainA.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
-
-                chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
+                var block = chainA.ProposeBlock(
+                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                chainA.Append(block, TestUtils.CreateBlockCommit(block));
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
 
                 Assert.Equal(chainB.BlockHashes, chainA.BlockHashes);
 
-                Block<DumbAction> block2 = chainA.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
-                chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
+                block = chainA.ProposeBlock(
+                    keyB, lastCommit: CreateBlockCommit(chainA.Tip));
+                chainA.Append(block, TestUtils.CreateBlockCommit(block));
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
@@ -797,9 +790,8 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            Block<DumbAction> block = chainA.ProposeBlock(
-                keyA,
-                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+            var block = chainA.ProposeBlock(
+                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
             BlockCommit blockCommit = TestUtils.CreateBlockCommit(block);
             chainA.Append(block, blockCommit);
             chainB.Append(block, blockCommit);
@@ -807,8 +799,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 3))
             {
                 block = chainA.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -859,8 +850,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = chainA.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -869,16 +859,14 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 5))
             {
                 Block<DumbAction> block = chainB.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(chainB.Tip.Hash, chainB.Tip.Index, 0));
+                    keyB, lastCommit: CreateBlockCommit(chainB.Tip));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
                 Block<DumbAction> block = chainC.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(chainC.Tip.Hash, chainC.Tip.Index, 0));
+                    keyB, lastCommit: CreateBlockCommit(chainC.Tip));
                 chainC.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -40,9 +40,10 @@ namespace Libplanet.Net.Tests
             var minerChain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             foreach (int i in Enumerable.Range(0, 10))
             {
-                minerChain.Append(minerChain.ProposeBlock(
+                Block<DumbAction> block = minerChain.ProposeBlock(
                     miner,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             Swarm<DumbAction> seed = CreateSwarm(
@@ -66,7 +67,9 @@ namespace Libplanet.Net.Tests
 
             foreach (BlockHash blockHash in minerChain.BlockHashes.Skip(1).Take(4))
             {
-                seedChain.Append(minerChain[blockHash]);
+                seedChain.Append(
+                    minerChain[blockHash],
+                    TestUtils.CreateBlockCommit(minerChain[blockHash]));
             }
 
             try
@@ -88,7 +91,9 @@ namespace Libplanet.Net.Tests
 
                 foreach (BlockHash blockHash in minerChain.BlockHashes.Skip(5))
                 {
-                    seedChain.Append(minerChain[blockHash]);
+                    seedChain.Append(
+                        minerChain[blockHash],
+                        TestUtils.CreateBlockCommit(minerChain[blockHash]));
                 }
 
                 await swarmB.AddPeersAsync(new[] { seed.AsPeer }, null);
@@ -154,7 +159,7 @@ namespace Libplanet.Net.Tests
 
                 await receiverSwarm.AddPeersAsync(new[] { seedSwarm.AsPeer }, null);
                 Block<DumbAction> block = seedChain.ProposeBlock(seedMiner);
-                seedChain.Append(block);
+                seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 seedSwarm.BroadcastBlock(block);
                 Assert.NotEqual(seedChain.Tip, receiverChain.Tip);
             }
@@ -194,8 +199,8 @@ namespace Libplanet.Net.Tests
                         {
                             var block = chain.ProposeBlock(
                                 miner,
-                                lastCommit: CreateLastCommit(chain.Tip.Hash, chain.Tip.Index, 0));
-                            chain.Append(block);
+                                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                            chain.Append(block, TestUtils.CreateBlockCommit(block));
 
                             Log.Debug(
                                 "Block mined. [Node: {0}, Block: {1}]",
@@ -266,7 +271,8 @@ namespace Libplanet.Net.Tests
             );
 
             chainA.StageTransaction(tx);
-            chainA.Append(chainA.ProposeBlock(minerA));
+            Block<DumbAction> block = chainA.ProposeBlock(minerA);
+            chainA.Append(block, TestUtils.CreateBlockCommit(block));
 
             try
             {
@@ -327,9 +333,10 @@ namespace Libplanet.Net.Tests
                 {
                     for (var i = 0; i < 10; i++)
                     {
-                        chainC.Append(chainC.ProposeBlock(
+                        Block<DumbAction> block = chainC.ProposeBlock(
                             minerC,
-                            lastCommit: CreateLastCommit(chainC.Tip.Hash, chainC.Tip.Index, 0)));
+                            lastCommit: CreateBlockCommit(chainC.Tip.Hash, chainC.Tip.Index, 0));
+                        chainC.Append(block, TestUtils.CreateBlockCommit(block));
                     }
                 });
 
@@ -521,7 +528,8 @@ namespace Libplanet.Net.Tests
                 Assert.Empty(swarmA.Peers);
                 Assert.Empty(swarmB.Peers);
 
-                chainB.Append(chainB.ProposeBlock(keyB));
+                Block<DumbAction> block = chainB.ProposeBlock(keyB);
+                chainB.Append(block, TestUtils.CreateBlockCommit(block));
 
                 var tx3 = chainA.MakeTransaction(
                     privateKey: privateKey,
@@ -587,16 +595,18 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                chainA.Append(chainA.ProposeBlock(
+                Block<DumbAction> block = chainA.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
-                chainB.Append(chainB.ProposeBlock(
+                Block<DumbAction> block = chainB.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(chainB.Tip.Hash, chainB.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainB.Tip.Hash, chainB.Tip.Index, 0));
+                chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             try
@@ -694,14 +704,14 @@ namespace Libplanet.Net.Tests
                 new[] { transactions[0] },
                 miner: GenesisMiner.PublicKey
             ).Evaluate(GenesisMiner, blockChain);
-            blockChain.Append(block1, true, true, false);
+            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true, true, false);
             Block<DumbAction> block2 = ProposeNext(
                 block1,
                 new[] { transactions[1] },
                 miner: GenesisMiner.PublicKey,
-                lastCommit: CreateLastCommit(block1.Hash, block1.Index, 0)
+                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(GenesisMiner, blockChain);
-            blockChain.Append(block2, true, true, false);
+            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true, true, false);
 
             try
             {
@@ -747,19 +757,21 @@ namespace Libplanet.Net.Tests
                 await StartAsync(swarmB);
 
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
-
-                chainA.Append(chainA.ProposeBlock(
+                Block<DumbAction> block1 = chainA.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+
+                chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
 
                 Assert.Equal(chainB.BlockHashes, chainA.BlockHashes);
 
-                chainA.Append(chainA.ProposeBlock(
+                Block<DumbAction> block2 = chainA.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
                 swarmA.BroadcastBlock(chainA[-1]);
 
                 await swarmB.BlockAppended.WaitAsync();
@@ -787,15 +799,17 @@ namespace Libplanet.Net.Tests
 
             Block<DumbAction> block = chainA.ProposeBlock(
                 keyA,
-                lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
-            chainA.Append(block);
-            chainB.Append(block);
+                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+            BlockCommit blockCommit = TestUtils.CreateBlockCommit(block);
+            chainA.Append(block, blockCommit);
+            chainB.Append(block, blockCommit);
 
             foreach (int i in Enumerable.Range(0, 3))
             {
-                chainA.Append(chainA.ProposeBlock(
+                block = chainA.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             try
@@ -844,25 +858,28 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                chainA.Append(chainA.ProposeBlock(
+                Block<DumbAction> block = chainA.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             Block<DumbAction> chainATip = chainA.Tip;
 
             foreach (int i in Enumerable.Range(0, 5))
             {
-                chainB.Append(chainB.ProposeBlock(
+                Block<DumbAction> block = chainB.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(chainB.Tip.Hash, chainB.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainB.Tip.Hash, chainB.Tip.Index, 0));
+                chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
-                chainC.Append(chainC.ProposeBlock(
+                Block<DumbAction> block = chainC.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(chainC.Tip.Hash, chainC.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(chainC.Tip.Hash, chainC.Tip.Index, 0));
+                chainC.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             try

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -52,8 +52,7 @@ namespace Libplanet.Net.Tests
                         }
 
                         Block<DumbAction> block = chain.ProposeBlock(
-                            miner,
-                            lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                            miner, lastCommit: CreateBlockCommit(chain.Tip));
                         Log.Logger.Information("  #{0,2} {1}", block.Index, block.Hash);
                         chain.Append(block, CreateBlockCommit(block));
                     }

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -53,9 +53,9 @@ namespace Libplanet.Net.Tests
 
                         Block<DumbAction> block = chain.ProposeBlock(
                             miner,
-                            lastCommit: CreateLastCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                            lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
                         Log.Logger.Information("  #{0,2} {1}", block.Index, block.Hash);
-                        chain.Append(block);
+                        chain.Append(block, CreateBlockCommit(block));
                     }
 
                     var blockList = new List<Block<DumbAction>>();

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -41,9 +41,10 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                minerChain.Append(minerChain.ProposeBlock(
+                Block<DumbAction> block = minerChain.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             try
@@ -83,19 +84,22 @@ namespace Libplanet.Net.Tests
                 transfer: Tuple.Create<Address, Address, BigInteger>(address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
-            minerChain.Append(minerChain.ProposeBlock(
+            Block<DumbAction> block1 = minerChain.ProposeBlock(
                 minerKey,
-                lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+            minerChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
-            minerChain.Append(minerChain.ProposeBlock(
+            Block<DumbAction> block2 = minerChain.ProposeBlock(
                 minerKey,
-                lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+            minerChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
-            minerChain.Append(minerChain.ProposeBlock(
+            Block<DumbAction> block3 = minerChain.ProposeBlock(
                 minerKey,
-                lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+            minerChain.Append(block3, TestUtils.CreateBlockCommit(block3));
 
             try
             {
@@ -129,12 +133,12 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
                 ).Evaluate(ChainPrivateKey, minerChain);
                 blocks.Add(block);
                 if (i != 10)
                 {
-                    minerChain.Append(blocks[i]);
+                    minerChain.Append(blocks[i], TestUtils.CreateBlockCommit(blocks[i]));
                 }
             }
 
@@ -148,7 +152,7 @@ namespace Libplanet.Net.Tests
 
                     if (actualStates.Count == 9)
                     {
-                        minerChain.Append(blocks[10]);
+                        minerChain.Append(blocks[10], CreateBlockCommit(blocks[10]));
                     }
                 }
             });
@@ -297,12 +301,13 @@ namespace Libplanet.Net.Tests
             for (var i = 0; i < iteration; i++)
             {
                 sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-                sender.BlockChain.Append(sender.BlockChain.ProposeBlock(
+                Block<DumbAction> block = sender.BlockChain.ProposeBlock(
                     senderKey,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         sender.BlockChain.Tip.Hash,
                         sender.BlockChain.Tip.Index,
-                        0)));
+                        0));
+                sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             renderer1.RenderEventHandler += (_, a) =>
@@ -343,12 +348,13 @@ namespace Libplanet.Net.Tests
 
             foreach (var unused in Enumerable.Range(0, 10))
             {
-                minerSwarm.BlockChain.Append(minerSwarm.BlockChain.ProposeBlock(
+                Block<ThrowException> block = minerSwarm.BlockChain.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         minerSwarm.BlockChain.Tip.Hash,
                         minerSwarm.BlockChain.Tip.Index,
-                        0)));
+                        0));
+                minerSwarm.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             try
@@ -375,9 +381,9 @@ namespace Libplanet.Net.Tests
                     new[] { tx },
                     miner: ChainPrivateKey.PublicKey,
                     blockInterval: TimeSpan.FromSeconds(1),
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
                 ).Evaluate(ChainPrivateKey, minerChain);
-                minerSwarm.BlockChain.Append(block, false, true, false);
+                minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), false, true, false);
 
                 await receiverSwarm.PreloadAsync();
 
@@ -421,9 +427,10 @@ namespace Libplanet.Net.Tests
 
             foreach (int i in Enumerable.Range(0, 10))
             {
-                minerChain.Append(minerChain.ProposeBlock(
+                Block<DumbAction> block = minerChain.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
             var actualStates = new List<PreloadState>();
@@ -547,12 +554,12 @@ namespace Libplanet.Net.Tests
             {
                 var block = swarm0.BlockChain.ProposeBlock(
                     key0,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         swarm0.BlockChain.Tip.Hash,
                         swarm0.BlockChain.Tip.Index,
                         0));
-                swarm0.BlockChain.Append(block);
-                swarm1.BlockChain.Append(block);
+                swarm0.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
+                swarm1.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             await StartAsync(swarm0);
@@ -610,10 +617,10 @@ namespace Libplanet.Net.Tests
             var blockArray = blocks.ToArray();
             foreach (Block<DumbAction> block in blockArray)
             {
-                minerChain.Append(block);
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
-            receiverChain.Append(blockArray[0]);
+            receiverChain.Append(blockArray[0], CreateBlockCommit(blockArray[0]));
 
             Assert.NotNull(minerChain.Tip);
 
@@ -688,7 +695,7 @@ namespace Libplanet.Net.Tests
 
             foreach (Block<DumbAction> block in blocks)
             {
-                minerChain.Append(block);
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
             minerSwarm.FindNextHashesChunkSize = 2;
@@ -727,29 +734,31 @@ namespace Libplanet.Net.Tests
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
-                minerChain.Append(block);
-                receiverChain.Append(block);
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                minerChain.Append(block, CreateBlockCommit(block));
+                receiverChain.Append(block, CreateBlockCommit(block));
             }
 
             var receiverForked = receiverChain.Fork(receiverChain[5].Hash);
             foreach (int i in Enumerable.Range(0, 20))
             {
-                receiverForked.Append(receiverForked.ProposeBlock(
+                Block<DumbAction> block = receiverForked.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         receiverForked.Tip.Hash,
                         receiverForked.Tip.Index,
-                        0)));
+                        0));
+                receiverForked.Append(block, CreateBlockCommit(block));
             }
 
             receiverChain.Swap(receiverForked, false);
 
             foreach (int i in Enumerable.Range(0, 1))
             {
-                minerChain.Append(minerChain.ProposeBlock(
+                Block<DumbAction> block = minerChain.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
             minerSwarm.FindNextHashesChunkSize = 1;
@@ -784,15 +793,16 @@ namespace Libplanet.Net.Tests
 
             foreach (Block<DumbAction> block in blocks)
             {
-                minerChain.Append(block);
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
             BlockChain<DumbAction> forked = minerChain.Fork(minerChain.Genesis.Hash);
             while (forked.Count <= minerChain.Count)
             {
-                forked.Append(forked.ProposeBlock(
+                Block<DumbAction> block = forked.ProposeBlock(
                     minerKey,
-                    lastCommit: CreateLastCommit(forked.Tip.Hash, forked.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                forked.Append(block, CreateBlockCommit(block));
             }
 
             minerSwarm.FindNextHashesChunkSize = 2;
@@ -836,7 +846,7 @@ namespace Libplanet.Net.Tests
 
             foreach (Block<DumbAction> block in blocks)
             {
-                minerChain.Append(block);
+                minerChain.Append(block, CreateBlockCommit(block));
             }
 
             try
@@ -865,19 +875,21 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> minerChain2 = minerSwarm2.BlockChain;
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
-            minerChain1.Append(minerChain1.ProposeBlock(
+            Block<DumbAction> block1 = minerChain1.ProposeBlock(
                 minerKey1,
-                lastCommit: CreateLastCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0)));
-            minerChain1.Append(minerChain1.ProposeBlock(
+                lastCommit: CreateBlockCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0));
+            minerChain1.Append(block1, CreateBlockCommit(block1));
+            Block<DumbAction> block2 = minerChain1.ProposeBlock(
                 minerKey1,
-                lastCommit: CreateLastCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0));
+            minerChain1.Append(block2, CreateBlockCommit(block2));
 
             Block<DumbAction> block = ProposeNext(
                 minerChain2.Tip,
                 miner: ChainPrivateKey.PublicKey,
-                lastCommit: CreateLastCommit(minerChain2.Tip.Hash, minerChain2.Tip.Index, 0)
+                lastCommit: CreateBlockCommit(minerChain2.Tip.Hash, minerChain2.Tip.Index, 0)
             ).Evaluate(ChainPrivateKey, minerChain2);
-            minerChain2.Append(block);
+            minerChain2.Append(block, CreateBlockCommit(block));
 
             Assert.True(minerChain1.Count > minerChain2.Count);
 
@@ -958,22 +970,24 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                validSeedChain.Append(validSeedChain.ProposeBlock(
+                Block<DumbAction> block = validSeedChain.ProposeBlock(
                     key1,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         validSeedChain.Tip.Hash,
                         validSeedChain.Tip.Index,
-                        0)));
+                        0));
+                validSeedChain.Append(block, CreateBlockCommit(block));
             }
 
             for (int i = 0; i < 20; i++)
             {
-                invalidSeedChain.Append(invalidSeedChain.ProposeBlock(
+                Block<DumbAction> block = invalidSeedChain.ProposeBlock(
                     key1,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         invalidSeedChain.Tip.Hash,
                         invalidSeedChain.Tip.Index,
-                        0)));
+                        0));
+                invalidSeedChain.Append(block, CreateBlockCommit(block));
             }
 
             try
@@ -1020,18 +1034,19 @@ namespace Libplanet.Net.Tests
             {
                 var block = seedChain.ProposeBlock(
                     seedKey,
-                    lastCommit: CreateLastCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
-                seedChain.Append(block);
-                receiverChain.Append(block);
+                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                seedChain.Append(block, TestUtils.CreateBlockCommit(block));
+                receiverChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             var forked = seedChain.Fork(seedChain[5].Hash);
             seedChain.Swap(forked, false);
             for (int i = 0; i < 10; i++)
             {
-                seedChain.Append(seedChain.ProposeBlock(
+                Block<DumbAction> block = seedChain.ProposeBlock(
                     seedKey,
-                    lastCommit: CreateLastCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                seedChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             var actionExecutionCount = 0;
@@ -1084,9 +1099,10 @@ namespace Libplanet.Net.Tests
                     {
                         new DumbAction(default, $"Item{i}"),
                     });
-                seedChain.Append(seedChain.ProposeBlock(
+                Block<DumbAction> block = seedChain.ProposeBlock(
                     seedKey,
-                    lastCommit: CreateLastCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 transactions.Add(transaction);
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -42,8 +42,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -84,22 +83,19 @@ namespace Libplanet.Net.Tests
                 transfer: Tuple.Create<Address, Address, BigInteger>(address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
-            Block<DumbAction> block1 = minerChain.ProposeBlock(
-                minerKey,
-                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
-            minerChain.Append(block1, TestUtils.CreateBlockCommit(block1));
+            var block = minerChain.ProposeBlock(
+                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+            minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
-            Block<DumbAction> block2 = minerChain.ProposeBlock(
-                minerKey,
-                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
-            minerChain.Append(block2, TestUtils.CreateBlockCommit(block2));
+            block = minerChain.ProposeBlock(
+                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+            minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
-            Block<DumbAction> block3 = minerChain.ProposeBlock(
-                minerKey,
-                lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
-            minerChain.Append(block3, TestUtils.CreateBlockCommit(block3));
+            block = minerChain.ProposeBlock(
+                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+            minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             try
             {
@@ -133,7 +129,7 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(minerChain.Tip)
                 ).Evaluate(ChainPrivateKey, minerChain);
                 blocks.Add(block);
                 if (i != 10)
@@ -302,11 +298,7 @@ namespace Libplanet.Net.Tests
             {
                 sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
                 Block<DumbAction> block = sender.BlockChain.ProposeBlock(
-                    senderKey,
-                    lastCommit: CreateBlockCommit(
-                        sender.BlockChain.Tip.Hash,
-                        sender.BlockChain.Tip.Index,
-                        0));
+                    senderKey, lastCommit: CreateBlockCommit(sender.BlockChain.Tip));
                 sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -349,11 +341,7 @@ namespace Libplanet.Net.Tests
             foreach (var unused in Enumerable.Range(0, 10))
             {
                 Block<ThrowException> block = minerSwarm.BlockChain.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(
-                        minerSwarm.BlockChain.Tip.Hash,
-                        minerSwarm.BlockChain.Tip.Index,
-                        0));
+                    minerKey, lastCommit: CreateBlockCommit(minerSwarm.BlockChain.Tip));
                 minerSwarm.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -381,7 +369,7 @@ namespace Libplanet.Net.Tests
                     new[] { tx },
                     miner: ChainPrivateKey.PublicKey,
                     blockInterval: TimeSpan.FromSeconds(1),
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(minerChain.Tip)
                 ).Evaluate(ChainPrivateKey, minerChain);
                 minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), false, true, false);
 
@@ -428,8 +416,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -554,10 +541,7 @@ namespace Libplanet.Net.Tests
             {
                 var block = swarm0.BlockChain.ProposeBlock(
                     key0,
-                    lastCommit: CreateBlockCommit(
-                        swarm0.BlockChain.Tip.Hash,
-                        swarm0.BlockChain.Tip.Index,
-                        0));
+                    lastCommit: CreateBlockCommit(swarm0.BlockChain.Tip));
                 swarm0.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 swarm1.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -733,8 +717,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 25))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
                 receiverChain.Append(block, CreateBlockCommit(block));
             }
@@ -743,11 +726,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 20))
             {
                 Block<DumbAction> block = receiverForked.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(
-                        receiverForked.Tip.Hash,
-                        receiverForked.Tip.Index,
-                        0));
+                    minerKey, lastCommit: CreateBlockCommit(receiverForked.Tip));
                 receiverForked.Append(block, CreateBlockCommit(block));
             }
 
@@ -756,8 +735,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 1))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip.Hash, minerChain.Tip.Index, 0));
+                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -800,8 +778,7 @@ namespace Libplanet.Net.Tests
             while (forked.Count <= minerChain.Count)
             {
                 Block<DumbAction> block = forked.ProposeBlock(
-                    minerKey,
-                    lastCommit: CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                    minerKey, lastCommit: CreateBlockCommit(forked.Tip));
                 forked.Append(block, CreateBlockCommit(block));
             }
 
@@ -876,18 +853,16 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Block<DumbAction> block1 = minerChain1.ProposeBlock(
-                minerKey1,
-                lastCommit: CreateBlockCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0));
+                minerKey1, lastCommit: CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block1, CreateBlockCommit(block1));
             Block<DumbAction> block2 = minerChain1.ProposeBlock(
-                minerKey1,
-                lastCommit: CreateBlockCommit(minerChain1.Tip.Hash, minerChain1.Tip.Index, 0));
+                minerKey1, lastCommit: CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
             Block<DumbAction> block = ProposeNext(
                 minerChain2.Tip,
                 miner: ChainPrivateKey.PublicKey,
-                lastCommit: CreateBlockCommit(minerChain2.Tip.Hash, minerChain2.Tip.Index, 0)
+                lastCommit: CreateBlockCommit(minerChain2.Tip)
             ).Evaluate(ChainPrivateKey, minerChain2);
             minerChain2.Append(block, CreateBlockCommit(block));
 
@@ -971,22 +946,14 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 Block<DumbAction> block = validSeedChain.ProposeBlock(
-                    key1,
-                    lastCommit: CreateBlockCommit(
-                        validSeedChain.Tip.Hash,
-                        validSeedChain.Tip.Index,
-                        0));
+                    key1, lastCommit: CreateBlockCommit(validSeedChain.Tip));
                 validSeedChain.Append(block, CreateBlockCommit(block));
             }
 
             for (int i = 0; i < 20; i++)
             {
                 Block<DumbAction> block = invalidSeedChain.ProposeBlock(
-                    key1,
-                    lastCommit: CreateBlockCommit(
-                        invalidSeedChain.Tip.Hash,
-                        invalidSeedChain.Tip.Index,
-                        0));
+                    key1, lastCommit: CreateBlockCommit(invalidSeedChain.Tip));
                 invalidSeedChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -1033,8 +1000,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 var block = seedChain.ProposeBlock(
-                    seedKey,
-                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 receiverChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -1044,8 +1010,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 Block<DumbAction> block = seedChain.ProposeBlock(
-                    seedKey,
-                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1100,8 +1065,7 @@ namespace Libplanet.Net.Tests
                         new DumbAction(default, $"Item{i}"),
                     });
                 Block<DumbAction> block = seedChain.ProposeBlock(
-                    seedKey,
-                    lastCommit: CreateBlockCommit(seedChain.Tip.Hash, seedChain.Tip.Index, 0));
+                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 transactions.Add(transaction);
             }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -345,8 +345,7 @@ namespace Libplanet.Net.Tests
             Block<DumbAction> block1 = chainA.ProposeBlock(keyA);
             chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = chainA.ProposeBlock(
-                keyA,
-                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0));
+                keyA, lastCommit: CreateBlockCommit(block1));
             chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
@@ -416,12 +415,10 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             Block<DumbAction> block1 = chainA.ProposeBlock(
-                keyA,
-                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
             chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = chainA.ProposeBlock(
-                keyA,
-                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
             chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
@@ -771,29 +768,17 @@ namespace Libplanet.Net.Tests
 
             miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             Block<DumbAction> block1 = miner1.BlockChain.ProposeBlock(
-                key1,
-                lastCommit: CreateBlockCommit(
-                    miner1.BlockChain.Tip.Hash,
-                    miner1.BlockChain.Tip.Index,
-                    0));
+                key1, lastCommit: CreateBlockCommit(miner1.BlockChain.Tip));
             miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             Block<DumbAction> block2 = miner2.BlockChain.ProposeBlock(
-                key2,
-                lastCommit: CreateBlockCommit(
-                    miner2.BlockChain.Tip.Hash,
-                    miner2.BlockChain.Tip.Index,
-                    0));
+                key2, lastCommit: CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             var latest = miner2.BlockChain.ProposeBlock(
-                key2,
-                lastCommit: CreateBlockCommit(
-                    miner2.BlockChain.Tip.Hash,
-                    miner2.BlockChain.Tip.Index,
-                    0));
+                key2, lastCommit: CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
 
             renderer.RenderEventHandler += (_, a) =>
@@ -923,25 +908,13 @@ namespace Libplanet.Net.Tests
 
                 Log.Debug("Make minerB's chain longer than minerA's chain.");
                 Block<DumbAction> blockA = minerA.BlockChain.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(
-                        minerA.BlockChain.Tip.Hash,
-                        minerA.BlockChain.Tip.Index,
-                        0));
+                    keyA, lastCommit: CreateBlockCommit(minerA.BlockChain.Tip));
                 minerA.BlockChain.Append(blockA, TestUtils.CreateBlockCommit(blockA));
                 Block<DumbAction> blockB = minerB.BlockChain.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(
-                        minerB.BlockChain.Tip.Hash,
-                        minerB.BlockChain.Tip.Index,
-                        0));
+                    keyB, lastCommit: CreateBlockCommit(minerB.BlockChain.Tip));
                 minerB.BlockChain.Append(blockB, TestUtils.CreateBlockCommit(blockB));
                 Block<DumbAction> blockC = minerB.BlockChain.ProposeBlock(
-                    keyB,
-                    lastCommit: CreateBlockCommit(
-                        minerB.BlockChain.Tip.Hash,
-                        minerB.BlockChain.Tip.Index,
-                        0));
+                    keyB, lastCommit: CreateBlockCommit(minerB.BlockChain.Tip));
                 minerB.BlockChain.Append(blockC, TestUtils.CreateBlockCommit(blockC));
 
                 Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
@@ -969,11 +942,7 @@ namespace Libplanet.Net.Tests
                     minerA.BlockChain.GetStagedTransactionIds().Contains(txA.Id));
 
                 Block<DumbAction> block = minerA.BlockChain.ProposeBlock(
-                    keyA,
-                    lastCommit: CreateBlockCommit(
-                        minerA.BlockChain.Tip.Hash,
-                        minerA.BlockChain.Tip.Index,
-                        0));
+                    keyA, lastCommit: CreateBlockCommit(minerA.BlockChain.Tip));
                 minerA.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 minerA.BroadcastBlock(minerA.BlockChain.Tip);
                 await minerB.BlockAppended.WaitAsync();
@@ -1142,12 +1111,12 @@ namespace Libplanet.Net.Tests
                 aBlock1,
                 keyA,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateBlockCommit(aBlock1.Hash, aBlock1.Index, 0));
+                lastCommit: CreateBlockCommit(aBlock1));
             Block<DumbAction> aBlock3 = ProposeNextBlock(
                 aBlock2,
                 keyA,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateBlockCommit(aBlock2.Hash, aBlock2.Index, 0));
+                lastCommit: CreateBlockCommit(aBlock2));
             Block<DumbAction> bBlock1 = ProposeNextBlock(
                 genesis,
                 keyB,
@@ -1156,7 +1125,7 @@ namespace Libplanet.Net.Tests
                 bBlock1,
                 keyB,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateBlockCommit(bBlock1.Hash, bBlock1.Index, 0));
+                lastCommit: CreateBlockCommit(bBlock1));
 
             policyA.BlockedMiners.Add(keyB.ToAddress());
             policyB.BlockedMiners.Add(keyA.ToAddress());
@@ -1465,7 +1434,7 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip)
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -1508,7 +1477,7 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip)
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -1552,7 +1521,7 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip)
                 ).Evaluate(ChainPrivateKey, chain);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -343,11 +343,11 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             Block<DumbAction> block1 = chainA.ProposeBlock(keyA);
-            chainA.Append(block1);
+            chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = chainA.ProposeBlock(
                 keyA,
-                lastCommit: CreateLastCommit(block1.Hash, block1.Index, 0));
-            chainA.Append(block2);
+                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0));
+            chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
             {
@@ -415,12 +415,14 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
-            chainA.Append(chainA.ProposeBlock(
+            Block<DumbAction> block1 = chainA.ProposeBlock(
                 keyA,
-                lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
-            chainA.Append(chainA.ProposeBlock(
+                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+            chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
+            Block<DumbAction> block2 = chainA.ProposeBlock(
                 keyA,
-                lastCommit: CreateLastCommit(chainA.Tip.Hash, chainA.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(chainA.Tip.Hash, chainA.Tip.Index, 0));
+            chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
             {
@@ -484,7 +486,8 @@ namespace Libplanet.Net.Tests
                 new DumbAction[0]
             );
             chainB.StageTransaction(tx);
-            chainB.Append(chainB.ProposeBlock(keyB));
+            Block<DumbAction> block = chainB.ProposeBlock(keyB);
+            chainB.Append(block, TestUtils.CreateBlockCommit(block));
 
             try
             {
@@ -692,7 +695,7 @@ namespace Libplanet.Net.Tests
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     var block = seed.BlockChain.ProposeBlock(seedKey);
-                    seed.BlockChain.Append(block);
+                    seed.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                     seed.BroadcastBlock(block);
                     await Task.Delay(1000, cancellationToken);
                 }
@@ -767,29 +770,31 @@ namespace Libplanet.Net.Tests
             var item = "foo";
 
             miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-            miner1.BlockChain.Append(miner1.BlockChain.ProposeBlock(
+            Block<DumbAction> block1 = miner1.BlockChain.ProposeBlock(
                 key1,
-                lastCommit: CreateLastCommit(
+                lastCommit: CreateBlockCommit(
                     miner1.BlockChain.Tip.Hash,
                     miner1.BlockChain.Tip.Index,
-                    0)));
+                    0));
+            miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
-            miner2.BlockChain.Append(miner2.BlockChain.ProposeBlock(
+            Block<DumbAction> block2 = miner2.BlockChain.ProposeBlock(
                 key2,
-                lastCommit: CreateLastCommit(
+                lastCommit: CreateBlockCommit(
                     miner2.BlockChain.Tip.Hash,
                     miner2.BlockChain.Tip.Index,
-                    0)));
+                    0));
+            miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             var latest = miner2.BlockChain.ProposeBlock(
                 key2,
-                lastCommit: CreateLastCommit(
+                lastCommit: CreateBlockCommit(
                     miner2.BlockChain.Tip.Hash,
                     miner2.BlockChain.Tip.Index,
                     0));
-            miner2.BlockChain.Append(latest);
+            miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
 
             renderer.RenderEventHandler += (_, a) =>
                 renderCount += a is DumbAction ? 1 : 0;
@@ -843,12 +848,12 @@ namespace Libplanet.Net.Tests
                 );
                 var b = miner1.BlockChain.ProposeBlock(
                     key1,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         miner1.BlockChain.Tip.Hash,
                         miner1.BlockChain.Tip.Index,
                         0));
-                miner1.BlockChain.Append(b);
-                miner2.BlockChain.Append(b);
+                miner1.BlockChain.Append(b, TestUtils.CreateBlockCommit(b));
+                miner2.BlockChain.Append(b, TestUtils.CreateBlockCommit(b));
             }
 
             try
@@ -860,10 +865,12 @@ namespace Libplanet.Net.Tests
                 await BootstrapAsync(receiver, miner1.AsPeer);
 
                 var t = receiver.PreloadAsync();
-                miner1.BlockChain.Append(miner1.BlockChain.ProposeBlock(key1));
-                miner2.BlockChain.Append(miner2.BlockChain.ProposeBlock(key2));
+                Block<Sleep> block1 = miner1.BlockChain.ProposeBlock(key1);
+                miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
+                Block<Sleep> block2 = miner2.BlockChain.ProposeBlock(key1);
+                miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
                 Block<Sleep> latest = miner2.BlockChain.ProposeBlock(key2);
-                miner2.BlockChain.Append(latest);
+                miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
                 miner2.BroadcastBlock(latest);
                 await t;
 
@@ -917,25 +924,25 @@ namespace Libplanet.Net.Tests
                 Log.Debug("Make minerB's chain longer than minerA's chain.");
                 Block<DumbAction> blockA = minerA.BlockChain.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         minerA.BlockChain.Tip.Hash,
                         minerA.BlockChain.Tip.Index,
                         0));
-                minerA.BlockChain.Append(blockA);
+                minerA.BlockChain.Append(blockA, TestUtils.CreateBlockCommit(blockA));
                 Block<DumbAction> blockB = minerB.BlockChain.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         minerB.BlockChain.Tip.Hash,
                         minerB.BlockChain.Tip.Index,
                         0));
-                minerB.BlockChain.Append(blockB);
+                minerB.BlockChain.Append(blockB, TestUtils.CreateBlockCommit(blockB));
                 Block<DumbAction> blockC = minerB.BlockChain.ProposeBlock(
                     keyB,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         minerB.BlockChain.Tip.Hash,
                         minerB.BlockChain.Tip.Index,
                         0));
-                minerB.BlockChain.Append(blockC);
+                minerB.BlockChain.Append(blockC, TestUtils.CreateBlockCommit(blockC));
 
                 Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
                 Assert.Equal((Text)dumbItem, minerB.BlockChain.GetState(targetAddress2));
@@ -961,12 +968,13 @@ namespace Libplanet.Net.Tests
                     restage,
                     minerA.BlockChain.GetStagedTransactionIds().Contains(txA.Id));
 
-                minerA.BlockChain.Append(minerA.BlockChain.ProposeBlock(
+                Block<DumbAction> block = minerA.BlockChain.ProposeBlock(
                     keyA,
-                    lastCommit: CreateLastCommit(
+                    lastCommit: CreateBlockCommit(
                         minerA.BlockChain.Tip.Hash,
                         minerA.BlockChain.Tip.Index,
-                        0)));
+                        0));
+                minerA.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 minerA.BroadcastBlock(minerA.BlockChain.Tip);
                 await minerB.BlockAppended.WaitAsync();
 
@@ -1134,12 +1142,12 @@ namespace Libplanet.Net.Tests
                 aBlock1,
                 keyA,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateLastCommit(aBlock1.Hash, aBlock1.Index, 0));
+                lastCommit: CreateBlockCommit(aBlock1.Hash, aBlock1.Index, 0));
             Block<DumbAction> aBlock3 = ProposeNextBlock(
                 aBlock2,
                 keyA,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateLastCommit(aBlock2.Hash, aBlock2.Index, 0));
+                lastCommit: CreateBlockCommit(aBlock2.Hash, aBlock2.Index, 0));
             Block<DumbAction> bBlock1 = ProposeNextBlock(
                 genesis,
                 keyB,
@@ -1148,7 +1156,7 @@ namespace Libplanet.Net.Tests
                 bBlock1,
                 keyB,
                 stateRootHash: MerkleTrie.EmptyRootHash,
-                lastCommit: CreateLastCommit(bBlock1.Hash, bBlock1.Index, 0));
+                lastCommit: CreateBlockCommit(bBlock1.Hash, bBlock1.Index, 0));
 
             policyA.BlockedMiners.Add(keyB.ToAddress());
             policyB.BlockedMiners.Add(keyA.ToAddress());
@@ -1171,7 +1179,7 @@ namespace Libplanet.Net.Tests
                 await BootstrapAsync(minerSwarmB, receiverSwarm.AsPeer);
 
                 // Broadcast SwarmA's first block.
-                minerChainA.Append(aBlock1);
+                minerChainA.Append(aBlock1, TestUtils.CreateBlockCommit(aBlock1));
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),
@@ -1181,10 +1189,10 @@ namespace Libplanet.Net.Tests
                         $"{nameof(receiverChain)}'s tip being same to " +
                         $"{nameof(minerChainA)}'s tip 1st"
                 );
-                minerChainB.Append(bBlock1);
+                minerChainB.Append(bBlock1, TestUtils.CreateBlockCommit(bBlock1));
 
                 // Broadcast SwarmB's second block.
-                minerChainB.Append(bBlock2);
+                minerChainB.Append(bBlock2, TestUtils.CreateBlockCommit(bBlock2));
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainB.Tip),
@@ -1194,10 +1202,10 @@ namespace Libplanet.Net.Tests
                         $"{nameof(receiverChain)}'s tip being same to " +
                         $"{nameof(minerChainB)}'s tip 2nd"
                 );
-                minerChainA.Append(aBlock2);
+                minerChainA.Append(aBlock2, TestUtils.CreateBlockCommit(aBlock2));
 
                 // Broadcast SwarmA's third block.
-                minerChainA.Append(aBlock3);
+                minerChainA.Append(aBlock3, TestUtils.CreateBlockCommit(aBlock3));
                 await receiverSwarm.BlockAppended.WaitAsync();
                 await AssertThatEventually(
                     () => receiverChain.Tip.Equals(minerChainA.Tip),
@@ -1276,7 +1284,7 @@ namespace Libplanet.Net.Tests
                 await swarmC.AddPeersAsync(new[] { swarmA.AsPeer }, null);
 
                 var block = swarmA.BlockChain.ProposeBlock(privateKeyA);
-                swarmA.BlockChain.Append(block);
+                swarmA.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
                 Task.WaitAll(new[]
                 {
@@ -1457,9 +1465,9 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateLastCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
                 ).Evaluate(ChainPrivateKey, chain);
-                chain.Append(block);
+                chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             Log.Debug("Sender's BlockChain Tip index: #{index}", sender.BlockChain.Tip.Index);
@@ -1500,9 +1508,9 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateLastCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
                 ).Evaluate(ChainPrivateKey, chain);
-                chain.Append(block);
+                chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             Log.Debug("Sender's BlockChain Tip index: #{index}", sender.BlockChain.Tip.Index);
@@ -1544,9 +1552,9 @@ namespace Libplanet.Net.Tests
                 Block<DumbAction> block = ProposeNext(
                     chain.Tip,
                     miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateLastCommit(chain.Tip.Hash, chain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0)
                 ).Evaluate(ChainPrivateKey, chain);
-                chain.Append(block);
+                chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             Log.Debug("Sender's BlockChain Tip index: #{index}", sender.BlockChain.Tip.Index);
@@ -1619,7 +1627,8 @@ namespace Libplanet.Net.Tests
                     peerChainState.First()
                 );
 
-                swarm2.BlockChain.Append(swarm2.BlockChain.ProposeBlock(key2));
+                Block<DumbAction> block = swarm2.BlockChain.ProposeBlock(key2);
+                swarm2.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 peerChainState = await swarm1.GetPeerChainStateAsync(
                     TimeSpan.FromSeconds(1), default);
                 Assert.Equal(

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -113,22 +113,10 @@ namespace Libplanet.Net.Tests
         }
 
         public static BlockCommit CreateBlockCommit<T>(Block<T> block)
-            where T : IAction, new() =>
-            CreateBlockCommit(block.Hash, block.Index, 0);
+            where T : IAction, new() => Libplanet.Tests.TestUtils.CreateBlockCommit(block);
 
-        public static BlockCommit CreateBlockCommit(BlockHash blockHash, long height, int round)
-        {
-            var votes = PrivateKeys.Select(key => new VoteMetadata(
-                height,
-                round,
-                blockHash,
-                DateTimeOffset.UtcNow,
-                key.PublicKey,
-                VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
-
-            return new BlockCommit(
-                height, round, blockHash, votes);
-        }
+        public static BlockCommit CreateBlockCommit(BlockHash blockHash, long height, int round) =>
+            Libplanet.Tests.TestUtils.CreateBlockCommit(blockHash, height, round);
 
         public static void HandleFourPeersPreCommitMessages(
             ConsensusContext<DumbAction> consensusContext,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Bencodex;
+using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -110,6 +111,10 @@ namespace Libplanet.Net.Tests
                     codec.Encode(block.MarshalBlock()),
                     validRound).Sign(privateKey));
         }
+
+        public static BlockCommit CreateBlockCommit<T>(Block<T> block)
+            where T : IAction, new() =>
+            CreateBlockCommit(block.Hash, block.Index, 0);
 
         public static BlockCommit CreateBlockCommit(BlockHash blockHash, long height, int round)
         {

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -217,8 +217,7 @@ namespace Libplanet.Net.Consensus
 
                     if (lastCommit == null)
                     {
-                        // Note: Attempting to save a BlockCommit is in Context.Dispose() method.
-                        BlockCommit? storedCommit = _blockChain.Store.GetBlockCommit(height - 1);
+                        BlockCommit? storedCommit = _blockChain.GetBlockCommit(height - 1);
                         if (storedCommit != null)
                         {
                             lastCommit = storedCommit;

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -262,28 +262,18 @@ namespace Libplanet.Net.Consensus
         /// Committing the block to the <see cref="BlockChain{T}"/> and saves
         /// <see cref="BlockCommit"/> of currently committed height.
         /// </summary>
-        /// <param name="commit">A <see cref="BlockCommit"/> created from committed height.
-        /// </param>
         /// <param name="block">A <see cref="Block{T}"/> to committing to the
         /// <see cref="BlockChain{T}"/>.
+        /// </param>
+        /// <param name="commit">A <see cref="BlockCommit"/> created from committed height.
         /// </param>
         /// <remarks>the method is called when a block is voted by <see cref="Context{T}"/>
         /// in <see cref="Libplanet.Net.Consensus.Step.EndCommit"/>.
         /// </remarks>
-        public void Commit(BlockCommit? commit, Block<T> block)
+        public void Commit(Block<T> block, BlockCommit? commit)
         {
             _logger.Debug("Committing block #{Index} {Block}.", block.Index, block.Hash);
-            _blockChain.Append(block);
-            if (commit is null)
-            {
-                return;
-            }
-
-            _logger.Debug(
-                "Saving LastCommit of height #{Height} and round #{Round}.",
-                commit.Height,
-                commit.Round);
-            _blockChain.Store.PutBlockCommit(commit);
+            _blockChain.Append(block, commit);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -272,7 +272,7 @@ namespace Libplanet.Net.Consensus
                     Round,
                     ToString());
 
-                ConsensusContext.Commit(GetBlockCommit(), block4);
+                ConsensusContext.Commit(block4, GetBlockCommit());
                 return;
             }
 

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -172,8 +172,10 @@ namespace Libplanet.Net
              {
                  foreach (var block in blocks)
                  {
+                     // TODO: Block should be appended with commits.
                      workspace.Append(
                          block,
+                         null,
                          evaluateActions: evaluateActions,
                          renderBlocks: renderBlocks,
                          renderActions: renderActions);

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -535,8 +535,11 @@ namespace Libplanet.Net
                                     "Appending block #{Index} {Hash}",
                                     deltaBlock.Index,
                                     deltaBlock.Hash);
+
+                                // TODO : Block should be appended with commits.
                                 workspace.Append(
                                     deltaBlock,
+                                    null,
                                     evaluateActions: false,
                                     renderBlocks: renderBlocks,
                                     renderActions: renderActions

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1238,7 +1238,7 @@ namespace Libplanet.RocksDBStore
             }
             catch (Exception e)
             {
-                LogUnexpectedException(nameof(GetTxNonce), e);
+                LogUnexpectedException(nameof(GetBlockCommit), e);
             }
             finally
             {
@@ -1266,7 +1266,7 @@ namespace Libplanet.RocksDBStore
             }
             catch (Exception e)
             {
-                LogUnexpectedException(nameof(PutBlock), e);
+                LogUnexpectedException(nameof(PutBlockCommit), e);
                 throw;
             }
             finally
@@ -1292,7 +1292,7 @@ namespace Libplanet.RocksDBStore
             }
             catch (Exception e)
             {
-                LogUnexpectedException(nameof(DeleteBlock), e);
+                LogUnexpectedException(nameof(DeleteBlockCommit), e);
                 throw;
             }
             finally

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1304,15 +1304,24 @@ namespace Libplanet.RocksDBStore
         /// <inheritdoc />
         public override IEnumerable<long> GetBlockCommitIndices()
         {
-            IEnumerable<Iterator> iterators = IterateDb(_blockCommitDb, new byte[] { });
+            try
+            {
+                IEnumerable<Iterator> iterators = IterateDb(_blockCommitDb, new byte[] { });
 
-            // FIXME: Somehow key value comes with 0x76 prefix at the first index of
-            // byte array.
-            IEnumerable<long> indices =
-                iterators.Select(
-                        x => RocksDBStoreBitConverter.ToInt64(x.Key().Skip(1).ToArray())).ToArray();
+                // FIXME: Somehow key value comes with 0x76 prefix at the first index of
+                // byte array.
+                IEnumerable<long> indices =
+                    iterators.Select(
+                            x => RocksDBStoreBitConverter.ToInt64(x.Key().Skip(1).ToArray()))
+                        .ToArray();
 
-            return indices;
+                return indices;
+            }
+            catch (Exception e)
+            {
+                LogUnexpectedException(nameof(PutBlockCommit), e);
+                throw;
+            }
         }
 
         [StoreLoader("rocksdb+file")]

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -59,17 +59,20 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            chain.Append(
-                TestUtils.ProposeNext(
+            Block<DumbAction> block = TestUtils.ProposeNext(
                     chain.Tip,
                     new[] { tx },
                     miner: _keys[1].PublicKey,
                     protocolVersion: ProtocolVersion,
-                    lastCommit: TestUtils.CreateLastCommit(
+                    lastCommit: TestUtils.CreateBlockCommit(
                         chain.Tip.Hash,
                         chain.Tip.Index,
                         0)
-                ).Evaluate(_keys[1], chain)
+                )
+                .Evaluate(_keys[1], chain);
+            chain.Append(
+                block,
+                TestUtils.CreateBlockCommit(block)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -64,10 +64,7 @@ namespace Libplanet.Tests.Action
                     new[] { tx },
                     miner: _keys[1].PublicKey,
                     protocolVersion: ProtocolVersion,
-                    lastCommit: TestUtils.CreateBlockCommit(
-                        chain.Tip.Hash,
-                        chain.Tip.Index,
-                        0)
+                    lastCommit: TestUtils.CreateBlockCommit(chain.Tip)
                 )
                 .Evaluate(_keys[1], chain);
             chain.Append(

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -68,7 +68,8 @@ namespace Libplanet.Tests.Action
             );
             var stateRootHash = preEval.DetermineStateRootHash(chain);
             var hash = preEval.Header.DeriveBlockHash(stateRootHash, null);
-            chain.Append(new Block<DumbAction>(preEval, (stateRootHash, null, hash)));
+            Block<DumbAction> block = new Block<DumbAction>(preEval, (stateRootHash, null, hash));
+            chain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,
                 chain.GetBalance(_addr[0], DumbAction.DumbCurrency)

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -239,10 +239,12 @@ namespace Libplanet.Tests.Action
                 protocolVersion: ProtocolVersion);
             var stateRootHash = preEvalBlock.DetermineStateRootHash(chain);
             var hash = preEvalBlock.Header.DeriveBlockHash(stateRootHash, null);
-            chain.Append(
-                ProtocolVersion < 2
+            Block<DumbAction> block = ProtocolVersion < 2
                 ? new Block<DumbAction>(preEvalBlock, (stateRootHash, null, hash))
-                : preEvalBlock.Evaluate(privateKey, chain)
+                : preEvalBlock.Evaluate(privateKey, chain);
+            chain.Append(
+                block,
+                TestUtils.CreateBlockCommit(block)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -137,7 +137,8 @@ namespace Libplanet.Tests.Action
 
             chain.StageTransaction(tx);
             var miner = new PrivateKey();
-            chain.Append(chain.ProposeBlock(miner));
+            Block<EvaluateTestAction> block = chain.ProposeBlock(miner);
+            chain.Append(block, CreateBlockCommit(block));
 
             var evaluations = chain.ActionEvaluator.Evaluate(
                 chain.Tip,
@@ -173,7 +174,8 @@ namespace Libplanet.Tests.Action
                 customActions: new[] { action });
 
             chain.StageTransaction(tx);
-            chain.Append(chain.ProposeBlock(new PrivateKey()));
+            Block<ThrowException> block = chain.ProposeBlock(new PrivateKey());
+            chain.Append(block, CreateBlockCommit(block));
             var evaluations = chain.ActionEvaluator.Evaluate(
                 chain.Tip,
                 StateCompleterSet<ThrowException>.Recalculate);
@@ -461,7 +463,7 @@ namespace Libplanet.Tests.Action
                 block1,
                 GenesisMiner,
                 block2Txs,
-                lastCommit: CreateLastCommit(block1.Hash, block1.Index, 0));
+                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0));
             AccountStateGetter accountStateGetter = addrs =>
                 addrs.Select(dirty1.GetValueOrDefault).ToArray();
             AccountBalanceGetter accountBalanceGetter = (address, currency)
@@ -729,7 +731,7 @@ namespace Libplanet.Tests.Action
                     publicKey: GenesisMiner.PublicKey,
                     previousHash: hash,
                     txHash: BlockContent<ThrowException>.DeriveTxHash(txs),
-                    lastCommit: CreateLastCommit(hash, 122, 0)),
+                    lastCommit: CreateBlockCommit(hash, 122, 0)),
                 transactions: txs).Propose();
             var nextStates = actionEvaluator.EvaluateTxResult(
                 block: block,
@@ -940,6 +942,7 @@ namespace Libplanet.Tests.Action
             chain.ExecuteActions(block);
             chain.Append(
                 block,
+                CreateBlockCommit(block),
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false);
@@ -1114,7 +1117,8 @@ namespace Libplanet.Tests.Action
                 customActions: new[] { action });
             chain.StageTransaction(tx);
             var miner = new PrivateKey();
-            chain.Append(chain.ProposeBlock(miner));
+            Block<EvaluateTestAction> block = chain.ProposeBlock(miner);
+            chain.Append(block, CreateBlockCommit(block));
             var evaluations = chain.ActionEvaluator.Evaluate(
                 chain.Tip,
                 StateCompleterSet<EvaluateTestAction>.Recalculate);

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -463,7 +463,7 @@ namespace Libplanet.Tests.Action
                 block1,
                 GenesisMiner,
                 block2Txs,
-                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0));
+                lastCommit: CreateBlockCommit(block1));
             AccountStateGetter accountStateGetter = addrs =>
                 addrs.Select(dirty1.GetValueOrDefault).ToArray();
             AccountBalanceGetter accountBalanceGetter = (address, currency)

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -46,6 +46,7 @@ namespace Libplanet.Tests.Blockchain
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(keys[4], _blockChain);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
+            Assert.NotNull(_blockChain.Store.GetBlockCommit(block1.Index));
             Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 txs,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -45,13 +45,13 @@ namespace Libplanet.Tests.Blockchain
                 miner: keys[4].PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(keys[4], _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 txs,
                 miner: keys[4].PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateLastCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(keys[4], _blockChain);
             foreach (Transaction<DumbAction> tx in txs)
             {
@@ -65,7 +65,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Null(_fx.Store.GetFirstTxIdBlockHashIndex(tx.Id));
             }
 
-            _blockChain.Append(block2);
+            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             foreach (var tx in txs)
             {
@@ -203,9 +203,9 @@ namespace Libplanet.Tests.Blockchain
                 block2,
                 new[] { tx1Transfer, tx2Error, tx3Transfer },
                 miner: keys[4].PublicKey,
-                lastCommit: TestUtils.CreateLastCommit(block2.Hash, block2.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block2.Hash, block2.Index, 0)
             ).Evaluate(keys[4], _blockChain);
-            _blockChain.Append(block3);
+            _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             var txExecution1 = getTxExecution(block3.Hash, tx1Transfer.Id);
             _logger.Verbose(nameof(txExecution1) + " = {@TxExecution}", txExecution1);
             Assert.IsType<TxSuccess>(txExecution1);
@@ -326,7 +326,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.True(block.MarshalBlock().EncodingLength > maxBytes);
 
             var e = Assert.Throws<InvalidBlockBytesLengthException>(() =>
-                _blockChain.Append(block)
+                _blockChain.Append(block, TestUtils.CreateBlockCommit(block))
             );
         }
 
@@ -356,7 +356,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(manyTxs.Count, block.Transactions.Count());
 
             var e = Assert.Throws<InvalidBlockTxCountException>(() =>
-                _blockChain.Append(block)
+                _blockChain.Append(block, TestUtils.CreateBlockCommit(block))
             );
         }
 
@@ -374,6 +374,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Throws<ArgumentException>(() =>
                 _blockChain.Append(
                     block,
+                    TestUtils.CreateBlockCommit(block),
                     evaluateActions: false,
                     renderBlocks: true,
                     renderActions: true
@@ -384,6 +385,7 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.Append(
                 block,
+                TestUtils.CreateBlockCommit(block),
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false
@@ -408,7 +410,8 @@ namespace Libplanet.Tests.Blockchain
             blockChain.MakeTransaction(privateKey, new[] { action });
 
             renderer.ResetRecords();
-            blockChain.Append(blockChain.ProposeBlock(new PrivateKey()));
+            Block<ThrowException> block = blockChain.ProposeBlock(new PrivateKey());
+            blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             Assert.Equal(2, blockChain.Count);
             Assert.Empty(renderer.ActionSuccessRecords);
@@ -458,17 +461,18 @@ namespace Libplanet.Tests.Blockchain
                     blockInterval: TimeSpan.FromSeconds(10)
                 ).Evaluate(miner, blockChain);
 
-                blockChain.Append(block1);
+                blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
                 Block<DumbAction> block2 = TestUtils.ProposeNext(
                     block1,
                     new[] { invalidTx },
                     miner: miner.PublicKey,
                     blockInterval: TimeSpan.FromSeconds(10),
-                    lastCommit: TestUtils.CreateLastCommit(block1.Hash, block1.Index, 0)
+                    lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
                 ).Evaluate(miner, blockChain);
 
-                Assert.Throws<TxPolicyViolationException>(() => blockChain.Append(block2));
+                Assert.Throws<TxPolicyViolationException>(() => blockChain.Append(
+                    block2, TestUtils.CreateBlockCommit(block2)));
             }
         }
 
@@ -487,7 +491,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(privateKey, _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
             StageTransactions(txs);
@@ -499,9 +503,9 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateLastCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(privateKey, _blockChain);
-            _blockChain.Append(block2);
+            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
 
             // Two txs with nonce 1 are staged.
@@ -519,9 +523,9 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateLastCommit(block2.Hash, block2.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block2.Hash, block2.Index, 0)
             ).Evaluate(privateKey, _blockChain);
-            _blockChain.Append(block3);
+            _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
             Assert.Single(_blockChain.StagePolicy.Iterate(_blockChain, filtered: false));
@@ -552,13 +556,13 @@ namespace Libplanet.Tests.Blockchain
             ).Evaluate(privateKey, _blockChain);
 
             // Not actually unstaged, but lower nonce is filtered for workspace.
-            workspace.Append(block1);
+            workspace.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Equal(2, _blockChain.ListStagedTransactions().Count);
             Assert.Single(workspace.ListStagedTransactions());
             Assert.Equal(2, workspace.StagePolicy.Iterate(workspace, filtered: false).Count());
 
             // Actually gets unstaged.
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Single(_blockChain.ListStagedTransactions());
             Assert.Single(workspace.ListStagedTransactions());
             Assert.Single(workspace.StagePolicy.Iterate(workspace, filtered: false));
@@ -569,11 +573,11 @@ namespace Libplanet.Tests.Blockchain
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
                 transactions: ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
-                lastCommit: TestUtils.CreateLastCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(privateKey, _blockChain);
 
             // Actually gets unstaged.
-            _blockChain.Append(block2);
+            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Empty(_blockChain.ListStagedTransactions());
             Assert.Empty(workspace.ListStagedTransactions());
             Assert.Empty(workspace.StagePolicy.Iterate(workspace, filtered: false));
@@ -590,7 +594,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.StateStore,
                 _fx.GenesisBlock);
             Assert.Throws<BlockPolicyViolationException>(
-                () => blockChain.Append(_fx.Block1));
+                () => blockChain.Append(_fx.Block1, TestUtils.CreateBlockCommit(_fx.Block1)));
         }
 
         [Fact]
@@ -639,7 +643,7 @@ namespace Libplanet.Tests.Blockchain
                 }.Select(tx => tx.Id).ToImmutableHashSet(),
                 _blockChain.GetStagedTransactionIds());
 
-            _blockChain.Append(block);
+            _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             AssertTxIdSetEqual(
                 new Transaction<DumbAction>[]
                 {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Tests.Blockchain
                 txs,
                 miner: keys[4].PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1)
             ).Evaluate(keys[4], _blockChain);
             foreach (Transaction<DumbAction> tx in txs)
             {
@@ -204,7 +204,7 @@ namespace Libplanet.Tests.Blockchain
                 block2,
                 new[] { tx1Transfer, tx2Error, tx3Transfer },
                 miner: keys[4].PublicKey,
-                lastCommit: TestUtils.CreateBlockCommit(block2.Hash, block2.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block2)
             ).Evaluate(keys[4], _blockChain);
             _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             var txExecution1 = getTxExecution(block3.Hash, tx1Transfer.Id);
@@ -469,7 +469,7 @@ namespace Libplanet.Tests.Blockchain
                     new[] { invalidTx },
                     miner: miner.PublicKey,
                     blockInterval: TimeSpan.FromSeconds(10),
-                    lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
+                    lastCommit: TestUtils.CreateBlockCommit(block1)
                 ).Evaluate(miner, blockChain);
 
                 Assert.Throws<TxPolicyViolationException>(() => blockChain.Append(
@@ -504,7 +504,7 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[0]),
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1)
             ).Evaluate(privateKey, _blockChain);
             _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
@@ -524,7 +524,7 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block2.Hash, block2.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block2)
             ).Evaluate(privateKey, _blockChain);
             _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
@@ -574,7 +574,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: privateKey.PublicKey,
                 blockInterval: TimeSpan.FromSeconds(10),
                 transactions: ImmutableArray<Transaction<DumbAction>>.Empty.Add(txs[1]),
-                lastCommit: TestUtils.CreateBlockCommit(block1.Hash, block1.Index, 0)
+                lastCommit: TestUtils.CreateBlockCommit(block1)
             ).Evaluate(privateKey, _blockChain);
 
             // Actually gets unstaged.

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -111,6 +111,7 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.Append(
                 block1,
+                CreateBlockCommit(block1),
                 evaluateActions: false,
                 renderBlocks: true,
                 renderActions: false

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -354,10 +354,9 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock);
 
             blockChain.MakeTransaction(privateKey2, new[] { new DumbAction(address2, "baz") });
-            Block<DumbAction> block1 = blockChain.ProposeBlock(
-                privateKey1,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
-            blockChain.Append(block1, CreateBlockCommit(block1));
+            var block = blockChain.ProposeBlock(
+                privateKey1, lastCommit: CreateBlockCommit(_blockChain.Tip));
+            blockChain.Append(block, CreateBlockCommit(block));
 
             var state1 = blockChain.GetState(address1);
             var state2 = blockChain.GetState(address2);
@@ -368,10 +367,9 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal((Text)"baz", state2);
 
             blockChain.MakeTransaction(privateKey1, new[] { new DumbAction(address1, "bar") });
-            Block<DumbAction> block2 = blockChain.ProposeBlock(
-                privateKey1,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
-            blockChain.Append(block2, CreateBlockCommit(block2));
+            block = blockChain.ProposeBlock(
+                privateKey1, lastCommit: CreateBlockCommit(_blockChain.Tip));
+            blockChain.Append(block, CreateBlockCommit(block));
 
             state1 = blockChain.GetState(address1);
             state2 = blockChain.GetState(address2);
@@ -471,7 +469,7 @@ namespace Libplanet.Tests.Blockchain
             // Propose only txs having higher or equal with nonce than expected nonce.
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateBlockCommit(b1.Hash, b1.Index, 0));
+                lastCommit: CreateBlockCommit(b1));
             Assert.Single(b2.Transactions);
             Assert.Contains(txsB[3], b2.Transactions);
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blockchain
 
             var minerA = new PrivateKey();
             Block<DumbAction> block = _blockChain.ProposeBlock(minerA);
-            _blockChain.Append(block);
+            _blockChain.Append(block, CreateBlockCommit(block));
             Assert.True(_blockChain.ContainsBlock(block.Hash));
             Assert.Equal(2, _blockChain.Count);
             Assert.True(
@@ -42,8 +42,8 @@ namespace Libplanet.Tests.Blockchain
             var minerB = new PrivateKey();
             Block<DumbAction> anotherBlock = _blockChain.ProposeBlock(
                 minerB,
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
-            _blockChain.Append(anotherBlock);
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+            _blockChain.Append(anotherBlock, CreateBlockCommit(anotherBlock));
             Assert.True(_blockChain.ContainsBlock(anotherBlock.Hash));
             Assert.Equal(3, _blockChain.Count);
             Assert.True(
@@ -56,7 +56,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block3 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             Assert.False(_blockChain.ContainsBlock(block3.Hash));
             Assert.Equal(3, _blockChain.Count);
             Assert.True(
@@ -89,7 +89,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block4 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             Assert.False(_blockChain.ContainsBlock(block4.Hash));
             _logger.Debug(
                 $"{nameof(block4)}: {0} bytes",
@@ -181,7 +181,7 @@ namespace Libplanet.Tests.Blockchain
             }
 
             Block<DumbAction> block = _blockChain.ProposeBlock(keyA);
-            _blockChain.Append(block);
+            _blockChain.Append(block, CreateBlockCommit(block));
 
             Assert.True(_blockChain.ContainsBlock(block.Hash));
             Assert.Contains(txs[0], block.Transactions);
@@ -250,7 +250,7 @@ namespace Libplanet.Tests.Blockchain
 
                 var miner = new PrivateKey();
                 var block = blockChain.ProposeBlock(miner);
-                blockChain.Append(block);
+                blockChain.Append(block, CreateBlockCommit(block));
 
                 var txs = block.Transactions.ToHashSet();
 
@@ -307,7 +307,8 @@ namespace Libplanet.Tests.Blockchain
                     ),
                 }
             );
-            _blockChain.Append(_blockChain.ProposeBlock(new PrivateKey()));
+            Block<DumbAction> block1 = _blockChain.ProposeBlock(new PrivateKey());
+            _blockChain.Append(block1, CreateBlockCommit(block1));
 
             // Trying to propose with lower nonce (0) than expected.
             StageTransactions(
@@ -321,12 +322,12 @@ namespace Libplanet.Tests.Blockchain
                     ),
                 }
             );
-            Block<DumbAction> block = _blockChain.ProposeBlock(
+            Block<DumbAction> block2 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
-            _blockChain.Append(block);
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+            _blockChain.Append(block2, CreateBlockCommit(block2));
 
-            Assert.Empty(block.Transactions);
+            Assert.Empty(block2.Transactions);
             Assert.Empty(_blockChain.ListStagedTransactions());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
             Assert.Single(_blockChain.StagePolicy.Iterate(_blockChain, filtered: false));
@@ -353,9 +354,10 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock);
 
             blockChain.MakeTransaction(privateKey2, new[] { new DumbAction(address2, "baz") });
-            blockChain.Append(blockChain.ProposeBlock(
+            Block<DumbAction> block1 = blockChain.ProposeBlock(
                 privateKey1,
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+            blockChain.Append(block1, CreateBlockCommit(block1));
 
             var state1 = blockChain.GetState(address1);
             var state2 = blockChain.GetState(address2);
@@ -366,9 +368,10 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal((Text)"baz", state2);
 
             blockChain.MakeTransaction(privateKey1, new[] { new DumbAction(address1, "bar") });
-            blockChain.Append(blockChain.ProposeBlock(
+            Block<DumbAction> block2 = blockChain.ProposeBlock(
                 privateKey1,
-                lastCommit: CreateLastCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0)));
+                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+            blockChain.Append(block2, CreateBlockCommit(block2));
 
             state1 = blockChain.GetState(address1);
             state2 = blockChain.GetState(address2);
@@ -449,7 +452,7 @@ namespace Libplanet.Tests.Blockchain
                 .ToArray();
             StageTransactions(txsA);
             Block<DumbAction> b1 = _blockChain.ProposeBlock(new PrivateKey());
-            _blockChain.Append(b1);
+            _blockChain.Append(b1, CreateBlockCommit(b1));
             Assert.Equal(
                 txsA,
                 ActionEvaluator<DumbAction>.OrderTxsForEvaluation(
@@ -468,7 +471,7 @@ namespace Libplanet.Tests.Blockchain
             // Propose only txs having higher or equal with nonce than expected nonce.
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateLastCommit(b1.Hash, b1.Index, 0));
+                lastCommit: CreateBlockCommit(b1.Hash, b1.Index, 0));
             Assert.Single(b2.Transactions);
             Assert.Contains(txsB[3], b2.Transactions);
         }
@@ -485,7 +488,7 @@ namespace Libplanet.Tests.Blockchain
                 .ToArray();
             StageTransactions(txs);
             Block<DumbAction> b = _blockChain.ProposeBlock(privateKey);
-            _blockChain.Append(b);
+            _blockChain.Append(b, CreateBlockCommit(b));
 
             Assert.Single(b.Transactions);
             Assert.Contains(b.Transactions.Single(), txs);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
@@ -84,8 +84,8 @@ namespace Libplanet.Tests.Blockchain
 
             // stage tx_0_0 -> mine tx_0_0 -> stage tx_0_1
             Assert.True(_blockChain.StageTransaction(tx_0_0));
-            Block<DumbAction> block1 = _blockChain.ProposeBlock(key);
-            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
+            var block = _blockChain.ProposeBlock(key);
+            _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: false));
@@ -105,13 +105,9 @@ namespace Libplanet.Tests.Blockchain
                 txIds.OrderBy(id => id),
                 _blockChain.GetStagedTransactionIds().OrderBy(id => id)
             );
-            Block<DumbAction> block2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(
-                    _blockChain.Tip.Hash,
-                    _blockChain.Tip.Index,
-                    0));
-            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
+            block = _blockChain.ProposeBlock(
+                key, lastCommit: TestUtils.CreateBlockCommit(_blockChain.Tip));
+            _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             // tx_0_1 and tx_1_x should be still staged, just filtered
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
@@ -84,7 +84,8 @@ namespace Libplanet.Tests.Blockchain
 
             // stage tx_0_0 -> mine tx_0_0 -> stage tx_0_1
             Assert.True(_blockChain.StageTransaction(tx_0_0));
-            _blockChain.Append(_blockChain.ProposeBlock(key));
+            Block<DumbAction> block1 = _blockChain.ProposeBlock(key);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: false));
@@ -104,12 +105,13 @@ namespace Libplanet.Tests.Blockchain
                 txIds.OrderBy(id => id),
                 _blockChain.GetStagedTransactionIds().OrderBy(id => id)
             );
-            _blockChain.Append(_blockChain.ProposeBlock(
+            Block<DumbAction> block2 = _blockChain.ProposeBlock(
                 key,
-                lastCommit: TestUtils.CreateLastCommit(
+                lastCommit: TestUtils.CreateBlockCommit(
                     _blockChain.Tip.Hash,
                     _blockChain.Tip.Index,
-                    0)));
+                    0));
+            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             // tx_0_1 and tx_1_x should be still staged, just filtered
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -59,7 +59,7 @@ namespace Libplanet.Tests.Blockchain
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
 
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                _blockChain.Append(block2, null));
+                _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2)));
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
             {
                 Block<DumbAction> block3 = new BlockContent<DumbAction>(
@@ -72,7 +72,7 @@ namespace Libplanet.Tests.Blockchain
                         previousHash: block1.Hash,
                         txHash: null,
                         lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-                _blockChain.Append(block3, null);
+                _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             });
         }
 
@@ -106,7 +106,9 @@ namespace Libplanet.Tests.Blockchain
                     lastCommit: TestUtils.CreateBlockCommit(prev.Hash, prev.Index + 1, 0)))
                     .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockIndexException>(
-                () => _blockChain.Append(blockWithIndexAfterNonexistentIndex, null)
+                () => _blockChain.Append(
+                    blockWithIndexAfterNonexistentIndex,
+                    TestUtils.CreateBlockCommit(blockWithIndexAfterNonexistentIndex))
             );
         }
 
@@ -127,7 +129,9 @@ namespace Libplanet.Tests.Blockchain
                     lastCommit: TestUtils.CreateBlockCommit(_validNext.PreviousHash.Value, 1, 0)))
                 .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                    _blockChain.Append(invalidPreviousHashBlock, null));
+                    _blockChain.Append(
+                        invalidPreviousHashBlock,
+                        TestUtils.CreateBlockCommit(invalidPreviousHashBlock)));
         }
 
         [Fact]
@@ -142,10 +146,12 @@ namespace Libplanet.Tests.Blockchain
                     publicKey: _fx.Miner.PublicKey,
                     previousHash: _validNext.Hash,
                     txHash: null,
-                    lastCommit: TestUtils.CreateBlockCommit(_validNext.Hash, _validNext.Index, 0)))
+                    lastCommit: TestUtils.CreateBlockCommit(_validNext)))
                 .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockTimestampException>(() =>
-                    _blockChain.Append(invalidPreviousTimestamp, null));
+                    _blockChain.Append(
+                        invalidPreviousTimestamp,
+                        TestUtils.CreateBlockCommit(invalidPreviousTimestamp)));
         }
 
         [Fact]
@@ -230,7 +236,7 @@ namespace Libplanet.Tests.Blockchain
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-            var blockCommit = TestUtils.CreateBlockCommit(block1.Hash, 1, 0);
+            var blockCommit = TestUtils.CreateBlockCommit(block1);
             Block<DumbAction> block2 = new BlockContent<DumbAction>(
                 new BlockMetadata(
                     index: 2L,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(validNextBlock);
+            _blockChain.Append(validNextBlock, TestUtils.CreateBlockCommit(validNextBlock));
             Assert.Equal(_blockChain.Tip, validNextBlock);
         }
 
@@ -45,7 +45,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             Block<DumbAction> block2 = new BlockContent<DumbAction>(
                 new BlockMetadata(
@@ -58,7 +58,8 @@ namespace Libplanet.Tests.Blockchain
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
 
-            Assert.Throws<InvalidBlockProtocolVersionException>(() => _blockChain.Append(block2));
+            Assert.Throws<InvalidBlockProtocolVersionException>(() =>
+                _blockChain.Append(block2, null));
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
             {
                 Block<DumbAction> block3 = new BlockContent<DumbAction>(
@@ -71,14 +72,14 @@ namespace Libplanet.Tests.Blockchain
                         previousHash: block1.Hash,
                         txHash: null,
                         lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-                _blockChain.Append(block3);
+                _blockChain.Append(block3, null);
             });
         }
 
         [Fact]
         public void ValidateNextBlockInvalidIndex()
         {
-            _blockChain.Append(_validNext);
+            _blockChain.Append(_validNext, TestUtils.CreateBlockCommit(_validNext));
 
             Block<DumbAction> prev = _blockChain.Tip;
             Block<DumbAction> blockWithAlreadyUsedIndex = new BlockContent<DumbAction>(
@@ -90,7 +91,9 @@ namespace Libplanet.Tests.Blockchain
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockIndexException>(
-                () => _blockChain.Append(blockWithAlreadyUsedIndex)
+                () => _blockChain.Append(
+                    blockWithAlreadyUsedIndex,
+                    TestUtils.CreateBlockCommit(blockWithAlreadyUsedIndex))
             );
 
             Block<DumbAction> blockWithIndexAfterNonexistentIndex = new BlockContent<DumbAction>(
@@ -100,17 +103,17 @@ namespace Libplanet.Tests.Blockchain
                     publicKey: _fx.Miner.PublicKey,
                     previousHash: prev.Hash,
                     txHash: null,
-                    lastCommit: TestUtils.CreateLastCommit(prev.Hash, prev.Index + 1, 0)))
+                    lastCommit: TestUtils.CreateBlockCommit(prev.Hash, prev.Index + 1, 0)))
                     .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockIndexException>(
-                () => _blockChain.Append(blockWithIndexAfterNonexistentIndex)
+                () => _blockChain.Append(blockWithIndexAfterNonexistentIndex, null)
             );
         }
 
         [Fact]
         public void ValidateNextBlockInvalidPreviousHash()
         {
-            _blockChain.Append(_validNext);
+            _blockChain.Append(_validNext, TestUtils.CreateBlockCommit(_validNext));
 
             Block<DumbAction> invalidPreviousHashBlock = new BlockContent<DumbAction>(
                 new BlockMetadata(
@@ -121,16 +124,16 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _validNext.PreviousHash,
                     txHash: null,
                     // ReSharper disable once PossibleInvalidOperationException
-                    lastCommit: TestUtils.CreateLastCommit(_validNext.PreviousHash.Value, 1, 0)))
+                    lastCommit: TestUtils.CreateBlockCommit(_validNext.PreviousHash.Value, 1, 0)))
                 .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockPreviousHashException>(() =>
-                    _blockChain.Append(invalidPreviousHashBlock));
+                    _blockChain.Append(invalidPreviousHashBlock, null));
         }
 
         [Fact]
         public void ValidateNextBlockInvalidTimestamp()
         {
-            _blockChain.Append(_validNext);
+            _blockChain.Append(_validNext, TestUtils.CreateBlockCommit(_validNext));
 
             Block<DumbAction> invalidPreviousTimestamp = new BlockContent<DumbAction>(
                 new BlockMetadata(
@@ -139,10 +142,10 @@ namespace Libplanet.Tests.Blockchain
                     publicKey: _fx.Miner.PublicKey,
                     previousHash: _validNext.Hash,
                     txHash: null,
-                    lastCommit: TestUtils.CreateLastCommit(_validNext.Hash, _validNext.Index, 0)))
+                    lastCommit: TestUtils.CreateBlockCommit(_validNext.Hash, _validNext.Index, 0)))
                 .Propose().Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidBlockTimestampException>(() =>
-                    _blockChain.Append(invalidPreviousTimestamp));
+                    _blockChain.Append(invalidPreviousTimestamp, null));
         }
 
         [Fact]
@@ -195,7 +198,8 @@ namespace Libplanet.Tests.Blockchain
                 stateStore,
                 genesisBlock
             );
-            Assert.Throws<InvalidBlockStateRootHashException>(() => chain2.Append(block1));
+            Assert.Throws<InvalidBlockStateRootHashException>(() =>
+                chain2.Append(block1, TestUtils.CreateBlockCommit(block1)));
         }
 
         [Fact]
@@ -209,7 +213,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(validNextBlock);
+            _blockChain.Append(validNextBlock, TestUtils.CreateBlockCommit(validNextBlock));
             Assert.Equal(_blockChain.Tip, validNextBlock);
         }
 
@@ -224,9 +228,9 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-            var blockCommit = TestUtils.CreateLastCommit(block1.Hash, 1, 0);
+            var blockCommit = TestUtils.CreateBlockCommit(block1.Hash, 1, 0);
             Block<DumbAction> block2 = new BlockContent<DumbAction>(
                 new BlockMetadata(
                     index: 2L,
@@ -235,7 +239,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: block1.Hash,
                     txHash: null,
                     lastCommit: blockCommit)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block2);
+            _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(_blockChain.Tip, block2);
         }
 
@@ -250,7 +254,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             var invalidValidator = new PrivateKey();
             var validators = TestUtils.ValidatorPrivateKeys.Append(invalidValidator).ToList();
@@ -271,7 +275,8 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: block1.Hash,
                     txHash: null,
                     lastCommit: blockCommit)).Propose().Evaluate(_fx.Miner, _blockChain);
-            Assert.Throws<InvalidBlockLastCommitException>(() => _blockChain.Append(block2));
+            Assert.Throws<InvalidBlockLastCommitException>(() =>
+                _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2)));
         }
 
         [Fact]
@@ -285,7 +290,7 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: _fx.GenesisBlock.Hash,
                     txHash: null,
                     lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
-            _blockChain.Append(block1);
+            _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             var keysExceptPeer0 = TestUtils.ValidatorPrivateKeys.Where(
                 key => key != TestUtils.ValidatorPrivateKeys[0]).ToList();
@@ -305,7 +310,8 @@ namespace Libplanet.Tests.Blockchain
                     previousHash: block1.Hash,
                     txHash: null,
                     lastCommit: blockCommit)).Propose().Evaluate(_fx.Miner, _blockChain);
-            Assert.Throws<InvalidBlockLastCommitException>(() => _blockChain.Append(block2));
+            Assert.Throws<InvalidBlockLastCommitException>(() =>
+                _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2)));
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1034,6 +1034,20 @@ namespace Libplanet.Tests.Blockchain
             }
         }
 
+        [Fact]
+        public void GetBlockCommit()
+        {
+            // Requesting blockCommit of genesis block returns null.
+            Assert.Null(_blockChain.GetBlockCommit(0));
+            Assert.Null(_blockChain.GetBlockCommit(_blockChain.Genesis.Hash));
+            // BlockCommit is put to store when block is appended.
+            Block<DumbAction> block = _blockChain.ProposeBlock(new PrivateKey());
+            BlockCommit blockCommit = CreateBlockCommit(block);
+            _blockChain.Append(block, blockCommit);
+            Assert.Equal(blockCommit, _blockChain.GetBlockCommit(block.Index));
+            Assert.Equal(blockCommit, _blockChain.GetBlockCommit(block.Hash));
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -151,14 +151,12 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block1 = chain1.ProposeBlock(key);
             chain1.Append(block1, CreateBlockCommit(block1));
             Block<DumbAction> block2 = chain1.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(chain1.Tip.Hash, chain1.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(chain1.Tip));
             chain1.Append(block2, CreateBlockCommit(block2));
             Assert.Equal(chain1.Id, _fx.Store.GetCanonicalChainId());
             var chain2 = chain1.Fork(chain1.Tip.Hash);
             Block<DumbAction> block3 = chain2.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(chain1.Tip.Hash, chain1.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(chain1.Tip));
             chain2.Append(block3, CreateBlockCommit(block3));
             Assert.Equal(chain1.Id, _fx.Store.GetCanonicalChainId());
 
@@ -186,8 +184,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(new[] { genesis.Hash, b1.Hash }, _blockChain.BlockHashes);
 
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b2, CreateBlockCommit(b2));
             Assert.Equal(
                 new[] { genesis.Hash, b1.Hash, b2.Hash },
@@ -195,8 +192,7 @@ namespace Libplanet.Tests.Blockchain
             );
 
             Block<DumbAction> b3 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b3, CreateBlockCommit(b3));
             Assert.Equal(
                 new[] { genesis.Hash, b1.Hash, b2.Hash, b3.Hash },
@@ -278,8 +274,7 @@ namespace Libplanet.Tests.Blockchain
 
             chain.StageTransaction(tx2);
             Block<PolymorphicAction<BaseAction>> block2 = chain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                new PrivateKey(), lastCommit: CreateBlockCommit(chain.Tip));
             chain.Append(block2, CreateBlockCommit(block2));
 
             state = chain.GetState(_fx.Address1);
@@ -301,8 +296,7 @@ namespace Libplanet.Tests.Blockchain
                 }
             );
             Block<PolymorphicAction<BaseAction>> block3 = chain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                new PrivateKey(), lastCommit: CreateBlockCommit(chain.Tip));
             chain.StageTransaction(tx3);
             chain.Append(block3, CreateBlockCommit(block3));
             state = chain.GetState(_fx.Address1);
@@ -483,12 +477,10 @@ namespace Libplanet.Tests.Blockchain
             var block1 = _blockChain.ProposeBlock(key);
             _blockChain.Append(block1, CreateBlockCommit(block1));
             var block2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block2, CreateBlockCommit(block2));
             var block3 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block3, CreateBlockCommit(block3));
 
             _blockChain.FindNextHashes(new BlockLocator(new[] { block0.Hash }))
@@ -520,12 +512,10 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block = _blockChain.ProposeBlock(key);
             _blockChain.Append(block, CreateBlockCommit(block));
             Block<DumbAction> block2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block2, CreateBlockCommit(block2));
             Block<DumbAction> block3 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block3, CreateBlockCommit(block3));
 
             BlockChain<DumbAction> forked = _blockChain.Fork(_blockChain.Genesis.Hash);
@@ -548,12 +538,10 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block1 = _blockChain.ProposeBlock(key);
             _blockChain.Append(block1, CreateBlockCommit(block1));
             Block<DumbAction> block2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block2, CreateBlockCommit(block2));
             Block<DumbAction> block3 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block3, CreateBlockCommit(block3));
 
             BlockChain<DumbAction> forked = _blockChain.Fork(block2.Hash);
@@ -594,8 +582,7 @@ namespace Libplanet.Tests.Blockchain
             for (var i = 0; i < 2; i++)
             {
                 Block<DumbAction> block = _blockChain.ProposeBlock(
-                    key,
-                    lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                    key, lastCommit: CreateBlockCommit(_blockChain.Tip));
                 _blockChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -636,8 +623,7 @@ namespace Libplanet.Tests.Blockchain
 
             _blockChain.MakeTransaction(signer, actions2);
             var b2 = _blockChain.ProposeBlock(
-                miner,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                miner, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b2, CreateBlockCommit(b2));
             var state = _blockChain.GetState(address);
 
@@ -690,8 +676,7 @@ namespace Libplanet.Tests.Blockchain
                 Block<DumbAction> block1 = blockChain.ProposeBlock(miner);
                 blockChain.Append(block1, CreateBlockCommit(block1));
                 Block<DumbAction> block2 = blockChain.ProposeBlock(
-                    miner,
-                    lastCommit: CreateBlockCommit(blockChain.Tip.Hash, blockChain.Tip.Index, 0));
+                    miner, lastCommit: CreateBlockCommit(blockChain.Tip));
                 blockChain.Append(block2, CreateBlockCommit(block2));
 
                 int blockRecordsBeforeFork = renderer.BlockRecords.Count;
@@ -731,7 +716,7 @@ namespace Libplanet.Tests.Blockchain
                 txsA,
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey,
-                lastCommit: CreateBlockCommit(b1.Hash, b1.Index, 0)
+                lastCommit: CreateBlockCommit(b1)
             ).Evaluate(_fx.Miner, _blockChain);
             Assert.Throws<InvalidTxNonceException>(() =>
                 _blockChain.Append(b2, CreateBlockCommit(b2)));
@@ -748,7 +733,7 @@ namespace Libplanet.Tests.Blockchain
                 txsB,
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey,
-                lastCommit: CreateBlockCommit(b1.Hash, b1.Index, 0)
+                lastCommit: CreateBlockCommit(b1)
             ).Evaluate(_fx.Miner, _blockChain);
             _blockChain.Append(b2, CreateBlockCommit(b2));
         }
@@ -799,7 +784,7 @@ namespace Libplanet.Tests.Blockchain
                 txsB,
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: _fx.Miner.PublicKey,
-                lastCommit: CreateBlockCommit(b1.Hash, b1.Index, 0)
+                lastCommit: CreateBlockCommit(b1)
             ).Evaluate(_fx.Miner, _blockChain);
             _blockChain.Append(b2, CreateBlockCommit(b2));
 
@@ -819,7 +804,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 var block = _blockChain.ProposeBlock(
                     key,
-                    lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                    lastCommit: CreateBlockCommit(_blockChain.Tip));
                 _blockChain.Append(block, CreateBlockCommit(block));
                 blocks.Add(block);
             }
@@ -920,7 +905,7 @@ namespace Libplanet.Tests.Blockchain
                     txs,
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: miner.PublicKey,
-                    lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0)
+                    lastCommit: CreateBlockCommit(_blockChain.Tip)
                 ).Evaluate(miner, _blockChain);
                 _blockChain.Append(b, CreateBlockCommit(b));
             }
@@ -951,7 +936,7 @@ namespace Libplanet.Tests.Blockchain
                 txsB,
                 blockInterval: TimeSpan.FromSeconds(10),
                 miner: miner.PublicKey,
-                lastCommit: CreateBlockCommit(fork.Tip.Hash, fork.Tip.Index, 0)
+                lastCommit: CreateBlockCommit(fork.Tip)
             ).Evaluate(miner, fork);
             fork.Append(
                 forkTip,
@@ -1125,16 +1110,11 @@ namespace Libplanet.Tests.Blockchain
                 for (int i = 0; i < 5; i++)
                 {
                     Block<DumbAction> block1 = _blockChain.ProposeBlock(
-                        key,
-                        lastCommit: CreateBlockCommit(
-                            _blockChain.Tip.Hash,
-                            _blockChain.Tip.Index,
-                            0));
+                        key, lastCommit: CreateBlockCommit(_blockChain.Tip));
                     _blockChain.Append(block1, CreateBlockCommit(block1));
 
                     Block<DumbAction> block2 = chain2.ProposeBlock(
-                        key,
-                        lastCommit: CreateBlockCommit(chain2.Tip.Hash, chain2.Tip.Index, 0));
+                        key, lastCommit: CreateBlockCommit(chain2.Tip));
                     chain2.Append(block2, CreateBlockCommit(block2));
                 }
 
@@ -1237,7 +1217,7 @@ namespace Libplanet.Tests.Blockchain
                     b,
                     txs,
                     miner: _fx.Miner.PublicKey,
-                    lastCommit: CreateBlockCommit(b.Hash, b.Index, 0)
+                    lastCommit: CreateBlockCommit(b)
                 ).Evaluate(_fx.Miner, chain);
                 chain.Append(b, CreateBlockCommit(b));
             }
@@ -1278,7 +1258,7 @@ namespace Libplanet.Tests.Blockchain
                     b,
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: _fx.Miner.PublicKey,
-                    lastCommit: CreateBlockCommit(b.Hash, b.Index, 0)
+                    lastCommit: CreateBlockCommit(b)
                 ).Evaluate(_fx.Miner, chain);
                 chain.Append(b, CreateBlockCommit(b));
             }
@@ -1417,8 +1397,7 @@ namespace Libplanet.Tests.Blockchain
             }
 
             Block<DumbAction> block1 = chain.ProposeBlock(
-                privateKeys[0],
-                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                privateKeys[0], lastCommit: CreateBlockCommit(chain.Tip));
 
             chain.Append(block1, CreateBlockCommit(block1));
 
@@ -1430,8 +1409,7 @@ namespace Libplanet.Tests.Blockchain
 
             chain.MakeTransaction(privateKeys[0], new[] { new DumbAction(addresses[0], "2") });
             Block<DumbAction> block2 = chain.ProposeBlock(
-                privateKeys[0],
-                lastCommit: CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                privateKeys[0], lastCommit: CreateBlockCommit(chain.Tip));
             chain.Append(block2, CreateBlockCommit(block2));
             Assert.Equal((Text)"1,2", chain.GetState(addresses[0]));
             Assert.All(
@@ -1447,16 +1425,13 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> b1 = _blockChain.ProposeBlock(key);
             _blockChain.Append(b1, CreateBlockCommit(b1));
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b2, CreateBlockCommit(b2));
             Block<DumbAction> b3 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b3, CreateBlockCommit(b3));
             Block<DumbAction> b4 = _blockChain.ProposeBlock(
-                key,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b4, CreateBlockCommit(b4));
 
             Assert.Equal(b1.PreviousHash, _blockChain.Genesis.Hash);
@@ -1483,8 +1458,7 @@ namespace Libplanet.Tests.Blockchain
                 fork.Append(b1, CreateBlockCommit(b1));
                 fork.Append(b2, CreateBlockCommit(b2));
                 Block<DumbAction> b5 = fork.ProposeBlock(
-                    key,
-                    lastCommit: CreateBlockCommit(fork.Tip.Hash, fork.Tip.Index, 0));
+                    key, lastCommit: CreateBlockCommit(fork.Tip));
                 fork.Append(b5, CreateBlockCommit(b5));
 
                 Assert.Null(emptyChain.FindBranchpoint(emptyLocator));
@@ -1621,7 +1595,7 @@ namespace Libplanet.Tests.Blockchain
                     txs,
                     blockInterval: TimeSpan.FromSeconds(10),
                     miner: _fx.Miner.PublicKey,
-                    lastCommit: CreateBlockCommit(block.Hash, block.Index, 0)
+                    lastCommit: CreateBlockCommit(block)
                 ).Evaluate(_fx.Miner, _blockChain);
 
             Transaction<DumbAction>[] txsA =
@@ -1751,16 +1725,13 @@ namespace Libplanet.Tests.Blockchain
             var rewardRecordAddress = MinerReward.RewardRecordAddress;
 
             Block<DumbAction> block1 = _blockChain.ProposeBlock(
-                miner1,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                miner1, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block1, CreateBlockCommit(block1));
             Block<DumbAction> block2 = _blockChain.ProposeBlock(
-                miner1,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                miner1, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block2, CreateBlockCommit(block2));
             Block<DumbAction> block3 = _blockChain.ProposeBlock(
-                miner2,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                miner2, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block3, CreateBlockCommit(block3));
 
             IValue miner1state = _blockChain.GetState(miner1.ToAddress());
@@ -1912,7 +1883,7 @@ namespace Libplanet.Tests.Blockchain
                         new[] { tx },
                         blockInterval: TimeSpan.FromSeconds(10),
                         miner: GenesisMiner.PublicKey,
-                        lastCommit: CreateBlockCommit(b.Hash, b.Index, 0)
+                        lastCommit: CreateBlockCommit(b)
                     ).Evaluate(GenesisMiner, chain);
                     previousStates = AccountStateDeltaImpl.ChooseVersion(
                         b.ProtocolVersion,

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -582,8 +582,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#2") });
             Block<DumbAction> block1 = chain.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             Assert.Equal(chain[0], delayedRenderer.Tip);
@@ -594,8 +593,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var forked = chain.Fork(chain[0].Hash);
             chain.StagePolicy.Stage(chain, tx1);
             Block<DumbAction> block2 = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -605,8 +603,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 );
             chain.StagePolicy.Stage(chain, tx2);
             block2 = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -616,8 +613,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#3") });
             block2 = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -627,8 +623,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#4") });
             block2 = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -717,8 +712,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#2") });
             Block<DumbAction> block2 = chain.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             Assert.Equal(chain[0], delayedRenderer.Tip);
@@ -729,8 +723,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var forked = chain.Fork(chain[1].Hash);
             chain.StagePolicy.Stage(chain, tx2);
             var block = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block,
                     TestUtils.CreateBlockCommit(block),
@@ -739,8 +732,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     renderActions: false
                 );
             block = forked.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(forked.Tip.Hash, forked.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block,
                     TestUtils.CreateBlockCommit(block),
@@ -757,8 +749,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Equal(2, renderLogs.Count);
 
             Block<DumbAction> block3 = chain.ProposeBlock(
-                key,
-                lastCommit: TestUtils.CreateBlockCommit(chain.Tip.Hash, chain.Tip.Index, 0));
+                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block3, TestUtils.CreateBlockCommit(block3));
             Assert.Equal(chain[2], delayedRenderer.Tip);
             Assert.Empty(reorgLogs);

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _branchpoint = chainA[i] = chainB[i] = TestUtils.ProposeNextBlock(
                     chainA[i - 1],
                     TestUtils.GenesisMiner,
-                    lastCommit: TestUtils.CreateLastCommit(
+                    lastCommit: TestUtils.CreateBlockCommit(
                         chainA[i - 1].Hash,
                         chainA[i - 1].Index,
                         0)
@@ -44,14 +44,14 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 chainA[i] = TestUtils.ProposeNextBlock(
                     chainA[i - 1],
                     TestUtils.GenesisMiner,
-                    lastCommit: TestUtils.CreateLastCommit(
+                    lastCommit: TestUtils.CreateBlockCommit(
                         chainA[i - 1].Hash,
                         chainA[i - 1].Index,
                         0));
                 chainB[i] = TestUtils.ProposeNextBlock(
                     chainB[i - 1],
                     TestUtils.GenesisMiner,
-                    lastCommit: TestUtils.CreateLastCommit(
+                    lastCommit: TestUtils.CreateBlockCommit(
                         chainB[i - 1].Hash,
                         chainB[i - 1].Index,
                         0));

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -44,17 +44,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 chainA[i] = TestUtils.ProposeNextBlock(
                     chainA[i - 1],
                     TestUtils.GenesisMiner,
-                    lastCommit: TestUtils.CreateBlockCommit(
-                        chainA[i - 1].Hash,
-                        chainA[i - 1].Index,
-                        0));
+                    lastCommit: TestUtils.CreateBlockCommit(chainA[i - 1]));
                 chainB[i] = TestUtils.ProposeNextBlock(
                     chainB[i - 1],
                     TestUtils.GenesisMiner,
-                    lastCommit: TestUtils.CreateBlockCommit(
-                        chainB[i - 1].Hash,
-                        chainB[i - 1].Index,
-                        0));
+                    lastCommit: TestUtils.CreateBlockCommit(chainB[i - 1]));
             }
 
             _chainA = chainA;

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -79,7 +79,7 @@ namespace Libplanet.Tests.Blocks
                     preEval1.DetermineStateRootHash(blockChain);
                 AssertBytesEqual(block1.StateRootHash, identicalBlock1StateRootHash);
 
-                blockChain.Append(block1);
+                blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
                 AssertBencodexEqual((Bencodex.Types.Integer)158, blockChain.GetState(address));
             }
         }
@@ -139,7 +139,7 @@ namespace Libplanet.Tests.Blocks
                 Block<Arithmetic> block1 = preEval1.Sign(_contents.Block1Key, b1StateRootHash);
                 _output.WriteLine("#1: {0}", block1);
 
-                blockChain.Append(block1);
+                blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
                 AssertBencodexEqual((Bencodex.Types.Integer)158, blockChain.GetState(address));
             }
         }

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -152,8 +152,7 @@ namespace Libplanet.Tests.Fixtures
             Sign(PrivateKeys[signerIndex], actions);
 
         public Block<Arithmetic> Propose() => Chain.ProposeBlock(
-            Miner,
-            lastCommit: TestUtils.CreateBlockCommit(Chain.Tip.Hash, Chain.Tip.Index, 0));
+            Miner, lastCommit: TestUtils.CreateBlockCommit(Chain.Tip));
 
         public void Append(Block<Arithmetic> block) =>
             Chain.Append(block, TestUtils.CreateBlockCommit(block));

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -153,9 +153,10 @@ namespace Libplanet.Tests.Fixtures
 
         public Block<Arithmetic> Propose() => Chain.ProposeBlock(
             Miner,
-            lastCommit: TestUtils.CreateLastCommit(Chain.Tip.Hash, Chain.Tip.Index, 0));
+            lastCommit: TestUtils.CreateBlockCommit(Chain.Tip.Hash, Chain.Tip.Index, 0));
 
-        public void Append(Block<Arithmetic> block) => Chain.Append(block);
+        public void Append(Block<Arithmetic> block) =>
+            Chain.Append(block, TestUtils.CreateBlockCommit(block));
 
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)
         {

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -120,12 +120,12 @@ namespace Libplanet.Tests.Store
             Block2 = TestUtils.ProposeNextBlock(
                 Block1,
                 miner: Miner,
-                lastCommit: TestUtils.CreateLastCommit(Block1.Hash, Block1.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(Block1.Hash, Block1.Index, 0));
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
             Block3 = TestUtils.ProposeNextBlock(
                 Block2,
                 miner: Miner,
-                lastCommit: TestUtils.CreateLastCommit(Block2.Hash, Block2.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(Block2.Hash, Block2.Index, 0));
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
             Block4 = TestUtils.ProposeNextBlock(Block3, miner: Miner);
             stateRootHashes[Block4.Hash] = Block4.StateRootHash;

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -120,12 +120,12 @@ namespace Libplanet.Tests.Store
             Block2 = TestUtils.ProposeNextBlock(
                 Block1,
                 miner: Miner,
-                lastCommit: TestUtils.CreateBlockCommit(Block1.Hash, Block1.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(Block1));
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
             Block3 = TestUtils.ProposeNextBlock(
                 Block2,
                 miner: Miner,
-                lastCommit: TestUtils.CreateBlockCommit(Block2.Hash, Block2.Index, 0));
+                lastCommit: TestUtils.CreateBlockCommit(Block2));
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
             Block4 = TestUtils.ProposeNextBlock(Block3, miner: Miner);
             stateRootHashes[Block4.Hash] = Block4.StateRootHash;

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1027,7 +1027,7 @@ namespace Libplanet.Tests.Store
             Block<DumbAction> anotherBlock3 = ProposeNextBlock(
                 Fx.Block2,
                 Fx.Miner,
-                lastCommit: CreateLastCommit(Fx.Block2.Hash, 2, 0));
+                lastCommit: CreateBlockCommit(Fx.Block2.Hash, 2, 0));
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
             store.PutBlock(Fx.Block2);
@@ -1100,13 +1100,16 @@ namespace Libplanet.Tests.Store
 
                 // FIXME: Need to add more complex blocks/transactions.
                 var key = new PrivateKey();
-                blocks.Append(blocks.ProposeBlock(key));
-                blocks.Append(blocks.ProposeBlock(
+                Block<DumbAction> block = blocks.ProposeBlock(key);
+                blocks.Append(block, CreateBlockCommit(block));
+                Block<DumbAction> block2 = blocks.ProposeBlock(
                     key,
-                    lastCommit: CreateLastCommit(blocks.Tip.Hash, blocks.Tip.Index, 0)));
-                blocks.Append(blocks.ProposeBlock(
+                    lastCommit: CreateBlockCommit(blocks.Tip.Hash, blocks.Tip.Index, 0));
+                blocks.Append(block2, CreateBlockCommit(block2));
+                Block<DumbAction> block3 = blocks.ProposeBlock(
                     key,
-                    lastCommit: CreateLastCommit(blocks.Tip.Hash, blocks.Tip.Index, 0)));
+                    lastCommit: CreateBlockCommit(blocks.Tip.Hash, blocks.Tip.Index, 0));
+                blocks.Append(block3, CreateBlockCommit(block3));
 
                 s1.Copy(to: Fx.Store);
                 Fx.Store.Copy(to: s2);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1100,16 +1100,14 @@ namespace Libplanet.Tests.Store
 
                 // FIXME: Need to add more complex blocks/transactions.
                 var key = new PrivateKey();
-                Block<DumbAction> block = blocks.ProposeBlock(key);
+                var block = blocks.ProposeBlock(key);
                 blocks.Append(block, CreateBlockCommit(block));
-                Block<DumbAction> block2 = blocks.ProposeBlock(
-                    key,
-                    lastCommit: CreateBlockCommit(blocks.Tip.Hash, blocks.Tip.Index, 0));
-                blocks.Append(block2, CreateBlockCommit(block2));
-                Block<DumbAction> block3 = blocks.ProposeBlock(
-                    key,
-                    lastCommit: CreateBlockCommit(blocks.Tip.Hash, blocks.Tip.Index, 0));
-                blocks.Append(block3, CreateBlockCommit(block3));
+                block = blocks.ProposeBlock(
+                    key, lastCommit: CreateBlockCommit(blocks.Tip));
+                blocks.Append(block, CreateBlockCommit(block));
+                block = blocks.ProposeBlock(
+                    key, lastCommit: CreateBlockCommit(blocks.Tip));
+                blocks.Append(block, CreateBlockCommit(block));
 
                 s1.Copy(to: Fx.Store);
                 Fx.Store.Copy(to: s2);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -354,13 +354,15 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
         public static BlockCommit CreateBlockCommit<T>(Block<T> block)
             where T : IAction, new() =>
-            CreateBlockCommit(block.Hash, block.Index, 0);
+                block.Index > 0 &&
+                block.ProtocolVersion > BlockMetadata.PoWProtocolVersion
+                    ? CreateBlockCommit(block.Hash, block.Index, 0)
+                    : null;
 
         public static BlockCommit CreateBlockCommit(
             BlockHash blockHash,
             long height,
-            int round,
-            VoteFlag voteFlag = VoteFlag.PreCommit)
+            int round)
         {
             // Index #1 block cannot have lastCommit: There was no consensus of genesis block.
             if (height == 0)

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -352,7 +352,11 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             return bytes;
         }
 
-        public static BlockCommit CreateLastCommit(
+        public static BlockCommit CreateBlockCommit<T>(Block<T> block)
+            where T : IAction, new() =>
+            CreateBlockCommit(block.Hash, block.Index, 0);
+
+        public static BlockCommit CreateBlockCommit(
             BlockHash blockHash,
             long height,
             int round,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1140,6 +1140,36 @@ namespace Libplanet.Blockchain
             }
         }
 
+        /// <summary>
+        /// Returns a <see cref="BlockCommit"/> of given <see cref="Block{T}"/> index.
+        /// </summary>
+        /// <param name="index">A index value (height) of <see cref="Block{T}"/> to retrieve.
+        /// </param>
+        /// <returns>Returns a <see cref="BlockCommit"/> of given <see cref="Block{T}"/> index, if
+        /// the <see cref="BlockCommit"/> of <see cref="BlockChain{T}.Genesis"/> block is requested,
+        /// which is <c>0</c>, then returns <see langword="null"/>.</returns>
+        /// <remarks>The <see cref="BlockChain{T}.Genesis"/> block does not have
+        /// <see cref="BlockCommit"/> because the genesis block is not committed by a consensus.
+        /// </remarks>
+        public BlockCommit GetBlockCommit(long index) =>
+            index == 0 ? null : Store.GetBlockCommit(index);
+
+        /// <summary>
+        /// Returns a <see cref="BlockCommit"/> of given <see cref="Block{T}"/> index.
+        /// </summary>
+        /// <param name="blockHash">A hash value of <see cref="Block{T}"/> to retrieve.
+        /// </param>
+        /// <returns>Returns a <see cref="BlockCommit"/> of given <see cref="Block{T}"/> hash, if
+        /// the <see cref="BlockCommit"/> of <see cref="BlockChain{T}.Genesis"/> block is requested,
+        /// then returns <see langword="null"/>.</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if given hash does not exist in the
+        /// blockchain.</exception>
+        /// <remarks>The <see cref="BlockChain{T}.Genesis"/> block does not have
+        /// <see cref="BlockCommit"/> because the genesis block is not committed by a consensus.
+        /// </remarks>
+        public BlockCommit GetBlockCommit(BlockHash blockHash) =>
+            GetBlockCommit(this[blockHash].Index);
+
 #pragma warning disable MEN003
         internal void Append(
             Block<T> block,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -255,6 +255,7 @@ namespace Libplanet.Blockchain
                 {
                     Append(
                         genesisBlock,
+                        null,
                         renderBlocks: !inFork,
                         renderActions: !inFork,
                         evaluateActions: !inFork
@@ -700,6 +701,8 @@ namespace Libplanet.Blockchain
         /// </summary>
         /// <param name="block">A next <see cref="Block{T}"/>, which is mined,
         /// to add.</param>
+        /// <param name="blockCommit">A <see cref="BlockCommit"/> that has +2/3 commits for the
+        /// given block.</param>
         /// <param name="stateCompleters">The strategy to complement incomplete block states which
         /// are required for action execution and rendering.
         /// <see cref="StateCompleterSet{T}.Recalculate"/> by default.
@@ -716,10 +719,12 @@ namespace Libplanet.Blockchain
         /// <see cref="Transaction{T}.Signer"/>.</exception>
         public void Append(
             Block<T> block,
+            BlockCommit blockCommit,
             StateCompleterSet<T>? stateCompleters = null
         ) =>
             Append(
                 block,
+                blockCommit,
                 evaluateActions: true,
                 renderBlocks: true,
                 renderActions: true,
@@ -1138,6 +1143,7 @@ namespace Libplanet.Blockchain
 #pragma warning disable MEN003
         internal void Append(
             Block<T> block,
+            BlockCommit blockCommit,
             bool evaluateActions,
             bool renderBlocks,
             bool renderActions,
@@ -1292,6 +1298,15 @@ namespace Libplanet.Blockchain
                     "Appended the block #{BlockIndex} {BlockHash}.",
                     block.Index,
                     block.Hash);
+
+                // FIXME: Checks given BlockCommit is belong to block. Also BlockCommit is not
+                // stored if value is null in temporary measure.
+                // Note: Genesis block is not committed by PBFT consensus, so it has no its
+                // blockCommit.
+                if (block.Index != 0 && blockCommit is { })
+                {
+                    Store.PutBlockCommit(blockCommit);
+                }
 
                 if (renderBlocks)
                 {

--- a/Libplanet/Blocks/InvalidBlockCommitException.cs
+++ b/Libplanet/Blocks/InvalidBlockCommitException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Libplanet.Blocks
+{
+    [Serializable]
+    public class InvalidBlockCommitException : InvalidBlockException
+    {
+        public InvalidBlockCommitException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Reopened PR of #2547, due to mistakenly pushed pbft branch directly.
Resolves #2542.

- `Append()` takes the given block's `BlockCommit`. 
  - `BlockCommit` of a given block is the commit results from a consensus.
- Added new methods, `BlockChain<T>.GetBlockCommit()`, for height and `BlockHash`.
- Some `BlockCommit` related methods have exception-catching mistakes in RocksDB.