### PR TITLE
Fix benchmark script error

### DIFF
--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -78,4 +78,4 @@ jobs:
 #        auto-push: true
 
     - name: Copy benchmark results to cache
-      run: cp BenchmarkDotNet.Artifacts/results/*-full-compressed.json ./cache
+      run: rm -rf ./cache && cp -R BenchmarkDotNet.Artifacts/results ./cache


### PR DESCRIPTION
I thought `./cache` already existed but not...