### PR TITLE
Fix typo 'dail' → 'dial'

### DIFF
--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Net
                             "Count of {BlockCandidateTable}: {Count}",
                             nameof(ConsumeBlockCandidates),
                             latest.Value.Index,
-                            latest.Value.Header,
+                            latest.Value.Hash,
                             nameof(BlockCandidateTable),
                             BlockCandidateTable.Count);
                         _ = BlockCandidateProcess(

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -1230,7 +1230,7 @@ namespace Libplanet.Net
                     case CommunicationFailException cfe:
                         _logger.Debug(
                             cfe,
-                            "Failed to dail {Peer}.",
+                            "Failed to dial {Peer}.",
                             peer);
                         break;
                     case Exception e:


### PR DESCRIPTION
This pull request just fixes a typo in `Swarm`'s logs, 'dail' → 'dial'.