### PR TITLE
🧹 Removed `IStore.GetCanonicalGenesisBlock<T>()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ To be released.
  -  Replaced `IAction?`-typed `policyBlockAction` parameter with
     `PolicyBlockActionGetter`-typed `policyBlockActionGetter` parameter
     in `ActionEvaluator` constructor.  [[#2646]]
+ -  Removed `IStore.GetCanonicalGenesisBlock<T>()` interface method and all its
+    implementations.  [[#2664]]
+
 
 ### Backward-incompatible network protocol changes
 
@@ -51,6 +54,7 @@ To be released.
 [#2609]: https://github.com/planetarium/libplanet/pull/2609
 [#2619]: https://github.com/planetarium/libplanet/pull/2619
 [#2646]: https://github.com/planetarium/libplanet/pull/2646
+[#2664]: https://github.com/planetarium/libplanet/pull/2664
 
 
 Version 0.45.0

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -81,7 +81,6 @@ namespace Libplanet.Benchmarks
                 nameof(PutBlockOnManyBlocks),
                 nameof(GetOldBlockOutOfManyBlocks),
                 nameof(GetRecentBlockOutOfManyBlocks),
-                nameof(GetCanonicalGenesisBlockOutOfManyBlocks),
             }
         )]
         public void PutManyBlocks()
@@ -123,16 +122,6 @@ namespace Libplanet.Benchmarks
             // during dead code elimination optimization.
             // https://benchmarkdotnet.org/articles/guides/good-practices.html#avoid-dead-code-elimination
             return _store.GetBlock<DumbAction>(Blocks[BlocksCount - 2].Hash);
-        }
-
-        [Benchmark]
-        public Block<DumbAction> GetCanonicalGenesisBlockOutOfManyBlocks()
-        {
-            // Note that why this benchmark method returns something is
-            // because without this JIT can remove the below statement at all
-            // during dead code elimination optimization.
-            // https://benchmarkdotnet.org/articles/guides/good-practices.html#avoid-dead-code-elimination
-            return _store.GetCanonicalGenesisBlock<DumbAction>();
         }
 
         [Benchmark]

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -228,14 +228,6 @@ namespace Libplanet.Explorer.Store
             _store.SetCanonicalChainId(chainId);
         }
 
-        /// <inheritdoc cref="IStore.GetCanonicalGenesisBlock{T}"/>
-        public Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new() =>
-            _store.GetCanonicalChainId() is { } canonicalChainId
-            && _store.IndexBlockHash(canonicalChainId, 0) is { } genesisHash
-                ? _store.GetBlock<T>(genesisHash)
-                : null;
-
         /// <inheritdoc cref="IStore.CountIndex(Guid)"/>
         public long CountIndex(Guid chainId)
         {

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -191,14 +191,6 @@ namespace Libplanet.Explorer.Store
             _store.SetCanonicalChainId(chainId);
         }
 
-        /// <inheritdoc cref="IStore.GetCanonicalGenesisBlock{T}"/>
-        public Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new() =>
-            _store.GetCanonicalChainId() is { } canonicalChainId
-            && _store.IndexBlockHash(canonicalChainId, 0) is { } genesisHash
-                ? _store.GetBlock<T>(genesisHash)
-                : null;
-
         /// <inheritdoc cref="IStore.CountIndex(Guid)"/>
         public long CountIndex(Guid chainId)
         {

--- a/Libplanet.Tests/Store/ProxyStore.cs
+++ b/Libplanet.Tests/Store/ProxyStore.cs
@@ -50,10 +50,6 @@ namespace Libplanet.Tests.Store
         public virtual void SetCanonicalChainId(Guid chainId) =>
             Store.SetCanonicalChainId(chainId);
 
-        public virtual Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new() =>
-            Store.GetCanonicalGenesisBlock<T>();
-
         /// <inheritdoc cref="IStore.CountIndex(Guid)"/>
         public virtual long CountIndex(Guid chainId) =>
             Store.CountIndex(chainId);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -319,41 +319,6 @@ namespace Libplanet.Tests.Store
         }
 
         [SkippableFact]
-        public void CanonicalGenesisBlock()
-        {
-            var chainId1 = Guid.NewGuid();
-            var chainId2 = Guid.NewGuid();
-            var chainId3 = Guid.NewGuid();
-            var canonicalGenesisBlock = new Func<Block<DumbAction>>(() =>
-                Fx.Store.GetCanonicalGenesisBlock<DumbAction>());
-
-            Assert.Null(canonicalGenesisBlock());
-
-            Fx.Store.SetCanonicalChainId(chainId1);
-            Assert.Null(canonicalGenesisBlock());
-            Fx.Store.PutBlock(Fx.Block1);
-            Assert.Null(canonicalGenesisBlock());
-            Fx.Store.AppendIndex(chainId1, Fx.Block1.Hash);
-            Assert.Equal(Fx.Block1, canonicalGenesisBlock());
-
-            Fx.Store.SetCanonicalChainId(chainId2);
-            Assert.Null(canonicalGenesisBlock());
-            Fx.Store.AppendIndex(chainId2, Fx.Block1.Hash);
-            Assert.Equal(Fx.Block1, canonicalGenesisBlock());
-            Fx.Store.PutBlock(Fx.Block2);
-            Assert.Equal(Fx.Block1, canonicalGenesisBlock());
-            Fx.Store.AppendIndex(chainId2, Fx.Block2.Hash);
-            Assert.Equal(Fx.Block1, canonicalGenesisBlock());
-
-            Fx.Store.SetCanonicalChainId(chainId3);
-            Fx.Store.PutBlock(Fx.Block3);
-            Fx.Store.AppendIndex(chainId3, Fx.Block3.Hash);
-            Assert.Equal(Fx.Block3, canonicalGenesisBlock());
-            Fx.Store.SetCanonicalChainId(chainId1);
-            Assert.Equal(Fx.Block1, canonicalGenesisBlock());
-        }
-
-        [SkippableFact]
         public void StoreBlock()
         {
             Assert.Empty(Fx.Store.IterateBlockHashes());

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -216,13 +216,6 @@ namespace Libplanet.Tests.Store
             _store.SetCanonicalChainId(chainId);
         }
 
-        public Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new()
-        {
-            Log(nameof(GetCanonicalGenesisBlock));
-            return _store.GetCanonicalGenesisBlock<T>();
-        }
-
         public void Dispose()
         {
             if (!_disposed)

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -28,14 +28,6 @@ namespace Libplanet.Store
         /// <inheritdoc/>
         public abstract void SetCanonicalChainId(Guid chainId);
 
-        /// <inheritdoc/>
-        public Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new() =>
-            GetCanonicalChainId() is { } canonicalChainId
-            && IndexBlockHash(canonicalChainId, 0) is { } genesisHash
-                ? GetBlock<T>(genesisHash)
-                : null;
-
         public abstract long CountIndex(Guid chainId);
 
         /// <inheritdoc/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -42,15 +42,6 @@ namespace Libplanet.Store
         /// <seealso cref="GetCanonicalChainId()"/>
         void SetCanonicalChainId(Guid chainId);
 
-        /// <summary>
-        /// Returns the genesis block of the current canonical chain.
-        /// </summary>
-        /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
-        /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
-        /// <returns>The genesis block of the current canonical chain.</returns>
-        Block<T> GetCanonicalGenesisBlock<T>()
-            where T : IAction, new();
-
         long CountIndex(Guid chainId);
 
         /// <summary>

--- a/Libplanet/Store/MemoryStore.cs
+++ b/Libplanet/Store/MemoryStore.cs
@@ -71,13 +71,6 @@ namespace Libplanet.Store
         void IStore.SetCanonicalChainId(Guid chainId) =>
             _canonicalChainId = chainId;
 
-        Block<T> IStore.GetCanonicalGenesisBlock<T>() =>
-            _canonicalChainId is { } canonicalChainId
-            && _indices.TryGetValue(canonicalChainId, out ImmutableTrieList<BlockHash> indices)
-            && indices.Count > 0
-                ? ((IStore)this).GetBlock<T>(indices[0])
-                : null;
-
         long IStore.CountIndex(Guid chainId) =>
             _indices.TryGetValue(chainId, out ImmutableTrieList<BlockHash> index) ? index.Count : 0;
 


### PR DESCRIPTION
See [the discussion](https://github.com/planetarium/libplanet/discussions/2617) for more context.

The naming `GetCanonicalGenesisBlock<T>()` suggests there can be non-canonical genesis `Block<T>`s in `IStore`. This is problematic since this can be interpreted two different ways:

- There can be other genesis `Block<T>`s in `IStore`
- There can be some other chain id with a different genesis `Block<T>` in `IStore`

If it is the former, then there isn't much of a problem , but since the term "canonical" is closely tied to chain ids, I would say it is more likely than not to be interpreted as the latter. The rest of the API for `IStore` allowing there to be a chain id with a different genesis `Block<T>` also seem to suggest that the latter may be intended.

In any case, and thankfully, `IStore.GetCanonicalGenesisBlock<T>()` doesn't seem to be really used anywhere, so I think its just better to remove it altogether to reduce overall confusion.