### PR TITLE
Fix bugs and stabilize unit test again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.44.7
 
 To be released.
 
+ -  (Libplanet.Net) Fixed bugs where `NetMQTransport` hadn't worked expected
+    when not many threads were available.  [[#2684]]
+ -  (Libplanet.Net) Fixed a bug where `NetMQTransport.ReplyMessageAsync()`
+    hadn't worked properly.  [[#2684]]
+
+[#2684]: https://github.com/planetarium/libplanet/pull/2684
+
 
 Version 0.44.6
 --------------

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -529,7 +529,7 @@ namespace Libplanet.Net.Tests
                 await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
 
                 swarmA.BroadcastTxs(new[] { tx3, tx4 });
-                await swarmC.TxReceived.WaitAsync();
+                await swarmB.TxReceived.WaitAsync();
 
                 // SwarmB receives tx3 and is staged, but policy filters it.
                 Assert.DoesNotContain(tx3.Id, chainB.GetStagedTransactionIds());
@@ -538,6 +538,7 @@ namespace Libplanet.Net.Tests
                     chainB.StagePolicy.Iterate(chainB, filtered: false).Select(tx => tx.Id));
                 Assert.Contains(tx4.Id, chainB.GetStagedTransactionIds());
 
+                await swarmC.TxReceived.WaitAsync();
                 // SwarmC can not receive tx3 because SwarmB does not rebroadcast it.
                 Assert.DoesNotContain(tx3.Id, chainC.GetStagedTransactionIds());
                 Assert.DoesNotContain(

--- a/Libplanet.Net/AsyncDelegate.cs
+++ b/Libplanet.Net/AsyncDelegate.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net
         public async Task InvokeAsync(T arg)
         {
             IEnumerable<Task> tasks = _functions.Select(f => f(arg));
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }
 }

--- a/Libplanet.Net/Libplanet.Net.csproj
+++ b/Libplanet.Net/Libplanet.Net.csproj
@@ -47,9 +47,7 @@
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers; buildtransitive
@@ -62,6 +60,7 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -177,7 +177,7 @@ namespace Libplanet.Net.Protocols
                             cancellationToken))
                     .ToList();
 
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
             }
             catch (TimeoutException)
@@ -202,7 +202,8 @@ namespace Libplanet.Net.Protocols
                 _logger.Verbose("Start to validate all peers: ({Count})", _table.Peers.Count);
                 foreach (var peer in _table.Peers)
                 {
-                    await ValidateAsync(peer, timeout ?? _requestTimeout, cancellationToken);
+                    await ValidateAsync(peer, timeout ?? _requestTimeout, cancellationToken)
+                        .ConfigureAwait(false);
                 }
             }
             catch (TimeoutException e)
@@ -243,7 +244,7 @@ namespace Libplanet.Net.Protocols
                     cancellationToken));
             try
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             catch (TimeoutException)
             {
@@ -263,7 +264,8 @@ namespace Libplanet.Net.Protocols
                         _logger.Verbose("Check peer {Peer}.", replacement);
 
                         _table.RemoveCache(replacement);
-                        await PingAsync(replacement, _requestTimeout, cancellationToken);
+                        await PingAsync(replacement, _requestTimeout, cancellationToken)
+                            .ConfigureAwait(false);
                     }
                     catch (PingTimeoutException)
                     {
@@ -305,7 +307,8 @@ namespace Libplanet.Net.Protocols
             {
                 try
                 {
-                    await PingAsync(boundPeer, _requestTimeout, cancellationToken);
+                    await PingAsync(boundPeer, _requestTimeout, cancellationToken)
+                        .ConfigureAwait(false);
                 }
                 catch (PingTimeoutException)
                 {
@@ -342,7 +345,8 @@ namespace Libplanet.Net.Protocols
 
                 history.Add(viaPeer);
                 IEnumerable<BoundPeer> foundPeers =
-                    await GetNeighbors(viaPeer, target, timeout, cancellationToken);
+                    await GetNeighbors(viaPeer, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 IEnumerable<BoundPeer> filteredPeers = foundPeers
                     .Where(peer =>
                         !history.Contains(peer) &&
@@ -354,7 +358,8 @@ namespace Libplanet.Net.Protocols
                 {
                     try
                     {
-                        await PingAsync(found, _requestTimeout, cancellationToken);
+                        await PingAsync(found, _requestTimeout, cancellationToken)
+                            .ConfigureAwait(false);
                         if (found.Address.Equals(target))
                         {
                             return found;
@@ -476,7 +481,7 @@ namespace Libplanet.Net.Protocols
             {
                 _logger.Verbose("Starting to validate peer {Peer}...", peer);
                 DateTimeOffset check = DateTimeOffset.UtcNow;
-                await PingAsync(peer, timeout, cancellationToken);
+                await PingAsync(peer, timeout, cancellationToken).ConfigureAwait(false);
                 _table.Check(peer, check, DateTimeOffset.UtcNow);
             }
             catch (PingTimeoutException)
@@ -539,11 +544,13 @@ namespace Libplanet.Net.Protocols
             IEnumerable<BoundPeer> found;
             if (viaPeer is null)
             {
-                found = await QueryNeighborsAsync(history, target, timeout, cancellationToken);
+                found = await QueryNeighborsAsync(history, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
             }
             else
             {
-                found = await GetNeighbors(viaPeer, target, timeout, cancellationToken);
+                found = await GetNeighbors(viaPeer, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 history.Add(viaPeer);
             }
 
@@ -558,7 +565,7 @@ namespace Libplanet.Net.Protocols
                 target,
                 depth,
                 timeout,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<BoundPeer>> QueryNeighborsAsync(
@@ -573,7 +580,8 @@ namespace Libplanet.Net.Protocols
             for (var i = 0; i < count; i++)
             {
                 var peers =
-                    await GetNeighbors(neighbors[i], target, timeout, cancellationToken);
+                    await GetNeighbors(neighbors[i], target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 history.Add(neighbors[i]);
                 found.AddRange(peers.Where(peer => !found.Contains(peer)));
             }
@@ -631,7 +639,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            await _transport.ReplyMessageAsync(pong, default);
+            await _transport.ReplyMessageAsync(pong, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -689,7 +697,7 @@ namespace Libplanet.Net.Protocols
             Task aggregateTask = Task.WhenAll(tasks);
             try
             {
-                await aggregateTask;
+                await aggregateTask.ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -742,7 +750,7 @@ namespace Libplanet.Net.Protocols
 
             try
             {
-                await Task.WhenAll(findPeerTasks);
+                await Task.WhenAll(findPeerTasks).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -764,7 +772,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            await _transport.ReplyMessageAsync(neighbors, default);
+            await _transport.ReplyMessageAsync(neighbors, default).ConfigureAwait(false);
         }
     }
 }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -610,12 +610,15 @@ namespace Libplanet.Net.Transports
 
                     LastMessageTimestamp = DateTimeOffset.UtcNow;
 
+                    // Duplicate received message before distributing.
+                    var copied = new NetMQMessage(raw.Select(f => f.Duplicate()));
+
                     Task.Factory.StartNew(
                         async () =>
                         {
                             try
                             {
-                                Message message = _messageCodec.Decode(raw, false);
+                                Message message = _messageCodec.Decode(copied, false);
                                 _logger
                                     .ForContext("Tag", "Metric")
                                     .ForContext("Subtag", "InboundMessageReport")

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -14,6 +14,7 @@ using Libplanet.Net.Messages;
 using Libplanet.Stun;
 using NetMQ;
 using NetMQ.Sockets;
+using Nito.AsyncEx;
 using Serilog;
 
 namespace Libplanet.Net.Transports
@@ -33,7 +34,7 @@ namespace Libplanet.Net.Transports
         private readonly Channel<MessageRequest> _requests;
         private readonly Task _runtimeProcessor;
 
-        private NetMQQueue<NetMQMessage> _replyQueue;
+        private NetMQQueue<(AsyncManualResetEvent, NetMQMessage)> _replyQueue;
 
         private RouterSocket _router;
         private NetMQPoller _routerPoller;
@@ -266,7 +267,7 @@ namespace Libplanet.Net.Transports
             _turnCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            _replyQueue = new NetMQQueue<NetMQMessage>();
+            _replyQueue = new NetMQQueue<(AsyncManualResetEvent, NetMQMessage)>();
             _routerPoller = new NetMQPoller { _router, _replyQueue };
 
             _router.ReceiveReady += ReceiveMessage;
@@ -517,7 +518,7 @@ namespace Libplanet.Net.Transports
         }
 
         /// <inheritdoc/>
-        public Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
+        public async Task ReplyMessageAsync(Message message, CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -526,17 +527,22 @@ namespace Libplanet.Net.Transports
 
             string identityHex = ByteUtil.Hex(message.Identity);
             _logger.Debug("Reply {Message} to {Identity}...", message, identityHex);
+
+            var ev = new AsyncManualResetEvent();
             _replyQueue.Enqueue(
-                _messageCodec.Encode(
-                    message,
-                    _privateKey,
-                    _appProtocolVersion,
-                    AsPeer,
-                    DateTimeOffset.UtcNow
+                (
+                    ev,
+                    _messageCodec.Encode(
+                        message,
+                        _privateKey,
+                        _appProtocolVersion,
+                        AsPeer,
+                        DateTimeOffset.UtcNow
+                    )
                 )
             );
 
-            return Task.CompletedTask;
+            await ev.WaitAsync(cancellationToken);
         }
 
         /// <summary>
@@ -673,9 +679,12 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        private void DoReply(object sender, NetMQQueueEventArgs<NetMQMessage> e)
+        private void DoReply(
+            object sender,
+            NetMQQueueEventArgs<(AsyncManualResetEvent, NetMQMessage)> e
+        )
         {
-            NetMQMessage message = e.Queue.Dequeue();
+            (AsyncManualResetEvent ev, NetMQMessage message) = e.Queue.Dequeue();
             string identityHex = ByteUtil.Hex(message[0].Buffer);
 
             // FIXME The current timeout value(1 sec) is arbitrary.
@@ -690,6 +699,8 @@ namespace Libplanet.Net.Transports
                 _logger.Debug(
                     "Failed to send {Message} as a reply to {Identity}.", message, identityHex);
             }
+
+            ev.Set();
         }
 
         private async Task ProcessRuntime(CancellationToken cancellationToken)

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -671,8 +671,10 @@ namespace Libplanet.Net.Transports
                                     "Something went wrong during message processing.");
                             }
                         },
-                        TaskCreationOptions.HideScheduler | TaskCreationOptions.DenyChildAttach
-                    );
+                        CancellationToken.None,
+                        TaskCreationOptions.HideScheduler | TaskCreationOptions.DenyChildAttach,
+                        TaskScheduler.Default
+                    ).Unwrap();
                 }
             }
             catch (Exception ex)

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -759,7 +759,7 @@ namespace Libplanet.Net.Transports
                 req.Id,
                 req.Peer
             );
-            var result = new List<Message>();
+            int receivedCount = 0;
 
             // Normal OperationCanceledException initiated from outside should bubble up.
             try
@@ -847,6 +847,7 @@ namespace Libplanet.Net.Transports
                     }
 
                     await channel.Writer.WriteAsync(reply, cancellationToken);
+                    receivedCount += 1;
                 }
 
                 channel.Writer.Complete();
@@ -881,7 +882,7 @@ namespace Libplanet.Net.Transports
                         req.Message,
                         req.Id,
                         (DateTimeOffset.UtcNow - startedTime).TotalMilliseconds,
-                        result.Count,
+                        receivedCount,
                         req.ExpectedResponses);
             }
         }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -168,7 +168,9 @@ namespace Libplanet.Net.Transports
                 }
                 else
                 {
-                    _runningEvent = new TaskCompletionSource<object>();
+                    _runningEvent = new TaskCompletionSource<object>(
+                        TaskCreationOptions.RunContinuationsAsynchronously
+                    );
                 }
             }
         }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -915,8 +915,13 @@ namespace Libplanet.Net.Transports
             }
         }
 
-        private Task RunPoller(NetMQPoller poller) =>
-            Task.Factory.StartNew(
+        private async Task RunPoller(NetMQPoller poller)
+        {
+            TaskCreationOptions taskCreationOptions =
+                TaskCreationOptions.DenyChildAttach |
+                TaskCreationOptions.LongRunning |
+                TaskCreationOptions.HideScheduler;
+            await Task.Factory.StartNew(
                 () =>
                 {
                     // Ignore NetMQ related exceptions during NetMQPoller.Run() to stabilize
@@ -941,9 +946,10 @@ namespace Libplanet.Net.Transports
                     }
                 },
                 CancellationToken.None,
-                TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
+                taskCreationOptions,
                 TaskScheduler.Default
             );
+        }
 
         private CommunicationFailException WrapCommunicationFailException(
             Exception innerException,

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -262,7 +262,7 @@ namespace Libplanet.Net.Transports
 
             Running = true;
 
-            await pollerTask;
+            await pollerTask.ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -501,13 +501,16 @@ namespace Libplanet.Net.Transports
 
             CancellationToken ct = _runtimeCancellationTokenSource.Token;
             List<BoundPeer> boundPeers = peers.ToList();
-            boundPeers.ParallelForEachAsync(
-                async peer =>
+            Task.Run(
+                async () =>
                 {
-                    await SendMessageAsync(peer, message, TimeSpan.FromSeconds(1), ct)
-                        .ConfigureAwait(false);
+                    await boundPeers.ParallelForEachAsync(
+                        peer => SendMessageAsync(peer, message, TimeSpan.FromSeconds(1), ct),
+                        ct
+                    );
                 },
-                ct);
+                ct
+            );
 
             _logger.Debug(
                 "Broadcasting message {Message} as {AsPeer} to {PeerCount} peers",

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -603,7 +603,7 @@ namespace Libplanet.Net.Transports
                     LastMessageTimestamp = DateTimeOffset.UtcNow;
 
                     Message message = _messageCodec.Decode(raw, false);
-                    Task.Run(() =>
+                    Task.Run(async () =>
                     {
                         try
                         {
@@ -618,8 +618,8 @@ namespace Libplanet.Net.Transports
                             {
                                 _messageValidator.ValidateTimestamp(message);
                                 _messageValidator.ValidateAppProtocolVersion(message);
-
-                                _ = ProcessMessageHandler.InvokeAsync(message);
+                                await ProcessMessageHandler.InvokeAsync(message)
+                                    .ConfigureAwait(false);
                             }
                             catch (InvalidMessageTimestampException imte)
                             {
@@ -643,10 +643,10 @@ namespace Libplanet.Net.Transports
                                 _logger.Debug(
                                     "Replying to {Peer} with {Reply}.",
                                     diffVersion);
-                                _ = ReplyMessageAsync(
+                                await ReplyMessageAsync(
                                     diffVersion,
                                     _runtimeCancellationTokenSource.Token
-                                );
+                                ).ConfigureAwait(false);
                             }
                         }
                         catch (InvalidMessageException ex)

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -770,8 +770,6 @@ namespace Libplanet.Net.Transports
 
         private async Task ProcessRequest(MessageRequest req, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             DateTimeOffset startedTime = DateTimeOffset.UtcNow;
             _logger.Debug(
                 "Request {Message} {RequestId} is ready to be processed in {TimeSpan}.",
@@ -792,6 +790,8 @@ namespace Libplanet.Net.Transports
             // Normal OperationCanceledException initiated from outside should bubble up.
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 using var dealer = GetRequestDealerSocket(req);
                 NetMQMessage message = _messageCodec.Encode(
                     req.Message,

--- a/Libplanet.Net/TxCompletion.cs
+++ b/Libplanet.Net/TxCompletion.cs
@@ -125,7 +125,7 @@ namespace Libplanet.Net
         {
             try
             {
-                var validTxs = new HashSet<Transaction<TAction>>(
+                var policyCompatTxs = new HashSet<Transaction<TAction>>(
                     txs.Where(
                         tx =>
                         {
@@ -151,7 +151,7 @@ namespace Libplanet.Net
                         }));
 
                 var stagedTxs = new List<Transaction<TAction>>();
-                foreach (var tx in validTxs)
+                foreach (var tx in policyCompatTxs)
                 {
                     try
                     {
@@ -169,7 +169,10 @@ namespace Libplanet.Net
                 }
 
                 // To maintain the consistency of the unit tests.
-                TxReceived.Set();
+                if (policyCompatTxs.Any())
+                {
+                    TxReceived.Set();
+                }
 
                 if (stagedTxs.Any())
                 {


### PR DESCRIPTION
This PR fixes a bug causing instability in environments with limited available CPU resources (e.g., CI).
it also fixes that `NetMQTransport.ReplyMessageAsync()` hadn't worked properly. [^1]

[^1]: To be honest, I thought that the method would never wait, so I plan to fix the interface in the main, but I couldn't because Gossip, which is for PBFT, relies on that wait.
