### PR TITLE
Introduce `IActionTypeLoaderContext`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,11 @@ To be released.
     in `ActionEvaluator` constructor.  [[#2646]]
  -  Removed `IStore.GetCanonicalGenesisBlock<T>()` interface method and all its
     implementations.  [[#2664]]
-
+ -  Replaced `IPreEvaluationBlockHeader`-typed `blockHeader` parameter with
+    `IActionTypeLoaderContext`-typed `context` parameter in the below methods.
+    [[#2653]]
+     - `IActionTypeLoader.Load()`.
+     - `IActionTypeLoader.LoadAllActionTypes()`.
 
 ### Backward-incompatible network protocol changes
 
@@ -40,6 +44,7 @@ To be released.
  -  Added `PolicyBlockActionGetter` delegator type.  [[#2646]]
  -  Added `IActionTypeLoader.LoadAllActionTypes()` method.  [[#2646]]
      -  Added `StaticActionTypeLoader.LoadAllActionTypes()` method.
+ -  Added `IActionTypeLoaderContext` interface.  [[#2653]]
 
 ### Behavioral changes
 
@@ -54,6 +59,7 @@ To be released.
 [#2609]: https://github.com/planetarium/libplanet/pull/2609
 [#2619]: https://github.com/planetarium/libplanet/pull/2619
 [#2646]: https://github.com/planetarium/libplanet/pull/2646
+[#2653]: https://github.com/planetarium/libplanet/pull/2653
 [#2664]: https://github.com/planetarium/libplanet/pull/2664
 
 

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -586,7 +586,8 @@ namespace Libplanet.Action
             ITrie? previousBlockStatesTrie = null)
         {
             IAction? systemAction = CreateSystemAction(tx);
-            IEnumerable<IAction> customActions = CreateCustomActions(blockHeader, tx);
+            IEnumerable<IAction> customActions = CreateCustomActions(
+                ActionTypeLoaderContext.From(blockHeader), tx);
 
             ImmutableList<IAction> actions = systemAction is { }
                 ? ImmutableList.Create(systemAction)
@@ -775,13 +776,13 @@ namespace Libplanet.Action
         }
 
         private IEnumerable<IAction> CreateCustomActions(
-            IPreEvaluationBlockHeader blockHeader,
+            IActionTypeLoaderContext actionTypeLoaderContext,
             ITransaction tx
         )
         {
             if (tx.CustomActions is { } customActions)
             {
-                IDictionary<string, Type> types = _actionTypeLoader.Load(blockHeader);
+                IDictionary<string, Type> types = _actionTypeLoader.Load(actionTypeLoaderContext);
 
                 foreach (IValue rawAction in customActions)
                 {

--- a/Libplanet/Action/ActionTypeLoaderContext.cs
+++ b/Libplanet/Action/ActionTypeLoaderContext.cs
@@ -1,0 +1,24 @@
+using Libplanet.Blocks;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// An <see cref="IActionTypeLoaderContext" /> implementation.
+    /// </summary>
+    internal class ActionTypeLoaderContext : IActionTypeLoaderContext
+    {
+        public ActionTypeLoaderContext(long index)
+        {
+            Index = index;
+        }
+
+        /// <inheritdoc />
+        public long Index { get; }
+
+        internal static ActionTypeLoaderContext From(
+            IPreEvaluationBlockHeader blockHeader)
+        {
+            return new ActionTypeLoaderContext(blockHeader.Index);
+        }
+    }
+}

--- a/Libplanet/Action/IActionTypeLoader.cs
+++ b/Libplanet/Action/IActionTypeLoader.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Libplanet.Blocks;
 
 namespace Libplanet.Action
 {
@@ -10,20 +9,20 @@ namespace Libplanet.Action
     public interface IActionTypeLoader
     {
         /// <summary>
-        /// Load action types branched by <paramref name="blockHeader"/>.
+        /// Load action types branched by <paramref name="context"/>.
         /// </summary>
-        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
-        /// use.</param>
+        /// <param name="context">A <see cref="IActionTypeLoaderContext"/> to determine
+        /// what action types to use.</param>
         /// <returns>A dictionary made of action id to action type pairs.</returns>
-        public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader);
+        public IDictionary<string, Type> Load(IActionTypeLoaderContext context);
 
         /// <summary>
-        /// Load action types branched by <paramref name="blockHeader"/>.
+        /// Load action types branched by <paramref name="context"/>.
         /// </summary>
-        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
-        /// use.</param>
+        /// <param name="context">A <see cref="IActionTypeLoader"/> to determine
+        /// what action types to use.</param>
         /// <returns>Types of available actions. It also includes actions not having
         /// <see cref="ActionTypeAttribute"/>.</returns>
-        public IEnumerable<Type> LoadAllActionTypes(IPreEvaluationBlockHeader blockHeader);
+        public IEnumerable<Type> LoadAllActionTypes(IActionTypeLoaderContext context);
     }
 }

--- a/Libplanet/Action/IActionTypeLoaderContext.cs
+++ b/Libplanet/Action/IActionTypeLoaderContext.cs
@@ -1,0 +1,13 @@
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// An interface to provide contextual variables to load action types.
+    /// </summary>
+    public interface IActionTypeLoaderContext
+    {
+        /// <summary>
+        /// A block index.
+        /// </summary>
+        long Index { get; }
+    }
+}

--- a/Libplanet/Action/StaticActionTypeLoader.cs
+++ b/Libplanet/Action/StaticActionTypeLoader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
-using Libplanet.Blocks;
 
 namespace Libplanet.Action
 {
@@ -32,18 +31,18 @@ namespace Libplanet.Action
         /// <summary>
         /// Load action types inherited the base type given in the constructor from assemblies.
         /// </summary>
-        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
-        /// use. But it isn't used in this implementation.</param>
+        /// <param name="context">A <see cref="IActionTypeLoaderContext"/> to determine
+        /// what action types to use. But it isn't used in this implementation.</param>
         /// <returns>A dictionary made of action id to action type pairs.</returns>
-        public IDictionary<string, Type> Load(IPreEvaluationBlockHeader blockHeader) => Load();
+        public IDictionary<string, Type> Load(IActionTypeLoaderContext context) => Load();
 
         /// <summary>
         /// Load all action types from assemblies.
         /// </summary>
-        /// <param name="blockHeader">A <see cref="BlockHeader"/> to determine what action types to
-        /// use. But it isn't used in this implementation.</param>
+        /// <param name="context">A <see cref="IActionTypeLoaderContext"/> to determine what action
+        /// types to use. But it isn't used in this implementation.</param>
         /// <returns>A dictionary made of action id to action type pairs.</returns>
-        public IEnumerable<Type> LoadAllActionTypes(IPreEvaluationBlockHeader blockHeader)
+        public IEnumerable<Type> LoadAllActionTypes(IActionTypeLoaderContext context)
             => LoadAllActionTypesImpl(_assembliesSet);
 
         internal IDictionary<string, Type> Load() =>


### PR DESCRIPTION
> You can see the below content in `CHANGES.md` too.

## Backward-incompatible changes

 -  Replaced `IPreEvaluationBlockHeader`-typed `blockHeader` parameter with
    `IActionTypeLoaderContext`-typed `context` parameter in the below methods.
     - `IActionTypeLoader.Load()`.
     - `IActionTypeLoader.LoadAllActionTypes()`.

## Added APIs

 -  Added `IActionTypeLoaderContext` interface.