### PR TITLE
Fix NetMQSocket leak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,9 @@ To be released.
 
  -  (Libplanet.Net) Fixed a bug `NetMQTransport` log shows socket count wrongly.
     [[#2708]]
+ -  (Libplanet.Net) Fixed a bug where `NetMQTransport.SendMessageAsync()` method
+    hadn't disposed of internal sockets properly when connecting failed.
+    [[#2719]]
 
 ### Dependencies
 
@@ -111,6 +114,7 @@ To be released.
 [#2708]: https://github.com/planetarium/libplanet/pull/2708
 [#2718]: https://github.com/planetarium/libplanet/pull/2718
 [#2716]: https://github.com/planetarium/libplanet/pull/2716
+[#2719]: https://github.com/planetarium/libplanet/pull/2719
 
 
 Version 0.45.4

--- a/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/NetMQTransportTest.cs
@@ -1,6 +1,11 @@
 #nullable disable
 using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Libplanet.Crypto;
+using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
 using NetMQ;
 using Serilog;
@@ -41,6 +46,78 @@ namespace Libplanet.Net.Tests.Transports
         ~NetMQTransportTest()
         {
             Dispose(false);
+        }
+
+        [SkippableFact]
+        public async Task SendMessageAsyncNetMQSocketLeak()
+        {
+            int previousMaxSocket = NetMQConfig.MaxSockets;
+
+            try
+            {
+                // An arbitrary number to fit one transport testing.
+                NetMQConfig.MaxSockets = 12;
+                NetMQTransport transport = await NetMQTransport.Create(
+                    new PrivateKey(),
+                    new AppProtocolVersionOptions(),
+                    new HostOptions(IPAddress.Loopback.ToString(), new IceServer[] { }, 0)
+                );
+                transport.ProcessMessageHandler.Register(
+                    async m =>
+                    {
+                        await transport.ReplyMessageAsync(
+                            new PongMsg
+                            {
+                                Identity = m.Identity,
+                            },
+                            CancellationToken.None
+                        );
+                    }
+                );
+                await InitializeAsync(transport);
+
+                string invalidHost = Guid.NewGuid().ToString();
+
+                // it isn't assertion for Libplanet codes, but to make sure that `invalidHost`
+                // really fails lookup before moving to the next step.
+                Assert.ThrowsAny<SocketException>(() =>
+                {
+                    Dns.GetHostEntry(invalidHost);
+                });
+                var invalidPeer = new BoundPeer(
+                    new PrivateKey().PublicKey,
+                    new DnsEndPoint(invalidHost, 0)
+                );
+
+                CommunicationFailException exc =
+                    await Assert.ThrowsAsync<CommunicationFailException>(
+                        () => transport.SendMessageAsync(
+                            invalidPeer,
+                            new PingMsg(),
+                            TimeSpan.FromSeconds(5),
+                            default
+                        )
+                    );
+
+                // Expecting SocketException about host resolving since `invalidPeer` has an
+                // invalid hostname
+                Assert.IsAssignableFrom<SocketException>(exc.InnerException);
+
+                // Check sending/receiving after exceptions exceeding NetMQConifg.MaxSockets.
+                Message reply = await transport.SendMessageAsync(
+                    transport.AsPeer,
+                    new PingMsg(),
+                    TimeSpan.FromSeconds(1),
+                    default
+                );
+                Assert.IsType<PongMsg>(reply);
+
+                await transport.StopAsync(TimeSpan.Zero, CancellationToken.None);
+            }
+            finally
+            {
+                NetMQConfig.MaxSockets = previousMaxSocket;
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
This PR fixes a leakage of `NetMQSocket` on `NetMQTransport.SendMessageAsync()` when it has failed on connecting.

I splitted commits with intention because

- We should back-port this change to 0.45-maintenance after merging with #2708.
- I borrowed 2a194d7 from my other experimental PR(#2714) and perhaps I think the current way of handling is enough. however, there may be better implementations or implementations also need test cases for confirmation.