### PR TITLE
Use .NET 6 & C# 10 on CLI tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,17 @@ Version 0.47.0
 
 To be released.
 
+### Deprecated APIs
+
 ### Backward-incompatible API changes
+
+ -  (Libplanet.Extensions.Cocona)  Dropped .NET Standard 2.0 and .NET Core 3.1
+    target assemblies.  [[#2732]]
+ -  (Libplanet.Extensions.Cocona)  Added .NET 6 target assembly.  [[#2732]]
+
+### Backward-incompatible network protocol changes
+
+### Backward-incompatible storage format changes
 
 ### Added APIs
 
@@ -14,7 +24,11 @@ To be released.
 
 ### Bug fixes
 
+### Dependencies
+
 ### CLI tools
+
+[[#2732]]: https://github.com/planetarium/libplanet/pull/2732
 
 
 Version 0.46.0

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Tools.Tests;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,89 +11,86 @@ using Libplanet.Store.Trie;
 using Libplanet.Tools.Tests.Services;
 using Xunit;
 
-namespace Libplanet.Tools.Tests
+public class MptCommandTest : IDisposable
 {
-    public class MptCommandTest : IDisposable
+    private readonly MptCommand _command;
+    private readonly string _pathA;
+    private readonly string _pathB;
+    private readonly ITrie _trieA;
+    private readonly ITrie _trieB;
+
+    public MptCommandTest()
     {
-        private readonly MptCommand _command;
-        private readonly string _pathA;
-        private readonly string _pathB;
-        private readonly ITrie _trieA;
-        private readonly ITrie _trieB;
+        _command = new MptCommand();
 
-        public MptCommandTest()
-        {
-            _command = new MptCommand();
-
-            _pathA = NewTempPath();
-            _pathB = NewTempPath();
-            using var stateKeyValueStoreA = new DefaultKeyValueStore(_pathA);
-            using var stateKeyValueStoreB = new DefaultKeyValueStore(_pathB);
-            _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
-                ImmutableDictionary<string, IValue>.Empty
-                    .Add("deleted", Null.Value)
-                    .Add("common", (Text)"before")).Commit();
-            _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
-                ImmutableDictionary<string, IValue>.Empty
-                    .Add("created", Null.Value)
-                    .Add("common", (Text)"after")).Commit();
-        }
-
-        [Fact]
-        public void Diff_PrintsAsJson()
-        {
-            using StringWriter stringWriter = new StringWriter { NewLine = "\n" };
-            var originalOutWriter = Console.Out;
-            try
-            {
-                Console.SetOut(stringWriter);
-                var kvStoreUri = $"default://{_pathA}";
-                var otherKvStoreUri = $"default://{_pathB}";
-                var configuration =
-                    new ToolConfiguration(new MptConfiguration(new Dictionary<string, string>()));
-                string stateRootHashHex = ByteUtil.Hex(_trieA.Hash.ByteArray);
-                string otherStateRootHashHex = ByteUtil.Hex(_trieB.Hash.ByteArray);
-
-                _command.Diff(
-                    kvStoreUri,
-                    stateRootHashHex,
-                    otherKvStoreUri,
-                    otherStateRootHashHex,
-                    new TestToolConfigurationService(configuration));
-
-                string expected = string.Format(
-                    @"{{""Key"":""636f6d6d6f6e"",""StateRootHashToValue"":" +
-                    @"{{""{0}"":""75363a6265666f7265"",""{1}"":""75353a6166746572""}}}}" + "\n" +
-                    @"{{""Key"":""64656c65746564""," +
-                    @"""StateRootHashToValue"":{{""{0}"":""6e"",""{1}"":""null""}}}}" + "\n",
-                    stateRootHashHex,
-                    otherStateRootHashHex);
-                Assert.Equal(
-                    expected,
-                    stringWriter.ToString());
-            }
-            finally
-            {
-                Console.SetOut(originalOutWriter);
-            }
-        }
-
-        public void Dispose()
-        {
-            if (Directory.Exists(_pathA))
-            {
-                Directory.Delete(_pathA, true);
-            }
-
-            if (Directory.Exists(_pathB))
-            {
-                Directory.Delete(_pathB, true);
-            }
-        }
-
-        private static string NewTempPath() =>
-            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
-                .Replace("\\", "/")
-                .Replace("C:", string.Empty);
+        _pathA = NewTempPath();
+        _pathB = NewTempPath();
+        using var stateKeyValueStoreA = new DefaultKeyValueStore(_pathA);
+        using var stateKeyValueStoreB = new DefaultKeyValueStore(_pathB);
+        _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
+            ImmutableDictionary<string, IValue>.Empty
+                .Add("deleted", Null.Value)
+                .Add("common", (Text)"before")).Commit();
+        _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
+            ImmutableDictionary<string, IValue>.Empty
+                .Add("created", Null.Value)
+                .Add("common", (Text)"after")).Commit();
     }
+
+    [Fact]
+    public void Diff_PrintsAsJson()
+    {
+        using StringWriter stringWriter = new StringWriter { NewLine = "\n" };
+        var originalOutWriter = Console.Out;
+        try
+        {
+            Console.SetOut(stringWriter);
+            var kvStoreUri = $"default://{_pathA}";
+            var otherKvStoreUri = $"default://{_pathB}";
+            var configuration =
+                new ToolConfiguration(new MptConfiguration(new Dictionary<string, string>()));
+            string stateRootHashHex = ByteUtil.Hex(_trieA.Hash.ByteArray);
+            string otherStateRootHashHex = ByteUtil.Hex(_trieB.Hash.ByteArray);
+
+            _command.Diff(
+                kvStoreUri,
+                stateRootHashHex,
+                otherKvStoreUri,
+                otherStateRootHashHex,
+                new TestToolConfigurationService(configuration));
+
+            string expected = string.Format(
+                @"{{""Key"":""636f6d6d6f6e"",""StateRootHashToValue"":" +
+                @"{{""{0}"":""75363a6265666f7265"",""{1}"":""75353a6166746572""}}}}" + "\n" +
+                @"{{""Key"":""64656c65746564""," +
+                @"""StateRootHashToValue"":{{""{0}"":""6e"",""{1}"":""null""}}}}" + "\n",
+                stateRootHashHex,
+                otherStateRootHashHex);
+            Assert.Equal(
+                expected,
+                stringWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOutWriter);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_pathA))
+        {
+            Directory.Delete(_pathA, true);
+        }
+
+        if (Directory.Exists(_pathB))
+        {
+            Directory.Delete(_pathB, true);
+        }
+    }
+
+    private static string NewTempPath() =>
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+            .Replace("\\", "/")
+            .Replace("C:", string.Empty);
 }

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StatsCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StatsCommandTest.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Extensions.Cocona.Tests.Commands;
+
 using System;
 using System.Collections.Immutable;
 using System.IO;
@@ -6,92 +8,89 @@ using Libplanet.RocksDBStore.Tests;
 using Libplanet.Tests.Store;
 using Xunit;
 
-namespace Libplanet.Extensions.Cocona.Tests.Commands
+public class StatsCommandTest : IDisposable
 {
-    public class StatsCommandTest : IDisposable
+    private readonly ImmutableArray<StoreFixture> _storeFixtures;
+    private readonly StatsCommand _command;
+    private readonly TextWriter _originalWriter;
+
+    public StatsCommandTest()
     {
-        private readonly ImmutableArray<StoreFixture> _storeFixtures;
-        private readonly StatsCommand _command;
-        private readonly TextWriter _originalWriter;
-
-        public StatsCommandTest()
+        _command = new StatsCommand();
+        _originalWriter = Console.Out;
+        try
         {
-            _command = new StatsCommand();
-            _originalWriter = Console.Out;
-            try
-            {
-                _storeFixtures = ImmutableArray.Create<StoreFixture>(
-                    new DefaultStoreFixture(false),
-                    new RocksDBStoreFixture()
-                );
-            }
-            catch (TypeInitializationException)
-            {
-                throw new SkipException("RocksDB is not available.");
-            }
-
-            foreach (var storeFixture in _storeFixtures)
-            {
-                var guid = Guid.NewGuid();
-                storeFixture.Store.SetCanonicalChainId(guid);
-                storeFixture.Store.PutBlock(storeFixture.Block1);
-                storeFixture.Store.AppendIndex(guid, storeFixture.Block1.Hash);
-                storeFixture.Store.PutTransaction(storeFixture.Transaction1);
-            }
+            _storeFixtures = ImmutableArray.Create<StoreFixture>(
+                new DefaultStoreFixture(false),
+                new RocksDBStoreFixture()
+            );
+        }
+        catch (TypeInitializationException)
+        {
+            throw new SkipException("RocksDB is not available.");
         }
 
-        [SkippableFact]
-        public void SummaryInvalidArguments()
+        foreach (var storeFixture in _storeFixtures)
         {
-            string badPathFormat = "rocksdb+foo+bar://" + "/bar";
-            string badPathScheme = "foo://" + "/bar";
-            long badOffset = long.MaxValue;
-            long badLimit = 0;
+            var guid = Guid.NewGuid();
+            storeFixture.Store.SetCanonicalChainId(guid);
+            storeFixture.Store.PutBlock(storeFixture.Block1);
+            storeFixture.Store.AppendIndex(guid, storeFixture.Block1.Hash);
+            storeFixture.Store.PutTransaction(storeFixture.Transaction1);
+        }
+    }
 
-            foreach (var storeFixture in _storeFixtures)
-            {
+    [SkippableFact]
+    public void SummaryInvalidArguments()
+    {
+        string badPathFormat = "rocksdb+foo+bar://" + "/bar";
+        string badPathScheme = "foo://" + "/bar";
+        long badOffset = long.MaxValue;
+        long badLimit = 0;
+
+        foreach (var storeFixture in _storeFixtures)
+        {
+            _command.Summary(
+                store: storeFixture.Store,
+                header: true,
+                offset: 0,
+                limit: 1);
+
+            Assert.Throws<ArgumentException>(() =>
+                _command.Summary(
+                    path: badPathFormat,
+                    header: true,
+                    offset: 0,
+                    limit: 1));
+            Assert.Throws<ArgumentException>(() =>
+                _command.Summary(
+                    path: badPathScheme,
+                    header: true,
+                    offset: 0,
+                    limit: 1));
+            Assert.Throws<ArgumentException>(() =>
+                _command.Summary(
+                    store: storeFixture.Store,
+                    header: true,
+                    offset: badOffset,
+                    limit: 1));
+            Assert.Throws<ArgumentException>(() =>
                 _command.Summary(
                     store: storeFixture.Store,
                     header: true,
                     offset: 0,
-                    limit: 1);
-
-                Assert.Throws<ArgumentException>(() =>
-                    _command.Summary(
-                        path: badPathFormat,
-                        header: true,
-                        offset: 0,
-                        limit: 1));
-                Assert.Throws<ArgumentException>(() =>
-                    _command.Summary(
-                        path: badPathScheme,
-                        header: true,
-                        offset: 0,
-                        limit: 1));
-                Assert.Throws<ArgumentException>(() =>
-                    _command.Summary(
-                        store: storeFixture.Store,
-                        header: true,
-                        offset: badOffset,
-                        limit: 1));
-                Assert.Throws<ArgumentException>(() =>
-                    _command.Summary(
-                        store: storeFixture.Store,
-                        header: true,
-                        offset: 0,
-                        limit: badLimit));
-            }
+                    limit: badLimit));
         }
+    }
 
-        public void Dispose()
+    public void Dispose()
+    {
+        foreach (var storeFixture in _storeFixtures)
         {
-            foreach (var storeFixture in _storeFixtures)
-            {
-                storeFixture.Store?.Dispose();
-                storeFixture.StateStore?.Dispose();
-            }
-
-            Console.SetOut(_originalWriter);
+            storeFixture.Store?.Dispose();
+            storeFixture.StateStore?.Dispose();
         }
+
+        Console.SetOut(_originalWriter);
     }
 }

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -1,8 +1,10 @@
+namespace Libplanet.Extensions.Cocona.Tests.Commands;
+
 using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Security.Cryptography;
-using Cocona;
+using global::Cocona;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Extensions.Cocona.Commands;
@@ -13,337 +15,334 @@ using Libplanet.Tx;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Libplanet.Extensions.Cocona.Tests.Commands
+public class StoreCommandTest : IDisposable
 {
-    public class StoreCommandTest : IDisposable
+    private readonly ImmutableArray<StoreFixture> _storeFixtures;
+    private readonly ITestOutputHelper _testOutput;
+    private readonly TextWriter _originalOut;
+    private readonly TextWriter _originalError;
+    private readonly Block<Utils.DummyAction> _genesisBlock;
+    private readonly Block<Utils.DummyAction> _block1;
+    private readonly Block<Utils.DummyAction> _block2;
+    private readonly Block<Utils.DummyAction> _block3;
+    private readonly Block<Utils.DummyAction> _block4;
+    private readonly Block<Utils.DummyAction> _block5;
+    private readonly Transaction<Utils.DummyAction> _transaction1;
+    private readonly Transaction<Utils.DummyAction> _transaction2;
+    private readonly Transaction<Utils.DummyAction> _transaction3;
+    private readonly Transaction<Utils.DummyAction> _transaction4;
+
+    public StoreCommandTest(ITestOutputHelper testOutput)
     {
-        private readonly ImmutableArray<StoreFixture> _storeFixtures;
-        private readonly ITestOutputHelper _testOutput;
-        private readonly TextWriter _originalOut;
-        private readonly TextWriter _originalError;
-        private readonly Block<Utils.DummyAction> _genesisBlock;
-        private readonly Block<Utils.DummyAction> _block1;
-        private readonly Block<Utils.DummyAction> _block2;
-        private readonly Block<Utils.DummyAction> _block3;
-        private readonly Block<Utils.DummyAction> _block4;
-        private readonly Block<Utils.DummyAction> _block5;
-        private readonly Transaction<Utils.DummyAction> _transaction1;
-        private readonly Transaction<Utils.DummyAction> _transaction2;
-        private readonly Transaction<Utils.DummyAction> _transaction3;
-        private readonly Transaction<Utils.DummyAction> _transaction4;
+        _testOutput = testOutput;
+        _originalOut = Console.Out;
+        _originalError = Console.Error;
 
-        public StoreCommandTest(ITestOutputHelper testOutput)
+        try
         {
-            _testOutput = testOutput;
-            _originalOut = Console.Out;
-            _originalError = Console.Error;
-
-            try
-            {
-                _storeFixtures = ImmutableArray.Create<StoreFixture>(
-                    new DefaultStoreFixture(false),
-                    new RocksDBStoreFixture()
-                );
-            }
-            catch (TypeInitializationException)
-            {
-                throw new SkipException("RocksDB is not available.");
-            }
-
-            _genesisBlock = TestUtils.MineGenesisBlock<Utils.DummyAction>(TestUtils.GenesisMiner);
-            _transaction1 = DummyTransaction();
-            _transaction2 = DummyTransaction();
-            _transaction3 = DummyTransaction();
-            _transaction4 = DummyTransaction();
-
-            _block1 = TestUtils.MineNextBlock(
-                _genesisBlock, TestUtils.GenesisMiner, new[] { _transaction1 });
-            _block2 = TestUtils.MineNextBlock(
-                _block1, TestUtils.GenesisMiner, new[] { _transaction2 });
-            _block3 = TestUtils.MineNextBlock(
-                _block2, TestUtils.GenesisMiner, new[] { _transaction3 });
-            _block4 = TestUtils.MineNextBlock(
-                _block3, TestUtils.GenesisMiner, new[] { _transaction3 });
-            _block5 = TestUtils.MineNextBlock(
-                _block4, TestUtils.GenesisMiner);
-
-            var guid = Guid.NewGuid();
-            foreach (var v in _storeFixtures)
-            {
-                v.Store.SetCanonicalChainId(guid);
-                v.Store.PutBlock(_genesisBlock);
-                v.Store.AppendIndex(guid, _genesisBlock.Hash);
-
-                v.Store.PutBlock(_block1);
-                v.Store.AppendIndex(guid, _block1.Hash);
-                v.Store.PutTransaction(_transaction1);
-
-                v.Store.PutBlock(_block2);
-                v.Store.AppendIndex(guid, _block2.Hash);
-                v.Store.PutTransaction(_transaction2);
-
-                v.Store.PutBlock(_block3);
-                v.Store.AppendIndex(guid, _block3.Hash);
-                v.Store.PutTransaction(_transaction3);
-
-                v.Store.PutBlock(_block4);
-                v.Store.AppendIndex(guid, _block4.Hash);
-
-                v.Store?.Dispose();
-                v.StateStore?.Dispose();
-            }
-        }
-
-        [SkippableFact]
-        public void TestInvalidArguments()
-        {
-            Assert.Throws<ArgumentException>(() =>
-                new StoreCommand().BlockByHash(
-                    "rocksdb+file+file://" + "/blah",
-                    "dummy"
-                ));
-            Assert.Throws<ArgumentException>(() =>
-                new StoreCommand().BlockByHash(
-                    "rocksdb+memory://" + "/blah",
-                    "dummy"
-                ));
-            Assert.Throws<ArgumentException>(() =>
-                new StoreCommand().BlockByHash(
-                    "leveldb://" + "/blah",
-                    "dummy"
-                ));
-        }
-
-        [SkippableFact]
-        public void TestBlockByTxIdNotExist()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                new StoreCommand().BuildIndexTxBlock(
-                    fx.Scheme + fx.Path,
-                    0,
-                    10);
-            }
-
-            foreach (var fx in _storeFixtures)
-            {
-                Assert.Throws<CommandExitedException>(() =>
-                    new StoreCommand().BlocksByTxId(
-                        fx.Scheme + fx.Path,
-                        _transaction4.Id.ToString()
-                    ));
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockByTxIdTwo()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                new StoreCommand().BuildIndexTxBlock(
-                    fx.Scheme + fx.Path,
-                    0,
-                    10);
-            }
-
-            foreach (var fx in _storeFixtures)
-            {
-                using var stdout = new StringWriter();
-                using var stderr = new StringWriter();
-                Console.SetOut(stdout);
-                Console.SetError(stderr);
-                new StoreCommand().BlocksByTxId(
-                    fx.Scheme + fx.Path,
-                    _transaction3.Id.ToString()
-                );
-                var actual = stdout.ToString();
-                _testOutput.WriteLine($"stdout:\n  {actual.Replace("\n", "\n  ")}\n");
-                _testOutput.WriteLine($"stderr:\n  {stderr.ToString().Replace("\n", "\n  ")}\n");
-                var expected = Utils.SerializeHumanReadable(new[] { _block3, _block4 });
-                if (expected.TrimEnd() != actual.TrimEnd())
-                {
-                    expected = Utils.SerializeHumanReadable(new[] { _block4, _block3 });
-                }
-
-                _testOutput.WriteLine($"expected:\n  {expected.Replace("\n", "\n  ")}\n");
-                Assert.Equal(
-                    expected.TrimEnd(),
-                    actual.TrimEnd(),
-                    ignoreLineEndingDifferences: true,
-                    ignoreWhiteSpaceDifferences: true
-                );
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockHashesByTxId()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                new StoreCommand().BuildIndexTxBlock(
-                    fx.Scheme + fx.Path,
-                    0,
-                    10);
-            }
-
-            foreach (var fx in _storeFixtures)
-            {
-                using var sw = new StringWriter();
-                Console.SetOut(sw);
-                new StoreCommand().BlockHashesByTxId(
-                    fx.Scheme + fx.Path,
-                    _transaction3.Id.ToString()
-                );
-                var actual = sw.ToString();
-                var expected = Utils.SerializeHumanReadable(new[] { _block3.Hash, _block4.Hash });
-                if (expected.TrimEnd() != actual.TrimEnd())
-                {
-                    expected = Utils.SerializeHumanReadable(new[] { _block4.Hash, _block3.Hash });
-                }
-
-                Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
-            }
-        }
-
-        [SkippableFact]
-        public void TestBuildIndexTxBlockBlockByTxId()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                new StoreCommand().BuildIndexTxBlock(
-                    fx.Scheme + fx.Path,
-                    0,
-                    10);
-            }
-
-            foreach (var fx in _storeFixtures)
-            {
-                void AssertTxBlockIndex(
-                    Transaction<Utils.DummyAction> tx,
-                    Block<Utils.DummyAction> block
-                )
-                {
-                    using var sw = new StringWriter();
-                    Console.SetOut(sw);
-                    new StoreCommand().BlocksByTxId(
-                        fx.Scheme + fx.Path,
-                        tx.Id.ToString()
-                    );
-                    var actual = sw.ToString();
-                    var expected = Utils.SerializeHumanReadable(new[] { block });
-                    Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
-                }
-
-                AssertTxBlockIndex(_transaction1, _block1);
-                AssertTxBlockIndex(_transaction2, _block2);
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockByHashNotExists()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                Assert.Throws<CommandExitedException>(() =>
-                    new StoreCommand().BlockByHash(
-                        fx.Scheme + fx.Path,
-                        _block5.Hash.ToString())
-                );
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockByHash()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                using var sw = new StringWriter();
-                Console.SetOut(sw);
-                new StoreCommand().BlockByHash(
-                    fx.Scheme + fx.Path,
-                    _block1.Hash.ToString());
-                var actual = sw.ToString();
-                var expected = Utils.SerializeHumanReadable(_block1);
-                Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockByIndexNotExists()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                Assert.Throws<CommandExitedException>(() =>
-                    new StoreCommand().BlockByIndex(
-                        fx.Scheme + fx.Path,
-                        9999999 * 100
-                    )
-                );
-            }
-        }
-
-        [SkippableFact]
-        public void TestBlockByIndex()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                using var sw = new StringWriter();
-                Console.SetOut(sw);
-                new StoreCommand().BlockByIndex(fx.Scheme + fx.Path, 0);
-                var actual = sw.ToString();
-                var expected = Utils.SerializeHumanReadable(_genesisBlock);
-                Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
-            }
-        }
-
-        [SkippableFact]
-        public void TestTxByIdNotExists()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                Assert.Throws<CommandExitedException>(() =>
-                    new StoreCommand().TxById(
-                        fx.Scheme + fx.Path,
-                        fx.Transaction2.Id.ToString())
-                );
-            }
-        }
-
-        [SkippableFact]
-        public void TestTxById()
-        {
-            foreach (var fx in _storeFixtures)
-            {
-                using var sw = new StringWriter();
-                Console.SetOut(sw);
-                new StoreCommand().TxById(
-                    fx.Scheme + fx.Path,
-                    _transaction1.Id.ToString());
-                var actual = sw.ToString();
-                var expected = Utils.SerializeHumanReadable(_transaction1);
-                Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
-            }
-        }
-
-        public void Dispose()
-        {
-            Console.SetOut(_originalOut);
-            Console.SetError(_originalError);
-        }
-
-        private HashAlgorithmType GetHashAlgorithm(long blockIndex) =>
-            HashAlgorithmType.Of<SHA256>();
-
-        private Transaction<Utils.DummyAction> DummyTransaction()
-        {
-            return Transaction<Utils.DummyAction>.Create(
-                0,
-                new PrivateKey(),
-                _genesisBlock.Hash,
-                new[] { new Utils.DummyAction() },
-                null,
-                DateTimeOffset.UtcNow
+            _storeFixtures = ImmutableArray.Create<StoreFixture>(
+                new DefaultStoreFixture(false),
+                new RocksDBStoreFixture()
             );
         }
+        catch (TypeInitializationException)
+        {
+            throw new SkipException("RocksDB is not available.");
+        }
+
+        _genesisBlock = TestUtils.MineGenesisBlock<Utils.DummyAction>(TestUtils.GenesisMiner);
+        _transaction1 = DummyTransaction();
+        _transaction2 = DummyTransaction();
+        _transaction3 = DummyTransaction();
+        _transaction4 = DummyTransaction();
+
+        _block1 = TestUtils.MineNextBlock(
+            _genesisBlock, TestUtils.GenesisMiner, new[] { _transaction1 });
+        _block2 = TestUtils.MineNextBlock(
+            _block1, TestUtils.GenesisMiner, new[] { _transaction2 });
+        _block3 = TestUtils.MineNextBlock(
+            _block2, TestUtils.GenesisMiner, new[] { _transaction3 });
+        _block4 = TestUtils.MineNextBlock(
+            _block3, TestUtils.GenesisMiner, new[] { _transaction3 });
+        _block5 = TestUtils.MineNextBlock(
+            _block4, TestUtils.GenesisMiner);
+
+        var guid = Guid.NewGuid();
+        foreach (var v in _storeFixtures)
+        {
+            v.Store.SetCanonicalChainId(guid);
+            v.Store.PutBlock(_genesisBlock);
+            v.Store.AppendIndex(guid, _genesisBlock.Hash);
+
+            v.Store.PutBlock(_block1);
+            v.Store.AppendIndex(guid, _block1.Hash);
+            v.Store.PutTransaction(_transaction1);
+
+            v.Store.PutBlock(_block2);
+            v.Store.AppendIndex(guid, _block2.Hash);
+            v.Store.PutTransaction(_transaction2);
+
+            v.Store.PutBlock(_block3);
+            v.Store.AppendIndex(guid, _block3.Hash);
+            v.Store.PutTransaction(_transaction3);
+
+            v.Store.PutBlock(_block4);
+            v.Store.AppendIndex(guid, _block4.Hash);
+
+            v.Store?.Dispose();
+            v.StateStore?.Dispose();
+        }
+    }
+
+    [SkippableFact]
+    public void TestInvalidArguments()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new StoreCommand().BlockByHash(
+                "rocksdb+file+file://" + "/blah",
+                "dummy"
+            ));
+        Assert.Throws<ArgumentException>(() =>
+            new StoreCommand().BlockByHash(
+                "rocksdb+memory://" + "/blah",
+                "dummy"
+            ));
+        Assert.Throws<ArgumentException>(() =>
+            new StoreCommand().BlockByHash(
+                "leveldb://" + "/blah",
+                "dummy"
+            ));
+    }
+
+    [SkippableFact]
+    public void TestBlockByTxIdNotExist()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            new StoreCommand().BuildIndexTxBlock(
+                fx.Scheme + fx.Path,
+                0,
+                10);
+        }
+
+        foreach (var fx in _storeFixtures)
+        {
+            Assert.Throws<CommandExitedException>(() =>
+                new StoreCommand().BlocksByTxId(
+                    fx.Scheme + fx.Path,
+                    _transaction4.Id.ToString()
+                ));
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockByTxIdTwo()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            new StoreCommand().BuildIndexTxBlock(
+                fx.Scheme + fx.Path,
+                0,
+                10);
+        }
+
+        foreach (var fx in _storeFixtures)
+        {
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            new StoreCommand().BlocksByTxId(
+                fx.Scheme + fx.Path,
+                _transaction3.Id.ToString()
+            );
+            var actual = stdout.ToString();
+            _testOutput.WriteLine($"stdout:\n  {actual.Replace("\n", "\n  ")}\n");
+            _testOutput.WriteLine($"stderr:\n  {stderr.ToString().Replace("\n", "\n  ")}\n");
+            var expected = Utils.SerializeHumanReadable(new[] { _block3, _block4 });
+            if (expected.TrimEnd() != actual.TrimEnd())
+            {
+                expected = Utils.SerializeHumanReadable(new[] { _block4, _block3 });
+            }
+
+            _testOutput.WriteLine($"expected:\n  {expected.Replace("\n", "\n  ")}\n");
+            Assert.Equal(
+                expected.TrimEnd(),
+                actual.TrimEnd(),
+                ignoreLineEndingDifferences: true,
+                ignoreWhiteSpaceDifferences: true
+            );
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockHashesByTxId()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            new StoreCommand().BuildIndexTxBlock(
+                fx.Scheme + fx.Path,
+                0,
+                10);
+        }
+
+        foreach (var fx in _storeFixtures)
+        {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+            new StoreCommand().BlockHashesByTxId(
+                fx.Scheme + fx.Path,
+                _transaction3.Id.ToString()
+            );
+            var actual = sw.ToString();
+            var expected = Utils.SerializeHumanReadable(new[] { _block3.Hash, _block4.Hash });
+            if (expected.TrimEnd() != actual.TrimEnd())
+            {
+                expected = Utils.SerializeHumanReadable(new[] { _block4.Hash, _block3.Hash });
+            }
+
+            Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
+        }
+    }
+
+    [SkippableFact]
+    public void TestBuildIndexTxBlockBlockByTxId()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            new StoreCommand().BuildIndexTxBlock(
+                fx.Scheme + fx.Path,
+                0,
+                10);
+        }
+
+        foreach (var fx in _storeFixtures)
+        {
+            void AssertTxBlockIndex(
+                Transaction<Utils.DummyAction> tx,
+                Block<Utils.DummyAction> block
+            )
+            {
+                using var sw = new StringWriter();
+                Console.SetOut(sw);
+                new StoreCommand().BlocksByTxId(
+                    fx.Scheme + fx.Path,
+                    tx.Id.ToString()
+                );
+                var actual = sw.ToString();
+                var expected = Utils.SerializeHumanReadable(new[] { block });
+                Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
+            }
+
+            AssertTxBlockIndex(_transaction1, _block1);
+            AssertTxBlockIndex(_transaction2, _block2);
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockByHashNotExists()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            Assert.Throws<CommandExitedException>(() =>
+                new StoreCommand().BlockByHash(
+                    fx.Scheme + fx.Path,
+                    _block5.Hash.ToString())
+            );
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockByHash()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+            new StoreCommand().BlockByHash(
+                fx.Scheme + fx.Path,
+                _block1.Hash.ToString());
+            var actual = sw.ToString();
+            var expected = Utils.SerializeHumanReadable(_block1);
+            Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockByIndexNotExists()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            Assert.Throws<CommandExitedException>(() =>
+                new StoreCommand().BlockByIndex(
+                    fx.Scheme + fx.Path,
+                    9999999 * 100
+                )
+            );
+        }
+    }
+
+    [SkippableFact]
+    public void TestBlockByIndex()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+            new StoreCommand().BlockByIndex(fx.Scheme + fx.Path, 0);
+            var actual = sw.ToString();
+            var expected = Utils.SerializeHumanReadable(_genesisBlock);
+            Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
+        }
+    }
+
+    [SkippableFact]
+    public void TestTxByIdNotExists()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            Assert.Throws<CommandExitedException>(() =>
+                new StoreCommand().TxById(
+                    fx.Scheme + fx.Path,
+                    fx.Transaction2.Id.ToString())
+            );
+        }
+    }
+
+    [SkippableFact]
+    public void TestTxById()
+    {
+        foreach (var fx in _storeFixtures)
+        {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+            new StoreCommand().TxById(
+                fx.Scheme + fx.Path,
+                _transaction1.Id.ToString());
+            var actual = sw.ToString();
+            var expected = Utils.SerializeHumanReadable(_transaction1);
+            Assert.Equal(expected.TrimEnd(), actual.TrimEnd());
+        }
+    }
+
+    public void Dispose()
+    {
+        Console.SetOut(_originalOut);
+        Console.SetError(_originalError);
+    }
+
+    private HashAlgorithmType GetHashAlgorithm(long blockIndex) =>
+        HashAlgorithmType.Of<SHA256>();
+
+    private Transaction<Utils.DummyAction> DummyTransaction()
+    {
+        return Transaction<Utils.DummyAction>.Create(
+            0,
+            new PrivateKey(),
+            _genesisBlock.Hash,
+            new[] { new Utils.DummyAction() },
+            null,
+            DateTimeOffset.UtcNow
+        );
     }
 }

--- a/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -6,7 +6,7 @@
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>
-        <LangVersion>8</LangVersion>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
@@ -47,7 +47,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/Libplanet.Extensions.Cocona.Tests/Services/TestToolConfigurationService.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Services/TestToolConfigurationService.cs
@@ -1,25 +1,24 @@
+namespace Libplanet.Tools.Tests.Services;
+
 using Libplanet.Extensions.Cocona.Configuration;
 using Libplanet.Extensions.Cocona.Services;
 
-namespace Libplanet.Tools.Tests.Services
+public class TestToolConfigurationService : IConfigurationService<ToolConfiguration>
 {
-    public class TestToolConfigurationService : IConfigurationService<ToolConfiguration>
+    public TestToolConfigurationService(ToolConfiguration configuration)
     {
-        public TestToolConfigurationService(ToolConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+        Configuration = configuration;
+    }
 
-        private ToolConfiguration Configuration { get; set; }
+    private ToolConfiguration Configuration { get; set; }
 
-        public ToolConfiguration Load()
-        {
-            return Configuration;
-        }
+    public ToolConfiguration Load()
+    {
+        return Configuration;
+    }
 
-        public void Store(ToolConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+    public void Store(ToolConfiguration configuration)
+    {
+        Configuration = configuration;
     }
 }

--- a/Libplanet.Extensions.Cocona.Tests/UtilsTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/UtilsTest.cs
@@ -1,50 +1,49 @@
+namespace Libplanet.Extensions.Cocona.Tests;
+
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using Xunit;
 
-namespace Libplanet.Extensions.Cocona.Tests
+public class UtilsTest
 {
-    public class UtilsTest
+    [Fact]
+    public void TestHumanReadable()
     {
-        [Fact]
-        public void TestHumanReadable()
-        {
-            var byteArray = ImmutableArray.Create<byte>(
-                0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57
-            );
-            var dateTimeOffset = DateTimeOffset.ParseExact(
-                DateTimeOffset.UtcNow.ToString(
-                    Utils.DateTimeOffsetFormat,
-                    CultureInfo.InvariantCulture
-                ), Utils.DateTimeOffsetFormat,
-                CultureInfo.InvariantCulture);
-            var dummyClass = new DummyClass(byteArray, dateTimeOffset);
+        var byteArray = ImmutableArray.Create<byte>(
+            0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57
+        );
+        var dateTimeOffset = DateTimeOffset.ParseExact(
+            DateTimeOffset.UtcNow.ToString(
+                Utils.DateTimeOffsetFormat,
+                CultureInfo.InvariantCulture
+            ), Utils.DateTimeOffsetFormat,
+            CultureInfo.InvariantCulture);
+        var dummyClass = new DummyClass(byteArray, dateTimeOffset);
 
-            var serialized = Utils.SerializeHumanReadable(dummyClass);
-            var dummyClass2 = Utils.DeserializeHumanReadable<DummyClass>(serialized);
-            Assert.True(dummyClass.SampleByteArray.SequenceEqual(dummyClass2.SampleByteArray));
-            Assert.Equal(dummyClass.SampleDateTimeOffset, dummyClass2.SampleDateTimeOffset);
+        var serialized = Utils.SerializeHumanReadable(dummyClass);
+        var dummyClass2 = Utils.DeserializeHumanReadable<DummyClass>(serialized);
+        Assert.True(dummyClass.SampleByteArray.SequenceEqual(dummyClass2.SampleByteArray));
+        Assert.Equal(dummyClass.SampleDateTimeOffset, dummyClass2.SampleDateTimeOffset);
+    }
+
+    private class DummyClass
+    {
+        public DummyClass()
+        {
         }
 
-        private class DummyClass
+        public DummyClass(
+            ImmutableArray<byte> sampleByteArray,
+            DateTimeOffset sampleDateTimeOffset)
         {
-            public DummyClass()
-            {
-            }
-
-            public DummyClass(
-                ImmutableArray<byte> sampleByteArray,
-                DateTimeOffset sampleDateTimeOffset)
-            {
-                SampleByteArray = sampleByteArray;
-                SampleDateTimeOffset = sampleDateTimeOffset;
-            }
-
-            public ImmutableArray<byte> SampleByteArray { get; set; }
-
-            public DateTimeOffset SampleDateTimeOffset { get; set; }
+            SampleByteArray = sampleByteArray;
+            SampleDateTimeOffset = sampleDateTimeOffset;
         }
+
+        public ImmutableArray<byte> SampleByteArray { get; set; }
+
+        public DateTimeOffset SampleDateTimeOffset { get; set; }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -12,332 +14,330 @@ using Libplanet.KeyStore;
 using Libplanet.Net;
 using Libplanet.Net.Transports;
 
-namespace Libplanet.Extensions.Cocona.Commands
+public class ApvCommand
 {
-    public class ApvCommand
+    [Command(Description = "Sign a new app protocol version.")]
+    public void Sign(
+        [Argument(Name = "KEY-ID", Description = "A private key to use for signing.")]
+        Guid keyId,
+        [Argument(Name = "VERSION", Description = "A version number to sign.")]
+        int version,
+        PassphraseParameters passphrase,
+        [Option(
+            'E',
+            ValueName = "FILE",
+            Description = "Bencodex file to use for extra data.  " +
+                "For standard input, use a hyphen (`-').  " +
+                "For an actual file named a hyphen, prepend `./', i.e., `./-'."
+        )]
+        string? extraFile = null,
+        [Option(
+            'e',
+            ValueName = "KEY=VALUE",
+            Description = "Set a value to a key on extra Bencodex dictionary.  " +
+                "Can be applied multiple times (e.g., `-e foo=1 -e bar=baz').  " +
+                "This option implies the extra data to be a Bencodex dictionary, " +
+                "hence cannot be used together with -E/--extra-file option."
+        )]
+        string[]? extra = null
+    )
     {
-        [Command(Description = "Sign a new app protocol version.")]
-        public void Sign(
-            [Argument(Name = "KEY-ID", Description = "A private key to use for signing.")]
-            Guid keyId,
-            [Argument(Name = "VERSION", Description = "A version number to sign.")]
-            int version,
-            PassphraseParameters passphrase,
-            [Option(
-                'E',
-                ValueName = "FILE",
-                Description = "Bencodex file to use for extra data.  " +
-                    "For standard input, use a hyphen (`-').  " +
-                    "For an actual file named a hyphen, prepend `./', i.e., `./-'."
-            )]
-            string? extraFile = null,
-            [Option(
-                'e',
-                ValueName = "KEY=VALUE",
-                Description = "Set a value to a key on extra Bencodex dictionary.  " +
-                    "Can be applied multiple times (e.g., `-e foo=1 -e bar=baz').  " +
-                    "This option implies the extra data to be a Bencodex dictionary, " +
-                    "hence cannot be used together with -E/--extra-file option."
-            )]
-            string[]? extra = null
-        )
+        if (passphrase.PassphraseFile == "-" && extraFile == "-")
         {
-            if (passphrase.PassphraseFile == "-" && extraFile == "-")
+            throw Utils.Error(
+                "-P/--passphrase-file and -E/--extra-file cannot read standard input at a " +
+                "time.  Please specify one of both to read from a regular file."
+            );
+        }
+
+        PrivateKey key = new KeyCommand().UnprotectKey(keyId, passphrase, ignoreStdin: true);
+        IValue? extraValue = null;
+        if (extraFile is string path)
+        {
+            if (extra is string[] e && e.Length > 0)
             {
                 throw Utils.Error(
-                    "-P/--passphrase-file and -E/--extra-file cannot read standard input at a " +
-                    "time.  Please specify one of both to read from a regular file."
+                    "-E/--extra-file and -e/--extra cannot be used together at a time."
                 );
             }
 
-            PrivateKey key = new KeyCommand().UnprotectKey(keyId, passphrase, ignoreStdin: true);
-            IValue? extraValue = null;
-            if (extraFile is string path)
+            var codec = new Codec();
+            if (path == "-")
             {
-                if (extra is string[] e && e.Length > 0)
+                // Stream for stdin does not support .Seek()
+                using MemoryStream buffer = new MemoryStream();
+                using (Stream stream = Console.OpenStandardInput())
                 {
-                    throw Utils.Error(
-                        "-E/--extra-file and -e/--extra cannot be used together at a time."
-                    );
+                    stream.CopyTo(buffer);
                 }
 
-                var codec = new Codec();
-                if (path == "-")
-                {
-                    // Stream for stdin does not support .Seek()
-                    using MemoryStream buffer = new MemoryStream();
-                    using (Stream stream = Console.OpenStandardInput())
-                    {
-                        stream.CopyTo(buffer);
-                    }
-
-                    buffer.Seek(0, SeekOrigin.Begin);
-                    extraValue = codec.Decode(buffer);
-                }
-                else
-                {
-                    using Stream stream = File.Open(path, FileMode.Open, FileAccess.Read);
-                    extraValue = codec.Decode(stream);
-                }
-            }
-            else if (extra is string[] e && e.Length > 0)
-            {
-                var dict = Bencodex.Types.Dictionary.Empty;
-                foreach (string pair in e)
-                {
-                    int sepPos = pair.IndexOf('=');
-                    if (sepPos < 0)
-                    {
-                        throw Utils.Error(
-                            "-e/--extra must be a pair of KEY=VALUE, but no equal (=) separator: " +
-                            $"`{pair}'."
-                        );
-                    }
-
-                    string key_ = pair.Substring(0, sepPos);
-                    string value = pair.Substring(sepPos + 1);
-                    dict = dict.SetItem(key_, value);
-                }
-
-                extraValue = dict;
-            }
-
-            AppProtocolVersion v = AppProtocolVersion.Sign(key, version, extraValue);
-            Console.WriteLine(v.Token);
-        }
-
-        [Command(Description = "Verify a given app protocol version token's signature.")]
-        public void Verify(
-            [Argument(
-                Name = "APV-TOKEN",
-                Description = "An app protocol version token to verify.  " +
-                    "Read from the standard input if omitted."
-            )]
-            string? token = null,
-            [Option(
-                'p',
-                ValueName = "PUBLIC-KEY",
-                Description = "Public key(s) to be used for verification.  " +
-                    "Can be applied multiple times."
-            )]
-            string[]? publicKey = null,
-            [Option(
-                'K',
-                Description = "Do not use any keys in the key store, " +
-                    "but only -p/--public-key options."
-            )]
-            bool noKeyStore = false
-        )
-        {
-            AppProtocolVersion v = ParseAppProtocolVersionToken(token);
-
-            if (publicKey is string[] pubKeyHexes)
-            {
-                foreach (string pubKeyHex in pubKeyHexes)
-                {
-                    string opt = $"-p/--public-key=\"{pubKeyHex}\"";
-                    PublicKey pubKey;
-                    try
-                    {
-                        pubKey = new PublicKey(ByteUtil.ParseHex(pubKeyHex));
-                    }
-                    catch (Exception e)
-                    {
-                        throw Utils.Error($"The {opt} is not a valid public key.  {e.Message}");
-                    }
-
-                    if (v.Verify(pubKey))
-                    {
-                        Console.Error.WriteLine(
-                            "The signature successfully was verified using the {0}.",
-                            opt
-                        );
-                        return;
-                    }
-
-                    Console.Error.WriteLine(
-                        "The signature was failed to verify using the {0}.",
-                        opt
-                    );
-                }
-            }
-
-            if (!noKeyStore)
-            {
-                KeyCommand keyInstance = new KeyCommand();
-                IEnumerable<Tuple<Guid, ProtectedPrivateKey>> ppks = keyInstance.KeyStore.List()
-                    .Where(pair => pair.Item2.Address.Equals(v.Signer));
-                foreach (Tuple<Guid, ProtectedPrivateKey> pair in ppks)
-                {
-                    pair.Deconstruct(out Guid keyId, out ProtectedPrivateKey ppk);
-
-                    // FIXME: The command should take options like --key-id, --key-passphrase, &
-                    // --key-passphrase-file:
-                    PublicKey pubKey = keyInstance.UnprotectKey(
-                        keyId,
-                        new PassphraseParameters()
-                    ).PublicKey;
-                    if (v.Verify(pubKey))
-                    {
-                        Console.Error.WriteLine(
-                            "The signature successfully was verified using the key {0}.",
-                            keyId
-                        );
-                        return;
-                    }
-
-                    Console.Error.WriteLine(
-                        "The signature was failed to verify using the key {0}.",
-                        keyId
-                    );
-                }
-            }
-
-            throw Utils.Error("Failed to verify.");
-        }
-
-        [Command(Description = "Parse and analyze a given app protocol version token.")]
-        public void Analyze(
-            [Argument(
-                Name = "APV-TOKEN",
-                Description = "An app protocol version token to analyze.  " +
-                    "Read from the standard input if omitted."
-            )]
-            string? token = null,
-            [Option(Description = "Print information of given token as JSON.")]
-            bool json = false
-        )
-        {
-            AppProtocolVersion v = ParseAppProtocolVersionToken(token);
-
-            var data = new List<(string, string)>
-            {
-                ("version", v.Version.ToString(CultureInfo.InvariantCulture)),
-                ("signature", ByteUtil.Hex(v.Signature)),
-                ("signer", v.Signer.ToString()),
-            };
-
-            if (v.Extra is IValue extra)
-            {
-                void TreeIntoTable(IValue tree, List<(string, string)> table, string key)
-                {
-                    switch (tree)
-                    {
-                        case Null _:
-                            table.Add((key, "null"));
-                            return;
-
-                        case Bencodex.Types.Boolean b:
-                            table.Add((key, b ? "true" : "false"));
-                            return;
-
-                        case Binary bin:
-                            table.Add((key, ByteUtil.Hex(bin.ToByteArray())));
-                            return;
-
-                        case Text t:
-                            table.Add((key, t.Value));
-                            return;
-
-                        case Bencodex.Types.Integer i:
-                            table.Add((key, i.Value.ToString(CultureInfo.InvariantCulture)));
-                            return;
-
-                        case Bencodex.Types.List l:
-                            int idx = 0;
-                            foreach (IValue el in l)
-                            {
-                                TreeIntoTable(el, table, $"{key}[{idx}]");
-                                idx++;
-                            }
-
-                            return;
-
-                        case Bencodex.Types.Dictionary d:
-                            foreach (KeyValuePair<IKey, IValue> kv in d)
-                            {
-                                string k = kv.Key switch
-                                {
-                                    Binary bk => ByteUtil.Hex(bk),
-                                    Text txt => txt.Value,
-                                    _ => kv.Key.ToString() ?? string.Empty,
-                                };
-                                TreeIntoTable(kv.Value, table, $"{key}.{k}");
-                            }
-
-                            return;
-
-                        default:
-                            table.Add((key, tree.ToString() ?? string.Empty));
-                            return;
-                    }
-                }
-
-                TreeIntoTable(v.Extra, data, "extra");
-            }
-
-            if (json)
-            {
-                Console.WriteLine(
-                    JsonSerializer.Serialize(
-                        data.ToDictionary(e => e.Item1, e => e.Item2)));
+                buffer.Seek(0, SeekOrigin.Begin);
+                extraValue = codec.Decode(buffer);
             }
             else
             {
-                Utils.PrintTable(("Field", "Value"), data);
+                using Stream stream = File.Open(path, FileMode.Open, FileAccess.Read);
+                extraValue = codec.Decode(stream);
+            }
+        }
+        else if (extra is string[] e && e.Length > 0)
+        {
+            var dict = Bencodex.Types.Dictionary.Empty;
+            foreach (string pair in e)
+            {
+                int sepPos = pair.IndexOf('=');
+                if (sepPos < 0)
+                {
+                    throw Utils.Error(
+                        "-e/--extra must be a pair of KEY=VALUE, but no equal (=) separator: " +
+                        $"`{pair}'."
+                    );
+                }
+
+                string key_ = pair.Substring(0, sepPos);
+                string value = pair.Substring(sepPos + 1);
+                dict = dict.SetItem(key_, value);
+            }
+
+            extraValue = dict;
+        }
+
+        AppProtocolVersion v = AppProtocolVersion.Sign(key, version, extraValue);
+        Console.WriteLine(v.Token);
+    }
+
+    [Command(Description = "Verify a given app protocol version token's signature.")]
+    public void Verify(
+        [Argument(
+            Name = "APV-TOKEN",
+            Description = "An app protocol version token to verify.  " +
+                "Read from the standard input if omitted."
+        )]
+        string? token = null,
+        [Option(
+            'p',
+            ValueName = "PUBLIC-KEY",
+            Description = "Public key(s) to be used for verification.  " +
+                "Can be applied multiple times."
+        )]
+        string[]? publicKey = null,
+        [Option(
+            'K',
+            Description = "Do not use any keys in the key store, " +
+                "but only -p/--public-key options."
+        )]
+        bool noKeyStore = false
+    )
+    {
+        AppProtocolVersion v = ParseAppProtocolVersionToken(token);
+
+        if (publicKey is string[] pubKeyHexes)
+        {
+            foreach (string pubKeyHex in pubKeyHexes)
+            {
+                string opt = $"-p/--public-key=\"{pubKeyHex}\"";
+                PublicKey pubKey;
+                try
+                {
+                    pubKey = new PublicKey(ByteUtil.ParseHex(pubKeyHex));
+                }
+                catch (Exception e)
+                {
+                    throw Utils.Error($"The {opt} is not a valid public key.  {e.Message}");
+                }
+
+                if (v.Verify(pubKey))
+                {
+                    Console.Error.WriteLine(
+                        "The signature successfully was verified using the {0}.",
+                        opt
+                    );
+                    return;
+                }
+
+                Console.Error.WriteLine(
+                    "The signature was failed to verify using the {0}.",
+                    opt
+                );
             }
         }
 
-        [Command(Description = "Query app protocol version (a.k.a. APV) of target node.")]
-        public void Query(
-            [Argument(
-                Name = "TARGET",
-#pragma warning disable MEN002 // Line is too long
-                Description = "Comma seperated peer information({pubkey},{host},{port}) of target node. (e.g. 027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c.planetarium.dev,31236)")]
-#pragma warning restore MEN002 // Line is too long
-            string peerInfo)
+        if (!noKeyStore)
         {
-            BoundPeer peer;
-            AppProtocolVersion apv;
+            KeyCommand keyInstance = new KeyCommand();
+            IEnumerable<Tuple<Guid, ProtectedPrivateKey>> ppks = keyInstance.KeyStore.List()
+                .Where(pair => pair.Item2.Address.Equals(v.Signer));
+            foreach (Tuple<Guid, ProtectedPrivateKey> pair in ppks)
+            {
+                pair.Deconstruct(out Guid keyId, out ProtectedPrivateKey ppk);
 
-            try
-            {
-                peer = BoundPeer.ParsePeer(peerInfo);
-            }
-            catch
-            {
-                throw Utils.Error($"Failed to parse peer. Please check the input. [{peerInfo}]");
-            }
+                // FIXME: The command should take options like --key-id, --key-passphrase, &
+                // --key-passphrase-file:
+                PublicKey pubKey = keyInstance.UnprotectKey(
+                    keyId,
+                    new PassphraseParameters()
+                ).PublicKey;
+                if (v.Verify(pubKey))
+                {
+                    Console.Error.WriteLine(
+                        "The signature successfully was verified using the key {0}.",
+                        keyId
+                    );
+                    return;
+                }
 
-            try
-            {
-                // FIXME: Must provide --transport option.
-                // https://github.com/planetarium/libplanet/issues/1623
-                apv = peer.QueryAppProtocolVersionNetMQ();
+                Console.Error.WriteLine(
+                    "The signature was failed to verify using the key {0}.",
+                    keyId
+                );
             }
-            catch
-            {
-                throw Utils.Error($"Failed to query app protocol version.");
-            }
-
-            Console.WriteLine(apv.Token);
         }
 
-        private AppProtocolVersion ParseAppProtocolVersionToken(string? token)
+        throw Utils.Error("Failed to verify.");
+    }
+
+    [Command(Description = "Parse and analyze a given app protocol version token.")]
+    public void Analyze(
+        [Argument(
+            Name = "APV-TOKEN",
+            Description = "An app protocol version token to analyze.  " +
+                "Read from the standard input if omitted."
+        )]
+        string? token = null,
+        [Option(Description = "Print information of given token as JSON.")]
+        bool json = false
+    )
+    {
+        AppProtocolVersion v = ParseAppProtocolVersionToken(token);
+
+        var data = new List<(string, string)>
         {
-            if (token is null)
+            ("version", v.Version.ToString(CultureInfo.InvariantCulture)),
+            ("signature", ByteUtil.Hex(v.Signature)),
+            ("signer", v.Signer.ToString()),
+        };
+
+        if (v.Extra is IValue extra)
+        {
+            void TreeIntoTable(IValue tree, List<(string, string)> table, string key)
             {
-                token = Console.ReadLine();
+                switch (tree)
+                {
+                    case Null _:
+                        table.Add((key, "null"));
+                        return;
+
+                    case Bencodex.Types.Boolean b:
+                        table.Add((key, b ? "true" : "false"));
+                        return;
+
+                    case Binary bin:
+                        table.Add((key, ByteUtil.Hex(bin.ToByteArray())));
+                        return;
+
+                    case Text t:
+                        table.Add((key, t.Value));
+                        return;
+
+                    case Bencodex.Types.Integer i:
+                        table.Add((key, i.Value.ToString(CultureInfo.InvariantCulture)));
+                        return;
+
+                    case Bencodex.Types.List l:
+                        int idx = 0;
+                        foreach (IValue el in l)
+                        {
+                            TreeIntoTable(el, table, $"{key}[{idx}]");
+                            idx++;
+                        }
+
+                        return;
+
+                    case Bencodex.Types.Dictionary d:
+                        foreach (KeyValuePair<IKey, IValue> kv in d)
+                        {
+                            string k = kv.Key switch
+                            {
+                                Binary bk => ByteUtil.Hex(bk),
+                                Text txt => txt.Value,
+                                _ => kv.Key.ToString() ?? string.Empty,
+                            };
+                            TreeIntoTable(kv.Value, table, $"{key}.{k}");
+                        }
+
+                        return;
+
+                    default:
+                        table.Add((key, tree.ToString() ?? string.Empty));
+                        return;
+                }
             }
 
-            try
-            {
-                return AppProtocolVersion.FromToken(token.Trim());
-            }
-            catch (FormatException e)
-            {
-                throw Utils.Error($"Not a valid app protocol version token.  {e.Message}");
-            }
+            TreeIntoTable(v.Extra, data, "extra");
+        }
+
+        if (json)
+        {
+            Console.WriteLine(
+                JsonSerializer.Serialize(
+                    data.ToDictionary(e => e.Item1, e => e.Item2)));
+        }
+        else
+        {
+            Utils.PrintTable(("Field", "Value"), data);
+        }
+    }
+
+    [Command(Description = "Query app protocol version (a.k.a. APV) of target node.")]
+    public void Query(
+        [Argument(
+            Name = "TARGET",
+            Description = "Comma separated peer information({pubkey},{host},{port}) " +
+                "of target node.  " +
+                "(E.g., 027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6," +
+                "9c.planetarium.dev,31236)")]
+        string peerInfo)
+    {
+        BoundPeer peer;
+        AppProtocolVersion apv;
+
+        try
+        {
+            peer = BoundPeer.ParsePeer(peerInfo);
+        }
+        catch
+        {
+            throw Utils.Error($"Failed to parse peer. Please check the input. [{peerInfo}]");
+        }
+
+        try
+        {
+            // FIXME: Must provide --transport option.
+            // https://github.com/planetarium/libplanet/issues/1623
+            apv = peer.QueryAppProtocolVersionNetMQ();
+        }
+        catch
+        {
+            throw Utils.Error($"Failed to query app protocol version.");
+        }
+
+        Console.WriteLine(apv.Token);
+    }
+
+    private AppProtocolVersion ParseAppProtocolVersionToken(string? token)
+    {
+        if (token is null)
+        {
+            token = Console.ReadLine() ?? string.Empty;
+        }
+
+        try
+        {
+            return AppProtocolVersion.FromToken(token.Trim());
+        }
+        catch (FormatException e)
+        {
+            throw Utils.Error($"Not a valid app protocol version token.  {e.Message}");
         }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,375 +8,372 @@ using global::Cocona;
 using Libplanet.Crypto;
 using Libplanet.KeyStore;
 
-namespace Libplanet.Extensions.Cocona.Commands
+public class KeyCommand
 {
-    public class KeyCommand
+    public KeyCommand()
     {
-        public KeyCommand()
+        KeyStore = Web3KeyStore.DefaultKeyStore;
+    }
+
+    public IKeyStore KeyStore { get; set; }
+
+    [PrimaryCommand]
+    [Command(Description = "List all private keys.")]
+    public void List(
+        [Option(
+            Description = "Specify key store path to list."
+        )]
+        string? path = null)
+    {
+        ChangeKeyStorePath(path);
+        PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
+    }
+
+    [Command(Description = "Create a new private key.")]
+    public void Create(
+        PassphraseParameters passphrase,
+        [Option(
+            Description = "Print created private key as Web3 Secret Storage format."
+        )]
+        bool json = false,
+        [Option(Description = "Do not add to the key store, but only show the created key.")]
+        bool dryRun = false,
+        [Option(Description = "Path to key store")]
+        string? path = null
+    )
+    {
+        ChangeKeyStorePath(path);
+        string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
+        PrivateKey pkey = new PrivateKey();
+        ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(pkey, passphraseValue);
+        Guid keyId = Add(ppk, dryRun);
+        if (json)
         {
-            KeyStore = Web3KeyStore.DefaultKeyStore;
+            Stream stdout = Console.OpenStandardOutput();
+            ppk.WriteJson(stdout, keyId);
+            stdout.WriteByte(0x0a);
         }
-
-        public IKeyStore KeyStore { get; set; }
-
-        [PrimaryCommand]
-        [Command(Description = "List all private keys.")]
-        public void List(
-            [Option(
-                Description = "Specify key store path to list."
-            )]
-            string? path = null)
+        else
         {
-            ChangeKeyStorePath(path);
-            PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
+            PrintKeys(new[] { (keyId, ppk) });
         }
+    }
 
-        [Command(Description = "Create a new private key.")]
-        public void Create(
-            PassphraseParameters passphrase,
-            [Option(
-                Description = "Print created private key as Web3 Secret Storage format."
-            )]
-            bool json = false,
-            [Option(Description = "Do not add to the key store, but only show the created key.")]
-            bool dryRun = false,
-            [Option(Description = "Path to key store")]
-            string? path = null
-        )
+    [Command(Aliases = new[] { "rm" }, Description = "Remove a private key.")]
+    public void Remove(
+        [Argument(Name = "KEY-ID", Description = "A key UUID to remove.")]
+        Guid keyId,
+        PassphraseParameters passphrase,
+        [Option(Description = "Remove without asking passphrase.")]
+        bool noPassphrase = false,
+        [Option(Description = "Path to key store.")]
+        string? path = null
+    )
+    {
+        ChangeKeyStorePath(path);
+        try
         {
-            ChangeKeyStorePath(path);
-            string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
-            PrivateKey pkey = new PrivateKey();
-            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(pkey, passphraseValue);
-            Guid keyId = Add(ppk, dryRun);
-            if (json)
+            if (!noPassphrase)
             {
-                Stream stdout = Console.OpenStandardOutput();
-                ppk.WriteJson(stdout, keyId);
-                stdout.WriteByte(0x0a);
+                UnprotectKey(keyId, passphrase);
             }
-            else
-            {
-                PrintKeys(new[] { (keyId, ppk) });
-            }
-        }
 
-        [Command(Aliases = new[] { "rm" }, Description = "Remove a private key.")]
-        public void Remove(
-            [Argument(Name = "KEY-ID", Description = "A key UUID to remove.")]
-            Guid keyId,
-            PassphraseParameters passphrase,
-            [Option(Description = "Remove without asking passphrase.")]
-            bool noPassphrase = false,
-            [Option(Description = "Path to key store.")]
-            string? path = null
-        )
+            KeyStore.Remove(keyId);
+        }
+        catch (NoKeyException)
         {
-            ChangeKeyStorePath(path);
+            throw Utils.Error($"No such key ID: {keyId}");
+        }
+    }
+
+    [Command(Description = "Import a raw private key or Web3 Secret Storage.")]
+    public void Import(
+        [Argument(
+            "PRIVATE-KEY",
+            Description = "A raw private key in hexadecimal string, or path to Web3 Secret " +
+                            "Storage to import"
+        )]
+        string key,
+        PassphraseParameters passphrase,
+        [Option(
+            Description = "Import Web3 Secret Storage key."
+        )]
+        bool json = false,
+        [Option(Description = "Do not add to the key store, but only show the created key.")]
+        bool dryRun = false,
+        [Option(Description = "Path to key store.")]
+        string? path = null
+    )
+    {
+        ChangeKeyStorePath(path);
+        if (json)
+        {
             try
             {
-                if (!noPassphrase)
-                {
-                    UnprotectKey(keyId, passphrase);
-                }
-
-                KeyStore.Remove(keyId);
-            }
-            catch (NoKeyException)
-            {
-                throw Utils.Error($"No such key ID: {keyId}");
-            }
-        }
-
-        [Command(Description = "Import a raw private key or Web3 Secret Storage.")]
-        public void Import(
-            [Argument(
-                "PRIVATE-KEY",
-                Description = "A raw private key in hexadecimal string, or path to Web3 Secret " +
-                              "Storage to import"
-            )]
-            string key,
-            PassphraseParameters passphrase,
-            [Option(
-                Description = "Import Web3 Secret Storage key."
-            )]
-            bool json = false,
-            [Option(Description = "Do not add to the key store, but only show the created key.")]
-            bool dryRun = false,
-            [Option(Description = "Path to key store.")]
-            string? path = null
-        )
-        {
-            ChangeKeyStorePath(path);
-            if (json)
-            {
-                try
-                {
-                    ProtectedPrivateKey ppk = ProtectedPrivateKey.FromJson(ValidateJsonPath(key));
-                    PrintKeys(new[] { (Add(ppk, dryRun), ppk) });
-                }
-                catch (CommandExitedException)
-                {
-                    throw;
-                }
-                catch (Exception)
-                {
-                    throw Utils.Error("Couldn't load ppk from json.");
-                }
-            }
-            else
-            {
-                PrivateKey privateKey = ValidateRawHex(key);
-                string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
-                ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(
-                    privateKey, passphraseValue);
+                ProtectedPrivateKey ppk = ProtectedPrivateKey.FromJson(ValidateJsonPath(key));
                 PrintKeys(new[] { (Add(ppk, dryRun), ppk) });
             }
-        }
-
-        [Command(Description = "Export a raw private key (or public key).")]
-        public void Export(
-            [Argument("KEY-ID", Description = "A key UUID to export.")]
-            Guid keyId,
-            PassphraseParameters passphrase,
-            [Option('P', Description = "Export a public key instead of private key.")]
-            bool publicKey = false,
-            [Option(
-                'b',
-                Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended."
-            )]
-            bool bytes = false,
-            [Option(Description = "Export a Web3 Secret Storage Formatted json")]
-            bool json = false,
-            [Option(Description = "Path to key store to export from.")]
-            string? path = null
-        )
-        {
-            ChangeKeyStorePath(path);
-            PrivateKey key = UnprotectKey(keyId, passphrase);
-            byte[] rawKey = publicKey ? key.PublicKey.Format(true) : key.ToByteArray();
-            using Stream stdout = Console.OpenStandardOutput();
-            if (bytes)
+            catch (CommandExitedException)
             {
-                stdout.Write(rawKey, 0, rawKey.Length);
-            }
-            else if (json)
-            {
-                var ppk = KeyStore.Get(keyId);
-                ppk.WriteJson(stdout, keyId);
-                stdout.WriteByte(0x0a);
-            }
-            else
-            {
-                Console.WriteLine(ByteUtil.Hex(rawKey));
-            }
-        }
-
-        [Command(
-            Aliases = new[] { "gen" },
-            Description = "Generate a raw private key without storing it."
-        )]
-        public void Generate(
-            [Option('A', Description = "Do not show a derived address.")]
-            bool noAddress = false,
-            [Option('p', Description = "Show a public key as well.")]
-            bool publicKey = false
-        )
-        {
-            var key = new PrivateKey();
-            string priv = ByteUtil.Hex(key.ByteArray);
-            string addr = key.ToAddress().ToString();
-            string pub = ByteUtil.Hex(key.PublicKey.Format(compress: true));
-
-            if (!noAddress && publicKey)
-            {
-                Utils.PrintTable(
-                    ("Private key", "Address", "Public key"),
-                    new[] { (priv, addr, pub) }
-                );
-            }
-            else if (!noAddress)
-            {
-                Utils.PrintTable(("Private key", "Address"), new[] { (priv, addr) });
-            }
-            else if (publicKey)
-            {
-                Utils.PrintTable(("Private key", "Public key"), new[] { (priv, pub) });
-            }
-            else
-            {
-                Console.WriteLine(priv);
-            }
-        }
-
-        [Command(Description = "Sign a message.")]
-        public void Sign(
-            [Argument("KEY-ID", Description = "A key UUID to sign.")]
-            Guid keyId,
-            [Argument(
-                "FILE",
-                Description = "A path of the file to sign. If you pass '-' dash character, " +
-                              "it will receive the message to sign from stdin."
-            )]
-            string path,
-            PassphraseParameters passphrase,
-            [Option(Description = "A path of the file to save the signature. " +
-                                  "If you pass '-' dash character, it will print to stdout " +
-                                  "as raw bytes not hexadecimal string or else. " +
-                                  "If this option isn't given, it will print hexadecimal string " +
-                                  "to stdout as default behaviour.")]
-            string? binaryOutput = null,
-            [Option(Description = "Path to key store to use key from.")]
-            string? storePath = null
-        )
-        {
-            ChangeKeyStorePath(storePath);
-            PrivateKey key = UnprotectKey(keyId, passphrase);
-
-            byte[] message;
-            if (path == "-")
-            {
-                // Stream for stdin does not support .Seek()
-                using MemoryStream buffer = new MemoryStream();
-                using (Stream stream = Console.OpenStandardInput())
-                {
-                    stream.CopyTo(buffer);
-                }
-
-                message = buffer.ToArray();
-            }
-            else
-            {
-                message = File.ReadAllBytes(path);
-            }
-
-            var signature = key.Sign(message);
-            if (binaryOutput is null)
-            {
-                Console.WriteLine(ByteUtil.Hex(signature));
-            }
-            else if (binaryOutput == "-")
-            {
-                using Stream stdout = Console.OpenStandardOutput();
-                stdout.Write(signature, 0, signature.Length);
-            }
-            else
-            {
-                File.WriteAllBytes(binaryOutput, signature);
-            }
-        }
-
-        [Command(Description = "Derive public key and address from private key.")]
-        public void Derive(
-            [Argument(
-                "KEY",
-                Description = "A raw private key (or a public key if -P/--public-key is used) " +
-                    "to derive the address from."
-            )]
-            string key,
-            [Option('P', Description = "Derive from a public key instead of a private key.")]
-            bool publicKey = false
-        )
-        {
-            PublicKey pubKey = publicKey
-                ? new PublicKey(ByteUtil.ParseHex(key))
-                : ValidateRawHex(key).PublicKey;
-            string addr = pubKey.ToAddress().ToString();
-            string pub = ByteUtil.Hex(pubKey.Format(compress: true));
-            Utils.PrintTable(("Public Key", "Address"), new[] { (pub, addr) });
-        }
-
-        public PrivateKey UnprotectKey(
-            Guid keyId,
-            PassphraseParameters passphrase,
-            bool ignoreStdin = false
-        )
-        {
-            ProtectedPrivateKey ppk;
-            try
-            {
-                ppk = KeyStore.Get(keyId);
-            }
-            catch (NoKeyException)
-            {
-                throw Utils.Error($"No such key ID: {keyId}");
-            }
-
-            string passphraseValue = passphrase.Take($"Passphrase (of {keyId}): ");
-
-            try
-            {
-                return ppk.Unprotect(passphraseValue);
-            }
-            catch (IncorrectPassphraseException)
-            {
-                throw Utils.Error("The passphrase is wrong.");
-            }
-        }
-
-        private Guid Add(
-            ProtectedPrivateKey ppk,
-            bool dryRun
-        )
-        {
-            Guid keyId = dryRun ? Guid.NewGuid() : KeyStore.Add(ppk);
-            return keyId;
-        }
-
-        private void PrintKeys(IEnumerable<(Guid KeyId, ProtectedPrivateKey Key)> keys)
-        {
-            Utils.PrintTable(
-                ("Key ID", "Address"),
-                keys.Select(t => (t.KeyId.ToString(), t.Key.Address.ToString()))
-            );
-        }
-
-        private PrivateKey ValidateRawHex(string rawKeyHex)
-        {
-            PrivateKey key;
-            try
-            {
-                key = PrivateKey.FromString(rawKeyHex);
-            }
-            catch (FormatException)
-            {
-                throw Utils.Error("A raw private key should be hexadecimal.");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                throw Utils.Error("Hexadecimal characters should be even (not odd).");
+                throw;
             }
             catch (Exception)
             {
-                throw Utils.Error("Invalid private key.");
-            }
-
-            return key;
-        }
-
-        private string ValidateJsonPath(string jsonPath)
-        {
-            try
-            {
-                string json = new StreamReader(jsonPath).ReadToEnd();
-                return json;
-            }
-            catch (System.IO.FileNotFoundException)
-            {
-                throw Utils.Error("This file does not exist.");
+                throw Utils.Error("Couldn't load ppk from json.");
             }
         }
-
-        private void ChangeKeyStorePath(string? path)
+        else
         {
-            if (path != null)
+            PrivateKey privateKey = ValidateRawHex(key);
+            string passphraseValue = passphrase.Take("Passphrase: ", "Retype passphrase: ");
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(
+                privateKey, passphraseValue);
+            PrintKeys(new[] { (Add(ppk, dryRun), ppk) });
+        }
+    }
+
+    [Command(Description = "Export a raw private key (or public key).")]
+    public void Export(
+        [Argument("KEY-ID", Description = "A key UUID to export.")]
+        Guid keyId,
+        PassphraseParameters passphrase,
+        [Option('P', Description = "Export a public key instead of private key.")]
+        bool publicKey = false,
+        [Option(
+            'b',
+            Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended."
+        )]
+        bool bytes = false,
+        [Option(Description = "Export a Web3 Secret Storage Formatted json")]
+        bool json = false,
+        [Option(Description = "Path to key store to export from.")]
+        string? path = null
+    )
+    {
+        ChangeKeyStorePath(path);
+        PrivateKey key = UnprotectKey(keyId, passphrase);
+        byte[] rawKey = publicKey ? key.PublicKey.Format(true) : key.ToByteArray();
+        using Stream stdout = Console.OpenStandardOutput();
+        if (bytes)
+        {
+            stdout.Write(rawKey, 0, rawKey.Length);
+        }
+        else if (json)
+        {
+            var ppk = KeyStore.Get(keyId);
+            ppk.WriteJson(stdout, keyId);
+            stdout.WriteByte(0x0a);
+        }
+        else
+        {
+            Console.WriteLine(ByteUtil.Hex(rawKey));
+        }
+    }
+
+    [Command(
+        Aliases = new[] { "gen" },
+        Description = "Generate a raw private key without storing it."
+    )]
+    public void Generate(
+        [Option('A', Description = "Do not show a derived address.")]
+        bool noAddress = false,
+        [Option('p', Description = "Show a public key as well.")]
+        bool publicKey = false
+    )
+    {
+        var key = new PrivateKey();
+        string priv = ByteUtil.Hex(key.ByteArray);
+        string addr = key.ToAddress().ToString();
+        string pub = ByteUtil.Hex(key.PublicKey.Format(compress: true));
+
+        if (!noAddress && publicKey)
+        {
+            Utils.PrintTable(
+                ("Private key", "Address", "Public key"),
+                new[] { (priv, addr, pub) }
+            );
+        }
+        else if (!noAddress)
+        {
+            Utils.PrintTable(("Private key", "Address"), new[] { (priv, addr) });
+        }
+        else if (publicKey)
+        {
+            Utils.PrintTable(("Private key", "Public key"), new[] { (priv, pub) });
+        }
+        else
+        {
+            Console.WriteLine(priv);
+        }
+    }
+
+    [Command(Description = "Sign a message.")]
+    public void Sign(
+        [Argument("KEY-ID", Description = "A key UUID to sign.")]
+        Guid keyId,
+        [Argument(
+            "FILE",
+            Description = "A path of the file to sign. If you pass '-' dash character, " +
+                            "it will receive the message to sign from stdin."
+        )]
+        string path,
+        PassphraseParameters passphrase,
+        [Option(Description = "A path of the file to save the signature. " +
+                                "If you pass '-' dash character, it will print to stdout " +
+                                "as raw bytes not hexadecimal string or else. " +
+                                "If this option isn't given, it will print hexadecimal string " +
+                                "to stdout as default behaviour.")]
+        string? binaryOutput = null,
+        [Option(Description = "Path to key store to use key from.")]
+        string? storePath = null
+    )
+    {
+        ChangeKeyStorePath(storePath);
+        PrivateKey key = UnprotectKey(keyId, passphrase);
+
+        byte[] message;
+        if (path == "-")
+        {
+            // Stream for stdin does not support .Seek()
+            using MemoryStream buffer = new MemoryStream();
+            using (Stream stream = Console.OpenStandardInput())
             {
-                KeyStore = new Web3KeyStore(Path.GetFullPath(path));
+                stream.CopyTo(buffer);
             }
-            else
-            {
-                KeyStore = Web3KeyStore.DefaultKeyStore;
-            }
+
+            message = buffer.ToArray();
+        }
+        else
+        {
+            message = File.ReadAllBytes(path);
+        }
+
+        var signature = key.Sign(message);
+        if (binaryOutput is null)
+        {
+            Console.WriteLine(ByteUtil.Hex(signature));
+        }
+        else if (binaryOutput == "-")
+        {
+            using Stream stdout = Console.OpenStandardOutput();
+            stdout.Write(signature, 0, signature.Length);
+        }
+        else
+        {
+            File.WriteAllBytes(binaryOutput, signature);
+        }
+    }
+
+    [Command(Description = "Derive public key and address from private key.")]
+    public void Derive(
+        [Argument(
+            "KEY",
+            Description = "A raw private key (or a public key if -P/--public-key is used) " +
+                "to derive the address from."
+        )]
+        string key,
+        [Option('P', Description = "Derive from a public key instead of a private key.")]
+        bool publicKey = false
+    )
+    {
+        PublicKey pubKey = publicKey
+            ? new PublicKey(ByteUtil.ParseHex(key))
+            : ValidateRawHex(key).PublicKey;
+        string addr = pubKey.ToAddress().ToString();
+        string pub = ByteUtil.Hex(pubKey.Format(compress: true));
+        Utils.PrintTable(("Public Key", "Address"), new[] { (pub, addr) });
+    }
+
+    public PrivateKey UnprotectKey(
+        Guid keyId,
+        PassphraseParameters passphrase,
+        bool ignoreStdin = false
+    )
+    {
+        ProtectedPrivateKey ppk;
+        try
+        {
+            ppk = KeyStore.Get(keyId);
+        }
+        catch (NoKeyException)
+        {
+            throw Utils.Error($"No such key ID: {keyId}");
+        }
+
+        string passphraseValue = passphrase.Take($"Passphrase (of {keyId}): ");
+
+        try
+        {
+            return ppk.Unprotect(passphraseValue);
+        }
+        catch (IncorrectPassphraseException)
+        {
+            throw Utils.Error("The passphrase is wrong.");
+        }
+    }
+
+    private Guid Add(
+        ProtectedPrivateKey ppk,
+        bool dryRun
+    )
+    {
+        Guid keyId = dryRun ? Guid.NewGuid() : KeyStore.Add(ppk);
+        return keyId;
+    }
+
+    private void PrintKeys(IEnumerable<(Guid KeyId, ProtectedPrivateKey Key)> keys)
+    {
+        Utils.PrintTable(
+            ("Key ID", "Address"),
+            keys.Select(t => (t.KeyId.ToString(), t.Key.Address.ToString()))
+        );
+    }
+
+    private PrivateKey ValidateRawHex(string rawKeyHex)
+    {
+        PrivateKey key;
+        try
+        {
+            key = PrivateKey.FromString(rawKeyHex);
+        }
+        catch (FormatException)
+        {
+            throw Utils.Error("A raw private key should be hexadecimal.");
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            throw Utils.Error("Hexadecimal characters should be even (not odd).");
+        }
+        catch (Exception)
+        {
+            throw Utils.Error("Invalid private key.");
+        }
+
+        return key;
+    }
+
+    private string ValidateJsonPath(string jsonPath)
+    {
+        try
+        {
+            string json = new StreamReader(jsonPath).ReadToEnd();
+            return json;
+        }
+        catch (System.IO.FileNotFoundException)
+        {
+            throw Utils.Error("This file does not exist.");
+        }
+    }
+
+    private void ChangeKeyStorePath(string? path)
+    {
+        if (path != null)
+        {
+            KeyStore = new Web3KeyStore(Path.GetFullPath(path));
+        }
+        else
+        {
+            KeyStore = Web3KeyStore.DefaultKeyStore;
         }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -14,300 +16,298 @@ using Libplanet.RocksDBStore;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 
-namespace Libplanet.Extensions.Cocona.Commands
+internal enum SchemeType
 {
-    internal enum SchemeType
+    // This is set to 0 for `default` value.
+    File = 0,
+}
+
+public class MptCommand
+{
+    private const string KVStoreURIExample =
+        "<kv-store-type>://<kv-store-path> (e.g., rocksdb:///path/to/kv-store)";
+
+    private const string KVStoreArgumentDescription =
+        "The alias name registered through `planet mpt add' command or the URI included " +
+        "the type of " + nameof(IKeyValueStore) + " implementation and the path where " +
+        "it was used at. " + KVStoreURIExample;
+
+    private readonly IImmutableDictionary<string, Func<string, IKeyValueStore>>
+        _kvStoreConstructors =
+            new Dictionary<string, Func<string, IKeyValueStore>>
+            {
+                ["default"] = kvStorePath => new DefaultKeyValueStore(kvStorePath),
+                ["rocksdb"] = kvStorePath => new RocksDBKeyValueStore(kvStorePath),
+            }.ToImmutableSortedDictionary();
+
+    [Command(Description = "Compare two trees via root hash.")]
+    public void Diff(
+        [Argument(
+            Name = "KV-STORE",
+            Description = KVStoreArgumentDescription)]
+        string kvStoreUri,
+        [Argument(
+            Name = "STATE-ROOT-HASH",
+            Description = "The state root hash to compare.")]
+        string stateRootHashHex,
+        [Argument(
+            Name = "OTHER-KV-STORE",
+            Description = KVStoreArgumentDescription)]
+        string otherKvStoreUri,
+        [Argument(
+            Name = "OTHER-STATE-ROOT-HASH",
+            Description = "Another state root hash to compare.")]
+        string otherStateRootHashHex,
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
     {
-        // This is set to 0 for `default` value.
-        File = 0,
+        ToolConfiguration toolConfiguration = configurationService.Load();
+        kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
+        otherKvStoreUri = ConvertKVStoreUri(otherKvStoreUri, toolConfiguration);
+
+        IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
+        IKeyValueStore otherKeyValueStore = LoadKVStoreFromURI(otherKvStoreUri);
+        var trie = new MerkleTrie(
+            keyValueStore,
+            HashDigest<SHA256>.FromString(stateRootHashHex));
+        var otherTrie = new MerkleTrie(
+            otherKeyValueStore,
+            HashDigest<SHA256>.FromString(otherStateRootHashHex));
+
+        var codec = new Codec();
+        HashDigest<SHA256> originRootHash = trie.Hash;
+        HashDigest<SHA256> otherRootHash = otherTrie.Hash;
+
+        string originRootHashHex = ByteUtil.Hex(originRootHash.ByteArray);
+        string otherRootHashHex = ByteUtil.Hex(otherRootHash.ByteArray);
+        foreach (var (key, originValue, otherValue) in trie.DifferentNodes(otherTrie))
+        {
+            var data = new DiffData(ByteUtil.Hex(key.ByteArray), new Dictionary<string, string>
+            {
+                [originRootHashHex] = ByteUtil.Hex(codec.Encode(originValue)),
+                [otherRootHashHex] = otherValue is null
+                    ? "null"
+                    : ByteUtil.Hex(codec.Encode(otherValue)),
+            });
+
+            Console.WriteLine(JsonSerializer.Serialize(data));
+        }
     }
 
-    public class MptCommand
+    [Command(Description = "Export all states of the state root hash as JSON.")]
+    public void Export(
+        [Argument(
+            Name = "KV-STORE",
+            Description = KVStoreArgumentDescription)]
+        string kvStoreUri,
+        [Argument(
+            Name = "STATE-ROOT-HASH",
+            Description = "The state root hash to compare.")]
+        string stateRootHashHex,
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
     {
-        private const string KVStoreURIExample =
-            "<kv-store-type>://<kv-store-path> (e.g., rocksdb:///path/to/kv-store)";
+        ToolConfiguration toolConfiguration = configurationService.Load();
+        kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
 
-        private const string KVStoreArgumentDescription =
-            "The alias name registered through `planet mpt add' command or the URI included " +
-            "the type of " + nameof(IKeyValueStore) + " implementation and the path where " +
-            "it was used at. " + KVStoreURIExample;
+        IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
+        var trie = new MerkleTrie(
+            keyValueStore,
+            HashDigest<SHA256>.FromString(stateRootHashHex));
+        var codec = new Codec();
+        ImmutableDictionary<string, byte[]> decoratedStates = trie.ListAllStates()
+            .ToImmutableDictionary(
+                pair => StateStoreExtensions.DecodeKey(pair.Key),
+                pair => codec.Encode(pair.Value));
 
-        private readonly IImmutableDictionary<string, Func<string, IKeyValueStore>>
-            _kvStoreConstructors =
-                new Dictionary<string, Func<string, IKeyValueStore>>
-                {
-                    ["default"] = kvStorePath => new DefaultKeyValueStore(kvStorePath),
-                    ["rocksdb"] = kvStorePath => new RocksDBKeyValueStore(kvStorePath),
-                }.ToImmutableSortedDictionary();
+        Console.WriteLine(JsonSerializer.Serialize(decoratedStates));
+    }
 
-        [Command(Description = "Compare two trees via root hash.")]
-        public void Diff(
-            [Argument(
-                Name = "KV-STORE",
-                Description = KVStoreArgumentDescription)]
-            string kvStoreUri,
-            [Argument(
-                Name = "STATE-ROOT-HASH",
-                Description = "The state root hash to compare.")]
-            string stateRootHashHex,
-            [Argument(
-                Name = "OTHER-KV-STORE",
-                Description = KVStoreArgumentDescription)]
-            string otherKvStoreUri,
-            [Argument(
-                Name = "OTHER-STATE-ROOT-HASH",
-                Description = "Another state root hash to compare.")]
-            string otherStateRootHashHex,
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
+    // FIXME: Now, it works like `set` not `add`. It allows override.
+    [Command(Description="Register an alias name to refer to a key-value store.")]
+    public void Add(
+        [Argument(
+            Name = "ALIAS",
+            Description = "The alias to refer to the fully qualified key-value store URI.")]
+        string alias,
+        [Argument(
+            Name = "KV-STORE-URI",
+            Description = KVStoreURIExample)]
+        string uri,
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
+    {
+        if (Uri.IsWellFormedUriString(alias, UriKind.Absolute))
         {
-            ToolConfiguration toolConfiguration = configurationService.Load();
-            kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
-            otherKvStoreUri = ConvertKVStoreUri(otherKvStoreUri, toolConfiguration);
-
-            IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
-            IKeyValueStore otherKeyValueStore = LoadKVStoreFromURI(otherKvStoreUri);
-            var trie = new MerkleTrie(
-                keyValueStore,
-                HashDigest<SHA256>.FromString(stateRootHashHex));
-            var otherTrie = new MerkleTrie(
-                otherKeyValueStore,
-                HashDigest<SHA256>.FromString(otherStateRootHashHex));
-
-            var codec = new Codec();
-            HashDigest<SHA256> originRootHash = trie.Hash;
-            HashDigest<SHA256> otherRootHash = otherTrie.Hash;
-
-            string originRootHashHex = ByteUtil.Hex(originRootHash.ByteArray);
-            string otherRootHashHex = ByteUtil.Hex(otherRootHash.ByteArray);
-            foreach (var (key, originValue, otherValue) in trie.DifferentNodes(otherTrie))
-            {
-                var data = new DiffData(ByteUtil.Hex(key.ByteArray), new Dictionary<string, string>
-                {
-                    [originRootHashHex] = ByteUtil.Hex(codec.Encode(originValue)),
-                    [otherRootHashHex] = otherValue is null
-                        ? "null"
-                        : ByteUtil.Hex(codec.Encode(otherValue)),
-                });
-
-                Console.WriteLine(JsonSerializer.Serialize(data));
-            }
+            throw new CommandExitedException(
+                "The alias should not look like a URI to prevent it" +
+                "from being ambiguous. Please try to use other alias name.",
+                -1);
         }
 
-        [Command(Description = "Export all states of the state root hash as JSON.")]
-        public void Export(
-            [Argument(
-                Name = "KV-STORE",
-                Description = KVStoreArgumentDescription)]
-            string kvStoreUri,
-            [Argument(
-                Name = "STATE-ROOT-HASH",
-                Description = "The state root hash to compare.")]
-            string stateRootHashHex,
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
+        try
         {
-            ToolConfiguration toolConfiguration = configurationService.Load();
-            kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
-
-            IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
-            var trie = new MerkleTrie(
-                keyValueStore,
-                HashDigest<SHA256>.FromString(stateRootHashHex));
-            var codec = new Codec();
-            ImmutableDictionary<string, byte[]> decoratedStates = trie.ListAllStates()
-                .ToImmutableDictionary(
-                    pair => StateStoreExtensions.DecodeKey(pair.Key),
-                    pair => codec.Encode(pair.Value));
-
-            Console.WriteLine(JsonSerializer.Serialize(decoratedStates));
+            // Checks the `uri` is valid.
+            LoadKVStoreFromURI(uri);
+        }
+        catch (Exception e)
+        {
+            throw new CommandExitedException(
+                $"It seems the uri is not valid. (exceptionMessage: {e.Message})", -1);
         }
 
-        // FIXME: Now, it works like `set` not `add`. It allows override.
-        [Command(Description="Register an alias name to refer to a key-value store.")]
-        public void Add(
-            [Argument(
-                Name = "ALIAS",
-                Description = "The alias to refer to the fully qualified key-value store URI.")]
-            string alias,
-            [Argument(
-                Name = "KV-STORE-URI",
-                Description = KVStoreURIExample)]
-            string uri,
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
-        {
-            if (Uri.IsWellFormedUriString(alias, UriKind.Absolute))
-            {
-                throw new CommandExitedException(
-                    "The alias should not look like a URI to prevent it" +
-                    "from being ambiguous. Please try to use other alias name.",
-                    -1);
-            }
+        var configuration = configurationService.Load();
+        configuration.Mpt.Aliases.Add(alias, uri);
+        configurationService.Store(configuration);
+    }
 
+    [Command(Description="Deregister an alias to a key-value store.")]
+    public void Remove(
+        [Argument(
+            Name = "ALIAS",
+            Description = "The alias name to deregister.")]
+        string alias,
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
+    {
+        var configuration = configurationService.Load();
+        configuration.Mpt.Aliases.Remove(alias);
+        configurationService.Store(configuration);
+    }
+
+    [Command(Description="List all aliases stored.")]
+    public void List(
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
+    {
+        ToolConfiguration configuration = configurationService.Load();
+        Dictionary<string, string> aliases = configuration.Mpt.Aliases;
+
+        int maxAliasLength = aliases.Keys.Max(alias => alias.Length),
+            maxPathLength = aliases.Values.Max(alias => alias.Length);
+        Console.Error.WriteLine(
+            $"{{0,-{maxAliasLength}}} | {{1,-{maxPathLength}}}",
+            "ALIAS",
+            "PATH");
+        Console.Error.WriteLine(new string('-', 3 + maxAliasLength + maxPathLength));
+        Console.Error.Flush();
+        foreach (KeyValuePair<string, string> pair in aliases)
+        {
+            Console.Write($"{{0,-{maxAliasLength}}} ", pair.Key);
+            Console.Out.Flush();
+            Console.Error.Write("| ");
+            Console.Error.Flush();
+            Console.WriteLine($"{{0,-{maxPathLength}}}", pair.Value);
+            Console.Out.Flush();
+        }
+    }
+
+    [Command(
+        Description = "Query a state of the state key at the state root hash.  It will " +
+            "print the state as hexadecimal bytes string into stdout.  " +
+            "If it doesn't exist, it will not print anything.")]
+    public void Query(
+        [Argument(
+            Name = "KV-STORE",
+            Description = KVStoreArgumentDescription)]
+        string kvStoreUri,
+        [Argument(
+            Name = "STATE-ROOT-HASH",
+            Description = "The state root hash to compare.")]
+        string stateRootHashHex,
+        [Argument(
+            Name = "STATE-KEY",
+            Description = "The key of the state to query.")]
+        string stateKey,
+        [FromService] IConfigurationService<ToolConfiguration> configurationService)
+    {
+        ToolConfiguration toolConfiguration = configurationService.Load();
+        kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
+        IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
+        var trie = new MerkleTrie(
+            keyValueStore,
+            HashDigest<SHA256>.FromString(stateRootHashHex));
+        KeyBytes stateKeyBytes = StateStoreExtensions.EncodeKey(stateKey);
+        IReadOnlyList<IValue?> values = trie.Get(new[] { stateKeyBytes });
+        if (values.Count > 0 && values[0] is { } value)
+        {
+            var codec = new Codec();
+            Console.WriteLine(ByteUtil.Hex(codec.Encode(value)));
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                $"The state corresponded to {stateKey} at the state root hash " +
+                $"\"{stateRootHashHex}\" in the KV store \"{kvStoreUri}\" seems not existed.");
+        }
+    }
+
+    [PrimaryCommand]
+    public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+    {
+        Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
+    }
+
+    private IKeyValueStore LoadKVStoreFromURI(string rawUri)
+    {
+        var uri = new Uri(rawUri);
+        var scheme = uri.Scheme;
+        var splitScheme = scheme.Split('+');
+        if (splitScheme.Length <= 0 || splitScheme.Length > 2)
+        {
+            var exceptionMessage = "A key-value store URI must have a scheme, " +
+                                    "e.g., default://, rocksdb+file://.";
+            throw new ArgumentException(exceptionMessage, nameof(rawUri));
+        }
+
+        if (!_kvStoreConstructors.TryGetValue(
+            splitScheme[0],
+            out Func<string, IKeyValueStore>? constructor))
+        {
+            throw new NotSupportedException(
+                $"No key-value store backend supports the such scheme: {splitScheme[0]}.");
+        }
+
+        // NOTE: Actually, there is only File scheme support and it will work to check only.
+        if (splitScheme.Length == 2
+            && !SchemeType.TryParse(splitScheme[1], ignoreCase: true, out SchemeType _))
+        {
+            throw new NotSupportedException(
+                $"No key-value store backend supports the such scheme: {splitScheme[1]}.");
+        }
+
+        return constructor(uri.AbsolutePath);
+    }
+
+    private string ConvertKVStoreUri(string kvStoreUri, ToolConfiguration toolConfiguration)
+    {
+        // If it is not Uri format,
+        // try to get uri from configuration service by using it as alias.
+        if (!Uri.IsWellFormedUriString(kvStoreUri, UriKind.Absolute))
+        {
             try
             {
-                // Checks the `uri` is valid.
-                LoadKVStoreFromURI(uri);
+                kvStoreUri = toolConfiguration.Mpt.Aliases[kvStoreUri];
             }
-            catch (Exception e)
+            catch (KeyNotFoundException)
             {
+                var exceptionMessage =
+                    $"The alias, '{kvStoreUri}' doesn't exist. " +
+                    $"Please pass correct uri or alias.";
                 throw new CommandExitedException(
-                    $"It seems the uri is not valid. (exceptionMessage: {e.Message})", -1);
+                    exceptionMessage,
+                    -1);
             }
-
-            var configuration = configurationService.Load();
-            configuration.Mpt.Aliases.Add(alias, uri);
-            configurationService.Store(configuration);
         }
 
-        [Command(Description="Deregister an alias to a key-value store.")]
-        public void Remove(
-            [Argument(
-                Name = "ALIAS",
-                Description = "The alias name to deregister.")]
-            string alias,
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
+        return kvStoreUri;
+    }
+
+    private sealed class DiffData
+    {
+        public DiffData(string key, Dictionary<string, string> stateRootHashToValue)
         {
-            var configuration = configurationService.Load();
-            configuration.Mpt.Aliases.Remove(alias);
-            configurationService.Store(configuration);
+            Key = key;
+            StateRootHashToValue = stateRootHashToValue;
         }
 
-        [Command(Description="List all aliases stored.")]
-        public void List(
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
-        {
-            ToolConfiguration configuration = configurationService.Load();
-            Dictionary<string, string> aliases = configuration.Mpt.Aliases;
+        public string Key { get; }
 
-            int maxAliasLength = aliases.Keys.Max(alias => alias.Length),
-                maxPathLength = aliases.Values.Max(alias => alias.Length);
-            Console.Error.WriteLine(
-                $"{{0,-{maxAliasLength}}} | {{1,-{maxPathLength}}}",
-                "ALIAS",
-                "PATH");
-            Console.Error.WriteLine(new string('-', 3 + maxAliasLength + maxPathLength));
-            Console.Error.Flush();
-            foreach (KeyValuePair<string, string> pair in aliases)
-            {
-                Console.Write($"{{0,-{maxAliasLength}}} ", pair.Key);
-                Console.Out.Flush();
-                Console.Error.Write("| ");
-                Console.Error.Flush();
-                Console.WriteLine($"{{0,-{maxPathLength}}}", pair.Value);
-                Console.Out.Flush();
-            }
-        }
-
-        [Command(Description="Query a state of the state key at the state root hash.  It will " +
-                             "print the state as hexadecimal bytes string into stdout.  " +
-                             "If it doesn't exist, it will not print anything.")]
-        public void Query(
-            [Argument(
-                Name = "KV-STORE",
-                Description = KVStoreArgumentDescription)]
-            string kvStoreUri,
-            [Argument(
-                Name = "STATE-ROOT-HASH",
-                Description = "The state root hash to compare.")]
-            string stateRootHashHex,
-            [Argument(
-                Name = "STATE-KEY",
-                Description = "The key of the state to query.")]
-            string stateKey,
-            [FromService] IConfigurationService<ToolConfiguration> configurationService)
-        {
-            ToolConfiguration toolConfiguration = configurationService.Load();
-            kvStoreUri = ConvertKVStoreUri(kvStoreUri, toolConfiguration);
-            IKeyValueStore keyValueStore = LoadKVStoreFromURI(kvStoreUri);
-            var trie = new MerkleTrie(
-                keyValueStore,
-                HashDigest<SHA256>.FromString(stateRootHashHex));
-            KeyBytes stateKeyBytes = StateStoreExtensions.EncodeKey(stateKey);
-            IReadOnlyList<IValue?> values = trie.Get(new[] { stateKeyBytes });
-            if (values.Count > 0 && values[0] is { } value)
-            {
-                var codec = new Codec();
-                Console.WriteLine(ByteUtil.Hex(codec.Encode(value)));
-            }
-            else
-            {
-                Console.Error.WriteLine(
-                    $"The state corresponded to {stateKey} at the state root hash " +
-                    $"\"{stateRootHashHex}\" in the KV store \"{kvStoreUri}\" seems not existed.");
-            }
-        }
-
-        [PrimaryCommand]
-        public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
-        {
-            Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
-        }
-
-        private IKeyValueStore LoadKVStoreFromURI(string rawUri)
-        {
-            var uri = new Uri(rawUri);
-            var scheme = uri.Scheme;
-            var splitScheme = scheme.Split('+');
-            if (splitScheme.Length <= 0 || splitScheme.Length > 2)
-            {
-                var exceptionMessage = "A key-value store URI must have a scheme, " +
-                                       "e.g., default://, rocksdb+file://.";
-                throw new ArgumentException(exceptionMessage, nameof(rawUri));
-            }
-
-            if (!_kvStoreConstructors.TryGetValue(
-                splitScheme[0],
-                out Func<string, IKeyValueStore>? constructor))
-            {
-                throw new NotSupportedException(
-                    $"No key-value store backend supports the such scheme: {splitScheme[0]}.");
-            }
-
-            // NOTE: Actually, there is only File scheme support and it will work to check only.
-            if (splitScheme.Length == 2
-                && !SchemeType.TryParse(splitScheme[1], ignoreCase: true, out SchemeType _))
-            {
-                throw new NotSupportedException(
-                    $"No key-value store backend supports the such scheme: {splitScheme[1]}.");
-            }
-
-            return constructor(uri.AbsolutePath);
-        }
-
-        private string ConvertKVStoreUri(string kvStoreUri, ToolConfiguration toolConfiguration)
-        {
-            // If it is not Uri format,
-            // try to get uri from configuration service by using it as alias.
-            if (!Uri.IsWellFormedUriString(kvStoreUri, UriKind.Absolute))
-            {
-                try
-                {
-                    kvStoreUri = toolConfiguration.Mpt.Aliases[kvStoreUri];
-                }
-                catch (KeyNotFoundException)
-                {
-                    var exceptionMessage =
-                        $"The alias, '{kvStoreUri}' doesn't exist. " +
-                        $"Please pass correct uri or alias.";
-                    throw new CommandExitedException(
-                        exceptionMessage,
-                        -1);
-                }
-            }
-
-            return kvStoreUri;
-        }
-
-        private class DiffData
-        {
-            public DiffData(string key, Dictionary<string, string> stateRootHashToValue)
-            {
-                Key = key;
-                StateRootHashToValue = stateRootHashToValue;
-            }
-
-            public string Key { get; }
-
-            public Dictionary<string, string> StateRootHashToValue { get; }
-        }
+        public Dictionary<string, string> StateRootHashToValue { get; }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/StatsCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/StatsCommand.cs
@@ -1,84 +1,83 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.Collections.Generic;
-using Cocona;
+using global::Cocona;
 using Libplanet.Blocks;
 using Libplanet.Store;
 
-namespace Libplanet.Extensions.Cocona.Commands
+public class StatsCommand
 {
-    public class StatsCommand
+    private const string StoreArgumentDescription =
+        "The URI denotes the type and path of concrete class for " + nameof(IStore) + "."
+        + "<store-type>://<store-path> (e.g., rocksdb+file:///path/to/store)";
+
+    [Command(Description = "Outputs a summary of a stored chain in a CSV format.")]
+    public void Summary(
+        [Option('p', Description = StoreArgumentDescription)]
+        string path,
+        [Option('r', Description = "Whether to include header row")]
+        bool header,
+        [Option('o', Description =
+            "Starting index offset; " +
+            "supports negative indexing")]
+        long offset = 0,
+        [Option('l', Description =
+            "Maximum number of results to return; " +
+            "no limit by default")]
+        long? limit = null) => Summary(
+            store: Utils.LoadStoreFromUri(path),
+            header: header,
+            offset: offset,
+            limit: limit);
+
+    internal void Summary(
+        IStore store,
+        bool header,
+        long offset,
+        long? limit)
     {
-        private const string StoreArgumentDescription =
-            "The URI denotes the type and path of concrete class for " + nameof(IStore) + "."
-            + "<store-type>://<store-path> (e.g., rocksdb+file:///path/to/store)";
-
-        [Command(Description = "Outputs a summary of a stored chain in a CSV format.")]
-        public void Summary(
-            [Option('p', Description = StoreArgumentDescription)]
-            string path,
-            [Option('r', Description = "Whether to include header row")]
-            bool header,
-            [Option('o', Description =
-                "Starting index offset; " +
-                "supports negative indexing")]
-            long offset = 0,
-            [Option('l', Description =
-                "Maximum number of results to return; " +
-                "no limit by default")]
-            long? limit = null) => Summary(
-                store: Utils.LoadStoreFromUri(path),
-                header: header,
-                offset: offset,
-                limit: limit);
-
-        internal void Summary(
-            IStore store,
-            bool header,
-            long offset,
-            long? limit)
+        if (limit is { } && limit < 1)
         {
-            if (limit is { } && limit < 1)
-            {
-                throw new ArgumentException($"limit must be at least 1: {limit}");
-            }
+            throw new ArgumentException($"limit must be at least 1: {limit}");
+        }
 
-            Guid chainId = store.GetCanonicalChainId()
-                ?? throw Utils.Error($"Failed to find the canonical chain in store.");
-            long chainLength = store.CountIndex(chainId);
+        Guid chainId = store.GetCanonicalChainId()
+            ?? throw Utils.Error($"Failed to find the canonical chain in store.");
+        long chainLength = store.CountIndex(chainId);
 
-            if (offset >= chainLength || (offset < 0 && chainLength + offset < 0))
-            {
-                throw new ArgumentException(
-                    $"invalid offset value {offset} for found chain length {chainLength}");
-            }
+        if (offset >= chainLength || (offset < 0 && chainLength + offset < 0))
+        {
+            throw new ArgumentException(
+                $"invalid offset value {offset} for found chain length {chainLength}");
+        }
 
-            IEnumerable<BlockHash> hashes = store.IterateIndexes(
-                chainId,
-                offset: offset >= 0
-                    ? (int)offset
-                    : (int)(chainLength + offset),
-                limit: (int?)limit);
+        IEnumerable<BlockHash> hashes = store.IterateIndexes(
+            chainId,
+            offset: offset >= 0
+                ? (int)offset
+                : (int)(chainLength + offset),
+            limit: (int?)limit);
 
-            if (header)
-            {
-                Console.WriteLine("index,hash,difficulty,miner,txCount,timestamp,perceivedTime");
-            }
+        if (header)
+        {
+            Console.WriteLine("index,hash,difficulty,miner,txCount,timestamp,perceivedTime");
+        }
 
-            foreach (var hash in hashes)
-            {
-                BlockDigest blockDigest = store.GetBlockDigest(hash) ??
-                    throw Utils.Error($"Failed to load the block {hash}.");
-                BlockHeader blockHeader =
-                    blockDigest.GetHeader();
+        foreach (var hash in hashes)
+        {
+            BlockDigest blockDigest = store.GetBlockDigest(hash) ??
+                throw Utils.Error($"Failed to load the block {hash}.");
+            BlockHeader blockHeader =
+                blockDigest.GetHeader();
 
-                Console.WriteLine(
-                    $"{blockHeader.Index}," +
-                    $"{blockHeader.Hash}," +
-                    $"{blockHeader.Difficulty}," +
-                    $"{blockHeader.Miner}," +
-                    $"{blockDigest.TxIds.Length}," +
-                    $"{blockHeader.Timestamp.ToUnixTimeMilliseconds()}");
-            }
+            Console.WriteLine(
+                $"{blockHeader.Index}," +
+                $"{blockHeader.Hash}," +
+                $"{blockHeader.Difficulty}," +
+                $"{blockHeader.Miner}," +
+                $"{blockDigest.TxIds.Length}," +
+                $"{blockHeader.Timestamp.ToUnixTimeMilliseconds()}");
         }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/StoreCommand.cs
@@ -1,235 +1,234 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
-using Cocona;
+using global::Cocona;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Store;
 using Libplanet.Tx;
 
-namespace Libplanet.Extensions.Cocona.Commands
+public class StoreCommand
 {
-    public class StoreCommand
+    private const string StoreArgumentDescription =
+        "The URI denotes the type and path of concrete class for " + nameof(IStore) + "."
+        + "<store-type>://<store-path> (e.g., rocksdb+file:///path/to/store)";
+
+    [Command(Description = "List all chain IDs.")]
+    public void ChainIds(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string storeUri,
+        [Option("hash", Description = "Show the hash of the chain tip.")]
+        bool showHash
+    )
     {
-        private const string StoreArgumentDescription =
-            "The URI denotes the type and path of concrete class for " + nameof(IStore) + "."
-            + "<store-type>://<store-path> (e.g., rocksdb+file:///path/to/store)";
-
-        [Command(Description = "List all chain IDs.")]
-        public void ChainIds(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string storeUri,
-            [Option("hash", Description = "Show the hash of the chain tip.")]
-            bool showHash
-        )
+        IStore store = Utils.LoadStoreFromUri(storeUri);
+        Guid? canon = store.GetCanonicalChainId();
+        var headerWithoutHash = ("Chain ID", "Height", "Canon?");
+        var headerWithHash = ("Chain ID", "Height", "Canon?", "Hash");
+        var chainIds = store.ListChainIds().Select(id =>
         {
-            IStore store = Utils.LoadStoreFromUri(storeUri);
-            Guid? canon = store.GetCanonicalChainId();
-            var headerWithoutHash = ("Chain ID", "Height", "Canon?");
-            var headerWithHash = ("Chain ID", "Height", "Canon?", "Hash");
-            var chainIds = store.ListChainIds().Select(id =>
-            {
-                var height = store.CountIndex(id) - 1;
-                return (
-                    id.ToString(),
-                    height.ToString(CultureInfo.InvariantCulture),
-                    id == canon ? "*" : string.Empty,
-                    store.GetBlockDigest(
-                        store.IndexBlockHash(id, height)!.Value)!.Value.Hash.ToString());
-            });
-            if (showHash)
-            {
-                Utils.PrintTable(headerWithHash, chainIds);
-            }
-            else
-            {
-                Utils.PrintTable(
-                    headerWithoutHash, chainIds.Select(i => (i.Item1, i.Item2, i.Item3)));
-            }
+            var height = store.CountIndex(id) - 1;
+            return (
+                id.ToString(),
+                height.ToString(CultureInfo.InvariantCulture),
+                id == canon ? "*" : string.Empty,
+                store.GetBlockDigest(
+                    store.IndexBlockHash(id, height)!.Value)!.Value.Hash.ToString());
+        });
+        if (showHash)
+        {
+            Utils.PrintTable(headerWithHash, chainIds);
+        }
+        else
+        {
+            Utils.PrintTable(
+                headerWithoutHash, chainIds.Select(i => (i.Item1, i.Item2, i.Item3)));
+        }
+    }
+
+    [Command(Description = "Build an index for transaction id and block hash.")]
+    public void BuildIndexTxBlock(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("OFFSET", Description = "block index")]
+        int offset,
+        [Argument("LIMIT", Description = "block index")]
+        int limit
+    )
+    {
+        IStore store = Utils.LoadStoreFromUri(home);
+        var prev = DateTimeOffset.UtcNow;
+        foreach (var index in BuildTxIdBlockHashIndex(store, offset, limit))
+        {
+            Console.WriteLine($"processing {index}/{offset + limit}...");
         }
 
-        [Command(Description = "Build an index for transaction id and block hash.")]
-        public void BuildIndexTxBlock(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("OFFSET", Description = "block index")]
-            int offset,
-            [Argument("LIMIT", Description = "block index")]
-            int limit
-        )
-        {
-            IStore store = Utils.LoadStoreFromUri(home);
-            var prev = DateTimeOffset.UtcNow;
-            foreach (var index in BuildTxIdBlockHashIndex(store, offset, limit))
-            {
-                Console.WriteLine($"processing {index}/{offset + limit}...");
-            }
+        Console.WriteLine($"It taken {DateTimeOffset.UtcNow - prev}");
+        store?.Dispose();
+    }
 
-            Console.WriteLine($"It taken {DateTimeOffset.UtcNow - prev}");
-            store?.Dispose();
+    [Command(Description = "Query block hashes by transaction id.")]
+    public void BlockHashesByTxId(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("TX-ID", Description = "tx id")]
+        string strTxId
+    )
+    {
+        IStore store = Utils.LoadStoreFromUri(home);
+        var blockHashes = store.IterateTxIdBlockHashIndex(new TxId(ByteUtil.ParseHex(strTxId)))
+            .ToImmutableArray();
+        Console.WriteLine(Utils.SerializeHumanReadable(blockHashes));
+        store?.Dispose();
+    }
+
+    [Command(Description = "Query a list of blocks by transaction id.")]
+    public void BlocksByTxId(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("TX-ID", Description = "tx id")]
+        string strTxId
+    )
+    {
+        using IStore store = Utils.LoadStoreFromUri(home);
+        var txId = new TxId(ByteUtil.ParseHex(strTxId));
+        if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } ))
+        {
+            throw Utils.Error($"cannot find the block with the TxId[{txId.ToString()}]");
         }
 
-        [Command(Description = "Query block hashes by transaction id.")]
-        public void BlockHashesByTxId(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("TX-ID", Description = "tx id")]
-            string strTxId
-        )
+        var blocks = IterateBlocks<Utils.DummyAction>(store, txId).ToImmutableList();
+
+        Console.WriteLine(Utils.SerializeHumanReadable(blocks));
+    }
+
+    [Command(Description = "Query a block by index.")]
+    public void BlockByIndex(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("BLOCK-INDEX", Description = "block index")]
+        int blockIndex
+    )
+    {
+        using IStore store = Utils.LoadStoreFromUri(home);
+        var blockHash = GetBlockHash(store, blockIndex);
+        var block = GetBlock<Utils.DummyAction>(store, blockHash);
+        Console.WriteLine(Utils.SerializeHumanReadable(block));
+    }
+
+    [Command(Description = "Query a block by hash.")]
+    public void BlockByHash(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("BLOCK-HASH", Description = "block hash")]
+        string blockHash
+    )
+    {
+        using IStore store = Utils.LoadStoreFromUri(home);
+        var block = GetBlock<Utils.DummyAction>(store, BlockHash.FromString(blockHash));
+        Console.WriteLine(Utils.SerializeHumanReadable(block));
+    }
+
+    [Command(Description = "Query a transaction by tx id.")]
+    public void TxById(
+        [Argument("STORE", Description = StoreArgumentDescription)]
+        string home,
+        [Argument("TX-ID", Description = "tx id")]
+        string strTxId
+    )
+    {
+        IStore store = Utils.LoadStoreFromUri(home);
+        var tx = GetTransaction<Utils.DummyAction>(store, new TxId(ByteUtil.ParseHex(strTxId)));
+        Console.WriteLine(Utils.SerializeHumanReadable(tx));
+        store?.Dispose();
+    }
+
+    [Command]
+    public void MigrateIndex(string storePath)
+    {
+        if (RocksDBStore.RocksDBStore.MigrateChainDBFromColumnFamilies(storePath))
         {
-            IStore store = Utils.LoadStoreFromUri(home);
-            var blockHashes = store.IterateTxIdBlockHashIndex(new TxId(ByteUtil.ParseHex(strTxId)))
-                .ToImmutableArray();
-            Console.WriteLine(Utils.SerializeHumanReadable(blockHashes));
-            store?.Dispose();
+            Console.WriteLine("Successfully migrated.");
+        }
+        else
+        {
+            Console.WriteLine("Already migrated, no need to migrate.");
+        }
+    }
+
+    private static Block<T> GetBlock<T>(IStore store, BlockHash blockHash)
+        where T : IAction, new()
+    {
+        if (!(store.GetBlock<T>(blockHash) is { } block))
+        {
+            throw Utils.Error($"cannot find the block with the hash[{blockHash.ToString()}]");
         }
 
-        [Command(Description = "Query a list of blocks by transaction id.")]
-        public void BlocksByTxId(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("TX-ID", Description = "tx id")]
-            string strTxId
-        )
+        return block;
+    }
+
+    private static BlockHash GetBlockHash(IStore store, int blockIndex)
+    {
+        if (!(store.GetCanonicalChainId() is { } chainId))
         {
-            using IStore store = Utils.LoadStoreFromUri(home);
-            var txId = new TxId(ByteUtil.ParseHex(strTxId));
-            if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } ))
-            {
-                throw Utils.Error($"cannot find the block with the TxId[{txId.ToString()}]");
-            }
-
-            var blocks = IterateBlocks<Utils.DummyAction>(store, txId).ToImmutableList();
-
-            Console.WriteLine(Utils.SerializeHumanReadable(blocks));
+            throw Utils.Error("Cannot find the main branch of the blockchain.");
         }
 
-        [Command(Description = "Query a block by index.")]
-        public void BlockByIndex(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("BLOCK-INDEX", Description = "block index")]
-            int blockIndex
-        )
+        if (!(store.IndexBlockHash(chainId, blockIndex) is { } blockHash))
         {
-            using IStore store = Utils.LoadStoreFromUri(home);
-            var blockHash = GetBlockHash(store, blockIndex);
-            var block = GetBlock<Utils.DummyAction>(store, blockHash);
-            Console.WriteLine(Utils.SerializeHumanReadable(block));
+            throw Utils.Error(
+                $"Cannot find the block with the height {blockIndex}" +
+                $" within the blockchain {chainId}."
+            );
         }
 
-        [Command(Description = "Query a block by hash.")]
-        public void BlockByHash(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("BLOCK-HASH", Description = "block hash")]
-            string blockHash
-        )
+        return blockHash;
+    }
+
+    private static IEnumerable<Block<T>> IterateBlocks<T>(IStore store, TxId txId)
+        where T : IAction, new()
+    {
+        foreach (var blockHash in store.IterateTxIdBlockHashIndex(txId))
         {
-            using IStore store = Utils.LoadStoreFromUri(home);
-            var block = GetBlock<Utils.DummyAction>(store, BlockHash.FromString(blockHash));
-            Console.WriteLine(Utils.SerializeHumanReadable(block));
+            yield return GetBlock<T>(store, blockHash);
+        }
+    }
+
+    private static Transaction<T> GetTransaction<T>(IStore store, TxId txId)
+        where T : IAction, new()
+    {
+        if (!(store.GetTransaction<T>(txId) is { } tx))
+        {
+            throw Utils.Error($"cannot find the tx with the tx id[{txId.ToString()}]");
         }
 
-        [Command(Description = "Query a transaction by tx id.")]
-        public void TxById(
-            [Argument("STORE", Description = StoreArgumentDescription)]
-            string home,
-            [Argument("TX-ID", Description = "tx id")]
-            string strTxId
-        )
+        return tx;
+    }
+
+    private static IEnumerable<int> BuildTxIdBlockHashIndex(IStore store, int offset, int limit)
+    {
+        if (!(store.GetCanonicalChainId() is { } chainId))
         {
-            IStore store = Utils.LoadStoreFromUri(home);
-            var tx = GetTransaction<Utils.DummyAction>(store, new TxId(ByteUtil.ParseHex(strTxId)));
-            Console.WriteLine(Utils.SerializeHumanReadable(tx));
-            store?.Dispose();
+            throw Utils.Error("Cannot find the main branch of the blockchain.");
         }
 
-        [Command]
-        public void MigrateIndex(string storePath)
+        var index = offset;
+        foreach (BlockHash blockHash in store.IterateIndexes(chainId, offset, limit))
         {
-            if (RocksDBStore.RocksDBStore.MigrateChainDBFromColumnFamilies(storePath))
-            {
-                Console.WriteLine("Successfully migrated.");
-            }
-            else
-            {
-                Console.WriteLine("Already migrated, no need to migrate.");
-            }
-        }
-
-        private static Block<T> GetBlock<T>(IStore store, BlockHash blockHash)
-            where T : IAction, new()
-        {
-            if (!(store.GetBlock<T>(blockHash) is { } block))
-            {
-                throw Utils.Error($"cannot find the block with the hash[{blockHash.ToString()}]");
-            }
-
-            return block;
-        }
-
-        private static BlockHash GetBlockHash(IStore store, int blockIndex)
-        {
-            if (!(store.GetCanonicalChainId() is { } chainId))
-            {
-                throw Utils.Error("Cannot find the main branch of the blockchain.");
-            }
-
-            if (!(store.IndexBlockHash(chainId, blockIndex) is { } blockHash))
+            yield return index++;
+            if (!(store.GetBlockDigest(blockHash) is { } blockDigest))
             {
                 throw Utils.Error(
-                    $"Cannot find the block with the height {blockIndex}" +
-                    $" within the blockchain {chainId}."
-                );
+                    $"Block is missing for BlockHash: {blockHash} index: {index}.");
             }
 
-            return blockHash;
-        }
-
-        private static IEnumerable<Block<T>> IterateBlocks<T>(IStore store, TxId txId)
-            where T : IAction, new()
-        {
-            foreach (var blockHash in store.IterateTxIdBlockHashIndex(txId))
+            foreach (TxId txId in blockDigest.TxIds.Select(bytes => new TxId(bytes.ToArray())))
             {
-                yield return GetBlock<T>(store, blockHash);
-            }
-        }
-
-        private static Transaction<T> GetTransaction<T>(IStore store, TxId txId)
-            where T : IAction, new()
-        {
-            if (!(store.GetTransaction<T>(txId) is { } tx))
-            {
-                throw Utils.Error($"cannot find the tx with the tx id[{txId.ToString()}]");
-            }
-
-            return tx;
-        }
-
-        private static IEnumerable<int> BuildTxIdBlockHashIndex(IStore store, int offset, int limit)
-        {
-            if (!(store.GetCanonicalChainId() is { } chainId))
-            {
-                throw Utils.Error("Cannot find the main branch of the blockchain.");
-            }
-
-            var index = offset;
-            foreach (BlockHash blockHash in store.IterateIndexes(chainId, offset, limit))
-            {
-                yield return index++;
-                if (!(store.GetBlockDigest(blockHash) is { } blockDigest))
-                {
-                    throw Utils.Error(
-                        $"Block is missing for BlockHash: {blockHash} index: {index}.");
-                }
-
-                foreach (TxId txId in blockDigest.TxIds.Select(bytes => new TxId(bytes.ToArray())))
-                {
-                    store.PutTxIdBlockHashIndex(txId, blockHash);
-                }
+                store.PutTxIdBlockHashIndex(txId, blockHash);
             }
         }
     }

--- a/Libplanet.Extensions.Cocona/Commands/TxCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/TxCommand.cs
@@ -1,156 +1,155 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
 using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using Cocona;
-using Cocona.Help;
+using global::Cocona;
+using global::Cocona.Help;
 using Libplanet.Action;
 using Libplanet.Tx;
 
-namespace Libplanet.Extensions.Cocona.Commands
+public class TxCommand
 {
-    public class TxCommand
+    [Command(Description = "Analyze the given signed or unsigned transaction.")]
+    public int Analyze(
+        [Argument(
+            Description = "The file path of the transaction to analyze.  If " +
+                "a hyphen (-) is given it reads from the standard input (if you want to read " +
+                "just a file named \"-\", use \"./-\" instead)."
+        )]
+        string file,
+        [Option(
+            'u',
+            Description = "Analyze an unsigned transaction.  This option is " +
+                "mutually exclusive with -i/--ignore-signature."
+        )]
+        bool unsigned = false,
+        [Option(
+            'i',
+            Description = "Terminate the program with a zero exit code (success) even if " +
+                "the signature is invalid.  However, it still prints the error message to " +
+                "the standard error, and the exit code is still non-zero if the transaction " +
+                "is invalid in other ways.  This option is mutually exclusive with " +
+                "-u/--unsigned."
+        )]
+        bool ignoreSignature = false
+    )
     {
-        [Command(Description = "Analyze the given signed or unsigned transaction.")]
-        public int Analyze(
-            [Argument(
-                Description = "The file path of the transaction to analyze.  If " +
-                    "a hyphen (-) is given it reads from the standard input (if you want to read " +
-                    "just a file named \"-\", use \"./-\" instead)."
-            )]
-            string file,
-            [Option(
-                'u',
-                Description = "Analyze an unsigned transaction.  This option is " +
-                    "mutually exclusive with -i/--ignore-signature."
-            )]
-            bool unsigned = false,
-            [Option(
-                'i',
-                Description = "Terminate the program with a zero exit code (success) even if " +
-                    "the signature is invalid.  However, it still prints the error message to " +
-                    "the standard error, and the exit code is still non-zero if the transaction " +
-                    "is invalid in other ways.  This option is mutually exclusive with " +
-                    "-u/--unsigned."
-            )]
-            bool ignoreSignature = false
-        )
+        if (unsigned && ignoreSignature)
         {
-            if (unsigned && ignoreSignature)
+            throw new CommandExitedException(
+                "The -u/--unsigned and -i/--ignore-signature options are mutually exclusive.",
+                -1
+            );
+        }
+
+        byte[] bytes;
+        string sourceName;
+        if (file == "-")
+        {
+            sourceName = "stdin";
+            using var stdin = Console.OpenStandardInput();
+            using var buffer = new MemoryStream();
+            stdin.CopyTo(buffer);
+            bytes = buffer.GetBuffer();
+            Array.Resize(ref bytes, (int)buffer.Length);
+        }
+        else
+        {
+            sourceName = $"file {file}";
+            try
+            {
+                bytes = File.ReadAllBytes(file);
+            }
+            catch (Exception)
             {
                 throw new CommandExitedException(
-                    "The -u/--unsigned and -i/--ignore-signature options are mutually exclusive.",
+                    $"Failed to read the file {file}; it may not exist nor be readable.",
                     -1
                 );
             }
+        }
 
-            byte[] bytes;
-            string sourceName;
-            if (file == "-")
-            {
-                sourceName = "stdin";
-                using var stdin = Console.OpenStandardInput();
-                using var buffer = new MemoryStream();
-                stdin.CopyTo(buffer);
-                bytes = buffer.GetBuffer();
-                Array.Resize(ref bytes, (int)buffer.Length);
-            }
-            else
-            {
-                sourceName = $"file {file}";
-                try
-                {
-                    bytes = File.ReadAllBytes(file);
-                }
-                catch (Exception)
-                {
-                    throw new CommandExitedException(
-                        $"Failed to read the file {file}; it may not exist nor be readable.",
-                        -1
-                    );
-                }
-            }
+        Transaction<NullAction> tx;
+        try
+        {
+            tx = Transaction<NullAction>.Deserialize(bytes, validate: false);
+        }
+        catch (Exception e)
+        {
+            throw new CommandExitedException(
+                $"Failed to deserialize the {sourceName}: {e}",
+                -1
+            );
+        }
 
-            Transaction<NullAction> tx;
+        if (!unsigned && !tx.Signature.Any())
+        {
+            throw new CommandExitedException(
+                "The transaction is unsigned.  If you want to analyze it anyway, " +
+                    "use the -u/--unsigned option.",
+                -1
+            );
+        }
+        else if (unsigned && tx.Signature.Any())
+        {
+            throw new CommandExitedException(
+                "The transaction is signed, but the -u/--unsigned option is given.",
+                -1
+            );
+        }
+
+        bool invalid = false;
+        if (!unsigned)
+        {
             try
             {
-                tx = Transaction<NullAction>.Deserialize(bytes, validate: false);
+                tx.Validate();
             }
             catch (Exception e)
             {
-                throw new CommandExitedException(
-                    $"Failed to deserialize the {sourceName}: {e}",
-                    -1
+                invalid = true;
+                Console.Error.WriteLine(
+                    "The signature from the transaction {0} is invalid: {1}",
+                    sourceName,
+                    e
                 );
             }
 
-            if (!unsigned && !tx.Signature.Any())
+            if (invalid)
             {
-                throw new CommandExitedException(
-                    "The transaction is unsigned.  If you want to analyze it anyway, " +
-                        "use the -u/--unsigned option.",
-                    -1
+                invalid = !ignoreSignature;
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    "The signature from the transaction {0} is valid.",
+                    sourceName
                 );
             }
-            else if (unsigned && tx.Signature.Any())
-            {
-                throw new CommandExitedException(
-                    "The transaction is signed, but the -u/--unsigned option is given.",
-                    -1
-                );
-            }
-
-            bool invalid = false;
-            if (!unsigned)
-            {
-                try
-                {
-                    tx.Validate();
-                }
-                catch (Exception e)
-                {
-                    invalid = true;
-                    Console.Error.WriteLine(
-                        "The signature from the transaction {0} is invalid: {1}",
-                        sourceName,
-                        e
-                    );
-                }
-
-                if (invalid)
-                {
-                    invalid = !ignoreSignature;
-                }
-                else
-                {
-                    Console.Error.WriteLine(
-                        "The signature from the transaction {0} is valid.",
-                        sourceName
-                    );
-                }
-            }
-
-            var writerOptions = new JsonWriterOptions { Indented = true };
-            using var stdout = Console.OpenStandardOutput();
-            using var writer = new Utf8JsonWriter(stdout, writerOptions);
-
-            var serializerOptions = new JsonSerializerOptions
-            {
-                AllowTrailingCommas = false,
-                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreReadOnlyProperties = false,
-            };
-            JsonSerializer.Serialize(writer, tx, serializerOptions);
-            writer.Flush();
-            Console.WriteLine();
-            return invalid ? -1 : 0;
         }
 
-        [Command(Description = "Show this help message.")]
-        public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+        var writerOptions = new JsonWriterOptions { Indented = true };
+        using var stdout = Console.OpenStandardOutput();
+        using var writer = new Utf8JsonWriter(stdout, writerOptions);
+
+        var serializerOptions = new JsonSerializerOptions
         {
-            Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
-        }
+            AllowTrailingCommas = false,
+            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            IgnoreReadOnlyProperties = false,
+        };
+        JsonSerializer.Serialize(writer, tx, serializerOptions);
+        writer.Flush();
+        Console.WriteLine();
+        return invalid ? -1 : 0;
+    }
+
+    [Command(Description = "Show this help message.")]
+    public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+    {
+        Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
     }
 }

--- a/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
+++ b/Libplanet.Extensions.Cocona/ConsolePasswordReader.cs
@@ -1,45 +1,44 @@
+namespace Libplanet.Extensions.Cocona;
+
 using System;
 using System.Text;
 
-namespace Libplanet.Extensions.Cocona
+public class ConsolePasswordReader
 {
-    public class ConsolePasswordReader
+    public static string Read(string prompt)
     {
-        public static string Read(string prompt)
+        var password = new StringBuilder();
+
+        Console.Write(prompt);
+        do
         {
-            var password = new StringBuilder();
+            var key = Console.ReadKey(true).KeyChar;
 
-            Console.Write(prompt);
-            do
+            if (key == '\b')
             {
-                var key = Console.ReadKey(true).KeyChar;
+                if (password.Length <= 0)
+                {
+                    continue;
+                }
 
-                if (key == '\b')
-                {
-                    if (password.Length <= 0)
-                    {
-                        continue;
-                    }
-
-                    password.Remove(password.Length - 1, 1);
-                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
-                    Console.Write(' ');
-                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
-                }
-                else if (key == '\r')
-                {
-                    Console.WriteLine();
-                    break;
-                }
-                else if (!char.IsControl(key))
-                {
-                    password.Append(key);
-                    Console.Write('*');
-                }
+                password.Remove(password.Length - 1, 1);
+                Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                Console.Write(' ');
+                Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
             }
-            while (true);
-
-            return password.ToString();
+            else if (key == '\r')
+            {
+                Console.WriteLine();
+                break;
+            }
+            else if (!char.IsControl(key))
+            {
+                password.Append(key);
+                Console.Write('*');
+            }
         }
+        while (true);
+
+        return password.ToString();
     }
 }

--- a/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
+++ b/Libplanet.Extensions.Cocona/Extensions/ICoconaLiteServiceCollectionExtensions.cs
@@ -1,32 +1,32 @@
+namespace Libplanet.Extensions.Cocona.Extensions;
+
 using System.IO;
 using global::Cocona.Lite;
 using Libplanet.Extensions.Cocona.Configuration;
 using Libplanet.Extensions.Cocona.Services;
 using Zio.FileSystems;
 
-namespace Libplanet.Extensions.Cocona.Extensions
+public static class ICoconaLiteServiceCollectionExtensions
 {
-    public static class ICoconaLiteServiceCollectionExtensions
+    public static void AddJsonConfigurationService(
+        this ICoconaLiteServiceCollection services,
+        string jsonConfigurationPath)
     {
-        public static void AddJsonConfigurationService(
-            this ICoconaLiteServiceCollection services,
-            string jsonConfigurationPath)
+        string jsonConfigurationDirectory = Directory.GetParent(jsonConfigurationPath)?.FullName
+            ?? Directory.GetCurrentDirectory();
+        if (!Directory.Exists(jsonConfigurationDirectory))
         {
-            string jsonConfigurationDirectory = Directory.GetParent(jsonConfigurationPath).FullName;
-            if (!Directory.Exists(jsonConfigurationDirectory))
-            {
-                Directory.CreateDirectory(jsonConfigurationDirectory);
-            }
-
-            var pfs = new PhysicalFileSystem();
-            var fileSystem = new SubFileSystem(
-                pfs,
-                pfs.ConvertPathFromInternal(jsonConfigurationDirectory),
-                owned: true);
-            services.AddTransient<IConfigurationService<ToolConfiguration>>(
-                _ => new JsonConfigurationService(
-                    fileSystem,
-                    Path.GetFileName(jsonConfigurationPath)));
+            Directory.CreateDirectory(jsonConfigurationDirectory);
         }
+
+        var pfs = new PhysicalFileSystem();
+        var fileSystem = new SubFileSystem(
+            pfs,
+            pfs.ConvertPathFromInternal(jsonConfigurationDirectory),
+            owned: true);
+        services.AddTransient<IConfigurationService<ToolConfiguration>>(
+            _ => new JsonConfigurationService(
+                fileSystem,
+                Path.GetFileName(jsonConfigurationPath)));
     }
 }

--- a/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Extensions.Cocona/PassphraseParameters.cs
+++ b/Libplanet.Extensions.Cocona/PassphraseParameters.cs
@@ -1,88 +1,87 @@
+namespace Libplanet.Extensions.Cocona;
+
 using System;
 using System.IO;
 using global::Cocona;
 
-namespace Libplanet.Extensions.Cocona
+public class PassphraseParameters : ICommandParameterSet
 {
-    public class PassphraseParameters : ICommandParameterSet
+    [Option(
+        'p',
+        ValueName = "PASSPHRASE",
+        Description = "Take passphrase through this option instead of prompt.  " +
+            "Mutually exclusive with --passphrase-file option."
+    )]
+    [HasDefaultValue]
+    public string? Passphrase { get; set; } = null;
+
+    [Option(
+        ValueName = "FILE",
+        Description = "Read passphrase from the specified file instead of taking it " +
+            "through prompt.  Mutually exclusive with -p/--passphrase option.  " +
+            "For standard input, use a hyphen (`-').  For an actual file named a hyphen, " +
+            "prepend `./', i.e., `./-'.  Note that the trailing CR/LF is trimmed."
+    )]
+    [HasDefaultValue]
+    public string? PassphraseFile { get; set; } = null;
+
+    public string Take(string prompt, string? retypePrompt = null, bool ignoreStdin = false)
     {
-        [Option(
-            'p',
-            ValueName = "PASSPHRASE",
-            Description = "Take passphrase through this option instead of prompt.  " +
-                "Mutually exclusive with --passphrase-file option."
-        )]
-        [HasDefaultValue]
-        public string? Passphrase { get; set; } = null;
-
-        [Option(
-            ValueName = "FILE",
-            Description = "Read passphrase from the specified file instead of taking it " +
-                "through prompt.  Mutually exclusive with -p/--passphrase option.  " +
-                "For standard input, use a hyphen (`-').  For an actual file named a hyphen, " +
-                "prepend `./', i.e., `./-'.  Note that the trailing CR/LF is trimmed."
-        )]
-        [HasDefaultValue]
-        public string? PassphraseFile { get; set; } = null;
-
-        public string Take(string prompt, string? retypePrompt = null, bool ignoreStdin = false)
+        if (Passphrase is { } passphrase)
         {
-            if (Passphrase is { } passphrase)
-            {
-                if (PassphraseFile is { })
-                {
-                    throw Utils.Error(
-                        $"-p/--passphrase and --passphrase-file options are mutually exclusive."
-                    );
-                }
-
-                return passphrase;
-            }
-            else if (PassphraseFile is { } filePath)
-            {
-                if (filePath == "-")
-                {
-                    if (File.Exists("-"))
-                    {
-                        Console.Error.WriteLine(
-                            "Note: Passphrase is read from standard input (`-').  If you want " +
-                            "to read from a file, prepend `./', i.e.: --passphrase-file=./-"
-                        );
-                    }
-
-                    return Console.In.ReadToEnd().TrimEnd('\r', '\n');
-                }
-
-                try
-                {
-                    return File.ReadAllText(filePath).TrimEnd('\r', '\n');
-                }
-                catch (FileNotFoundException)
-                {
-                    throw Utils.Error($"Passphrase file is not found: {filePath}");
-                }
-            }
-
-            if (Console.IsInputRedirected && !ignoreStdin)
+            if (PassphraseFile is { })
             {
                 throw Utils.Error(
-                    "Error: The standard input is not associated to any terminal device (tty), " +
-                    "which means it probably is piped.  If you need to pass the passphrase " +
-                    "through pipe, use --passphrase-file=- option instead (`-' means stdin)."
+                    $"-p/--passphrase and --passphrase-file options are mutually exclusive."
                 );
             }
 
-            string first = ConsolePasswordReader.Read(prompt);
-            if (retypePrompt is { })
+            return passphrase;
+        }
+        else if (PassphraseFile is { } filePath)
+        {
+            if (filePath == "-")
             {
-                string retype = ConsolePasswordReader.Read(retypePrompt);
-                if (first != retype)
+                if (File.Exists("-"))
                 {
-                    throw Utils.Error("Passphrases do not match.");
+                    Console.Error.WriteLine(
+                        "Note: Passphrase is read from standard input (`-').  If you want " +
+                        "to read from a file, prepend `./', i.e.: --passphrase-file=./-"
+                    );
                 }
+
+                return Console.In.ReadToEnd().TrimEnd('\r', '\n');
             }
 
-            return first;
+            try
+            {
+                return File.ReadAllText(filePath).TrimEnd('\r', '\n');
+            }
+            catch (FileNotFoundException)
+            {
+                throw Utils.Error($"Passphrase file is not found: {filePath}");
+            }
         }
+
+        if (Console.IsInputRedirected && !ignoreStdin)
+        {
+            throw Utils.Error(
+                "Error: The standard input is not associated to any terminal device (tty), " +
+                "which means it probably is piped.  If you need to pass the passphrase " +
+                "through pipe, use --passphrase-file=- option instead (`-' means stdin)."
+            );
+        }
+
+        string first = ConsolePasswordReader.Read(prompt);
+        if (retypePrompt is { })
+        {
+            string retype = ConsolePasswordReader.Read(retypePrompt);
+            if (first != retype)
+            {
+                throw Utils.Error("Passphrases do not match.");
+            }
+        }
+
+        return first;
     }
 }

--- a/Libplanet.Extensions.Cocona/Services/IConfigurationService.cs
+++ b/Libplanet.Extensions.Cocona/Services/IConfigurationService.cs
@@ -1,9 +1,8 @@
-namespace Libplanet.Extensions.Cocona.Services
-{
-    public interface IConfigurationService<TConfiguration>
-    {
-        TConfiguration Load();
+namespace Libplanet.Extensions.Cocona.Services;
 
-        void Store(TConfiguration configuration);
-    }
+public interface IConfigurationService<TConfiguration>
+{
+    TConfiguration Load();
+
+    void Store(TConfiguration configuration);
 }

--- a/Libplanet.Extensions.Cocona/Services/JsonConfigurationService.cs
+++ b/Libplanet.Extensions.Cocona/Services/JsonConfigurationService.cs
@@ -1,40 +1,39 @@
+namespace Libplanet.Extensions.Cocona.Services;
+
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Libplanet.Extensions.Cocona.Configuration;
 using Zio;
 
-namespace Libplanet.Extensions.Cocona.Services
+public class JsonConfigurationService : IConfigurationService<ToolConfiguration>
 {
-    public class JsonConfigurationService : IConfigurationService<ToolConfiguration>
+    private readonly IFileSystem _fileSystem;
+    private readonly string _configurationFileName;
+
+    public JsonConfigurationService(IFileSystem fileSystem, string configurationFileName)
     {
-        private readonly IFileSystem _fileSystem;
-        private readonly string _configurationFileName;
+        _fileSystem = fileSystem;
+        _configurationFileName = configurationFileName;
+    }
 
-        public JsonConfigurationService(IFileSystem fileSystem, string configurationFileName)
+    public ToolConfiguration Load()
+    {
+        if (!_fileSystem.FileExists(UPath.Root / _configurationFileName))
         {
-            _fileSystem = fileSystem;
-            _configurationFileName = configurationFileName;
+            return new ToolConfiguration(
+                new MptConfiguration(new Dictionary<string, string>()));
         }
 
-        public ToolConfiguration Load()
-        {
-            if (!_fileSystem.FileExists(UPath.Root / _configurationFileName))
-            {
-                return new ToolConfiguration(
-                    new MptConfiguration(new Dictionary<string, string>()));
-            }
+        return JsonSerializer.Deserialize<ToolConfiguration>(
+            _fileSystem.ReadAllText(UPath.Root / _configurationFileName));
+    }
 
-            return JsonSerializer.Deserialize<ToolConfiguration>(
-                _fileSystem.ReadAllText(UPath.Root / _configurationFileName));
-        }
-
-        public void Store(ToolConfiguration configuration)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(configuration));
-            _fileSystem.WriteAllText(
-                UPath.Root / _configurationFileName,
-                JsonSerializer.Serialize(configuration));
-        }
+    public void Store(ToolConfiguration configuration)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(configuration));
+        _fileSystem.WriteAllText(
+            UPath.Root / _configurationFileName,
+            JsonSerializer.Serialize(configuration));
     }
 }

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Extensions.Cocona;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -10,303 +12,300 @@ using global::Cocona;
 using Libplanet.Action;
 using Libplanet.Store;
 
-namespace Libplanet.Extensions.Cocona
+public static class Utils
 {
-    public static class Utils
+    public static readonly string DateTimeOffsetFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+
+    public static CommandExitedException Error(string message, int exitCode = 128)
     {
-        public static readonly string DateTimeOffsetFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        Console.Error.WriteLine("Error: {0}", message);
+        Console.Error.Flush();
+        return new CommandExitedException(exitCode);
+    }
 
-        public static CommandExitedException Error(string message, int exitCode = 128)
-        {
-            Console.Error.WriteLine("Error: {0}", message);
-            Console.Error.Flush();
-            return new CommandExitedException(exitCode);
-        }
-
-        public static void
-            PrintTable<T1>(ValueTuple<string> header, IEnumerable<ValueTuple<T1>> rows)
-            where T1 : notnull
-        {
-            PrintTable(
-                new object[]
-                {
-                    header.Item1,
-                },
-                rows.Select(row => new object[]
-                {
-                    row.Item1,
-                }));
-        }
-
-        public static void
-            PrintTable<T1, T2>((string, string) header, IEnumerable<(T1, T2)> rows)
-            where T1 : notnull
-            where T2 : notnull
-        {
-            PrintTable(
-                new object[]
-                {
-                    header.Item1,
-                    header.Item2,
-                },
-                rows.Select(row => new object[]
-                {
-                    row.Item1,
-                    row.Item2,
-                }));
-        }
-
-        public static void
-            PrintTable<T1, T2, T3>(
-                (string, string, string) header,
-                IEnumerable<(T1, T2, T3)> rows)
-            where T1 : notnull
-            where T2 : notnull
-            where T3 : notnull
-        {
-            PrintTable(
-                new object[]
-                {
-                    header.Item1,
-                    header.Item2,
-                    header.Item3,
-                },
-                rows.Select(row => new object[]
-                {
-                    row.Item1,
-                    row.Item2,
-                    row.Item3,
-                }));
-        }
-
-        public static void
-            PrintTable<T1, T2, T3, T4>(
-                (string, string, string, string) header,
-                IEnumerable<(T1, T2, T3, T4)> rows)
-            where T1 : notnull
-            where T2 : notnull
-            where T3 : notnull
-            where T4 : notnull
-        {
-            PrintTable(
-                new object[]
-                {
-                    header.Item1,
-                    header.Item2,
-                    header.Item3,
-                    header.Item4,
-                },
-                rows.Select(row => new object[]
-                {
-                    row.Item1,
-                    row.Item2,
-                    row.Item3,
-                    row.Item4,
-                }));
-        }
-
-        public static IStore LoadStoreFromUri(string uriString)
-        {
-            // TODO: Cocona supports .NET's TypeConverter protocol for instantiating objects
-            // from CLI options/arguments.  We'd better to implement it for IStore, and simply
-            // use IStore as the option/argument types rather than taking them as strings.
-            var uri = new Uri(uriString);
-
-            switch (uri.Scheme)
+    public static void
+        PrintTable<T1>(ValueTuple<string> header, IEnumerable<ValueTuple<T1>> rows)
+        where T1 : notnull
+    {
+        PrintTable(
+            new object[]
             {
-                case "default":
-                case "rocksdb":
-                    Console.Error.WriteLine(
-                        "Warning: The scheme {0}:// for the store URI is deprecated.  " +
-                        "Use {0}+file:// instead.",
-                        uri.Scheme
-                    );
-                    Console.Error.Flush();
-                    uri = new Uri($"{uri.Scheme}+file{uri.ToString().Substring(7)}");
-                    break;
+                header.Item1,
+            },
+            rows.Select(row => new object[]
+            {
+                row.Item1,
+            }));
+    }
 
-                case "":
-                case null:
-                    const string? exceptionMessage = "A store URI must have a scheme, " +
-                                                     "e.g., default+file://, rocksdb+file://.";
-                    throw new ArgumentException(exceptionMessage, nameof(uriString));
+    public static void
+        PrintTable<T1, T2>((string, string) header, IEnumerable<(T1, T2)> rows)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        PrintTable(
+            new object[]
+            {
+                header.Item1,
+                header.Item2,
+            },
+            rows.Select(row => new object[]
+            {
+                row.Item1,
+                row.Item2,
+            }));
+    }
+
+    public static void
+        PrintTable<T1, T2, T3>(
+            (string, string, string) header,
+            IEnumerable<(T1, T2, T3)> rows)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        PrintTable(
+            new object[]
+            {
+                header.Item1,
+                header.Item2,
+                header.Item3,
+            },
+            rows.Select(row => new object[]
+            {
+                row.Item1,
+                row.Item2,
+                row.Item3,
+            }));
+    }
+
+    public static void
+        PrintTable<T1, T2, T3, T4>(
+            (string, string, string, string) header,
+            IEnumerable<(T1, T2, T3, T4)> rows)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        PrintTable(
+            new object[]
+            {
+                header.Item1,
+                header.Item2,
+                header.Item3,
+                header.Item4,
+            },
+            rows.Select(row => new object[]
+            {
+                row.Item1,
+                row.Item2,
+                row.Item3,
+                row.Item4,
+            }));
+    }
+
+    public static IStore LoadStoreFromUri(string uriString)
+    {
+        // TODO: Cocona supports .NET's TypeConverter protocol for instantiating objects
+        // from CLI options/arguments.  We'd better to implement it for IStore, and simply
+        // use IStore as the option/argument types rather than taking them as strings.
+        var uri = new Uri(uriString);
+
+        switch (uri.Scheme)
+        {
+            case "default":
+            case "rocksdb":
+                Console.Error.WriteLine(
+                    "Warning: The scheme {0}:// for the store URI is deprecated.  " +
+                    "Use {0}+file:// instead.",
+                    uri.Scheme
+                );
+                Console.Error.Flush();
+                uri = new Uri($"{uri.Scheme}+file{uri.ToString().Substring(7)}");
+                break;
+
+            case "":
+            case null:
+                const string? exceptionMessage = "A store URI must have a scheme, " +
+                                                 "e.g., default+file://, rocksdb+file://.";
+                throw new ArgumentException(exceptionMessage, nameof(uriString));
+        }
+
+        if (StoreLoaderAttribute.LoadStore(uri) is { } pair)
+        {
+            pair.StateStore.Dispose();
+            return pair.Store;
+        }
+
+        (string UriScheme, Type DeclaringType)[] loaders =
+            StoreLoaderAttribute.ListStoreLoaders().ToArray();
+        int longestSchemeLength = Math.Max(
+            "URI SCHEME".Length,
+            loaders.Max(loader => loader.UriScheme.Length + 1)
+        );
+        string loaderTable = string.Join(
+            "\n",
+            loaders.Select(pair =>
+                $"  {(pair.UriScheme + ":").PadRight(longestSchemeLength)}" +
+                $"  {pair.DeclaringType.Name}")
+        );
+
+        throw new ArgumentException(
+            $"The store URI scheme {uri.Scheme}:// is not supported.  See also " +
+            $"the list of supported store URI schemes:\n\n" +
+            $"  {"URI SCHEME".PadRight(longestSchemeLength)}  PROVIDED BY\n{loaderTable}\n",
+            nameof(uriString)
+        );
+    }
+
+    public static string SerializeHumanReadable<T>(T target) =>
+        JsonSerializer.Serialize(
+            target,
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters =
+                {
+                    new ByteArrayStringJsonConverter(),
+                    new DateTimeOffsetJsonConverter(),
+                },
             }
+        );
 
-            if (StoreLoaderAttribute.LoadStore(uri) is { } pair)
+    public static T? DeserializeHumanReadable<T>(string target)
+        where T : notnull
+    =>
+        JsonSerializer.Deserialize<T>(
+            target, new JsonSerializerOptions
             {
-                pair.StateStore.Dispose();
-                return pair.Store;
+                Converters =
+                {
+                    new ByteArrayStringJsonConverter(),
+                    new DateTimeOffsetJsonConverter(),
+                },
             }
+        );
 
-            (string UriScheme, Type DeclaringType)[] loaders =
-                StoreLoaderAttribute.ListStoreLoaders().ToArray();
-            int longestSchemeLength = Math.Max(
-                "URI SCHEME".Length,
-                loaders.Max(loader => loader.UriScheme.Length + 1)
-            );
-            string loaderTable = string.Join(
-                "\n",
-                loaders.Select(pair =>
-                    $"  {(pair.UriScheme + ":").PadRight(longestSchemeLength)}" +
-                    $"  {pair.DeclaringType.Name}")
-            );
-
-            throw new ArgumentException(
-                $"The store URI scheme {uri.Scheme}:// is not supported.  See also " +
-                $"the list of supported store URI schemes:\n\n" +
-                $"  {"URI SCHEME".PadRight(longestSchemeLength)}  PROVIDED BY\n{loaderTable}\n",
-                nameof(uriString)
-            );
+    private static void PrintTable(object[] header, IEnumerable<object[]> rows)
+    {
+        IEnumerable<(int, string)> RowToStrings(object[] row)
+        {
+            return Enumerable.Range(0, row.Length)
+                .Select(i => (i, row[i]?.ToString()?.Normalize() ?? string.Empty));
         }
 
-        public static string SerializeHumanReadable<T>(T target) =>
-            JsonSerializer.Serialize(
-                target,
-                new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    Converters =
-                    {
-                        new ByteArrayStringJsonConverter(),
-                        new DateTimeOffsetJsonConverter(),
-                    },
-                }
-            );
-
-        public static T? DeserializeHumanReadable<T>(string target)
-            where T : notnull
-        =>
-            JsonSerializer.Deserialize<T>(
-                target, new JsonSerializerOptions
-                {
-                    Converters =
-                    {
-                        new ByteArrayStringJsonConverter(),
-                        new DateTimeOffsetJsonConverter(),
-                    },
-                }
-            );
-
-        private static void PrintTable(object[] header, IEnumerable<object[]> rows)
+        // Calculates the column lengths:
+        object[][] rowsArray = rows.ToArray();
+        int[] columnLengths = RowToStrings(header).Select(pair => pair.Item2.Length).ToArray();
+        foreach (object[] row in rowsArray)
         {
-            IEnumerable<(int, string)> RowToStrings(object[] row)
+            foreach ((int i, string col) in RowToStrings(row))
             {
-                return Enumerable.Range(0, row.Length)
-                    .Select(i => (i, row[i]?.ToString()?.Normalize() ?? string.Empty));
-            }
-
-            // Calculates the column lengths:
-            object[][] rowsArray = rows.ToArray();
-            int[] columnLengths = RowToStrings(header).Select(pair => pair.Item2.Length).ToArray();
-            foreach (object[] row in rowsArray)
-            {
-                foreach ((int i, string col) in RowToStrings(row))
+                int length = col.Length;
+                if (columnLengths[i] < length)
                 {
-                    int length = col.Length;
-                    if (columnLengths[i] < length)
-                    {
-                        columnLengths[i] = length;
-                    }
+                    columnLengths[i] = length;
                 }
             }
+        }
 
-            // Prints column names (into /dev/stderr):
-            foreach ((int i, string col) in RowToStrings(header))
+        // Prints column names (into /dev/stderr):
+        foreach ((int i, string col) in RowToStrings(header))
+        {
+            int length = columnLengths[i];
+            Console.Error.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+        }
+
+        Console.Error.WriteLine();
+
+        // Prints horizontal lines (into /dev/stderr):
+        foreach ((int i, string col) in RowToStrings(header))
+        {
+            Console.Error.Write(i > 0 ? " {0}" : "{0}", new string('-', columnLengths[i]));
+        }
+
+        Console.Error.WriteLine();
+        Console.Error.Flush();
+
+        // Print rows:
+        foreach (object[] row in rowsArray)
+        {
+            foreach ((int i, string col) in RowToStrings(row))
             {
                 int length = columnLengths[i];
-                Console.Error.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+                Console.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
             }
 
-            Console.Error.WriteLine();
+            Console.WriteLine();
+        }
+    }
 
-            // Prints horizontal lines (into /dev/stderr):
-            foreach ((int i, string col) in RowToStrings(header))
-            {
-                Console.Error.Write(i > 0 ? " {0}" : "{0}", new string('-', columnLengths[i]));
-            }
-
-            Console.Error.WriteLine();
-            Console.Error.Flush();
-
-            // Print rows:
-            foreach (object[] row in rowsArray)
-            {
-                foreach ((int i, string col) in RowToStrings(row))
-                {
-                    int length = columnLengths[i];
-                    Console.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
-                }
-
-                Console.WriteLine();
-            }
+    public class DummyAction : IAction
+    {
+        public DummyAction()
+        {
+            PlainValue = Null.Value;
         }
 
-        public class DummyAction : IAction
+        /// <inheritdoc/>
+        public IValue PlainValue { get; private set; }
+
+        /// <inheritdoc/>
+        public IAccountStateDelta Execute(IActionContext context) =>
+            context.PreviousStates;
+
+        /// <inheritdoc/>
+        public void LoadPlainValue(IValue plainValue)
         {
-            public DummyAction()
-            {
-                PlainValue = Null.Value;
-            }
+            PlainValue = plainValue;
+        }
+    }
 
-            /// <inheritdoc/>
-            public IValue PlainValue { get; private set; }
-
-            /// <inheritdoc/>
-            public IAccountStateDelta Execute(IActionContext context) =>
-                context.PreviousStates;
-
-            /// <inheritdoc/>
-            public void LoadPlainValue(IValue plainValue)
-            {
-                PlainValue = plainValue;
-            }
+    private sealed class ByteArrayStringJsonConverter : JsonConverter<ImmutableArray<byte>>
+    {
+        public override ImmutableArray<byte> Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var hexString = reader.GetString() ?? throw new JsonException("Expected a string.");
+            return ImmutableArray.Create(ByteUtil.ParseHex(hexString));
         }
 
-        private class ByteArrayStringJsonConverter : JsonConverter<ImmutableArray<byte>>
+        public override void Write(
+            Utf8JsonWriter writer, ImmutableArray<byte> value, JsonSerializerOptions options)
         {
-            public override ImmutableArray<byte> Read(
-                ref Utf8JsonReader reader,
-                Type typeToConvert,
-                JsonSerializerOptions options)
-            {
-                var hexString = reader.GetString() ?? throw new JsonException("Expected a string.");
-                return ImmutableArray.Create(ByteUtil.ParseHex(hexString));
-            }
+            writer.WriteStringValue(ByteUtil.Hex(value));
+        }
+    }
 
-            public override void Write(
-                Utf8JsonWriter writer, ImmutableArray<byte> value, JsonSerializerOptions options)
-            {
-                writer.WriteStringValue(ByteUtil.Hex(value));
-            }
+    private sealed class DateTimeOffsetJsonConverter : JsonConverter<DateTimeOffset>
+    {
+        public override DateTimeOffset Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var jsonString = reader.GetString()
+                ?? throw new JsonException("Expected a string.");
+            return DateTimeOffset.ParseExact(
+                jsonString,
+                DateTimeOffsetFormat,
+                CultureInfo.InvariantCulture
+            );
         }
 
-        private class DateTimeOffsetJsonConverter : JsonConverter<DateTimeOffset>
+        public override void Write(
+            Utf8JsonWriter writer,
+            DateTimeOffset value,
+            JsonSerializerOptions options)
         {
-            public override DateTimeOffset Read(
-                ref Utf8JsonReader reader,
-                Type typeToConvert,
-                JsonSerializerOptions options)
-            {
-                var jsonString = reader.GetString()
-                    ?? throw new JsonException("Expected a string.");
-                return DateTimeOffset.ParseExact(
-                    jsonString,
+            writer.WriteStringValue(
+                value.ToString(
                     DateTimeOffsetFormat,
                     CultureInfo.InvariantCulture
-                );
-            }
-
-            public override void Write(
-                Utf8JsonWriter writer,
-                DateTimeOffset value,
-                JsonSerializerOptions options)
-            {
-                writer.WriteStringValue(
-                    value.ToString(
-                        DateTimeOffsetFormat,
-                        CultureInfo.InvariantCulture
-                    ));
-            }
+                ));
         }
     }
 }

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10</LangVersion>
     <TargetFramework>net6</TargetFramework>
     <RootNamespace>Libplanet.Tools</RootNamespace>
     <ToolCommandName>planet</ToolCommandName>
@@ -81,7 +81,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -1,3 +1,5 @@
+namespace Libplanet.Tools;
+
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -5,39 +7,36 @@ using Cocona;
 using Libplanet.Extensions.Cocona.Commands;
 using Libplanet.Extensions.Cocona.Extensions;
 
-namespace Libplanet.Tools
+[HasSubCommands(typeof(ApvCommand), "apv", Description = "App protocol version utilities.")]
+[HasSubCommands(typeof(KeyCommand), "key", Description = "Manage private keys.")]
+[HasSubCommands(typeof(MptCommand), "mpt", Description = "Merkle Patricia Trie utilities.")]
+[HasSubCommands(typeof(StoreCommand), "store", Description = "Store utilities.")]
+[HasSubCommands(typeof(StatsCommand), "stats", Description = "Stats utilities.")]
+[HasSubCommands(typeof(TxCommand), "tx", Description = "Transaction utilities.")]
+public class Program
 {
-    [HasSubCommands(typeof(ApvCommand), "apv", Description = "App protocol version utilities.")]
-    [HasSubCommands(typeof(KeyCommand), "key", Description = "Manage private keys.")]
-    [HasSubCommands(typeof(MptCommand), "mpt", Description = "Merkle Patricia Trie utilities.")]
-    [HasSubCommands(typeof(StoreCommand), "store", Description = "Store utilities.")]
-    [HasSubCommands(typeof(StatsCommand), "stats", Description = "Stats utilities.")]
-    [HasSubCommands(typeof(TxCommand), "tx", Description = "Transaction utilities.")]
-    public class Program
-    {
-        private static readonly string FileConfigurationServiceRoot = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "planetarium",
-            "cli.json");
+    private static readonly string FileConfigurationServiceRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "planetarium",
+        "cli.json");
 
-        // Workaround for linking with Libplanet.RocksDBStore.
-        private static readonly Type _rocksdb = typeof(Libplanet.RocksDBStore.RocksDBStore);
+    // Workaround for linking with Libplanet.RocksDBStore.
+    private static readonly Type _rocksdb = typeof(Libplanet.RocksDBStore.RocksDBStore);
 
-        public static Task Main(string[] args) =>
-            CoconaLiteApp.CreateHostBuilder()
-                .ConfigureServices(services =>
-                {
-                    services.AddJsonConfigurationService(FileConfigurationServiceRoot);
-                })
-                .RunAsync<Program>(args, options =>
-                {
-                    options.TreatPublicMethodsAsCommands = false;
-                    options.EnableShellCompletionSupport = true;
-                });
+    public static Task Main(string[] args) =>
+        CoconaLiteApp.CreateHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddJsonConfigurationService(FileConfigurationServiceRoot);
+            })
+            .RunAsync<Program>(args, options =>
+            {
+                options.TreatPublicMethodsAsCommands = false;
+                options.EnableShellCompletionSupport = true;
+            });
 
-        [PrimaryCommand]
-        public Task Help() =>
-            /* FIXME: I believe there is a better way... */
-            Main(new[] { "--help" });
-    }
+    [PrimaryCommand]
+    public Task Help() =>
+        /* FIXME: I believe there is a better way... */
+        Main(new[] { "--help" });
 }


### PR DESCRIPTION
Made changes on CLI-related projects (*Libplanet.Extensions.Cocona*, *Libplanet.Extensions.Cocona.Tests*, *Libplanet.Tools*):

-  Dropped .NET Standard 2.0 & .NET Core 3.1 targets, and added .NET 6.0 target instead.  (.NET Standard 2.1 remains.)
-  Use [file-scoped namespace declarations][1].
-  Upgraded *SonarAnalyzer.CSharp* to 8.51.0.59060 as [the existing version does not recognize file-scoped namespace declarations.][2]

[1]: https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#file-scoped-namespace-declaration
[2]: https://github.com/SonarSource/sonar-dotnet/issues/4731