### PR TITLE
Indexing in `Libplanet.Explorer`

### DIFF
--- a/.github/bin/constants.sh
+++ b/.github/bin/constants.sh
@@ -12,6 +12,7 @@ projects=(
   "Libplanet.Tools"
   "Libplanet.Explorer"
   "Libplanet.Explorer.Executable"
+  "Libplanet.Explorer.Cocona"
   "Libplanet.Extensions.Cocona"
 )
 configuration=Release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,8 @@ To be released.
  -  (@planetarium/account-web3-secret-storage) `Web3KeyStore` no more implements
     `ImportableKeyStore<KeyId, RawPrivateKey>`.  Instead, it now implements
     `ImportableKeyStore<KeyId, Web3Account>`.  [[#3061]]
+ -  (Libplanet.Explorer) Added `Index` field to `IBlockChainContext` interface.
+    [[#2613]]
 
 ### Backward-incompatible network protocol changes
 
@@ -107,6 +109,18 @@ To be released.
     [[#3061]]
  -  (@planetarium/account-web3-secret-storage) Added `Web3KeyObject` interface.
     [[#3061]]
+ -  (Libplanet.Explorer) Added several interfaces and classes that pertain to
+    blockchain indexing.  [[#2613]]
+     -  Added `IBlockChainIndex` interface.
+     -  Added `IIndexingContext` interface.
+     -  Added `BlockChainIndexBase` abstract class.
+     -  Added `RocksDbBlockChainIndex` class.
+     -  Added `RocksDbIndexingContext` class.
+     -  Added `IndexingService` class.
+     -  Added `IndexMismatchException` class.
+ -  (Libplanet.Explorer.Cocona) New project was added to provide Cocona
+    commands related to *Libplanet.Explorer* project.  [[#2613]]
+     -  Added `IndexCommand` Cocona command class.
 
 ### Behavioral changes
 
@@ -158,6 +172,18 @@ To be released.
     Instead, `PassphraseEntry.authenticate()` is called when operations that
     require unlocking `Web3Account` are called, such as `sign()` or
     `getPublicKey()`.  [[#3061]]
+ -  (Libplanet.Explorer) Now, when an `IBlockChainIndex` instance is available
+    in the optional `Index` property of the injected `IBlockChainContext`
+    instance, GraphQL queries can benefit from the improved lookup performace
+    of the index.  Applications willing to take advantage of the index should
+    provide an instance of `IBlockChainIndex` to the `IBlockChainContext`
+    implementation and add the `IndexingService` hosted service to sync the
+    index in the background.  Note that the synchronization may take a long
+    time if you have a lot of blocks (over 24 hours for ~5M blocks).  [[#2613]]
+     -  `BlockRef` property of `TransactionType` now uses `IBlockChainIndex`
+        if available.
+     -  `transactionResult` query in `TransactionQuery` now uses
+        `IBlockChainIndex` if available.
 
 ### Bug fixes
 
@@ -176,6 +202,12 @@ To be released.
 
 ### CLI tools
 
+ -  (Libplanet.Explorer.Executable) Project is now deprecated. It is currently
+    nonfunctional.  [[#2243], [#2588]]
+
+[#2243]: https://github.com/planetarium/libplanet/discussions/2243
+[#2588]: https://github.com/planetarium/libplanet/discussions/2588
+[#2613]: https://github.com/planetarium/libplanet/pull/2613
 [#2709]: https://github.com/planetarium/libplanet/issues/2709
 [#2711]: https://github.com/planetarium/libplanet/issues/2711
 [#2986]: https://github.com/planetarium/libplanet/pull/2986
@@ -629,6 +661,7 @@ and the specification might change in the near future.
     correctly in some situations.  [[#2872]]
 
 ### Dependencies
+
  -  Added *[@planetarium/account]* npm package.  [[#2848]]
 
 [#2848]: https://github.com/planetarium/libplanet/pull/2848

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,32 +131,38 @@ on GitHub consists of several projects.  There are two types of projects:
     an executable is done by a below project named
     *Libplanet.Explorer.Executable*.
 
- -  *Libplanet.Explorer.Executable*: Turns Libplanet Explorer into a single
-    executable binary so that it is easy to distribute.
+ -  *Libplanet.Explorer.Cocona*: Provides [Cocona] commands related to
+    *Libplanet.Explorer*.
+
+ -  *Libplanet.Explorer.Executable*: (**DEPRECATED**) Turns Libplanet Explorer
+    into a single executable binary so that it is easy to distribute.
 
  -  *Libplanet.Benchmarks*: Performance benchmarks.
     See the [*Benchmarks*](#benchmarks) section below.
 
- -  *Libplanet.Tests*: Unit tests of the *Libplanet* project.  See the *Tests*
+ -  *Libplanet.Tests*: Unit tests for the *Libplanet* project.  See the *Tests*
     section below.
 
- -  *Libplanet.Net.Tests*: Unit tests of the *Libplanet.Net* project.
+ -  *Libplanet.Net.Tests*: Unit tests for the *Libplanet.Net* project.
 
  -  *Libplanet.Stun.Tests*: Unit tests of the *Libplanet.Stun* project.
 
- -  *Libplanet.Crypto.Secp256k1.Tests*: Unit tests of
+ -  *Libplanet.Crypto.Secp256k1.Tests*: Unit tests for
     the *Libplanet.Crypto.Secp256k1* project.
 
- -  *Libplanet.RocksDBStore.Tests*: Unit tests of the *Libplanet.RocksDBStore*
+ -  *Libplanet.RocksDBStore.Tests*: Unit tests for the *Libplanet.RocksDBStore*
     project.
 
- -  *Libplanet.Analyzers.Tests*: Unit tests of the *Libplanet.Analyzers*
+ -  *Libplanet.Analyzers.Tests*: Unit tests for the *Libplanet.Analyzers*
     project.
 
- -  *Libplanet.Explorer.Tests*: Unit tests of the *Libplanet.Explorer*
+ -  *Libplanet.Explorer.Tests*: Unit tests for the *Libplanet.Explorer*
     project.
 
- -  *Libplanet.Extensions.Cocona.Tests*: Unit tests of the
+ -  *Libplanet.Explorer.Cocona.Tests*: Unit tests for the
+    *Libplanet.Explorer.Cocona* project.
+
+ -  *Libplanet.Extensions.Cocona.Tests*: Unit tests for the
     *Libplanet.Extensions.Cocona* project.
 
 

--- a/Docs/docfx.json
+++ b/Docs/docfx.json
@@ -8,6 +8,7 @@
             "Libplanet.Net/Libplanet.Net.csproj",
             "Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj",
             "Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj",
+            "Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj",
             "Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj",
             "Libplanet.Stun/Libplanet.Stun.csproj"
           ],

--- a/Libplanet.Explorer.Cocona.Tests/Commands/IndexCommandTest.cs
+++ b/Libplanet.Explorer.Cocona.Tests/Commands/IndexCommandTest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using Libplanet.Action;
+using Libplanet.Explorer.Cocona.Commands;
+using Xunit;
+
+namespace Libplanet.Explorer.Cocona.Tests.Commands
+{
+    public class IndexCommandTest
+    {
+        [Fact]
+        public void LoadIndexFromUri()
+        {
+            var tempFileName = Path.GetTempFileName();
+            File.Delete(tempFileName);
+            Directory.CreateDirectory(tempFileName);
+            IndexCommand<NullAction>.LoadIndexFromUri(
+                $"rocksdb+file://{Path.Combine(tempFileName, "success")}");
+            Assert.Throws<ArgumentException>(
+                () => IndexCommand<NullAction>.LoadIndexFromUri(
+                    $"{Path.Combine(tempFileName, "no-scheme")}"));
+            Assert.Throws<ArgumentException>(
+                () => IndexCommand<NullAction>.LoadIndexFromUri(
+                    $"rocksdb://{Path.Combine(tempFileName, "no-transport")}"));
+            Assert.Throws<ArgumentException>(
+                () => IndexCommand<NullAction>.LoadIndexFromUri(
+                    $"rocksdb+://{Path.Combine(tempFileName, "empty-transport")}"));
+            Assert.Throws<ArgumentException>(
+                () => IndexCommand<NullAction>.LoadIndexFromUri(
+                    $"rocksdb+foo://{Path.Combine(tempFileName, "unknown-transport")}"));
+        }
+    }
+}

--- a/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>Libplanet.Explorer.Cocona.Tests</RootNamespace>
+        <LangVersion>8</LangVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+        <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
+        <Link>Menees.Analyzers.Settings.xml</Link>
+      </AdditionalFiles>
+      <AdditionalFiles Include="..\stylecop.json" />
+    </ItemGroup>
+
+    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+      <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
+      <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>
+          runtime; build; native; contentfiles; analyzers
+        </IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />
+        <ProjectReference Include="..\Libplanet.Explorer.Tests\Libplanet.Explorer.Tests.csproj" />
+    </ItemGroup>
+
+</Project>
+

--- a/Libplanet.Explorer.Cocona/AssemblyInfo.cs
+++ b/Libplanet.Explorer.Cocona/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Libplanet.Explorer.Cocona.Tests")]

--- a/Libplanet.Explorer.Cocona/Commands/IndexCommand.cs
+++ b/Libplanet.Explorer.Cocona/Commands/IndexCommand.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading.Tasks;
+using Cocona;
+using Cocona.Help;
+using Libplanet.Action;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Extensions.Cocona;
+using Libplanet.Store;
+using Serilog;
+
+namespace Libplanet.Explorer.Cocona.Commands
+{
+    /// <summary>
+    /// A class that provides <see cref="Cocona"/> commands related to
+    /// <see cref="IBlockChainIndex"/>.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.</typeparam>
+    /// <remarks>Due to a limitation in the current version (v2.0.3) of <see cref="Cocona"/>, the
+    /// generic class cannot be used as follows:
+    /// <code><![CDATA[
+    /// [HasSubCommands(typeof(IndexCommand<PolymorphicAction<ActionBase>>), "index")]
+    /// ]]></code>
+    /// Instead, you would have to subclass this class with the desired <see cref="IAction"/> type
+    /// and use the new class with <see cref="Cocona"/>:
+    /// <code><![CDATA[
+    /// public class IndexCommand : IndexCommand<PolymorphicAction<ActionBase>>;
+    /// {
+    /// }
+    /// ]]></code>
+    /// <code><![CDATA[
+    /// [HasSubCommands(typeof(IndexCommand), "index")]
+    /// ]]></code></remarks>
+    public class IndexCommand<T> : CoconaLiteConsoleAppBase
+        where T : IAction, new()
+    {
+        private const string StoreArgumentDescription =
+            "The URI that represents the backend of an " + nameof(IStore) + " object."
+            + " <store-type>://<store-path> (e.g., rocksdb+file:///path/to/store)";
+
+        private const string IndexArgumentDescription =
+            "The URI that represents the backend of an " + nameof(IBlockChainIndex) + " object."
+            + " <index-type>://<index-path (e.g., sqlite+file:///path/to/store)";
+
+        public IndexCommand()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.Console()
+                .CreateLogger();
+        }
+
+        [Command(
+            Description =
+                "Synchronizes an index database for use with libplanet explorer services.")]
+        public async Task Sync(
+            [Argument("STORE", Description = StoreArgumentDescription)]
+            string storeUri,
+            [Argument("INDEX", Description = IndexArgumentDescription)]
+            string indexUri
+        )
+        {
+            try
+            {
+                await LoadIndexFromUri(indexUri).SynchronizeAsync<T>(
+                        Utils.LoadStoreFromUri(storeUri), Context.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        [PrimaryCommand]
+        public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder) =>
+            Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
+
+        internal static IBlockChainIndex LoadIndexFromUri(string uriString)
+        {
+            // Adapted from Libplanet.Extensions.Cocona.Utils.LoadStoreFromUri().
+            // TODO: Cocona supports .NET's TypeConverter protocol for instantiating objects
+            // from CLI options/arguments.  We'd better to implement it for IStore, and simply
+            // use IStore as the option/argument types rather than taking them as strings.
+            var uri = new Uri(uriString);
+
+            var protocol = uri.Scheme.Split('+')[0];
+            var transport = string.Join('+', uri.Scheme.Split('+')[1..]);
+
+            if (string.IsNullOrWhiteSpace(transport))
+            {
+                throw new ArgumentException(
+                    $"The index URI scheme must contain a transport (e.g. sqlite+file://).",
+                    nameof(uriString)
+                );
+            }
+
+            if (protocol is "rocksdb" && transport is "file")
+            {
+                return new RocksDbBlockChainIndex(uri.LocalPath);
+            }
+
+            throw new ArgumentException(
+                $"The index URI scheme {uri.Scheme}:// is not supported.",
+                nameof(uriString)
+            );
+        }
+    }
+}

--- a/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -1,0 +1,68 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Libplanet.Explorer.Cocona</PackageId>
+    <Authors>Planetarium</Authors>
+    <Company>Planetarium</Company>
+    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
+    <AssemblyName>Libplanet.Explorer.Cocona</AssemblyName>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>9.0</LangVersion>
+    <RootNamespace>Libplanet.Explorer.Cocona</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Nullable>enable</Nullable>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
+    <IsTestProject>false</IsTestProject>
+    <CodeAnalysisRuleSet>..\Libplanet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cocona.Lite" Version="2.0.*" />
+    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers; buildtransitive
+      </IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <ProjectReference Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\Menees.Analyzers.Settings.xml">
+      <Link>Menees.Analyzers.Settings.xml</Link>
+    </AdditionalFiles>
+    <AdditionalFiles Include="..\stylecop.json" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -18,6 +18,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Explorer.Executable.Exceptions;
+using Libplanet.Explorer.Indexing;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Schemas;
 using Libplanet.Explorer.Store;
@@ -30,6 +31,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using NetMQ;
+using Nito.AsyncEx;
 using Serilog;
 using Serilog.Events;
 
@@ -479,6 +481,12 @@ If omitted (default) explorer only the local blockchain store.")]
             public IStore Store => StoreSingleton;
 
             public Swarm<NullAction> Swarm => SwarmSingleton;
+
+            // XXX workaround for build; we decided to decommission Libplanet.Explorer.Executable
+            // project, but it will be removed after we move the schema command. As this project
+            // does not work as is, this change is barely enough to allow the build.
+            // See also: https://github.com/planetarium/libplanet/discussions/2588
+            public IBlockChainIndex Index => null;
 
             internal static bool PreloadedSingleton { get; set; }
 

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Action.Sys;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Tx;
+
+namespace Libplanet.Explorer.Tests;
+
+public class GeneratedBlockChainFixture
+{
+    public static Currency TestCurrency => Currency.Uncapped("TEST", 0, null);
+
+    public BlockChain<PolymorphicAction<SimpleAction>> Chain { get; }
+
+    public ImmutableArray<PrivateKey> PrivateKeys { get; }
+
+    public ImmutableDictionary<Address, ImmutableArray<Block<PolymorphicAction<SimpleAction>>>>
+        MinedBlocks { get; private set; }
+
+    public ImmutableDictionary<
+            Address,
+            ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>>
+        SignedTxs { get; private set; }
+
+    public ImmutableDictionary<
+            Address,
+            ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>>
+        InvolvedTxs { get; private set; }
+
+    public GeneratedBlockChainFixture(
+        int seed,
+        int blockCount = 20,
+        int maxTxCount = 20,
+        int privateKeyCount = 10,
+        ImmutableArray<ImmutableArray<ImmutableArray<PolymorphicAction<SimpleAction>>>>?
+            txActionsForPrefixBlocks = null,
+        ImmutableArray<ImmutableArray<ImmutableArray<PolymorphicAction<SimpleAction>>>>?
+            txActionsForSuffixBlocks = null)
+    {
+        var random = new System.Random(seed);
+        var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+        PrivateKeys = Enumerable.Range(0, privateKeyCount)
+            .Aggregate(ImmutableArray<PrivateKey>.Empty, (arr, _) => arr.Add(new PrivateKey()));
+        MinedBlocks = PrivateKeys.Aggregate(
+            ImmutableDictionary<Address, ImmutableArray<Block<PolymorphicAction<SimpleAction>>>>
+                .Empty,
+            (dict, pk) =>
+                dict.SetItem(
+                    pk.ToAddress(),
+                    ImmutableArray<Block<PolymorphicAction<SimpleAction>>>.Empty));
+        SignedTxs = PrivateKeys.Aggregate(
+            ImmutableDictionary<
+                Address,
+                ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>>.Empty,
+            (dict, pk) =>
+                dict.SetItem(
+                    pk.ToAddress(),
+                    ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>.Empty));
+        InvolvedTxs = PrivateKeys.Aggregate(
+            ImmutableDictionary<
+                Address,
+                ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>>.Empty,
+            (dict, pk) =>
+                dict.SetItem(
+                    pk.ToAddress(),
+                    ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>.Empty));
+
+        Chain = BlockChain<PolymorphicAction<SimpleAction>>.Create(
+            new BlockPolicy<PolymorphicAction<SimpleAction>>(
+                blockInterval: TimeSpan.FromMilliseconds(1),
+                getMaxTransactionsPerBlock: _ => int.MaxValue,
+                getMaxTransactionsBytes: _ => long.MaxValue,
+                nativeTokens: ImmutableHashSet<Currency>.Empty.Add(TestCurrency)
+            ),
+            new VolatileStagePolicy<PolymorphicAction<SimpleAction>>(),
+            new MemoryStore(),
+            stateStore,
+            BlockChain<PolymorphicAction<SimpleAction>>.ProposeGenesisBlock(
+                systemActions: PrivateKeys
+                    .OrderBy(pk => pk.ToAddress().ToHex())
+                    .Select(
+                    pk => new Initialize(
+                        new ValidatorSet(
+                            ImmutableList<Validator>.Empty.Add(
+                                new Validator(pk.PublicKey, 1)).ToList()),
+                        ImmutableDictionary<Address, IValue>.Empty))));
+
+        MinedBlocks = MinedBlocks.SetItem(
+            Chain.Genesis.Miner,
+            ImmutableArray<Block<PolymorphicAction<SimpleAction>>>.Empty.Add(Chain.Genesis));
+
+        if (txActionsForPrefixBlocks is { } txActionsForPrefixBlocksVal)
+        {
+            foreach (var actionsForTransactions in txActionsForPrefixBlocksVal)
+            {
+                var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+                AddBlock(
+                    random.Next(),
+                    actionsForTransactions.Select(actions =>
+                            Transaction<PolymorphicAction<SimpleAction>>.Create(
+                                Chain.GetNextTxNonce(pk.ToAddress()),
+                                pk,
+                                Chain.Genesis.Hash,
+                                actions))
+                        .ToImmutableArray());
+            }
+        }
+
+        while (Chain.Count < blockCount + (txActionsForPrefixBlocks?.Length ?? 0) + 1)
+        {
+            AddBlock(
+                random.Next(),
+                GetRandomTransactions(random.Next(), maxTxCount, Chain.Count == 1));
+        }
+
+        if (txActionsForSuffixBlocks is { } txActionsForSuffixBlocksVal)
+        {
+            foreach (var actionsForTransactions in txActionsForSuffixBlocksVal)
+            {
+                var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+                AddBlock(
+                    random.Next(),
+                    actionsForTransactions.Select(actions =>
+                            Transaction<PolymorphicAction<SimpleAction>>.Create(
+                                Chain.GetNextTxNonce(pk.ToAddress()),
+                                pk,
+                                Chain.Genesis.Hash,
+                                actions))
+                        .ToImmutableArray());
+            }
+        }
+    }
+
+    private ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>> GetRandomTransactions(
+        int seed, int maxCount, bool giveMax = false)
+    {
+        var random = new System.Random(seed);
+        var nonces = ImmutableDictionary<PrivateKey, long>.Empty;
+        return Enumerable.Range(0, giveMax ? maxCount : random.Next(maxCount))
+            .Aggregate(
+                ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>>.Empty,
+                (arr, _) =>
+                {
+                    var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+                    if (!nonces.TryGetValue(pk, out var nonce))
+                    {
+                        nonce = Chain.GetNextTxNonce(pk.ToAddress());
+                    }
+
+                    nonces = nonces.SetItem(pk, nonce + 1);
+
+                    return arr.Add(GetRandomTransaction(random.Next(), pk, nonce));
+                })
+            .OrderBy(tx => tx.Id)
+            .ToImmutableArray();
+    }
+
+    private Transaction<PolymorphicAction<SimpleAction>>
+        GetRandomTransaction(int seed, PrivateKey pk, long nonce)
+    {
+        var random = new System.Random(seed);
+        var addr = pk.ToAddress();
+        var bal = (int)(Chain.GetBalance(addr, TestCurrency).MajorUnit & int.MaxValue);
+        return (random.Next() % 3) switch
+        {
+            0 => Transaction<PolymorphicAction<SimpleAction>>.Create(
+                nonce,
+                pk,
+                Chain.Genesis.Hash,
+                Chain.GetBalance(addr, TestCurrency).MajorUnit > 0 &&
+                random.Next() % 2 == 0
+                    ? new Transfer(addr,
+                        TestCurrency * random.Next(1, bal))
+                    : new Mint(addr, TestCurrency * random.Next(1, 100)),
+                GetRandomAddresses(random.Next())
+            ),
+            _ => Transaction<PolymorphicAction<SimpleAction>>.Create(
+                nonce,
+                pk,
+                Chain.Genesis.Hash,
+                random.Next() % 2 == 0
+                    ? GetRandomActions(random.Next())
+                    : ImmutableHashSet<PolymorphicAction<SimpleAction>>.Empty,
+                GetRandomAddresses(random.Next())
+            ),
+        };
+    }
+
+    private ImmutableArray<PolymorphicAction<SimpleAction>> GetRandomActions(int seed)
+    {
+        var random = new System.Random(seed);
+        return Enumerable.Range(0, random.Next(10))
+            .Aggregate(
+                ImmutableArray<PolymorphicAction<SimpleAction>>.Empty,
+                (arr, _) => arr.Add(SimpleAction.GetAction(random.Next())));
+    }
+
+    private IImmutableSet<Address> GetRandomAddresses(int seed)
+    {
+        var random = new System.Random(seed);
+        return Enumerable.Range(0, random.Next(PrivateKeys.Length - 1) + 1)
+            .Aggregate(
+                ImmutableHashSet<Address>.Empty,
+                (arr, _) => arr.Add(PrivateKeys[random.Next(PrivateKeys.Length)].ToAddress()));
+    }
+
+    private void AddBlock(
+        int seed,
+        ImmutableArray<Transaction<PolymorphicAction<SimpleAction>>> transactions)
+    {
+        var random = new System.Random(seed);
+        var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+        var block = new BlockContent<PolymorphicAction<SimpleAction>>(
+                new BlockMetadata(
+                    Chain.Tip.Index + 1,
+                    DateTimeOffset.UtcNow,
+                    pk.PublicKey,
+                    Chain.Tip.Hash,
+                    BlockContent<PolymorphicAction<SimpleAction>>.DeriveTxHash(transactions),
+                    Chain.Store.GetChainBlockCommit(Chain.Store.GetCanonicalChainId()!.Value)),
+                transactions)
+            .Propose()
+            .Evaluate(pk, Chain);
+        Chain.Append(
+            block,
+            new BlockCommit(
+                Chain.Tip.Index + 1,
+                0,
+                block.Hash,
+                PrivateKeys
+                    .OrderBy(pk => pk.ToAddress().ToHex())
+                    .Select(pk => new VoteMetadata(
+                        Chain.Tip.Index + 1,
+                        0,
+                        block.Hash,
+                        DateTimeOffset.UtcNow,
+                        pk.PublicKey,
+                        VoteFlag.PreCommit).Sign(pk)).ToImmutableArray()));
+        MinedBlocks =
+            MinedBlocks.SetItem(pk.ToAddress(), MinedBlocks[pk.ToAddress()].Add(block));
+        SignedTxs = transactions.Aggregate(
+            SignedTxs,
+            (dict, tx) =>
+                dict.SetItem(
+                    tx.Signer,
+                    dict[tx.Signer]
+                        .Add(tx)
+                        .OrderBy(tx => tx.Nonce)
+                        .ToImmutableArray()));
+        InvolvedTxs = transactions.Aggregate(
+            InvolvedTxs,
+            (dict, tx) => tx.UpdatedAddresses.Aggregate(
+                dict,
+                (dict, addr) => dict.SetItem(addr, dict[addr].Add(tx))));
+    }
+}

--- a/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
@@ -10,6 +10,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.Tests.Queries;
 using Libplanet.Store;
 using Xunit;
 using static Libplanet.Explorer.Tests.GraphQLTestUtils;
@@ -75,7 +76,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                 }";
 
             var store = new MemoryStore();
-            var blockType = new BlockType<NullAction>(store);
+            var blockType = new BlockType<NullAction>(new MockBlockChainContext<NullAction>(store));
             ExecutionResult result = await ExecuteQueryAsync(
                 query,
                 blockType,

--- a/Libplanet.Explorer.Tests/GraphTypes/TransactionTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/TransactionTypeTest.cs
@@ -8,6 +8,7 @@ using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.Tests.Queries;
 using Libplanet.Tx;
 using Xunit;
 using static Libplanet.Explorer.Tests.GraphQLTestUtils;
@@ -38,7 +39,10 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                 }";
 
             ExecutionResult result =
-                await ExecuteQueryAsync<TransactionType<NullAction>>(query, source: transaction);
+                await ExecuteQueryAsync(
+                    query,
+                    new TransactionType<NullAction>(new MockBlockChainContext<NullAction>()),
+                    source: transaction);
             Dictionary<string, object> resultData =
                 (Dictionary<string, object>)((ExecutionNode) result.Data!)?.ToValue()!;
             Assert.Null(result.Errors);

--- a/Libplanet.Explorer.Tests/Indexing/BlockChainIndexFixture.cs
+++ b/Libplanet.Explorer.Tests/Indexing/BlockChainIndexFixture.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using Libplanet.Action;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Store;
+
+namespace Libplanet.Explorer.Tests.Indexing;
+
+public abstract class BlockChainIndexFixture<T> : IBlockChainIndexFixture<T>
+    where T : IAction, new()
+{
+    public IBlockChainIndex Index { get; }
+
+    protected BlockChainIndexFixture(IStore store, IBlockChainIndex index)
+    {
+        Index = index;
+        Index.SynchronizeAsync<T>(store, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    public abstract IBlockChainIndex CreateEphemeralIndexInstance();
+}

--- a/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Explorer.Tests.Indexing;
+
+public abstract class BlockChainIndexTest
+{
+    protected const int BlockCount = 20;
+
+    protected const int MaxTxCount = 20;
+
+    protected abstract IBlockChainIndexFixture<PolymorphicAction<SimpleAction>> Fx { get; set; }
+
+    protected GeneratedBlockChainFixture ChainFx { get; set; }
+
+    protected System.Random RandomGenerator { get; }
+
+    protected BlockChainIndexTest()
+    {
+        RandomGenerator = new System.Random();
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), BlockCount, MaxTxCount);
+    }
+
+    [Fact]
+    public async Task Synchronize()
+    {
+        var index = Fx.CreateEphemeralIndexInstance();
+        await index.SynchronizeAsync<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store, CancellationToken.None);
+
+        var forkedChain = ChainFx.Chain.Fork(ChainFx.Chain.Tip.PreviousHash!.Value);
+        var divergentBlock = forkedChain.ProposeBlock(
+            ChainFx.PrivateKeys[0],
+            lastCommit: forkedChain.GetBlockCommit(forkedChain.Tip.Hash));
+        forkedChain.Append(
+            divergentBlock,
+            new BlockCommit(
+                forkedChain.Tip.Index + 1,
+                0,
+                divergentBlock.Hash,
+                ChainFx.PrivateKeys
+                    .OrderBy(pk => pk.ToAddress().ToHex())
+                    .Select(pk => new VoteMetadata(
+                        forkedChain.Tip.Index + 1,
+                        0,
+                        divergentBlock.Hash,
+                        DateTimeOffset.UtcNow,
+                        pk.PublicKey,
+                        VoteFlag.PreCommit)
+                        .Sign(pk))
+                    .ToImmutableArray()));
+        await index.IndexAsync(
+            ChainFx.Chain.Store.GetBlockDigest(ChainFx.Chain.Tip.Hash)!.Value,
+            ChainFx.Chain.Tip.Transactions,
+            CancellationToken.None);
+        await Assert.ThrowsAsync<IndexMismatchException>(
+            async () => await index.IndexAsync(
+                forkedChain.Store.GetBlockDigest(forkedChain.Tip.Hash)!.Value,
+                forkedChain.Tip.Transactions,
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Tip()
+    {
+        var tip = await Fx.Index.GetTipAsync();
+        Assert.Equal(tip, Fx.Index.Tip);
+        Assert.Equal(ChainFx.Chain.Tip.Hash, tip.Hash);
+        Assert.Equal(ChainFx.Chain.Tip.Index, tip.Index);
+    }
+
+    [Fact]
+    public async Task GetLastNonceByAddress()
+    {
+        foreach (var pk in ChainFx.PrivateKeys)
+        {
+            var address = pk.ToAddress();
+            Assert.Equal(
+                ChainFx.Chain.GetNextTxNonce(address) - 1,
+                // ReSharper disable once MethodHasAsyncOverload
+                Fx.Index.GetLastNonceByAddress(address) ?? -1);
+            Assert.Equal(
+                ChainFx.Chain.GetNextTxNonce(address) - 1,
+                await Fx.Index.GetLastNonceByAddressAsync(address) ?? -1);
+        }
+
+        // ReSharper disable once MethodHasAsyncOverload
+        Assert.Null(Fx.Index.GetLastNonceByAddress(new Address()));
+        Assert.Null(await Fx.Index.GetLastNonceByAddressAsync(new Address()));
+    }
+
+    [Fact]
+    public async Task BlockHashToIndex()
+    {
+        for (var i = 0; i < ChainFx.Chain.Count; i++)
+        {
+            var inChain = ChainFx.Chain[i];
+            // ReSharper disable once MethodHasAsyncOverload
+            Assert.Equal(i, Fx.Index.BlockHashToIndex(inChain.Hash));
+            Assert.Equal(i, await Fx.Index.BlockHashToIndexAsync(inChain.Hash));
+        }
+
+        Assert.Throws<IndexOutOfRangeException>(() => Fx.Index.BlockHashToIndex(new BlockHash()));
+        await Assert.ThrowsAsync<IndexOutOfRangeException>(
+            async () => await Fx.Index.BlockHashToIndexAsync(new BlockHash()));
+    }
+
+    [Fact]
+    public async Task IndexToBlockHash()
+    {
+        for (var i = 0; i < ChainFx.Chain.Count; i++)
+        {
+            var inChain = ChainFx.Chain[i];
+            // ReSharper disable once MethodHasAsyncOverload
+            Assert.Equal(inChain.Hash, Fx.Index.IndexToBlockHash(i));
+            Assert.Equal(inChain.Hash, await Fx.Index.IndexToBlockHashAsync(i));
+        }
+
+        Assert.Throws<IndexOutOfRangeException>(() => Fx.Index.IndexToBlockHash(long.MaxValue));
+        await Assert.ThrowsAsync<IndexOutOfRangeException>(
+            async () => await Fx.Index.IndexToBlockHashAsync(long.MaxValue));
+
+        Assert.Equal(
+            await Fx.Index.IndexToBlockHashAsync(Fx.Index.Tip.Index),
+            await Fx.Index.IndexToBlockHashAsync(-1));
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetBlockHashes(bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        var blockCount = (int)ChainFx.Chain.Count;
+        int? fromHeight = fromHalfway ? blockCount / 4 : null;
+        int? maxCount = throughHalfway ? blockCount / 2 : null;
+        int rangeEnd =
+            maxCount is { } limitValue
+                ? (fromHeight ?? 0) + limitValue
+                : blockCount;
+        var blocks = Enumerable.Range(0, (int)ChainFx.Chain.Count)
+            .Select(i => ChainFx.Chain[i])
+            .ToImmutableArray();
+        blocks = desc ? blocks.Reverse().ToImmutableArray() : blocks;
+        var inChain = Enumerable.Range(fromHeight ?? 0, rangeEnd - (fromHeight ?? 0))
+            .Select(i => blocks[i])
+            .ToImmutableArray();
+        var indexed = Fx.Index.GetBlockHashesFromIndex(fromHeight, maxCount, desc).ToArray();
+        Assert.Equal(
+            indexed,
+            await Fx.Index.GetBlockHashesFromIndexAsync(
+                fromHeight, maxCount, desc).ToArrayAsync());
+        Assert.Equal(
+            indexed,
+            Fx.Index.GetBlockHashesByRange((fromHeight ?? 0)..rangeEnd, desc));
+        Assert.Equal(
+            indexed,
+            await Fx.Index.GetBlockHashesByRangeAsync(
+                (fromHeight ?? 0)..rangeEnd, desc).ToArrayAsync());
+        if (!desc)
+        {
+            Assert.Equal(
+                indexed.Select(tuple => tuple.Hash),
+                Fx.Index[(fromHeight ?? 0)..rangeEnd]);
+        }
+
+        Assert.Equal(inChain.Length, indexed.Length);
+        for (var i = 0; i < indexed.Length; i++)
+        {
+            Assert.Equal(inChain[i].Hash, indexed[i].Hash);
+            Assert.Equal(inChain[i].Index, indexed[i].Index);
+        }
+    }
+
+    [Fact]
+    public async Task GetBlockHashesByRangeOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Fx.Index.GetBlockHashesByRange(..((int)Fx.Index.Tip.Index + 2)));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await Fx.Index.GetBlockHashesByRangeAsync(
+                ..((int)Fx.Index.Tip.Index + 2)).ToArrayAsync());
+    }
+
+    [Theory]
+    [InlineData(SpecialRangeKind.OmitStartEnd, false)]
+    [InlineData(SpecialRangeKind.OmitStartEnd, true)]
+    [InlineData(SpecialRangeKind.OmitEnd, false)]
+    [InlineData(SpecialRangeKind.OmitEnd, true)]
+    [InlineData(SpecialRangeKind.StartFromEnd, false)]
+    [InlineData(SpecialRangeKind.StartFromEnd, true)]
+    [InlineData(SpecialRangeKind.EndFromEnd, false)]
+    [InlineData(SpecialRangeKind.EndFromEnd, true)]
+    public async Task GetBlockHashesByRangeSpecial(SpecialRangeKind kind, bool desc)
+    {
+        var (special, regular) = GetSpecialRange(kind);
+        var byRegular = Fx.Index.GetBlockHashesByRange(regular, desc).ToArray();
+        var byRegularAsync =
+            await Fx.Index.GetBlockHashesByRangeAsync(regular, desc).ToArrayAsync();
+        var bySpecial = Fx.Index.GetBlockHashesByRange(special, desc).ToArray();
+        var bySpecialAsync =
+            await Fx.Index.GetBlockHashesByRangeAsync(special, desc).ToArrayAsync();
+        Assert.Equal(byRegular, bySpecial);
+        Assert.Equal(byRegularAsync, bySpecialAsync);
+        Assert.Equal(byRegular, byRegularAsync);
+        Assert.Equal(bySpecial, bySpecialAsync);
+        if (!desc)
+        {
+            Assert.Equal(
+                Fx.Index[regular],
+                Fx.Index[special]);
+        }
+    }
+
+    public (Range special, Range regular) GetSpecialRange(SpecialRangeKind kind)
+    {
+        var blockCount = (int)ChainFx.Chain.Count;
+        switch (kind)
+        {
+            case SpecialRangeKind.OmitStartEnd:
+                return (.., ..blockCount);
+            case SpecialRangeKind.OmitEnd:
+                return ((blockCount / 4).., (blockCount / 4)..blockCount);
+            case SpecialRangeKind.StartFromEnd:
+                return blockCount < 4
+                    ? (^0.., blockCount..blockCount)
+                    : (
+                    ^(blockCount - blockCount / 4)..,
+                    (blockCount / 4)..blockCount);
+            case SpecialRangeKind.EndFromEnd:
+                return blockCount < 4
+                    ? (..^blockCount, ..0)
+                    : (..^(blockCount / 4), ..(blockCount - blockCount / 4));
+        }
+
+        throw new ArgumentOutOfRangeException();
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetBlockHashesByMiner(bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        foreach (var pk in ChainFx.PrivateKeys)
+        {
+            var address = pk.ToAddress();
+            var inChain = ChainFx.MinedBlocks[address].ToArray();
+            inChain = desc ? inChain.Reverse().ToArray() : inChain;
+            int? fromHeight = fromHalfway ? inChain.Length / 4 : null;
+            int? maxCount = throughHalfway ? inChain.Length / 2 : null;
+            inChain = inChain[
+                (fromHeight ?? 0)
+                ..(maxCount is { } limitValue ? (fromHeight ?? 0) + limitValue : inChain.Length)];
+            var indexed =
+                Fx.Index.GetBlockHashesFromIndex(fromHeight, maxCount, desc, address).ToArray();
+            Assert.Equal(
+                indexed,
+                await Fx.Index.GetBlockHashesFromIndexAsync(
+                    fromHeight, maxCount, desc, address)
+                    .ToArrayAsync());
+            Assert.Equal(inChain.Length, indexed.Length);
+            for (var i = 0; i < indexed.Length; i++)
+            {
+                Assert.Equal(inChain[i].Hash, indexed[i].Hash);
+                Assert.Equal(inChain[i].Index, indexed[i].Index);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetContainedBlockHashByTxId()
+    {
+        for (var i = 0; i < ChainFx.Chain.Count; i++)
+        {
+            foreach (var txId in ChainFx.Chain[i].Transactions.Select(tx => tx.Id))
+            {
+                // ReSharper disable once MethodHasAsyncOverload
+                var indexed = Fx.Index.GetContainedBlockHashByTxId(txId);
+                Assert.Equal(ChainFx.Chain[i].Hash, indexed);
+                Assert.Equal(indexed, await Fx.Index.GetContainedBlockHashByTxIdAsync(txId));
+                Assert.True(Fx.Index.TryGetContainedBlockHashById(txId, out var indexed2));
+                Assert.Equal(indexed, indexed2);
+            }
+        }
+
+        Assert.Throws<IndexOutOfRangeException>(
+            () => Fx.Index.GetContainedBlockHashByTxId(new TxId()));
+        await Assert.ThrowsAsync<IndexOutOfRangeException>(
+            async () => await Fx.Index.GetContainedBlockHashByTxIdAsync(new TxId()));
+        Assert.False(Fx.Index.TryGetContainedBlockHashById(new TxId(), out _));
+        Assert.Null(await Fx.Index.TryGetContainedBlockHashByIdAsync(new TxId()));
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetSignedTxIdsByAddress(bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        foreach (var pk in ChainFx.PrivateKeys)
+        {
+            var address = pk.ToAddress();
+            var inChain = ChainFx.SignedTxs[address].ToArray();
+            inChain = desc ? inChain.Reverse().ToArray() : inChain;
+            int? fromNonce = fromHalfway ? inChain.Length / 4 : null;
+            int? maxCount = throughHalfway ? inChain.Length / 2 : null;
+            inChain = inChain[
+                (fromNonce ?? 0)
+                ..(maxCount is { } limitValue ? (fromNonce ?? 0) + limitValue : inChain.Length)];
+            var indexed =
+                Fx.Index.GetSignedTxIdsByAddress(address, fromNonce, maxCount, desc).ToArray();
+            Assert.Equal(inChain.Length, indexed.Length);
+            Assert.Equal(
+                indexed,
+                await Fx.Index.GetSignedTxIdsByAddressAsync(address, fromNonce, maxCount, desc)
+                    .ToArrayAsync());
+            for (var i = 0; i < indexed.Length; i++)
+            {
+                Assert.Equal(inChain[i].Id, indexed[i]);
+            }
+        }
+    }
+
+    public static IEnumerable<object[]> BooleanPermutation(short count) =>
+        Enumerable.Range(0, 1 << count)
+            .Aggregate(
+                ImmutableArray<object[]>.Empty,
+                (arr, bitString) =>
+                    arr.Add(
+                        Enumerable.Range(0, count)
+                            .Aggregate(
+                                ImmutableArray<object>.Empty,
+                                (arr, item) =>
+                                {
+                                    var newArr = arr.Add(bitString % 2 != 0);
+                                    bitString >>= 1;
+                                    return newArr;
+                                }).ToArray()));
+
+    public static IEnumerable<object[]> BooleanPermutation3() => BooleanPermutation(3);
+
+    public enum SpecialRangeKind
+    {
+        OmitStartEnd,
+        OmitEnd,
+        StartFromEnd,
+        EndFromEnd
+    }
+}

--- a/Libplanet.Explorer.Tests/Indexing/IBlockChainIndexFixture.cs
+++ b/Libplanet.Explorer.Tests/Indexing/IBlockChainIndexFixture.cs
@@ -1,0 +1,12 @@
+using Libplanet.Action;
+using Libplanet.Explorer.Indexing;
+
+namespace Libplanet.Explorer.Tests.Indexing;
+
+public interface IBlockChainIndexFixture<T>
+    where T : IAction, new()
+{
+    IBlockChainIndex Index { get; }
+
+    IBlockChainIndex CreateEphemeralIndexInstance();
+}

--- a/Libplanet.Explorer.Tests/Indexing/RocksDbBlockChainIndexFixture.cs
+++ b/Libplanet.Explorer.Tests/Indexing/RocksDbBlockChainIndexFixture.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using Libplanet.Action;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Store;
+
+namespace Libplanet.Explorer.Tests.Indexing;
+
+public class RocksDbBlockChainIndexFixture<T>: BlockChainIndexFixture<T>
+    where T : IAction, new()
+{
+    public RocksDbBlockChainIndexFixture(IStore store)
+        : base(
+            store,
+            new RocksDbBlockChainIndex(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())))
+    {
+    }
+
+    public override IBlockChainIndex CreateEphemeralIndexInstance() =>
+        new RocksDbBlockChainIndex(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+}

--- a/Libplanet.Explorer.Tests/Indexing/RocksDbBlockChainIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Indexing/RocksDbBlockChainIndexTest.cs
@@ -1,0 +1,77 @@
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Xunit;
+
+namespace Libplanet.Explorer.Tests.Indexing;
+
+public class RocksDbBlockChainIndexTest: BlockChainIndexTest
+{
+    public RocksDbBlockChainIndexTest()
+    {
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+    }
+
+    protected sealed override IBlockChainIndexFixture<PolymorphicAction<SimpleAction>> Fx {
+        get;
+        set;
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetBlockHashesMultiByteIndex(bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), byte.MaxValue + 2, 1, 1);
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+        await GetBlockHashes(fromHalfway, throughHalfway, desc);
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetBlockHashesByMinerMultiByteIndex(
+        bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), byte.MaxValue + 2, 1, 1);
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+        await GetBlockHashesByMiner(fromHalfway, throughHalfway, desc);
+    }
+
+    [Fact]
+    public async Task TipMultiByteIndex()
+    {
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), byte.MaxValue + 2, 1, 1);
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+        var tip = await Fx.Index.GetTipAsync();
+        Assert.Equal(tip, Fx.Index.Tip);
+        Assert.Equal(ChainFx.Chain.Tip.Hash, tip.Hash);
+        Assert.Equal(ChainFx.Chain.Tip.Index, tip.Index);
+    }
+
+    [Fact]
+    public async Task GetLastNonceByAddressMultiByteIndex()
+    {
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), 2, byte.MaxValue + 2, 1);
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+        await GetLastNonceByAddress();
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanPermutation3))]
+    public async Task GetSignedTxIdsByAddressMultiByteIndex(
+        bool fromHalfway, bool throughHalfway, bool desc)
+    {
+        ChainFx = new GeneratedBlockChainFixture(
+            RandomGenerator.Next(), 2, byte.MaxValue + 2, 1);
+        Fx = new RocksDbBlockChainIndexFixture<PolymorphicAction<SimpleAction>>(
+            ChainFx.Chain.Store);
+        await GetSignedTxIdsByAddress(fromHalfway, throughHalfway, desc);
+    }
+}

--- a/Libplanet.Explorer.Tests/Queries/MockBlockChainContext.cs
+++ b/Libplanet.Explorer.Tests/Queries/MockBlockChainContext.cs
@@ -1,0 +1,37 @@
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Explorer.Interfaces;
+using Libplanet.Net;
+using Libplanet.Store;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class MockBlockChainContext<T> : IBlockChainContext<T>
+    where T : IAction, new()
+{
+    public bool Preloaded => true;
+
+    public BlockChain<T> BlockChain { get; }
+
+    public IStore Store { get; }
+
+    public Swarm<T> Swarm { get; }
+
+    public IBlockChainIndex Index { get; protected init; }
+
+    public MockBlockChainContext(BlockChain<T> chain)
+    {
+        BlockChain = chain;
+        Store = BlockChain.Store;
+    }
+
+    public MockBlockChainContext(IStore store)
+    {
+        Store = store;
+    }
+
+    public MockBlockChainContext()
+    {
+    }
+}

--- a/Libplanet.Explorer.Tests/Queries/MockBlockChainContextWithIndex.cs
+++ b/Libplanet.Explorer.Tests/Queries/MockBlockChainContextWithIndex.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Explorer.Indexing;
+using Libplanet.Explorer.Interfaces;
+using Libplanet.Net;
+using Libplanet.Store;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class MockBlockChainContextWithIndex<T> : MockBlockChainContext<T>
+    where T : IAction, new()
+{
+    public MockBlockChainContextWithIndex(BlockChain<T> chain)
+        : base(chain)
+    {
+        var indexPath = Path.GetTempFileName();
+        File.Delete(indexPath);
+        Directory.CreateDirectory(indexPath);
+        Index = new RocksDbBlockChainIndex(indexPath);
+        Task.Run(
+                async () =>
+                    await Index.SynchronizeAsync<T>(
+                        Store,
+                        CancellationToken.None))
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
@@ -1,0 +1,328 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Execution;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Explorer.Queries;
+using Libplanet.Tx;
+using Xunit;
+using static Libplanet.Explorer.Tests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class TransactionQueryGeneratedTest
+{
+    protected readonly GeneratedBlockChainFixture Fx;
+    protected MockBlockChainContext<PolymorphicAction<SimpleAction>> Source;
+    protected TransactionQuery<PolymorphicAction<SimpleAction>> QueryGraph;
+
+    public TransactionQueryGeneratedTest()
+    {
+        Fx = new GeneratedBlockChainFixture(
+            new System.Random().Next(),
+            txActionsForSuffixBlocks:
+            ImmutableArray<ImmutableArray<ImmutableArray<PolymorphicAction<SimpleAction>>>>
+                .Empty
+                .Add(ImmutableArray<ImmutableArray<PolymorphicAction<SimpleAction>>>
+                    .Empty
+                    .Add(ImmutableArray<PolymorphicAction<SimpleAction>>
+                        .Empty
+                        .Add(new SimpleAction0())))
+                .Add(ImmutableArray<ImmutableArray<PolymorphicAction<SimpleAction>>>
+                    .Empty
+                    .Add(ImmutableArray<PolymorphicAction<SimpleAction>>
+                        .Empty
+                        .Add(new SimpleAction0Fail()))));
+        Source = new MockBlockChainContext<PolymorphicAction<SimpleAction>>(Fx.Chain);
+        var _ = new ExplorerQuery<PolymorphicAction<SimpleAction>>(Source);
+        QueryGraph = new TransactionQuery<PolymorphicAction<SimpleAction>>(Source);
+    }
+
+    [Fact]
+    public async Task TransactionResult()
+    {
+        var failBlock = Fx.Chain.Tip;
+        var failTx = failBlock.Transactions.First();
+        var successBlock =
+            Fx.Chain.Store.GetBlock<PolymorphicAction<SimpleAction>>(failBlock.PreviousHash!.Value);
+        var successTx = successBlock.Transactions.First();
+        var pk = Fx.PrivateKeys[0];
+        var stagingTx = Transaction<PolymorphicAction<SimpleAction>>.Create(
+            Fx.Chain.GetNextTxNonce(pk.ToAddress()),
+            pk,
+            Fx.Chain.Genesis.Hash,
+            ImmutableArray<PolymorphicAction<SimpleAction>>.Empty.Add(new SimpleAction1()));
+        Fx.Chain.StageTransaction(stagingTx);
+
+        var queryResult = await ExecuteTransactionResultQueryAsync(successTx.Id);
+        Assert.Equal("SUCCESS", queryResult.TxStatus);
+        Assert.Equal(successBlock.Index, queryResult.BlockIndex);
+        Assert.Equal(successBlock.Hash.ToString(), queryResult.BlockHash);
+        Assert.Null(queryResult.ExceptionName);
+        queryResult = await ExecuteTransactionResultQueryAsync(failTx.Id);
+        Assert.Equal("FAILURE", queryResult.TxStatus);
+        Assert.Equal(failBlock.Index, queryResult.BlockIndex);
+        Assert.Equal(failBlock.Hash.ToString(), queryResult.BlockHash);
+        Assert.Equal(
+            "Libplanet.Action.CurrencyPermissionException",
+            queryResult.ExceptionName);
+        queryResult = await ExecuteTransactionResultQueryAsync(new TxId());
+        Assert.Equal("INVALID", queryResult.TxStatus);
+        Assert.Null(queryResult.BlockIndex);
+        Assert.Null(queryResult.BlockHash);
+        Assert.Null(queryResult.ExceptionName);
+        queryResult = await ExecuteTransactionResultQueryAsync(stagingTx.Id);
+        Assert.Equal("STAGING", queryResult.TxStatus);
+        Assert.Null(queryResult.BlockIndex);
+        Assert.Null(queryResult.BlockHash);
+        Assert.Null(queryResult.ExceptionName);
+    }
+
+    [Fact]
+    public virtual async Task Transactions()
+    {
+        var allBlocks = Fx.Chain.IterateBlocks().ToImmutableArray();
+        await AssertTransactionsQueryPermutation(allBlocks, null, null);
+        foreach (var signer in Fx.PrivateKeys.Select(pk => pk.ToAddress()))
+        {
+            await AssertTransactionsQueryPermutation(allBlocks, signer, null);
+            await AssertTransactionsQueryPermutation(allBlocks, null, signer);
+            foreach (var involved in Fx.PrivateKeys.Select(pk => pk.ToAddress()))
+            {
+                await AssertTransactionsQueryPermutation(allBlocks, signer, involved);
+            }
+        }
+    }
+
+    private async Task AssertTransactionsQueryPermutation(
+        ImmutableArray<Block<PolymorphicAction<SimpleAction>>> blocksToTest,
+        Address? signer,
+        Address? involvedAddress)
+    {
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, false, null, null);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, true, null, null);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, false, blocksToTest.Length / 4, null);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            false,
+            blocksToTest.Length / 4 - blocksToTest.Length,
+            null);
+        Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
+            await ExecuteTransactionsQueryAsync(
+                signer, involvedAddress, false, blocksToTest.Length / 4, null),
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                false,
+                blocksToTest.Length / 4 - blocksToTest.Length,
+                null));
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, true, blocksToTest.Length / 4, null);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            true,
+            blocksToTest.Length / 4 - blocksToTest.Length,
+            null);
+        Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
+            await ExecuteTransactionsQueryAsync(
+                signer, involvedAddress, true, blocksToTest.Length / 4, null),
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                true,
+                blocksToTest.Length / 4 - blocksToTest.Length,
+                null));
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, false, null, blocksToTest.Length / 4);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest, signer, involvedAddress, true, null, blocksToTest.Length / 4);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            false,
+            blocksToTest.Length / 3,
+            blocksToTest.Length / 4);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            false,
+            blocksToTest.Length / 3 - blocksToTest.Length,
+            blocksToTest.Length / 4);
+        Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                false,
+                blocksToTest.Length / 3,
+                blocksToTest.Length / 4),
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                false,
+                blocksToTest.Length / 3 - blocksToTest.Length,
+                blocksToTest.Length / 4));
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            true,
+            blocksToTest.Length / 3,
+            blocksToTest.Length / 4);
+        await AssertAgainstTransactionsQuery(
+            blocksToTest,
+            signer,
+            involvedAddress,
+            true,
+            blocksToTest.Length / 3 - blocksToTest.Length,
+            blocksToTest.Length / 4);
+        Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                true,
+                blocksToTest.Length / 3,
+                blocksToTest.Length / 4),
+            await ExecuteTransactionsQueryAsync(
+                signer,
+                involvedAddress,
+                true,
+                blocksToTest.Length / 3 - blocksToTest.Length,
+                blocksToTest.Length / 4));
+    }
+
+    private async Task AssertAgainstTransactionsQuery(
+        IReadOnlyList<Block<PolymorphicAction<SimpleAction>>> blocksToTest,
+        Address? signer,
+        Address? involvedAddress,
+        bool desc,
+        int? offset,
+        int? limit)
+    {
+        IEnumerable<Block<PolymorphicAction<SimpleAction>>> blocks = blocksToTest;
+        if (offset is { } offsetVal)
+        {
+            offsetVal = offsetVal >= 0 ? offsetVal : blocksToTest.Count + offsetVal;
+            blocks = desc ? blocks.SkipLast(offsetVal) : blocks.Skip(offsetVal);
+        }
+        IEnumerable<Transaction<PolymorphicAction<SimpleAction>>> txs =
+            blocks.SelectMany(block => block.Transactions);
+
+        if (desc)
+        {
+            txs = txs.Reverse();
+        }
+
+        if (signer is { } signerVal)
+        {
+            txs = txs.Where(tx => tx.Signer.Equals(signerVal));
+        }
+        else if (involvedAddress is { } involvedAddressVal)
+        {
+            txs = txs.Where(tx => tx.UpdatedAddresses.Contains(involvedAddressVal));
+        }
+
+        if (limit is { } limitVal)
+        {
+            txs = txs.Take(limitVal);
+        }
+
+        var expected = txs.ToImmutableArray();
+        var actual =
+            await ExecuteTransactionsQueryAsync(signer, involvedAddress, desc, offset, limit);
+
+        foreach (var i in Enumerable.Range(0, actual.Length))
+        {
+            Assert.Equal(expected[i].Id.ToHex(), actual[i].Id);
+            if (Source.Index is not null)
+            {
+                Assert.Equal(
+                    (
+                        await Source.Index.GetContainedBlockHashByTxIdAsync(expected[i].Id)
+                            .ConfigureAwait(false))
+                    .ToString(),
+                    actual[i].BlockHash);
+            }
+        }
+    }
+
+    private async Task<ImmutableArray<(string Id, string? BlockHash)>>
+        ExecuteTransactionsQueryAsync(
+            Address? signer,
+            Address? involvedAddress,
+            bool desc,
+            int? offset,
+            int? limit)
+    {
+        ExecutionResult result = await ExecuteQueryAsync(@$"
+        {{
+            transactions(
+                {(signer is { } signerVal ? @$"signer: ""{signerVal}""" : "")}
+                {(involvedAddress is { } invVal ? @$"involvedAddress: ""{invVal}""" : "")}
+                desc: {(desc ? "true" : "false")}
+                offset: {offset?.ToString(CultureInfo.InvariantCulture) ?? "0"}
+                {(limit is { } limitVal ? $"limit: {limitVal}" : "")}
+            )
+            {{
+                id
+                {(Source.Index is not null ? "blockRef { hash }" : "")}
+            }}
+         }}
+        ", QueryGraph, source: Source);
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData.ToValue());
+        return ((IReadOnlyList<object>)resultDict["transactions"])
+            .Select(txData =>
+            (
+                (string)((IDictionary<string, object>)txData)["id"],
+                (string?)(Source.Index is not null
+                    ? ((IDictionary<string, object>)
+                        ((IDictionary<string, object>)txData)["blockRef"]
+                    )["hash"]
+                    : null)))
+            .ToImmutableArray();
+    }
+
+    private async Task<
+            (string TxStatus, long? BlockIndex, string? BlockHash, string? ExceptionName)>
+        ExecuteTransactionResultQueryAsync(TxId txId)
+    {
+        ExecutionResult result = await ExecuteQueryAsync(@$"
+        {{
+            transactionResult(txId: ""{txId.ToHex()}"")
+            {{
+                txStatus
+                blockIndex
+                blockHash
+                exceptionName
+            }}
+         }}
+        ", QueryGraph, source: Source);
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            (IDictionary<string, object>)Assert.IsAssignableFrom<IDictionary<string, object>>(
+                resultData.ToValue())["transactionResult"];
+        return (
+            (string)resultDict["txStatus"],
+            (long?)resultDict["blockIndex"],
+            (string?)resultDict["blockHash"],
+            (string?)resultDict["exceptionName"]);
+    }
+}

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedWithIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedWithIndexTest.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Explorer.Queries;
+using Xunit;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class TransactionQueryGeneratedWithIndexTest : TransactionQueryGeneratedTest
+{
+    public TransactionQueryGeneratedWithIndexTest()
+    {
+        Source = new MockBlockChainContextWithIndex<PolymorphicAction<SimpleAction>>(Fx.Chain);
+        var _ = new ExplorerQuery<PolymorphicAction<SimpleAction>>(Source);
+        QueryGraph = new TransactionQuery<PolymorphicAction<SimpleAction>>(Source);
+    }
+
+    [SkippableFact(Skip = "transactionQuery.transactions does not support indexing.")]
+    public override Task Transactions() => Task.CompletedTask;
+}

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryWithIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryWithIndexTest.cs
@@ -1,0 +1,13 @@
+using Libplanet.Action;
+using Libplanet.Explorer.Queries;
+
+namespace Libplanet.Explorer.Tests.Queries;
+
+public class TransactionQueryWithIndexTest : TransactionQueryTest
+{
+    public TransactionQueryWithIndexTest()
+    {
+        Source = new MockBlockChainContextWithIndex<NullAction>(Chain);
+        QueryGraph = new TransactionQuery<NullAction>(Source);
+    }
+}

--- a/Libplanet.Explorer.Tests/SimpleAction.cs
+++ b/Libplanet.Explorer.Tests/SimpleAction.cs
@@ -1,0 +1,84 @@
+using System;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Explorer.Tests;
+
+public class SimpleAction : IAction
+{
+    public IValue PlainValue => Null.Value;
+
+    public void LoadPlainValue(IValue plainValue)
+    {
+    }
+
+    public virtual IAccountStateDelta Execute(IActionContext context) => context.PreviousStates;
+
+    public static SimpleAction GetAction(int seed) =>
+        (seed % 10) switch
+        {
+            1 => new SimpleAction1(),
+            2 => new SimpleAction2(),
+            3 => new SimpleAction3(),
+            4 => new SimpleAction4(),
+            5 => new SimpleAction5(),
+            6 => new SimpleAction6(),
+            7 => new SimpleAction7(),
+            8 => new SimpleAction8(),
+            9 => new SimpleAction0Fail(),
+            _ => new SimpleAction0(),
+        };
+}
+
+[ActionType(nameof(SimpleAction0))]
+public class SimpleAction0 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction1))]
+public class SimpleAction1 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction2))]
+public class SimpleAction2 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction3))]
+public class SimpleAction3 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction4))]
+public class SimpleAction4 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction5))]
+public class SimpleAction5 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction6))]
+public class SimpleAction6 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction7))]
+public class SimpleAction7 : SimpleAction
+{
+}
+
+[ActionType(nameof(SimpleAction8))]
+public class SimpleAction8 : SimpleAction
+{
+}
+
+// For overlapping custom action id test and fail test
+[ActionType(nameof(SimpleAction0Fail))]
+public class SimpleAction0Fail : SimpleAction
+{
+    public override IAccountStateDelta Execute(IActionContext context) =>
+        throw new CurrencyPermissionException("test message", context.Signer, default);
+}

--- a/Libplanet.Explorer/AssemblyInfo.cs
+++ b/Libplanet.Explorer/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Libplanet.Explorer.Tests")]
+[assembly: InternalsVisibleTo("Libplanet.Explorer.Cocona")]

--- a/Libplanet.Explorer/AssemblyInfo.cs
+++ b/Libplanet.Explorer/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Libplanet.Explorer.Tests")]

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -1,10 +1,7 @@
-#nullable disable
-using GraphQL;
 using GraphQL.Server;
-using GraphQL.SystemTextJson;
-using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.Indexing;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Queries;
 using Libplanet.Explorer.Schemas;
@@ -44,7 +41,9 @@ namespace Libplanet.Explorer
 
             services.AddSingleton<IBlockChainContext<T>, TU>();
             services.AddSingleton<IStore>(
-                services => services.GetService<IBlockChainContext<T>>().Store);
+                provider => provider.GetRequiredService<IBlockChainContext<T>>().Store);
+            services.AddSingleton<IBlockChainIndex>(
+                provider => provider.GetRequiredService<IBlockChainContext<T>>().Index);
 
             services.TryAddSingleton<ActionType<T>>();
             services.TryAddSingleton<BlockType<T>>();

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -2,71 +2,69 @@ using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Explorer.Interfaces;
-using Libplanet.Store;
 
-namespace Libplanet.Explorer.GraphTypes
+namespace Libplanet.Explorer.GraphTypes;
+
+public class BlockType<T> : ObjectGraphType<Block<T>>
+    where T : IAction, new()
 {
-    public class BlockType<T> : ObjectGraphType<Block<T>>
-        where T : IAction, new()
+    public BlockType(IBlockChainContext<T> context)
     {
-        public BlockType(IStore store)
-        {
-            // We need multiple row of description for clearer, not confusing explanation of field.
-            Field<NonNullGraphType<IdGraphType>>(
-                "Hash",
-                description: "A block's hash.",
-                resolve: ctx => ctx.Source.Hash.ToString()
-            );
-            Field<NonNullGraphType<LongGraphType>>(
-                name: "Index",
-                description: "The height of the block.",
-                resolve: x => x.Source.Index
-            );
-            Field<NonNullGraphType<AddressType>>(
-                name: "Miner",
-                description: "The address of the miner.",
-                resolve: x => x.Source.Miner
-            );
-            Field<PublicKeyType>(
-                name: "PublicKey",
-                description: "The public key of the Miner.",
-                resolve: x => x.Source.PublicKey
-            );
-            Field<BlockType<T>>(
-                name: "PreviousBlock",
-                description: "The previous block.  If it's a genesis block (i.e., its index is " +
-                    "0) this must be null.",
-                resolve: ctx =>
+        // We need multiple row of description for clearer, not confusing explanation of field.
+        Field<NonNullGraphType<IdGraphType>>(
+            "Hash",
+            description: "A block's hash.",
+            resolve: ctx => ctx.Source.Hash.ToString()
+        );
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "Index",
+            description: "The height of the block.",
+            resolve: x => x.Source.Index
+        );
+        Field<NonNullGraphType<AddressType>>(
+            name: "Miner",
+            description: "The address of the miner.",
+            resolve: x => x.Source.Miner
+        );
+        Field<PublicKeyType>(
+            name: "PublicKey",
+            description: "The public key of the Miner.",
+            resolve: x => x.Source.PublicKey
+        );
+        Field<BlockType<T>>(
+            name: "PreviousBlock",
+            description: "The previous block.  If it's a genesis block (i.e., its index is " +
+                         "0) this must be null.",
+            resolve: ctx =>
+            {
+                if (ctx.Source.PreviousHash is not { } h)
                 {
-                    if (!(ctx.Source.PreviousHash is { } h))
-                    {
-                        return null;
-                    }
-
-                    return store.GetBlock<T>(h);
+                    return null;
                 }
-            );
-            Field(x => x.Timestamp);
-            Field<NonNullGraphType<ByteStringType>>(
-                name: "StateRootHash",
-                description: "The hash of the resulting states after evaluating transactions " +
-                    "and a block action (if exists)",
-                resolve: ctx => ctx.Source.StateRootHash.ToByteArray());
-            Field<ByteStringType>(
-                name: "Signature",
-                description: "The digital signature of the whole block content (except for hash, " +
-                    "which is derived from the signature and other contents)",
-                resolve: ctx => ctx.Source.Signature?.ToBuilder().ToArray());
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
-                name: "transactions",
-                description: "Transactions belonging to the block."
-            );
-            Field<BlockCommitType>(
-                name: "LastCommit",
-                description: "The LastCommit of the block.",
-                resolve: ctx => ctx.Source.LastCommit);
 
-            Name = "Block";
-        }
+                return context.Store.GetBlock<T>(h);
+            }
+        );
+        Field(x => x.Timestamp);
+        Field<NonNullGraphType<ByteStringType>>(
+            name: "StateRootHash",
+            description: "The hash of the resulting states after evaluating transactions " +
+                         "and a block action (if exists)",
+            resolve: ctx => ctx.Source.StateRootHash.ToByteArray());
+        Field<ByteStringType>(
+            name: "Signature",
+            description: "The digital signature of the whole block content (except for hash, " +
+                         "which is derived from the signature and other contents)",
+            resolve: ctx => ctx.Source.Signature?.ToBuilder().ToArray());
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
+            name: "transactions",
+            description: "Transactions belonging to the block."
+        );
+        Field<BlockCommitType>(
+            name: "LastCommit",
+            description: "The LastCommit of the block.",
+            resolve: ctx => ctx.Source.LastCommit);
+
+        Name = "Block";
     }
 }

--- a/Libplanet.Explorer/Indexing/BlockChainIndexBase.cs
+++ b/Libplanet.Explorer/Indexing/BlockChainIndexBase.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
+using Serilog;
+
+namespace Libplanet.Explorer.Indexing;
+
+/// <summary>
+/// A base implementation of <see cref="IBlockChainIndex"/>.
+/// </summary>
+public abstract class BlockChainIndexBase : IBlockChainIndex
+{
+    private ILogger? _logger;
+
+    private ILogger? _defaultLogger;
+
+    /// <inheritdoc />
+    public (long Index, BlockHash Hash) Tip
+        => GetTipImpl() ?? throw new IndexOutOfRangeException("The index is empty.");
+
+    protected ILogger Logger
+    {
+        get
+        {
+            _defaultLogger ??= Log
+                .ForContext<IBlockChainIndex>()
+                .ForContext("Source", GetType().Name);
+            return _logger ?? _defaultLogger;
+        }
+        set => _logger = _logger is null ? value : throw new InvalidOperationException(
+            "The logger is already set.");
+    }
+
+    /// <inheritdoc />
+    public async Task<(long Index, BlockHash Hash)> GetTipAsync() =>
+        await GetTipAsyncImpl().ConfigureAwait(false)
+        ?? throw new IndexOutOfRangeException("The index is empty.");
+
+    /// <inheritdoc />
+    public abstract long BlockHashToIndex(BlockHash hash);
+
+    /// <inheritdoc />
+    public abstract Task<long> BlockHashToIndexAsync(BlockHash hash);
+
+    /// <inheritdoc />
+    public abstract BlockHash IndexToBlockHash(long index);
+
+    /// <inheritdoc />
+    public abstract Task<BlockHash> IndexToBlockHashAsync(long index);
+
+    /// <inheritdoc />
+    public IEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesByRange(Range indexRange, bool desc, Address? producer)
+    {
+        var (fromHeight, maxCount) =
+            indexRange.GetOffsetAndLength((int)(Tip.Index + 1 & int.MaxValue));
+        return GetBlockHashesFromIndex(fromHeight, maxCount, desc, producer);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesByRangeAsync(Range indexRange, bool desc, Address? producer)
+    {
+        var (fromHeight, maxCount) =
+            indexRange.GetOffsetAndLength((int)(Tip.Index + 1 & int.MaxValue));
+        await foreach (
+            var item in GetBlockHashesFromIndexAsync(fromHeight, maxCount, desc, producer)
+                .ConfigureAwait(false))
+        {
+            yield return item;
+        }
+    }
+
+    /// <inheritdoc />
+    public abstract IEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesFromIndex(int? fromHeight, int? maxCount, bool desc, Address? producer);
+
+    /// <inheritdoc />
+    public abstract IAsyncEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesFromIndexAsync(int? fromHeight, int? maxCount, bool desc, Address? producer);
+
+    /// <inheritdoc />
+    public abstract IEnumerable<TxId>
+        GetSignedTxIdsByAddress(Address signer, int? fromNonce, int? maxCount, bool desc);
+
+    /// <inheritdoc />
+    public abstract IAsyncEnumerable<TxId>
+        GetSignedTxIdsByAddressAsync(Address signer, int? fromNonce, int? maxCount, bool desc);
+
+    /// <inheritdoc />
+    public abstract long? GetLastNonceByAddress(Address address);
+
+    /// <inheritdoc />
+    public abstract Task<long?> GetLastNonceByAddressAsync(Address address);
+
+    /// <inheritdoc />
+    public BlockHash GetContainedBlockHashByTxId(TxId txId) =>
+        TryGetContainedBlockHashById(txId, out var containedBlock)
+            ? containedBlock
+            : throw new IndexOutOfRangeException(
+                $"The txId {txId} does not exist in the index.");
+
+    /// <inheritdoc />
+    public async Task<BlockHash> GetContainedBlockHashByTxIdAsync(TxId txId) =>
+        await TryGetContainedBlockHashByIdAsync(txId).ConfigureAwait(false)
+        ?? throw new IndexOutOfRangeException(
+            $"The txId {txId} does not exist in the index.");
+
+    /// <inheritdoc />
+    public abstract bool TryGetContainedBlockHashById(TxId txId, out BlockHash containedBlock);
+
+    /// <inheritdoc />
+    public abstract Task<BlockHash?> TryGetContainedBlockHashByIdAsync(TxId txId);
+
+    /// <inheritdoc />
+    async Task IBlockChainIndex.IndexAsync(
+        BlockDigest blockDigest, IEnumerable<ITransaction> txs, CancellationToken stoppingToken) =>
+        await IndexAsyncImpl(blockDigest, txs, null, stoppingToken).ConfigureAwait(false);
+
+    async Task IBlockChainIndex.SynchronizeForeverAsync<T>(
+        IStore store, TimeSpan pollInterval, CancellationToken stoppingToken)
+    {
+        var syncMetadata = await GetSyncMetadata(store).ConfigureAwait(false);
+        await CheckIntegrity(store, syncMetadata).ConfigureAwait(false);
+        while (true)
+        {
+            await SynchronizeAsyncImpl<T>(store, syncMetadata, false, stoppingToken)
+                .ConfigureAwait(false);
+            await Task.Delay(pollInterval, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    async Task IBlockChainIndex.SynchronizeAsync<T>(IStore store, CancellationToken stoppingToken)
+    {
+        var syncMetadata = await GetSyncMetadata(store).ConfigureAwait(false);
+        await CheckIntegrity(store, syncMetadata).ConfigureAwait(false);
+        await SynchronizeAsyncImpl<T>(store, syncMetadata, true, stoppingToken)
+            .ConfigureAwait(false);
+    }
+
+    protected abstract (long Index, BlockHash Hash)? GetTipImpl();
+
+    protected abstract Task<(long Index, BlockHash Hash)?> GetTipAsyncImpl();
+
+    protected abstract Task IndexAsyncImpl(
+        BlockDigest blockDigest,
+        IEnumerable<ITransaction> txs,
+        IIndexingContext? context,
+        CancellationToken token);
+
+    /// <summary>
+    /// Get a context that can be consumed by <see cref="IBlockChainIndex.IndexAsync"/> and
+    /// <see cref="IBlockChainIndex.IndexAsync"/> for batch processing.
+    /// </summary>
+    /// <returns>A context that can be consumed by <see cref="IBlockChainIndex.IndexAsync"/>.
+    /// </returns>
+    protected abstract IIndexingContext GetIndexingContext();
+
+    /// <summary>
+    /// Commits the data gathered in the context gained from <see cref="GetIndexingContext"/>.
+    /// </summary>
+    /// <param name="context">A context gained from <see cref="GetIndexingContext"/>.</param>
+    protected abstract void CommitIndexingContext(IIndexingContext context);
+
+    /// <inheritdoc cref="CommitIndexingContext"/>
+    protected abstract Task CommitIndexingContextAsync(IIndexingContext context);
+
+    private static string FormatSeconds(int seconds)
+    {
+        var minutes = seconds / 60;
+        seconds %= 60;
+        var hours = minutes / 60;
+        minutes %= 60;
+        return hours > 0
+            ? $"{hours}h{minutes}m{seconds}s"
+            : minutes > 0
+                ? $"{minutes}m{seconds}s"
+                : $"{seconds}s";
+    }
+
+    private async Task CheckIntegrity(
+        IStore store,
+        (
+            Guid ChainId,
+            long IndexTipIndex,
+            long ChainTipIndex,
+            BlockHash? IndexTipHash) syncMetadata)
+    {
+        var chainId = syncMetadata.ChainId;
+        var indexTipIndex = syncMetadata.IndexTipIndex;
+        var chainTipIndex = syncMetadata.ChainTipIndex;
+        var indexTipHash = syncMetadata.IndexTipHash;
+        if (indexTipIndex >= 0)
+        {
+            var indexHash = await IndexToBlockHashAsync(0).ConfigureAwait(false);
+            using var chainIndexEnumerator =
+                store.IterateIndexes(chainId, limit: 1).GetEnumerator();
+            if (!chainIndexEnumerator.MoveNext())
+            {
+                throw new InvalidOperationException(
+                    "The store does not contain a valid genesis block.");
+            }
+
+            var chainHash = chainIndexEnumerator.Current;
+            if (!indexHash.Equals(chainHash))
+            {
+                throw new IndexMismatchException(0, indexHash, chainHash);
+            }
+        }
+
+        if (indexTipIndex >= 1)
+        {
+            var commonLatestIndex = Math.Min(indexTipIndex, chainTipIndex);
+            using var chainIndexEnumerator =
+                store.IterateIndexes(chainId, (int)commonLatestIndex, limit: 1).GetEnumerator();
+            BlockHash? chainTipHash = chainIndexEnumerator.MoveNext()
+                ? chainIndexEnumerator.Current
+                : null;
+            if (chainTipHash is not { } chainTipHashValue
+                || !indexTipHash!.Value.Equals(chainTipHashValue))
+            {
+                throw new IndexMismatchException(
+                    indexTipIndex, indexTipHash!.Value, chainTipHash);
+            }
+        }
+
+        if (indexTipIndex > chainTipIndex)
+        {
+            Logger.Information(
+                "The height of the index is higher than the height of the blockchain. The index"
+                + " will continue to be synchronized, but if a block of an existing height and a"
+                + $" different hash is encountered, an {nameof(IndexMismatchException)} will be"
+                + " raised.");
+        }
+    }
+
+    private async Task SynchronizeAsyncImpl<T>(
+        IStore store,
+        (
+            Guid ChainId,
+            long IndexTipIndex,
+            long ChainTipIndex,
+            BlockHash? IndexTipHash) syncMetadata,
+        bool log,
+        CancellationToken stoppingToken
+    )
+        where T : IAction, new()
+    {
+        var chainId = syncMetadata.ChainId;
+        var indexTipIndex = syncMetadata.IndexTipIndex;
+        var chainTipIndex = syncMetadata.ChainTipIndex;
+
+        if (indexTipIndex > chainTipIndex)
+        {
+            return;
+        }
+
+        if (indexTipIndex == chainTipIndex)
+        {
+            if (log)
+            {
+                Logger.Information("Index is up to date.");
+            }
+
+            return;
+        }
+
+        if (log)
+        {
+            Logger.Information("Index is out of date. Synchronizing...");
+        }
+
+        long processedBlockCount = 0,
+            totalBlocksToSync = chainTipIndex - indexTipIndex,
+            intervalBlockCount = 0,
+            intervalTxCount = 0;
+        var populateStart = DateTimeOffset.Now;
+        var intervalStart = populateStart;
+
+        using var indexEnumerator =
+            store.IterateIndexes(chainId, (int)indexTipIndex + 1).GetEnumerator();
+        var addBlockContext = GetIndexingContext();
+        while (indexEnumerator.MoveNext() && indexTipIndex + processedBlockCount < chainTipIndex)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                if (log)
+                {
+                    Logger.Information("Index synchronization interrupted.");
+                }
+
+                break;
+            }
+
+            var blockDigest = store.GetBlockDigest(indexEnumerator.Current)!.Value;
+            var txs = blockDigest.TxIds.Select(
+                txId => (ITransaction)store.GetTransaction<T>(new TxId(txId))).ToArray();
+            try
+            {
+                await IndexAsyncImpl(blockDigest, txs, addBlockContext, stoppingToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            intervalTxCount += txs.Length;
+            ++processedBlockCount;
+            ++intervalBlockCount;
+
+            var now = DateTimeOffset.Now;
+            var interval = (now - intervalStart).TotalSeconds;
+            if (interval > 10)
+            {
+                var processedPercentage =
+                    (float)(indexTipIndex + processedBlockCount) / chainTipIndex * 100;
+                var totalElapsedSec = (now - populateStart).TotalSeconds;
+                var currentRate = intervalBlockCount / interval;
+                var totalRate = processedBlockCount / totalElapsedSec;
+                var txRate = intervalTxCount / interval;
+                var elapsedStr = FormatSeconds((int)totalElapsedSec);
+                var eta = FormatSeconds(
+                    (int)TimeSpan.FromSeconds(
+                            (chainTipIndex - indexTipIndex - processedBlockCount) / currentRate)
+                        .TotalSeconds);
+
+                if (log)
+                {
+                    Logger.Information(
+                        $"Height #{blockDigest.Index} of {chainTipIndex},"
+                        + $" {totalBlocksToSync - processedBlockCount} to go"
+                        + $" ({processedPercentage:F1}% synced),"
+                        + $" session: {processedBlockCount}/{totalBlocksToSync},"
+                        + $" current: {(int)currentRate}blk/s, total: {(int)totalRate}blk/s,"
+                        + $" txrate: {(int)txRate}tx/s,"
+                        + $" tx density: {intervalTxCount / intervalBlockCount}tx/blk,"
+                        + $" elapsed: {elapsedStr}, eta: {eta}");
+                }
+
+                intervalStart = now;
+                intervalBlockCount = 0;
+                intervalTxCount = 0;
+            }
+        }
+
+        await CommitIndexingContextAsync(addBlockContext).ConfigureAwait(false);
+
+        if (log)
+        {
+            Logger.Information(
+                $"{processedBlockCount} out of {totalBlocksToSync} blocks processed, elapsed:"
+                + $" {FormatSeconds((int)(DateTimeOffset.Now - populateStart).TotalSeconds)}");
+        }
+
+        stoppingToken.ThrowIfCancellationRequested();
+
+        if (totalBlocksToSync == processedBlockCount && log)
+        {
+            Logger.Information("Finished synchronizing index.");
+        }
+    }
+
+    private async Task<(
+        Guid ChainId,
+        long IndexTipIndex,
+        long ChainTipIndex,
+        BlockHash? IndexTipHash)>
+        GetSyncMetadata(IStore store)
+    {
+        var indexTip = await GetTipAsyncImpl().ConfigureAwait(false);
+        var indexTipIndex = indexTip?.Index ?? -1;
+        var chainId = store.GetCanonicalChainId()
+                      ?? throw new InvalidOperationException(
+                          "The store does not contain a valid chain.");
+        var chainTipIndex = store.CountIndex(chainId) - 1;
+        return (chainId, indexTipIndex, chainTipIndex, indexTip?.Hash);
+    }
+}

--- a/Libplanet.Explorer/Indexing/IBlockChainIndex.cs
+++ b/Libplanet.Explorer/Indexing/IBlockChainIndex.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
+
+namespace Libplanet.Explorer.Indexing;
+
+/// <summary>
+/// An interface that provides indexing to Libplanet.Explorer.
+/// </summary>
+public interface IBlockChainIndex
+{
+    /// <summary>
+    /// The height and the <see cref="BlockHash"/> of the most recently indexed
+    /// <see cref="Block{T}"/>.
+    /// </summary>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the index is empty.</exception>
+    (long Index, BlockHash Hash) Tip { get; }
+
+    /// <inheritdoc cref="IndexToBlockHash"/>
+    BlockHash this[long index] => IndexToBlockHash(index);
+
+    /// <inheritdoc cref="GetBlockHashesByRange"/>
+    IEnumerable<BlockHash> this[Range indexRange] =>
+        GetBlockHashesByRange(indexRange).Select(tuple => tuple.Hash);
+
+    /// <summary>
+    /// Get the height and the <see cref="BlockHash"/> of the most recently indexed
+    /// <see cref="Block{T}"/>.
+    /// </summary>
+    /// <returns>A <see cref="ValueTuple{Long,BlockHash}"/> that contains the height and the
+    /// <see cref="BlockHash"/> of the most recently indexed <see cref="Block{T}"/>.</returns>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the index is empty.</exception>
+    Task<(long Index, BlockHash Hash)> GetTipAsync();
+
+    /// <summary>
+    /// Get the indexed height of the <see cref="Block{T}"/> with the given <paramref name="hash"/>.
+    /// </summary>
+    /// <param name="hash">The <see cref="BlockHash"/> of the desired indexed
+    /// <see cref="Block{T}"/>.</param>
+    /// <returns>The height of the block with the <paramref name="hash"/>.</returns>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the <see cref="Block{T}"/> with the
+    /// given <paramref name="hash"/> is not indexed yet.</exception>
+    long BlockHashToIndex(BlockHash hash);
+
+    /// <inheritdoc cref="BlockHashToIndex"/>
+    Task<long> BlockHashToIndexAsync(BlockHash hash);
+
+    /// <summary>
+    /// Gets the indexed <see cref="BlockHash"/> of the <see cref="Block{T}"/> at
+    /// <paramref name="index"/> height.
+    /// </summary>
+    /// <param name="index">The height of the desired indexed <see cref="Block{T}"/>.</param>
+    /// <returns>The indexed <see cref="BlockHash"/> of the <see cref="Block{T}"/> at
+    /// <paramref name="index"/> height.</returns>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the index does not contain the
+    /// <see cref="Block{T}"/> at the given <paramref name="index"/>.</exception>
+    BlockHash IndexToBlockHash(long index);
+
+    /// <inheritdoc cref="IndexToBlockHash"/>
+    Task<BlockHash> IndexToBlockHashAsync(long index);
+
+    /// <summary>
+    /// Get the height and the <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/>s in the
+    /// given <paramref name="indexRange"/>.
+    /// </summary>
+    /// <param name="indexRange">The range of <see cref="Block{T}"/> height to look up.</param>
+    /// <param name="desc">Whether to look up the index in the descending order.</param>
+    /// <param name="producer">The producer of the block, if filtering by the producer is desired.
+    /// </param>
+    /// <returns>The height and the <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/>s
+    /// in the given <paramref name="indexRange"/>.</returns>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the given range exceeds the block
+    /// count.</exception>
+    IEnumerable<(long Index, BlockHash Hash)> GetBlockHashesByRange(
+        Range indexRange, bool desc = false, Address? producer = null);
+
+    /// <inheritdoc cref="GetBlockHashesByRange"/>
+    IAsyncEnumerable<(long Index, BlockHash Hash)> GetBlockHashesByRangeAsync(
+        Range indexRange, bool desc = false, Address? producer = null);
+
+    /// <summary>
+    /// Get the height and the <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/>s
+    /// starting at <paramref name="fromHeight"/>, at most <paramref name="maxCount"/>.
+    /// </summary>
+    /// <param name="fromHeight">The starting height.</param>
+    /// <param name="maxCount">The upper limit of <see cref="Block{T}"/>s to look up.</param>
+    /// <param name="desc">Whether to look up the index in the descending order.</param>
+    /// <param name="producer">The producer of the block, if filtering by the producer is desired.
+    /// </param>
+    /// <returns>The height and the <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/>s
+    /// starting at <paramref name="fromHeight"/> and at most <paramref name="maxCount"/>.
+    /// </returns>
+    IEnumerable<(long Index, BlockHash Hash)> GetBlockHashesFromIndex(
+        int? fromHeight = null, int? maxCount = null, bool desc = false, Address? producer = null);
+
+    /// <inheritdoc cref="GetBlockHashesFromIndex"/>
+    IAsyncEnumerable<(long Index, BlockHash Hash)> GetBlockHashesFromIndexAsync(
+        int? fromHeight = null, int? maxCount = null, bool desc = false, Address? producer = null);
+
+    /// <summary>
+    /// Get the <see cref="TxId"/> of the indexed <see cref="Transaction{T}"/>s starting at
+    /// <paramref name="fromNonce"/> that was signed by the <paramref name="signer"/>, at most
+    /// <paramref name="maxCount"/>.
+    /// </summary>
+    /// <param name="signer">The signer of the <see cref="Transaction{T}"/>.</param>
+    /// <param name="fromNonce">The tx nonce to start from (inclusive).</param>
+    /// <param name="maxCount">The upper limit of <see cref="TxId"/>s to return.</param>
+    /// <param name="desc">Whether to look up the <see cref="TxId"/>s in the descending order.
+    /// </param>
+    /// <returns>The <see cref="TxId"/> of the indexed <see cref="Transaction{T}"/>s signed by
+    /// the <paramref name="signer"/> starting at <paramref name="fromNonce"/> and at most
+    /// <paramref name="maxCount"/>.</returns>
+    IEnumerable<TxId> GetSignedTxIdsByAddress(
+            Address signer, int? fromNonce = null, int? maxCount = null, bool desc = false);
+
+    /// <inheritdoc cref="GetSignedTxIdsByAddress"/>
+    IAsyncEnumerable<TxId> GetSignedTxIdsByAddressAsync(
+        Address signer, int? fromNonce = null, int? maxCount = null, bool desc = false);
+
+    /// <summary>
+    /// Get the <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/> that contains the
+    /// <see cref="Transaction{T}"/> with the <paramref name="txId"/>.
+    /// </summary>
+    /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/> to look up the
+    /// containing <see cref="Block{T}"/>.</param>
+    /// <returns>The <see cref="BlockHash"/> of the indexed <see cref="Block{T}"/> that contains the
+    /// <see cref="Transaction{T}"/> with the <paramref name="txId"/>.</returns>
+    /// <exception cref="IndexOutOfRangeException">Thrown if the <paramref name="txId"/> does not
+    /// exist in the index.</exception>
+    BlockHash GetContainedBlockHashByTxId(TxId txId);
+
+    /// <inheritdoc cref="GetContainedBlockHashByTxId"/>
+    Task<BlockHash> GetContainedBlockHashByTxIdAsync(TxId txId);
+
+    /// <summary>
+    /// Attempt to get the <see cref="BlockHash"/> of the indexed block that contains the
+    /// <see cref="Transaction{T}"/> with the <paramref name="txId"/>, and return whether if the
+    /// lookup was successful.
+    /// </summary>
+    /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/> to find the
+    /// containing <see cref="Block{T}"/>.</param>
+    /// <param name="containedBlock">The <see cref="BlockHash"/> of the indexed block that contains
+    /// the <see cref="Transaction{T}"/> with the <paramref name="txId"/>, if it exists.</param>
+    /// <returns>Whether the retrieval was successful.</returns>
+    bool TryGetContainedBlockHashById(TxId txId, out BlockHash containedBlock);
+
+    /// <summary>
+    /// Attempt to get the <see cref="BlockHash"/> of the indexed block that contains the
+    /// <see cref="Transaction{T}"/> with the <paramref name="txId"/>, and return the retrieved
+    /// <see cref="BlockHash"/> if it exists, or <c>null</c> if it does not.
+    /// </summary>
+    /// <param name="txId">The <see cref="TxId"/> of the <see cref="Transaction{T}"/> to find the
+    /// containing <see cref="Block{T}"/>.</param>
+    /// <returns>The <see cref="BlockHash"/> of the block containing the
+    /// <see cref="Transaction{T}"/> with the <paramref name="txId"/> if it exists, or <c>null</c>
+    /// if it does not.</returns>
+    Task<BlockHash?> TryGetContainedBlockHashByIdAsync(TxId txId);
+
+    /// <summary>
+    /// Get the last tx nonce of the <paramref name="address"/> that was indexed.
+    /// </summary>
+    /// <param name="address">The address to retrieve the tx nonce.</param>
+    /// <returns>The last tx nonce of the <paramref name="address"/> that was indexed.</returns>
+    /// <remarks>This method does not return the tx nonces of <see cref="Transaction{T}"/>s that
+    /// are currently staged.</remarks>
+    long? GetLastNonceByAddress(Address address);
+
+    /// <inheritdoc cref="GetLastNonceByAddress"/>
+    Task<long?> GetLastNonceByAddressAsync(Address address);
+
+    /// <summary>
+    /// Index the metadata of a <see cref="Block{T}"/> corresponding to the given
+    /// <paramref name="blockDigest"/>.
+    /// </summary>
+    /// <param name="blockDigest">The block digest object to index.</param>
+    /// <param name="txs">An <see cref="IEnumerable{T}"/> containing the <see cref="ITransaction"/>
+    /// instances corresponding to <see cref="BlockDigest.TxIds"/> of given
+    /// <paramref name="blockDigest"/>.</param>
+    /// <param name="token">A token to mark the cancellation of processing.</param>
+    /// <returns>A <see cref="Task"/> that represents this asynchronous method.</returns>
+    /// <exception cref="IndexMismatchException">Thrown if the index already has seen a block in
+    /// the height of the given block, but the hash of the indexed block and the given block is
+    /// different.</exception>
+    internal Task IndexAsync(
+        BlockDigest blockDigest, IEnumerable<ITransaction> txs, CancellationToken token);
+
+    internal Task SynchronizeForeverAsync<T>(
+        IStore store, TimeSpan pollInterval, CancellationToken stoppingToken)
+        where T : IAction, new();
+
+    internal Task SynchronizeAsync<T>(IStore store, CancellationToken stoppingToken)
+        where T : IAction, new();
+}

--- a/Libplanet.Explorer/Indexing/IIndexingContext.cs
+++ b/Libplanet.Explorer/Indexing/IIndexingContext.cs
@@ -1,0 +1,5 @@
+namespace Libplanet.Explorer.Indexing;
+
+public interface IIndexingContext
+{
+}

--- a/Libplanet.Explorer/Indexing/IndexMismatchException.cs
+++ b/Libplanet.Explorer/Indexing/IndexMismatchException.cs
@@ -1,0 +1,38 @@
+using System;
+using Libplanet.Blocks;
+
+namespace Libplanet.Explorer.Indexing;
+
+/// <summary>
+/// An exception raised when the indexed blocks do not match the blocks in the provided
+/// <see cref="Blockchain.BlockChain{T}"/> object at the same height.
+/// </summary>
+public class IndexMismatchException : Exception
+{
+    internal IndexMismatchException(long index, BlockHash indexHash, BlockHash? chainHash)
+        : base(
+            $"The existing hash in the index for block #{index} doesn't match the hash"
+            + $" in the chain. ({indexHash} != {chainHash}) This means the index is inconsistent"
+            + " with the chain. Please make sure that the index is intended for the chain,"
+            + " and if absolutely sure, delete the index database and try again.")
+    {
+        Index = index;
+        IndexHash = indexHash;
+        ChainHash = chainHash;
+    }
+
+    /// <summary>
+    /// The index of the mismatched blocks.
+    /// </summary>
+    public long Index { get; }
+
+    /// <summary>
+    /// The hash of the indexed block.
+    /// </summary>
+    public BlockHash IndexHash { get; }
+
+    /// <summary>
+    /// The hash of the block inside the <see cref="Blockchain.BlockChain{T}"/> object.
+    /// </summary>
+    public BlockHash? ChainHash { get; }
+}

--- a/Libplanet.Explorer/Indexing/IndexingService.cs
+++ b/Libplanet.Explorer/Indexing/IndexingService.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Store;
+using Microsoft.Extensions.Hosting;
+
+namespace Libplanet.Explorer.Indexing;
+
+/// <summary>
+/// An ASP.NET Core service that indexes blocks added to the given <see cref="IStore"/>
+/// instance to the provided <see cref="IBlockChainIndex"/> instance.
+/// </summary>
+/// <typeparam name="T">The <see cref="IAction"/> type of the blocks that will be indexed.
+/// </typeparam>
+public class IndexingService<T> : BackgroundService
+    where T : IAction, new()
+{
+    private readonly IBlockChainIndex _index;
+    private readonly IStore _store;
+    private readonly TimeSpan _pollInterval;
+
+    /// <summary>
+    /// Create an instance of the service that indexes blocks added to the <paramref name="chain"/>
+    /// to the <paramref name="index"/>.
+    /// </summary>
+    /// <param name="index">The index object that blocks will be indexed.</param>
+    /// <param name="store">The <see cref="IStore"/> object that will be indexed by the
+    /// <paramref name="index"/>.</param>
+    /// <param name="pollInterval">The interval between index synchronization polls in
+    /// <see cref="TimeSpan"/>. Recommended value is about the same as block interval.</param>
+    public IndexingService(IBlockChainIndex index, IStore store, TimeSpan pollInterval)
+    {
+        _index = index;
+        _store = store;
+        _pollInterval = pollInterval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _index.SynchronizeForeverAsync<T>(_store, _pollInterval, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}

--- a/Libplanet.Explorer/Indexing/RocksDbBlockChainIndex.cs
+++ b/Libplanet.Explorer/Indexing/RocksDbBlockChainIndex.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
+using RocksDbSharp;
+
+namespace Libplanet.Explorer.Indexing;
+
+/// <summary>
+/// An <see cref="IBlockChainIndex"/> object that uses RocksDB as the backend.
+/// </summary>
+public class RocksDbBlockChainIndex : BlockChainIndexBase
+{
+    private static readonly byte[] BlockHashToIndexPrefix = { (byte)'b' };
+    private static readonly byte[] IndexToBlockHashPrefix = { (byte)'i' };
+    private static readonly byte[] ProducerToBlockIndexPrefix = { (byte)'p' };
+    private static readonly byte[] SignerToTxIdPrefix = { (byte)'s' };
+    private static readonly byte[] InvolvedAddressToTxIdPrefix = { (byte)'I' };
+    private static readonly byte[] TxIdToContainedBlockHashPrefix = { (byte)'t' };
+    private static readonly byte[] SystemActionTypeIdToTxIdPrefix = { (byte)'S' };
+    private static readonly byte[] CustomActionTypeIdToTxIdPrefix = { (byte)'C' };
+    private static readonly byte[] CustomActionTypeIdPrefix = { (byte)'c' };
+    private static readonly Codec Codec = new();
+    private readonly RocksDb _db;
+
+    /// <summary>
+    /// Create an instance of <see cref="IBlockChainIndex"/> that uses RocksDB as the backend.
+    /// </summary>
+    /// <param name="path">The path containing the RocksDB index database.</param>
+    public RocksDbBlockChainIndex(string path)
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        path = Path.GetFullPath(path);
+
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        if (!Directory.Exists(Path.Combine(path, "indexdb")))
+        {
+            Directory.CreateDirectory(Path.Combine(path, "indexdb"));
+        }
+
+        var rocksDbOption = new DbOptions()
+            .SetCreateIfMissing();
+
+        _db = RocksDb.Open(rocksDbOption, Path.Combine(path, "indexdb"));
+    }
+
+    /// <inheritdoc />
+    public override long BlockHashToIndex(BlockHash hash) =>
+        _db.Get(
+            BlockHashToIndexPrefix.Concat(hash.ByteArray).ToArray()) is { } arr
+            ? BigEndianByteArrayToLong(arr)
+            : throw new IndexOutOfRangeException(
+                $"The hash {hash} does not exist in the index.");
+
+    /// <inheritdoc />
+    public override async Task<long> BlockHashToIndexAsync(BlockHash hash) =>
+        await Task.Run(() => BlockHashToIndex(hash)).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public override IEnumerable<TxId>
+        GetSignedTxIdsByAddress(Address signer, int? fromNonce, int? maxCount, bool desc) =>
+        IteratePrefix(
+                fromNonce, maxCount, desc, SignerToTxIdPrefix.Concat(signer.ByteArray).ToArray())
+            .Select(kv => new TxId(kv.Value));
+
+    /// <inheritdoc />
+    public override async IAsyncEnumerable<TxId>
+        GetSignedTxIdsByAddressAsync(Address signer, int? fromNonce, int? maxCount, bool desc)
+    {
+        using var enumerator =
+            GetSignedTxIdsByAddress(signer, fromNonce, maxCount, desc).GetEnumerator();
+        while (await Task.Run(() => enumerator.MoveNext()).ConfigureAwait(false))
+        {
+            yield return enumerator.Current;
+        }
+    }
+
+    /// <inheritdoc />
+    public override long? GetLastNonceByAddress(Address address)
+    {
+        using var iter = IteratePrefix(
+                0, 1, true, SignerToTxIdPrefix.Concat(address.ByteArray).ToArray())
+            .Select(kv => BigEndianByteArrayToLong(kv.Key)).GetEnumerator();
+        return iter.MoveNext()
+            ? iter.Current
+            : null;
+    }
+
+    /// <inheritdoc />
+    public override async Task<long?> GetLastNonceByAddressAsync(Address address) =>
+        await Task.Run(() => GetLastNonceByAddress(address)).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public override bool TryGetContainedBlockHashById(TxId txId, out BlockHash containedBlock)
+    {
+        containedBlock = default;
+        var bytes =
+            _db.Get(TxIdToContainedBlockHashPrefix.Concat(txId.ByteArray).ToArray());
+        if (bytes is not { })
+        {
+            return false;
+        }
+
+        containedBlock = new BlockHash(bytes);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override async Task<BlockHash?> TryGetContainedBlockHashByIdAsync(TxId txId) =>
+        await Task.Run(() =>
+            TryGetContainedBlockHashById(txId, out var containedBlock)
+                ? containedBlock
+                : (BlockHash?)null
+        ).ConfigureAwait(false);
+
+    public override BlockHash IndexToBlockHash(long index)
+    {
+        return _db.Get(
+                IndexToBlockHashPrefix.Concat(
+                    LongToBigEndianByteArray(
+                        index >= 0 ? index : (GetTipImpl()?.Index ?? 0) + index + 1)).ToArray())
+            is { } arr
+            ? new BlockHash(arr)
+            : throw new IndexOutOfRangeException(
+                $"The block #{index} does not exist in the index.");
+    }
+
+    public override async Task<BlockHash> IndexToBlockHashAsync(long index)
+        => await Task.Run(() => IndexToBlockHash(index)).ConfigureAwait(false);
+
+    public override IEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesFromIndex(int? fromHeight, int? maxCount, bool desc, Address? producer)
+    {
+        if (producer is { } minerVal)
+        {
+            return IteratePrefix(
+                    fromHeight,
+                    maxCount,
+                    desc,
+                    ProducerToBlockIndexPrefix.Concat(minerVal.ByteArray).ToArray())
+                .Select(
+                    kv => (
+                        BigEndianByteArrayToLong(kv.Value[..8]),
+                        new BlockHash(kv.Value[8..40])));
+        }
+
+        return IteratePrefix(fromHeight, maxCount, desc, IndexToBlockHashPrefix)
+            .Select(kv => (BigEndianByteArrayToLong(kv.Key), new BlockHash(kv.Value)));
+    }
+
+    public override async IAsyncEnumerable<(long Index, BlockHash Hash)>
+        GetBlockHashesFromIndexAsync(int? fromHeight, int? maxCount, bool desc, Address? producer)
+    {
+        using var enumerator =
+            GetBlockHashesFromIndex(fromHeight, maxCount, desc, producer)
+                .GetEnumerator();
+        while (await Task.Run(() => enumerator.MoveNext()).ConfigureAwait(false))
+        {
+            yield return enumerator.Current;
+        }
+    }
+
+    protected override (long Index, BlockHash Hash)? GetTipImpl()
+    {
+        using var iter =
+            GetBlockHashesFromIndex(0, 1, true, null)
+                .GetEnumerator();
+        return iter.MoveNext()
+            ? iter.Current
+            : null;
+    }
+
+    protected override async Task<(long Index, BlockHash Hash)?> GetTipAsyncImpl()
+        => await Task.Run(GetTipImpl).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    protected override async Task IndexAsyncImpl(
+        BlockDigest blockDigest,
+        IEnumerable<ITransaction> txs,
+        IIndexingContext? context,
+        CancellationToken stoppingToken) =>
+        await Task.Run(() => IndexImpl(blockDigest, txs, context, stoppingToken), stoppingToken)
+            .ConfigureAwait(false);
+
+    protected override IIndexingContext GetIndexingContext() =>
+        new RocksDbIndexingContext();
+
+    protected override void CommitIndexingContext(IIndexingContext context)
+    {
+        if (context is not RocksDbIndexingContext)
+        {
+            throw new ArgumentException(
+                $"Received an unsupported {nameof(IIndexingContext)}: {context.GetType()}");
+        }
+    }
+
+    protected override async Task CommitIndexingContextAsync(IIndexingContext context) =>
+        await Task.Run(() => CommitIndexingContext(context));
+
+    // Use big endian for easier iterator prev seek
+    private static byte[] ShortToBigEndianByteArray(short val)
+    {
+        byte[] arr = BitConverter.GetBytes(val);
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(arr);
+        }
+
+        return arr;
+    }
+
+    private static byte[] LongToBigEndianByteArray(long val)
+    {
+        byte[] arr = BitConverter.GetBytes(val);
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(arr);
+        }
+
+        return arr;
+    }
+
+    private static long BigEndianByteArrayToLong(byte[] val)
+    {
+        var len = val.Length;
+        if (len != 8)
+        {
+            throw new ArgumentException(
+                $"a byte array of size 8 must be provided, but the size of given array was {len}.",
+                nameof(val));
+        }
+
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(val);
+        }
+
+        return BitConverter.ToInt64(val);
+    }
+
+    private void IndexImpl(
+        BlockDigest blockDigest,
+        IEnumerable<ITransaction> txs,
+        IIndexingContext? context,
+        CancellationToken stoppingToken)
+    {
+        var minerAddress = blockDigest.Miner.ByteArray.ToArray();
+        var blockHash = blockDigest.Hash.ByteArray.ToArray();
+        var indexToBlockHashKey = IndexToBlockHashPrefix
+            .Concat(LongToBigEndianByteArray(blockDigest.Index)).ToArray();
+
+        var writeBatch = new WriteBatch();
+        if (_db.Get(indexToBlockHashKey) is { } existingHash)
+        {
+            writeBatch.Dispose();
+            if (new BlockHash(existingHash).Equals(blockDigest.Hash))
+            {
+                return;
+            }
+
+            throw new IndexMismatchException(
+                blockDigest.Index, GetTipImpl()!.Value.Hash, blockDigest.Hash);
+        }
+
+        writeBatch.Put(indexToBlockHashKey, blockHash);
+        writeBatch.Put(
+            BlockHashToIndexPrefix.Concat(blockHash).ToArray(),
+            LongToBigEndianByteArray(blockDigest.Index));
+        writeBatch.Put(
+            GetNextOrdinalKey(ProducerToBlockIndexPrefix.Concat(minerAddress).ToArray()),
+            LongToBigEndianByteArray(blockDigest.Index).Concat(blockHash).ToArray());
+
+        IImmutableDictionary<byte[], long> duplicateSystemActionTypeIdTxTimestampOrdinalMemos =
+            ImmutableDictionary<byte[], long>.Empty.WithComparers(ByteArrayComparer.Instance);
+        IImmutableDictionary<byte[], long> duplicateCustomActionTypeIdToTxTimestampOrdinalMemos =
+            ImmutableDictionary<byte[], long>.Empty.WithComparers(ByteArrayComparer.Instance);
+        IImmutableDictionary<byte[], long> duplicateAccountNonceOrdinalMemos =
+            ImmutableDictionary<byte[], long>.Empty.WithComparers(ByteArrayComparer.Instance);
+        IImmutableDictionary<byte[], long> duplicateInvolvedTxTimestampOrdinalMemos =
+            ImmutableDictionary<byte[], long>.Empty.WithComparers(ByteArrayComparer.Instance);
+        IImmutableSet<byte[]> encounteredSystemActionTypeIdToTxIdKeys =
+            ImmutableHashSet<byte[]>.Empty.WithComparer(ByteArrayComparer.Instance);
+        IImmutableSet<byte[]> encounteredCustomActionTypeIdToTxIdKeys =
+            ImmutableHashSet<byte[]>.Empty.WithComparer(ByteArrayComparer.Instance);
+        IImmutableSet<byte[]> encounteredSignerToTxIdKeys =
+            ImmutableHashSet<byte[]>.Empty.WithComparer(ByteArrayComparer.Instance);
+        IImmutableSet<byte[]> encounteredInvolvedAddressToTxIdKeys =
+            ImmutableHashSet<byte[]>.Empty.WithComparer(ByteArrayComparer.Instance);
+        foreach (var tx in txs)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                writeBatch.Dispose();
+                throw new OperationCanceledException(stoppingToken);
+            }
+
+            var signerAddress = tx.Signer.ByteArray.ToArray();
+            var txId = tx.Id.ByteArray.ToArray();
+            var txIdToContainedBlockHashKey = TxIdToContainedBlockHashPrefix.Concat(txId).ToArray();
+            if (_db.Get(txIdToContainedBlockHashKey) is { })
+            {
+                continue;
+            }
+
+            PutOrPutDuplicateOrdinal(
+                ref writeBatch,
+                SignerToTxIdPrefix
+                    .Concat(signerAddress)
+                    .Concat(LongToBigEndianByteArray(tx.Nonce))
+                    .ToArray(),
+                txId,
+                ref encounteredSignerToTxIdKeys,
+                ref duplicateAccountNonceOrdinalMemos);
+
+            writeBatch.Put(txIdToContainedBlockHashKey, blockHash);
+            if (tx.SystemAction is { } systemAction)
+            {
+                PutOrPutDuplicateOrdinal(
+                    ref writeBatch,
+                    SystemActionTypeIdToTxIdPrefix
+                        .Concat(
+                            ShortToBigEndianByteArray(
+                                (short)systemAction.GetValue<Integer>("type_id")))
+                        .Concat(LongToBigEndianByteArray(tx.Timestamp.UtcTicks))
+                        .ToArray(),
+                    txId,
+                    ref encounteredSystemActionTypeIdToTxIdKeys,
+                    ref duplicateSystemActionTypeIdTxTimestampOrdinalMemos);
+            }
+
+            foreach (var address in tx.UpdatedAddresses.Select(address => address.ByteArray))
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    writeBatch.Dispose();
+                    throw new OperationCanceledException(stoppingToken);
+                }
+
+                PutOrPutDuplicateOrdinal(
+                    ref writeBatch,
+                    InvolvedAddressToTxIdPrefix
+                        .Concat(address)
+                        .Concat(LongToBigEndianByteArray(tx.Timestamp.UtcTicks))
+                        .ToArray(),
+                    txId,
+                    ref encounteredInvolvedAddressToTxIdKeys,
+                    ref duplicateInvolvedTxTimestampOrdinalMemos);
+            }
+
+            if (tx.CustomActions is not { } customActions)
+            {
+                continue;
+            }
+
+            foreach (var customAction in customActions)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    writeBatch.Dispose();
+                    throw new OperationCanceledException(stoppingToken);
+                }
+
+                if (customAction is not Dictionary actionDict
+                    || !actionDict.TryGetValue((Text)"type_id", out var typeId))
+                {
+                    continue;
+                }
+
+                // Use IValue for string, as "abc" and "abcd" as raw byte strings overlap.
+                writeBatch.Put(
+                    CustomActionTypeIdPrefix.Concat(Codec.Encode(typeId)).ToArray(),
+                    Array.Empty<byte>());
+                PutOrPutDuplicateOrdinal(
+                    ref writeBatch,
+                    CustomActionTypeIdToTxIdPrefix
+                        .Concat(Codec.Encode(typeId))
+                        .Concat(LongToBigEndianByteArray(tx.Timestamp.UtcTicks))
+                        .ToArray(),
+                    txId,
+                    ref encounteredCustomActionTypeIdToTxIdKeys,
+                    ref duplicateCustomActionTypeIdToTxTimestampOrdinalMemos);
+            }
+        }
+
+        _db.Write(writeBatch);
+        writeBatch.Dispose();
+    }
+
+    private IEnumerable<(byte[] Key, byte[] Value)>
+        IteratePrefix(int? offset, int? limit, bool desc, byte[] prefix)
+    {
+        if (limit == 0)
+        {
+            yield break;
+        }
+
+        Iterator iter = _db.NewIterator().Seek(prefix);
+        if (!iter.Valid() || !iter.Key().StartsWith(prefix))
+        {
+            yield break;
+        }
+
+        if (desc)
+        {
+            byte[] upper = new byte[iter.Key().Length - prefix.Length];
+            Array.Fill(upper, byte.MaxValue);
+            iter.Dispose();
+            iter = _db.NewIterator().SeekForPrev(prefix.Concat(upper).ToArray());
+        }
+
+        byte[] key;
+        Func<long> GetAdvancer()
+        {
+            long count = 0;
+            System.Action advance = desc
+                ? () => iter.Prev()
+                : () => iter.Next();
+            return () =>
+            {
+                advance();
+                return ++count;
+            };
+        }
+
+        var advance = GetAdvancer();
+        for (var i = 0; i < offset; ++i)
+        {
+            advance();
+        }
+
+        for (long count = 0L;
+             iter.Valid()
+             && (key = iter.Key()).StartsWith(prefix)
+             && (limit is not { } || count < (offset ?? 0) + limit);
+             count = advance())
+        {
+            yield return (key[prefix.Length..], iter.Value());
+        }
+
+        iter.Dispose();
+    }
+
+    private long GetNextOrdinal(byte[] prefix)
+    {
+        using Iterator iter = _db.NewIterator().Seek(prefix);
+        if (!iter.Valid() || !iter.Key().StartsWith(prefix))
+        {
+            return 0L;
+        }
+
+        byte[] upper = new byte[iter.Key().Length - prefix.Length];
+        Array.Fill(upper, byte.MaxValue);
+        using Iterator lastIter = _db.NewIterator().SeekForPrev(prefix.Concat(upper).ToArray());
+        return BigEndianByteArrayToLong(lastIter.Key()[prefix.Length..]) + 1;
+    }
+
+    private byte[] GetNextOrdinalKey(byte[] prefix)
+    {
+        long? memo = null;
+        return GetNextOrdinalKey(prefix, ref memo);
+    }
+
+    private byte[] GetNextOrdinalKey(byte[] prefix, ref long? memo) =>
+        prefix.Concat(
+            LongToBigEndianByteArray(
+                (long)(memo = memo is { } memoVal
+                    ? ++memoVal
+                    : (memo = GetNextOrdinal(prefix)).Value))).ToArray();
+
+    private void PutOrdinalWithMemo(
+        ref WriteBatch writeBatch,
+        byte[] prefix,
+        byte[] value,
+        ref IImmutableDictionary<byte[], long> memos)
+    {
+        long? memo = memos.TryGetValue(prefix, out var memoValue)
+            ? memoValue
+            : null;
+        writeBatch.Put(GetNextOrdinalKey(prefix, ref memo), value);
+        memos = memos.SetItem(prefix, memo!.Value);
+    }
+
+    private void PutOrPutDuplicateOrdinal(
+        ref WriteBatch writeBatch,
+        byte[] key,
+        byte[] value,
+        ref IImmutableSet<byte[]> encounteredKeys,
+        ref IImmutableDictionary<byte[], long> duplicateMemos)
+    {
+        if (
+            !encounteredKeys.Contains(key)
+            && _db.Get(key) is null)
+        {
+            writeBatch.Put(key, value);
+            encounteredKeys = encounteredKeys.Add(key);
+        }
+        else
+        {
+            PutOrdinalWithMemo(
+                ref writeBatch,
+                key,
+                value,
+                ref duplicateMemos);
+        }
+    }
+
+    private class ByteArrayComparer : IEqualityComparer<byte[]>
+    {
+        public static readonly ByteArrayComparer Instance = new ByteArrayComparer();
+
+        public bool Equals(byte[]? x, byte[]? y) =>
+            ((ReadOnlySpan<byte>)x).SequenceEqual(y);
+
+        public int GetHashCode(byte[] obj)
+        {
+            HashCode hash = default;
+            hash.AddBytes(obj);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/Libplanet.Explorer/Indexing/RocksDbIndexingContext.cs
+++ b/Libplanet.Explorer/Indexing/RocksDbIndexingContext.cs
@@ -1,0 +1,5 @@
+using System.Data;
+
+namespace Libplanet.Explorer.Indexing;
+
+public record RocksDbIndexingContext : IIndexingContext;

--- a/Libplanet.Explorer/Interfaces/IBlockChainContext.cs
+++ b/Libplanet.Explorer/Interfaces/IBlockChainContext.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Explorer.Indexing;
 using Libplanet.Explorer.Queries;
 using Libplanet.Net;
 using Libplanet.Store;
@@ -19,6 +20,8 @@ namespace Libplanet.Explorer.Interfaces
         IStore Store { get; }
 
         Swarm<T> Swarm { get; }
+
+        IBlockChainIndex Index { get; }
     }
 
     public static class BlockChainContext

--- a/Libplanet.Explorer/Queries/ExplorerQuery.cs
+++ b/Libplanet.Explorer/Queries/ExplorerQuery.cs
@@ -1,14 +1,13 @@
 #nullable disable
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.Indexing;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Store;
 using Libplanet.Store;
@@ -44,6 +43,8 @@ namespace Libplanet.Explorer.Queries
         private static BlockChain<T> Chain => ChainContext.BlockChain;
 
         private static IStore Store => ChainContext.Store;
+
+        private static IBlockChainIndex Index => ChainContext.Index;
 
         internal static IEnumerable<Block<T>> ListBlocks(
             bool desc,
@@ -215,18 +216,17 @@ namespace Libplanet.Explorer.Queries
             Address? signer,
             Address? involved)
         {
-            if (involved is null && signer is null)
+            if (signer is { } signerVal)
             {
-                return true;
+                return tx.Signer.Equals(signerVal);
             }
-            else if (!(signer is null))
+
+            if (involved is { } involvedVal)
             {
-                return tx.Signer.Equals(signer.Value);
+                return tx.UpdatedAddresses.Contains(involvedVal);
             }
-            else
-            {
-                return tx.UpdatedAddresses.Contains(involved.Value);
-            }
+
+            return true;
         }
     }
 }

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -11,7 +11,6 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Explorer.Interfaces;
-using Libplanet.Store;
 using Libplanet.Tx;
 
 namespace Libplanet.Explorer.Queries
@@ -60,7 +59,7 @@ namespace Libplanet.Explorer.Queries
                     var involved = context.GetArgument<Address?>("involvedAddress");
                     bool desc = context.GetArgument<bool>("desc");
                     long offset = context.GetArgument<long>("offset");
-                    int? limit = context.GetArgument<int?>("limit", null);
+                    int? limit = context.GetArgument<int?>("limit");
 
                     return ExplorerQuery<T>.ListTransactions(signer, involved, desc, offset, limit);
                 }
@@ -221,12 +220,28 @@ namespace Libplanet.Explorer.Queries
                 ),
                 resolve: context =>
                 {
-                    BlockChain<T> blockChain = _context.BlockChain;
-                    IStore store = _context.Store;
-                    TxId txId = new TxId(
+                    var blockChain = _context.BlockChain;
+                    var store = _context.Store;
+                    var index = _context.Index;
+                    var txId = new TxId(
                         ByteUtil.ParseHex(context.GetArgument<string>("txId"))
                     );
-                    if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
+                    BlockHash? txExecutedBlockHash = null;
+                    if (
+                        index is not null
+                        && index.TryGetContainedBlockHashById(txId, out var hash))
+                    {
+                        txExecutedBlockHash = hash;
+                    }
+                    else if (
+                        index is null
+                        && store.GetFirstTxIdBlockHashIndex(txId)
+                            is { } txExecutedBlockHashFromStore)
+                    {
+                        txExecutedBlockHash = txExecutedBlockHashFromStore;
+                    }
+
+                    if (txExecutedBlockHash is not { } txExecutedBlockHashValue)
                     {
                         return blockChain.GetStagedTransactionIds().Contains(txId)
                             ? new TxResult(
@@ -253,15 +268,12 @@ namespace Libplanet.Explorer.Queries
 
                     try
                     {
-                        TxExecution execution = blockChain.GetTxExecution(
-                            txExecutedBlockHash,
+                        var execution = blockChain.GetTxExecution(
+                            txExecutedBlockHashValue,
                             txId
                         );
-                        Block<T> txExecutedBlock = blockChain[txExecutedBlockHash];
+                        var txExecutedBlock = blockChain[txExecutedBlockHashValue];
 
-                        var updatedStates = ((TxSuccess)execution).UpdatedStates;
-                        var updatedFungibleAssets = ((TxSuccess)execution).UpdatedFungibleAssets;
-                        var fungibleAssetsDelta = ((TxSuccess)execution).FungibleAssetsDelta;
                         return execution switch
                         {
                             TxSuccess txSuccess => new TxResult(

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -113,6 +113,12 @@ public static class Utils
         // use IStore as the option/argument types rather than taking them as strings.
         var uri = new Uri(uriString);
 
+        // FIXME: A workaround for MSBuild not including unused references. Find a better way
+        // to handle this. See: https://github.com/planetarium/libplanet/issues/2623
+#pragma warning disable CS0219
+        RocksDBStore.RocksDBStore? rocksDbStore = null;
+#pragma warning restore CS0219
+
         switch (uri.Scheme)
         {
             case "default":

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -41,6 +41,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Crypto.Secp256k1"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Crypto.Secp256k1.Tests", "Libplanet.Crypto.Secp256k1.Tests\Libplanet.Crypto.Secp256k1.Tests.csproj", "{B1A38DDE-5534-4625-A3F2-A585BA7A1198}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Explorer.Cocona", "Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj", "{8698E0C2-1A82-43E6-8A26-3D9A825CF574}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Explorer.Cocona.Tests", "Libplanet.Explorer.Cocona.Tests\Libplanet.Explorer.Cocona.Tests.csproj", "{F782BC86-9CE6-4F69-8F77-710A399CB54F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -387,6 +391,42 @@ Global
 		{B1A38DDE-5534-4625-A3F2-A585BA7A1198}.ReleaseMono|x64.Build.0 = Debug|Any CPU
 		{B1A38DDE-5534-4625-A3F2-A585BA7A1198}.ReleaseMono|x86.ActiveCfg = Debug|Any CPU
 		{B1A38DDE-5534-4625-A3F2-A585BA7A1198}.ReleaseMono|x86.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|x64.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Debug|x86.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|x64.ActiveCfg = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|x64.Build.0 = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|x86.ActiveCfg = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.Release|x86.Build.0 = Release|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|Any CPU.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|Any CPU.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|x64.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|x64.Build.0 = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|x86.ActiveCfg = Debug|Any CPU
+		{8698E0C2-1A82-43E6-8A26-3D9A825CF574}.ReleaseMono|x86.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|x64.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Debug|x86.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|x64.ActiveCfg = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|x64.Build.0 = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|x86.ActiveCfg = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.Release|x86.Build.0 = Release|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|Any CPU.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|Any CPU.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x64.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x64.Build.0 = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x86.ActiveCfg = Debug|Any CPU
+		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Libplanet/AssemblyInfo.cs
+++ b/Libplanet/AssemblyInfo.cs
@@ -1,6 +1,7 @@
-#nullable disable
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Libplanet.Explorer")]
+[assembly: InternalsVisibleTo("Libplanet.Explorer.Tests")]
 [assembly: InternalsVisibleTo("Libplanet.Extensions.Cocona")]
 [assembly: InternalsVisibleTo("Libplanet.Extensions.Cocona.Tests")]
 [assembly: InternalsVisibleTo("Libplanet.Net")]


### PR DESCRIPTION
A new class for indexing, `IBlockChainIndex`, was added in `Libplanet.Explorer`, and is used for queries that can benefit from indexing.
Since this PR, apps that use the queries in `Libplanet.Explorer` must provide an `IBlockChainIndex` instance to the DI context, and must run `PrepareIndexService` which takes in an `Nito.AsyncEx.AsyncManualResetEvent` that other services that may modify the `BlockChain<T>` state. Otherwise, the index object will throw an `IndexNotReadyException`, which in turn will make queries that use the index fail.

EF Core is used for migrations, but are not used for database mutation and retrieval due to performance concerns.

An example of app using the new IBlockChainIndex: https://github.com/tkiapril/planet-node/tree/feature/index & https://github.com/tkiapril/ninechronicles.headless/tree/feature/index