### PR TITLE
Load block action from delegator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ To be released.
  -  (Libplanet.Explorer) Added `actionsLogsList` field to `TxResultType`.
     [[#2474], [#2505]]
  -  Added `PolicyBlockActionGetter` delegator type.  [[#2646]]
+ -  Added `IActionTypeLoader.LoadAllActionTypes()` method.  [[#2646]]
+     -  Added `StaticActionTypeLoader.LoadAllActionTypes()` method.
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ To be released.
     [[#2474], [#2505]]
  -  Added `actionsLogsList` parameter to `TxFailure` constructor.
     [[#2474], [#2505]]
+ -  Replaced `IAction?`-typed `policyBlockAction` parameter with
+    `PolicyBlockActionGetter`-typed `policyBlockActionGetter` parameter
+    in `ActionEvaluator` constructor.  [[#2646]]
 
 ### Backward-incompatible network protocol changes
 
@@ -31,6 +34,7 @@ To be released.
     [[#2474], [#2505]]
  -  (Libplanet.Explorer) Added `actionsLogsList` field to `TxResultType`.
     [[#2474], [#2505]]
+ -  Added `PolicyBlockActionGetter` delegator type.  [[#2646]]
 
 ### Behavioral changes
 
@@ -44,6 +48,7 @@ To be released.
 [#2505]: https://github.com/planetarium/libplanet/pull/2505
 [#2609]: https://github.com/planetarium/libplanet/pull/2609
 [#2619]: https://github.com/planetarium/libplanet/pull/2619
+[#2646]: https://github.com/planetarium/libplanet/pull/2646
 
 
 Version 0.45.0

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Tests.Action
                 noStateRootBlock.Evaluate(GenesisMiner, null, _ => true, stateStore);
             var actionEvaluator =
                 new ActionEvaluator<RandomAction>(
-                    policyBlockAction: null,
+                    policyBlockActionGetter: _ => null,
                     blockChainStates: NullChainStates<RandomAction>.Instance,
                     trieGetter: null,
                     genesisHash: null,
@@ -302,7 +302,7 @@ namespace Libplanet.Tests.Action
             };
             Block<DumbAction> genesis = MineGenesisBlock<DumbAction>(TestUtils.GenesisMiner);
             ActionEvaluator<DumbAction> actionEvaluator = new ActionEvaluator<DumbAction>(
-                policyBlockAction: null,
+                policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates<DumbAction>.Instance,
                 trieGetter: null,
                 genesisHash: null,
@@ -595,7 +595,7 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent<DumbAction>.DeriveTxHash(txs)),
                 transactions: txs).Mine();
             var actionEvaluator = new ActionEvaluator<DumbAction>(
-                policyBlockAction: null,
+                policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates<DumbAction>.Instance,
                 trieGetter: null,
                 genesisHash: tx.GenesisHash,
@@ -728,7 +728,7 @@ namespace Libplanet.Tests.Action
             var txs = new Transaction<ThrowException>[] { tx };
             var hash = new BlockHash(GetRandomBytes(32));
             var actionEvaluator = new ActionEvaluator<ThrowException>(
-                policyBlockAction: null,
+                policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates<ThrowException>.Instance,
                 trieGetter: null,
                 genesisHash: tx.GenesisHash,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1816,7 +1816,7 @@ namespace Libplanet.Tests.Blockchain
                 renderers: renderer is null ? null : new[] { renderer },
                 blockChainStates: chainStates,
                 actionEvaluator: new ActionEvaluator<DumbAction>(
-                    blockPolicy.BlockAction,
+                    _ => blockPolicy.BlockAction,
                     chainStates,
                     trieGetter: hash => stateStore.GetStateRoot(
                         store.GetBlockDigest(hash)?.StateRootHash

--- a/Libplanet/Action/IActionTypeLoader.cs
+++ b/Libplanet/Action/IActionTypeLoader.cs
@@ -16,5 +16,14 @@ namespace Libplanet.Action
         /// use.</param>
         /// <returns>A dictionary made of action id to action type pairs.</returns>
         public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader);
+
+        /// <summary>
+        /// Load action types branched by <paramref name="blockHeader"/>.
+        /// </summary>
+        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
+        /// use.</param>
+        /// <returns>Types of available actions. It also includes actions not having
+        /// <see cref="ActionTypeAttribute"/>.</returns>
+        public IEnumerable<Type> LoadAllActionTypes(IPreEvaluationBlockHeader blockHeader);
     }
 }

--- a/Libplanet/Action/PolicyBlockActionGetter.cs
+++ b/Libplanet/Action/PolicyBlockActionGetter.cs
@@ -1,0 +1,6 @@
+using Libplanet.Blocks;
+
+namespace Libplanet.Action
+{
+    public delegate IAction? PolicyBlockActionGetter(IPreEvaluationBlockHeader blockHeader);
+}

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -37,42 +37,62 @@ namespace Libplanet.Action
         /// <returns>A dictionary made of action id to action type pairs.</returns>
         public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader) => Load();
 
+        /// <summary>
+        /// Load all action types from assemblies.
+        /// </summary>
+        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
+        /// use. But it isn't used in this implementation.</param>
+        /// <returns>A dictionary made of action id to action type pairs.</returns>
+        public IEnumerable<Type> LoadAllActionTypes(IPreEvaluationBlockHeader blockHeader)
+            => LoadAllActionTypesImpl(_assembliesSet);
+
         internal IDictionary<string, Type> Load() =>
             _types ??= LoadImpl(_assembliesSet, _baseType);
+
+        private static IEnumerable<Type> LoadAllActionTypesImpl(IEnumerable<Assembly> assembliesSet)
+        {
+            var actionType = typeof(IAction);
+            foreach (Assembly asm in assembliesSet)
+            {
+                foreach (Type t in asm.GetTypes())
+                {
+                    if (actionType.IsAssignableFrom(t))
+                    {
+                        yield return t;
+                    }
+                }
+            }
+        }
 
         private static IDictionary<string, Type> LoadImpl(
             IEnumerable<Assembly> assembliesSet, Type? baseType = null)
         {
             var types = new Dictionary<string, Type>();
             var actionType = typeof(IAction);
-            foreach (Assembly asm in assembliesSet)
+            foreach (Type t in LoadAllActionTypesImpl(assembliesSet))
             {
-                foreach (Type t in asm.GetTypes())
+                if (baseType is { } bt && !bt.IsAssignableFrom(t))
                 {
-                    if (baseType is { } bt && !bt.IsAssignableFrom(t))
+                    continue;
+                }
+
+                if (ActionTypeAttribute.ValueOf(t) is string actionId)
+                {
+                    if (types.TryGetValue(actionId, out Type? existing))
                     {
+                        if (existing != t)
+                        {
+                            throw new DuplicateActionTypeIdentifierException(
+                                "Multiple action types are associated with the same type ID.",
+                                actionId,
+                                ImmutableHashSet.Create(existing, t)
+                            );
+                        }
+
                         continue;
                     }
 
-                    if (actionType.IsAssignableFrom(t) &&
-                        ActionTypeAttribute.ValueOf(t) is string actionId)
-                    {
-                        if (types.TryGetValue(actionId, out Type? existing))
-                        {
-                            if (existing != t)
-                            {
-                                throw new DuplicateActionTypeIdentifierException(
-                                    "Multiple action types are associated with the same type ID.",
-                                    actionId,
-                                    ImmutableHashSet.Create(existing, t)
-                                );
-                            }
-
-                            continue;
-                        }
-
-                        types[actionId] = t;
-                    }
+                    types[actionId] = t;
                 }
             }
 

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Action
         }
 
         /// <summary>
-        /// Load action types from assemblies.
+        /// Load action types inherited the base type given in the constructor from assemblies.
         /// </summary>
         /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
         /// use. But it isn't used in this implementation.</param>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -130,7 +130,7 @@ namespace Libplanet.Blockchain
                 renderers,
                 blockChainStates,
                 new ActionEvaluator<T>(
-                    policy.BlockAction,
+                    _ => policy.BlockAction,
                     blockChainStates: blockChainStates,
                     trieGetter: hash => stateStore.GetStateRoot(
                         store.GetBlockDigest(hash)?.StateRootHash

--- a/Libplanet/Blocks/PreEvaluationBlock.cs
+++ b/Libplanet/Blocks/PreEvaluationBlock.cs
@@ -263,7 +263,7 @@ namespace Libplanet.Blocks
             }
 
             var actionEvaluator = new ActionEvaluator<T>(
-                blockAction,
+                _ => blockAction,
                 blockChainStates: NullChainStates<T>.Instance,
                 trieGetter: null,
                 genesisHash: null,


### PR DESCRIPTION
This pull request makes `ActionEvaluator` receive `PolicyBlockActionGetter policyBlockActionGetter` instead of `IAction? policyBlockAction` and use loaded block action from the `policyBlockActionGetter`. Also, this pull request introduces `IActionTypeLoader.LoadAllActionTypes()`, a method to load all available action types by the block header. Its difference between itself and `IActionTypeLoader.Load()` method, is that it includes all actions even if it doesn't have `ActionTypeAttribute`. In other words, it includes non-polymorphic-actions too.

## Reviewers

- @longfin : the proposer and designer of the `IActionTypeLoader` design. You can see the usage in https://github.com/planetarium/NineChronicles.Headless/pull/1774.