### PR TITLE
Elide duplicated prefix of paths in Web3KeyStore & Release 0.45.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Libplanet changelog
 Version 0.45.5
 --------------
 
-To be released.
+Released on January 19, 2023.
 
   -  Fixed a bug when `Web3KeyStore.Get()` hadn't worked properly on IL2CPP
      environment.  [[#2727]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.45.5
 
 To be released.
 
+  -  Fixed a bug when `Web3KeyStore.Get()` hadn't worked properly on IL2CPP
+     environment.  [[#2727]]
+
+[#2727]: https://github.com/planetarium/libplanet/pull/2727
+
 
 Version 0.45.4
 --------------

--- a/Libplanet/KeyStore/Web3KeyStore.cs
+++ b/Libplanet/KeyStore/Web3KeyStore.cs
@@ -106,17 +106,17 @@ namespace Libplanet.KeyStore
         public ProtectedPrivateKey Get(Guid id)
         {
             IEnumerable<(Guid, string)> files = ListFiles();
-            string name;
+            string keyPath;
             try
             {
-                (_, name) = files.First(pair => pair.Item1.Equals(id));
+                (_, keyPath) = files.First(pair => pair.Item1.Equals(id));
             }
             catch (InvalidOperationException)
             {
                 throw new NoKeyException("There is no key with such ID", id);
             }
 
-            return Get(name);
+            return Get(keyPath);
         }
 
         /// <inheritdoc/>
@@ -179,12 +179,10 @@ namespace Libplanet.KeyStore
             }
         }
 
-        private ProtectedPrivateKey Get(string name)
+        private ProtectedPrivateKey Get(string keyPath)
         {
-            using (StreamReader reader = new StreamReader(System.IO.Path.Combine(Path, name)))
-            {
-                return ProtectedPrivateKey.FromJson(reader.ReadToEnd());
-            }
+            using StreamReader reader = new StreamReader(keyPath);
+            return ProtectedPrivateKey.FromJson(reader.ReadToEnd());
         }
     }
 }


### PR DESCRIPTION
This PR adjusts internal codes of `Web3KeyStore`, to remove duplicated prefixes from return values of `.ListFiles()`. ([`Directory.EnumerateFiles()`](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles?view=netstandard-2.0#system-io-directory-enumeratefiles(system-string)) returns full name so we don't need to combine return values and `Path`)

I couldn't prepare a regression test case since `System.IO.Path.Combine()` seems to elide duplicated parts automatically. but it didn't work so that on IL2CPP environment.

p.s. thanks for helping debug :) @sonohoshi 