### PR TITLE
Validate `BlockCommit` while in `BlockChain<T>.Append()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Version PBFT
  -  Added `BlockMarshaler.UnmarshalBlockHash()` method. [[#PBFT]]
  -  Added `BlockChain<T>.GetBlockCommit()` method.  [[#PBFT]]
  -  Added `BlockChain<T>.CleanupBlockCommitStore()` method.  [[#PBFT]]
+ -  Added `InvalidBlockCommitException` class.  [[#PBFT]]
  -  Added `BlockChain<T>.ValidateBlockCommit()` method  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Version PBFT
  -  Added `BlockMarshaler.UnmarshalBlockHash()` method. [[#PBFT]]
  -  Added `BlockChain<T>.GetBlockCommit()` method.  [[#PBFT]]
  -  Added `BlockChain<T>.CleanupBlockCommitStore()` method.  [[#PBFT]]
+ -  Added `BlockChain<T>.ValidateBlockCommit()` method  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]
  -  (Libplanet.Net) Added `ConsensusReactor` class which inherits
     `IReactor` interface.  [[#PBFT]]
@@ -88,6 +89,12 @@ Version PBFT
  -  `PreEvaluationBlockHeader()` constructor became to throw
     `InvalidBlockLastCommitException` when its metadata's `LastCommit` is
     invalid.  [[#PBFT]]
+ -  `BlockChain<T>.Append()` has new parameter `BlockCommit blockCommit`, which
+    is a set of commits for given block. `BlockCommit` is used for checks
+    whether a block is committed in consensus.  [[#PBFT]]
+ -  `BlockChain<T>.Append()` method became to throw
+    `InvalidBlockCommitException` when the given `BlockCommit` is invalid with
+    given block.  [[#PBFT]]
 
 ### Bug fixes
 

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -123,14 +123,9 @@ public class TransactionQueryTest
 
         // staging txs of key2 does not increase nonce of key1
         _source.BlockChain.MakeTransaction(key2, ImmutableList<NullAction>.Empty.Add(new NullAction()));
-        var lastCommit = new BlockCommit(
-                height: 1,
-                round: 0,
-                blockHash: block.Hash,
-                votes: ImmutableArray<Vote>.Empty
-                    .Add(new VoteMetadata(1, 0, block.Hash, DateTimeOffset.UtcNow,
-                    _source.Validator.PublicKey, VoteFlag.PreCommit).Sign(_source.Validator)));
-        block = _source.BlockChain.ProposeBlock(new PrivateKey(), lastCommit: lastCommit);
+        block = _source.BlockChain.ProposeBlock(
+            new PrivateKey(),
+            lastCommit: Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         _source.BlockChain.Append(block, Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         await AssertNextNonce(1, key2.ToAddress());
         await AssertNextNonce(2, key1.ToAddress());
@@ -157,7 +152,7 @@ public class TransactionQueryTest
 
         public MockBlockChainContext()
         {
-            Validator = new PrivateKey();
+            Validator = Libplanet.Tests.TestUtils.ValidatorPrivateKeys[1];
             Store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var minerKey = new PrivateKey();
@@ -175,8 +170,8 @@ public class TransactionQueryTest
                 _ => true,
                 stateStore);
             BlockChain = new BlockChain<T>(
-                new BlockPolicy<T>(getValidatorSet: index => new ValidatorSet(
-                    new List<PublicKey> { Validator.PublicKey })),
+                new BlockPolicy<T>(
+                    getValidatorSet: index => Libplanet.Tests.TestUtils.ValidatorSet),
                 new VolatileStagePolicy<T>(),
                 Store,
                 stateStore,

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -703,7 +703,7 @@ namespace Libplanet.Net.Tests
             Assert.Equal(expectedBlocks, demands);
         }
 
-        [Fact(Timeout = Timeout)]
+        [Fact(Timeout = Timeout, Skip = "No Reorganization in PBFT")]
         public async Task PreloadAfterReorg()
         {
             var minerKey = new PrivateKey();

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -470,7 +470,9 @@ namespace Libplanet.Net.Tests
         {
             var keyB = new PrivateKey();
 
-            var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
+            var policy = new BlockPolicy<DumbAction>(
+                new MinerReward(1),
+                getValidatorSet: idx => ValidatorSet);
             Block<DumbAction> genesis = BlockChain<DumbAction>.ProposeGenesisBlock(
                 privateKey: new PrivateKey(), blockAction: policy.BlockAction);
             Swarm<DumbAction> swarmA = CreateSwarm(genesis: genesis, policy: policy);
@@ -1222,7 +1224,8 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> MakeGenesisChain(
                 IStore store, IStateStore stateStore, Block<DumbAction> genesisBlock) =>
                 new BlockChain<DumbAction>(
-                    new BlockPolicy<DumbAction>(),
+                    new BlockPolicy<DumbAction>(
+                        getValidatorSet: idx => ValidatorSet),
                     new VolatileStagePolicy<DumbAction>(),
                     store,
                     stateStore,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -126,7 +126,8 @@ namespace Libplanet.Tests.Action
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var chain = TestUtils.MakeBlockChain<EvaluateTestAction>(
-                policy: new BlockPolicy<EvaluateTestAction>(),
+                policy: new BlockPolicy<EvaluateTestAction>(
+                    getValidatorSet: idx => ValidatorSet),
                 store: store,
                 stateStore: stateStore);
             var tx = Transaction<EvaluateTestAction>.Create(
@@ -164,7 +165,8 @@ namespace Libplanet.Tests.Action
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var chain = TestUtils.MakeBlockChain<ThrowException>(
-                policy: new BlockPolicy<ThrowException>(),
+                policy: new BlockPolicy<ThrowException>(
+                    getValidatorSet: idx => ValidatorSet),
                 store: store,
                 stateStore: stateStore);
             var tx = Transaction<ThrowException>.Create(
@@ -1099,7 +1101,8 @@ namespace Libplanet.Tests.Action
         private void CheckGenesisHashInAction()
         {
             var chain = MakeBlockChain<EvaluateTestAction>(
-                    policy: new BlockPolicy<EvaluateTestAction>(),
+                    policy: new BlockPolicy<EvaluateTestAction>(
+                        getValidatorSet: idx => ValidatorSet),
                     store: _storeFx.Store,
                     stateStore: _storeFx.StateStore);
             var privateKey = new PrivateKey();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -398,7 +398,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void AppendWhenActionEvaluationFailed()
         {
-            var policy = new NullBlockPolicy<ThrowException>();
+            var policy = new NullBlockPolicy<ThrowException>(
+                getValidatorSet: idx => TestUtils.ValidatorSet);
             var store = new MemoryStore();
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore());

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -235,7 +235,9 @@ namespace Libplanet.Tests.Blockchain
                     : new TxPolicyViolationException("invalid signer", tx.Id);
             }
 
-            var policy = new BlockPolicy<DumbAction>(validateNextBlockTx: IsSignerValid);
+            var policy = new BlockPolicy<DumbAction>(
+                validateNextBlockTx: IsSignerValid,
+                getValidatorSet: idx => TestUtils.ValidatorSet);
             using (var fx = new MemoryStoreFixture())
             {
                 var blockChain = new BlockChain<DumbAction>(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -159,7 +159,8 @@ namespace Libplanet.Tests.Blockchain
         {
             IKeyValueStore stateKeyValueStore = new MemoryKeyValueStore();
             var policy = new BlockPolicy<DumbAction>(
-                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000)
+                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000),
+                getValidatorSet: idx => TestUtils.ValidatorSet
             );
             var stateStore = new TrieStateStore(stateKeyValueStore);
             IStore store = new MemoryStore();
@@ -195,7 +196,8 @@ namespace Libplanet.Tests.Blockchain
 
             var policyWithBlockAction = new BlockPolicy<DumbAction>(
                 new SetStatesAtBlock(default, (Text)"foo", 1),
-                policy.BlockInterval
+                policy.BlockInterval,
+                getValidatorSet: idx => TestUtils.ValidatorSet
             );
             var chain2 = new BlockChain<DumbAction>(
                 policyWithBlockAction,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -321,5 +321,118 @@ namespace Libplanet.Tests.Blockchain
             Assert.Throws<InvalidBlockLastCommitException>(() =>
                 _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2)));
         }
+
+        [Fact]
+        public void ValidateBlockCommitGenesis()
+        {
+            InvalidBlockCommitException ibcm =
+                _blockChain.ValidateBlockCommit(_fx.GenesisBlock, null);
+
+            Assert.Null(ibcm);
+
+            ibcm = _blockChain.ValidateBlockCommit(
+                _fx.GenesisBlock,
+                new BlockCommit(
+                    0,
+                    0,
+                    _fx.GenesisBlock.Hash,
+                    TestUtils.ValidatorPrivateKeys.Select(x => new VoteMetadata(
+                        0,
+                        0,
+                        _fx.GenesisBlock.Hash,
+                        DateTimeOffset.UtcNow,
+                        x.PublicKey,
+                        VoteFlag.PreCommit).Sign(x)).ToImmutableArray()));
+
+            Assert.NotNull(ibcm);
+        }
+
+        [Fact]
+        public void ValidateBlockCommitFailsDifferentBlockHash()
+        {
+            Block<DumbAction> validNextBlock = new BlockContent<DumbAction>(
+                new BlockMetadata(
+                    index: 1L,
+                    timestamp: _fx.GenesisBlock.Timestamp.AddDays(1),
+                    publicKey: _fx.Miner.PublicKey,
+                    previousHash: _fx.GenesisBlock.Hash,
+                    txHash: null,
+                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
+
+            Assert.Throws<InvalidBlockCommitException>(() =>
+                _blockChain.Append(
+                    validNextBlock,
+                    TestUtils.CreateBlockCommit(
+                        new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
+                        1,
+                        0)));
+        }
+
+        [Fact]
+        public void ValidateBlockCommitFailsDifferentHeight()
+        {
+            Block<DumbAction> validNextBlock = new BlockContent<DumbAction>(
+                new BlockMetadata(
+                    index: 1L,
+                    timestamp: _fx.GenesisBlock.Timestamp.AddDays(1),
+                    publicKey: _fx.Miner.PublicKey,
+                    previousHash: _fx.GenesisBlock.Hash,
+                    txHash: null,
+                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
+
+            Assert.Throws<InvalidBlockCommitException>(() =>
+                _blockChain.Append(
+                    validNextBlock,
+                    TestUtils.CreateBlockCommit(
+                        validNextBlock.Hash,
+                        2,
+                        0)));
+        }
+
+        [Fact]
+        public void ValidateBlockCommitFailsDifferentValidatorSet()
+        {
+            Block<DumbAction> validNextBlock = new BlockContent<DumbAction>(
+                new BlockMetadata(
+                    index: 1L,
+                    timestamp: _fx.GenesisBlock.Timestamp.AddDays(1),
+                    publicKey: _fx.Miner.PublicKey,
+                    previousHash: _fx.GenesisBlock.Hash,
+                    txHash: null,
+                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
+
+            Assert.Throws<InvalidBlockCommitException>(() =>
+                _blockChain.Append(
+                    validNextBlock,
+                    new BlockCommit(
+                        1,
+                        0,
+                        validNextBlock.Hash,
+                        Enumerable.Range(0, TestUtils.ValidatorSet.TotalCount)
+                            .Select(x => new PrivateKey())
+                            .Select(x => new VoteMetadata(
+                            1,
+                            0,
+                            validNextBlock.Hash,
+                            DateTimeOffset.UtcNow,
+                            x.PublicKey,
+                            VoteFlag.PreCommit).Sign(x)).ToImmutableArray())));
+        }
+
+        [Fact]
+        public void ValidateBlockCommitFailsNullBlockCommit()
+        {
+            Block<DumbAction> validNextBlock = new BlockContent<DumbAction>(
+                new BlockMetadata(
+                    index: 1L,
+                    timestamp: _fx.GenesisBlock.Timestamp.AddDays(1),
+                    publicKey: _fx.Miner.PublicKey,
+                    previousHash: _fx.GenesisBlock.Hash,
+                    txHash: null,
+                    lastCommit: null)).Propose().Evaluate(_fx.Miner, _blockChain);
+
+            Assert.Throws<InvalidBlockCommitException>(() =>
+                _blockChain.Append(validNextBlock, null));
+        }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -310,7 +310,8 @@ namespace Libplanet.Tests.Blockchain
             IEnumerable<ExecuteRecord> NonRehearsalExecutions() =>
                 DumbAction.ExecuteRecords.Value.Where(r => !r.Rehearsal);
 
-            var policy = new BlockPolicy<DumbAction>();
+            var policy = new BlockPolicy<DumbAction>(
+                getValidatorSet: idx => ValidatorSet);
             var key = new PrivateKey();
             Address miner = key.ToAddress();
 
@@ -363,7 +364,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void ActionRenderersHaveDistinctContexts()
         {
-            var policy = new NullBlockPolicy<DumbAction>();
+            var policy = new NullBlockPolicy<DumbAction>(
+                getValidatorSet: idx => ValidatorSet);
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var generatedRandomValueLogs = new List<int>();
@@ -401,7 +403,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void RenderActionsAfterBlockIsRendered()
         {
-            var policy = new NullBlockPolicy<DumbAction>();
+            var policy = new NullBlockPolicy<DumbAction>(
+                getValidatorSet: idx => ValidatorSet);
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var recordingRenderer = new RecordingActionRenderer<DumbAction>();
@@ -439,7 +442,8 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void RenderActionsAfterAppendComplete()
         {
-            var policy = new NullBlockPolicy<DumbAction>();
+            var policy = new NullBlockPolicy<DumbAction>(
+                getValidatorSet: idx => ValidatorSet);
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             IActionRenderer<DumbAction> renderer = new AnonymousActionRenderer<DumbAction>
@@ -1332,7 +1336,8 @@ namespace Libplanet.Tests.Blockchain
 
             var chain =
                 new BlockChain<DumbAction>(
-                    new NullBlockPolicy<DumbAction>(),
+                    new NullBlockPolicy<DumbAction>(
+                        getValidatorSet: idx => ValidatorSet),
                     new VolatileStagePolicy<DumbAction>(),
                     store,
                     stateStore,

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -29,7 +29,8 @@ namespace Libplanet.Tests.Blocks
             var blockAction = new SetStatesAtBlock(address, (Bencodex.Types.Integer)123, 0);
             var policy = new BlockPolicy<Arithmetic>(
                 blockAction: blockAction,
-                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
+                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000),
+                getValidatorSet: idx => ValidatorSet);
             var stagePolicy = new VolatileStagePolicy<Arithmetic>();
 
             PreEvaluationBlock<Arithmetic> preEvalGenesis =
@@ -91,7 +92,8 @@ namespace Libplanet.Tests.Blocks
             var blockAction = new SetStatesAtBlock(address, (Bencodex.Types.Integer)123, 0);
             var policy = new BlockPolicy<Arithmetic>(
                 blockAction: blockAction,
-                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
+                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000),
+                getValidatorSet: idx => ValidatorSet);
             var stagePolicy = new VolatileStagePolicy<Arithmetic>();
 
             PreEvaluationBlock<Arithmetic> preEvalGenesis =

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1578,7 +1578,7 @@ namespace Libplanet.Blockchain
         }
 
 #pragma warning disable SA1202
-        public InvalidBlockCommitException ValidateBlockCommit(
+        internal InvalidBlockCommitException ValidateBlockCommit(
             Block<T> block,
             BlockCommit blockCommit)
 #pragma warning restore SA1202

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1551,6 +1551,32 @@ namespace Libplanet.Blockchain
             }
         }
 
+        /// <summary>
+        /// Clean up <see cref="BlockCommit"/>s in the store. The <paramref name="except"/> height
+        /// of <see cref="BlockCommit"/> will not be removed. If the stored
+        /// <see cref="BlockCommit"/> count is not over <paramref name="maxCacheSize"/>, the removal
+        /// is skipped.
+        /// </summary>
+        /// <param name="except">A exceptional index that is not to be removed.</param>
+        /// <param name="maxCacheSize">A maximum count value of <see cref="BlockCommit"/> cache.
+        /// </param>
+        internal void CleanupBlockCommitStore(long except, long maxCacheSize = 30)
+        {
+            IEnumerable<long> indices = Store.GetBlockCommitIndices().ToArray();
+
+            if (indices.Count() < maxCacheSize)
+            {
+                return;
+            }
+
+            _logger.Debug("Removing old BlockCommit caches except {Except}...", except);
+
+            foreach (var height in indices.Except(new[] { except }))
+            {
+                Store.DeleteBlockCommit(height);
+            }
+        }
+
 #pragma warning disable SA1202
         public InvalidBlockCommitException ValidateBlockCommit(
             Block<T> block,
@@ -1727,32 +1753,6 @@ namespace Libplanet.Blockchain
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Clean up <see cref="BlockCommit"/>s in the store. The <paramref name="except"/> height
-        /// of <see cref="BlockCommit"/> will not be removed. If the stored
-        /// <see cref="BlockCommit"/> count is not over <paramref name="maxCacheSize"/>, the removal
-        /// is skipped.
-        /// </summary>
-        /// <param name="except">A exceptional index that is not to be removed.</param>
-        /// <param name="maxCacheSize">A maximum count value of <see cref="BlockCommit"/> cache.
-        /// </param>
-        internal void CleanupBlockCommitStore(long except, long maxCacheSize = 30)
-        {
-            IEnumerable<long> indices = Store.GetBlockCommitIndices().ToArray();
-
-            if (indices.Count() < maxCacheSize)
-            {
-                return;
-            }
-
-            _logger.Debug("Removing old BlockCommit caches except {Except}...", except);
-
-            foreach (var height in indices.Except(new[] { except }))
-            {
-                Store.DeleteBlockCommit(height);
-            }
         }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -717,6 +717,8 @@ namespace Libplanet.Blockchain
         /// <see cref="Transaction{T}.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the
         /// <see cref="Transaction{T}.Signer"/>.</exception>
+        /// <exception cref="InvalidBlockCommitException">Thrown when the given
+        /// <paramref name="block"/> and <paramref name="blockCommit"/> is invalid.</exception>
         public void Append(
             Block<T> block,
             BlockCommit blockCommit,
@@ -1233,6 +1235,17 @@ namespace Libplanet.Blockchain
                     throw ibe;
                 }
 
+                InvalidBlockCommitException ibce = ValidateBlockCommit(block, blockCommit);
+
+                if (!(ibce is null))
+                {
+                    _logger.Error(
+                        ibce,
+                        "Failed to append block {BlockHash} due to invalid blockCommit.",
+                        block.Hash);
+                    throw ibce;
+                }
+
                 var nonceDeltas = new Dictionary<Address, long>();
 
                 foreach (Transaction<T> tx1 in block.Transactions.OrderBy(tx => tx.Nonce))
@@ -1310,8 +1323,6 @@ namespace Libplanet.Blockchain
                         Store.PutTxIdBlockHashIndex(tx.Id, block.Hash);
                     }
 
-                    // FIXME: Checks given BlockCommit is belong to block. Also BlockCommit is not
-                    // stored if value is null in temporary measure.
                     // Note: Genesis block is not committed by PBFT consensus, so it has no its
                     // blockCommit.
                     if (block.Index != 0 && blockCommit is { })
@@ -1538,6 +1549,69 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.ExitUpgradeableReadLock();
             }
+        }
+
+#pragma warning disable SA1202
+        public InvalidBlockCommitException ValidateBlockCommit(
+            Block<T> block,
+            BlockCommit blockCommit)
+#pragma warning restore SA1202
+        {
+            if (block.ProtocolVersion <= BlockMetadata.PoWProtocolVersion)
+            {
+                if (blockCommit != null)
+                {
+                    return new InvalidBlockCommitException(
+                        "PoW Block doesn't have blockCommit.");
+                }
+                else
+                {
+                    // To allow the PoW block to be appended, we skips the validation.
+                    return null;
+                }
+            }
+
+            if (block.Index == 0)
+            {
+                if (blockCommit == null)
+                {
+                    return null;
+                }
+
+                return new InvalidBlockCommitException(
+                    "Genesis block does not have blockCommit.");
+            }
+
+            if (block.Index != 0 && blockCommit == null)
+            {
+                return new InvalidBlockCommitException(
+                    $"Block #{block.Hash} BlockCommit is required except for the genesis block.");
+            }
+
+            if (block.Index != blockCommit.Height)
+            {
+                return new InvalidBlockCommitException(
+                    "BlockCommit has height value that is not same with block index. " +
+                    $"Block index is {block.Index}, however, BlockCommit height is " +
+                    $"{blockCommit.Height}.");
+            }
+
+            if (!block.Hash.Equals(blockCommit.BlockHash))
+            {
+                return new InvalidBlockCommitException(
+                    $"BlockCommit has different block. Block hash is {block.Hash}, " +
+                    $"however, BlockCommit block hash is {blockCommit.BlockHash}.");
+            }
+
+            // FIXME: When the dynamic validator set is possible, the functionality of this
+            // condition should be checked once more.
+            if (!Policy.GetValidatorSet(block.Index).ValidateBlockCommitValidators(blockCommit))
+            {
+                return new InvalidBlockCommitException(
+                    "BlockCommit has different validator set with policy's validator set.");
+            }
+
+            return null;
         }
 
 #pragma warning disable SA1202


### PR DESCRIPTION
Resolves #2541
This PR adds validation of `BlockCommit` in `BlockChain<T>.Append()`.

There are some cases we should consider: 
- `PreloadAfterReorg` is failing but there will be no reorganization in PBFT, so skipped the test (Reorganization code should be removed.)
- When the validator set is dynamically changing, in my opinion, we should revisit this and think about how would block synchronization be done.