### PR TITLE
Upgrade GraphQL-related dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@ To be released.
  -  Added `StaticActionTypeLoader` class.  [[#2539]]
  -  (Libplanet.Explorer) Added a new GraphQL endpoint on `/graphql/explorer`.
     [[#2562]]
+ -  (Libplanet.Explorer) Added `ConfigureLibplanetExplorerSchema` class.
+    [[#2572]]
 
 [#2507]: https://github.com/planetarium/libplanet/pull/2507
 [#2539]: https://github.com/planetarium/libplanet/pull/2539
@@ -50,8 +52,16 @@ To be released.
     did not work as intended.  [[#2518], [#2520]]
 
 ### Dependencies
+
  -  Replaced *[BouncyCastle.NetCore 1.8.6]* with
    *[BouncyCastle.Cryptography 2.0.0]*.  [[#2571]]
+ -  (Libplanet.Explorer) Upgraded GraphQL-related dependencies.  [[#2572]]
+     -  *GraphQL*: 4.7.1 → 7.1.1
+     -  *GraphQL.Server.Authorization.AspNetCore*: 5.1.1 → 7.1.1
+     -  *GraphQL.Server.Transports.AspNetCore*: 5.1.1 → 7.1.1
+     -  *GraphQL.Server.Ui.Playground*: 5.1.1 → 7.1.1
+     -  *GraphQL.SystemTextJson*: 4.7.1 → 7.1.1
+     -  *GraphQL.Server.Transports.AspNetCore.SystemTextJson*: 5.1.1 → removed
 
 ### CLI tools
 
@@ -71,6 +81,7 @@ To be released.
 [#2555]: https://github.com/planetarium/libplanet/pull/2555
 [#2563]: https://github.com/planetarium/libplanet/pull/2563
 [#2571]: https://github.com/planetarium/libplanet/pull/2571
+[#2572]: https://github.com/planetarium/libplanet/pull/2572
 
 
 Version 0.44.1

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -6,9 +6,8 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Bencodex.Types;
 using Cocona;
-using GraphQL.Server;
+using GraphQL;
 using GraphQL.Utilities;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -21,7 +20,6 @@ using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Schemas;
 using Libplanet.Explorer.Store;
 using Libplanet.Net;
-using Libplanet.Net.Protocols;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
@@ -60,8 +58,8 @@ namespace Libplanet.Explorer.Executable
         public void Schema()
         {
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddGraphQL()
-                .AddGraphTypes(typeof(LibplanetExplorerSchema<NullAction>));
+            serviceCollection.AddGraphQL(builder =>
+                builder.AddLibplanetExplorerSchema<NullAction>());
 
             serviceCollection.AddSingleton<IBlockChainContext<NullAction>, Startup>();
             serviceCollection.AddSingleton<IStore, MemoryStore>();

--- a/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
+++ b/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
@@ -4,14 +4,20 @@ using GraphQL;
 using GraphQL.Types;
 using Libplanet.Store;
 using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.Schemas;
 using Libplanet.Action;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Concurrent;
+using GraphQL.DI;
 
 namespace Libplanet.Explorer.Tests
 {
     public static class GraphQLTestUtils
     {
+        private static readonly ConcurrentDictionary<IObjectGraphType, ISchema> CachedSchemaMap =
+            new(ReferenceEqualityComparer.Instance);
+
         public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
             string query,
             IDictionary<string, object> userContext = null,
@@ -55,14 +61,26 @@ namespace Libplanet.Explorer.Tests
                 }
             );
 
+            // A IGraphType instance can be used as a query root type only once.
+            if (!CachedSchemaMap.TryGetValue(queryGraphType, out ISchema schema))
+            {
+                IConfigureSchema[] configurations =
+                {
+                    ConfigureLibplanetExplorerSchema.Instance,
+                };
+                schema = new Schema(failSafeServiceProvider, configurations)
+                {
+                    Query = queryGraphType,
+                };
+
+                CachedSchemaMap[queryGraphType] = schema;
+            }
+
             return documentExecutor.ExecuteAsync(
                 new ExecutionOptions
                 {
                     Query = query,
-                    Schema = new Schema(failSafeServiceProvider)
-                    {
-                        Query = queryGraphType,
-                    },
+                    Schema = schema,
                     UserContext = userContext,
                     Root = source,
                 }

--- a/Libplanet.Explorer.Tests/GraphTypes/ByteStringTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/ByteStringTypeTest.cs
@@ -1,4 +1,4 @@
-using GraphQL.Language.AST;
+using GraphQLParser.AST;
 using Libplanet.Explorer.GraphTypes;
 using Xunit;
 
@@ -31,16 +31,15 @@ namespace Libplanet.Explorer.Tests.GraphTypes
         public void ParseLiteral(string stringValue, object parsed)
         {
             var actual =
-                stringValue is { } v ? _type.ParseLiteral(new StringValue(v)) : null;
+                stringValue is { } v ? _type.ParseLiteral(new GraphQLStringValue(v)) : null;
             Assert.Equal(parsed, actual);
         }
 
         [Fact]
         public void ParseLiteral_NotStringValue_ReturnNull()
         {
-            Assert.Null(_type.ParseLiteral(new IntValue(0)));
-            Assert.Null(_type.ParseLiteral(new BigIntValue(0)));
-            Assert.Null(_type.ParseLiteral(new EnumValue("NAME")));
+            Assert.Null(_type.ParseLiteral(new GraphQLIntValue(0)));
+            Assert.Null(_type.ParseLiteral(new GraphQLTrueBooleanValue()));
         }
     }
 }

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Bencodex.Types;
 using GraphQL;
 using GraphQL.Execution;
 using Libplanet.Action;

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -1,8 +1,5 @@
 #nullable disable
 using GraphQL;
-using GraphQL.Server;
-using GraphQL.SystemTextJson;
-using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Explorer.Interfaces;
@@ -55,9 +52,7 @@ namespace Libplanet.Explorer
             services.TryAddSingleton<ExplorerQuery<T>>();
             services.TryAddSingleton<LibplanetExplorerSchema<T>>();
 
-            services.AddGraphQL()
-                    .AddSystemTextJson()
-                    .AddGraphTypes(typeof(LibplanetExplorerSchema<T>));
+            services.AddGraphQL(builder => builder.AddLibplanetExplorerSchema<T>());
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/Libplanet.Explorer/GraphTypes/ActionType.cs
+++ b/Libplanet.Explorer/GraphTypes/ActionType.cs
@@ -1,13 +1,9 @@
 #nullable disable
 using System;
-using System.Buffers;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Bencodex;
-using Bencodex.Types;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
@@ -19,16 +15,10 @@ namespace Libplanet.Explorer.GraphTypes
     {
         public ActionType()
         {
-            Field<NonNullGraphType<StringGraphType>>(
-                name: "Raw",
-                description: "Raw Action data ('hex' or 'base64' encoding available.)",
-                arguments: new QueryArguments(
-                    new QueryArgument<StringGraphType>
-                    {
-                        DefaultValue = "hex",
-                        Name = "encode",
-                    }),
-                resolve: ctx =>
+            Field<NonNullGraphType<StringGraphType>>("Raw")
+                .Description("Raw Action data ('hex' or 'base64' encoding available.)")
+                .Argument<string>("encode", false, arg => arg.DefaultValue = "hex")
+                .Resolve(ctx =>
                 {
                     var codec = new Codec();
                     var encoded = codec.Encode(ctx.Source.PlainValue);
@@ -48,27 +38,22 @@ namespace Libplanet.Explorer.GraphTypes
                                 "It supports only 'hex' or 'base64'.";
                             throw new ExecutionError(msg);
                     }
-                }
-            );
+                });
 
-            Field<NonNullGraphType<StringGraphType>>(
-                name: "Inspection",
-                description: "A readable representation for debugging.",
-                resolve: ctx => ctx.Source.PlainValue.Inspect(loadAll: true)
-            );
+            Field<NonNullGraphType<StringGraphType>>("Inspection")
+                .Description("A readable representation for debugging.")
+                .Resolve(ctx => ctx.Source.PlainValue.Inspect(loadAll: true));
 
-            Field<NonNullGraphType<StringGraphType>>(
-                name: "json",
-                description: "A JSON representaion of action data",
-                resolve: ctx =>
+            Field<NonNullGraphType<StringGraphType>>("json")
+                .Description("A JSON representation of action data")
+                .Resolve(ctx =>
                 {
                     var converter = new Bencodex.Json.BencodexJsonConverter();
                     var buffer = new MemoryStream();
                     var writer = new Utf8JsonWriter(buffer);
                     converter.Write(writer, ctx.Source.PlainValue, new JsonSerializerOptions());
                     return Encoding.UTF8.GetString(buffer.ToArray());
-                }
-            );
+                });
 
             Name = "Action";
         }

--- a/Libplanet.Explorer/GraphTypes/AddressType.cs
+++ b/Libplanet.Explorer/GraphTypes/AddressType.cs
@@ -1,7 +1,6 @@
-#nullable disable
 using System;
-using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser.AST;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -12,7 +11,7 @@ namespace Libplanet.Explorer.GraphTypes
             Name = "Address";
         }
 
-        public override object Serialize(object value)
+        public override object? Serialize(object? value)
         {
             if (value is Address addr)
             {
@@ -22,7 +21,7 @@ namespace Libplanet.Explorer.GraphTypes
             return value;
         }
 
-        public override object ParseValue(object value)
+        public override object? ParseValue(object? value)
         {
             switch (value)
             {
@@ -41,14 +40,7 @@ namespace Libplanet.Explorer.GraphTypes
             }
         }
 
-        public override object ParseLiteral(IValue value)
-        {
-            if (value is StringValue)
-            {
-                return ParseValue(value.Value);
-            }
-
-            return null;
-        }
+        public override object? ParseLiteral(GraphQLValue? value) =>
+            value is GraphQLStringValue v ? ParseValue((string)v.Value) : null;
     }
 }

--- a/Libplanet.Explorer/GraphTypes/BencodexValueType.cs
+++ b/Libplanet.Explorer/GraphTypes/BencodexValueType.cs
@@ -1,7 +1,7 @@
 using System;
 using Bencodex;
-using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser.AST;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -37,14 +37,7 @@ namespace Libplanet.Explorer.GraphTypes
             };
         }
 
-        public override object? ParseLiteral(IValue? value)
-        {
-            if (value is StringValue)
-            {
-                return ParseValue(value.Value);
-            }
-
-            return null;
-        }
+        public override object? ParseLiteral(GraphQLValue? value) =>
+            value is GraphQLStringValue v ? ParseValue((string)v.Value) : null;
     }
 }

--- a/Libplanet.Explorer/GraphTypes/BlockPolicyType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockPolicyType.cs
@@ -13,12 +13,14 @@ public class BlockPolicyType<T> : ObjectGraphType<IBlockPolicy<T>>
     {
         Name = "BlockPolicy";
         Field<NonNullGraphType<ListGraphType<NonNullGraphType<CurrencyType>>>>(
-            "nativeTokens",
-            "A fixed set of native tokens, which are supported by the blockchain as " +
-                "first-class assets.",
-            resolve: context => context.Source.NativeTokens
-                .OrderBy(c => c.Ticker, StringComparer.InvariantCultureIgnoreCase)
-                .ToList()
-        );
+            "nativeTokens")
+            .Description(
+                "A fixed set of native tokens, which are supported by the blockchain as " +
+                    "first-class assets."
+            )
+            .Resolve(context =>
+                context.Source.NativeTokens
+                    .OrderBy(c => c.Ticker, StringComparer.InvariantCultureIgnoreCase)
+                    .ToList());
     }
 }

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,7 +1,6 @@
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
-using Libplanet.Explorer.Interfaces;
 using Libplanet.Store;
 
 namespace Libplanet.Explorer.GraphTypes
@@ -12,69 +11,45 @@ namespace Libplanet.Explorer.GraphTypes
         public BlockType(IStore store)
         {
             // We need multiple row of description for clearer, not confusing explanation of field.
-            Field<NonNullGraphType<IdGraphType>>(
-                "Hash",
-                description: "A block's hash.",
-                resolve: ctx => ctx.Source.Hash.ToString()
-            );
-            Field<NonNullGraphType<LongGraphType>>(
-                name: "Index",
-                description: "The height of the block.",
-                resolve: x => x.Source.Index
-            );
-            Field<NonNullGraphType<LongGraphType>>(
-                name: "Difficulty",
-                description: "The mining difficulty that the block's nonce has to satisfy.",
-                resolve: x => x.Source.Difficulty);
-            Field<NonNullGraphType<BigIntGraphType>>(
-                name: "TotalDifficulty",
-                description: "The total mining difficulty since the genesis including " +
-                    "the block's difficulty.",
-                resolve: x => x.Source.TotalDifficulty);
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "Nonce",
-                description: "The proof-of-work nonce which satisfies the required difficulty.",
-                resolve: ctx => ctx.Source.Nonce.ToByteArray()
-            );
-            Field<NonNullGraphType<AddressType>>(
-                name: "Miner",
-                description: "The address of the miner.",
-                resolve: x => x.Source.Miner
-            );
-            Field<PublicKeyType>(
-                name: "PublicKey",
-                description: "The public key of the Miner.",
-                resolve: x => x.Source.PublicKey
-            );
-            Field<BlockType<T>>(
-                name: "PreviousBlock",
-                description: "The previous block.  If it's a genesis block (i.e., its index is " +
-                    "0) this must be null.",
-                resolve: ctx =>
-                {
-                    if (!(ctx.Source.PreviousHash is { } h))
-                    {
-                        return null;
-                    }
-
-                    return store.GetBlock<T>(h);
-                }
-            );
-            Field(x => x.Timestamp);
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "StateRootHash",
-                description: "The hash of the resulting states after evaluating transactions " +
-                    "and a block action (if exists)",
-                resolve: ctx => ctx.Source.StateRootHash.ToByteArray());
-            Field<ByteStringType>(
-                name: "Signature",
-                description: "The digital signature of the whole block content (except for hash, " +
-                    "which is derived from the signature and other contents)",
-                resolve: ctx => ctx.Source.Signature?.ToBuilder().ToArray());
+            Field<NonNullGraphType<IdGraphType>>("Hash")
+                .Description("A block's hash.")
+                .Resolve(ctx => ctx.Source.Hash.ToString());
+            Field<NonNullGraphType<LongGraphType>>("Index")
+                .Description("The height of the block.")
+                .Resolve(ctx => ctx.Source.Index);
+            Field<NonNullGraphType<LongGraphType>>("Difficulty")
+                .Description("The mining difficulty that the block's nonce has to satisfy.")
+                .Resolve(ctx => ctx.Source.Difficulty);
+            Field<NonNullGraphType<BigIntGraphType>>("TotalDifficulty")
+                .Description("The total mining difficulty since the genesis including " +
+                    "the block's difficulty.")
+                .Resolve(ctx => ctx.Source.TotalDifficulty);
+            Field<NonNullGraphType<ByteStringType>>("Nonce")
+                .Description("The proof-of-work nonce which satisfies the required difficulty.")
+                .Resolve(ctx => ctx.Source.Nonce.ToByteArray());
+            Field<NonNullGraphType<AddressType>>("Miner")
+                .Description("The address of the miner.")
+                .Resolve(ctx => ctx.Source.Miner);
+            Field<PublicKeyType>("PublicKey")
+                .Description("The public key of the Miner.")
+                .Resolve(ctx => ctx.Source.PublicKey);
+            Field<BlockType<T>>("PreviousBlock")
+                .Description("The previous block.  If it's a genesis block (i.e., its index is " +
+                    "0) this must be null.")
+                .Resolve(ctx => ctx.Source.PreviousHash is { } h ? store.GetBlock<T>(h) : null);
+            Field(ctx => ctx.Timestamp);
+            Field<NonNullGraphType<ByteStringType>>("StateRootHash")
+                .Description("The hash of the resulting states after evaluating transactions " +
+                    "and a block action (if exists)")
+                .Resolve(ctx => ctx.Source.StateRootHash.ToByteArray());
+            Field<ByteStringType>("Signature")
+                .Description("The digital signature of the whole block content (except for hash, " +
+                    "which is derived from the signature and other contents)")
+                .Resolve(ctx => ctx.Source.Signature?.ToBuilder().ToArray());
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
-                name: "transactions",
-                description: "Transactions belonging to the block."
-            );
+                "transactions")
+                .Description("Transactions belonging to the block.")
+                .Resolve(ctx => ctx.Source.Transactions);
 
             Name = "Block";
         }

--- a/Libplanet.Explorer/GraphTypes/ByteStringType.cs
+++ b/Libplanet.Explorer/GraphTypes/ByteStringType.cs
@@ -1,7 +1,6 @@
-#nullable disable
 using System;
-using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser.AST;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -12,7 +11,7 @@ namespace Libplanet.Explorer.GraphTypes
             Name = "ByteString";
         }
 
-        public override object Serialize(object value)
+        public override object? Serialize(object? value)
         {
             return value switch
             {
@@ -22,7 +21,7 @@ namespace Libplanet.Explorer.GraphTypes
             };
         }
 
-        public override object ParseValue(object value)
+        public override object? ParseValue(object? value)
         {
             switch (value)
             {
@@ -35,13 +34,7 @@ namespace Libplanet.Explorer.GraphTypes
             }
         }
 
-        public override object ParseLiteral(IValue value)
-        {
-            return value switch
-            {
-                StringValue stringValue => ParseValue(stringValue.Value),
-                _ => null,
-            };
-        }
+        public override object? ParseLiteral(GraphQLValue? value) =>
+            value is GraphQLStringValue v ? ParseValue((string)v.Value) : null;
     }
 }

--- a/Libplanet.Explorer/GraphTypes/CurrencyType.cs
+++ b/Libplanet.Explorer/GraphTypes/CurrencyType.cs
@@ -9,40 +9,28 @@ public class CurrencyType : ObjectGraphType<Currency>
     public CurrencyType()
     {
         Name = "Currency";
-        Field<NonNullGraphType<StringGraphType>>(
-            "ticker",
-            "The ticker symbol, e.g., USD.",
-            resolve: context => context.Source.Ticker
-        );
-        Field<NonNullGraphType<UIntGraphType>>(
-            "decimalPlaces",
-            "The number of digits to treat as minor units (i.e., exponents).",
-            resolve: context => (uint)context.Source.DecimalPlaces
-        );
-        Field<ListGraphType<NonNullGraphType<AddressType>>>(
-            "minters",
-            "The addresses who can mint this currency.  If this is null anyone can " +
-                "mint the currency.  On the other hand, unlike null, an empty set means no one " +
-                "can mint the currency.",
-            resolve: context => context.Source.Minters
-                ?.OrderBy(a => a)
-                ?.ToList()
-        );
-        Field<FungibleAssetValueType>(
-            "maximumSupply",
-            "The uppermost quantity of currency allowed to exist.  " +
-                "null means unlimited supply.",
-            resolve: context => context.Source.MaximumSupply
-        );
-        Field<NonNullGraphType<BooleanGraphType>>(
-            "totalSupplyTrackable",
-            "Whether the total supply of this currency is trackable.",
-            resolve: context => context.Source.TotalSupplyTrackable
-        );
-        Field<NonNullGraphType<ByteStringType>>(
-            "hash",
-            "The deterministic hash derived from other fields.",
-            resolve: context => context.Source.Hash.ToByteArray()
-        );
+        Field<NonNullGraphType<StringGraphType>>("ticker")
+            .Description("The ticker symbol, e.g., USD.")
+            .Resolve(context => context.Source.Ticker);
+        Field<NonNullGraphType<UIntGraphType>>("decimalPlaces")
+            .Description("The number of digits to treat as minor units (i.e., exponents).")
+            .Resolve(context => (uint)context.Source.DecimalPlaces);
+        Field<ListGraphType<NonNullGraphType<AddressType>>>("minters")
+            .Description(
+                "The addresses who can mint this currency.  If this is null anyone can " +
+                    "mint the currency.  On the other hand, unlike null, an empty set means no " +
+                    "one can mint the currency.")
+            .Resolve(context => context.Source.Minters?.OrderBy(a => a)?.ToList());
+        Field<FungibleAssetValueType>("maximumSupply")
+            .Description(
+                "The uppermost quantity of currency allowed to exist.  " +
+                    "null means unlimited supply.")
+            .Resolve(context => context.Source.MaximumSupply);
+        Field<NonNullGraphType<BooleanGraphType>>("totalSupplyTrackable")
+            .Description("Whether the total supply of this currency is trackable.")
+            .Resolve(context => context.Source.TotalSupplyTrackable);
+        Field<NonNullGraphType<ByteStringType>>("hash")
+            .Description("The deterministic hash derived from other fields.")
+            .Resolve(context => context.Source.Hash.ToByteArray());
     }
 }

--- a/Libplanet.Explorer/GraphTypes/FungibleAssetValueType.cs
+++ b/Libplanet.Explorer/GraphTypes/FungibleAssetValueType.cs
@@ -9,28 +9,20 @@ public class FungibleAssetValueType : ObjectGraphType<FungibleAssetValue>
     {
         Name = "FungibleAssetValue";
         Description = "Holds a fungible asset value which holds its currency together.";
-        Field<NonNullGraphType<CurrencyType>>(
-            "currency",
-            "The currency of the fungible asset.",
-            resolve: ctx => ctx.Source.Currency
-        );
-        Field<NonNullGraphType<IntGraphType>>(
-            "sign",
-            "Gets a number that indicates the sign (-1: negative, 1: positive, " +
-                "or 0: zero) of the value.",
-            resolve: ctx => ctx.Source.Sign
-        );
-        Field("majorUnit", source => source.MajorUnit);
-        Field("minorUnit", source => source.MinorUnit);
-        Field<NonNullGraphType<StringGraphType>>(
-            "quantity",
-            "The value quantity without its currency in string, e.g., \"123.45\".",
-            resolve: ctx => ctx.Source.GetQuantityString()
-        );
-        Field<NonNullGraphType<StringGraphType>>(
-            "string",
-            "The value quantity with its currency in string, e.g., \"123.45 ABC\".",
-            resolve: ctx => ctx.Source.ToString()
-        );
+        Field<NonNullGraphType<CurrencyType>>("currency")
+            .Description("The currency of the fungible asset.")
+            .Resolve(ctx => ctx.Source.Currency);
+        Field<NonNullGraphType<IntGraphType>>("sign")
+            .Description("Gets a number that indicates the sign (-1: negative, 1: positive, " +
+                "or 0: zero) of the value.")
+            .Resolve(ctx => ctx.Source.Sign);
+        Field<NonNullGraphType<BigIntGraphType>>("majorUnit").Resolve(ctx => ctx.Source.MajorUnit);
+        Field<NonNullGraphType<BigIntGraphType>>("minorUnit").Resolve(ctx => ctx.Source.MinorUnit);
+        Field<NonNullGraphType<StringGraphType>>("quantity")
+            .Description("The value quantity without its currency in string, e.g., \"123.45\".")
+            .Resolve(ctx => ctx.Source.GetQuantityString());
+        Field<NonNullGraphType<StringGraphType>>("string")
+            .Description("The value quantity with its currency in string, e.g., \"123.45 ABC\".")
+            .Resolve(ctx => ctx.Source.ToString());
     }
 }

--- a/Libplanet.Explorer/GraphTypes/NodeStateType.cs
+++ b/Libplanet.Explorer/GraphTypes/NodeStateType.cs
@@ -2,7 +2,6 @@
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.Interfaces;
-using Libplanet.Explorer.Queries;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -11,10 +10,9 @@ namespace Libplanet.Explorer.GraphTypes
     {
         public NodeStateType()
         {
-            Field<NonNullGraphType<BooleanGraphType>>(
-                "preloaded",
-                resolve: context => context.Source.Preloaded
-            );
+            Field<NonNullGraphType<BooleanGraphType>>("preloaded")
+                .Resolve(context => context.Source.Preloaded);
+
             Name = "NodeState";
         }
     }

--- a/Libplanet.Explorer/GraphTypes/PublicKeyType.cs
+++ b/Libplanet.Explorer/GraphTypes/PublicKeyType.cs
@@ -1,7 +1,6 @@
-#nullable disable
 using System;
-using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser.AST;
 using Libplanet.Crypto;
 
 namespace Libplanet.Explorer.GraphTypes
@@ -13,7 +12,7 @@ namespace Libplanet.Explorer.GraphTypes
             Name = "PublicKey";
         }
 
-        public override object Serialize(object value)
+        public override object? Serialize(object? value)
         {
             if (value is PublicKey pubKey)
             {
@@ -23,7 +22,7 @@ namespace Libplanet.Explorer.GraphTypes
             return value;
         }
 
-        public override object ParseValue(object value)
+        public override object? ParseValue(object? value)
         {
             switch (value)
             {
@@ -37,14 +36,7 @@ namespace Libplanet.Explorer.GraphTypes
             }
         }
 
-        public override object ParseLiteral(IValue value)
-        {
-            if (value is StringValue)
-            {
-                return ParseValue(value.Value);
-            }
-
-            return null;
-        }
+        public override object? ParseLiteral(GraphQLValue? value) =>
+            value is GraphQLStringValue v ? ParseValue((string)v.Value) : null;
     }
 }

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types;
@@ -15,60 +16,44 @@ namespace Libplanet.Explorer.GraphTypes
     {
         public TransactionType()
         {
-            Field<NonNullGraphType<IdGraphType>>(
-                name: "Id",
-                description: "A unique identifier derived from this transaction content.",
-                resolve: ctx => ctx.Source.Id.ToString());
-            Field<NonNullGraphType<LongGraphType>>(
-                name: "Nonce",
-                description: "The number of previous transactions committed by the signer of " +
-                    "this tx.",
-                resolve: x => x.Source.Nonce
-            );
-            Field(
-                type: typeof(NonNullGraphType<AddressType>),
-                name: "Signer",
-                description: "An address of the account who signed this transaction.",
-                resolve: x => x.Source.Signer
-            );
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "PublicKey",
-                description: "A PublicKey of the account who signed this transaction.",
-                resolve: ctx => ctx.Source.PublicKey.Format(true)
-            );
+            Field<NonNullGraphType<IdGraphType>>("Id")
+                .Description("A unique identifier derived from this transaction content.")
+                .Resolve(ctx => ctx.Source.Id.ToString());
+            Field<NonNullGraphType<LongGraphType>>("Nonce")
+                .Description("The number of previous transactions committed by the signer of " +
+                    "this tx.")
+                .Resolve(ctx => ctx.Source.Nonce);
+            Field<NonNullGraphType<AddressType>>("Signer")
+                .Description("An address of the account who signed this transaction.")
+                .Resolve(ctx => ctx.Source.Signer);
+            Field<NonNullGraphType<ByteStringType>>("PublicKey")
+                .Description("A PublicKey of the account who signed this transaction.")
+                .Resolve(ctx => ctx.Source.PublicKey.Format(true));
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>(
-                name: "UpdatedAddresses",
-                description: "Addresses whose states were affected by Actions.",
-                resolve: x => x.Source.UpdatedAddresses
-            );
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "Signature",
-                description: "A digital signature of the content of this transaction.",
-                resolve: x => x.Source.Signature
-            );
-            Field<NonNullGraphType<DateTimeOffsetGraphType>>(
-                name: "Timestamp",
-                description: "The time this transaction was created and signed.",
-                resolve: x => x.Source.Timestamp
-            );
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ActionType<T>>>>>(
-                name: "Actions",
-                description: "A list of actions in this transaction."
-            );
-            Field<NonNullGraphType<StringGraphType>>(
-                name: "SerializedPayload",
-                description: "A serialized tx payload in base64 string.",
-                resolve: x =>
+                "UpdatedAddresses")
+                .Description("Addresses whose states were affected by Actions.")
+                .Resolve(ctx => ctx.Source.UpdatedAddresses);
+            Field<NonNullGraphType<ByteStringType>>("Signature")
+                .Description("A digital signature of the content of this transaction.")
+                .Resolve(ctx => ctx.Source.Signature);
+            Field<NonNullGraphType<DateTimeOffsetGraphType>>("Timestamp")
+                .Description("The time this transaction was created and signed.")
+                .Resolve(ctx => ctx.Source.Timestamp);
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ActionType<T>>>>>("Actions")
+                .Description("A list of actions in this transaction.")
+                .Resolve(ctx => (IEnumerable<T>?)ctx.Source.CustomActions ?? Enumerable.Empty<T>());
+            Field<NonNullGraphType<StringGraphType>>("SerializedPayload")
+                .Description("A serialized tx payload in base64 string.")
+                .Resolve(ctx =>
                 {
-                    byte[] bytes = x.Source.Serialize(true);
+                    byte[] bytes = ctx.Source.Serialize(true);
                     return Convert.ToBase64String(bytes);
                 });
 
             // The block including the transaction. - Only RichStore supports.
-            Field<ListGraphType<NonNullGraphType<BlockType<T>>>>(
-                name: "BlockRef",
-                description: "The block including the transaction.",
-                resolve: ctx =>
+            Field<ListGraphType<NonNullGraphType<BlockType<T>>>>("BlockRef")
+                .Description("The block including the transaction.")
+                .Resolve(ctx =>
                 {
                     // FIXME: use context with DI.
                     const string storeKey = nameof(IBlockChainContext<T>.Store);

--- a/Libplanet.Explorer/GraphTypes/TxResultType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResultType.cs
@@ -9,53 +9,48 @@ namespace Libplanet.Explorer.GraphTypes
     {
         public TxResultType()
         {
-            Field<NonNullGraphType<TxStatusType>>(
-                nameof(TxResult.TxStatus),
-                description: "The transaction status.",
-                resolve: context => context.Source.TxStatus
-            );
+            Field<NonNullGraphType<TxStatusType>>(nameof(TxResult.TxStatus))
+                .Description("The transaction status.")
+                .Resolve(context => context.Source.TxStatus);
 
-            Field<LongGraphType>(
-                nameof(TxResult.BlockIndex),
-                description: "The block index which the target transaction executed.",
-                resolve: context => context.Source.BlockIndex
-            );
+            Field<LongGraphType>(nameof(TxResult.BlockIndex))
+                .Description("The block index which the target transaction executed.")
+                .Resolve(context => context.Source.BlockIndex);
 
-            Field<StringGraphType>(
-                nameof(TxResult.BlockHash),
-                description: "The block hash which the target transaction executed.",
-                resolve: context => context.Source.BlockHash
-            );
+            Field<StringGraphType>(nameof(TxResult.BlockHash))
+                .Description("The block hash which the target transaction executed.")
+                .Resolve(context => context.Source.BlockHash);
 
-            Field<StringGraphType>(
-                nameof(TxResult.ExceptionName),
-                description: "The name of exception. (when only failed)",
-                resolve: context => context.Source.ExceptionName
-            );
+            Field<StringGraphType>(nameof(TxResult.ExceptionName))
+                .Description("The name of exception. (when only failed)")
+                .Resolve(context => context.Source.ExceptionName);
 
-            Field<BencodexValueType>(
-                nameof(TxResult.ExceptionMetadata),
-                description: "The hexadecimal string of the exception metadata. (when only failed)",
-                resolve: context => context.Source.ExceptionMetadata
-            );
+            Field<BencodexValueType>(nameof(TxResult.ExceptionMetadata))
+                .Description(
+                    "The hexadecimal string of the exception metadata. (when only failed)")
+                .Resolve(context => context.Source.ExceptionMetadata);
 
             Field<ListGraphType<NonNullGraphType<UpdatedStateType>>>(
-                nameof(TxResult.UpdatedStates),
-                resolve: context => context.Source.UpdatedStates?
-                    .Select(pair => new UpdatedState(pair.Key, pair.Value))
-            );
+                nameof(TxResult.UpdatedStates))
+                .Resolve(context =>
+                    context.Source.UpdatedStates?.Select(pair =>
+                        new UpdatedState(pair.Key, pair.Value)
+                    )
+                );
 
             Field<ListGraphType<NonNullGraphType<FungibleAssetBalancesType>>>(
-                nameof(TxResult.UpdatedFungibleAssets),
-                resolve: context => context.Source.UpdatedFungibleAssets?
-                    .Select(pair => new FungibleAssetBalances(pair.Key, pair.Value.Values))
-            );
+                nameof(TxResult.UpdatedFungibleAssets))
+                .Resolve(context =>
+                    context.Source.UpdatedFungibleAssets?.Select(pair =>
+                        new FungibleAssetBalances(pair.Key, pair.Value.Values)
+                    ));
 
             Field<ListGraphType<NonNullGraphType<FungibleAssetBalancesType>>>(
-                nameof(TxResult.FungibleAssetsDelta),
-                resolve: context => context.Source.FungibleAssetsDelta?
-                    .Select(pair => new FungibleAssetBalances(pair.Key, pair.Value.Values))
-            );
+                nameof(TxResult.FungibleAssetsDelta))
+                .Resolve(context =>
+                    context.Source.FungibleAssetsDelta?.Select(pair =>
+                        new FungibleAssetBalances(pair.Key, pair.Value.Values)
+                    ));
         }
 
         public record UpdatedState(Address Address, Bencodex.Types.IValue? State);
@@ -64,14 +59,10 @@ namespace Libplanet.Explorer.GraphTypes
         {
             public UpdatedStateType()
             {
-                Field<NonNullGraphType<AddressType>>(
-                    nameof(UpdatedState.Address),
-                    resolve: context => context.Source.Address
-                );
-                Field<BencodexValueType>(
-                    nameof(UpdatedState.State),
-                    resolve: context => context.Source.State
-                );
+                Field<NonNullGraphType<AddressType>>(nameof(UpdatedState.Address))
+                    .Resolve(context => context.Source.Address);
+                Field<BencodexValueType>(nameof(UpdatedState.State))
+                    .Resolve(context => context.Source.State);
             }
         }
 
@@ -82,14 +73,11 @@ namespace Libplanet.Explorer.GraphTypes
         {
             public FungibleAssetBalancesType()
             {
-                Field<NonNullGraphType<AddressType>>(
-                    nameof(FungibleAssetBalances.Address),
-                    resolve: context => context.Source.Address
-                );
+                Field<NonNullGraphType<AddressType>>(nameof(FungibleAssetBalances.Address))
+                    .Resolve(context => context.Source.Address);
                 Field<NonNullGraphType<ListGraphType<NonNullGraphType<FungibleAssetValueType>>>>(
-                    nameof(FungibleAssetBalances.FungibleAssetValues),
-                    resolve: context => context.Source.FungibleAssetValues
-                );
+                    nameof(FungibleAssetBalances.FungibleAssetValues))
+                    .Resolve(context => context.Source.FungibleAssetValues);
             }
         }
     }

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -50,12 +50,11 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GraphQL" Version="4.7.1" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="4.7.1" />
-    <PackageReference Include="GraphQL.Server.Authorization.AspNetCore" Version="5.1.1" />
-    <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.1.1" />
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.1.1" />
-    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="5.1.1" />
+    <PackageReference Include="GraphQL" Version="7.1.1" />
+    <PackageReference Include="GraphQL.Server.Authorization.AspNetCore" Version="7.1.1" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="7.1.1" />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.1.1" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="7.1.1" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Libplanet.Explorer/Mutations/TransactionMutation.cs
+++ b/Libplanet.Explorer/Mutations/TransactionMutation.cs
@@ -18,19 +18,12 @@ namespace Libplanet.Explorer.Mutations
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
 
-            Field<TransactionType<T>>(
-                "stage",
-                description: "Stage transaction to current chain",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "payload",
-                        #pragma warning disable MEN002
-                        Description = "The hexadecimal string of the serialized transaction to stage.",
-                        #pragma warning restore MEN002
-                    }
-                ),
-                resolve: context =>
+            Field<TransactionType<T>>("stage")
+                .Description("Stage transaction to current chain")
+                .Argument<StringGraphType>(
+                    "payload",
+                    description: "The hexadecimal string of the serialized transaction to stage.")
+                .Resolve(context =>
                 {
                     BlockChain<T> chain = _context.BlockChain;
                     byte[] payload = ByteUtil.ParseHex(context.GetArgument<string>("payload"));
@@ -43,8 +36,7 @@ namespace Libplanet.Explorer.Mutations
                     }
 
                     return tx;
-                }
-            );
+                });
         }
     }
 }

--- a/Libplanet.Explorer/Queries/BlockQuery.cs
+++ b/Libplanet.Explorer/Queries/BlockQuery.cs
@@ -13,8 +13,8 @@ namespace Libplanet.Explorer.Queries
         public BlockQuery()
         {
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<BlockType<T>>>>>(
-                "blocks",
-                arguments: new QueryArguments(
+                "blocks")
+                .Arguments(new QueryArguments(
                     new QueryArgument<BooleanGraphType>
                     {
                         Name = "desc",
@@ -32,8 +32,8 @@ namespace Libplanet.Explorer.Queries
                         DefaultValue = false,
                     },
                     new QueryArgument<AddressType> { Name = "miner" }
-                ),
-                resolve: context =>
+                ))
+                .Resolve(context =>
                 {
                     bool desc = context.GetArgument<bool>("desc");
                     long offset = context.GetArgument<long>("offset");
@@ -41,16 +41,12 @@ namespace Libplanet.Explorer.Queries
                     bool excludeEmptyTxs = context.GetArgument<bool>("excludeEmptyTxs");
                     Address? miner = context.GetArgument<Address?>("miner", null);
                     return ExplorerQuery<T>.ListBlocks(desc, offset, limit, excludeEmptyTxs, miner);
-                }
-            );
+                });
 
-            Field<BlockType<T>>(
-                "block",
-                arguments: new QueryArguments(
-                    new QueryArgument<IdGraphType> { Name = "hash" },
-                    new QueryArgument<IdGraphType> { Name = "index" }
-                ),
-                resolve: context =>
+            Field<BlockType<T>>("block")
+                .Argument<IdGraphType>("hash")
+                .Argument<IdGraphType>("index")
+                .Resolve(context =>
                 {
                     string hash = context.GetArgument<string>("hash");
                     long? index = context.GetArgument<long?>("index", null);
@@ -73,8 +69,7 @@ namespace Libplanet.Explorer.Queries
                     }
 
                     throw new GraphQL.ExecutionError("Unexpected block query");
-                }
-            );
+                });
 
             Name = "BlockQuery";
         }

--- a/Libplanet.Explorer/Queries/ExplorerQuery.cs
+++ b/Libplanet.Explorer/Queries/ExplorerQuery.cs
@@ -22,17 +22,16 @@ namespace Libplanet.Explorer.Queries
         public ExplorerQuery(IBlockChainContext<T> chainContext)
         {
             ChainContext = chainContext;
-            Field<BlockQuery<T>>("blockQuery", resolve: context => new { });
-            Field<TransactionQuery<T>>("transactionQuery", resolve: context => new { });
-            Field<StateQuery<T>>("stateQuery", resolve: context => new { });
-            Field<NonNullGraphType<NodeStateType<T>>>(
-                "nodeState",
-                resolve: context => chainContext
-            );
-            Field<NonNullGraphType<BlockPolicyType<T>>>(
-                "blockPolicy",
-                resolve: context => chainContext.BlockChain.Policy
-            );
+            Field<BlockQuery<T>>("blockQuery")
+                .Resolve(context => new { });
+            Field<TransactionQuery<T>>("transactionQuery")
+                .Resolve(context => new { });
+            Field<StateQuery<T>>("stateQuery")
+                .Resolve(context => new { });
+            Field<NonNullGraphType<NodeStateType<T>>>("nodeState")
+                .Resolve(context => chainContext);
+            Field<NonNullGraphType<BlockPolicyType<T>>>("blockPolicy")
+                .Resolve(context => chainContext.BlockChain.Policy);
 
             Name = "ExplorerQuery";
         }

--- a/Libplanet.Explorer/Queries/StateQuery.cs
+++ b/Libplanet.Explorer/Queries/StateQuery.cs
@@ -20,23 +20,15 @@ public class StateQuery<T>
     public StateQuery()
     {
         Name = "StateQuery";
-        Field<NonNullGraphType<FungibleAssetValueType>>(
-            "balance",
-            arguments: new QueryArguments(
-                new QueryArgument<NonNullGraphType<AddressType>> { Name = "owner" },
-                new QueryArgument<NonNullGraphType<ByteStringType>> { Name = "currencyHash" },
-                new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "offsetBlockHash" }
-            ),
-            resolve: ResolveBalance
-        );
-        Field<FungibleAssetValueType>(
-            "totalSupply",
-            arguments: new QueryArguments(
-                new QueryArgument<NonNullGraphType<ByteStringType>> { Name = "currencyHash" },
-                new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "offsetBlockHash" }
-            ),
-            resolve: ResolveTotalSupply
-        );
+        Field<NonNullGraphType<FungibleAssetValueType>>("balance")
+            .Argument<Address>("owner")
+            .Argument<NonNullGraphType<ByteStringType>>("currencyHash")
+            .Argument<NonNullGraphType<IdGraphType>>("offsetBlockHash")
+            .Resolve(ResolveBalance);
+        Field<FungibleAssetValueType>("totalSupply")
+            .Argument<NonNullGraphType<ByteStringType>>("currencyHash")
+            .Argument<NonNullGraphType<IdGraphType>>("offsetBlockHash")
+            .Resolve(ResolveTotalSupply);
     }
 
     private static Currency GetNativeTokenFromHash(

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -29,31 +29,24 @@ namespace Libplanet.Explorer.Queries
             _context = context ?? throw new ArgumentNullException(nameof(context));
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
-                "transactions",
-                arguments: new QueryArguments(
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "signer",
-                        DefaultValue = null,
-                    },
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "involvedAddress",
-                        DefaultValue = null,
-                    },
-                    new QueryArgument<BooleanGraphType>
-                    {
-                        Name = "desc",
-                        DefaultValue = false,
-                    },
-                    new QueryArgument<IntGraphType>
-                    {
-                        Name = "offset",
-                        DefaultValue = 0,
-                    },
-                    new QueryArgument<IntGraphType> { Name = "limit" }
-                ),
-                resolve: context =>
+                "transactions")
+                .Argument<Address>(
+                    "signer",
+                    true,
+                    "Filter by signer (if given).",
+                    arg => arg.DefaultValue = null)
+                .Argument<Address>(
+                    "involvedAddress",
+                    true,
+                    "Filter by involved addresses (if given).",
+                    arg => arg.DefaultValue = null)
+                .Argument<bool>(
+                    "desc",
+                    true,
+                    arg => arg.DefaultValue = false)
+                .Argument<int>("offset", false, arg => arg.DefaultValue = 0)
+                .Argument<int>("limit", true, arg => arg.DefaultValue = null)
+                .Resolve(context =>
                 {
                     var signer = context.GetArgument<Address?>("signer");
                     var involved = context.GetArgument<Address?>("involvedAddress");
@@ -62,35 +55,16 @@ namespace Libplanet.Explorer.Queries
                     int? limit = context.GetArgument<int?>("limit", null);
 
                     return ExplorerQuery<T>.ListTransactions(signer, involved, desc, offset, limit);
-                }
-            );
+                });
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
-                "stagedTransactions",
-                arguments: new QueryArguments(
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "signer",
-                        DefaultValue = null,
-                    },
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "involvedAddress",
-                        DefaultValue = null,
-                    },
-                    new QueryArgument<BooleanGraphType>
-                    {
-                        Name = "desc",
-                        DefaultValue = false,
-                    },
-                    new QueryArgument<IntGraphType>
-                    {
-                        Name = "offset",
-                        DefaultValue = 0,
-                    },
-                    new QueryArgument<IntGraphType> { Name = "limit" }
-                ),
-                resolve: context =>
+                "stagedTransactions")
+                .Argument<Address>("signer", false, arg => arg.DefaultValue = null)
+                .Argument<Address>("involvedAddress", false, arg => arg.DefaultValue = null)
+                .Argument<bool>("desc", false, arg => arg.DefaultValue = false)
+                .Argument<int>("offset", false, arg => arg.DefaultValue = 0)
+                .Argument<int>("limit", true, arg => arg.DefaultValue = null)
+                .Resolve(context =>
                 {
                     var signer = context.GetArgument<Address?>("signer");
                     var involved = context.GetArgument<Address?>("involvedAddress");
@@ -105,43 +79,29 @@ namespace Libplanet.Explorer.Queries
                         offset,
                         limit
                     );
-                }
-            );
+                });
 
-            Field<TransactionType<T>>(
-                "transaction",
-                arguments: new QueryArguments(
-                    new QueryArgument<IdGraphType> { Name = "id" }
-                ),
-                resolve: context =>
+            Field<TransactionType<T>>("transaction")
+                .Argument<IdGraphType>("id")
+                .Resolve(context =>
                 {
                     var id = new TxId(
                         ByteUtil.ParseHex(context.GetArgument<string>("id"))
                     );
                     return ExplorerQuery<T>.GetTransaction(id);
-                }
-            );
+                });
 
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "unsignedTransaction",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "publicKey",
-                        Description = "The hexadecimal string of public key for Transaction.",
-                    },
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "plainValue",
-                        Description = "The hexadecimal string of plain value for Action.",
-                    },
-                    new QueryArgument<LongGraphType>
-                    {
-                        Name = "nonce",
-                        Description = "The nonce for Transaction.",
-                    }
-                ),
-                resolve: context =>
+            Field<NonNullGraphType<ByteStringType>>("unsignedTransaction")
+                .Argument<string>(
+                    "publicKey",
+                    false,
+                    "The hexadecimal string of public key for transaction.")
+                .Argument<string>(
+                    "plainValue",
+                    false,
+                    "The hexadecimal string of plain value for action.")
+                .Argument<long>("nonce", false, "The nonce for transaction.")
+                .Resolve(context =>
                 {
                     BlockChain<T> chain = _context.BlockChain;
                     string plainValueString = context.GetArgument<string>("plainValue");
@@ -163,44 +123,29 @@ namespace Libplanet.Explorer.Queries
                             new[] { action }
                         );
                     return unsignedTransaction.Serialize(false);
-                }
-            );
+                });
 
-            Field<NonNullGraphType<LongGraphType>>(
-                name: "nextNonce",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<AddressType>>
-                    {
-                        Name = "address",
-                        Description = "Address of the account to get the next tx nonce.",
-                    }
-                ),
-                resolve: context =>
-                    _context.BlockChain.GetNextTxNonce(context.GetArgument<Address>("address"))
-            );
+            Field<NonNullGraphType<LongGraphType>>("nextNonce")
+                .Argument<Address>(
+                    "address",
+                    false,
+                    "Address of the account to get the next tx nonce.")
+                .Resolve(ctx =>
+                    _context.BlockChain.GetNextTxNonce(ctx.GetArgument<Address>("address")));
 
-            Field<NonNullGraphType<StringGraphType>>(
-                name: "bindSignature",
-                #pragma warning disable MEN002
-                description: "Attach the given signature to the given transaction and return tx as hexadecimal",
-                #pragma warning restore MEN002
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "unsignedTransaction",
-                        #pragma warning disable MEN002
-                        Description = "The hexadecimal string of unsigned transaction to attach the given signature.",
-                        #pragma warning restore MEN002
-                    },
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "signature",
-                        #pragma warning disable MEN002
-                        Description = "The hexadecimal string of the given unsigned transaction.",
-                        #pragma warning restore MEN002
-                    }
-                ),
-                resolve: context =>
+            Field<NonNullGraphType<StringGraphType>>("bindSignature")
+                .Description(
+                    "Attach the given signature to the given transaction and return tx " +
+                    "as hexadecimal")
+                .Argument<string>(
+                    "unsignedTransaction",
+                    false,
+                    "The hexadecimal string of unsigned transaction to attach the given signature.")
+                .Argument<string>(
+                    "signature",
+                    false,
+                    "The hexadecimal string of the given unsigned transaction.")
+                .Resolve(context =>
                 {
                     byte[] signature = ByteUtil.ParseHex(
                         context.GetArgument<string>("signature")
@@ -224,19 +169,11 @@ namespace Libplanet.Explorer.Queries
                             signature: signature
                         );
                     return ByteUtil.Hex(signedTransaction.Serialize(true));
-                }
-            );
+                });
 
-            Field<NonNullGraphType<TxResultType>>(
-                name: "transactionResult",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<IdGraphType>>
-                    {
-                        Name = "txId",
-                        Description = "transaction id.",
-                    }
-                ),
-                resolve: context =>
+            Field<NonNullGraphType<TxResultType>>("transactionResult")
+                .Argument<IdGraphType>("txId", description: "A transaction ID.")
+                .Resolve(context =>
                 {
                     BlockChain<T> blockChain = _context.BlockChain;
                     IStore store = _context.Store;
@@ -319,8 +256,7 @@ namespace Libplanet.Explorer.Queries
                             null
                         );
                     }
-                }
-            );
+                });
 
             Name = "TransactionQuery";
         }

--- a/Libplanet.Explorer/Schemas/ConfigureLibplanetExplorerSchema.cs
+++ b/Libplanet.Explorer/Schemas/ConfigureLibplanetExplorerSchema.cs
@@ -1,0 +1,17 @@
+using System;
+using GraphQL;
+using GraphQL.DI;
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+
+namespace Libplanet.Explorer.Schemas;
+
+public sealed class ConfigureLibplanetExplorerSchema : IConfigureSchema
+{
+    public static readonly ConfigureLibplanetExplorerSchema Instance = new();
+
+    public void Configure(ISchema schema, IServiceProvider serviceProvider)
+    {
+        schema.RegisterTypeMapping<Address, AddressType>();
+    }
+}

--- a/Libplanet.Explorer/Schemas/GraphQLBuilderExtensions.cs
+++ b/Libplanet.Explorer/Schemas/GraphQLBuilderExtensions.cs
@@ -1,0 +1,16 @@
+using GraphQL;
+using GraphQL.DI;
+using Libplanet.Action;
+
+namespace Libplanet.Explorer.Schemas;
+
+public static class GraphQLBuilderExtensions
+{
+    public static IGraphQLBuilder AddLibplanetExplorerSchema<T>(this IGraphQLBuilder builder)
+        where T : IAction, new()
+    =>
+        builder
+            .AddSystemTextJson()
+            .AddSchema<LibplanetExplorerSchema<T>>()
+            .AddGraphTypes(typeof(LibplanetExplorerSchema<T>).Assembly);
+}

--- a/Libplanet.Explorer/Schemas/LibplanetExplorerSchema.cs
+++ b/Libplanet.Explorer/Schemas/LibplanetExplorerSchema.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Explorer.Schemas
         where T : IAction, new()
     {
         public LibplanetExplorerSchema(IServiceProvider serviceProvider)
-            : base(serviceProvider)
+            : base(serviceProvider, new[] { ConfigureLibplanetExplorerSchema.Instance })
         {
             Query = serviceProvider.GetRequiredService<ExplorerQuery<T>>();
         }


### PR DESCRIPTION
Here's the set of changed dependencies:

-  *GraphQL*: 4.7.1 → 7.1.1
-  *GraphQL.Server.Authorization.AspNetCore*: 5.1.1 → 7.1.1
-  *GraphQL.Server.Transports.AspNetCore*: 5.1.1 → 7.1.1
-  *GraphQL.Server.Ui.Playground*: 5.1.1 → 7.1.1
-  *GraphQL.SystemTextJson*: 4.7.1 → 7.1.1
-  *GraphQL.Server.Transports.AspNetCore.SystemTextJson*: 5.1.1 → removed

Also check out the below official migration guide:

- 4.x → 5.x
   - [Changes caused by GraphQL-Parser v8](https://graphql-dotnet.github.io/docs/migrations/migration5/#15-changes-caused-by-graphql-parser-v8)
   - [`AddGraphQL` now accepts a configuration delegate instead of returning `IGraphQLBuilder`](https://graphql-dotnet.github.io/docs/migrations/migration5/#6-code-classlanguage-textaddgraphqlcode-now-accepts-a-configuration-delegate-instead-of-returning-code-classlanguage-textigraphqlbuildercode)
- 5.x → 7.x
   - [`Field<TReturnType>` and `Argument` overloads to create field and argument builders with inferred graph types](https://graphql-dotnet.github.io/docs/migrations/migration7/#9-code-classlanguage-textfieldlttreturntypecode-and-argumenttargumentclrtype-overloads-to-create-field-and-argument-builders-with-inferred-graph-types)
   - [A bunch of FieldXXX APIs were deprecated](https://graphql-dotnet.github.io/docs/migrations/migration7/#11-a-bunch-of-fieldxxx-apis-were-deprecated)