### PR TITLE
Improve performance of `VolatileStagePolicy.Iterate()` and `.GetNextTxNonce()` & Release 0.44.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.44.2
 
 To be released.
 
+ - Improved performance of `.Iterate()` and `.GetNextTxNonce()` of
+   `VolatileStagePolicy`.  [[#2589]]
+
+[#2589]: https://github.com/planetarium/libplanet/pull/2589
 
 Version 0.44.1
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.44.2
 --------------
 
-To be released.
+Released on November 29, 2022.
 
  - Improved performance of `.Iterate()` and `.GetNextTxNonce()` of
    `VolatileStagePolicy`.  [[#2589]]

--- a/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
+++ b/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Blockchain.Policies
         where T : IAction, new()
     {
         private readonly ConcurrentDictionary<TxId, Transaction<T>> _staged;
-        private readonly ConcurrentBag<TxId> _ignored;
+        private readonly HashSet<TxId> _ignored;
         private readonly ReaderWriterLockSlim _lock;
         private readonly ILogger _logger;
 
@@ -62,7 +62,7 @@ namespace Libplanet.Blockchain.Policies
             _logger = Log.ForContext<VolatileStagePolicy<T>>();
             Lifetime = lifetime;
             _staged = new ConcurrentDictionary<TxId, Transaction<T>>();
-            _ignored = new ConcurrentBag<TxId>();
+            _ignored = new HashSet<TxId>();
             _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
         }
 

--- a/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
+++ b/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
@@ -251,6 +251,10 @@ namespace Libplanet.Blockchain.Policies
         private bool Expired(Transaction<T> transaction) =>
             transaction.Timestamp + Lifetime < DateTimeOffset.UtcNow;
 
+        /// <remarks>
+        /// It has been intended to avoid recursive lock, hence doesn't hold any synchronous scope.
+        /// Therefore, we should manage the lock from its caller side.
+        /// </remarks>
         private Transaction<T>? GetInner(BlockChain<T> blockChain, TxId id, bool filtered)
         {
             if (_staged.TryGetValue(id, out Transaction<T>? tx) && tx is { })

--- a/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
+++ b/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
@@ -196,7 +196,7 @@ namespace Libplanet.Blockchain.Policies
             }
             finally
             {
-                _lock.EnterReadLock();
+                _lock.ExitReadLock();
             }
         }
 


### PR DESCRIPTION
As the title suggests, it enhances `VolatilePolicy`'s performance through two approaches.

1. Change `VolatilePolicy._ignored`'s implementation, from `ConcurrentBag<T>` to `HashSet<T>`.
    - On my machine[^1], `ConcurrentBag<T>.Contains` was 20x slower than plain `HashSet<T>`'s.
    - I've considered `ConccurentDictionary<K, V>` as an alternative, but `HashSet<T>` might be okay because `VolatilePolicy`already assumes rw lock hardly[^2].
2. Adjusts lock-scopes of `.Iterate()` to avoid unintended blocking.

Also, this PR doesn't suggest a long-term solution for `._ignored` at this moment, but we need to revisit it again in the near future because there is still no consideration about its expiration. 😢 


[^1]: i9-12900k, 32GB RAM, .NET 6.0.400, arch linux
[^2]: But also I believe that it can be the next challenge since it will be the bottleneck of whole block processing again, due to holding the global lock. 