### PR TITLE
New subcommands to CLI: `planet block analyze` & `planet block generate-genesis`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,8 @@ To be released.
 
 ### CLI tools
 
+ -  Added `planet block` subcommand group. [[#2758]]
+     -  Added `planet block analyze` subcommand.
  -  Fixed a bug of `planet tx analyze` subcommand where a serialized transaction
     had lacked the content of its `"publicKey"`.  [[#2756]]
 
@@ -64,6 +66,7 @@ To be released.
 [#2733]: https://github.com/planetarium/libplanet/pull/2733
 [#2743]: https://github.com/planetarium/libplanet/pull/2743
 [#2756]: https://github.com/planetarium/libplanet/pull/2756
+[#2758]: https://github.com/planetarium/libplanet/pull/2758
 
 
 Version 0.46.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ To be released.
 
  -  Added `planet block` subcommand group. [[#2758]]
      -  Added `planet block analyze` subcommand.
+     -  Added `planet block generate-genesis` subcommand.
  -  Fixed a bug of `planet tx analyze` subcommand where a serialized transaction
     had lacked the content of its `"publicKey"`.  [[#2756]]
 

--- a/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
@@ -1,0 +1,169 @@
+namespace Libplanet.Extensions.Cocona.Tests;
+
+using System;
+using System.Collections.Immutable;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blockchain.Policies;
+using Xunit;
+
+public class BlockPolicyParamsTest
+{
+    private static readonly ImmutableHashSet<Currency> _nativeTokens =
+        ImmutableHashSet.Create(Currency.Uncapped("FOO", 2, minters: null));
+
+    [Fact]
+    public void DefaultState()
+    {
+        var blockPolicyParams = new BlockPolicyParams();
+        Assert.Null(blockPolicyParams.GetBlockPolicy());
+        Assert.Null(blockPolicyParams.GetBlockAction());
+        Assert.Null(blockPolicyParams.GetNativeTokens());
+    }
+
+    [Fact]
+    public void GetBlockPolicy()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
+        };
+        BlockPolicy<NullAction> blockPolicy = Assert.IsType<BlockPolicy<NullAction>>(
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly })
+        );
+        Assert.IsType<NullAction>(blockPolicy.BlockAction);
+        Assert.Equal(_nativeTokens, blockPolicy.NativeTokens);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_NonQualifiedName()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = nameof(BlockPolicyFactory),
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains("qualified name", e.Message, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_ReferringNonExistentType()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}__NonExistent__.{nameof(BlockPolicyFactory)}",
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains(
+            "failed to load policy type",
+            e.Message,
+            StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_ReferringNonExistentMethod()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}__NonExistent__",
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains(
+            "failed to find a static method",
+            e.Message,
+            StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_ReferringInstanceMethod()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactoryInstanceMethod)}",
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains(
+            "failed to find a static method",
+            e.Message,
+            StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_NotAcceptingMethodWithParams()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactoryWithParams)}",
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains("parameters", e.Message, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_NotAcceptingMethodWithWrongReturnType()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactoryWithWrongReturnType)}",
+        };
+        var e = Assert.Throws<TypeLoadException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains("return type", e.Message, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockPolicy_FactoryReturningNull()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactoryReturningNull)}",
+        };
+        var e = Assert.Throws<InvalidOperationException>(() =>
+            blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly }));
+        Assert.Contains("returned null", e.Message, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void GetBlockAction()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
+        };
+        var blockAction = blockPolicyParams.GetBlockAction(new[] { GetType().Assembly });
+        Assert.IsType<NullAction>(blockAction);
+    }
+
+    [Fact]
+    public void GetNativeTokens()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
+        };
+        var nativeTokens = blockPolicyParams.GetNativeTokens(new[] { GetType().Assembly });
+        Assert.Equal(_nativeTokens, nativeTokens);
+    }
+
+    internal static BlockPolicy<NullAction> BlockPolicyFactory() =>
+        new BlockPolicy<NullAction>(
+            blockAction: new NullAction(),
+            nativeTokens: _nativeTokens
+        );
+
+    internal static BlockPolicy<NullAction> BlockPolicyFactoryWithParams(bool param) =>
+        new BlockPolicy<NullAction>();
+
+    internal static int BlockPolicyFactoryWithWrongReturnType() => 0;
+
+    internal static BlockPolicy<NullAction> BlockPolicyFactoryReturningNull() =>
+        null!;
+
+    internal BlockPolicy<NullAction> BlockPolicyFactoryInstanceMethod() =>
+        new BlockPolicy<NullAction>();
+}

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Libplanet.Tools.Tests;
 
 using System;

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Libplanet.Extensions.Cocona.Tests.Commands;
 
 using System;

--- a/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>

--- a/Libplanet.Extensions.Cocona.Tests/UtilsTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/UtilsTest.cs
@@ -24,7 +24,8 @@ public class UtilsTest
 
         var serialized = Utils.SerializeHumanReadable(dummyClass);
         var dummyClass2 = Utils.DeserializeHumanReadable<DummyClass>(serialized);
-        Assert.True(dummyClass.SampleByteArray.SequenceEqual(dummyClass2.SampleByteArray));
+        Assert.NotNull(dummyClass2);
+        Assert.True(dummyClass.SampleByteArray.SequenceEqual(dummyClass2!.SampleByteArray));
         Assert.Equal(dummyClass.SampleDateTimeOffset, dummyClass2.SampleDateTimeOffset);
     }
 

--- a/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
+++ b/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
@@ -1,0 +1,169 @@
+namespace Libplanet.Extensions.Cocona;
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using global::Cocona;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blockchain.Policies;
+
+public class BlockPolicyParams : ICommandParameterSet
+{
+    private string[] _assembliesToLoad = Array.Empty<string>();
+    private string? _policyFactory;
+    private Assembly[]? _loadedAssemblies;
+
+    [Option(
+        "load-assembly",
+        new[] { 'A' },
+        Description = "The path of the assembly DLL to load.  Can be specified multiple times.  " +
+            "Note that all referenced assemblies of the specified assemblies are also loaded " +
+            "automatically if they are placed in the same directory.  Tip: In case there are " +
+            "missing references, you can use `dotnet publish` to copy all the required " +
+            "assemblies to a single directory.")]
+    [HasDefaultValue]
+    public string[] AssembliesToLoad
+    {
+        get => _assembliesToLoad;
+        set
+        {
+            _assembliesToLoad = value;
+            _loadedAssemblies = null;
+        }
+    }
+
+    [Option(
+        'F',
+        Description = "The qualified name of the factory method to instantiate a " +
+            nameof(IBlockPolicy<NullAction>) + "<T>.  The factory method must be static and " +
+            "has no parameters.  An assembly that the factory method and " +
+            "the policy type belong to has to be loaded using -A/--load-assembly option.")]
+    [HasDefaultValue]
+    public string? PolicyFactory
+    {
+        get => _policyFactory;
+        set
+        {
+            _policyFactory = value;
+            _loadedAssemblies = null;
+        }
+    }
+
+    [SuppressMessage(
+        "Major Code Smell",
+        "S3885:\"Assembly.Load\" should be used",
+        Justification = "Assembly.Load does not automatically resolve dependencies from target "
+            + "assembly path, whereas Assembly.LoadFrom does, which is appropriate in this use "
+            + "case.")]
+    public Assembly[] LoadAssemblies()
+    {
+        if (_loadedAssemblies is { } assemblies)
+        {
+            return assemblies;
+        }
+
+        _loadedAssemblies = AssembliesToLoad.Select(Assembly.LoadFrom).ToArray();
+        return _loadedAssemblies;
+    }
+
+    public object? GetBlockPolicy() =>
+        GetBlockPolicy(LoadAssemblies());
+
+    public IAction? GetBlockAction() =>
+        GetBlockAction(LoadAssemblies());
+
+    public IImmutableSet<Currency>? GetNativeTokens() =>
+        GetNativeTokens(LoadAssemblies());
+
+    [SuppressMessage(
+        "Major Code Smell",
+        "S3011:Reflection should not be used to increase accessibility of classes, methods, " +
+            "or fields",
+        Justification = "It might not be practical to have BlockPolicy factory method to be "
+            + "public, as it is not likely to be used as a public API.")]
+    internal object? GetBlockPolicy(Assembly[] assemblies)
+    {
+        // TODO: Consider to refer to a method in an inner class.
+        if (PolicyFactory is null)
+        {
+            return null;
+        }
+
+        int separatorIndex = PolicyFactory.LastIndexOf('.');
+        string typeName = separatorIndex < 0
+            ? throw new TypeLoadException("Expected a qualified name of a factory method.")
+            : PolicyFactory.Substring(0, separatorIndex);
+        string methodName = PolicyFactory.Substring(separatorIndex + 1);
+        foreach (Assembly asm in assemblies)
+        {
+            if (asm.GetType(typeName, throwOnError: false) is { } type)
+            {
+                MethodInfo method = type.GetMethod(
+                    methodName,
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
+                ) ?? throw new TypeLoadException(
+                    $"Failed to find a static method named {methodName}() in {type.FullName}.");
+
+                if (method.GetParameters().Length != 0)
+                {
+                    throw new TypeLoadException(
+                        $"The factory method {PolicyFactory}() must have no parameters."
+                    );
+                }
+
+                Type returnType = method.ReturnType;
+                if (!returnType.IsGenericType ||
+                    typeof(IBlockPolicy<>).IsAssignableFrom(
+                        returnType.GetGenericTypeDefinition()) ||
+                    returnType.GenericTypeArguments.Length != 1)
+                {
+                    throw new TypeLoadException(
+                        $"The return type of {PolicyFactory}() must be " +
+                        $"{nameof(IBlockPolicy<NullAction>)}<T>."
+                    );
+                }
+
+                return method.Invoke(null, Array.Empty<object>()) ??
+                    throw new InvalidOperationException(
+                        $"The factory method {PolicyFactory}() returned null."
+                    );
+            }
+        }
+
+        throw new TypeLoadException(
+            $"Failed to load policy type {typeName} from assemblies:\n\n" +
+            string.Join("\n", assemblies.Select(asm => asm.FullName))
+        );
+    }
+
+    internal IAction? GetBlockAction(Assembly[] assemblies)
+    {
+        object? policy = GetBlockPolicy(assemblies);
+        if (policy is null)
+        {
+            return null;
+        }
+
+        PropertyInfo? prop = policy
+            .GetType()
+            .GetProperty(nameof(IBlockPolicy<NullAction>.BlockAction));
+        return (IAction?)prop!.GetValue(policy);
+    }
+
+    internal IImmutableSet<Currency>? GetNativeTokens(Assembly[] assemblies)
+    {
+        object? policy = GetBlockPolicy(assemblies);
+        if (policy is null)
+        {
+            return null;
+        }
+
+        PropertyInfo? prop = policy
+            .GetType()
+            .GetProperty(nameof(IBlockPolicy<NullAction>.NativeTokens));
+        return (IImmutableSet<Currency>)prop!.GetValue(policy)!;
+    }
+}

--- a/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/ApvCommand.cs
@@ -50,6 +50,7 @@ public class ApvCommand
             );
         }
 
+        // FIXME: Declare a ICommandParameterSet type taking key ID and keystore path instead:
         PrivateKey key = new KeyCommand().UnprotectKey(keyId, passphrase, ignoreStdin: true);
         IValue? extraValue = null;
         if (extraFile is string path)

--- a/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -1,0 +1,91 @@
+namespace Libplanet.Extensions.Cocona.Commands;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Bencodex;
+using global::Cocona;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+public class BlockCommand
+{
+    [Command(Description = "Analyze the given block.")]
+    public void Analyze(
+        [Argument(
+            Description = "The file path of the block to analyze.  If " +
+                "a hyphen (-) is given it reads from the standard input (if you want to read " +
+                "just a file named \"-\", use \"./-\" instead)."
+        )]
+        string file,
+        [Option(
+            'o',
+            Description = "The file path to write the analysis result to.  " +
+                "If a hyphen (-) is given it writes to the standard output (if you want to write " +
+                "just a file named \"-\", use \"./-\" instead).  If not given, it writes to " +
+                "the standard output."
+        )]
+        string output = "-"
+    )
+    {
+        using Stream inputStream = file == "-"
+            ? Console.OpenStandardInput()
+            : File.OpenRead(file);
+        string sourceName = file == "-" ? "stdin" : $"file {file}";
+        Codec codec = new ();
+        Block<NullAction> block;
+        try
+        {
+            var dict = (Bencodex.Types.Dictionary)codec.Decode(inputStream);
+            block = BlockMarshaler.UnmarshalBlock<NullAction>(dict);
+        }
+        catch (DecodingException e)
+        {
+            throw new CommandExitedException(
+                $"The {sourceName} does not contain a valid Bencodex data: {e.Message}",
+                -1
+            );
+        }
+        catch (InvalidCastException)
+        {
+            throw new CommandExitedException(
+                $"The {sourceName} does not contain a valid Bencodex dictionary.",
+                -2
+            );
+        }
+        catch (InvalidBlockException e)
+        {
+            throw new CommandExitedException(
+                $"The {sourceName} does not contain a valid block: {e.Message}",
+                -4
+            );
+        }
+        catch (Exception e) when (e is IndexOutOfRangeException or KeyNotFoundException)
+        {
+            throw new CommandExitedException(
+                $"The {sourceName} lacks some required fields.",
+                -3
+            );
+        }
+
+        using Stream outputStream = output == "-"
+            ? Console.OpenStandardOutput()
+            : File.OpenWrite(file);
+        var writerOptions = new JsonWriterOptions { Indented = true };
+        using (var writer = new Utf8JsonWriter(outputStream, writerOptions))
+        {
+            var serializerOptions = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = false,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                IgnoreReadOnlyProperties = false,
+            };
+            JsonSerializer.Serialize(writer, block, serializerOptions);
+        }
+
+        using var textWriter = new StreamWriter(outputStream);
+        textWriter.WriteLine();
+    }
+}

--- a/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -7,10 +7,18 @@ using System.Text.Json;
 using Bencodex;
 using global::Cocona;
 using Libplanet.Action;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 
 public class BlockCommand
 {
+    public enum OutputFormat
+    {
+        Bencodex,
+        Json,
+    }
+
     [Command(Description = "Analyze the given block.")]
     public void Analyze(
         [Argument(
@@ -87,5 +95,61 @@ public class BlockCommand
 
         using var textWriter = new StreamWriter(outputStream);
         textWriter.WriteLine();
+    }
+
+    [Command(Description = "Generate a genesis block.")]
+    public void GenerateGenesis(
+        [Argument(Name = "KEY-ID", Description = "A private key to use for signing.")]
+        Guid keyId,
+        PassphraseParameters passphrase,
+        [Argument(Name = "FILE", Description = "File to write the genesis block to.  " +
+            "Use `-` for stdout (you can still refer to a file named \"-\" by \"./-\").")]
+        string file,
+        BlockPolicyParams blockPolicyParams,
+        [Option('f', Description = "Output format.")]
+        OutputFormat format = OutputFormat.Bencodex
+    )
+    {
+        // FIXME: Declare a ICommandParameterSet type taking key ID and keystore path instead:
+        PrivateKey key = new KeyCommand().UnprotectKey(keyId, passphrase, ignoreStdin: true);
+        Block<NullAction> genesis = BlockChain<NullAction>.MakeGenesisBlock(
+            privateKey: key,
+            blockAction: blockPolicyParams.GetBlockAction(),
+            nativeTokenPredicate: blockPolicyParams is { } p && p.GetNativeTokens() is { } tokens
+                ? tokens.Contains
+                : null
+        );
+        using Stream stream = file == "-"
+            ? Console.OpenStandardOutput()
+            : File.OpenWrite(file);
+        switch (format)
+        {
+            // FIXME: Configure JsonConverter for Block<T>:
+            case OutputFormat.Json:
+                var writerOptions = new JsonWriterOptions { Indented = true };
+                using (var writer = new Utf8JsonWriter(stream, writerOptions))
+                {
+                    var serializerOptions = new JsonSerializerOptions
+                    {
+                        AllowTrailingCommas = false,
+                        DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                        IgnoreReadOnlyProperties = false,
+                    };
+                    JsonSerializer.Serialize(writer, genesis, serializerOptions);
+                }
+
+                using (var textWriter = new StreamWriter(stream))
+                {
+                    textWriter.WriteLine();
+                }
+
+                break;
+
+            default:
+                Codec codec = new ();
+                codec.Encode(genesis.MarshalBlock(), stream);
+                break;
+        }
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/KeyCommand.cs
@@ -284,6 +284,7 @@ public class KeyCommand
         Utils.PrintTable(("Public Key", "Address"), new[] { (pub, addr) });
     }
 
+    // FIXME: Declare a ICommandParameterSet type taking key ID and keystore path instead:
     public PrivateKey UnprotectKey(
         Guid keyId,
         PassphraseParameters passphrase,
@@ -365,6 +366,7 @@ public class KeyCommand
         }
     }
 
+    // FIXME: Declare a ICommandParameterSet type taking key ID and keystore path instead:
     private void ChangeKeyStorePath(string? path)
     {
         if (path != null)

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -13,6 +13,7 @@ using Libplanet.Extensions.Cocona.Extensions;
 [HasSubCommands(typeof(StoreCommand), "store", Description = "Store utilities.")]
 [HasSubCommands(typeof(StatsCommand), "stats", Description = "Stats utilities.")]
 [HasSubCommands(typeof(TxCommand), "tx", Description = "Transaction utilities.")]
+[HasSubCommands(typeof(BlockCommand), "block", Description = "Block utilities.")]
 public class Program
 {
     private static readonly string FileConfigurationServiceRoot = Path.Combine(

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -444,6 +444,8 @@ namespace Libplanet.Blockchain
         /// <see cref="Libplanet.Blockchain.Policies.IBlockPolicy{T}.NativeTokens"/> or not.
         /// Treat no <see cref="Currency"/> as native token if the argument omitted.</param>
         /// <returns>The genesis block mined with parameters.</returns>
+        // FIXME: This method should take a IBlockPolicy<T> instead of params blockAction and
+        // nativeTokenPredicate.  (Or at least there should be such an overload.)
         public static Block<T> MakeGenesisBlock(
             IEnumerable<T> actions = null,
             PrivateKey privateKey = null,


### PR DESCRIPTION
This patch introduces two subcommands to `planet` CLI.

### `planet block analyze`

This subcommands takes a Bencodex-serialized block file and then show its contents as a prettified JSON tree.  E.g.:

```bash
curl https://release.nine-chronicles.com/genesis-block-9c-main | planet block analyze -
```

### `planet block generate-genesis`

This subcommands creates an empty genesis block and signs it in the specified key.  E.g.:

```bash
planet block generate-genesis KEY-ID ./genesis-block.bin
planet block analyze ./genesis-block.bin
```