### PR TITLE
Introduce `IFeeCalculator`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,8 @@ deployment if possible.
      -  Removed `Vote(byte[])`, `Vote.ByteArray`, and `Vote.ToByteArray()`.
      -  Removed `VoteMetadata(byte[])`, `VoteMetadata.ByteArray`,
         and `VoteMetadata.ToByteArray()`.
+ -  `ActionEvaluator()` constructor now explicitly requires a new
+    `feeCalculator` parameter.  [[#2566]]
 
 ### Backward-incompatible network protocol changes
 
@@ -95,6 +97,7 @@ deployment if possible.
      -  Added `ImportableKeyStore` interface.
      -  Added `KeyStore` interface.
      -  Added `MutableKeyStore` interface.
+ -  Added `IFeeCalculator` interface. [[#2566]]
 
 ### Behavioral changes
 
@@ -107,6 +110,7 @@ deployment if possible.
 ### CLI tools
 
 [Libplanet 0.52.0]: https://www.nuget.org/packages/Libplanet/0.52.0
+[#2566]: https://github.com/planetarium/libplanet/pull/2566
 [#2703]: https://github.com/planetarium/libplanet/pull/2703
 [#2915]: https://github.com/planetarium/libplanet/pull/2915
 [#2954]: https://github.com/planetarium/libplanet/pull/2954

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -443,6 +443,8 @@ If omitted (default) explorer only the local blockchain store.")]
             /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
             public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
 
+            public IFeeCalculator FeeCalculator => null;
+
             public int GetMinTransactionsPerBlock(long index) =>
                 _impl.GetMinTransactionsPerBlock(index);
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -90,7 +90,8 @@ namespace Libplanet.Tests.Action
                     trieGetter: null,
                     genesisHash: null,
                     nativeTokenPredicate: _ => true,
-                    actionTypeLoader: StaticActionTypeLoader.Create<RandomAction>()
+                    actionTypeLoader: StaticActionTypeLoader.Create<RandomAction>(),
+                    feeCalculator: null
                 );
             var generatedRandomNumbers = new List<int>();
 
@@ -297,7 +298,8 @@ namespace Libplanet.Tests.Action
                 trieGetter: null,
                 genesisHash: null,
                 nativeTokenPredicate: _ => true,
-                actionTypeLoader: StaticActionTypeLoader.Create<DumbAction>()
+                actionTypeLoader: StaticActionTypeLoader.Create<DumbAction>(),
+                feeCalculator: null
             );
             IAccountStateDelta previousStates = AccountStateDeltaImpl.ChooseVersion(
                 genesis.ProtocolVersion,
@@ -595,7 +597,8 @@ namespace Libplanet.Tests.Action
                 trieGetter: null,
                 genesisHash: tx.GenesisHash,
                 nativeTokenPredicate: _ => true,
-                actionTypeLoader: StaticActionTypeLoader.Create<DumbAction>()
+                actionTypeLoader: StaticActionTypeLoader.Create<DumbAction>(),
+                feeCalculator: null
             );
 
             foreach (bool rehearsal in new[] { false, true })
@@ -732,7 +735,8 @@ namespace Libplanet.Tests.Action
                 trieGetter: null,
                 genesisHash: tx.GenesisHash,
                 nativeTokenPredicate: _ => true,
-                actionTypeLoader: StaticActionTypeLoader.Create<ThrowException>()
+                actionTypeLoader: StaticActionTypeLoader.Create<ThrowException>(),
+                feeCalculator: null
             );
             var block = new BlockContent<ThrowException>(
                 new BlockMetadata(

--- a/Libplanet/Action/IFeeCalculator.cs
+++ b/Libplanet/Action/IFeeCalculator.cs
@@ -1,0 +1,9 @@
+using Libplanet.Assets;
+
+namespace Libplanet.Action
+{
+    public interface IFeeCalculator
+    {
+        FungibleAssetValue CalculateFee(IAction action);
+    }
+}

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -144,7 +144,8 @@ namespace Libplanet.Blockchain
                         stateStore.GetStateRoot(store.GetBlockDigest(hash)?.StateRootHash),
                     genesisHash: genesisBlock.Hash,
                     nativeTokenPredicate: policy.NativeTokens.Contains,
-                    actionTypeLoader: StaticActionTypeLoader.Create<T>()
+                    actionTypeLoader: StaticActionTypeLoader.Create<T>(),
+                    feeCalculator: null
                 )
             )
         {
@@ -479,7 +480,8 @@ namespace Libplanet.Blockchain
                     store.GetBlockDigest(hash)?.StateRootHash),
                 genesisHash: genesisBlock.Hash,
                 nativeTokenPredicate: policy.NativeTokens.Contains,
-                actionTypeLoader: StaticActionTypeLoader.Create<T>()
+                actionTypeLoader: StaticActionTypeLoader.Create<T>(),
+                feeCalculator: null
             );
 
             return new BlockChain<T>(

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -173,6 +173,9 @@ namespace Libplanet.Blockchain.Policies
         public TimeSpan BlockInterval { get; }
 
         /// <inheritdoc/>
+        public IFeeCalculator? FeeCalculator => null;
+
+        /// <inheritdoc/>
         public virtual TxPolicyViolationException? ValidateNextBlockTx(
             BlockChain<T> blockChain, Transaction<T> transaction)
         {

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -37,6 +37,9 @@ namespace Libplanet.Blockchain.Policies
         [Pure]
         IImmutableSet<Currency> NativeTokens { get; }
 
+        [Pure]
+        IFeeCalculator? FeeCalculator { get; }
+
         /// <summary>
         /// Checks if a <see cref="Transaction{T}"/> can be included in a yet to be mined
         /// <see cref="Block{T}"/> that can be appended to the given <see cref="BlockChain{T}"/>.

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -29,6 +29,8 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc cref="IBlockPolicy{T}.NativeTokens"/>
         public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
 
+        public IFeeCalculator FeeCalculator => null;
+
         public int GetMinTransactionsPerBlock(long index) => 0;
 
         public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;

--- a/Libplanet/Blocks/PreEvaluationBlock.cs
+++ b/Libplanet/Blocks/PreEvaluationBlock.cs
@@ -252,7 +252,8 @@ namespace Libplanet.Blocks
                 trieGetter: null,
                 genesisHash: null,
                 nativeTokenPredicate: nativeTokenPredicate,
-                actionTypeLoader: StaticActionTypeLoader.Create<T>()
+                actionTypeLoader: StaticActionTypeLoader.Create<T>(),
+                feeCalculator: null
             );
             IReadOnlyList<ActionEvaluation> actionEvaluations = actionEvaluator.Evaluate(this);
             statesDelta = actionEvaluations.GetTotalDelta(


### PR DESCRIPTION
# Context
NineChronicles has a Tx spamming problem. And it is caused by the non-fee Transaction model. 
In this PR. introduce `IFeeCalculator`. It is an interface for calculating Transaction fees and collecting from signers.

# Description
Get `IFeeCalculator` as an `IBlockPolicy` and check the fee in `ActionEvaluator.EvaluateActions()`.
