### PR TITLE
ci(gh-actions): update actions used node12

### DIFF
--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on:
       labels: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - name: Download previous benchmark data

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -17,10 +17,10 @@ jobs:
         - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.pull_request.head.sha }}
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - name: Download previous benchmark data

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         fi
       env:
         WEB_FLOW_KEY_URL: https://github.com/web-flow.gpg
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - uses: actions/setup-node@v1

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -22,7 +22,7 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - run: 'hooks/pre-commit'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         ref: ${{ github.pull_request.head.sha }}
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - run: dotnet build -p:SkipSonar=true

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -8,7 +8,7 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME  }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: login
         run: |
           docker login \

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         token: ${{ secrets.AUTO_REBASE_TOKEN }}


### PR DESCRIPTION
While running GitHub Actions jobs, you can see alerts like the below screenshot.

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/26626194/207561879-022c4972-99dc-404e-873c-138115a35207.png">

Nodejs 12 became out of support in April 2022 and the GitHub Actions team is planning to migrate all actions to Nodejs 16 environment.

See also https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/