### PR TITLE
Ignore too low length candidate

### DIFF
--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -49,7 +49,10 @@ namespace Libplanet.Net
             {
                 var sortedBlocks =
                     new SortedList<long, Block<T>>(blocks.ToDictionary(i => i.Index));
-                _blocks.TryAdd(blockHeader, sortedBlocks);
+                if (sortedBlocks.Count > 0)
+                {
+                    _blocks.TryAdd(blockHeader, sortedBlocks);
+                }
             }
             catch (ArgumentException e)
             {

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Net
                     BlockHeader tipHeader = BlockChain.Tip.Header;
                     SortedList<long, Block<T>> blocks =
                         BlockCandidateTable.GetCurrentRoundCandidate(tipHeader);
-                    if (!(blocks is null))
+                    if (!(blocks is null) && blocks.Count > 0)
                     {
                         var latest = blocks.Last();
                         _logger.Debug(


### PR DESCRIPTION
# Context
There is some problem when 0 length candidate is in the table.
In this PR. We ignore if we try to add 0 length candidate in the CandidateTable.