### PR TITLE
Fix NetMQ failures on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,11 @@ To be released.
 
  -  (Libplanet.Net) Fixed a bug where `NetMQTransport` hadn't worked properly
     on Windows.  [[#2667]]
+ -  Fixed a scope of readlock on `BlockChain<T>.GetBlockLocator()` method for
+    sake of parallelism.  [[#2667]]
 
 [#2667]: https://github.com/planetarium/libplanet/pull/2667
+
 
 Version 0.44.5
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.44.6
 
 To be released.
 
+ -  (Libplanet.Net) Fixed a bug where `NetMQTransport` hadn't worked properly
+    on Windows.  [[#2667]]
+
+[#2667]: https://github.com/planetarium/libplanet/pull/2667
 
 Version 0.44.5
 --------------

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -53,10 +53,7 @@ namespace Libplanet.Net.Transports
         static NetMQTransport()
         {
             NetMQConfig.ThreadPoolSize = 3;
-            if (!(Type.GetType("Mono.Runtime") is null))
-            {
-                ForceDotNet.Force();
-            }
+            ForceDotNet.Force();
         }
 
         /// <summary>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1095,20 +1095,26 @@ namespace Libplanet.Blockchain
         /// <returns>A instance of block locator.</returns>
         public BlockLocator GetBlockLocator(int threshold = 10)
         {
+            Guid chainId;
+            BlockHash tipHash;
+
+            _rwlock.EnterReadLock();
             try
             {
-                _rwlock.EnterReadLock();
-
-                return new BlockLocator(
-                    indexBlockHash: idx => Store.IndexBlockHash(Id, idx),
-                    indexByBlockHash: hash => _blocks[hash].Index,
-                    sampleAfter: threshold
-                );
+                chainId = Id;
+                tipHash = Tip.Hash;
             }
             finally
             {
                 _rwlock.ExitReadLock();
             }
+
+            return new BlockLocator(
+                tipHash: tipHash,
+                indexBlockHash: idx => Store.IndexBlockHash(chainId, idx),
+                indexByBlockHash: hash => _blocks[hash].Index,
+                sampleAfter: threshold
+            );
         }
 
 #pragma warning disable MEN003

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -27,8 +27,32 @@ namespace Libplanet.Blockchain
             Func<BlockHash, long> indexByBlockHash,
             int sampleAfter = 10
         )
+            : this(
+                indexBlockHash(-1),
+                indexBlockHash,
+                indexByBlockHash,
+                sampleAfter
+            )
         {
-            BlockHash? current = indexBlockHash(-1);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="BlockLocator"/> from <paramref name="hashes"/>.
+        /// </summary>
+        /// <param name="hashes">Enumerable of <see cref="BlockHash"/>es to convert from.</param>
+        public BlockLocator(IEnumerable<BlockHash> hashes)
+        {
+            _impl = hashes;
+        }
+
+        internal BlockLocator(
+            BlockHash? tipHash,
+            Func<long, BlockHash?> indexBlockHash,
+            Func<BlockHash, long> indexByBlockHash,
+            int sampleAfter
+        )
+        {
+            BlockHash? current = tipHash;
             long step = 1;
             var hashes = new List<BlockHash>();
             while (current is { } hash)
@@ -50,15 +74,6 @@ namespace Libplanet.Blockchain
                 }
             }
 
-            _impl = hashes;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="BlockLocator"/> from <paramref name="hashes"/>.
-        /// </summary>
-        /// <param name="hashes">Enumerable of <see cref="BlockHash"/>es to convert from.</param>
-        public BlockLocator(IEnumerable<BlockHash> hashes)
-        {
             _impl = hashes;
         }
 


### PR DESCRIPTION
This PR fixes two points as like below

- Fixed failures related to NetMQ, through `ForceDotNet.Force()` even upon Windows.
- Adjusted read-lock scope of `BlockChain<T>.GetBlockLocator()` method, to improve parallelism of block sync.