### PR TITLE
Validate hostname in `BoundPeer` type

### DIFF
--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -91,7 +91,21 @@ namespace Libplanet.Net.Tests
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"));
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1"));
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,192.168.0.1,999999"));
+            Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233,.ninodes.com,31234"));
 #pragma warning restore MEN002 // Line is too long
+        }
+
+        [Fact]
+        public void InvalidHostname()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new BoundPeer(
+#pragma warning disable MEN002 // Line is too long
+                    new PublicKey(ByteUtil.ParseHex("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233")),
+#pragma warning restore MEN002 // Line is too long
+                    new DnsEndPoint(".ninodes.com", 31234)
+                )
+            );
         }
     }
 }

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -99,13 +99,7 @@ namespace Libplanet.Net.Tests
         public void InvalidHostname()
         {
             Assert.Throws<ArgumentException>(() =>
-                new BoundPeer(
-#pragma warning disable MEN002 // Line is too long
-                    new PublicKey(ByteUtil.ParseHex("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233")),
-#pragma warning restore MEN002 // Line is too long
-                    new DnsEndPoint(".ninodes.com", 31234)
-                )
-            );
+                new BoundPeer(new PrivateKey().PublicKey, new DnsEndPoint(".ninodes.com", 31234)));
         }
     }
 }

--- a/Libplanet.Net.Tests/Transports/TransportTest.cs
+++ b/Libplanet.Net.Tests/Transports/TransportTest.cs
@@ -446,23 +446,7 @@ namespace Libplanet.Net.Tests.Transports
                 {
                     new BoundPeer(
                         new PrivateKey().PublicKey,
-                        new DnsEndPoint(
-                            "0.0.0.0",
-                            port
-                        )
-                    ),
-                };
-
-                // e.g., "127.0.0.1":0
-                yield return new[]
-                {
-                    new BoundPeer(
-                        new PrivateKey().PublicKey,
-                        new DnsEndPoint(
-                            $"\"{IPAddress.Loopback}\"",
-                            0
-                        )
-                    ),
+                        new DnsEndPoint("0.0.0.0", port)),
                 };
             }
 

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -50,12 +50,14 @@ namespace Libplanet.Net
             DnsEndPoint endPoint,
             IPAddress? publicIPAddress)
         {
-            PublicKey = publicKey;
             if (Uri.CheckHostName(endPoint.Host) == UriHostNameType.Unknown)
             {
-                throw new ArgumentException(nameof(endPoint));
+                throw new ArgumentException(
+                    $"Given {nameof(endPoint)} has unknown host name type: {endPoint.Host}",
+                    nameof(endPoint));
             }
 
+            PublicKey = publicKey;
             EndPoint = endPoint;
             PublicIPAddress = publicIPAddress;
         }
@@ -142,7 +144,6 @@ namespace Libplanet.Net
             {
                 var pubKey = new PublicKey(ByteUtil.ParseHex(tokens[0]));
                 var host = tokens[1];
-                Uri.CheckHostName(host);
                 var port = int.Parse(tokens[2], CultureInfo.InvariantCulture);
 
                 // FIXME: It might be better to make Peer.AppProtocolVersion property nullable...

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -51,6 +51,11 @@ namespace Libplanet.Net
             IPAddress? publicIPAddress)
         {
             PublicKey = publicKey;
+            if (Uri.CheckHostName(endPoint.Host) == UriHostNameType.Unknown)
+            {
+                throw new ArgumentException(nameof(endPoint));
+            }
+
             EndPoint = endPoint;
             PublicIPAddress = publicIPAddress;
         }
@@ -137,6 +142,7 @@ namespace Libplanet.Net
             {
                 var pubKey = new PublicKey(ByteUtil.ParseHex(tokens[0]));
                 var host = tokens[1];
+                Uri.CheckHostName(host);
                 var port = int.Parse(tokens[2], CultureInfo.InvariantCulture);
 
                 // FIXME: It might be better to make Peer.AppProtocolVersion property nullable...


### PR DESCRIPTION
This pull request makes `BoundPeer` not able to have an invalid hostname. (e.g., `.ninodes.com`, not `some.ninodes.com`).

I'm not sure but I'll request a review from members who looked network part usually according to my memory.