### PR TITLE
Bump BouncyCastle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@ To be released.
     did not work as intended.  [[#2518], [#2520]]
 
 ### Dependencies
+ -  Replaced *[BouncyCastle.NetCore 1.8.6]* with
+   *[BouncyCastle.Cryptography 2.0.0]*.  [[#2571]]
 
 ### CLI tools
 
@@ -61,11 +63,14 @@ To be released.
         You should use `serve` command instead.  [[#2563]]
  -  (Libplanet.Explorer) Added `schema` subcommand.  [[#2563]]
 
+[BouncyCastle.NetCore 1.8.6]: https://www.nuget.org/packages/BouncyCastle.NetCore/1.8.6
+[BouncyCastle.Cryptography 2.0.0]: https://www.nuget.org/packages/BouncyCastle.Cryptography/2.0.0
 [#2518]: https://github.com/planetarium/libplanet/issues/2518
 [#2520]: https://github.com/planetarium/libplanet/pull/2520
 [#2529]: https://github.com/planetarium/libplanet/pull/2529
 [#2555]: https://github.com/planetarium/libplanet/pull/2555
 [#2563]: https://github.com/planetarium/libplanet/pull/2563
+[#2571]: https://github.com/planetarium/libplanet/pull/2571
 
 
 Version 0.44.1

--- a/Libplanet/Crypto/DefaultCryptoBackend.cs
+++ b/Libplanet/Crypto/DefaultCryptoBackend.cs
@@ -26,11 +26,13 @@ namespace Libplanet.Crypto
                 s = otherS;
             }
 
-            var bos = new MemoryStream(72);
-            var seq = new DerSequenceGenerator(bos);
-            seq.AddObject(new DerInteger(r));
-            seq.AddObject(new DerInteger(s));
-            seq.Close();
+            using var bos = new MemoryStream(72);
+            using (var seq = new DerSequenceGenerator(bos))
+            {
+                seq.AddObject(new DerInteger(r));
+                seq.AddObject(new DerInteger(s));
+            }
+
             return bos.ToArray();
         }
 

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -64,7 +64,7 @@ https://docs.libplanet.io/</Description>
   <ItemGroup>
     <PackageReference Include="Bencodex" Version="0.7.0-dev.20220923062845" />
     <PackageReference Include="Bencodex.Json" Version="0.7.0-dev.20220923062845" />
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="ImmutableTrie" Version="1.0.0-alpha" />


### PR DESCRIPTION
As the title suggests, this PR bumps BouncyCastle to 2.0.0 (I think it's mainly a maintained version).