### PR TITLE
Context bootstrapping

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -33,6 +33,7 @@ namespace Libplanet.Net.Consensus
         private readonly Dictionary<long, Context<T>> _contexts;
 
         private CancellationTokenSource? _newHeightCts;
+        private bool _bootstrapping;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsensusContext{T}"/> class.
@@ -71,6 +72,7 @@ namespace Libplanet.Net.Consensus
 
             _contexts = new Dictionary<long, Context<T>>();
             _blockChain.TipChanged += OnBlockChainTipChanged;
+            _bootstrapping = true;
 
             _logger = Log
                 .ForContext("Tag", "Consensus")
@@ -241,7 +243,7 @@ namespace Libplanet.Net.Consensus
                         AttachEventHandlers(_contexts[height]);
                     }
 
-                    _contexts[height].Start(lastCommit);
+                    _contexts[height].Start(lastCommit, _bootstrapping);
                 }
             }
         }
@@ -260,6 +262,7 @@ namespace Libplanet.Net.Consensus
         /// </remarks>
         public void Commit(Block<T> block, BlockCommit? commit)
         {
+            _bootstrapping = false;
             _logger.Debug("Committing block #{Index} {Block}.", block.Index, block.Hash);
             _blockChain.Append(block, commit);
         }

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -91,6 +91,9 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="ConsensusContext{T}.Height"/>
         public long Height => _consensusContext.Height;
 
+        // FIXME: This should be exposed in a better way.
+        internal ConsensusContext<T> ConsensusContext => _consensusContext;
+
         /// <summary>
         /// <inheritdoc cref="IDisposable.Dispose()"/>
         /// </summary>

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -13,7 +13,10 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="lastCommit">A <see cref="Block{T}.LastCommit"/> from previous block.
         /// </param>
-        public void Start(BlockCommit? lastCommit = null)
+        /// <param name="bootstrapping">A <see langword="bool"/> flag indicating whether
+        /// this <see cref="Context{T}"/> should run as a bootstrapping <see cref="Context{T}"/>
+        /// or not.</param>
+        public void Start(BlockCommit? lastCommit = null, bool bootstrapping = false)
         {
             _logger.Debug(
                 "Starting context for height #{Height}, LastCommit: {LastCommit}",
@@ -25,6 +28,11 @@ namespace Libplanet.Net.Consensus
             // FIXME: Exceptions inside tasks should be handled properly.
             _ = MessageConsumerTask(_cancellationTokenSource.Token);
             _ = MutationConsumerTask(_cancellationTokenSource.Token);
+
+            if (bootstrapping)
+            {
+                _ = BootstrappingTask(_cancellationTokenSource.Token);
+            }
         }
 
         /// <summary>
@@ -87,6 +95,29 @@ namespace Libplanet.Net.Consensus
                         nameof(ConsumeMutation));
                     ExceptionOccurred?.Invoke(this, e);
                     throw;
+                }
+            }
+        }
+
+        internal async Task BootstrappingTask(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+                catch (OperationCanceledException oce)
+                {
+                    _logger.Debug(oce, "Cancellation was requested");
+                    ExceptionOccurred?.Invoke(this, oce);
+                    throw;
+                }
+
+                if (_messageLog.GetRandomMessage() is { } message)
+                {
+                    BroadcastMessage(message);
                 }
             }
         }

--- a/Libplanet.Net/Consensus/MessageLog.cs
+++ b/Libplanet.Net/Consensus/MessageLog.cs
@@ -346,5 +346,21 @@ namespace Libplanet.Net.Consensus
                 }
             }
         }
+
+        internal ConsensusMsg? GetRandomMessage()
+        {
+            lock (_lock)
+            {
+                Random random = new Random();
+                List<ConsensusMsg> pool = new List<ConsensusMsg>()
+                    .Concat(_proposals.Values)
+                    .Concat(_preVotes.Values.SelectMany(kv => kv.Values))
+                    .Concat(_preCommits.Values.SelectMany(kv => kv.Values))
+                    .ToList();
+                return pool.Count > 0
+                    ? pool[random.Next(pool.Count)]
+                    : null;
+            }
+        }
     }
 }

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -260,6 +260,9 @@ namespace Libplanet.Net
 
         internal SwarmOptions Options { get; }
 
+        // FIXME: This should be exposed in a better way.
+        internal ConsensusReactor<T> ConsensusReactor => _consensusReactor;
+
         /// <summary>
         /// Waits until this <see cref="Swarm{T}"/> instance gets started to run.
         /// </summary>


### PR DESCRIPTION
This PR allows network nodes to come online sequentially, at least under the assumption all nodes' `BlockChain<T>` are synced[^1].

[^1]: If not, there are cases where a previously committed `Block<T>` can be invalidated. Consider the following scenario. Let there be a single node with the highest tip index (for whatever reason, before shutting down the network, other nodes might have not been able to sync and/or commit the latest `Block<T>`). If such node does not come online before 2/3+ of the network and reach the consensus, effectively, the said node's tip will be ignored.