### PR TITLE
🔧 Try running benchmarks to completion on other os failure

### DIFF
--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   benchmark:
     name: Run Benchmark.Net benchmarks
+    continue-on-error: true
     strategy:
       matrix:
         os:

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   benchmark:
     name: Run Benchmark.Net benchmarks
+    continue-on-error: true
     strategy:
       matrix:
         os:


### PR DESCRIPTION
If any of the operating system fails, then all benchmarks have to be run again. I suppose this could be intended depending on our policy. 🙄