### PR TITLE
Changed `NewHeight()` behavior

### DIFF
--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -159,15 +159,11 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Starts a consensus for a block of index <paramref name="height"/>.
+        /// Starts a new <see cref="Context{T}"/> for given <paramref name="height"/>.
         /// </summary>
-        /// <param name="height">The height of new consensus process. this should be increasing
-        /// monotonically by 1.
-        /// </param>
+        /// <param name="height">The height of a new <see cref="Context{T}"/> to start.</param>
         /// <exception cref="InvalidHeightIncreasingException">Thrown if given
-        /// <paramref name="height"/> is not the same as the index of
-        /// <see cref="BlockChain{T}.Tip"/> + 1, or a context corresponding to
-        /// <paramref name="height"/> is already running.</exception>
+        /// <paramref name="height"/> is less than or equal to <see cref="Height"/>.</exception>
         /// <remarks>The method is also called when the tip of the <see cref="BlockChain{T}"/> is
         /// changed (i.e., committed, synchronized).
         /// </remarks>
@@ -183,21 +179,14 @@ namespace Libplanet.Net.Consensus
                     height,
                     Height);
 
-                if (height == Height)
+                if (height <= Height)
                 {
                     throw new InvalidHeightIncreasingException(
-                        $"Context of height #{height} is already running.");
-                }
-
-                if (height != _blockChain.Tip.Index + 1)
-                {
-                    throw new InvalidHeightIncreasingException(
-                        $"Given height #{height} must be equal to " +
-                        $"the tip's index #{_blockChain.Tip.Index} + 1.");
+                        $"Given new height #{height} must be greater than " +
+                        $"the current height #{Height}.");
                 }
 
                 BlockCommit? lastCommit = null;
-
                 lock (_contextLock)
                 {
                     lastCommit = _contexts.ContainsKey(height - 1)

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -295,7 +295,7 @@ namespace Libplanet.Net.Consensus
             {
                 _logger.Debug(
                     "Discarding a received message as its height #{MessageHeight} " +
-                    "is lower than the current context's height ${ContextHeight}",
+                    "is lower than the current context's height #{ContextHeight}",
                     height,
                     Height);
                 return false;

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -338,15 +338,15 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls the
-        /// <see cref="NewHeight"/>. Starting a new height will be delayed for
-        /// <see cref="_newHeightDelay"/> to collecting remaining votes and stabilize the
-        /// consensus process by waiting for Global Stabilization Time.
+        /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls
+        /// <see cref="NewHeight"/>.  Starting a new height will be delayed for
+        /// <see cref="_newHeightDelay"/> in order to collect remaining delayed votes
+        /// and stabilize the consensus process by waiting for Global Stabilization Time.
         /// </summary>
-        /// <param name="sender">the object instance for <see cref="EventHandler"/>.
+        /// <param name="sender">The source object instance for <see cref="EventHandler"/>.
         /// </param>
-        /// <param name="e">the tuple of <see cref="Block{T}"/>s that are OldTip and NewTip
-        /// respectively.
+        /// <param name="e">The event arguments given by <see cref="BlockChain{T}.TipChanged"/>
+        /// as a tuple of the old tip and the new tip.
         /// </param>
         private void OnBlockChainTipChanged(object? sender, (Block<T> OldTip, Block<T> NewTip) e)
         {


### PR DESCRIPTION
Due to asynchronous nature between `BlockChain<T>` and `ConsensusContext`, `ConsensusContext.Height` cannot be guaranteed to be `BlockChain<T>.Tip.Index` + 1. Although seemingly a good practice for being defensive, this makes it harder to keep `ConsensusContext`'s state consistent as state transitions are generally triggered by an `event` while trying to rely on independently and continuously changing state of the `BlockChain<T>` that `ConsensusContext` relies on. In any case, `NewHeight()` is too dangerous of a method to be `public`.