### PR TITLE
Refactor/extract transport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,13 @@ To be released.
  -  (Libplanet.Extensions.Cocona)  Dropped .NET Standard 2.0 and .NET Core 3.1
     target assemblies.  [[#2732]]
  -  (Libplanet.Extensions.Cocona)  Added .NET 6 target assembly.  [[#2732]]
+ -  (Libplanet.Net) Added `ITransport.AppProtocolVersion`,
+    `ITransport.TrustedAppProtocolVersionSigners`,
+    and `ITransport.DifferentAppProtocolVersionEncountered` properties.
+    [[#2743]]
+ -  (Libplanet.Net) Changed `Swarm<T>(BlockChain<T>, PrivateKey,
+    AppProtocolVersionOptions, HostOptions, SwarmOptions)` to
+    `Swarm<T>(BlockChain<T>, PrivateKey, ITransport, SwarmOptions)`.  [[#2743]]
 
 ### Backward-incompatible network protocol changes
 
@@ -32,6 +39,7 @@ To be released.
 
 [#2732]: https://github.com/planetarium/libplanet/pull/2732
 [#2733]: https://github.com/planetarium/libplanet/pull/2733
+[#2743]: https://github.com/planetarium/libplanet/pull/2743
 
 
 Version 0.46.0

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -21,7 +21,7 @@ using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Schemas;
 using Libplanet.Explorer.Store;
 using Libplanet.Net;
-using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
@@ -285,13 +285,17 @@ If omitted (default) explorer only the local blockchain store.")]
 
                     var hostOptions = new HostOptions(null, new[] { options.IceServer });
 
-                    swarm = new Swarm<NullAction>(
-                        blockChain,
+                    var transport = await NetMQTransport.Create(
                         privateKey,
                         apvOptions,
                         hostOptions,
-                        options: swarmOptions
-                    );
+                        swarmOptions.MessageTimestampBuffer);
+
+                    swarm = new Swarm<NullAction>(
+                        blockChain,
+                        privateKey,
+                        transport,
+                        options: swarmOptions);
                 }
 
                 using (var cts = new CancellationTokenSource())

--- a/Libplanet.Net.Tests/Protocols/TestTransport.cs
+++ b/Libplanet.Net.Tests/Protocols/TestTransport.cs
@@ -18,9 +18,8 @@ namespace Libplanet.Net.Tests.Protocols
 {
     internal class TestTransport : ITransport
     {
-        private static readonly PrivateKey VersionSigner = new PrivateKey();
-        private static readonly AppProtocolVersion AppProtocolVersion =
-            AppProtocolVersion.Sign(VersionSigner, 1);
+        private static readonly AppProtocolVersion _appProtocolVersion =
+            AppProtocolVersion.Sign(new PrivateKey(), 1);
 
         private readonly Dictionary<Address, TestTransport> _transports;
         private readonly ILogger _logger;
@@ -100,6 +99,13 @@ namespace Libplanet.Net.Tests.Protocols
         }
 
         public ConcurrentQueue<Message> MessageHistory { get; }
+
+        public AppProtocolVersion AppProtocolVersion => _appProtocolVersion;
+
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners => null;
+
+        public DifferentAppProtocolVersionEncountered DifferentAppProtocolVersionEncountered =>
+            (peer, peerVersion, localVersion) => { };
 
         internal ConcurrentBag<Message> ReceivedMessages { get; }
 

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -9,6 +9,7 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Net.Transports;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Serilog;
@@ -105,11 +106,16 @@ namespace Libplanet.Net.Tests
             appProtocolVersionOptions ??= new AppProtocolVersionOptions();
             hostOptions ??= new HostOptions(IPAddress.Loopback.ToString(), new IceServer[] { });
             options ??= new SwarmOptions();
-            var swarm = new Swarm<T>(
-                blockChain,
-                privateKey ?? new PrivateKey(),
+            privateKey ??= new PrivateKey();
+            var transport = NetMQTransport.Create(
+                privateKey,
                 appProtocolVersionOptions,
                 hostOptions,
+                options.MessageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
+            var swarm = new Swarm<T>(
+                blockChain,
+                privateKey,
+                transport,
                 options);
             _finalizers.Add(async () =>
             {

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -529,7 +529,7 @@ namespace Libplanet.Net.Tests
         }
 
         [Fact(Timeout = Timeout)]
-        public void ThrowArgumentExceptionInConstructor()
+        public async Task ThrowArgumentExceptionInConstructor()
         {
             var fx = new MemoryStoreFixture();
             var policy = new BlockPolicy<DumbAction>();
@@ -539,11 +539,14 @@ namespace Libplanet.Net.Tests
             var apvOptions = new AppProtocolVersionOptions() { AppProtocolVersion = apv };
             var hostOptions = new HostOptions(
                 IPAddress.Loopback.ToString(), new IceServer[] { });
-
+            var transport = await NetMQTransport.Create(
+                key,
+                apvOptions,
+                hostOptions);
             Assert.Throws<ArgumentNullException>(() =>
-                new Swarm<DumbAction>(null, key, apvOptions, hostOptions));
+                new Swarm<DumbAction>(null, key, transport));
             Assert.Throws<ArgumentNullException>(() =>
-                new Swarm<DumbAction>(blockchain, null, apvOptions, hostOptions));
+                new Swarm<DumbAction>(blockchain, null, transport));
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -35,14 +35,15 @@ namespace Libplanet.Net.Tests.Transports
             int port = FreeTcpPort();
             var hostOptions = new HostOptions(
                 IPAddress.Loopback.ToString(), new IceServer[] { }, port);
-
             var option = new SwarmOptions();
-
+            var transport = await NetMQTransport.Create(
+                swarmKey,
+                apvOptions,
+                hostOptions);
             using (var swarm = new Swarm<DumbAction>(
                 blockchain,
                 swarmKey,
-                apvOptions,
-                hostOptions,
+                transport,
                 options: option))
             {
                 var peer = new BoundPeer(swarmKey.PublicKey, new DnsEndPoint(host, port));

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -31,7 +31,6 @@ namespace Libplanet.Net
         private static readonly Codec Codec = new Codec();
 
         private readonly PrivateKey _privateKey;
-        private readonly AppProtocolVersionOptions _appProtocolVersionOptions;
 
         private readonly AsyncLock _runningMutex;
 
@@ -74,8 +73,6 @@ namespace Libplanet.Net
 
             _runningMutex = new AsyncLock();
 
-            _appProtocolVersionOptions = appProtocolVersionOptions;
-
             string loggerId = _privateKey.ToAddress().ToHex();
             _logger = Log
                 .ForContext<Swarm<T>>()
@@ -92,7 +89,7 @@ namespace Libplanet.Net
             // https://github.com/planetarium/libplanet/discussions/2303.
             Transport = NetMQTransport.Create(
                 _privateKey,
-                _appProtocolVersionOptions,
+                appProtocolVersionOptions,
                 hostOptions,
                 Options.MessageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
@@ -135,18 +132,13 @@ namespace Libplanet.Net
         /// </summary>
         public BlockChain<T> BlockChain { get; private set; }
 
-        /// <summary>
-        /// <see cref="PublicKey"/>s of parties who signed <see cref="AppProtocolVersion"/>s to
-        /// trust.  In case of <see langword="null"/>, any parties are trusted.
-        /// </summary>
+        /// <inheritdoc cref="AppProtocolVersionOptions.TrustedAppProtocolVersionSigners"/>
         public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners =>
-            _appProtocolVersionOptions.TrustedAppProtocolVersionSigners;
+            Transport.TrustedAppProtocolVersionSigners;
 
-        /// <summary>
-        /// The application protocol version to comply.
-        /// </summary>
+        /// <inheritdoc cref="AppProtocolVersionOptions.AppProtocolVersion"/>
         public AppProtocolVersion AppProtocolVersion =>
-            _appProtocolVersionOptions.AppProtocolVersion;
+            Transport.AppProtocolVersion;
 
         internal RoutingTable RoutingTable { get; }
 

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -49,17 +49,13 @@ namespace Libplanet.Net
         /// <param name="blockChain">A blockchain to publicize on the network.</param>
         /// <param name="privateKey">A private key to sign messages.  The public part of
         /// this key become a part of its end address for being pointed by peers.</param>
-        /// <param name="appProtocolVersionOptions">The <see cref="AppProtocolVersionOptions"/>
-        /// to use when handling an <see cref="AppProtocolVersion"/> attached to
-        /// a <see cref="Message"/>.</param>
-        /// <param name="hostOptions">The <see cref="HostOptions"/> to use when binding
-        /// to the network.</param>
+        /// <param name="transport">The <see cref="ITransport"/> to use for
+        /// network communication.</param>
         /// <param name="options">Options for <see cref="Swarm{T}"/>.</param>
         public Swarm(
             BlockChain<T> blockChain,
             PrivateKey privateKey,
-            AppProtocolVersionOptions appProtocolVersionOptions,
-            HostOptions hostOptions,
+            ITransport transport,
             SwarmOptions options = null)
         {
             BlockChain = blockChain ?? throw new ArgumentNullException(nameof(blockChain));
@@ -87,11 +83,7 @@ namespace Libplanet.Net
             // code, the portion initializing the swarm in Agent.cs in NineChronicles should be
             // fixed. for context, refer to
             // https://github.com/planetarium/libplanet/discussions/2303.
-            Transport = NetMQTransport.Create(
-                _privateKey,
-                appProtocolVersionOptions,
-                hostOptions,
-                Options.MessageTimestampBuffer).ConfigureAwait(false).GetAwaiter().GetResult();
+            Transport = transport;
             Transport.ProcessMessageHandler.Register(ProcessMessageHandlerAsync);
             PeerDiscovery = new KademliaProtocol(RoutingTable, Transport, Address);
         }
@@ -144,7 +136,7 @@ namespace Libplanet.Net
 
         internal IProtocol PeerDiscovery { get; }
 
-        internal ITransport Transport { get; private set; }
+        internal ITransport Transport { get; }
 
         internal TxCompletion<BoundPeer, T> TxCompletion { get; }
 

--- a/Libplanet.Net/Transports/ITransport.cs
+++ b/Libplanet.Net/Transports/ITransport.cs
@@ -1,9 +1,11 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
+using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Transports
@@ -54,6 +56,16 @@ namespace Libplanet.Net.Transports
         /// <value>The value indicating whether the instance is running.</value>
         [Pure]
         bool Running { get; }
+
+        /// <inheritdoc cref="AppProtocolVersionOptions.AppProtocolVersion"/>
+        AppProtocolVersion AppProtocolVersion { get; }
+
+        /// <inheritdoc cref="AppProtocolVersionOptions.TrustedAppProtocolVersionSigners"/>
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners { get; }
+
+        /// <inheritdoc cref="AppProtocolVersionOptions.DifferentAppProtocolVersionEncountered"/>
+        public DifferentAppProtocolVersionEncountered
+            DifferentAppProtocolVersionEncountered { get; }
 
         /// <summary>
         /// Starts running a transport layer as to put it in a <see cref="Running"/> state.

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -133,6 +134,18 @@ namespace Libplanet.Net.Transports
 
         /// <inheritdoc/>
         public bool Running => _routerPoller?.IsRunning ?? false;
+
+        /// <inheritdoc/>
+        public AppProtocolVersion AppProtocolVersion =>
+            _appProtocolVersionOptions.AppProtocolVersion;
+
+        /// <inheritdoc/>
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners =>
+            _appProtocolVersionOptions.TrustedAppProtocolVersionSigners;
+
+        /// <inheritdoc/>
+        public DifferentAppProtocolVersionEncountered DifferentAppProtocolVersionEncountered =>
+            _appProtocolVersionOptions.DifferentAppProtocolVersionEncountered;
 
         /// <summary>
         /// Creates an initialized <see cref="NetMQTransport"/> instance.

--- a/Libplanet.Node/NodeConfig.cs
+++ b/Libplanet.Node/NodeConfig.cs
@@ -4,6 +4,7 @@ using Libplanet.Blockchain;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Net.Transports;
 using Libplanet.Store;
 
 namespace Libplanet.Node
@@ -113,12 +114,16 @@ namespace Libplanet.Node
                 SwarmConfig.InitConfig.Host,
                 SwarmConfig.InitConfig.IceServers,
                 SwarmConfig.InitConfig.Port);
-
+            var transport = NetMQTransport.Create(
+                _privateKey,
+                apvOptions,
+                hostOptions,
+                SwarmConfig.ToSwarmOptions().MessageTimestampBuffer)
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
             return new Swarm<T>(
-                privateKey: _privateKey,
                 blockChain: blockChain,
-                appProtocolVersionOptions: apvOptions,
-                hostOptions: hostOptions,
+                privateKey: _privateKey,
+                transport: transport,
                 options: SwarmConfig.ToSwarmOptions());
         }
     }


### PR DESCRIPTION
Several points:
- The ownership of `AppProtocolVersionOptions` shouldn't be `ITransport`.
- This further exposes the mangling of various options that should be for different layers. For instance, `SwarmOptions.MessageTimestampBuffer` should either be moved to a separate option explicitly for `ITransport`, or this should be moved together with `AppProtocolVersionOptions` to `Swarm<T>`. Also there are certain `TimeoutOptions` properties that should only be `ITransport`'s concern.
- At the moment, `Swarm<T>` should probably check `ITransport`'s `PublicKey` to make sure they both have the same `PrivateKey`. I'm not sure about whether they should actually be the same.