### PR TITLE
Port/0.45.4 & remove `workers` option for `NetMQTransport`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@ To be released.
     `AppProtocolVersionOptions` as a combined parameter instead of taking
     `AppProtocolVersion`, `IImmutableSet<PublicKey>?`, and
     `DifferentAppProtocolVersionEncountered` separately.  [[#2693]]
+ -  (Libplanet.Net) Removed `workers` parameter from `NetMQTransport.Create()`
+    method and `Swarm<T>()` constructor.  [[#2690]]
 
 ### Backward-incompatible network protocol changes
 
@@ -66,6 +68,7 @@ To be released.
 [#2646]: https://github.com/planetarium/libplanet/pull/2646
 [#2653]: https://github.com/planetarium/libplanet/pull/2653
 [#2664]: https://github.com/planetarium/libplanet/pull/2664
+[#2690]: https://github.com/planetarium/libplanet/pull/2690
 [#2693]: https://github.com/planetarium/libplanet/pull/2693
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,16 @@ To be released.
 [#2693]: https://github.com/planetarium/libplanet/pull/2693
 
 
+Version 0.45.4
+--------------
+
+Released on January 4, 2023.
+
+  -  Ported changes from [Libplaent 0.44.7] release.  [[#2684]]
+
+[Libplanet 0.44.7]: https://www.nuget.org/packages/Libplanet/0.44.7
+
+
 Version 0.45.3
 --------------
 
@@ -182,6 +192,19 @@ Released on December 3, 2022.
 [#2575]: https://github.com/planetarium/libplanet/pull/2575
 [#2586]: https://github.com/planetarium/libplanet/pull/2586
 [#2593]: https://github.com/planetarium/libplanet/pull/2593
+
+
+Version 0.44.7
+--------------
+
+Released on January 4, 2023.
+
+ -  (Libplanet.Net) Fixed bugs where `NetMQTransport` hadn't worked expected
+    when not many threads were available.  [[#2684]]
+ -  (Libplanet.Net) Fixed a bug where `NetMQTransport.ReplyMessageAsync()`
+    hadn't worked properly.  [[#2684]]
+
+[#2684]: https://github.com/planetarium/libplanet/pull/2684
 
 
 Version 0.44.6

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -22,7 +22,6 @@ namespace Libplanet.Explorer.Executable
             int blockIntervalMilliseconds,
             long minimumDifficulty,
             int difficultyBoundDivisor,
-            int workers,
             string appProtocolVersionToken,
             string mysqlServer,
             uint? mysqlPort,
@@ -45,7 +44,6 @@ namespace Libplanet.Explorer.Executable
             BlockIntervalMilliseconds = blockIntervalMilliseconds;
             MinimumDifficulty = minimumDifficulty;
             DifficultyBoundDivisor = difficultyBoundDivisor;
-            Workers = workers;
             AppProtocolVersionToken = appProtocolVersionToken;
             MySQLServer = mysqlServer;
             MySQLPort = mysqlPort;
@@ -73,8 +71,6 @@ namespace Libplanet.Explorer.Executable
         public long MinimumDifficulty { get; set; }
 
         public int DifficultyBoundDivisor { get; set; }
-
-        public int Workers { get; set; }
 
         public string AppProtocolVersionToken { get; set; }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -126,11 +126,6 @@ consecutive blocks.")]
                 Description = "A bound divisor to determine precision of block difficulties.")]
             int difficultyBoundDivisor = 128,
             [Option(
-                "workers",
-                new[] { 'W' },
-                Description = "The number of swarm workers.")]
-            int workers = 100,
-            [Option(
                 "app-protocol-version",
                 new[] { 'V' },
                 Description = "An app protocol version token.")]
@@ -192,7 +187,6 @@ If omitted (default) explorer only the local blockchain store.")]
                 blockIntervalMilliseconds,
                 minimumDifficulty,
                 difficultyBoundDivisor,
-                workers,
                 appProtocolVersionToken,
                 mysqlServer,
                 mysqlPort,
@@ -293,7 +287,6 @@ If omitted (default) explorer only the local blockchain store.")]
                         blockChain,
                         privateKey,
                         apvOptions,
-                        workers: options.Workers,
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions
                     );

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -529,7 +529,7 @@ namespace Libplanet.Net.Tests
                 await swarmB.AddPeersAsync(new[] { swarmC.AsPeer }, null);
 
                 swarmA.BroadcastTxs(new[] { tx3, tx4 });
-                await swarmC.TxReceived.WaitAsync();
+                await swarmB.TxReceived.WaitAsync();
 
                 // SwarmB receives tx3 and is staged, but policy filters it.
                 Assert.DoesNotContain(tx3.Id, chainB.GetStagedTransactionIds());
@@ -538,6 +538,7 @@ namespace Libplanet.Net.Tests
                     chainB.StagePolicy.Iterate(chainB, filtered: false).Select(tx => tx.Id));
                 Assert.Contains(tx4.Id, chainB.GetStagedTransactionIds());
 
+                await swarmC.TxReceived.WaitAsync();
                 // SwarmC can not receive tx3 because SwarmB does not rebroadcast it.
                 Assert.DoesNotContain(tx3.Id, chainC.GetStagedTransactionIds());
                 Assert.DoesNotContain(

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -475,9 +475,15 @@ namespace Libplanet.Net.Tests
             PrivateKey keyC = PrivateKey.FromString(
                 "941bc2edfab840d79914d80fe3b30840628ac37a5d812d7f922b5d2405a223d3");
 
-            var swarmA = CreateSwarm(keyA);
-            var swarmB = CreateSwarm(keyB);
-            var swarmC = CreateSwarm(keyC);
+            var autoBroadcastDisabled = new SwarmOptions
+            {
+                BlockBroadcastInterval = TimeSpan.FromSeconds(Timeout),
+                TxBroadcastInterval = TimeSpan.FromSeconds(Timeout),
+            };
+
+            var swarmA = CreateSwarm(keyA, options: autoBroadcastDisabled);
+            var swarmB = CreateSwarm(keyB, options: autoBroadcastDisabled);
+            var swarmC = CreateSwarm(keyC, options: autoBroadcastDisabled);
 
             BlockChain<DumbAction> chainA = swarmA.BlockChain;
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
@@ -508,10 +514,16 @@ namespace Libplanet.Net.Tests
                 chainA.UnstageTransaction(tx2);
                 Assert.Equal(1, chainA.GetNextTxNonce(privateKey.ToAddress()));
 
+                await StopAsync(swarmA);
+                await StopAsync(swarmB);
+
                 swarmA.RoutingTable.RemovePeer(swarmB.AsPeer);
                 swarmB.RoutingTable.RemovePeer(swarmA.AsPeer);
                 Assert.Empty(swarmA.Peers);
                 Assert.Empty(swarmB.Peers);
+
+                await StartAsync(swarmA);
+                await StartAsync(swarmB);
 
                 await chainB.MineBlock(keyB);
 

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -120,7 +120,6 @@ namespace Libplanet.Net.Tests
                 blockChain,
                 privateKey ?? new PrivateKey(),
                 appProtocolVersionOptions,
-                5,
                 host,
                 listenPort,
                 iceServers,

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -350,17 +350,7 @@ namespace Libplanet.Net.Tests
             );
 
             cts.Cancel();
-            bool canceled = false;
-            try
-            {
-                await task;
-            }
-            catch (OperationCanceledException)
-            {
-                canceled = true;
-            }
-
-            Assert.True(canceled);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -26,7 +26,6 @@ namespace Libplanet.Net.Tests.Transports
                 CreateNetMQTransport(
                     privateKey,
                     appProtocolVersionOptions,
-                    50,
                     host,
                     listenPort,
                     iceServers,
@@ -51,7 +50,6 @@ namespace Libplanet.Net.Tests.Transports
         private NetMQTransport CreateNetMQTransport(
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            int workers,
             string host,
             int? listenPort,
             IEnumerable<IceServer> iceServers,
@@ -65,7 +63,6 @@ namespace Libplanet.Net.Tests.Transports
             return NetMQTransport.Create(
                 privateKey,
                 appProtocolVersionOptions,
-                workers,
                 host,
                 listenPort,
                 iceServers,

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -14,6 +14,8 @@ namespace Libplanet.Net.Tests.Transports
     [Collection("NetMQConfiguration")]
     public class NetMQTransportTest : TransportTest, IDisposable
     {
+        private bool _disposed;
+
         public NetMQTransportTest(ITestOutputHelper testOutputHelper)
         {
             TransportConstructor = (
@@ -42,9 +44,28 @@ namespace Libplanet.Net.Tests.Transports
             Logger = Log.ForContext<NetMQTransportTest>();
         }
 
+        ~NetMQTransportTest()
+        {
+            Dispose(false);
+        }
+
         public void Dispose()
         {
-            NetMQConfig.Cleanup(false);
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    NetMQConfig.Cleanup(false);
+                }
+
+                _disposed = true;
+            }
         }
 
         private NetMQTransport CreateNetMQTransport(

--- a/Libplanet.Net/AsyncDelegate.cs
+++ b/Libplanet.Net/AsyncDelegate.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Net
         public async Task InvokeAsync(T arg)
         {
             IEnumerable<Task> tasks = _functions.Select(f => f(arg));
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }
 }

--- a/Libplanet.Net/Libplanet.Net.csproj
+++ b/Libplanet.Net/Libplanet.Net.csproj
@@ -47,9 +47,7 @@
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime; build; native; contentfiles; analyzers; buildtransitive
@@ -62,6 +60,7 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
 using Serilog;
@@ -169,15 +170,20 @@ namespace Libplanet.Net.Protocols
                     peers.Count,
                     _table.Peers.Count);
 
-                List<Task> tasks = peers
-                    .Select(peer =>
-                        ValidateAsync(
-                            peer,
-                            _requestTimeout,
-                            cancellationToken))
-                    .ToList();
-
-                await Task.WhenAll(tasks);
+                await peers.ParallelForEachAsync(
+                    async peer =>
+                    {
+                        try
+                        {
+                            await ValidateAsync(peer, _requestTimeout, cancellationToken);
+                        }
+                        catch (TimeoutException)
+                        {
+                            _logger.Debug("Can't validate peer: {Peer}", peer);
+                        }
+                    },
+                    cancellationToken
+                );
                 cancellationToken.ThrowIfCancellationRequested();
             }
             catch (TimeoutException)
@@ -202,7 +208,8 @@ namespace Libplanet.Net.Protocols
                 _logger.Verbose("Start to validate all peers: ({Count})", _table.Peers.Count);
                 foreach (var peer in _table.Peers)
                 {
-                    await ValidateAsync(peer, timeout ?? _requestTimeout, cancellationToken);
+                    await ValidateAsync(peer, timeout ?? _requestTimeout, cancellationToken)
+                        .ConfigureAwait(false);
                 }
             }
             catch (TimeoutException e)
@@ -243,7 +250,7 @@ namespace Libplanet.Net.Protocols
                     cancellationToken));
             try
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             catch (TimeoutException)
             {
@@ -263,7 +270,8 @@ namespace Libplanet.Net.Protocols
                         _logger.Verbose("Check peer {Peer}.", replacement);
 
                         _table.RemoveCache(replacement);
-                        await PingAsync(replacement, _requestTimeout, cancellationToken);
+                        await PingAsync(replacement, _requestTimeout, cancellationToken)
+                            .ConfigureAwait(false);
                     }
                     catch (PingTimeoutException)
                     {
@@ -305,7 +313,8 @@ namespace Libplanet.Net.Protocols
             {
                 try
                 {
-                    await PingAsync(boundPeer, _requestTimeout, cancellationToken);
+                    await PingAsync(boundPeer, _requestTimeout, cancellationToken)
+                        .ConfigureAwait(false);
                 }
                 catch (PingTimeoutException)
                 {
@@ -342,7 +351,8 @@ namespace Libplanet.Net.Protocols
 
                 history.Add(viaPeer);
                 IEnumerable<BoundPeer> foundPeers =
-                    await GetNeighbors(viaPeer, target, timeout, cancellationToken);
+                    await GetNeighbors(viaPeer, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 IEnumerable<BoundPeer> filteredPeers = foundPeers
                     .Where(peer =>
                         !history.Contains(peer) &&
@@ -354,7 +364,8 @@ namespace Libplanet.Net.Protocols
                 {
                     try
                     {
-                        await PingAsync(found, _requestTimeout, cancellationToken);
+                        await PingAsync(found, _requestTimeout, cancellationToken)
+                            .ConfigureAwait(false);
                         if (found.Address.Equals(target))
                         {
                             return found;
@@ -476,7 +487,7 @@ namespace Libplanet.Net.Protocols
             {
                 _logger.Verbose("Starting to validate peer {Peer}...", peer);
                 DateTimeOffset check = DateTimeOffset.UtcNow;
-                await PingAsync(peer, timeout, cancellationToken);
+                await PingAsync(peer, timeout, cancellationToken).ConfigureAwait(false);
                 _table.Check(peer, check, DateTimeOffset.UtcNow);
             }
             catch (PingTimeoutException)
@@ -539,11 +550,13 @@ namespace Libplanet.Net.Protocols
             IEnumerable<BoundPeer> found;
             if (viaPeer is null)
             {
-                found = await QueryNeighborsAsync(history, target, timeout, cancellationToken);
+                found = await QueryNeighborsAsync(history, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
             }
             else
             {
-                found = await GetNeighbors(viaPeer, target, timeout, cancellationToken);
+                found = await GetNeighbors(viaPeer, target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 history.Add(viaPeer);
             }
 
@@ -558,7 +571,7 @@ namespace Libplanet.Net.Protocols
                 target,
                 depth,
                 timeout,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<BoundPeer>> QueryNeighborsAsync(
@@ -573,7 +586,8 @@ namespace Libplanet.Net.Protocols
             for (var i = 0; i < count; i++)
             {
                 var peers =
-                    await GetNeighbors(neighbors[i], target, timeout, cancellationToken);
+                    await GetNeighbors(neighbors[i], target, timeout, cancellationToken)
+                    .ConfigureAwait(false);
                 history.Add(neighbors[i]);
                 found.AddRange(peers.Where(peer => !found.Contains(peer)));
             }
@@ -631,7 +645,7 @@ namespace Libplanet.Net.Protocols
                 Identity = ping.Identity,
             };
 
-            await _transport.ReplyMessageAsync(pong, default);
+            await _transport.ReplyMessageAsync(pong, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -689,7 +703,7 @@ namespace Libplanet.Net.Protocols
             Task aggregateTask = Task.WhenAll(tasks);
             try
             {
-                await aggregateTask;
+                await aggregateTask.ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -742,7 +756,7 @@ namespace Libplanet.Net.Protocols
 
             try
             {
-                await Task.WhenAll(findPeerTasks);
+                await Task.WhenAll(findPeerTasks).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -764,7 +778,7 @@ namespace Libplanet.Net.Protocols
                 Identity = findNeighbors.Identity,
             };
 
-            await _transport.ReplyMessageAsync(neighbors, default);
+            await _transport.ReplyMessageAsync(neighbors, default).ConfigureAwait(false);
         }
     }
 }

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -53,7 +53,6 @@ namespace Libplanet.Net
         /// <param name="appProtocolVersionOptions">The <see cref="AppProtocolVersionOptions"/>
         /// to use when handling an <see cref="AppProtocolVersion"/> attached to
         /// a <see cref="Message"/>.</param>
-        /// <param name="workers">The number of background workers (i.e., threads).</param>
         /// <param name="host">A hostname to be a part of a public endpoint, that peers use when
         /// they connect to this node.  Note that this is not a hostname to listen to;
         /// <see cref="Swarm{T}"/> always listens to 0.0.0.0 &amp; ::/0.</param>
@@ -66,7 +65,6 @@ namespace Libplanet.Net
             BlockChain<T> blockChain,
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            int workers = 100,
             string host = null,
             int? listenPort = null,
             IEnumerable<IceServer> iceServers = null,
@@ -102,7 +100,6 @@ namespace Libplanet.Net
             Transport = NetMQTransport.Create(
                 _privateKey,
                 _appProtocolVersionOptions,
-                workers,
                 host,
                 listenPort,
                 iceServers ?? new List<IceServer>(),

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -14,6 +14,7 @@ using Libplanet.Stun;
 using NetMQ;
 using NetMQ.Sockets;
 using Nito.AsyncEx;
+using Nito.AsyncEx.Synchronous;
 using Serilog;
 
 namespace Libplanet.Net.Transports
@@ -280,12 +281,17 @@ namespace Libplanet.Net.Transports
         /// <inheritdoc/>
         public void Dispose()
         {
+            if (Running)
+            {
+                StopAsync(TimeSpan.Zero).WaitWithoutException();
+            }
+
             if (!_disposed)
             {
                 _requests.Writer.TryComplete();
                 _runtimeCancellationTokenSource.Cancel();
                 _turnCancellationTokenSource.Cancel();
-                _runtimeProcessor.Wait();
+                _runtimeProcessor.WaitWithoutException();
 
                 _runtimeCancellationTokenSource.Dispose();
                 _turnCancellationTokenSource.Dispose();

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -64,7 +64,6 @@ namespace Libplanet.Net.Transports
         /// <param name="appProtocolVersionOptions">The <see cref="AppProtocolVersionOptions"/>
         /// to use when handling an <see cref="AppProtocolVersion"/> attached to
         /// a <see cref="Message"/>.</param>
-        /// <param name="workers">The number of background workers (i.e., threads).</param>
         /// <param name="host">A hostname to be a part of a public endpoint, that peers use when
         /// they connect to this node.  Note that this is not a hostname to listen to;
         /// <see cref="NetMQTransport"/> always listens to 0.0.0.0 &amp; ::/0.</param>
@@ -82,7 +81,6 @@ namespace Libplanet.Net.Transports
         private NetMQTransport(
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            int workers,
             string host,
             int? listenPort,
             IEnumerable<IceServer> iceServers,
@@ -180,7 +178,6 @@ namespace Libplanet.Net.Transports
         /// <param name="appProtocolVersionOptions">The <see cref="AppProtocolVersionOptions"/>
         /// to use when handling an <see cref="AppProtocolVersion"/> attached to
         /// a <see cref="Message"/>.</param>
-        /// <param name="workers">The number of background workers (i.e., threads).</param>
         /// <param name="host">A hostname to be a part of a public endpoint, that peers use when
         /// they connect to this node.  Note that this is not a hostname to listen to;
         /// <see cref="NetMQTransport"/> always listens to 0.0.0.0 &amp; ::/0.</param>
@@ -203,7 +200,6 @@ namespace Libplanet.Net.Transports
         public static async Task<NetMQTransport> Create(
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            int workers,
             string host,
             int? listenPort,
             IEnumerable<IceServer> iceServers,
@@ -212,7 +208,6 @@ namespace Libplanet.Net.Transports
             var transport = new NetMQTransport(
                 privateKey,
                 appProtocolVersionOptions,
-                workers,
                 host,
                 listenPort,
                 iceServers,
@@ -370,7 +365,7 @@ namespace Libplanet.Net.Transports
                 NetMQMessage rawMessage = _messageCodec.Encode(
                     message,
                     _privateKey,
-                    _appProtocolVersion,
+                    _appProtocolVersionOptions.AppProtocolVersion,
                     AsPeer,
                     DateTimeOffset.UtcNow
                 );

--- a/Libplanet.Net/TxCompletion.cs
+++ b/Libplanet.Net/TxCompletion.cs
@@ -125,7 +125,7 @@ namespace Libplanet.Net
         {
             try
             {
-                var validTxs = new HashSet<Transaction<TAction>>(
+                var policyCompatTxs = new HashSet<Transaction<TAction>>(
                     txs.Where(
                         tx =>
                         {
@@ -151,7 +151,7 @@ namespace Libplanet.Net
                         }));
 
                 var stagedTxs = new List<Transaction<TAction>>();
-                foreach (var tx in validTxs)
+                foreach (var tx in policyCompatTxs)
                 {
                     try
                     {
@@ -169,7 +169,10 @@ namespace Libplanet.Net
                 }
 
                 // To maintain the consistency of the unit tests.
-                TxReceived.Set();
+                if (policyCompatTxs.Any())
+                {
+                    TxReceived.Set();
+                }
 
                 if (stagedTxs.Any())
                 {


### PR DESCRIPTION
This PR mainly aims to port the changes from #2684. also, it drops `workers` options no longer necessary, from `NetMQ Transport.CreateAsync()`,

And more, I tried a few test stabilizations but failed as a result. In particular, socket errors occur very often on macOS, which will be covered in another PR.