### PR TITLE
♻️ Removed `ConsensusContext<T>.Commit()`

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
@@ -108,7 +109,110 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task ThrowInvalidProposer()
+        public async Task CanAcceptMessagesAfterCommitFailure()
+        {
+            Codec codec = new Codec();
+            var stepChangedToPreVote = new AsyncAutoResetEvent();
+            ConsensusProposalMsg? proposal = null;
+            var proposalSent = new AsyncAutoResetEvent();
+            Block<DumbAction>? proposedBlock = null;
+            var stepChangedToEndCommit = new AsyncAutoResetEvent();
+            var exceptionOccurred = new AsyncAutoResetEvent();
+            Exception? exceptionThrown = null;
+
+            var (blockChain, context) = TestUtils.CreateDummyContext(
+                height: 2,
+                privateKey: TestUtils.PrivateKeys[2]);
+
+            // Add block #1 so we can start with a last commit for height 2.
+            Block<DumbAction> heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+            blockChain.Append(heightOneBlock, TestUtils.CreateBlockCommit(heightOneBlock));
+            var lastCommit = TestUtils.CreateBlockCommit(heightOneBlock);
+
+            context.StateChanged += (_, eventArgs) =>
+            {
+                if (eventArgs.Step == Step.PreVote)
+                {
+                    stepChangedToPreVote.Set();
+                }
+                else if (eventArgs.Step == Step.EndCommit)
+                {
+                    stepChangedToEndCommit.Set();
+                }
+            };
+            context.MessageBroadcasted += (_, message) =>
+            {
+                if (message is ConsensusProposalMsg proposalMsg)
+                {
+                    proposal = proposalMsg;
+                    proposedBlock = BlockMarshaler.UnmarshalBlock<DumbAction>(
+                        (Dictionary)codec.Decode(proposalMsg!.Proposal.MarshaledBlock));
+                    proposalSent.Set();
+                }
+            };
+            context.ExceptionOccurred += (_, exception) =>
+            {
+                exceptionThrown = exception;
+                exceptionOccurred.Set();
+            };
+
+            context.Start(lastCommit);
+
+            await Task.WhenAll(stepChangedToPreVote.WaitAsync(), proposalSent.WaitAsync());
+
+            // Simulate bypass of context and block sync by swarm by
+            // directly appending to the blockchain.
+            Assert.NotNull(proposedBlock);
+            blockChain.Append(proposedBlock!, TestUtils.CreateBlockCommit(proposedBlock!));
+            Assert.Equal(2, blockChain.Tip.Index);
+
+            // Make PreVotes to normally move to PreCommit step.
+            foreach (int i in new int[] { 0, 1, 3 })
+            {
+                context.ProduceMessage(new ConsensusPreVoteMsg(new VoteMetadata(
+                    2,
+                    0,
+                    proposedBlock!.Hash,
+                    DateTimeOffset.UtcNow,
+                    TestUtils.PrivateKeys[i].PublicKey,
+                    VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[i])));
+            }
+
+            // Validator 2 will automatically vote its PreCommit.
+            foreach (int i in new int[] { 0, 1 })
+            {
+                context.ProduceMessage(new ConsensusPreCommitMsg(new VoteMetadata(
+                    2,
+                    0,
+                    proposedBlock!.Hash,
+                    DateTimeOffset.UtcNow,
+                    TestUtils.PrivateKeys[i].PublicKey,
+                    VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i])));
+            }
+
+            await Task.WhenAll(stepChangedToEndCommit.WaitAsync(), exceptionOccurred.WaitAsync());
+            Assert.IsType<InvalidBlockIndexException>(exceptionThrown);
+
+            // Check context has only three votes.
+            BlockCommit? commit = context.GetBlockCommit();
+            Assert.Equal(3, commit?.Votes.Where(vote => vote.Flag == VoteFlag.PreCommit).Count());
+
+            // Context should still accept new votes.
+            context.ProduceMessage(new ConsensusPreCommitMsg(new VoteMetadata(
+                2,
+                0,
+                proposedBlock!.Hash,
+                DateTimeOffset.UtcNow,
+                TestUtils.PrivateKeys[3].PublicKey,
+                VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[3])));
+
+            await Task.Delay(100);  // Wait for the new message to be added to the message log.
+            commit = context.GetBlockCommit();
+            Assert.Equal(4, commit?.Votes.Where(vote => vote.Flag == VoteFlag.PreCommit).Count());
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task ThrowOnInvalidProposerMessage()
         {
             Exception? exceptionThrown = null;
             var exceptionOccurred = new AsyncAutoResetEvent();

--- a/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -42,6 +42,12 @@ namespace Libplanet.Net.Consensus
                 MessageConsumed?.Invoke(this, (context.Height, message));
             context.MutationConsumed += (sender, action) =>
                 MutationConsumed?.Invoke(this, (context.Height, action));
+
+            if (_bootstrapping)
+            {
+                context.StateChanged += (sender, eventArgs) =>
+                    OnContextStateChanged(sender, eventArgs);
+            }
         }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -238,24 +238,6 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Committing the block to the <see cref="BlockChain{T}"/> and saves
-        /// <see cref="BlockCommit"/> of currently committed height.
-        /// </summary>
-        /// <param name="block">A <see cref="Block{T}"/> to committing to the
-        /// <see cref="BlockChain{T}"/>.
-        /// </param>
-        /// <param name="commit">A <see cref="BlockCommit"/> created from committed height.
-        /// </param>
-        /// <remarks>the method is called when a block is voted by <see cref="Context{T}"/>
-        /// in <see cref="Libplanet.Net.Consensus.Step.EndCommit"/>.
-        /// </remarks>
-        public void Commit(Block<T> block, BlockCommit? commit)
-        {
-            _logger.Debug("Committing block #{Index} {Block}.", block.Index, block.Hash);
-            _blockChain.Append(block, commit);
-        }
-
-        /// <summary>
         /// <para>
         /// Handles a received <see cref="ConsensusMsg"/> by either dispatching it to the right
         /// <see cref="Context{T}"/> or discarding it.

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Net.Consensus
         /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
         /// </param>
         /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block. <seealso cref="OnBlockChainTipChanged"/>
+        /// block. <seealso cref="OnTipChanged"/>
         /// </param>
         /// <param name="getValidatorSet">The function determining the set of validators
         /// for a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s index.</param>
@@ -71,7 +71,7 @@ namespace Libplanet.Net.Consensus
             _contextTimeoutOption = contextTimeoutOption;
 
             _contexts = new Dictionary<long, Context<T>>();
-            _blockChain.TipChanged += OnBlockChainTipChanged;
+            _blockChain.TipChanged += OnTipChanged;
             _bootstrapping = true;
 
             _logger = Log
@@ -97,8 +97,8 @@ namespace Libplanet.Net.Consensus
         /// The index of block that <see cref="ConsensusContext{T}"/> is watching. The value can be
         /// changed by starting a consensus or appending a block.
         /// </summary>
-        /// <seealso cref="NewHeight"/>  <seealso cref="OnBlockChainTipChanged"/>
-        /// <returns>If <see cref="NewHeight"/> or <see cref="OnBlockChainTipChanged"/> is called
+        /// <seealso cref="NewHeight"/>  <seealso cref="OnTipChanged"/>
+        /// <returns>If <see cref="NewHeight"/> or <see cref="OnTipChanged"/> is called
         /// before, returns current working height, otherwise returns <c>-1</c>.</returns>
         public long Height { get; private set; }
 
@@ -155,7 +155,7 @@ namespace Libplanet.Net.Consensus
                 }
             }
 
-            _blockChain.TipChanged -= OnBlockChainTipChanged;
+            _blockChain.TipChanged -= OnTipChanged;
         }
 
         /// <summary>
@@ -251,7 +251,6 @@ namespace Libplanet.Net.Consensus
         /// </remarks>
         public void Commit(Block<T> block, BlockCommit? commit)
         {
-            _bootstrapping = false;
             _logger.Debug("Committing block #{Index} {Block}.", block.Index, block.Hash);
             _blockChain.Append(block, commit);
         }
@@ -327,6 +326,28 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
+        /// A handler to process <see cref="Context{T}.StateChanged"/> <see langword="event"/>s.
+        /// In particular, this watches for a successful state change into
+        /// <see cref="Step.EndCommit"/> for a <see cref="Context{T}"/> to turn off
+        /// bootstrapping.
+        /// </summary>
+        /// <param name="sender">The source object invoking the event.</param>
+        /// <param name="e">The event arguments given by the source object.</param>
+        /// <remarks>
+        /// This is conditionally attached to <see cref="Context{T}.StateChanged"/>
+        /// to reduce memory usage.
+        /// </remarks>
+        /// <seealso cref="AttachEventHandlers"/>
+        private void OnContextStateChanged(
+            object? sender, (int MessageLogSize, int Round, Step Step) e)
+        {
+            if (e.Step == Step.EndCommit)
+            {
+                _bootstrapping = false;
+            }
+        }
+
+        /// <summary>
         /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls
         /// <see cref="NewHeight"/>.  Starting a new height will be delayed for
         /// <see cref="_newHeightDelay"/> in order to collect remaining delayed votes
@@ -337,7 +358,7 @@ namespace Libplanet.Net.Consensus
         /// <param name="e">The event arguments given by <see cref="BlockChain{T}.TipChanged"/>
         /// as a tuple of the old tip and the new tip.
         /// </param>
-        private void OnBlockChainTipChanged(object? sender, (Block<T> OldTip, Block<T> NewTip) e)
+        private void OnTipChanged(object? sender, (Block<T> OldTip, Block<T> NewTip) e)
         {
             // TODO: Should set delay by using GST.
             _newHeightCts?.Cancel();

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -45,7 +45,7 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="seedPeers">A list of seed's <see cref="BoundPeer"/>.</param>
         /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block. <seealso cref="ConsensusContext{T}.OnBlockChainTipChanged"/>
+        /// block.
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>

--- a/Libplanet.Net/Consensus/ConsensusReactorOption.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactorOption.cs
@@ -38,7 +38,6 @@ namespace Libplanet.Net.Consensus
 
         /// <summary>
         /// A time delay in starting the consensus for the next height block.
-        /// <seealso cref="ConsensusContext{T}.OnBlockChainTipChanged"/>
         /// </summary>
         public TimeSpan TargetBlockInterval { get; set; }
 

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -172,10 +172,10 @@ namespace Libplanet.Net.Consensus
                     "({NextMessageLogSize}, {NextRound}, {NextStep})",
                     prevState.MessageLogSize,
                     prevState.Round,
-                    prevState.Step.ToString(),
+                    prevState.Step,
                     nextState.MessageLogSize,
                     nextState.Round,
-                    nextState.Step.ToString());
+                    nextState.Step);
                 StateChanged?.Invoke(
                     this, (nextState.MessageLogSize, nextState.Round, nextState.Step));
 

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -270,7 +270,12 @@ namespace Libplanet.Net.Consensus
 
                 try
                 {
-                    ConsensusContext.Commit(block4, GetBlockCommit());
+                    _logger.Debug(
+                        "Committing block #{Index} {Hash}. (context: {Context})",
+                        block4.Index,
+                        block4.Hash,
+                        ToString());
+                    _blockChain.Append(block4, GetBlockCommit());
                 }
                 catch (Exception e)
                 {

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -118,7 +118,7 @@ namespace Libplanet.Net.Consensus
         {
             if (Step == Step.Default || Step == Step.EndCommit)
             {
-                _logger.Debug("Operation will not run in {Step} step.", Step.ToString());
+                _logger.Debug("Operation will not run in {Step} step", Step);
                 return;
             }
 
@@ -253,7 +253,7 @@ namespace Libplanet.Net.Consensus
         {
             if (Step == Step.Default || Step == Step.EndCommit)
             {
-                _logger.Debug("Operation will not run in {Step} step.", Step.ToString());
+                _logger.Debug("Operation will not run in {Step} step", Step);
                 return;
             }
 
@@ -271,7 +271,7 @@ namespace Libplanet.Net.Consensus
                 try
                 {
                     _logger.Debug(
-                        "Committing block #{Index} {Hash}. (context: {Context})",
+                        "Committing block #{Index} {Hash} (context: {Context})",
                         block4.Index,
                         block4.Hash,
                         ToString());
@@ -281,18 +281,17 @@ namespace Libplanet.Net.Consensus
                 {
                     _logger.Debug(
                         e,
-                        "Failed to commit block #{Index} {Hash}. (context: {Context})",
+                        "Failed to commit block #{Index} {Hash}",
                         block4.Index,
-                        block4.Hash,
-                        ToString());
+                        block4.Hash);
                     ExceptionOccurred?.Invoke(this, e);
                     return;
                 }
 
                 _logger.Debug(
-                    "Committed block in round #{Round}. (context: {Context})",
-                    Round,
-                    ToString());
+                    "Committed block #{Index} {Hash}",
+                    block4.Index,
+                    block4.Hash);
                 return;
             }
 
@@ -353,7 +352,7 @@ namespace Libplanet.Net.Consensus
         {
             if (Step == Step.Default || Step == Step.EndCommit)
             {
-                _logger.Debug("Operation will not run in {Step} step.", Step.ToString());
+                _logger.Debug("Operation will not run in {Step} step", Step);
                 return;
             }
 


### PR DESCRIPTION
Closes #2643.