### PR TITLE
Remove Validator related methods from interfaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `IAccountStateView.GetValidatorSet()` method.  [[#2733]]
+ -  Removed `IAccountStateDelta.SetValidator(Validator)` method.  [[#2733]]
  -  (Libplanet.Extensions.Cocona)  Dropped .NET Standard 2.0 and .NET Core 3.1
     target assemblies.  [[#2732]]
  -  (Libplanet.Extensions.Cocona)  Added .NET 6 target assembly.  [[#2732]]
@@ -29,6 +31,7 @@ To be released.
 ### CLI tools
 
 [[#2732]]: https://github.com/planetarium/libplanet/pull/2732
+[[#2733]]: https://github.com/planetarium/libplanet/pull/2733
 
 
 Version 0.46.0

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -179,7 +179,7 @@ namespace Libplanet.Tests.Action
             Assert.Equal(callPreviousStateRootHash ? 1 : 0, keyValueStore.ListKeys().Count());
         }
 
-        private class DumbAccountStateDelta : IAccountStateDelta
+        private class DumbAccountStateDelta : IValidatorSupportStateDelta, IAccountStateDelta
         {
             public IImmutableSet<Address> UpdatedAddresses =>
                 ImmutableHashSet<Address>.Empty;
@@ -214,7 +214,7 @@ namespace Libplanet.Tests.Action
                 return currency * 0;
             }
 
-            public ValidatorSet GetValidatorSet()
+            public virtual ValidatorSet GetValidatorSet()
             {
                 return new ValidatorSet();
             }

--- a/Libplanet/Action/AccountStateDeltaImpl.cs
+++ b/Libplanet/Action/AccountStateDeltaImpl.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Action
     /// An internal implementation of <see cref="IAccountStateDelta"/>.
     /// </summary>
     [Pure]
-    internal class AccountStateDeltaImpl : IAccountStateDelta
+    internal class AccountStateDeltaImpl : IValidatorSupportStateDelta, IAccountStateDelta
     {
         /// <summary>
         /// Creates a null delta from the given <paramref name="accountStateGetter"/>.
@@ -159,6 +159,7 @@ namespace Libplanet.Action
             return TotalSupplyGetter(currency);
         }
 
+        /// <inheritdoc/>
         [Pure]
         public virtual ValidatorSet GetValidatorSet() =>
             UpdatedValidatorSet ?? ValidatorSetGetter();
@@ -297,6 +298,8 @@ namespace Libplanet.Action
             );
         }
 
+        /// <inheritdoc/>
+        [Pure]
         public IAccountStateDelta SetValidator(Validator validator)
         {
             Log.Debug(

--- a/Libplanet/Action/IAccountStateDelta.cs
+++ b/Libplanet/Action/IAccountStateDelta.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using Bencodex.Types;
 using Libplanet.Assets;
-using Libplanet.Consensus;
 
 namespace Libplanet.Action
 {
@@ -153,15 +152,5 @@ namespace Libplanet.Action
         /// has insufficient balance than <paramref name="value"/> to burn.</exception>
         [Pure]
         IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value);
-
-        /// <summary>
-        /// Sets <paramref name="validator"/> to the stored <see cref="ValidatorSet"/>.
-        /// If 0 is given as its power, removes the validator from the <see cref="ValidatorSet"/>.
-        /// </summary>
-        /// <param name="validator">The <see cref="Validator"/> instance to write.</param>
-        /// <returns>A new <see cref="IAccountStateDelta"/> instance with
-        /// <paramref name="validator"/> set.</returns>
-        [Pure]
-        IAccountStateDelta SetValidator(Validator validator);
     }
 }

--- a/Libplanet/Action/IAccountStateView.cs
+++ b/Libplanet/Action/IAccountStateView.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Bencodex.Types;
 using Libplanet.Assets;
-using Libplanet.Consensus;
 
 namespace Libplanet.Action
 {
@@ -76,8 +75,5 @@ namespace Libplanet.Action
         /// <seealso cref="Currency.MaximumSupply"/>
         [Pure]
         FungibleAssetValue GetTotalSupply(Currency currency);
-
-        [Pure]
-        ValidatorSet GetValidatorSet();
     }
 }

--- a/Libplanet/Action/IValidatorSupportStateDelta.cs
+++ b/Libplanet/Action/IValidatorSupportStateDelta.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Contracts;
+using Libplanet.Consensus;
+
+namespace Libplanet.Action
+{
+    internal interface IValidatorSupportStateDelta
+    {
+        /// <summary>
+        /// Returns the validator set.
+        /// </summary>
+        /// <returns>The validator set of type <see cref="ValidatorSet"/>.
+        /// </returns>
+        [Pure]
+        ValidatorSet GetValidatorSet();
+
+        /// <summary>
+        /// Sets <paramref name="validator"/> to the stored <see cref="ValidatorSet"/>.
+        /// If 0 is given as its power, removes the validator from the <see cref="ValidatorSet"/>.
+        /// </summary>
+        /// <param name="validator">The <see cref="Validator"/> instance to write.</param>
+        /// <returns>A new <see cref="IAccountStateDelta"/> instance with
+        /// <paramref name="validator"/> set.</returns>
+        [Pure]
+        IAccountStateDelta SetValidator(Validator validator);
+    }
+}

--- a/Libplanet/Action/ValidatorStateExtensions.cs
+++ b/Libplanet/Action/ValidatorStateExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using Libplanet.Consensus;
+
+namespace Libplanet.Action
+{
+    internal static class ValidatorStateExtensions
+    {
+        public static ValidatorSet GetValidatorSet(this IAccountStateDelta delta)
+        {
+            if (delta is IValidatorSupportStateDelta impl)
+            {
+                return impl.GetValidatorSet();
+            }
+
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Sets <paramref name="validator"/> to the stored <see cref="ValidatorSet"/>.
+        /// If 0 is given as its power, removes the validator from the <see cref="ValidatorSet"/>.
+        /// </summary>
+        /// <param name="delta">The target <see cref="IAccountStateDelta"/> instance.</param>
+        /// <param name="validator">The <see cref="Validator"/> instance to write.</param>
+        /// <returns>A new <see cref="IAccountStateDelta"/> instance with
+        /// <paramref name="validator"/> set.</returns>
+        public static IAccountStateDelta SetValidator(
+            this IAccountStateDelta delta,
+            Validator validator)
+        {
+            if (delta is IValidatorSupportStateDelta impl)
+            {
+                return impl.SetValidator(validator);
+            }
+
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
`Validator`s dealt only in internal methods, so it had been removed from public interfaces.