### PR TITLE
♻️ Refactor `BlockLocator`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,14 @@ To be released.
 
 ### Deprecated APIs
 
+ -  Removed `BlockLocator(Func<long, BlockHash?>, Func<BlockHash, long>, int)`
+    constructor.  Use `BlockLocator.Create()` static method instead.
+    [[#2580], [#2584]]
+
 ### Backward-incompatible API changes
 
+ -  Changed `BlockLocator` to throw an `ArgumentException` if an empty set of
+    `BlockHash`es are given during construction.  [[#2584]]
  -  `BlockChain<T>()` now explicitly requires both `store` and `stateStore`
     arguments to be not `null`.  [[#2609]]
  -  `BlockChain<T>.Swap()` now throws an `InvalidOperationException` if called
@@ -60,6 +66,7 @@ To be released.
     [[#2474], [#2505]]
  -  (Libplanet.Explorer) Added `actionsLogsList` field to `TxResultType`.
     [[#2474], [#2505]]
+ -  Added `BlockLocator.Create()` static method.  [[#2584]]
  -  Added `PolicyBlockActionGetter` delegator type.  [[#2646]]
  -  Added `IActionTypeLoader.LoadAllActionTypes()` method.  [[#2646]]
      -  Added `StaticActionTypeLoader.LoadAllActionTypes()` method.
@@ -77,6 +84,14 @@ To be released.
 
 ### Behavioral changes
 
+ -  Changed `BlockChain<T>.FindNextHashes()` to return at most `count`
+    number of `BlockHash`es regardless of the result.
+    `BlockChain<T>`. [[#2581], [#2584]]
+ -  Changed `BlockChain<T>.FindNextHashes()` to return zero `BlockHash`es
+    if no branch point `BlockHash` is found instead of returning
+    `BlockHash`es starting with the genesis `BlockHash`.  [[#2582], [#2584]]
+ -  Chnaged the behavior of `BlockLocator` index selection and sampling when
+    creating an instance.  [[#2583], [#2584]]
  -  Changed the default `VolatileStagePolicy<T>.Lifetime` from 3 hours
     to 10 minutes.  [[#2718]]
 
@@ -100,6 +115,11 @@ To be released.
 
 [#2474]: https://github.com/planetarium/libplanet/discussions/2474
 [#2505]: https://github.com/planetarium/libplanet/pull/2505
+[#2580]: https://github.com/planetarium/libplanet/issues/2580
+[#2581]: https://github.com/planetarium/libplanet/issues/2581
+[#2582]: https://github.com/planetarium/libplanet/issues/2582
+[#2583]: https://github.com/planetarium/libplanet/issues/2583
+[#2584]: https://github.com/planetarium/libplanet/pull/2584
 [#2609]: https://github.com/planetarium/libplanet/pull/2609
 [#2619]: https://github.com/planetarium/libplanet/pull/2619
 [#2646]: https://github.com/planetarium/libplanet/pull/2646

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,6 @@ To be released.
 
 ### Deprecated APIs
 
- -  Removed `BlockLocator(Func<long, BlockHash?>, Func<BlockHash, long>, int)`
-    constructor.  Use `BlockLocator.Create()` static method instead.
-    [[#2580], [#2584]]
-
 ### Backward-incompatible API changes
 
  -  Changed `BlockLocator` to throw an `ArgumentException` if an empty set of
@@ -24,6 +20,9 @@ To be released.
     [[#2474], [#2505]]
  -  Added `actionsLogsList` parameter to `TxFailure` constructor.
     [[#2474], [#2505]]
+ -  Removed `BlockLocator(Func<long, BlockHash?>, Func<BlockHash, long>, int)`
+    constructor.  Use `BlockLocator.Create()` static method instead.
+    [[#2580], [#2584]]
  -  Replaced `IAction?`-typed `policyBlockAction` parameter with
     `PolicyBlockActionGetter`-typed `policyBlockActionGetter` parameter
     in `ActionEvaluator` constructor.  [[#2646]]

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             var blocks = new List<Block<DumbAction>>();
-            foreach (int i in Enumerable.Range(0, 11))
+            foreach (int i in Enumerable.Range(0, 12))
             {
                 Block<DumbAction> block = MineNext(
                     previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
@@ -124,7 +124,7 @@ namespace Libplanet.Net.Tests
                     difficulty: 1024
                 ).Evaluate(ChainPrivateKey, minerChain);
                 blocks.Add(block);
-                if (i != 10)
+                if (i != 11)
                 {
                     minerChain.Append(blocks[i]);
                 }
@@ -138,9 +138,9 @@ namespace Libplanet.Net.Tests
                 {
                     actualStates.Add(state);
 
-                    if (actualStates.Count == 9)
+                    if (actualStates.Count == 10)
                     {
-                        minerChain.Append(blocks[10]);
+                        minerChain.Append(blocks[11]);
                     }
                 }
             });
@@ -160,7 +160,7 @@ namespace Libplanet.Net.Tests
                     receiverChain
                 );
 
-                minerSwarm.FindNextHashesChunkSize = 2;
+                minerSwarm.FindNextHashesChunkSize = 3;
                 await receiverSwarm.PreloadAsync(progress);
 
                 // Await 1 second to make sure all progresses is reported.
@@ -176,6 +176,7 @@ namespace Libplanet.Net.Tests
                     "Receiver chain",
                     receiverChain
                 );
+
                 Assert.Equal(minerChain.BlockHashes, receiverChain.BlockHashes);
 
                 var expectedStates = new List<PreloadState>();
@@ -198,7 +199,7 @@ namespace Libplanet.Net.Tests
                     var state = new BlockDownloadState
                     {
                         ReceivedBlockHash = b.Hash,
-                        TotalBlockCount = i == 9 || i == 10 ? 11 : 10,
+                        TotalBlockCount = i == 10 || i == 11 ? 12 : 11,
                         ReceivedBlockCount = i,
                         SourcePeer = minerSwarm.AsPeer,
                     };
@@ -211,7 +212,7 @@ namespace Libplanet.Net.Tests
                     var state = new BlockVerificationState
                     {
                         VerifiedBlockHash = b.Hash,
-                        TotalBlockCount = i == 9 || i == 10 ? 11 : 10,
+                        TotalBlockCount = i == 10 || i == 11 ? 12 : 11,
                         VerifiedBlockCount = i,
                     };
                     expectedStates.Add(state);
@@ -223,7 +224,7 @@ namespace Libplanet.Net.Tests
                     var state = new ActionExecutionState
                     {
                         ExecutedBlockHash = b.Hash,
-                        TotalBlockCount = 11,
+                        TotalBlockCount = 12,
                         ExecutedBlockCount = i,
                     };
                     expectedStates.Add(state);
@@ -711,7 +712,7 @@ namespace Libplanet.Net.Tests
                 await minerChain.MineBlock(minerKey);
             }
 
-            minerSwarm.FindNextHashesChunkSize = 1;
+            minerSwarm.FindNextHashesChunkSize = 2;
             try
             {
                 await StartAsync(minerSwarm);

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1589,8 +1589,8 @@ namespace Libplanet.Net.Tests
             await StartAsync(receiver);
             await StartAsync(sender);
 
-            receiver.FindNextHashesChunkSize = 2;
-            sender.FindNextHashesChunkSize = 2;
+            receiver.FindNextHashesChunkSize = 3;
+            sender.FindNextHashesChunkSize = 3;
             BlockChain<DumbAction> chain = sender.BlockChain;
 
             for (int i = 0; i < 6; i++)
@@ -1616,7 +1616,7 @@ namespace Libplanet.Net.Tests
                 Log.Debug("Count: {Count}", receiver.BlockChain.Count);
                 sender.BroadcastBlock(sender.BlockChain.Tip);
                 Assert.Equal(
-                    2,
+                    3,
                     receiver.BlockChain.Count);
 
                 sender.BroadcastBlock(sender.BlockChain.Tip);
@@ -1626,7 +1626,7 @@ namespace Libplanet.Net.Tests
                 Log.Debug("Count: {Count}", receiver.BlockChain.Count);
                 sender.BroadcastBlock(sender.BlockChain.Tip);
                 Assert.Equal(
-                    4,
+                    5,
                     receiver.BlockChain.Count);
 
                 sender.BroadcastBlock(sender.BlockChain.Tip);
@@ -1636,7 +1636,7 @@ namespace Libplanet.Net.Tests
                 Log.Debug("Count: {Count}", receiver.BlockChain.Count);
                 sender.BroadcastBlock(sender.BlockChain.Tip);
                 Assert.Equal(
-                    6,
+                    7,
                     receiver.BlockChain.Count);
             }
             finally

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -1025,15 +1025,11 @@ namespace Libplanet.Net
                             );
                         }
 
-                        locator = new BlockLocator(
+                        locator = BlockLocator.Create(
+                            startIndex: branchingIndex + downloaded.Count,
                             idx =>
                             {
                                 long arg = idx;
-                                if (idx < 0)
-                                {
-                                    idx = branchingIndex + downloaded.Count + 1 + idx;
-                                }
-
                                 if (idx <= branchingIndex)
                                 {
                                     return blockChain.Store.IndexBlockHash(blockChain.Id, idx);
@@ -1054,13 +1050,6 @@ namespace Libplanet.Net
                                     _logger.Error(e, msg, arg, branchingIndex, downloaded.Count);
                                     return null;
                                 }
-                            },
-                            hash =>
-                            {
-                                Block<T> block = blockChain.Store.GetBlock<T>(hash);
-                                return block is { } b
-                                    ? b.Index
-                                    : branchingIndex + 1 + downloaded.IndexOf(hash);
                             });
                     }
                     while (downloaded.Count < totalBlockHashesToDownload);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -817,8 +817,8 @@ namespace Libplanet.Tests.Blockchain
                 blocks[8].Hash,
                 blocks[7].Hash,
                 blocks[6].Hash,
-                blocks[4].Hash,
-                blocks[0].Hash,
+                blocks[5].Hash,
+                blocks[3].Hash,
                 _blockChain.Genesis.Hash,
             });
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -458,9 +458,11 @@ namespace Libplanet.Tests.Blockchain
             long? offsetIndex;
             IReadOnlyList<BlockHash> hashes;
 
-            _blockChain.FindNextHashes(new BlockLocator(new BlockHash[] { }))
+            _blockChain.FindNextHashes(
+                new BlockLocator(new BlockHash[] { _blockChain.Genesis.Hash }))
                 .Deconstruct(out offsetIndex, out hashes);
             Assert.Single(hashes);
+            Assert.Equal(_blockChain.Genesis.Hash, hashes.First());
             var block0 = _blockChain.Genesis;
             var block1 = await _blockChain.MineBlock(key);
             var block2 = await _blockChain.MineBlock(key);
@@ -1433,13 +1435,15 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(b1.PreviousHash, _blockChain.Genesis.Hash);
 
-            var emptyLocator = new BlockLocator(new BlockHash[0]);
-            var locator = new BlockLocator(new[] { b4.Hash, b3.Hash, b1.Hash });
+            var emptyLocator = new BlockLocator(new[] { _blockChain.Genesis.Hash });
+            var invalidLocator = new BlockLocator(
+                new[] { new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)) });
+            var locator = new BlockLocator(
+                new[] { b4.Hash, b3.Hash, b1.Hash, _blockChain.Genesis.Hash });
 
             using (var emptyFx = new MemoryStoreFixture(_policy.BlockAction))
             using (var forkFx = new MemoryStoreFixture(_policy.BlockAction))
             {
-                var genesisBlock = BlockChain<DumbAction>.MakeGenesisBlock();
                 var emptyChain = new BlockChain<DumbAction>(
                     _blockChain.Policy,
                     new VolatileStagePolicy<DumbAction>(),
@@ -1456,14 +1460,20 @@ namespace Libplanet.Tests.Blockchain
                 fork.Append(b2);
                 await fork.MineBlock(key);
 
-                Assert.Null(emptyChain.FindBranchpoint(emptyLocator));
-                Assert.Null(emptyChain.FindBranchpoint(locator));
+                // Testing emptyChain
+                Assert.Equal(_blockChain.Genesis.Hash, emptyChain.FindBranchpoint(emptyLocator));
+                Assert.Equal(_blockChain.Genesis.Hash, emptyChain.FindBranchpoint(locator));
+                Assert.Null(emptyChain.FindBranchpoint(invalidLocator));
 
-                Assert.Null(_blockChain.FindBranchpoint(emptyLocator));
+                // Testing _blockChain
+                Assert.Equal(_blockChain.Genesis.Hash, _blockChain.FindBranchpoint(emptyLocator));
                 Assert.Equal(b4.Hash, _blockChain.FindBranchpoint(locator));
+                Assert.Null(_blockChain.FindBranchpoint(invalidLocator));
 
-                Assert.Null(fork.FindBranchpoint(emptyLocator));
+                // Testing fork
+                Assert.Equal(_blockChain.Genesis.Hash, fork.FindBranchpoint(emptyLocator));
                 Assert.Equal(b1.Hash, fork.FindBranchpoint(locator));
+                Assert.Null(_blockChain.FindBranchpoint(invalidLocator));
             }
         }
 

--- a/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -20,27 +20,82 @@ namespace Libplanet.Tests.Blockchain
         [Fact]
         public void Constructor()
         {
-            // Generate fixture block hashes looks like 0x000...1, 0x000...2, 0x000...3, and so on,
+            Assert.Throws<ArgumentException>(() =>
+                new BlockLocator(new List<BlockHash>()));
+        }
+
+        [Fact]
+        public void Factory()
+        {
+            // Generate fixture block hashes looks like 0x00...00 0x00...01, 0x00...02, and so on,
             // for the sake of easier debugging.
-            ImmutableArray<BlockHash> hashes = Enumerable.Range(0, 0x10).Select(i =>
+            List<long> indices = Enumerable.Range(0, 0x10).Select(i => (long)i).ToList();
+            Func<long, BlockHash> indexToBlockHash = i =>
             {
                 byte[] bytes = GetBigEndianBytes(i);
                 var buffer = new byte[32];
                 bytes.CopyTo(buffer, buffer.Length - bytes.Length);
                 return new BlockHash(buffer);
-            }).ToImmutableArray();
+            };
+            List<BlockHash> hashes = indices.Select(i => indexToBlockHash(i)).ToList();
+            Action<BlockLocator> printLocator = loc =>
+            {
+                _output.WriteLine(
+                    string.Join(", ", loc
+                        .Select(hash => hash.ToString())
+                        .Select(str => str.Substring(str.Length - 2))
+                        .Select(str => $"0x00..{str}")));
+            };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                BlockLocator.Create(
+                    startIndex: -1,
+                    indexToBlockHash: i => (BlockHash?)indexToBlockHash(i),
+                    sampleAfter: 0));
+            Assert.Throws<ArgumentException>(() =>
+                BlockLocator.Create(
+                    startIndex: 0,
+                    indexToBlockHash: i => i == 0 ? null : (BlockHash?)indexToBlockHash(i),
+                    sampleAfter: 0));
 
             var locator = BlockLocator.Create(
-                startIndex: hashes.Length - 1,
-                indexToBlockHash: idx => hashes[(int)idx],
-                sampleAfter: 5);
-
-            foreach (BlockHash hash in locator)
-            {
-                _output.WriteLine(hash.ToString());
-            }
-
+                startIndex: hashes.Count - 1,
+                indexToBlockHash: i => (BlockHash?)indexToBlockHash(i),
+                sampleAfter: 0);
             var expected = new BlockHash[]
+            {
+                hashes[0xf],    // Sampling starts here.
+                hashes[0xe],
+                hashes[0xc],
+                hashes[0x8],
+                hashes[0x0],
+            };
+
+            printLocator(locator);
+            Assert.Equal(expected, locator);
+
+            locator = BlockLocator.Create(
+                startIndex: hashes.Count - 1,
+                indexToBlockHash: i => (BlockHash?)indexToBlockHash(i),
+                sampleAfter: 1);
+            expected = new BlockHash[]
+            {
+                hashes[0xf],
+                hashes[0xe],    // Sampling starts here.
+                hashes[0xd],
+                hashes[0xb],
+                hashes[0x7],
+                hashes[0x0],
+            };
+
+            printLocator(locator);
+            Assert.Equal(expected, locator);
+
+            locator = BlockLocator.Create(
+                startIndex: hashes.Count - 1,
+                indexToBlockHash: i => (BlockHash?)indexToBlockHash(i),
+                sampleAfter: 5);
+            expected = new BlockHash[]
             {
                 hashes[0xf],
                 hashes[0xe],
@@ -48,11 +103,13 @@ namespace Libplanet.Tests.Blockchain
                 hashes[0xc],
                 hashes[0xb],
                 hashes[0xa],    // Sampling starts here.
-                hashes[0x8],
-                hashes[0x4],
+                hashes[0x9],
+                hashes[0x7],
+                hashes[0x3],
                 hashes[0x0],
             };
 
+            printLocator(locator);
             Assert.Equal(expected, locator);
         }
 

--- a/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockLocatorTest.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Tests.Blockchain
         {
             // Generate fixture block hashes looks like 0x000...1, 0x000...2, 0x000...3, and so on,
             // for the sake of easier debugging.
-            ImmutableArray<BlockHash> blocks = Enumerable.Range(0, 0x10).Select(i =>
+            ImmutableArray<BlockHash> hashes = Enumerable.Range(0, 0x10).Select(i =>
             {
                 byte[] bytes = GetBigEndianBytes(i);
                 var buffer = new byte[32];
@@ -30,32 +30,30 @@ namespace Libplanet.Tests.Blockchain
                 return new BlockHash(buffer);
             }).ToImmutableArray();
 
-            var locator = new BlockLocator(
-                indexBlockHash: idx => blocks[(int)(idx < 0 ? blocks.Length + idx : idx)],
-                indexByBlockHash: hash => blocks.IndexOf(hash),
-                sampleAfter: 5
-            );
+            var locator = BlockLocator.Create(
+                startIndex: hashes.Length - 1,
+                indexToBlockHash: idx => hashes[(int)idx],
+                sampleAfter: 5);
 
             foreach (BlockHash hash in locator)
             {
                 _output.WriteLine(hash.ToString());
             }
 
-            Assert.Equal(
-                new[]
-                {
-                    blocks[0xf],
-                    blocks[0xe],
-                    blocks[0xd],
-                    blocks[0xc],
-                    blocks[0xb],
-                    blocks[0xa],
-                    blocks[0x8],
-                    blocks[0x4],
-                    blocks[0x0],
-                },
-                locator
-            );
+            var expected = new BlockHash[]
+            {
+                hashes[0xf],
+                hashes[0xe],
+                hashes[0xd],
+                hashes[0xc],
+                hashes[0xb],
+                hashes[0xa],    // Sampling starts here.
+                hashes[0x8],
+                hashes[0x4],
+                hashes[0x0],
+            };
+
+            Assert.Equal(expected, locator);
         }
 
         private static byte[] GetBigEndianBytes(long value)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1121,8 +1121,12 @@ namespace Libplanet.Blockchain
             _rwlock.EnterReadLock();
             try
             {
-                chainId = Id;
-                tipHash = Tip.Hash;
+                _rwlock.EnterReadLock();
+
+                return BlockLocator.Create(
+                    startIndex: Tip.Index,
+                    indexToBlockHash: idx => Store.IndexBlockHash(Id, idx),
+                    sampleAfter: threshold);
             }
             finally
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -959,14 +959,20 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Find the branching point between this blockchain and <paramref name="locator"/>, and
-        /// the hashes of subsequent blocks from the point.</summary>
+        /// Finds the branch point <see cref="BlockHash"/> between this <see cref="BlockChain{T}"/>
+        /// and <paramref name="locator"/> and returns the list of <see cref="BlockHash"/>es of
+        /// successive <see cref="Block{T}"/>s starting from the branch point
+        /// <see cref="BlockHash"/>.</summary>
         /// <param name="locator">The <see cref="BlockLocator"/> to find the branching point
         /// from.</param>
-        /// <param name="stop">A block hash to stop looking for subsequent blocks once encountered.
+        /// <param name="stop">The <see cref="BlockHash"/> to stop looking for subsequent blocks
+        /// once encountered.
         /// </param>
-        /// <param name="count">Maximum number of block hashes to return.</param>
-        /// <returns>A tuple of the index of the branching point and block hashes.</returns>
+        /// <param name="count">The Maximum number of <see cref="BlockHash"/>es to return.</param>
+        /// <returns>A tuple of the index of the branch point and <see cref="BlockHash"/>es
+        /// including the branch point <see cref="BlockHash"/>.  If no branch point is found,
+        /// returns a tuple of <see langword="null"/> and an empty array of
+        /// <see cref="BlockHash"/>es.</returns>
         public Tuple<long?, IReadOnlyList<BlockHash>> FindNextHashes(
             BlockLocator locator,
             BlockHash? stop = null,
@@ -984,21 +990,18 @@ namespace Libplanet.Blockchain
                 return new Tuple<long?, IReadOnlyList<BlockHash>>(null, new BlockHash[0]);
             }
 
-            BlockHash? branchpoint = FindBranchpoint(locator);
-            var branchpointIndex = branchpoint is { } h ? (int)Store.GetBlockIndex(h)! : 0;
-
-            // FIXME: Currently, increasing count by one to satisfy
-            // the number defined by FindNextHashesChunkSize variable
-            // when branchPointIndex didn't indicate genesis block.
-            // Since branchPointIndex is same as the latest block of
-            // requesting peer.
-            if (branchpointIndex > 0)
+            if (!(FindBranchpoint(locator) is BlockHash branchpoint))
             {
-                count++;
+                return new Tuple<long?, IReadOnlyList<BlockHash>>(null, new BlockHash[0]);
+            }
+
+            if (!(Store.GetBlockIndex(branchpoint) is long branchpointIndex))
+            {
+                return new Tuple<long?, IReadOnlyList<BlockHash>>(null, new BlockHash[0]);
             }
 
             var result = new List<BlockHash>();
-            foreach (BlockHash hash in Store.IterateIndexes(Id, branchpointIndex, count))
+            foreach (BlockHash hash in Store.IterateIndexes(Id, (int)branchpointIndex, count))
             {
                 if (count == 0)
                 {
@@ -1006,13 +1009,12 @@ namespace Libplanet.Blockchain
                 }
 
                 result.Add(hash);
+                count--;
 
                 if (hash.Equals(stop))
                 {
                     break;
                 }
-
-                count--;
             }
 
             TimeSpan duration = DateTimeOffset.Now - startTime;

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1117,14 +1117,9 @@ namespace Libplanet.Blockchain
         /// <returns>A instance of block locator.</returns>
         public BlockLocator GetBlockLocator(int threshold = 10)
         {
-            Guid chainId;
-            BlockHash tipHash;
-
             _rwlock.EnterReadLock();
             try
             {
-                _rwlock.EnterReadLock();
-
                 return BlockLocator.Create(
                     startIndex: Tip.Index,
                     indexToBlockHash: idx => Store.IndexBlockHash(Id, idx),
@@ -1134,13 +1129,6 @@ namespace Libplanet.Blockchain
             {
                 _rwlock.ExitReadLock();
             }
-
-            return new BlockLocator(
-                tipHash: tipHash,
-                indexBlockHash: idx => Store.IndexBlockHash(chainId, idx),
-                indexByBlockHash: hash => _blocks[hash].Index,
-                sampleAfter: threshold
-            );
         }
 
 #pragma warning disable MEN003

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1117,18 +1117,23 @@ namespace Libplanet.Blockchain
         /// <returns>A instance of block locator.</returns>
         public BlockLocator GetBlockLocator(int threshold = 10)
         {
+            long startIndex;
+            Guid id;
             _rwlock.EnterReadLock();
             try
             {
-                return BlockLocator.Create(
-                    startIndex: Tip.Index,
-                    indexToBlockHash: idx => Store.IndexBlockHash(Id, idx),
-                    sampleAfter: threshold);
+                startIndex = Tip.Index;
+                id = Id;
             }
             finally
             {
                 _rwlock.ExitReadLock();
             }
+
+            return BlockLocator.Create(
+                startIndex: startIndex,
+                indexToBlockHash: idx => Store.IndexBlockHash(Id, idx),
+                sampleAfter: threshold);
         }
 
 #pragma warning disable MEN003

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -23,7 +23,8 @@ namespace Libplanet.Blockchain
         {
             _impl = hashes.Any()
                 ? hashes.ToList()
-                : throw new ArgumentException($"Given {nameof(hashes)} cannot be empty.");
+                : throw new ArgumentException(
+                    $"Given {nameof(hashes)} cannot be empty.", nameof(hashes));
         }
 
         /// <summary>
@@ -71,8 +72,8 @@ namespace Libplanet.Blockchain
         /// An instance of <see cref="BlockLocator"/> created with given arguments.
         /// </returns>
         /// <remarks>
-        /// Returned <see cref="BlockLocator"/> created this factory method is guaranteed to have
-        /// the <see cref="BlockHash"/> corresponding <c>0</c>.
+        /// Returned <see cref="BlockLocator"/> created by this factory method is guaranteed
+        /// to have the <see cref="BlockHash"/> corresponding to index <c>0</c>.
         /// </remarks>
         public static BlockLocator Create(
             long startIndex,
@@ -82,12 +83,14 @@ namespace Libplanet.Blockchain
             if (startIndex < 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    $"Given {nameof(startIndex)} cannot be negative: {startIndex}");
+                    $"Given {nameof(startIndex)} cannot be negative: {startIndex}",
+                    nameof(startIndex));
             }
 
             BlockHash genesisHash = indexToBlockHash(0) ??
                 throw new ArgumentException(
-                    $"Given {nameof(indexToBlockHash)} should not be null at zero index.");
+                    $"Given {nameof(indexToBlockHash)} should not be null at zero index.",
+                    nameof(indexToBlockHash));
             var hashes = new List<BlockHash>();
 
             foreach (long index in GetEnumeratedIndices(startIndex, sampleAfter))

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -7,7 +7,7 @@ using Libplanet.Blocks;
 namespace Libplanet.Blockchain
 {
     /// <summary>
-    /// A class that contains the hashes for a series of blocks.
+    /// A class that contains <see cref="BlockHash"/>es for a series of blocks.
     /// </summary>
     public class BlockLocator : IEnumerable<BlockHash>
     {
@@ -40,19 +40,19 @@ namespace Libplanet.Blockchain
         ///     <c>i_0 = startIndex</c>
         ///   </description></item>
         ///   <item><description>
-        ///     <c>i_(n + 1) = max(i_n - 1, 0)</c> if <c>n &lt; sampleAfter</c> and
-        ///     <c>i_n &gt; 0</c>
+        ///     <c>i_k = max(i_(k - 1) - 1, 0)</c> for <c>0 &lt; k</c> and  <c>k &lt;= s</c>
         ///   </description></item>
         ///   <item><description>
-        ///     <c>i_(n + 1) = max(i_n - 2 * (i_(n - 1) - i_n), 0)</c> if
-        ///     <c>sampleAfter &lt;= n</c> and <c>i_n &gt; 0</c>
+        ///     <c>i_k = max(i_(k - 1) - 2^(k - 1 - s), 0)</c> for <c>0 &lt; k</c>
+        ///     and <c>s &lt; k</c>
         ///   </description></item>
         /// </list>
-        /// where the sequence terminates after index <c>i_n</c> reaches zero or
-        /// the <see cref="BlockHash"/> returned by <paramref name="indexToBlockHash"/>
-        /// for <c>i_n</c> is <see langword="null"/>, in which case the <see cref="BlockHash"/>
-        /// corresponding to index <c>0</c> (presumably a <see cref="BlockHash"/> of the
-        /// genesis <see cref="Block{T}"/>) is added at the end.
+        /// where <c>s = max(sampleAfter, 0)</c> and the sequence terminates after index <c>i_k</c>
+        /// reaches zero or the <see cref="BlockHash"/> returned by
+        /// <paramref name="indexToBlockHash"/> for <c>i_k</c> is <see langword="null"/>,
+        /// in which case the <see cref="BlockHash"/> corresponding to index <c>0</c>
+        /// (presumably a <see cref="BlockHash"/> of the genesis <see cref="Block{T}"/>)
+        /// is added at the end.
         /// </para>
         /// </summary>
         /// <param name="startIndex">The starting index.</param>
@@ -128,7 +128,7 @@ namespace Libplanet.Blockchain
             {
                 yield return currentIndex;
                 currentIndex = Math.Max(currentIndex - step, 0);
-                step = startIndex - currentIndex < sampleAfter ? step : step * 2;
+                step = startIndex - currentIndex <= sampleAfter ? step : step * 2;
             }
 
             yield return currentIndex;

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Store
         long CountIndex(Guid chainId);
 
         /// <summary>
-        /// Lists all block hashes in the <parmaref name="chainId"/>.
+        /// Lists all block hashes in <paramref name="chainId"/>.
         /// </summary>
         /// <param name="chainId">The chain ID of the index that contains block hashes to
         /// iterate.</param>


### PR DESCRIPTION
Closes #2580, #2581, #2582, and #2583.

The implementation is still subject to change depending on what constraints we decide to impose on `BlockChain<T>` instances and how we want to handle variety of cases arising from constraints, or lack there of. The issue is rather far reaching and not obvious to resolve. See #2585.