### PR TITLE
🔧 Faster `BlockCommit` cache management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,6 @@ Version PBFT
  -  Added `ContextTimeoutOption` class.  [[#PBFT]]
  -  Added `BlockMarshaler.UnmarshalBlockHash()` method. [[#PBFT]]
  -  Added `BlockChain<T>.GetBlockCommit()` method.  [[#PBFT]]
- -  Added `BlockChain<T>.CleanupBlockCommitStore()` method.  [[#PBFT]]
  -  Added `InvalidBlockCommitException` class.  [[#PBFT]]
  -  Added `BlockChain<T>.ValidateBlockCommit()` method  [[#PBFT]]
  -  (Libplanet.Net) Added `IReactor` interface.  [[#PBFT]]

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -567,6 +567,8 @@ namespace Libplanet.Net
                                         VerifiedBlockHash = deltaBlock.Hash,
                                     });
                             }
+
+                            workspace.CleanupBlockCommitStore(workspace.Tip.Index);
                         }
                         catch (Exception e)
                         {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1064,19 +1064,10 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.Store.PutBlockCommit(blockCommit1);
             _blockChain.Store.PutBlockCommit(blockCommit2);
             _blockChain.Store.PutBlockCommit(blockCommit3);
-            _blockChain.CleanupBlockCommitStore(blockCommit3.Height, 3);
+            _blockChain.CleanupBlockCommitStore(blockCommit3.Height);
 
             Assert.Null(_blockChain.Store.GetBlockCommit(blockCommit1.BlockHash));
             Assert.Null(_blockChain.Store.GetBlockCommit(blockCommit2.BlockHash));
-            Assert.Equal(blockCommit3, _blockChain.Store.GetBlockCommit(blockCommit3.BlockHash));
-
-            _blockChain.Store.PutBlockCommit(blockCommit1);
-            _blockChain.Store.PutBlockCommit(blockCommit2);
-            _blockChain.Store.PutBlockCommit(blockCommit3);
-            _blockChain.CleanupBlockCommitStore(blockCommit3.Height, 4);
-
-            Assert.Equal(blockCommit1, _blockChain.Store.GetBlockCommit(blockCommit1.BlockHash));
-            Assert.Equal(blockCommit2, _blockChain.Store.GetBlockCommit(blockCommit2.BlockHash));
             Assert.Equal(blockCommit3, _blockChain.Store.GetBlockCommit(blockCommit3.BlockHash));
         }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1330,7 +1330,11 @@ namespace Libplanet.Blockchain
                     if (block.Index != 0 && blockCommit is { })
                     {
                         Store.PutBlockCommit(blockCommit);
-                        CleanupBlockCommitStore(blockCommit.Height);
+                    }
+
+                    if (block.PreviousHash is { } prevHash)
+                    {
+                        Store.DeleteBlockCommit(prevHash);
                     }
                 }
                 finally

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1558,22 +1558,13 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Clean up <see cref="BlockCommit"/>s in the store. The <paramref name="limit"/> height
-        /// of <see cref="BlockCommit"/> will not be removed. If the stored
-        /// <see cref="BlockCommit"/> count is not over <paramref name="maxCacheSize"/>, the removal
-        /// is skipped.
+        /// Cleans up every <see cref="BlockCommit"/> in the store with
+        /// <see cref="BlockCommit.Height"/> less than <paramref name="limit"/>.
         /// </summary>
         /// <param name="limit">A exceptional index that is not to be removed.</param>
-        /// <param name="maxCacheSize">A maximum count value of <see cref="BlockCommit"/> cache.
-        /// </param>
-        internal void CleanupBlockCommitStore(long limit, long maxCacheSize = 30)
+        internal void CleanupBlockCommitStore(long limit)
         {
             List<BlockHash> hashes = Store.GetBlockCommitHashes().ToList();
-
-            if (hashes.Count < maxCacheSize)
-            {
-                return;
-            }
 
             _logger.Debug("Removing old BlockCommits with heights lower than {Limit}...", limit);
             foreach (var hash in hashes)


### PR DESCRIPTION
Closes #2650.

We probably need a better fix. 😥

The problem was during preloading, a large number of `BlockCommit`s are downloaded and stored in `IStore` temporarily. This was causing trouble as iterating over all stored `BlockCommit`s was taking way too long. This changes the behavior of `BlockChain<T>.Append()` so that only the `BlockCommit` that the `BlockChain<T>` **immediately knows** that is no longer required is removed instead of iterating over all `BlockCommit`s. However, this leaves a potential loophole where `IStore` can be populated with unnecessary `BlockCommit`s.