### PR TITLE
fix/transport: socket count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@ To be released.
 
 ### Bug fixes
 
+ -  (Libplanet.Net) Fixed a bug `NetMQTransport` log shows socket count wrongly.
+    [[#2708]]
+
 ### Dependencies
 
 ### CLI tools
@@ -84,6 +87,7 @@ To be released.
 [#2701]: https://github.com/planetarium/libplanet/pull/2701
 [#2704]: https://github.com/planetarium/libplanet/pull/2704
 [#2705]: https://github.com/planetarium/libplanet/pull/2705
+[#2708]: https://github.com/planetarium/libplanet/pull/2708
 
 
 Version 0.45.4


### PR DESCRIPTION
This PR addresses a logging bug where the count of sockets is going negative value. Before the start, I couldn't find the current socket count-related property or field from NetMQ.

### Socket is not allocated but canceled
The socket count is incremented when the `GetRequestDealerSocket()` is called. If the `CancellationToken.ThrowIfCancellationRequested()` is thrown, then the socket is not allocated (i.e., `GetRequestDealerSocket()` is not called, the count is not incremented.)

### Failed to allocate a socket
The `DealerSocket` in `GetRequestDealerSocket()` throws `NetMQException` if allocating socket is failed. In this case, the socket is not allocated (socket count remains) and breaks out from `new DealerSocket` and `GetRequestDealerSocket()`.

### Socket is allocated and canceled or exception thrown
The socket count is incremented by calling `GetRequestDealerSocket()`. `OperationCanceledException` also can be thrown at `dealer.ReceiveMultipartMessageAsync()`, as an example. In this case, the socket has been allocated (count has incremented), and cancellation has been requested. 