### PR TITLE
Made `Swap()` no longer allowed on non canonical chains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  `BlockChain<T>()` now explicitly requires both `store` and `stateStore`
     arguments to be not `null`.  [[#2609]]
+ -  `BlockChain<T>.Swap()` now throws an `InvalidOperationException` if called
+    on a non-canonical chain.  [[#2619]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +30,7 @@ To be released.
 ### CLI tools
 
 [#2609]: https://github.com/planetarium/libplanet/pull/2609
+[#2619]: https://github.com/planetarium/libplanet/pull/2619
 
 
 Version 0.45.0

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -20,7 +20,12 @@ namespace Libplanet.Blockchain
             bool render,
             StateCompleterSet<T>? stateCompleters = null)
         {
-            if (other is null)
+            if (!IsCanonical)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot perform {nameof(Swap)} on a non canonical chain.");
+            }
+            else if (other is null)
             {
                 throw new ArgumentNullException(nameof(other));
             }
@@ -108,9 +113,10 @@ namespace Libplanet.Blockchain
                         StagePolicy.Stage(this, tx);
                     }
 
+                    Store.SetCanonicalChainId(other.Id);
                     Guid obsoleteId = Id;
                     Id = other.Id;
-                    Store.SetCanonicalChainId(Id);
+
                     _blocks = new BlockSet<T>(Store);
                     foreach (Transaction<T> tx in txsToUnstage)
                     {


### PR DESCRIPTION
Either this or if we really want to use `Swap()` on any chain for whatever reason, then canonicity of the current chain should be checked before changing the canonical chain stored in `IStore`. 🙄