### PR TITLE
Introduce `HostOptions`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,12 +28,15 @@ To be released.
     [[#2653]]
      - `IActionTypeLoader.Load()`.
      - `IActionTypeLoader.LoadAllActionTypes()`.
- -  Changed `Swarm<T>()` and `NetMQTransport.Create()` to take
+ -  (Libplanet.Net) Removed `workers` parameter from `NetMQTransport.Create()`
+    method and `Swarm<T>()` constructor.  [[#2690]]
+ -  (Libplanet.Net) Changed `Swarm<T>()` and `NetMQTransport.Create()` to take
     `AppProtocolVersionOptions` as a combined parameter instead of taking
     `AppProtocolVersion`, `IImmutableSet<PublicKey>?`, and
     `DifferentAppProtocolVersionEncountered` separately.  [[#2693]]
- -  (Libplanet.Net) Removed `workers` parameter from `NetMQTransport.Create()`
-    method and `Swarm<T>()` constructor.  [[#2690]]
+ -  (Libplanet.Net) Changed `Swarm<T>()` and `NetMQTransport.Create()` to take
+    `HostOptions` as a combined parameter instead of taking
+    `string?`, `IEnumerable<IceServer>?`, and `int?` separately.  [[#2701]]
 
 ### Backward-incompatible network protocol changes
 
@@ -52,6 +55,7 @@ To be released.
      -  Added `StaticActionTypeLoader.LoadAllActionTypes()` method.
  -  Added `IActionTypeLoaderContext` interface.  [[#2653]]
  -  Added `AppProtocolVersionOptions` class.  [[#2693]]
+ -  Added `HostOptions` class.  [[#2701]]
 
 ### Behavioral changes
 
@@ -75,6 +79,7 @@ To be released.
 [#2690]: https://github.com/planetarium/libplanet/pull/2690
 [#2693]: https://github.com/planetarium/libplanet/pull/2693
 [#2699]: https://github.com/planetarium/libplanet/pull/2699
+[#2701]: https://github.com/planetarium/libplanet/pull/2701
 
 
 Version 0.45.4

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -283,10 +283,7 @@ If omitted (default) explorer only the local blockchain store.")]
                             : default(AppProtocolVersion),
                     };
 
-                    var hostOptions = new HostOptions(
-                        null,
-                        new[] { options.IceServer }.ToImmutableList(),
-                        0);
+                    var hostOptions = new HostOptions(null, new[] { options.IceServer });
 
                     swarm = new Swarm<NullAction>(
                         blockChain,

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -283,11 +283,16 @@ If omitted (default) explorer only the local blockchain store.")]
                             : default(AppProtocolVersion),
                     };
 
+                    var hostOptions = new HostOptions(
+                        null,
+                        new[] { options.IceServer }.ToImmutableList(),
+                        0);
+
                     swarm = new Swarm<NullAction>(
                         blockChain,
                         privateKey,
                         apvOptions,
-                        iceServers: new[] { options.IceServer },
+                        hostOptions,
                         options: swarmOptions
                     );
                 }

--- a/Libplanet.Net.Tests/HostOptionsTest.cs
+++ b/Libplanet.Net.Tests/HostOptionsTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using Xunit;
 
 namespace Libplanet.Net.Tests
@@ -9,12 +8,11 @@ namespace Libplanet.Net.Tests
         [Fact]
         public void Constructor()
         {
-            var iceServers = ImmutableList<IceServer>.Empty
-                .Add(new IceServer("turn://user:info@some.path"));
             Assert.Throws<ArgumentException>(
-                () => new HostOptions(null, ImmutableList<IceServer>.Empty, 0));
+                () => new HostOptions(null, new IceServer[] { }));
             Assert.Throws<ArgumentException>(
-                () => new HostOptions("localhost", iceServers, 0));
+                () => new HostOptions(
+                    "localhost", new IceServer[] { new IceServer("turn://user:info@some.path") }));
         }
     }
 }

--- a/Libplanet.Net.Tests/HostOptionsTest.cs
+++ b/Libplanet.Net.Tests/HostOptionsTest.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Libplanet.Net.Tests
+{
+    public class HostOptionsTest
+    {
+        [Fact]
+        public void Constructor()
+        {
+            var iceServers = ImmutableList<IceServer>.Empty
+                .Add(new IceServer("turn://user:info@some.path"));
+            Assert.Throws<ArgumentException>(
+                () => new HostOptions(null, ImmutableList<IceServer>.Empty, 0));
+            Assert.Throws<ArgumentException>(
+                () => new HostOptions("localhost", iceServers, 0));
+        }
+    }
+}

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -71,9 +71,7 @@ namespace Libplanet.Net.Tests
         private Swarm<DumbAction> CreateSwarm(
             PrivateKey privateKey = null,
             AppProtocolVersionOptions appProtocolVersionOptions = null,
-            string host = null,
-            int? listenPort = null,
-            IEnumerable<IceServer> iceServers = null,
+            HostOptions hostOptions = null,
             SwarmOptions options = null,
             IBlockPolicy<DumbAction> policy = null,
             Block<DumbAction> genesis = null)
@@ -87,14 +85,14 @@ namespace Libplanet.Net.Tests
                 genesisBlock: genesis
             );
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
+            hostOptions ??= new HostOptions(
+                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0);
 
             return CreateSwarm(
                 blockchain,
                 privateKey,
                 appProtocolVersionOptions,
-                host,
-                listenPort,
-                iceServers,
+                hostOptions,
                 options);
         }
 
@@ -102,30 +100,14 @@ namespace Libplanet.Net.Tests
             BlockChain<T> blockChain,
             PrivateKey privateKey = null,
             AppProtocolVersionOptions appProtocolVersionOptions = null,
-            string host = null,
-            int? listenPort = null,
-            IEnumerable<IceServer> iceServers = null,
-            SwarmOptions options = null
-        )
+            HostOptions hostOptions = null,
+            SwarmOptions options = null)
             where T : IAction, new()
         {
-            if (host is null && !(iceServers?.Any() ?? false))
-            {
-                host = IPAddress.Loopback.ToString();
-            }
-
-            options ??= new SwarmOptions();
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
-            var hostOptions = iceServers is null
-                ? new HostOptions(
-                    host ?? IPAddress.Loopback.ToString(),
-                    ImmutableList<IceServer>.Empty,
-                    listenPort ?? 0)
-                : new HostOptions(
-                    null,
-                    iceServers.ToImmutableList(),
-                    listenPort ?? 0);
-
+            hostOptions ??= new HostOptions(
+                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0);
+            options ??= new SwarmOptions();
             var swarm = new Swarm<T>(
                 blockChain,
                 privateKey ?? new PrivateKey(),

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -85,8 +84,7 @@ namespace Libplanet.Net.Tests
                 genesisBlock: genesis
             );
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
-            hostOptions ??= new HostOptions(
-                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0);
+            hostOptions ??= new HostOptions(IPAddress.Loopback.ToString(), new IceServer[] { });
 
             return CreateSwarm(
                 blockchain,
@@ -105,8 +103,7 @@ namespace Libplanet.Net.Tests
             where T : IAction, new()
         {
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
-            hostOptions ??= new HostOptions(
-                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0);
+            hostOptions ??= new HostOptions(IPAddress.Loopback.ToString(), new IceServer[] { });
             options ??= new SwarmOptions();
             var swarm = new Swarm<T>(
                 blockChain,

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -115,14 +116,21 @@ namespace Libplanet.Net.Tests
 
             options ??= new SwarmOptions();
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
+            var hostOptions = iceServers is null
+                ? new HostOptions(
+                    host ?? IPAddress.Loopback.ToString(),
+                    ImmutableList<IceServer>.Empty,
+                    listenPort ?? 0)
+                : new HostOptions(
+                    null,
+                    iceServers.ToImmutableList(),
+                    listenPort ?? 0);
 
             var swarm = new Swarm<T>(
                 blockChain,
                 privateKey ?? new PrivateKey(),
                 appProtocolVersionOptions,
-                host,
-                listenPort,
-                iceServers,
+                hostOptions,
                 options);
             _finalizers.Add(async () =>
             {

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -533,23 +533,15 @@ namespace Libplanet.Net.Tests
             var key = new PrivateKey();
             var apv = AppProtocolVersion.Sign(key, 1);
             var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
+            var hostOptions = new HostOptions(
+                IPAddress.Loopback.ToString(),
+                ImmutableList<IceServer>.Empty,
+                0);
 
             Assert.Throws<ArgumentNullException>(() =>
-                new Swarm<DumbAction>(null, key, apvOptions));
+                new Swarm<DumbAction>(null, key, apvOptions, hostOptions));
             Assert.Throws<ArgumentNullException>(() =>
-                new Swarm<DumbAction>(blockchain, null, apvOptions));
-
-            // Swarm<DumbAction> needs host or iceServers.
-            Assert.Throws<ArgumentException>(() =>
-                new Swarm<DumbAction>(blockchain, key, apvOptions));
-
-            // Swarm<DumbAction> needs host or iceServers.
-            Assert.Throws<ArgumentException>(() =>
-                new Swarm<DumbAction>(
-                    blockchain,
-                    key,
-                    apvOptions,
-                    iceServers: new IceServer[] { }));
+                new Swarm<DumbAction>(blockchain, null, apvOptions, hostOptions));
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -290,9 +290,9 @@ namespace Libplanet.Net.Tests
         {
             var keyA = new PrivateKey();
             var hostOptionsA = new HostOptions(
-                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 20_000);
+                IPAddress.Loopback.ToString(), new IceServer[] { }, 20_000);
             var hostOptionsB = new HostOptions(
-                IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 20_001);
+                IPAddress.Loopback.ToString(), new IceServer[] { }, 20_001);
 
             Swarm<DumbAction> swarmA = CreateSwarm(keyA, hostOptions: hostOptionsA);
             Swarm<DumbAction> swarmB = CreateSwarm(hostOptions: hostOptionsB);
@@ -538,9 +538,7 @@ namespace Libplanet.Net.Tests
             var apv = AppProtocolVersion.Sign(key, 1);
             var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
             var hostOptions = new HostOptions(
-                IPAddress.Loopback.ToString(),
-                ImmutableList<IceServer>.Empty,
-                0);
+                IPAddress.Loopback.ToString(), new IceServer[] { });
 
             Assert.Throws<ArgumentNullException>(() =>
                 new Swarm<DumbAction>(null, key, apvOptions, hostOptions));
@@ -552,7 +550,7 @@ namespace Libplanet.Net.Tests
         public void CanResolveEndPoint()
         {
             var expected = new DnsEndPoint("1.2.3.4", 5678);
-            var hostOptions = new HostOptions("1.2.3.4", ImmutableList<IceServer>.Empty, 5678);
+            var hostOptions = new HostOptions("1.2.3.4", new IceServer[] { }, 5678);
             using (Swarm<DumbAction> s = CreateSwarm(hostOptions: hostOptions))
             {
                 Assert.Equal(expected, s.EndPoint);
@@ -595,7 +593,7 @@ namespace Libplanet.Net.Tests
         {
             var iceServers = FactOnlyTurnAvailableAttribute.GetIceServers();
             var seedHostOptions = new HostOptions("localhost", ImmutableList<IceServer>.Empty, 0);
-            var swarmHostOptions = new HostOptions(null, iceServers.ToImmutableList(), 0);
+            var swarmHostOptions = new HostOptions(null, iceServers);
             var seed = CreateSwarm(hostOptions: seedHostOptions);
             var swarmA = CreateSwarm(hostOptions: swarmHostOptions);
             var swarmB = CreateSwarm(hostOptions: swarmHostOptions);
@@ -651,18 +649,14 @@ namespace Libplanet.Net.Tests
             string username = userInfo[0];
             string password = userInfo[1];
             var proxyUri = new Uri($"turn://{username}:{password}@localhost:{port}/");
-
-            IEnumerable<IceServer> iceServers = new[]
-            {
-                new IceServer(url: proxyUri),
-            };
+            IEnumerable<IceServer> iceServers = new[] { new IceServer(url: proxyUri) };
 
             var cts = new CancellationTokenSource();
             var proxyTask = TurnProxy(port, turnUrl, cts.Token);
 
             var seedKey = new PrivateKey();
             var seedHostOptions = new HostOptions("localhost", ImmutableList<IceServer>.Empty, 0);
-            var swarmHostOptions = new HostOptions(null, iceServers.ToImmutableList(), 0);
+            var swarmHostOptions = new HostOptions(null, iceServers, 0);
             var seed = CreateSwarm(seedKey, hostOptions: seedHostOptions);
             var swarmA = CreateSwarm(hostOptions: swarmHostOptions);
 

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -33,9 +34,12 @@ namespace Libplanet.Net.Tests.Transports
             var swarmKey = new PrivateKey();
             var apv = AppProtocolVersion.Sign(apvKey, 1);
             var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
-
             string host = IPAddress.Loopback.ToString();
             int port = FreeTcpPort();
+            var hostOptions = new HostOptions(
+                IPAddress.Loopback.ToString(),
+                ImmutableList<IceServer>.Empty,
+                port);
 
             var option = new SwarmOptions();
 
@@ -43,8 +47,7 @@ namespace Libplanet.Net.Tests.Transports
                 blockchain,
                 swarmKey,
                 apvOptions,
-                host: host,
-                listenPort: port,
+                hostOptions,
                 options: option))
             {
                 var peer = new BoundPeer(swarmKey.PublicKey, new DnsEndPoint(host, port));

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -1,6 +1,4 @@
-#nullable disable
 using System;
-using System.Collections.Immutable;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -30,16 +28,13 @@ namespace Libplanet.Net.Tests.Transports
             var fx = new MemoryStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
             var blockchain = MakeBlockChain(policy, fx.Store, fx.StateStore);
-            var apvKey = new PrivateKey();
             var swarmKey = new PrivateKey();
-            var apv = AppProtocolVersion.Sign(apvKey, 1);
+            var apv = AppProtocolVersion.Sign(new PrivateKey(), 1);
             var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
             string host = IPAddress.Loopback.ToString();
             int port = FreeTcpPort();
             var hostOptions = new HostOptions(
-                IPAddress.Loopback.ToString(),
-                ImmutableList<IceServer>.Empty,
-                port);
+                IPAddress.Loopback.ToString(), new IceServer[] { }, port);
 
             var option = new SwarmOptions();
 

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -1,6 +1,8 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Net;
 using Libplanet.Crypto;
 using Libplanet.Net.Transports;
@@ -72,21 +74,23 @@ namespace Libplanet.Net.Tests.Transports
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
             string host,
-            int? listenPort,
+            int listenPort,
             IEnumerable<IceServer> iceServers,
             TimeSpan? messageTimestampBuffer
         )
         {
             privateKey = privateKey ?? new PrivateKey();
-            host = host ?? IPAddress.Loopback.ToString();
-            iceServers = iceServers ?? new List<IceServer>();
+            var hostOptions = iceServers.Any()
+                ? new HostOptions(null, iceServers.ToImmutableList(), listenPort)
+                : new HostOptions(
+                    host ?? IPAddress.Loopback.ToString(),
+                    ImmutableList<IceServer>.Empty,
+                    listenPort);
 
             return NetMQTransport.Create(
                 privateKey,
                 appProtocolVersionOptions,
-                host,
-                listenPort,
-                iceServers,
+                hostOptions,
                 messageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -1,9 +1,5 @@
 #nullable disable
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Net;
 using Libplanet.Crypto;
 using Libplanet.Net.Transports;
 using NetMQ;
@@ -23,16 +19,12 @@ namespace Libplanet.Net.Tests.Transports
             TransportConstructor = (
                     privateKey,
                     appProtocolVersionOptions,
-                    host,
-                    listenPort,
-                    iceServers,
+                    hostOptions,
                     messageTimestampBuffer) =>
                 CreateNetMQTransport(
                     privateKey,
                     appProtocolVersionOptions,
-                    host,
-                    listenPort,
-                    iceServers,
+                    hostOptions,
                     messageTimestampBuffer);
 
             const string outputTemplate =
@@ -73,20 +65,10 @@ namespace Libplanet.Net.Tests.Transports
         private NetMQTransport CreateNetMQTransport(
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            string host,
-            int listenPort,
-            IEnumerable<IceServer> iceServers,
-            TimeSpan? messageTimestampBuffer
-        )
+            HostOptions hostOptions,
+            TimeSpan? messageTimestampBuffer)
         {
             privateKey = privateKey ?? new PrivateKey();
-            var hostOptions = iceServers.Any()
-                ? new HostOptions(null, iceServers.ToImmutableList(), listenPort)
-                : new HostOptions(
-                    host ?? IPAddress.Loopback.ToString(),
-                    ImmutableList<IceServer>.Empty,
-                    listenPort);
-
             return NetMQTransport.Create(
                 privateKey,
                 appProtocolVersionOptions,

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -25,8 +26,7 @@ namespace Libplanet.Net.Tests.Transports
 
         protected ILogger Logger { get; set; }
 
-        protected Func<PrivateKey, AppProtocolVersionOptions,
-            string, int, IEnumerable<IceServer>, TimeSpan?, ITransport>
+        protected Func<PrivateKey, AppProtocolVersionOptions, HostOptions, TimeSpan?, ITransport>
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
@@ -415,9 +415,7 @@ namespace Libplanet.Net.Tests.Transports
         private ITransport CreateTransport(
             PrivateKey privateKey = null,
             AppProtocolVersionOptions appProtocolVersionOptions = null,
-            string host = null,
-            int listenPort = 0,
-            IEnumerable<IceServer> iceServers = null,
+            HostOptions hostOptions = null,
             TimeSpan? messageTimestampBuffer = null
         )
         {
@@ -427,14 +425,11 @@ namespace Libplanet.Net.Tests.Transports
             }
 
             privateKey = privateKey ?? new PrivateKey();
-            host = host ?? IPAddress.Loopback.ToString();
-
             return TransportConstructor(
                 privateKey,
                 appProtocolVersionOptions ?? new AppProtocolVersionOptions(),
-                host,
-                listenPort,
-                iceServers ?? Enumerable.Empty<IceServer>(),
+                hostOptions ?? new HostOptions(
+                    IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0),
                 messageTimestampBuffer);
         }
 

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Net.Tests.Transports
         protected ILogger Logger { get; set; }
 
         protected Func<PrivateKey, AppProtocolVersionOptions,
-            string, int?, IEnumerable<IceServer>, TimeSpan?, ITransport>
+            string, int, IEnumerable<IceServer>, TimeSpan?, ITransport>
             TransportConstructor { get; set; }
 
         [SkippableFact(Timeout = Timeout)]
@@ -416,7 +416,7 @@ namespace Libplanet.Net.Tests.Transports
             PrivateKey privateKey = null,
             AppProtocolVersionOptions appProtocolVersionOptions = null,
             string host = null,
-            int? listenPort = null,
+            int listenPort = 0,
             IEnumerable<IceServer> iceServers = null,
             TimeSpan? messageTimestampBuffer = null
         )

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -429,7 +428,7 @@ namespace Libplanet.Net.Tests.Transports
                 privateKey,
                 appProtocolVersionOptions ?? new AppProtocolVersionOptions(),
                 hostOptions ?? new HostOptions(
-                    IPAddress.Loopback.ToString(), ImmutableList<IceServer>.Empty, 0),
+                    IPAddress.Loopback.ToString(), new IceServer[] { }, 0),
                 messageTimestampBuffer);
         }
 

--- a/Libplanet.Net/HostOptions.cs
+++ b/Libplanet.Net/HostOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -11,7 +12,7 @@ namespace Libplanet.Net
     {
         public HostOptions(
             string? host,
-            ImmutableList<IceServer> iceServers,
+            IEnumerable<IceServer> iceServers,
             int port = 0)
         {
             if (port < 0)
@@ -25,7 +26,7 @@ namespace Libplanet.Net
             }
 
             Host = host;
-            IceServers = iceServers;
+            IceServers = iceServers.ToImmutableList();
             Port = port;
         }
 
@@ -42,7 +43,7 @@ namespace Libplanet.Net
         /// servers to use for TURN/STUN to traverse NAT.  This is empty when <see cref="Host"/>
         /// is provided.
         /// </summary>
-        public ImmutableList<IceServer> IceServers { get; }
+        public IReadOnlyList<IceServer> IceServers { get; }
 
         /// <summary>
         /// The port number to use for the host.  If set to zero, a free port will be assigned.

--- a/Libplanet.Net/HostOptions.cs
+++ b/Libplanet.Net/HostOptions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Libplanet.Net
+{
+    /// <summary>
+    /// Various options for determining <see cref="Swarm{T}"/>'s <see cref="BoundPeer"/> identity.
+    /// </summary>
+    public class HostOptions
+    {
+        public HostOptions(
+            string? host,
+            ImmutableList<IceServer> iceServers,
+            int port = 0)
+        {
+            if (port < 0)
+            {
+                throw new ArgumentException($"Given {nameof(port)} cannot be negative: {port}");
+            }
+            else if (!(host is { } ^ iceServers.Any()))
+            {
+                throw new ArgumentException(
+                    $"Either {nameof(host)} must be null or {nameof(iceServers)} must be empty.");
+            }
+
+            Host = host;
+            IceServers = iceServers;
+            Port = port;
+        }
+
+        /// <summary>
+        /// The hostname to be a part of a public endpoint that peers may use when
+        /// they connect to this node.  This is set to <see langword="null"/> when
+        /// a non-empty <see cref="IceServers"/> is provided.
+        /// </summary>
+        public string? Host { get; }
+
+        /// <summary>
+        /// The set of
+        /// <a href="https://en.wikipedia.org/wiki/Interactive_Connectivity_Establishment">ICE</a>
+        /// servers to use for TURN/STUN to traverse NAT.  This is empty when <see cref="Host"/>
+        /// is provided.
+        /// </summary>
+        public ImmutableList<IceServer> IceServers { get; }
+
+        /// <summary>
+        /// The port number to use for the host.  If set to zero, a free port will be assigned.
+        /// </summary>
+        public int Port { get; }
+    }
+}

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -97,12 +97,14 @@ namespace Libplanet.Net
             // code, the portion initializing the swarm in Agent.cs in NineChronicles should be
             // fixed. for context, refer to
             // https://github.com/planetarium/libplanet/discussions/2303.
+            var hostOptions = new HostOptions(
+                host,
+                iceServers?.ToImmutableList() ?? ImmutableList<IceServer>.Empty,
+                listenPort ?? 0);
             Transport = NetMQTransport.Create(
                 _privateKey,
                 _appProtocolVersionOptions,
-                host,
-                listenPort,
-                iceServers ?? new List<IceServer>(),
+                hostOptions,
                 Options.MessageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -53,21 +53,14 @@ namespace Libplanet.Net
         /// <param name="appProtocolVersionOptions">The <see cref="AppProtocolVersionOptions"/>
         /// to use when handling an <see cref="AppProtocolVersion"/> attached to
         /// a <see cref="Message"/>.</param>
-        /// <param name="host">A hostname to be a part of a public endpoint, that peers use when
-        /// they connect to this node.  Note that this is not a hostname to listen to;
-        /// <see cref="Swarm{T}"/> always listens to 0.0.0.0 &amp; ::/0.</param>
-        /// <param name="listenPort">A port number to listen to.</param>
-        /// <param name="iceServers">
-        /// <a href="https://en.wikipedia.org/wiki/Interactive_Connectivity_Establishment">ICE</a>
-        /// servers to use for TURN/STUN.  Purposes to traverse NAT.</param>
+        /// <param name="hostOptions">The <see cref="HostOptions"/> to use when binding
+        /// to the network.</param>
         /// <param name="options">Options for <see cref="Swarm{T}"/>.</param>
         public Swarm(
             BlockChain<T> blockChain,
             PrivateKey privateKey,
             AppProtocolVersionOptions appProtocolVersionOptions,
-            string host = null,
-            int? listenPort = null,
-            IEnumerable<IceServer> iceServers = null,
+            HostOptions hostOptions,
             SwarmOptions options = null)
         {
             BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
@@ -97,10 +90,6 @@ namespace Libplanet.Net
             // code, the portion initializing the swarm in Agent.cs in NineChronicles should be
             // fixed. for context, refer to
             // https://github.com/planetarium/libplanet/discussions/2303.
-            var hostOptions = new HostOptions(
-                host,
-                iceServers?.ToImmutableList() ?? ImmutableList<IceServer>.Empty,
-                listenPort ?? 0);
             Transport = NetMQTransport.Create(
                 _privateKey,
                 _appProtocolVersionOptions,

--- a/Libplanet.Node.Tests/SwarmConfigTest.cs
+++ b/Libplanet.Node.Tests/SwarmConfigTest.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Node.Tests
         [MemberData(nameof(SerializationData))]
         public void Serialization(
             string host,
-            int? port,
+            int port,
             IEnumerable<IceServer> iceServers,
             IEnumerable<BoundPeer> seedPeers,
             bool render,

--- a/Libplanet.Node/InitConfig.cs
+++ b/Libplanet.Node/InitConfig.cs
@@ -45,9 +45,9 @@ namespace Libplanet.Node
         public string? Host { get; set; } = "localhost";
 
         /// <summary>
-        /// Determines the <em>incoming</em> port.  Set to <see langword="null"/> by default.
+        /// Determines the <em>incoming</em> port.  Set to <c>0</c> by default.
         /// </summary>
-        public int? Port { get; set; } = null;
+        public int Port { get; set; } = 0;
 
         /// <summary>
         /// The list of <see cref="IceServers"/> to use when connecting to the network.

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
@@ -112,8 +111,8 @@ namespace Libplanet.Node
             };
             var hostOptions = new HostOptions(
                 SwarmConfig.InitConfig.Host,
-                SwarmConfig.InitConfig.IceServers.ToImmutableList(),
-                SwarmConfig.InitConfig.Port ?? 0);
+                SwarmConfig.InitConfig.IceServers,
+                SwarmConfig.InitConfig.Port);
 
             return new Swarm<T>(
                 privateKey: _privateKey,

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
@@ -109,14 +110,16 @@ namespace Libplanet.Node
                 DifferentAppProtocolVersionEncountered =
                     NetworkConfig.DifferentAppProtocolVersionEncountered,
             };
+            var hostOptions = new HostOptions(
+                SwarmConfig.InitConfig.Host,
+                SwarmConfig.InitConfig.IceServers.ToImmutableList(),
+                SwarmConfig.InitConfig.Port ?? 0);
 
             return new Swarm<T>(
                 privateKey: _privateKey,
                 blockChain: blockChain,
                 appProtocolVersionOptions: apvOptions,
-                host: SwarmConfig.InitConfig.Host,
-                listenPort: SwarmConfig.InitConfig.Port,
-                iceServers: SwarmConfig.InitConfig.IceServers,
+                hostOptions: hostOptions,
                 options: SwarmConfig.ToSwarmOptions());
         }
     }


### PR DESCRIPTION
Continuation of #2693.

On a side note, I thought about making `HostOptions` as a plain collection of properties with `{ get; set; }` for each, like `AppProtocolVersionOptions` and `SwarmOptions`, but decided against it. This breaks overall consistency, but I think parsing options should be done at "options level". If anyone disagrees with the design, I can change it back. 🙄