### PR TITLE
Removed automatic internal reassignment of `Store` to `StateStore`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `BlockChain<T>()` now explicitly requires both `store` and `stateStore`
+    arguments to be not `null`.  [[#2609]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +26,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#2609]: https://github.com/planetarium/libplanet/pull/2609
 
 
 Version 0.45.0

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -213,13 +213,11 @@ namespace Libplanet.Blockchain
         {
             if (store is null)
             {
-                throw new ArgumentNullException(
-                    nameof(store), $"Given {nameof(store)} cannot be null");
+                throw new ArgumentNullException(nameof(store));
             }
             else if (stateStore is null)
             {
-                throw new ArgumentNullException(
-                    nameof(stateStore), $"Given {nameof(stateStore)} cannot be null");
+                throw new ArgumentNullException(nameof(stateStore));
             }
 
             Id = id;

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -81,6 +81,8 @@ namespace Libplanet.Blockchain
         /// events made by unsuccessful transactions too; see also
         /// <see cref="AtomicActionRenderer{T}"/> for workaround.</param>
         /// <param name="stateStore"><see cref="IStateStore"/> to store states.</param>
+        /// <exception cref="ArgumentNullException">Thrown when either of <paramref name="store"/>
+        /// or <paramref name="stateStore"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidGenesisBlockException">Thrown when the <paramref name="store"/>
         /// has a genesis block and it does not match to what the network expects
         /// (i.e., <paramref name="genesisBlock"/>).</exception>
@@ -209,22 +211,27 @@ namespace Libplanet.Blockchain
             IBlockChainStates<T> blockChainStates,
             ActionEvaluator<T> actionEvaluator)
         {
+            if (store is null)
+            {
+                throw new ArgumentNullException(
+                    nameof(store), $"Given {nameof(store)} cannot be null");
+            }
+            else if (stateStore is null)
+            {
+                throw new ArgumentNullException(
+                    nameof(stateStore), $"Given {nameof(stateStore)} cannot be null");
+            }
+
             Id = id;
             Policy = policy;
             StagePolicy = stagePolicy;
             Store = store;
-            _blockChainStates = blockChainStates;
+            StateStore = stateStore;
 
+            _blockChainStates = blockChainStates;
             if (_blockChainStates is BlockChainStates<T> bindableImpl)
             {
                 bindableImpl.Bind(this);
-            }
-
-            // It expects store is DefaultStore or RocksDBStore.
-            StateStore = stateStore ?? store as IStateStore;
-            if (StateStore is null)
-            {
-                throw new ArgumentNullException(nameof(stateStore));
             }
 
             _blocks = new BlockSet<T>(store);


### PR DESCRIPTION
Issues:
- We don't really have any concrete `class` that implements both `IStore` and `IStateStore`.
- In any case, if one wishes to use the same object for both storing blocks and states, it shouldn't be up to `BlockChain<T>` to decide. The caller of `BlockChain<T>` should be responsible by passing the same object as both `IStore` and `IStateStore`.
- If we want to support the current behavior (or something similar to it), then we should have a combined `interface` such as `ISuperStore : IStore, IStateStore` to make the intention more pronounced.