### PR TITLE
♻️ Removed nullability from `TrustedAppProtocolVersionSigners`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@ To be released.
  -  (Libplanet.Net) Changed `Swarm<T>(BlockChain<T>, PrivateKey,
     AppProtocolVersionOptions, HostOptions, SwarmOptions)` to
     `Swarm<T>(BlockChain<T>, PrivateKey, ITransport, SwarmOptions)`.  [[#2743]]
+ -  (Libplanet.Net) Changed the type for
+    `AppProtocolVersionOptions.TrustedAppProtocolVersionSigners` from
+    `IImmutableHashSet<PublicKey>?` to `IImmutableHashSet<PublicKey>`.
+    [[#2759]]
 
 ### Backward-incompatible network protocol changes
 
@@ -85,6 +89,7 @@ To be released.
 [#2756]: https://github.com/planetarium/libplanet/pull/2756
 [#2757]: https://github.com/planetarium/libplanet/pull/2757
 [#2758]: https://github.com/planetarium/libplanet/pull/2758
+[#2759]: https://github.com/planetarium/libplanet/pull/2759
 [#2761]: https://github.com/planetarium/libplanet/pull/2761
 [Bencodex 0.8.0]: https://www.nuget.org/packages/Bencodex/0.8.0
 [Bencodex.Json 0.8.0]: https://www.nuget.org/packages/Bencodex.Json/0.8.0

--- a/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageValidatorTest.cs
@@ -72,7 +72,6 @@ namespace Libplanet.Net.Tests.Messages
                 new HashSet<PublicKey>() { trustedSigner.PublicKey }.ToImmutableHashSet();
             ImmutableHashSet<PublicKey>? emptyApvSigners =
                 new HashSet<PublicKey>() { }.ToImmutableHashSet();
-            ImmutableHashSet<PublicKey>? nullApvSigners = null;
 
             // Ping
             var trustedPing = new PingMsg()
@@ -181,41 +180,6 @@ namespace Libplanet.Net.Tests.Messages
                 () => messageValidator.ValidateAppProtocolVersion(unknownDifferentExtraPing));
             Assert.False(exception.Trusted);
             Assert.False(called);
-
-            // Trust anyone.
-            appProtocolVersionOptions = new AppProtocolVersionOptions()
-            {
-                AppProtocolVersion = trustedApv,
-                TrustedAppProtocolVersionSigners = nullApvSigners,
-                DifferentAppProtocolVersionEncountered = callback,
-            };
-
-            messageValidator = new MessageValidator(appProtocolVersionOptions, null);
-
-            // Check trust pings
-            messageValidator.ValidateAppProtocolVersion(trustedPing);
-            Assert.False(called);
-            exception = Assert.Throws<DifferentAppProtocolVersionException>(
-                () => messageValidator.ValidateAppProtocolVersion(trustedDifferentVersionPing));
-            Assert.True(exception.Trusted);
-            Assert.True(called);
-            called = false;
-            messageValidator.ValidateAppProtocolVersion(trustedDifferentExtraPing);
-            Assert.True(called);
-            called = false;
-
-            // Check unknown pings
-            messageValidator.ValidateAppProtocolVersion(unknownPing);
-            Assert.True(called);
-            called = false;
-            exception = Assert.Throws<DifferentAppProtocolVersionException>(
-                () => messageValidator.ValidateAppProtocolVersion(unknownDifferentVersionPing));
-            Assert.True(exception.Trusted);
-            Assert.True(called);
-            called = false;
-            messageValidator.ValidateAppProtocolVersion(unknownDifferentExtraPing);
-            Assert.True(called);
-            called = false;
         }
     }
 }

--- a/Libplanet.Net.Tests/Protocols/TestTransport.cs
+++ b/Libplanet.Net.Tests/Protocols/TestTransport.cs
@@ -102,7 +102,8 @@ namespace Libplanet.Net.Tests.Protocols
 
         public AppProtocolVersion AppProtocolVersion => _appProtocolVersion;
 
-        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners => null;
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners =>
+            ImmutableHashSet<PublicKey>.Empty;
 
         public DifferentAppProtocolVersionEncountered DifferentAppProtocolVersionEncountered =>
             (peer, peerVersion, localVersion) => { };

--- a/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
+++ b/Libplanet.Net.Tests/SwarmTest.AppProtocolVersion.cs
@@ -62,6 +62,8 @@ namespace Libplanet.Net.Tests
             AppProtocolVersionOptions v1 = new AppProtocolVersionOptions()
             {
                 AppProtocolVersion = AppProtocolVersion.Sign(signer, 1),
+                TrustedAppProtocolVersionSigners =
+                    new HashSet<PublicKey>() { signer.PublicKey }.ToImmutableHashSet(),
                 DifferentAppProtocolVersionEncountered = (_, ver, __) => { isCalled = true; },
             };
             AppProtocolVersionOptions v2 = new AppProtocolVersionOptions()

--- a/Libplanet.Net/AppProtocolVersionOptions.cs
+++ b/Libplanet.Net/AppProtocolVersionOptions.cs
@@ -19,10 +19,12 @@ namespace Libplanet.Net
         /// The set of <see cref="PublicKey"/>s to trust when a node encounters
         /// a <see cref="Message"/> with an <see cref="Net.AppProtocolVersion"/> that is different
         /// from <see cref="AppProtocolVersion"/>.  Any <see cref="Message"/> with an untrusted
-        /// <see cref="Net.AppProtocolVersion"/> is ignored by the node.  To trust any party,
-        /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
+        /// <see cref="Net.AppProtocolVersion"/> is ignored by the node.  Set to an
+        /// empty set of <see cref="PublicKey"/>s by default, i.e. not to trust any
+        /// <see cref="Message"/> with a different <see cref="Net.AppProtocolVersion"/>.
         /// </summary>
-        public IImmutableSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners { get; set; } =
+            ImmutableHashSet<PublicKey>.Empty;
 
         /// <summary>
         /// The callback triggered when a node encounters

--- a/Libplanet.Net/Messages/MessageValidator.cs
+++ b/Libplanet.Net/Messages/MessageValidator.cs
@@ -52,21 +52,12 @@ namespace Libplanet.Net.Messages
         /// <para>
         /// Whether to trust an unknown <see cref="AppProtocolVersion"/>, i.e.
         /// an <see cref="AppProtocolVersion"/> that is different
-        /// from <see cref="Apv"/>, depends on this value:
-        /// <list type="bullet">
-        ///     <item><description>
-        ///         If <see langword="null"/>, the <see cref="AppProtocolVersion"/> in question
-        ///         is trusted regardless of its signer.
-        ///     </description></item>
-        ///     <item><description>
-        ///         If not <see langword="null"/>, an <see cref="AppProtocolVersion"/> is trusted
-        ///         if it is signed by one of the signers in the set.  In particular, if the set
-        ///         is empty, no <see cref="AppProtocolVersion"/> is trusted.
-        ///     </description></item>
-        /// </list>
+        /// from <see cref="Apv"/>.  An <see cref="AppProtocolVersion"/> is trusted if it is signed
+        /// by one of the signers in the set.  In particular, if the set is empty,
+        /// no <see cref="AppProtocolVersion"/> is trusted.
         /// </para>
         /// </summary>
-        public IImmutableSet<PublicKey>? TrustedApvSigners =>
+        public IImmutableSet<PublicKey> TrustedApvSigners =>
             _appProtocolVersionOptions.TrustedAppProtocolVersionSigners;
 
         /// <summary>
@@ -134,7 +125,7 @@ namespace Libplanet.Net.Messages
 
         private static void ValidateAppProtocolVersion(
             AppProtocolVersion appProtocolVersion,
-            IImmutableSet<PublicKey>? trustedAppProtocolVersionSigners,
+            IImmutableSet<PublicKey> trustedAppProtocolVersionSigners,
             DifferentAppProtocolVersionEncountered differentAppProtocolVersionEncountered,
             Message message)
         {
@@ -145,9 +136,9 @@ namespace Libplanet.Net.Messages
                     return;
                 }
 
-                bool trusted = !(
-                    trustedAppProtocolVersionSigners is { } tapvs &&
-                    tapvs.All(publicKey => !message.Version.Verify(publicKey)));
+                bool trusted = !trustedAppProtocolVersionSigners.All(
+                    publicKey => !message.Version.Verify(publicKey));
+
                 if (trusted)
                 {
                     differentAppProtocolVersionEncountered(

--- a/Libplanet.Node/NetworkConfig.cs
+++ b/Libplanet.Node/NetworkConfig.cs
@@ -56,13 +56,6 @@ namespace Libplanet.Node
 
         /// <summary>
         /// The set of <see cref="PublicKey"/>s to trust when a node encounters
-        /// an <see cref="Libplanet.Net.AppProtocolVersion"/> that is different from
-        /// <see cref="NetworkConfig{T}.AppProtocolVersion"/>.  To trust any party,
-        /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
-        /// </summary>
-
-        /// <summary>
-        /// The set of <see cref="PublicKey"/>s to trust when a node encounters
         /// an <see cref="Net.AppProtocolVersion"/> that is different from
         /// <see cref="AppProtocolVersion"/>.  Set to an empty set of <see cref="PublicKey"/>s
         /// by default, i.e. not to trust any <see cref="Net.AppProtocolVersion"/> that

--- a/Libplanet.Node/NetworkConfig.cs
+++ b/Libplanet.Node/NetworkConfig.cs
@@ -60,7 +60,16 @@ namespace Libplanet.Node
         /// <see cref="NetworkConfig{T}.AppProtocolVersion"/>.  To trust any party,
         /// set this to <see langword="null"/>.  Set to <see langword="null"/> by default.
         /// </summary>
-        public IImmutableSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; } = null;
+
+        /// <summary>
+        /// The set of <see cref="PublicKey"/>s to trust when a node encounters
+        /// an <see cref="Net.AppProtocolVersion"/> that is different from
+        /// <see cref="AppProtocolVersion"/>.  Set to an empty set of <see cref="PublicKey"/>s
+        /// by default, i.e. not to trust any <see cref="Net.AppProtocolVersion"/> that
+        /// is different from <see cref="AppProtocolVersion"/>.
+        /// </summary>
+        public IImmutableSet<PublicKey> TrustedAppProtocolVersionSigners { get; set; } =
+            ImmutableHashSet<PublicKey>.Empty;
 
         /// <summary>
         /// The event triggered when a node encounters


### PR DESCRIPTION
Several points:
- I'm of the opinion that [`null`s are bad in general if they can be avoided](https://www.lucidchart.com/techblog/2015/08/31/the-worst-mistake-of-computer-science/).
- Currently, `null` option isn't really being used.
- Other than "it'd be nice to have trust any signer as an option", I still fail to see a concrete use case for this.
- Having both `null` and empty list as meaningful options are incompatible with current CLI.

If `null` is still that important, we should change the CLI to accept a formatted `string` to allow all possible cases. 🙄