### PR TITLE
Introduce `AppProtocolVersionOptions`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@ To be released.
     [[#2653]]
      - `IActionTypeLoader.Load()`.
      - `IActionTypeLoader.LoadAllActionTypes()`.
+ -  Changed `Swarm<T>()` and `NetMQTransport.Create()` to take
+    `AppProtocolVersionOptions` as a combined parameter instead of taking
+    `AppProtocolVersion`, `IImmutableSet<PublicKey>?`, and
+    `DifferentAppProtocolVersionEncountered` separately.  [[#2693]]
 
 ### Backward-incompatible network protocol changes
 
@@ -45,6 +49,7 @@ To be released.
  -  Added `IActionTypeLoader.LoadAllActionTypes()` method.  [[#2646]]
      -  Added `StaticActionTypeLoader.LoadAllActionTypes()` method.
  -  Added `IActionTypeLoaderContext` interface.  [[#2653]]
+ -  Added `AppProtocolVersionOptions` class.  [[#2693]]
 
 ### Behavioral changes
 
@@ -61,6 +66,7 @@ To be released.
 [#2646]: https://github.com/planetarium/libplanet/pull/2646
 [#2653]: https://github.com/planetarium/libplanet/pull/2653
 [#2664]: https://github.com/planetarium/libplanet/pull/2664
+[#2693]: https://github.com/planetarium/libplanet/pull/2693
 
 
 Version 0.45.3

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -282,13 +282,18 @@ If omitted (default) explorer only the local blockchain store.")]
                         },
                     };
 
+                    var apvOptions = new AppProtocolVersionOptions()
+                    {
+                        AppProtocolVersion = options.AppProtocolVersionToken is string t
+                            ? AppProtocolVersion.FromToken(t)
+                            : default(AppProtocolVersion),
+                        DifferentAppProtocolVersionEncountered = (p, pv, lv) => { },
+                    };
+
                     swarm = new Swarm<NullAction>(
                         blockChain,
                         privateKey,
-                        options.AppProtocolVersionToken is string t
-                            ? AppProtocolVersion.FromToken(t)
-                            : default(AppProtocolVersion),
-                        differentAppProtocolVersionEncountered: (p, pv, lv) => { },
+                        apvOptions,
                         workers: options.Workers,
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -287,7 +287,6 @@ If omitted (default) explorer only the local blockchain store.")]
                         AppProtocolVersion = options.AppProtocolVersionToken is string t
                             ? AppProtocolVersion.FromToken(t)
                             : default(AppProtocolVersion),
-                        DifferentAppProtocolVersionEncountered = (p, pv, lv) => { },
                     };
 
                     swarm = new Swarm<NullAction>(

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -16,11 +16,7 @@ namespace Libplanet.Net.Tests.Messages
         {
             var peer = new BoundPeer(new PrivateKey().PublicKey, new DnsEndPoint("0.0.0.0", 0));
             var buffer = TimeSpan.FromSeconds(1);
-            var messageValidator = new MessageValidator(
-                appProtocolVersion: default,
-                trustedAppProtocolVersionSigners: null,
-                messageTimestampBuffer: buffer,
-                differentAppProtocolVersionEncountered: null);
+            var messageValidator = new MessageValidator(new AppProtocolVersionOptions(), buffer);
 
             // Within buffer window is okay.
             messageValidator.ValidateTimestamp(
@@ -37,7 +33,7 @@ namespace Libplanet.Net.Tests.Messages
                     new PingMsg() { Timestamp = DateTimeOffset.UtcNow - buffer.Multiply(2) }));
 
             // If buffer is null, no exception gets thrown.
-            messageValidator = new MessageValidator(default, null, null, null);
+            messageValidator = new MessageValidator(new AppProtocolVersionOptions(), null);
             messageValidator.ValidateTimestamp(
                 new PingMsg() { Remote = peer, Timestamp = DateTimeOffset.MaxValue });
             messageValidator.ValidateTimestamp(
@@ -111,14 +107,18 @@ namespace Libplanet.Net.Tests.Messages
             };
 
             DifferentAppProtocolVersionException exception;
+            AppProtocolVersionOptions appProtocolVersionOptions;
             MessageValidator messageValidator;
 
             // Trust specific signers.
-            messageValidator = new MessageValidator(
-                appProtocolVersion: trustedApv,
-                trustedAppProtocolVersionSigners: trustedApvSigners,
-                messageTimestampBuffer: null,
-                differentAppProtocolVersionEncountered: callback);
+            appProtocolVersionOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = trustedApv,
+                TrustedAppProtocolVersionSigners = trustedApvSigners,
+                DifferentAppProtocolVersionEncountered = callback,
+            };
+
+            messageValidator = new MessageValidator(appProtocolVersionOptions, null);
 
             // Check trust pings
             messageValidator.ValidateAppProtocolVersion(trustedPing);
@@ -147,11 +147,14 @@ namespace Libplanet.Net.Tests.Messages
             Assert.False(called);
 
             // Trust no one.
-            messageValidator = new MessageValidator(
-                appProtocolVersion: trustedApv,
-                trustedAppProtocolVersionSigners: emptyApvSigners,
-                messageTimestampBuffer: null,
-                differentAppProtocolVersionEncountered: callback);
+            appProtocolVersionOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = trustedApv,
+                TrustedAppProtocolVersionSigners = emptyApvSigners,
+                DifferentAppProtocolVersionEncountered = callback,
+            };
+
+            messageValidator = new MessageValidator(appProtocolVersionOptions, null);
 
             // Check trust pings
             messageValidator.ValidateAppProtocolVersion(trustedPing);
@@ -180,11 +183,14 @@ namespace Libplanet.Net.Tests.Messages
             Assert.False(called);
 
             // Trust anyone.
-            messageValidator = new MessageValidator(
-                appProtocolVersion: trustedApv,
-                trustedAppProtocolVersionSigners: nullApvSigners,
-                messageTimestampBuffer: null,
-                differentAppProtocolVersionEncountered: callback);
+            appProtocolVersionOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = trustedApv,
+                TrustedAppProtocolVersionSigners = nullApvSigners,
+                DifferentAppProtocolVersionEncountered = callback,
+            };
+
+            messageValidator = new MessageValidator(appProtocolVersionOptions, null);
 
             // Check trust pings
             messageValidator.ValidateAppProtocolVersion(trustedPing);

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -11,9 +11,6 @@ namespace Libplanet.Net.Tests
 {
     public partial class SwarmTest
     {
-        private static readonly AppProtocolVersion DefaultAppProtocolVersion =
-            AppProtocolVersion.Sign(new PrivateKey(), 1);
-
         [Fact(Timeout = Timeout)]
         public async Task DetectAppProtocolVersion()
         {

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -119,16 +120,26 @@ namespace Libplanet.Net.Tests
 
             options ??= new SwarmOptions();
 
+            differentAppProtocolVersionEncountered =
+                differentAppProtocolVersionEncountered is { } dapve
+                    ? dapve
+                    : (boundPeer, peerVersion, localVersion) => { };
+            var apvOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = appProtocolVersion ?? DefaultAppProtocolVersion,
+                TrustedAppProtocolVersionSigners =
+                    trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
+            };
+
             var swarm = new Swarm<T>(
                 blockChain,
                 privateKey ?? new PrivateKey(),
-                appProtocolVersion ?? DefaultAppProtocolVersion,
+                apvOptions,
                 5,
                 host,
                 listenPort,
                 iceServers,
-                differentAppProtocolVersionEncountered,
-                trustedAppProtocolVersionSigners,
                 options);
             _finalizers.Add(async () =>
             {

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -92,7 +92,7 @@ namespace Libplanet.Net.Tests
                 (boundPeer, peerVersion, localVersion) => { };
             var apvOptions = new AppProtocolVersionOptions()
             {
-                AppProtocolVersion = appProtocolVersion ?? DefaultAppProtocolVersion,
+                AppProtocolVersion = appProtocolVersion ?? default,
                 TrustedAppProtocolVersionSigners =
                     trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
                 DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
@@ -125,12 +125,7 @@ namespace Libplanet.Net.Tests
             }
 
             options ??= new SwarmOptions();
-
-            // FIXME: This is only to conform with the existing tests.
-            appProtocolVersionOptions ??= new AppProtocolVersionOptions()
-            {
-                AppProtocolVersion = DefaultAppProtocolVersion,
-            };
+            appProtocolVersionOptions ??= new AppProtocolVersionOptions();
 
             var swarm = new Swarm<T>(
                 blockChain,

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -70,12 +69,10 @@ namespace Libplanet.Net.Tests
 
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
-            AppProtocolVersion? appProtocolVersion = null,
+            AppProtocolVersionOptions appProtocolVersionOptions = null,
             string host = null,
             int? listenPort = null,
             IEnumerable<IceServer> iceServers = null,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
-            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
             SwarmOptions options = null,
             IBlockPolicy<DumbAction> policy = null,
             Block<DumbAction> genesis = null)
@@ -88,20 +85,12 @@ namespace Libplanet.Net.Tests
                 fx.StateStore,
                 genesisBlock: genesis
             );
-            differentAppProtocolVersionEncountered ??=
-                (boundPeer, peerVersion, localVersion) => { };
-            var apvOptions = new AppProtocolVersionOptions()
-            {
-                AppProtocolVersion = appProtocolVersion ?? default,
-                TrustedAppProtocolVersionSigners =
-                    trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
-                DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
-            };
+            appProtocolVersionOptions ??= new AppProtocolVersionOptions();
 
             return CreateSwarm(
                 blockchain,
                 privateKey,
-                apvOptions,
+                appProtocolVersionOptions,
                 host,
                 listenPort,
                 iceServers,

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -539,25 +539,25 @@ namespace Libplanet.Net.Tests
             var policy = new BlockPolicy<DumbAction>();
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var key = new PrivateKey();
-            AppProtocolVersion ver = AppProtocolVersion.Sign(key, 1);
-            Assert.Throws<ArgumentNullException>(() => { new Swarm<DumbAction>(null, key, ver); });
+            var apv = AppProtocolVersion.Sign(key, 1);
+            var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
 
             Assert.Throws<ArgumentNullException>(() =>
-            {
-                new Swarm<DumbAction>(blockchain, null, ver);
-            });
+                new Swarm<DumbAction>(null, key, apvOptions));
+            Assert.Throws<ArgumentNullException>(() =>
+                new Swarm<DumbAction>(blockchain, null, apvOptions));
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
-            {
-                new Swarm<DumbAction>(blockchain, key, ver);
-            });
+                new Swarm<DumbAction>(blockchain, key, apvOptions));
 
             // Swarm<DumbAction> needs host or iceServers.
             Assert.Throws<ArgumentException>(() =>
-            {
-                new Swarm<DumbAction>(blockchain, key, ver, iceServers: new IceServer[] { });
-            });
+                new Swarm<DumbAction>(
+                    blockchain,
+                    key,
+                    apvOptions,
+                    iceServers: new IceServer[] { }));
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -31,7 +31,8 @@ namespace Libplanet.Net.Tests.Transports
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
             var apvKey = new PrivateKey();
             var swarmKey = new PrivateKey();
-            AppProtocolVersion apv = AppProtocolVersion.Sign(apvKey, 1);
+            var apv = AppProtocolVersion.Sign(apvKey, 1);
+            var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
 
             string host = IPAddress.Loopback.ToString();
             int port = FreeTcpPort();
@@ -41,7 +42,7 @@ namespace Libplanet.Net.Tests.Transports
             using (var swarm = new Swarm<DumbAction>(
                 blockchain,
                 swarmKey,
-                apv,
+                apvOptions,
                 host: host,
                 listenPort: port,
                 options: option))

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -69,16 +69,21 @@ namespace Libplanet.Net.Tests.Transports
             privateKey = privateKey ?? new PrivateKey();
             host = host ?? IPAddress.Loopback.ToString();
             iceServers = iceServers ?? new List<IceServer>();
+            var appProtocolVersionOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = appProtocolVersion,
+                TrustedAppProtocolVersionSigners =
+                    trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
+            };
 
             return NetMQTransport.Create(
                 privateKey,
-                appProtocolVersion,
-                trustedAppProtocolVersionSigners,
+                appProtocolVersionOptions,
                 workers,
                 host,
                 listenPort,
                 iceServers,
-                differentAppProtocolVersionEncountered,
                 messageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Net;
 using Libplanet.Crypto;
 using Libplanet.Net.Transports;
@@ -19,23 +18,18 @@ namespace Libplanet.Net.Tests.Transports
         {
             TransportConstructor = (
                     privateKey,
-                    appProtocolVersion,
-                    trustedAppProtocolVersionSigners,
+                    appProtocolVersionOptions,
                     host,
                     listenPort,
                     iceServers,
-                    differentAppProtocolVersionEncountered,
-                    messageTimestampBuffer
-                )
-                => CreateNetMQTransport(
+                    messageTimestampBuffer) =>
+                CreateNetMQTransport(
                     privateKey,
-                    appProtocolVersion,
-                    trustedAppProtocolVersionSigners,
+                    appProtocolVersionOptions,
                     50,
                     host,
                     listenPort,
                     iceServers,
-                    differentAppProtocolVersionEncountered,
                     messageTimestampBuffer);
 
             const string outputTemplate =
@@ -56,25 +50,17 @@ namespace Libplanet.Net.Tests.Transports
 
         private NetMQTransport CreateNetMQTransport(
             PrivateKey privateKey,
-            AppProtocolVersion appProtocolVersion,
-            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
+            AppProtocolVersionOptions appProtocolVersionOptions,
             int workers,
             string host,
             int? listenPort,
             IEnumerable<IceServer> iceServers,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
             TimeSpan? messageTimestampBuffer
         )
         {
             privateKey = privateKey ?? new PrivateKey();
             host = host ?? IPAddress.Loopback.ToString();
             iceServers = iceServers ?? new List<IceServer>();
-            var appProtocolVersionOptions = new AppProtocolVersionOptions()
-            {
-                AppProtocolVersion = appProtocolVersion,
-                TrustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners,
-                DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
-            };
 
             return NetMQTransport.Create(
                 privateKey,

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -72,8 +72,7 @@ namespace Libplanet.Net.Tests.Transports
             var appProtocolVersionOptions = new AppProtocolVersionOptions()
             {
                 AppProtocolVersion = appProtocolVersion,
-                TrustedAppProtocolVersionSigners =
-                    trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                TrustedAppProtocolVersionSigners = trustedAppProtocolVersionSigners,
                 DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
             };
 

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -26,9 +25,8 @@ namespace Libplanet.Net.Tests.Transports
 
         protected ILogger Logger { get; set; }
 
-        protected Func<PrivateKey, AppProtocolVersion, IImmutableSet<PublicKey>,
-            string, int?, IEnumerable<IceServer>, DifferentAppProtocolVersionEncountered,
-            TimeSpan?, ITransport>
+        protected Func<PrivateKey, AppProtocolVersionOptions,
+            string, int?, IEnumerable<IceServer>, TimeSpan?, ITransport>
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
@@ -416,12 +414,10 @@ namespace Libplanet.Net.Tests.Transports
 
         private ITransport CreateTransport(
             PrivateKey privateKey = null,
-            AppProtocolVersion appProtocolVersion = default,
-            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners = null,
+            AppProtocolVersionOptions appProtocolVersionOptions = null,
             string host = null,
             int? listenPort = null,
             IEnumerable<IceServer> iceServers = null,
-            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered = null,
             TimeSpan? messageTimestampBuffer = null
         )
         {
@@ -435,12 +431,10 @@ namespace Libplanet.Net.Tests.Transports
 
             return TransportConstructor(
                 privateKey,
-                appProtocolVersion,
-                trustedAppProtocolVersionSigners ?? ImmutableHashSet<PublicKey>.Empty,
+                appProtocolVersionOptions ?? new AppProtocolVersionOptions(),
                 host,
                 listenPort,
                 iceServers ?? Enumerable.Empty<IceServer>(),
-                differentAppProtocolVersionEncountered,
                 messageTimestampBuffer);
         }
 

--- a/Libplanet.Net/AppProtocolVersionOptions.cs
+++ b/Libplanet.Net/AppProtocolVersionOptions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// Various options for a <see cref="Swarm{T}"/>'s
+    /// <see cref="Libplanet.Net.AppProtocolVersion"/>.
+    /// </summary>
+    public class AppProtocolVersionOptions
+    {
+        /// <summary>
+        /// The application protocol version to comply.
+        /// </summary>
+        public AppProtocolVersion AppProtocolVersion { get; set; } = default;
+
+        /// <summary>
+        /// The set of <see cref="PublicKey"/>s to trust when a node encounters
+        /// a <see cref="Message"/> with an <see cref="Net.AppProtocolVersion"/> that is different
+        /// from <see cref="AppProtocolVersion"/>.  Any <see cref="Message"/> with an untrusted
+        /// <see cref="Net.AppProtocolVersion"/> is ignored by the node.  To trust any party,
+        /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
+        /// </summary>
+        public ImmutableHashSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
+
+        /// <summary>
+        /// The callback triggered when a node encounters
+        /// an <see cref="Net.AppProtocolVersion"/> that is different from
+        /// <see cref="AppProtocolVersion"/> that is signed by
+        /// a <em>trusted party</em>, that is, one of
+        /// <see cref="TrustedAppProtocolVersionSigners"/>.  Does nothing by default.
+        /// </summary>
+        public DifferentAppProtocolVersionEncountered
+            DifferentAppProtocolVersionEncountered { get; set; } =
+                (peer, peerVersion, localVersion) => { };
+    }
+}

--- a/Libplanet.Net/AppProtocolVersionOptions.cs
+++ b/Libplanet.Net/AppProtocolVersionOptions.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Net
         /// <see cref="Net.AppProtocolVersion"/> is ignored by the node.  To trust any party,
         /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
         /// </summary>
-        public ImmutableHashSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
+        public IImmutableSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
 
         /// <summary>
         /// The callback triggered when a node encounters

--- a/Libplanet.Net/AppProtocolVersionOptions.cs
+++ b/Libplanet.Net/AppProtocolVersionOptions.cs
@@ -1,13 +1,12 @@
 using System.Collections.Immutable;
 using Libplanet.Crypto;
-using Libplanet.Net;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net
 {
     /// <summary>
     /// Various options for a <see cref="Swarm{T}"/>'s
-    /// <see cref="Libplanet.Net.AppProtocolVersion"/>.
+    /// <see cref="Net.AppProtocolVersion"/>.
     /// </summary>
     public class AppProtocolVersionOptions
     {

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -14,16 +14,13 @@ namespace Libplanet.Net.Messages
     public class MessageValidator
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private readonly AppProtocolVersionOptions _appProtocolVersionOptions;
 
         internal MessageValidator(
-            AppProtocolVersion appProtocolVersion,
-            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
-            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            AppProtocolVersionOptions appProtocolVersionOptions,
             TimeSpan? messageTimestampBuffer)
         {
-            Apv = appProtocolVersion;
-            TrustedApvSigners = trustedAppProtocolVersionSigners;
-            DifferentApvEncountered = differentAppProtocolVersionEncountered;
+            _appProtocolVersionOptions = appProtocolVersionOptions;
             MessageTimestampBuffer = messageTimestampBuffer;
         }
 
@@ -45,7 +42,7 @@ namespace Libplanet.Net.Messages
         /// </list>
         /// </para>
         /// </summary>
-        public AppProtocolVersion Apv { get; }
+        public AppProtocolVersion Apv => _appProtocolVersionOptions.AppProtocolVersion;
 
         /// <summary>
         /// <para>
@@ -69,7 +66,8 @@ namespace Libplanet.Net.Messages
         /// </list>
         /// </para>
         /// </summary>
-        public IImmutableSet<PublicKey>? TrustedApvSigners { get; }
+        public IImmutableSet<PublicKey>? TrustedApvSigners =>
+            _appProtocolVersionOptions.TrustedAppProtocolVersionSigners;
 
         /// <summary>
         /// A callback method that gets invoked when a an <see cref="AppProtocolVersion"/>
@@ -78,7 +76,8 @@ namespace Libplanet.Net.Messages
         /// <remarks>
         /// If <see langword="null"/>, no action is taken.
         /// </remarks>
-        public DifferentAppProtocolVersionEncountered? DifferentApvEncountered { get; }
+        public DifferentAppProtocolVersionEncountered DifferentApvEncountered =>
+            _appProtocolVersionOptions.DifferentAppProtocolVersionEncountered;
 
         /// <summary>
         /// <para>

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -135,7 +135,7 @@ namespace Libplanet.Net.Messages
         private static void ValidateAppProtocolVersion(
             AppProtocolVersion appProtocolVersion,
             IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
-            DifferentAppProtocolVersionEncountered? differentAppProtocolVersionEncountered,
+            DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
             Message message)
         {
             if (message.Remote is BoundPeer peer)
@@ -148,9 +148,10 @@ namespace Libplanet.Net.Messages
                 bool trusted = !(
                     trustedAppProtocolVersionSigners is { } tapvs &&
                     tapvs.All(publicKey => !message.Version.Verify(publicKey)));
-                if (trusted && differentAppProtocolVersionEncountered is { } dapve)
+                if (trusted)
                 {
-                    dapve(peer, message.Version, appProtocolVersion);
+                    differentAppProtocolVersionEncountered(
+                        peer, message.Version, appProtocolVersion);
                 }
 
                 if (!trusted || !message.Version.Version.Equals(appProtocolVersion.Version))

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -128,43 +128,6 @@ namespace Libplanet.Net
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
         }
 
-        internal Swarm(
-            BlockChain<T> blockChain,
-            PrivateKey privateKey,
-            AppProtocolVersion appProtocolVersion,
-            RoutingTable routingTable,
-            ITransport transport,
-            IEnumerable<PublicKey> trustedAppProtocolVersionSigners = null,
-            SwarmOptions options = null)
-        {
-            BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
-            _store = BlockChain.Store;
-            _privateKey = privateKey ?? throw new ArgumentNullException(nameof(privateKey));
-            LastSeenTimestamps =
-                new ConcurrentDictionary<BoundPeer, DateTimeOffset>();
-            BlockHeaderReceived = new AsyncAutoResetEvent();
-            BlockAppended = new AsyncAutoResetEvent();
-            BlockReceived = new AsyncAutoResetEvent();
-
-            _runningMutex = new AsyncLock();
-            _appProtocolVersion = appProtocolVersion;
-            TrustedAppProtocolVersionSigners =
-                trustedAppProtocolVersionSigners?.ToImmutableHashSet();
-
-            string loggerId = _privateKey.ToAddress().ToHex();
-            _logger = Log
-                .ForContext<Swarm<T>>()
-                .ForContext("Source", nameof(Swarm<T>))
-                .ForContext("SwarmId", loggerId);
-
-            Options = options ?? new SwarmOptions();
-            TxCompletion = new TxCompletion<BoundPeer, T>(BlockChain, GetTxsAsync, BroadcastTxs);
-            RoutingTable = routingTable;
-            Transport = transport;
-            Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
-            PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
-        }
-
         ~Swarm()
         {
             // FIXME If possible, we should stop Swarm appropriately here.

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -94,6 +94,13 @@ namespace Libplanet.Net
             _appProtocolVersion = appProtocolVersion;
             TrustedAppProtocolVersionSigners =
                 trustedAppProtocolVersionSigners?.ToImmutableHashSet();
+            var appProtocolVersionOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = AppProtocolVersion,
+                TrustedAppProtocolVersionSigners =
+                    trustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                DifferentAppProtocolVersionEncountered = differentAppProtocolVersionEncountered,
+            };
 
             string loggerId = _privateKey.ToAddress().ToHex();
             _logger = Log
@@ -111,13 +118,11 @@ namespace Libplanet.Net
             // https://github.com/planetarium/libplanet/discussions/2303.
             Transport = NetMQTransport.Create(
                 _privateKey,
-                _appProtocolVersion,
-                TrustedAppProtocolVersionSigners,
+                appProtocolVersionOptions,
                 workers,
                 host,
                 listenPort,
                 iceServers ?? new List<IceServer>(),
-                differentAppProtocolVersionEncountered,
                 Options.MessageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);

--- a/Libplanet.Node/NetworkConfig.cs
+++ b/Libplanet.Node/NetworkConfig.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -60,7 +60,7 @@ namespace Libplanet.Node
         /// <see cref="NetworkConfig{T}.AppProtocolVersion"/>.  To trust any party,
         /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
         /// </summary>
-        public ISet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
+        public IImmutableSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
 
         /// <summary>
         /// The event triggered when a node encounters

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
@@ -106,7 +105,7 @@ namespace Libplanet.Node
             {
                 AppProtocolVersion = NetworkConfig.AppProtocolVersion,
                 TrustedAppProtocolVersionSigners =
-                    NetworkConfig.TrustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                    NetworkConfig.TrustedAppProtocolVersionSigners,
                 DifferentAppProtocolVersionEncountered =
                     NetworkConfig.DifferentAppProtocolVersionEncountered,
             };

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
@@ -101,18 +102,23 @@ namespace Libplanet.Node
         public Swarm<T> GetSwarm()
         {
             BlockChain<T> blockChain = GetBlockChain();
-#pragma warning disable MEN002
+            var apvOptions = new AppProtocolVersionOptions()
+            {
+                AppProtocolVersion = NetworkConfig.AppProtocolVersion,
+                TrustedAppProtocolVersionSigners =
+                    NetworkConfig.TrustedAppProtocolVersionSigners?.ToImmutableHashSet(),
+                DifferentAppProtocolVersionEncountered =
+                    NetworkConfig.DifferentAppProtocolVersionEncountered,
+            };
+
             return new Swarm<T>(
                 privateKey: _privateKey,
                 blockChain: blockChain,
-                appProtocolVersion: NetworkConfig.AppProtocolVersion,
-                trustedAppProtocolVersionSigners: NetworkConfig.TrustedAppProtocolVersionSigners,
-                differentAppProtocolVersionEncountered: NetworkConfig.DifferentAppProtocolVersionEncountered,
+                appProtocolVersionOptions: apvOptions,
                 host: SwarmConfig.InitConfig.Host,
                 listenPort: SwarmConfig.InitConfig.Port,
                 iceServers: SwarmConfig.InitConfig.IceServers,
                 options: SwarmConfig.ToSwarmOptions());
-#pragma warning restore MEN002
         }
     }
 }


### PR DESCRIPTION
Preparatory work to enable extracting `ITransport` initialization from `Swarm<T>`'s constructor easier.