### PR TITLE
fix/gossip/messageCache: message in cache is being modified from outside

### DIFF
--- a/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
+++ b/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Net;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
@@ -34,11 +36,37 @@ namespace Libplanet.Net.Tests.Consensus
         public void Get()
         {
             var cache = new MessageCache(3, 3);
-            var msg = new PingMsg();
+            var identity = TestUtils.GetRandomBytes(1);
+            var messageId = TestUtils.GetRandomBytes(MessageId.Size);
+            var pk = new PrivateKey();
+            var boundPeer = new BoundPeer(
+                pk.PublicKey,
+                new DnsEndPoint("0.0.0.0", 1234));
+            var version =
+                new AppProtocolVersion(1, null, ImmutableArray<byte>.Empty, pk.ToAddress());
+            var time = DateTimeOffset.UtcNow;
+            // Had to use HaveMessage for testing the persistent dataFrame.
+            var msg = new HaveMessage(new[] { messageId })
+            {
+                Identity = identity,
+                Remote = boundPeer,
+                Timestamp = time,
+                Version = version,
+            };
             Assert.Throws<KeyNotFoundException>(() => cache.Get(msg.Id));
             cache.Put(msg);
             var ret = cache.Get(msg.Id);
-            Assert.Equal(msg, ret);
+            Assert.NotEqual(ret, msg);
+
+            // Base Message data is removed
+            Assert.Null(ret.Identity);
+            Assert.Null(ret.Remote);
+            Assert.Equal(DateTimeOffset.MinValue, ret.Timestamp);
+            Assert.Equal(default, ret.Version);
+
+            // Message data is persistent
+            Assert.Equal(msg.Type, ret.Type);
+            Assert.Equal(msg.Ids, ((HaveMessage)ret).Ids);
         }
 
         [Fact]

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -360,6 +360,10 @@ namespace Libplanet.Net.Consensus
                 Message ret = _cache.Get(id);
                 ret.Remote = _transport.AsPeer;
                 ret.Identity = msg.Identity;
+                ret.Timestamp = DateTimeOffset.UtcNow;
+
+                // FIXME: This assumes if we receives a message, then version would match.
+                ret.Version = msg.Version;
                 return ret;
             }).ToArray();
             MessageId[] ids = messages.Select(m => m.Id).ToArray();

--- a/Libplanet.Net/Consensus/MessageCache.cs
+++ b/Libplanet.Net/Consensus/MessageCache.cs
@@ -101,7 +101,9 @@ namespace Libplanet.Net.Consensus
             {
                 if (_messages.TryGetValue(id, out Message? msg))
                 {
-                    return msg;
+                    // FIXME: This is a workaround for preventing any message modification in
+                    // message dictionary.
+                    return NetMQMessageCodec.CreateMessage(msg.Type, msg.DataFrames.ToArray());
                 }
 
                 throw new KeyNotFoundException($"A message of id {id} does not exist.");

--- a/Libplanet.Net/Consensus/MessageCache.cs
+++ b/Libplanet.Net/Consensus/MessageCache.cs
@@ -88,7 +88,8 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
-        /// Gets the message with <paramref name="id"/> if it exists in the message cache.
+        /// Gets the message with <paramref name="id"/> if it exists in the message cache. Returned
+        /// message contains no original metadata from <see cref="Message"/>.
         /// </summary>
         /// <param name="id">A <see cref="MessageId"/> of the <see cref="Message"/> to get.</param>
         /// <returns>A message with id <paramref name="id"/>.</returns>

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Messages
             return message;
         }
 
-        private Message CreateMessage(Message.MessageType type, byte[][] dataframes)
+        internal static Message CreateMessage(Message.MessageType type, byte[][] dataframes)
         {
             switch (type)
             {


### PR DESCRIPTION
This PR resolves the modification of `Message` in `MessageCache` from outside by `Get()`. If the multiple `HandleWantAsync()` tasks are called, `Message ret` is modified because `Message ret` from `MessageCache.Get()` references the message in actual `Message` in the dictionary.

```Csharp
private async Task HandleWantAsync(WantMessage msg, CancellationToken ctx)
{
    // FIXME: Message may have been discarded.
    // TODO: Message instance in cache itself is modified.
    // Should create new instance before modifying.
    Message[] messages = msg.Ids.Select(id =>
    {
        Message ret = _cache.Get(id); // <= Where the bug is happened.
        ret.Remote = _transport.AsPeer;
        ret.Identity = msg.Identity;
        return ret;
    }).ToArray();
    MessageId[] ids = messages.Select(m => m.Id).ToArray();

    _logger.Debug(
        "WantMessage: Requests are: {Idr}, Ids are: {Id}, Messages are: {@Messages}",
        msg.Ids,
        ids,
        messages);
    IEnumerable<Task> tasks = messages.Select(m => _transport.ReplyMessageAsync(m, ctx));
    await Task.WhenAll(tasks);
    _logger.Debug("Finished replying WantMessage.");
}
```

## Log
This is the proof of concept of the current bug. Note that `Identity` is one of the `Message` fields. Because of this, the `ConsensusMsg` is not received at the surface. (Because of this, https://github.com/planetarium/libplanet/pull/2770/commits/35916fc5255b5ae4c67a90c4741de43575f78107 revert is done.)
``` md
[13:15:05 DBG] [NetMQTransport] Received message cae2bc53-9711-4b75-a204-5ec6d0c8bb8d Libplanet.Net.Messages.WantMessage from-.Unspecified/localhost:6003..
[13:15:05 DBG] [NetMQTransport] A reply to request ["NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame"] b95be90e-62ad-4247-84bc-7d7409c1853f from -.Unspecified/localhost:6003. has parsed: Libplanet.Net.Messages.ConsensusPreVoteMsg.
[13:15:05 DBG] [NetMQTransport] Request b89c6c13-b54c-41cc-95fe-f0179e429a4b Libplanet.Net.Messages.WantMessage processed in 10ms with 1 replies received out of 1 expected replies.
[13:15:05 DBG] [RoutingTable] Adding peer -.Unspecified/localhost:6003. to the routing table...
[13:15:05 DBG] [NetMQTransport] Received 1 reply messages to b95be90e-62ad-4247-84bc-7d7409c1853f from -.Unspecified/localhost:6003.: ["Libplanet.Net.Messages.ConsensusPreVoteMsg"].
[13:15:05 DBG] [NetMQTransport] A reply to request ["NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame", "NetMQ.NetMQFrame"] b89c6c13-b54c-41cc-95fe-f0179e429a4b from -.Unspecified/localhost:6002. has parsed: Libplanet.Net.Messages.ConsensusPreVoteMsg.
[13:15:05 DBG] [NetMQTransport] Received 1 reply messages to b89c6c13-b54c-41cc-95fe-f0179e429a4b from -.Unspecified/localhost:6002.: ["Libplanet.Net.Messages.ConsensusPreVoteMsg"].
[13:15:05 DBG] [NetMQTransport] Received message 20211b88-0762-4925-9609-3ef92141d65c Libplanet.Net.Messages.WantMessage from -.Unspecified/localhost:6002..
[13:15:05 DBG] [RoutingTable] Adding peer -.Unspecified/localhost:6002. to the routing table...
[13:15:05 DBG] [Context] AddMessage: Message: Libplanet.Net.Messages.ConsensusPreVoteMsg => Height: 4939, Round: 0, Validator Address: -, Remote Address: -, Hash: -, MessageCount: 4. (context: {"node_id":"-","number_of_validators":4,"height":4939,"round":0,"step":"PreVote","locked_value":"null","locked_round":-1,"valid_value":"null","valid_round":-1})
[13:15:05 DBG] [Context] State (MessageLogSize, Round, Step) changed from (3, 0, PreVote) to (4, 0, PreVote)
[13:15:05 DBG] [Gossip] Creating: cae2bc53-9711-4b75-a204-5ec6d0c8bb8d
[13:15:05 DBG] [Gossip] Creating: 20211b88-0762-4925-9609-3ef92141d65c
[13:15:05 DBG] [Gossip] Creating: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Context] PreVote step in round 0 is scheduled to be timed out because 2/3+ PreVotes are collected for the round. (context: {"node_id":"-","number_of_validators":4,"height":4939,"round":0,"step":"PreVote","locked_value":"null","locked_round":-1,"valid_value":"null","valid_round":-1})
[13:15:05 DBG] [Gossip] Identity in cache: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Gossip] Identity in cache: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Gossip] Identity in cache: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Gossip] Reply Message: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Gossip] Reply Message: 093d3597-982d-4577-96d4-0f2e5fc51ecf
[13:15:05 DBG] [Gossip] Reply Message: 093d3597-982d-4577-96d4-0f2e5fc51ecf
```

## Changes
Before the `MessageCache.Get()` returns the `Message`, a new empty `Message` with the reference `Message` in the message dictionary. Before the reply to the message, the given `Message` from `MessageCache.Get()` should be filled with information (`Identity`, `Version`, `Remote`, `Timestamp`).

## Further discussion
For the nature of `MessageCache`, we should decide how should we clone the message or in an alternative way. See `NetMQMessageCodec` fix for context. (https://github.com/planetarium/libplanet/pull/2770/commits/327e2571413cff71397ddae15b1d57704e691c39)