### PR TITLE
Remove unnecessary policy for PBFT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@ Version PBFT
     methods.  [[#PBFT]]
  -  Removed `HashAlgorithmType` class.  [[#PBFT]]
  -  Removed `PreEvaluationBlock<T>(IBlockContent<T>)` constructor.  [[#PBFT]]
+ -  Removed `IBlockPolicy.GetMinBlockProtocolVersion()` interface method.
+    [[#PBFT]]
+
 
 ### Backward-incompatible API changes
 
@@ -34,6 +37,9 @@ Version PBFT
  -  Added `IStore.DeleteBlockCommit(BlockHash)` method.  [[#PBFT]]
  -  Added `IStore.GetBlockCommitHashes()` method.  [[#PBFT]]
  -  (Libplanet.Net) Removed `SwarmOptions.StaticPeers`.  [[#PBFT]]
+ -  Changed `BlockPolicy<T>()` constructor not to take
+    `Func<long, int>` type parameter named `getMinBlockProtocolVersion`.
+    [[#PBFT]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -462,9 +462,6 @@ If omitted (default) explorer only the local blockchain store.")]
 
             public int GetMaxTransactionsPerSignerPerBlock(long index) =>
                 _impl.GetMaxTransactionsPerSignerPerBlock(index);
-
-            public int GetMinBlockProtocolVersion(long index) =>
-                _impl.GetMinBlockProtocolVersion(index);
         }
 
         internal class Startup : IBlockChainContext<NullAction>

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -29,7 +29,6 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerSignerPerBlock;
-        private readonly Func<long, int> _getMinBlockProtocolVersion;
 
         /// <summary>
         /// <para>
@@ -71,9 +70,6 @@ namespace Libplanet.Blockchain.Policies
         /// a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s index.
         /// Goes to <see cref="GetMaxTransactionsPerSignerPerBlock"/>.  Set to
         /// <see cref="GetMaxTransactionsPerBlock"/> by default.</param>
-        /// <param name="getMinBlockProtocolVersion">The function determining the minimum
-        /// block protocol version of a <see cref="Block{T}"/> given the <see cref="Block{T}"/>'s
-        /// index.  Set to a constant function of <c>0</c> by default.</param>
         /// <param name="nativeTokens">A fixed set of <see cref="Currency"/> objects that are
         /// supported by the blockchain as first-class citizens.  Empty by default.</param>
         public BlockPolicy(
@@ -87,7 +83,6 @@ namespace Libplanet.Blockchain.Policies
             Func<long, int>? getMinTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null,
-            Func<long, int>? getMinBlockProtocolVersion = null,
             IImmutableSet<Currency>? nativeTokens = null)
         {
             BlockAction = blockAction;
@@ -98,7 +93,6 @@ namespace Libplanet.Blockchain.Policies
             _getMaxTransactionsPerBlock = getMaxTransactionsPerBlock ?? (_ => 100);
             _getMaxTransactionsPerSignerPerBlock = getMaxTransactionsPerSignerPerBlock
                 ?? GetMaxTransactionsPerBlock;
-            _getMinBlockProtocolVersion = getMinBlockProtocolVersion ?? (_ => 0);
 
             _validateNextBlockTx = validateNextBlockTx ?? ((_, __) => null);
             if (validateNextBlock is { } vnb)
@@ -114,21 +108,10 @@ namespace Libplanet.Blockchain.Policies
                     int maxTransactionsPerBlock = GetMaxTransactionsPerBlock(block.Index);
                     int maxTransactionsPerSignerPerBlock =
                         GetMaxTransactionsPerSignerPerBlock(block.Index);
-                    int minBlockProtocolVersion = GetMinBlockProtocolVersion(block.Index);
 
                     long blockBytes = BlockMarshaler.MarshalTransactions<T>(block.Transactions)
                         .EncodingLength;
-                    if (block.ProtocolVersion < minBlockProtocolVersion)
-                    {
-                        // NOTE: InvalidBlockProtocolVersionException would be more appropriate,
-                        // but it is not a BlockPolicyViolationException; as this is a temporary
-                        // solution to allow migration, we just use BlockPolicyViolationException.
-                        return new BlockPolicyViolationException(
-                            $"The minimum block protocol version of block #{block.Index} is " +
-                            $"{minBlockProtocolVersion} while the given block has " +
-                            $"block protocol versoin {block.ProtocolVersion}.");
-                    }
-                    else if (blockBytes > maxTransactionsBytes)
+                    if (blockBytes > maxTransactionsBytes)
                     {
                         return new InvalidBlockBytesLengthException(
                             $"The size of block #{block.Index} {block.Hash} is too large where " +
@@ -220,10 +203,5 @@ namespace Libplanet.Blockchain.Policies
         [Pure]
         public int GetMaxTransactionsPerSignerPerBlock(long index)
             => _getMaxTransactionsPerSignerPerBlock(index);
-
-        /// <inheritdoc/>
-        [Pure]
-        public int GetMinBlockProtocolVersion(long index)
-            => _getMinBlockProtocolVersion(index);
     }
 }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -123,16 +123,5 @@ namespace Libplanet.Blockchain.Policies
         /// a valid <see cref="Block{T}"/> can accept.</returns>
         [Pure]
         int GetMaxTransactionsPerSignerPerBlock(long index);
-
-        /// <summary>
-        /// Gets the minimum <see cref="Block{T}.ProtocolVersion"/> allowed for
-        /// a valid <see cref="Block{T}"/>.
-        /// </summary>
-        /// <param name="index">The <see cref="Block{T}.Index"/> of the <see cref="Block{T}"/>
-        /// for which this constraint should apply.</param>
-        /// <returns>The minimum value for <see cref="Block{T}.ProtocolVersion"/> allowed for
-        /// a valid <see cref="Block{T}"/>.</returns>
-        [Pure]
-        int GetMinBlockProtocolVersion(long index);
     }
 }

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -56,7 +56,5 @@ namespace Libplanet.Blockchain.Policies
 
         public int GetMaxTransactionsPerSignerPerBlock(long index) =>
             GetMaxTransactionsPerBlock(index);
-
-        public int GetMinBlockProtocolVersion(long index) => 0;
     }
 }


### PR DESCRIPTION
During merging main, unnecessary policy property has been introduced to pbft branch.
So, this have to be removed.