### PR TITLE
Catch exception of `AddressType`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ To be released.
 
 ### Behavioral changes
 
+ - If the length of the given hexadecimal string is less than 2,
+   `AddressType.ParseValue(object)` will throw `ArgumentException`. [[#2764]]
+
 ### Bug fixes
 
  -  Fixed a JSON serializer bug where a `Transaction<T>` serialized into JSON

--- a/Libplanet.Explorer/GraphTypes/AddressType.cs
+++ b/Libplanet.Explorer/GraphTypes/AddressType.cs
@@ -29,6 +29,12 @@ namespace Libplanet.Explorer.GraphTypes
                 case null:
                     return null;
                 case string hex:
+                    if (hex.Length < 2)
+                    {
+                        throw new ArgumentException(
+                            "The given value is too short to be an address.", nameof(value));
+                    }
+
                     if (hex.Substring(0, 2).ToLower().Equals("0x"))
                     {
                         hex = hex.Substring(2);


### PR DESCRIPTION
An exception occurred when the length of the `hex` less then 2.
So I catch that exception, wrap it inside of an `ArgumentException` and throw it.