### PR TITLE
Provide `schema` command to get explorer schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,11 +55,16 @@ To be released.
 
  -  Now `planet` can be installed using Homebrew on macOS: `brew install
     planetarium/brew/planet`.  [[#2555]]
+ -  (Libplanet.Explorer) Added `serve` subcommand.  [[#2563]]
+     -  (Libplanet.Explorer) Deprecated primary command.
+        It will obsoleted in 0.47.0 release.
+        You should use `serve` command instead.  [[#2563]]
 
 [#2518]: https://github.com/planetarium/libplanet/issues/2518
 [#2520]: https://github.com/planetarium/libplanet/pull/2520
 [#2529]: https://github.com/planetarium/libplanet/pull/2529
 [#2555]: https://github.com/planetarium/libplanet/pull/2555
+[#2563]: https://github.com/planetarium/libplanet/pull/2563
 
 
 Version 0.44.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,7 +57,7 @@ To be released.
     planetarium/brew/planet`.  [[#2555]]
  -  (Libplanet.Explorer) Added `serve` subcommand.  [[#2563]]
      -  (Libplanet.Explorer) Deprecated primary command.
-        It will obsoleted in 0.47.0 release.
+        It will be obsoleted in 0.47.0 release.
         You should use `serve` command instead.  [[#2563]]
  -  (Libplanet.Explorer) Added `schema` subcommand.  [[#2563]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ To be released.
      -  (Libplanet.Explorer) Deprecated primary command.
         It will obsoleted in 0.47.0 release.
         You should use `serve` command instead.  [[#2563]]
+ -  (Libplanet.Explorer) Added `schema` subcommand.  [[#2563]]
 
 [#2518]: https://github.com/planetarium/libplanet/issues/2518
 [#2520]: https://github.com/planetarium/libplanet/pull/2520

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -41,6 +41,18 @@ namespace Libplanet.Explorer.Executable
     {
         public static async Task Main(string[] args)
         {
+            if (args.Length > 0 && !new string[]
+            {
+                "serve",
+                "schema",
+            }.Contains(args[0]))
+            {
+                Console.Error.WriteLine(
+                    "NOTICE: root primary command was deprecated and moved " +
+                    "to the `serve` command. Currently the root primary command forwards " +
+                    "to the `serve` command but it'll be obsoleted in the 0.47.0 release.");
+            }
+
             await CoconaLiteApp.RunAsync<Program>(args);
         }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Cocona;
+using GraphQL.Server;
+using GraphQL.Utilities;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
@@ -16,6 +18,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Explorer.Executable.Exceptions;
 using Libplanet.Explorer.Interfaces;
+using Libplanet.Explorer.Schemas;
 using Libplanet.Explorer.Store;
 using Libplanet.Net;
 using Libplanet.Net.Protocols;
@@ -24,6 +27,7 @@ using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using NetMQ;
 using Serilog;
 using Serilog.Events;
@@ -40,12 +44,19 @@ namespace Libplanet.Explorer.Executable
             await CoconaLiteApp.RunAsync<Program>(args);
         }
 
+        // This command is deprecated now. It should use `serve` command instead.
+        // FIXME: Obsolete this command in 0.47.0 release.
+        [CommandMethodForwardedTo(typeof(Program), nameof(Serve))]
+        [PrimaryCommand]
+        public void Run()
+            => throw new NotSupportedException();
+
         [Command(Description = "Run libplanet-explorer with options.")]
         [SuppressMessage(
             "Microsoft.StyleCop.CSharp.ReadabilityRules",
             "MEN003",
             Justification = "Many lines are required for running the method.")]
-        public async Task Run(
+        public async Task Serve(
             [Option(
                 "store-path",
                 new[] { 'P' },

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Explorer.Executable
             }.Contains(args[0]))
             {
                 Console.Error.WriteLine(
-                    "NOTICE: root primary command was deprecated and moved " +
+                    "NOTICE: the root primary command has been deprecated and moved " +
                     "to the `serve` command. Currently the root primary command forwards " +
                     "to the `serve` command but it'll be obsoleted in the 0.47.0 release.");
             }
@@ -73,7 +73,7 @@ namespace Libplanet.Explorer.Executable
             Console.WriteLine(printer.Print());
         }
 
-        // This command is deprecated now. It should use `serve` command instead.
+        // This command has been deprecated. The `serve` command should be used instead.
         // FIXME: Obsolete this command in 0.47.0 release.
         [CommandMethodForwardedTo(typeof(Program), nameof(Serve))]
         [PrimaryCommand]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -44,6 +44,23 @@ namespace Libplanet.Explorer.Executable
             await CoconaLiteApp.RunAsync<Program>(args);
         }
 
+        [Command(Description = "Show GraphQL schema")]
+        public void Schema()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddGraphQL()
+                .AddGraphTypes(typeof(LibplanetExplorerSchema<NullAction>));
+
+            serviceCollection.AddSingleton<IBlockChainContext<NullAction>, Startup>();
+            serviceCollection.AddSingleton<IStore, MemoryStore>();
+
+            IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
+            var schema = new LibplanetExplorerSchema<NullAction>(serviceProvider);
+            var printer = new SchemaPrinter(schema);
+
+            Console.WriteLine(printer.Print());
+        }
+
         // This command is deprecated now. It should use `serve` command instead.
         // FIXME: Obsolete this command in 0.47.0 release.
         [CommandMethodForwardedTo(typeof(Program), nameof(Serve))]


### PR DESCRIPTION
## Changes

### Introduce `schema` command

This pull request introduces a new command, `schema`, on the `Libplanet.Explorer.Executable` project.

You can run it like the below:

```
$ dotnet run -- schema > schema.graphql
```

The `schema.graphql` file is on the gist link. ([link](https://gist.github.com/moreal/5ed64b5bcd1c1691bd1ad3ef3aa361fc)).

I expect this command can be used to get the explorer's GraphQL schema file of the specific Libplanet release.

### Move root command to `serve` command

Since this pull request, the root command (in C# code, `Program.Run()` method) became treated as a subcommand called `serve`. So you should run explorer like `dotnet run -- serve [OPTIONS]`. But it breaks backward compatibility. So it still supports root command by forwarding root command to `serve` subcommand.

Maybe this command will be introduced in *0.45.0* release, and I expect it is obsoleted in about *0.47.0* release.

#### Notice deprecation schedule

```
$ dotnet run -- --store-path
NOTICE: root primary command was deprecated and moved to the `serve` command. Currently the root primary command forwards to the `serve` command but it'll be obsoleted in the 0.47.0 release.
Error: Option '--store-path' requires a value. See '--help' for usage.
```

When running commands except for using subcommand like `serve` and `schema`, it shows notice message to let user know its deprecation schedule.

## Reviewers

 - @dahlia, @tkiapril: because I remembered you're SDK team.