### PR TITLE
Provide explorer in also `/graphql/explorer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,9 +35,12 @@ To be released.
      -  Added `ITransaction` interface.
  -  Added `IActionTypeLoader` interface.  [[#2539]]
  -  Added `StaticActionTypeLoader` class.  [[#2539]]
+ -  (Libplanet.Explorer) Added a new GraphQL endpoint on `/graphql/explorer`.
+    [[#2562]]
 
 [#2507]: https://github.com/planetarium/libplanet/pull/2507
 [#2539]: https://github.com/planetarium/libplanet/pull/2539
+[#2562]: https://github.com/planetarium/libplanet/pull/2562
 
 ### Behavioral changes
 

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -75,7 +75,10 @@ namespace Libplanet.Explorer
                 endpoints.MapControllers();
             });
 
+            // FIXME: '/graphql' endpoint will be deprecated after
+            //        libplanet-explorer-frontend migration.
             app.UseGraphQL<LibplanetExplorerSchema<T>>("/graphql");
+            app.UseGraphQL<LibplanetExplorerSchema<T>>("/graphql/explorer");
             app.UseGraphQLPlayground();
         }
     }


### PR DESCRIPTION
In our Planetarium Dev Discord Server, we decided to use the `/graphql/explorer` endpoint as its de-facto standard of `LibplanetExplorerSchema`'s endpoint.

This pull request makes `Libplanet.Explorer.Executable` also provide the `/graphql/explorer` endpoint, with `/graphql` endpoint for backward compatibility. I guess it should obsolete `/graphql` after applying it to [libplanet-explorer-frontend].

About the changelog, I'm not sure whether it should also be recorded or not.

[libplanet-explorer-frontend]: https://github.com/planetarium/libplanet-explorer-frontend

### Related links

 - https://github.com/planetarium/NineChronicles.Headless/pull/1706
 - https://github.com/planetarium/NineChronicles.Headless/discussions/1690
 - https://github.com/planetarium/planet-node/pull/42