### PR TITLE
Improve network performance & Release 0.44.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.44.4
 
 To be released.
 
+ -  Improved overall performance of `NetMQTransport` and `TxCompletion<T>`
+    classes.  [[#2631]]
+
+[#2631]: https://github.com/planetarium/libplanet/pull/2631
+
 
 Version 0.44.3
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.44.4
 --------------
 
-To be released.
+Released on December 15, 2022.
 
  -  Improved overall performance of `NetMQTransport` and `TxCompletion<T>`
     classes.  [[#2631]]

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -403,7 +403,7 @@ namespace Libplanet.Net.Protocols
                     new PingMsg(),
                     timeout,
                     cancellationToken
-                );
+                ).ConfigureAwait(false);
                 if (!(reply is PongMsg pong))
                 {
                     throw new InvalidMessageException(
@@ -585,15 +585,16 @@ namespace Libplanet.Net.Protocols
             TimeSpan? timeout,
             CancellationToken cancellationToken)
         {
-            var findPeer = new Messages.FindNeighborsMsg(target);
+            var findPeer = new FindNeighborsMsg(target);
             try
             {
                 Message reply = await _transport.SendMessageAsync(
                     peer,
                     findPeer,
                     timeout,
-                    cancellationToken);
-                if (!(reply is Messages.NeighborsMsg neighbors))
+                    cancellationToken
+                ).ConfigureAwait(false);
+                if (!(reply is NeighborsMsg neighbors))
                 {
                     throw new InvalidMessageException(
                         $"Reply to {nameof(Messages.FindNeighborsMsg)} is invalid.",

--- a/Libplanet.Net/Swarm.MessageHandlers.cs
+++ b/Libplanet.Net/Swarm.MessageHandlers.cs
@@ -12,19 +12,19 @@ namespace Libplanet.Net
 {
     public partial class Swarm<T>
     {
-        private async Task ProcessMessageHandlerAsync(Message message)
+        private Task ProcessMessageHandlerAsync(Message message)
         {
             switch (message)
             {
                 case PingMsg _:
                 case FindNeighborsMsg _:
-                    break;
+                    return Task.CompletedTask;
 
                 case GetChainStatusMsg getChainStatus:
                 {
                     _logger.Debug(
                         "Received a {MessageType} message.",
-                        nameof(Messages.GetChainStatusMsg));
+                        nameof(GetChainStatusMsg));
 
                     // This is based on the assumption that genesis block always exists.
                     Block<T> tip = BlockChain.Tip;
@@ -39,15 +39,14 @@ namespace Libplanet.Net
                         Identity = getChainStatus.Identity,
                     };
 
-                    await Transport.ReplyMessageAsync(chainStatus, default);
-                    break;
+                    return Transport.ReplyMessageAsync(chainStatus, default);
                 }
 
                 case GetBlockHashesMsg getBlockHashes:
                 {
                     _logger.Debug(
                         "Received a {MessageType} message (stop: {Stop}).",
-                        nameof(Messages.GetBlockHashesMsg),
+                        nameof(GetBlockHashesMsg),
                         getBlockHashes.Stop);
                     BlockChain.FindNextHashes(
                         getBlockHashes.Locator,
@@ -69,37 +68,34 @@ namespace Libplanet.Net
                         Identity = getBlockHashes.Identity,
                     };
 
-                    await Transport.ReplyMessageAsync(reply, default);
-                    break;
+                    return Transport.ReplyMessageAsync(reply, default);
                 }
 
                 case GetBlocksMsg getBlocks:
-                    await TransferBlocksAsync(getBlocks);
-                    break;
+                    return TransferBlocksAsync(getBlocks);
 
                 case GetTxsMsg getTxs:
-                    await TransferTxsAsync(getTxs);
-                    break;
+                    return TransferTxsAsync(getTxs);
 
                 case TxIdsMsg txIds:
-                    await Transport.ReplyMessageAsync(
-                        new PongMsg { Identity = txIds.Identity },
-                        default);
                     ProcessTxIds(txIds);
-                    break;
+                    return Transport.ReplyMessageAsync(
+                        new PongMsg { Identity = txIds.Identity },
+                        default
+                    );
 
                 case BlockHashesMsg _:
                     _logger.Error(
                         "{MessageType} messages are only for IBD.",
-                        nameof(Messages.BlockHashesMsg));
-                    break;
+                        nameof(BlockHashesMsg));
+                    return Task.CompletedTask;
 
                 case BlockHeaderMsg blockHeader:
-                    await Transport.ReplyMessageAsync(
-                        new PongMsg { Identity = blockHeader.Identity },
-                        default);
                     ProcessBlockHeader(blockHeader);
-                    break;
+                    return Transport.ReplyMessageAsync(
+                        new PongMsg { Identity = blockHeader.Identity },
+                        default
+                    );
 
                 default:
                     throw new InvalidMessageException(

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -779,7 +779,7 @@ namespace Libplanet.Net
                 request,
                 timeout: transportTimeout,
                 cancellationToken: cancellationToken
-            );
+            ).ConfigureAwait(false);
 
             if (parsedMessage is BlockHashesMsg blockHashes)
             {
@@ -850,7 +850,7 @@ namespace Libplanet.Net
                 ((hashCount - 1) / request.ChunkSize) + 1,
                 false,
                 cancellationToken
-            );
+            ).ConfigureAwait(false);
 
             _logger.Debug("Received replies from {Peer}.", peer);
             int count = 0;
@@ -859,7 +859,7 @@ namespace Libplanet.Net
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (message is Messages.BlocksMsg blockMessage)
+                if (message is BlocksMsg blockMessage)
                 {
                     IList<byte[]> payloads = blockMessage.Payloads;
                     _logger.Debug(
@@ -915,7 +915,7 @@ namespace Libplanet.Net
                 txCount,
                 true,
                 cancellationToken
-            );
+            ).ConfigureAwait(false);
 
             foreach (Message message in replies)
             {

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -281,13 +281,11 @@ namespace Libplanet.Net.Transports
             _router.ReceiveReady += ReceiveMessage;
             _replyQueue.ReceiveReady += DoReply;
 
-            List<Task> tasks = new List<Task>();
-
-            tasks.Add(RunPoller(_routerPoller));
+            Task pollerTask = RunPoller(_routerPoller);
 
             Running = true;
 
-            await await Task.WhenAny(tasks);
+            await pollerTask;
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -358,7 +358,7 @@ namespace Libplanet.Net.Transports
                     timeout,
                     1,
                     false,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             Message reply = replies.First();
 
             return reply;

--- a/Libplanet.Net/TxCompletion.cs
+++ b/Libplanet.Net/TxCompletion.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -21,6 +23,7 @@ namespace Libplanet.Net
         private readonly TxFetcher _txFetcher;
         private readonly TxBroadcaster _txBroadcaster;
         private readonly ILogger _logger;
+        private readonly ConcurrentDictionary<TPeer, TxFetchJob> _txFetchJobs;
 
         private bool _disposed;
 
@@ -33,6 +36,7 @@ namespace Libplanet.Net
             _blockChain = blockChain;
             _txFetcher = txFetcher;
             _txBroadcaster = txBroadcaster;
+            _txFetchJobs = new ConcurrentDictionary<TPeer, TxFetchJob>();
             TxReceived = new AsyncAutoResetEvent();
 
             _logger = Log
@@ -82,57 +86,46 @@ namespace Libplanet.Net
                 required.Count
             );
 
-            // spawn task.
-            _ = RequestTxsFromPeerAsync(peer, required, _cancellationTokenSource.Token);
+            do
+            {
+                TxFetchJob txFetchJob = _txFetchJobs.GetOrAdd(
+                    peer,
+                    peerAsKey => TxFetchJob.RunAfter(
+                        peerAsKey,
+                        _txFetcher,
+                        TimeSpan.FromSeconds(1),
+                        (task) =>
+                        {
+                            if (task.IsCompleted &&
+                                !task.IsFaulted &&
+                                !task.IsCanceled &&
+                                task.Result is ISet<Transaction<TAction>> txs)
+                            {
+                                ProcessFetchedTxIds(txs, peerAsKey);
+                            }
+
+                            _txFetchJobs.TryRemove(peer, out _);
+                        },
+                        _cancellationTokenSource.Token
+                    )
+                );
+
+                if (txFetchJob.TryAdd(required, out HashSet<TxId> rest))
+                {
+                    break;
+                }
+
+                required = rest;
+                _txFetchJobs.TryRemove(peer, out _);
+            }
+            while (true);
         }
 
-        private HashSet<TxId> GetRequiredTxIds(IEnumerable<TxId> ids)
-        {
-            return new HashSet<TxId>(ids
-                .Where(txId =>
-                    !_blockChain.StagePolicy.Ignores(_blockChain, txId)
-                        && _blockChain.StagePolicy.Get(_blockChain, txId, filtered: false) is null
-                        && _blockChain.Store.GetTransaction<TAction>(txId) is null));
-        }
-
-        private async Task RequestTxsFromPeerAsync(
-            TPeer peer,
-            HashSet<TxId> txIds,
-            CancellationToken cancellationToken)
+        private void ProcessFetchedTxIds(ISet<Transaction<TAction>> txs, TPeer peer)
         {
             try
             {
-                const string log =
-                    "Starting RequestTxsFromPeerAsync from {Peer}. " +
-                    "(_requiredTxIds count: {Count})";
-                _logger.Debug(log, peer, txIds.Count);
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    throw new TaskCanceledException();
-                }
-
-                _logger.Debug(
-                    "Start to run _txFetcher from {Peer}. (count: {Count})",
-                    peer,
-                    txIds.Count);
-                var stopWatch = new Stopwatch();
-                stopWatch.Start();
-                var txs = new HashSet<Transaction<TAction>>(
-                    await _txFetcher(
-                            peer,
-                            txIds,
-                            cancellationToken)
-                        .ToListAsync(cancellationToken)
-                        .AsTask());
-                _logger.Debug(
-                    "End of _txFetcher from {Peer}. (received: {Count}); " +
-                    "Time taken: {Elapsed}",
-                    peer,
-                    txs.Count,
-                    stopWatch.Elapsed);
-
-                txs = new HashSet<Transaction<TAction>>(
+                var validTxs = new HashSet<Transaction<TAction>>(
                     txs.Where(
                         tx =>
                         {
@@ -158,7 +151,7 @@ namespace Libplanet.Net
                         }));
 
                 var stagedTxs = new List<Transaction<TAction>>();
-                foreach (var tx in txs)
+                foreach (var tx in validTxs)
                 {
                     try
                     {
@@ -176,10 +169,7 @@ namespace Libplanet.Net
                 }
 
                 // To maintain the consistency of the unit tests.
-                if (txs.Any())
-                {
-                    TxReceived.Set();
-                }
+                TxReceived.Set();
 
                 if (stagedTxs.Any())
                 {
@@ -194,9 +184,10 @@ namespace Libplanet.Net
                 else
                 {
                     _logger.Information(
-                        "Failed to get {TxIdCount} transactions from {Peer}.",
-                        txIds.Count,
-                        peer);
+                        "No transaction has been staged among received {TxCount} from {Peer}.",
+                        txs.Count,
+                        peer
+                    );
                 }
             }
             catch (Exception e)
@@ -204,7 +195,7 @@ namespace Libplanet.Net
                 _logger.Error(
                     e,
                     "An error occurred during {FName} from {Peer}.",
-                    nameof(RequestTxsFromPeerAsync),
+                    nameof(ProcessFetchedTxIds),
                     peer);
                 throw;
             }
@@ -212,8 +203,150 @@ namespace Libplanet.Net
             {
                 _logger.Debug(
                     "End of {FName} from {Peer}.",
-                    nameof(RequestTxsFromPeerAsync),
+                    nameof(ProcessFetchedTxIds),
                     peer);
+            }
+        }
+
+        private HashSet<TxId> GetRequiredTxIds(IEnumerable<TxId> ids)
+        {
+            return new HashSet<TxId>(ids
+                .Where(txId =>
+                    !_blockChain.StagePolicy.Ignores(_blockChain, txId)
+                        && _blockChain.StagePolicy.Get(_blockChain, txId, filtered: false) is null
+                        && _blockChain.Store.GetTransaction<TAction>(txId) is null));
+        }
+
+        private class TxFetchJob
+        {
+            private readonly TxFetcher _txFetcher;
+            private readonly Channel<TxId> _txIds;
+            private readonly TPeer _peer;
+            private readonly ILogger _logger;
+            private readonly ReaderWriterLockSlim _txIdsWriterLock;
+
+            private TxFetchJob(TxFetcher txFetcher, TPeer peer)
+            {
+                _txFetcher = txFetcher;
+                _peer = peer;
+                _txIds = Channel.CreateUnbounded<TxId>(
+                    new UnboundedChannelOptions
+                    {
+                        SingleReader = true,
+                    }
+                );
+                _txIdsWriterLock = new ReaderWriterLockSlim();
+
+                _logger = Log
+                    .ForContext<TxFetchJob>()
+                    .ForContext("Source", nameof(TxFetchJob));
+            }
+
+            public static TxFetchJob RunAfter(
+                TPeer peer,
+                TxFetcher txFetcher,
+                TimeSpan waitFor,
+                Action<Task<ISet<Transaction<TAction>>>> continuation,
+                CancellationToken cancellationToken)
+            {
+                var task = new TxFetchJob(txFetcher, peer);
+                _ = task.RequestAsync(waitFor, cancellationToken).ContinueWith(continuation);
+                return task;
+            }
+
+            public bool TryAdd(IEnumerable<TxId> txIds, out HashSet<TxId> rest)
+            {
+                rest = new HashSet<TxId>(txIds);
+                _txIdsWriterLock.EnterReadLock();
+                try
+                {
+                    foreach (TxId txId in txIds)
+                    {
+                        _txIds.Writer.WriteAsync(txId);
+                        rest.Remove(txId);
+                    }
+
+                    return true;
+                }
+                catch (ChannelClosedException)
+                {
+                    return false;
+                }
+                finally
+                {
+                    _txIdsWriterLock.ExitReadLock();
+                }
+            }
+
+            private async Task<ISet<Transaction<TAction>>> RequestAsync(
+                TimeSpan waitFor,
+                CancellationToken cancellationToken
+            )
+            {
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(waitFor);
+                    _txIdsWriterLock.EnterWriteLock();
+                    try
+                    {
+                        _txIds.Writer.TryComplete();
+                    }
+                    finally
+                    {
+                        _txIdsWriterLock.ExitWriteLock();
+                    }
+                });
+
+                try
+                {
+                    var txIds = new HashSet<TxId>();
+
+                    while (await _txIds.Reader.WaitToReadAsync(cancellationToken))
+                    {
+                        while (_txIds.Reader.TryRead(out TxId txId))
+                        {
+                            txIds.Add(txId);
+                        }
+                    }
+
+                    _logger.Debug(
+                        "Start to run _txFetcher from {Peer}. (count: {Count})",
+                        _peer,
+                        txIds.Count);
+                    var stopWatch = new Stopwatch();
+                    stopWatch.Start();
+                    var txs = new HashSet<Transaction<TAction>>(
+                        await _txFetcher(
+                                _peer,
+                                txIds,
+                                cancellationToken)
+                            .ToListAsync(cancellationToken)
+                            .AsTask());
+                    _logger.Debug(
+                        "End of _txFetcher from {Peer}. (received: {Count}); " +
+                        "Time taken: {Elapsed}",
+                        _peer,
+                        txs.Count,
+                        stopWatch.Elapsed);
+
+                    return txs;
+                }
+                catch (Exception e)
+                {
+                    _logger.Error(
+                        e,
+                        "An error occurred during {FName} from {Peer}.",
+                        nameof(RequestAsync),
+                        _peer);
+                    throw;
+                }
+                finally
+                {
+                    _logger.Debug(
+                        "End of {FName} from {Peer}.",
+                        nameof(RequestAsync),
+                        _peer);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adjusts codes on `NetMQTransport`, `Swarm<T>`, and `TxCompletion<T>` to improve network throughput and latency.

- `TxCompletion<T>` now becomes to wait and buffer per node, for new requests.
- `NetMQTransport` now becomes to skip intermediates `Task` creations when not unnecessary.
- `NetMQTransport.ReplyMessageAsync()` now becomes to return `Task.CompletedTask` immediately after queuing.
- router socket in `NetMQTransport` now became to perform batch processing for `ReceiveMessage()` handler.
- `.ProcessRuntime()` now become to go ahead for each `.ProcessRequest()` instead of `await`.