### PR TITLE
♻️ Introduce `IBencodable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,14 @@ To be released.
     `AppProtocolVersionOptions.TrustedAppProtocolVersionSigners` from
     `IImmutableHashSet<PublicKey>?` to `IImmutableHashSet<PublicKey>`.
     [[#2759]]
+ -  (Libplanet.Net) Changed `BoundPeer` to implement `IBencodable` interface
+    and removed `[Serializable]` attribute from `BoundPeer`.  [[#2778]]
+ -  (Libplanet.Net) Changed `BoundPeer(Dictionary)` constructor's signature to
+    `BoundPeer(IValue)`.  [[#2778]]
+ -  Changed `Address` to implement `IBencodable` interface and removed
+    `[Serializable]` attribute from `Address`.  [[#2778]]
+ -  Changed `Address(Binary)` constructor's signature to `Address(IValue)`.
+    [[#2778]]
 
 ### Backward-incompatible network protocol changes
 
@@ -95,6 +103,7 @@ To be released.
 [#2758]: https://github.com/planetarium/libplanet/pull/2758
 [#2759]: https://github.com/planetarium/libplanet/pull/2759
 [#2761]: https://github.com/planetarium/libplanet/pull/2761
+[#2778]: https://github.com/planetarium/libplanet/pull/2778
 [#2780]: https://github.com/planetarium/libplanet/pull/2780
 [#2781]: https://github.com/planetarium/libplanet/pull/2781
 [Bencodex 0.8.0]: https://www.nuget.org/packages/Bencodex/0.8.0

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -1,9 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Runtime.Serialization.Formatters.Binary;
 using Libplanet.Crypto;
 using Xunit;
 
@@ -29,22 +27,6 @@ namespace Libplanet.Net.Tests
                     new DnsEndPoint("0.0.0.0", 1234)),
             },
         };
-
-        [Theory]
-        [MemberData(nameof(GetBoundPeers))]
-        public void Serializable(BoundPeer peer)
-        {
-            var formatter = new BinaryFormatter();
-            using (var stream = new MemoryStream())
-            {
-                formatter.Serialize(stream, peer);
-                byte[] serialized = stream.ToArray();
-                stream.Seek(0, SeekOrigin.Begin);
-                BoundPeer deserialized = (BoundPeer)formatter.Deserialize(stream);
-                Assert.IsType(peer.GetType(), deserialized);
-                Assert.Equal(peer, deserialized);
-            }
-        }
 
         [Theory]
         [MemberData(nameof(GetBoundPeers))]

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -48,12 +48,12 @@ namespace Libplanet.Net.Tests
 
         [Theory]
         [MemberData(nameof(GetBoundPeers))]
-        public void Serialize(BoundPeer peer)
+        public void Bencode(BoundPeer peer)
         {
-            Bencodex.Types.Dictionary serialized = peer.ToBencodex();
-            var deserialized = new BoundPeer(serialized);
+            Bencodex.Types.IValue bencoded = peer.Bencoded;
+            var decoded = new BoundPeer(bencoded);
 
-            Assert.Equal(peer, deserialized);
+            Assert.Equal(peer, decoded);
         }
 
         [Fact]

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -31,7 +31,12 @@ namespace Libplanet.Net
         }
 
         public BoundPeer(Bencodex.Types.IValue bencoded)
-            : this((Bencodex.Types.Dictionary)bencoded)
+            : this(bencoded is Bencodex.Types.Dictionary dict
+                ? dict
+                : throw new ArgumentException(
+                    $"Given {nameof(bencoded)} must be of type " +
+                    $"{typeof(Bencodex.Types.Dictionary)}: {bencoded.GetType()}",
+                    nameof(bencoded)))
         {
         }
 

--- a/Libplanet.Net/BoundPeer.cs
+++ b/Libplanet.Net/BoundPeer.cs
@@ -2,17 +2,14 @@ using System;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Net;
-using System.Runtime.Serialization;
 using Bencodex;
 using Bencodex.Types;
 using Destructurama.Attributed;
 using Libplanet.Crypto;
-using Libplanet.Serialization;
 
 namespace Libplanet.Net
 {
-    [Serializable]
-    public sealed class BoundPeer : ISerializable, IEquatable<BoundPeer>, IBencodable
+    public sealed class BoundPeer : IEquatable<BoundPeer>, IBencodable
     {
         private static readonly byte[] PublicKeyKey = { 0x70 }; // 'p'
         private static readonly byte[] EndPointHostKey = { 0x68 }; // 'h'
@@ -62,18 +59,6 @@ namespace Libplanet.Net
                     (Text)bencoded[EndPointHostKey], (Integer)bencoded[EndPointPortKey]),
                 bencoded[PublicIpAddressKey] is Text text ? IPAddress.Parse(text) : null)
         {
-        }
-
-        private BoundPeer(SerializationInfo info, StreamingContext context)
-        {
-            PublicKey = new PublicKey(info.GetValue<byte[]>(nameof(PublicKey)));
-            EndPoint = new DnsEndPoint(
-                info.GetString("end_point_host"),
-                info.GetInt32("end_point_port"));
-            if (info.GetString(nameof(PublicIPAddress)) is string address)
-            {
-                PublicIPAddress = IPAddress.Parse(address);
-            }
         }
 
         /// <summary>
@@ -195,16 +180,6 @@ namespace Libplanet.Net
 
         public override int GetHashCode() => HashCode.Combine(
             HashCode.Combine(PublicKey.GetHashCode(), PublicIPAddress?.GetHashCode()), EndPoint);
-
-        public void GetObjectData(
-            SerializationInfo info,
-            StreamingContext context)
-        {
-            info.AddValue(nameof(PublicKey), PublicKey.Format(true));
-            info.AddValue("end_point_host", EndPoint.Host);
-            info.AddValue("end_point_port", EndPoint.Port);
-            info.AddValue(nameof(PublicIPAddress), PublicIPAddress?.ToString());
-        }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Libplanet.Net/Messages/NeighborsMsg.cs
+++ b/Libplanet.Net/Messages/NeighborsMsg.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Net.Messages
             {
                 var frames = new List<byte[]>();
                 frames.Add(BitConverter.GetBytes(Found.Count));
-                frames.AddRange(Found.Select(boundPeer => Codec.Encode(boundPeer.ToBencodex())));
+                frames.AddRange(Found.Select(boundPeer => Codec.Encode(boundPeer.Bencoded)));
                 return frames;
             }
         }

--- a/Libplanet.Net/Messages/NeighborsMsg.cs
+++ b/Libplanet.Net/Messages/NeighborsMsg.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Messages
             var codec = new Codec();
             int foundCount = BitConverter.ToInt32(dataFrames[0], 0);
             Found = dataFrames.Skip(1).Take(foundCount)
-                .Select(ba => new BoundPeer((Bencodex.Types.Dictionary)codec.Decode(ba)))
+                .Select(ba => new BoundPeer(codec.Decode(ba)))
                 .ToImmutableList();
         }
 

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -100,9 +100,7 @@ namespace Libplanet.Net.Messages
             var versionToken = remains[(int)Message.MessageFrame.Version].ConvertToString();
 
             AppProtocolVersion remoteVersion = AppProtocolVersion.FromToken(versionToken);
-            var dictionary =
-                (Bencodex.Types.Dictionary)_codec.Decode(
-                    remains[(int)Message.MessageFrame.Peer].ToByteArray());
+            var dictionary = _codec.Decode(remains[(int)Message.MessageFrame.Peer].ToByteArray());
             BoundPeer remotePeer = new BoundPeer(dictionary);
 
             var type =

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Net.Messages
 
             // Write headers. (inverse order, version-type-peer-timestamp)
             netMqMessage.Push(timestamp.Ticks);
-            netMqMessage.Push(_codec.Encode(peer.ToBencodex()));
+            netMqMessage.Push(_codec.Encode(peer.Bencoded));
             netMqMessage.Push((int)message.Type);
             netMqMessage.Push(appProtocolVersion.Token);
 

--- a/Libplanet.Net/Transports/CommunicationFailException.cs
+++ b/Libplanet.Net/Transports/CommunicationFailException.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Net.Messages;
+using Libplanet.Serialization;
 
 namespace Libplanet.Net.Transports
 {
@@ -12,6 +14,8 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class CommunicationFailException : Exception
     {
+        private static Codec _codec = new Codec();
+
         public CommunicationFailException(
             string message,
             Message.MessageType messageType,
@@ -36,9 +40,7 @@ namespace Libplanet.Net.Transports
         public CommunicationFailException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Peer = info.GetValue(nameof(Peer), typeof(BoundPeer)) is BoundPeer peer
-                ? peer
-                : throw new SerializationException($"{nameof(Peer)} is of an invalid type.");
+            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
             MessageType = info.GetValue(nameof(MessageType), typeof(Message.MessageType))
                 is Message.MessageType messageType
                 ? messageType
@@ -52,7 +54,7 @@ namespace Libplanet.Net.Transports
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), Peer, typeof(BoundPeer));
+            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
             info.AddValue(nameof(MessageType), MessageType, typeof(Message.MessageType));
         }
     }

--- a/Libplanet.Net/Transports/CommunicationFailException.cs
+++ b/Libplanet.Net/Transports/CommunicationFailException.cs
@@ -47,9 +47,9 @@ namespace Libplanet.Net.Transports
                 : throw new SerializationException($"{nameof(MessageType)} is of an invalid type.");
         }
 
-        public BoundPeer Peer { get; private set; }
+        public BoundPeer Peer { get; }
 
-        public Message.MessageType MessageType { get; private set; }
+        public Message.MessageType MessageType { get; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
+++ b/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
@@ -41,13 +41,13 @@ namespace Libplanet.Net.Transports
             Signature = info.GetValue<byte[]>(nameof(Signature));
         }
 
-        public BoundPeer Peer { get; private set; }
+        public BoundPeer Peer { get; }
 
-        public PublicKey PublicKey { get; private set; }
+        public PublicKey PublicKey { get; }
 
-        public byte[] MessageToVerify { get; private set; }
+        public byte[] MessageToVerify { get; }
 
-        public byte[] Signature { get; private set; }
+        public byte[] Signature { get; }
 
         public override void GetObjectData(
             SerializationInfo info, StreamingContext context)

--- a/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
+++ b/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Serialization;
@@ -13,6 +14,8 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class InvalidMessageSignatureException : Exception
     {
+        private static Codec _codec = new Codec();
+
         internal InvalidMessageSignatureException(
             string message,
             BoundPeer peer,
@@ -32,7 +35,7 @@ namespace Libplanet.Net.Transports
             StreamingContext context)
             : base(info, context)
         {
-            Peer = info.GetValue<BoundPeer>(nameof(Peer));
+            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
             PublicKey = new PublicKey(info.GetValue<byte[]>(nameof(PublicKey)));
             MessageToVerify = info.GetValue<byte[]>(nameof(MessageToVerify));
             Signature = info.GetValue<byte[]>(nameof(Signature));
@@ -50,7 +53,7 @@ namespace Libplanet.Net.Transports
             SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), Peer);
+            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
             info.AddValue(nameof(PublicKey), PublicKey.Format(true));
             info.AddValue(nameof(MessageToVerify), MessageToVerify);
             info.AddValue(nameof(Signature), Signature);

--- a/Libplanet.Net/Transports/SendMessageFailException.cs
+++ b/Libplanet.Net/Transports/SendMessageFailException.cs
@@ -37,7 +37,7 @@ namespace Libplanet.Net.Transports
             Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
         }
 
-        public BoundPeer Peer { get; private set; }
+        public BoundPeer Peer { get; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/Libplanet.Net/Transports/SendMessageFailException.cs
+++ b/Libplanet.Net/Transports/SendMessageFailException.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Net.Messages;
+using Libplanet.Serialization;
 
 namespace Libplanet.Net.Transports
 {
@@ -10,6 +12,8 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class SendMessageFailException : Exception
     {
+        private static Codec _codec = new Codec();
+
         internal SendMessageFailException(
             string message,
             BoundPeer peer)
@@ -30,9 +34,7 @@ namespace Libplanet.Net.Transports
         protected SendMessageFailException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Peer = info.GetValue(nameof(Peer), typeof(BoundPeer)) is BoundPeer peer
-                ? peer
-                : throw new SerializationException($"{nameof(Peer)} is of an invalid type.");
+            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
         }
 
         public BoundPeer Peer { get; private set; }
@@ -40,7 +42,7 @@ namespace Libplanet.Net.Transports
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), Peer, typeof(BoundPeer));
+            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
         }
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1247,9 +1247,9 @@ namespace Libplanet.Tests.Action
             public void LoadPlainValue(IValue plainValue)
             {
                  var asList = (List)plainValue;
-                 SignerKey = new Address((Binary)asList[0]);
-                 MinerKey = new Address((Binary)asList[1]);
-                 BlockIndexKey = new Address((Binary)asList[2]);
+                 SignerKey = new Address(asList[0]);
+                 MinerKey = new Address(asList[1]);
+                 BlockIndexKey = new Address(asList[2]);
             }
 
             public IAccountStateDelta Execute(IActionContext context) =>

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -157,11 +157,11 @@ namespace Libplanet.Tests
 
             Assert.Equal(
                 new Address("0123456789ABcdefABcdEfABcdEFabcDEFabCDEF"),
-                new Address((Binary)addr)
+                new Address((IValue)new Binary(addr))
             );
 
             var invalidAddr = new byte[19];
-            Assert.Throws<ArgumentException>(() => new Address((Binary)invalidAddr));
+            Assert.Throws<ArgumentException>(() => new Address((IValue)new Binary(invalidAddr)));
         }
 
         [Fact]

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Xunit;
@@ -243,7 +241,7 @@ namespace Libplanet.Tests
         }
 
         [Fact]
-        public void SerializeAndDeserialize()
+        public void Bencode()
         {
             // Serialize and deserialize to and from memory
             var expectedAddress = new Address(
@@ -253,15 +251,7 @@ namespace Libplanet.Tests
                     0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
                 }
             );
-            Address deserializedAddress;
-            BinaryFormatter formatter = new BinaryFormatter();
-            using (var memoryStream = new MemoryStream())
-            {
-                formatter.Serialize(memoryStream, expectedAddress);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                deserializedAddress = (Address)formatter.Deserialize(memoryStream);
-            }
-
+            Address deserializedAddress = new Address(expectedAddress.Bencoded);
             Assert.Equal(deserializedAddress, expectedAddress);
         }
 
@@ -269,15 +259,8 @@ namespace Libplanet.Tests
         public void SerializeAndDeserializeWithDefault()
         {
             var defaultAddress = default(Address);
-            BinaryFormatter formatter = new BinaryFormatter();
-
-            using (var memoryStream = new MemoryStream())
-            {
-                formatter.Serialize(memoryStream, defaultAddress);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                var deserializedAddress = (Address)formatter.Deserialize(memoryStream);
-                Assert.Equal(default, deserializedAddress);
-            }
+            Address deserializedAddress = new Address(defaultAddress.Bencoded);
+            Assert.Equal(default, deserializedAddress);
         }
 
         [Fact]

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Common.Action
         {
             Weapon = (Text)plainValue["weapon"];
             Target = (Text)plainValue["target"];
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
+            TargetAddress = new Address(plainValue.GetValue<IValue>("target_address"));
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/DetectRehearsal.cs
+++ b/Libplanet.Tests/Common/Action/DetectRehearsal.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Common.Action
 
         public void LoadPlainValue(Bencodex.Types.Dictionary plainValue)
         {
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
+            TargetAddress = new Address(plainValue.GetValue<IValue>("target_address"));
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -234,7 +234,7 @@ namespace Libplanet.Tests.Common.Action
         public void LoadPlainValue(Dictionary plainValue)
         {
             Item = plainValue.GetValue<Text>("item");
-            TargetAddress = new Address(plainValue.GetValue<Binary>("target_address"));
+            TargetAddress = new Address(plainValue.GetValue<IValue>("target_address"));
             RecordRehearsal = plainValue.GetValue<Boolean>("record_rehearsal").Value;
             RecordRandom =
                 plainValue.ContainsKey((IKey)(Text)"record_random") &&
@@ -246,10 +246,8 @@ namespace Libplanet.Tests.Common.Action
                 Idempotent = plainValue.GetValue<Boolean>("idempotent");
             }
 
-            if (plainValue.TryGetValue((Text)"transfer_from", out IValue f) &&
-                f is Binary from &&
-                plainValue.TryGetValue((Text)"transfer_to", out IValue t) &&
-                t is Binary to &&
+            if (plainValue.TryGetValue((Text)"transfer_from", out IValue from) &&
+                plainValue.TryGetValue((Text)"transfer_to", out IValue to) &&
                 plainValue.TryGetValue((Text)"transfer_amount", out IValue a) &&
                 a is Integer amount)
             {

--- a/Libplanet.Tests/Common/Action/RandomAction.cs
+++ b/Libplanet.Tests/Common/Action/RandomAction.cs
@@ -14,6 +14,8 @@ namespace Libplanet.Tests.Common.Action
             Address = address;
         }
 
+        // FIXME: Should be encoded in bencodex binary, not text.  Left as is for
+        // old unit test spec compliance.
         public IValue PlainValue => Bencodex.Types.Dictionary.Empty
             .Add("address", Address.ToHex());
 
@@ -22,7 +24,7 @@ namespace Libplanet.Tests.Common.Action
         public void LoadPlainValue(IValue plainValue)
         {
             var dictionary = (Bencodex.Types.Dictionary)plainValue;
-            Address = new Address(dictionary.GetValue<Text>("address"));
+            Address = new Address((string)dictionary.GetValue<Text>("address"));
         }
 
         public IAccountStateDelta Execute(IActionContext context)

--- a/Libplanet.Tests/Common/Action/SetStatesAtBlock.cs
+++ b/Libplanet.Tests/Common/Action/SetStatesAtBlock.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Tests.Common.Action
         public void LoadPlainValue(IValue plainValue)
         {
             var dict = (Bencodex.Types.Dictionary)plainValue;
-            _address = new Address(dict.GetValue<Binary>("address"));
+            _address = new Address(dict.GetValue<IValue>("address"));
             _value = dict["value"];
             _blockIndex = dict.GetValue<Bencodex.Types.Integer>("block_index");
         }

--- a/Libplanet/Action/InsufficientBalanceException.cs
+++ b/Libplanet/Action/InsufficientBalanceException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Assets;
 using Libplanet.Serialization;
 
@@ -14,6 +15,8 @@ namespace Libplanet.Action
     [Serializable]
     public sealed class InsufficientBalanceException : Exception
     {
+        private static Codec _codec = new Codec();
+
         /// <summary>
         /// Creates a new <see cref="InsufficientBalanceException"/> object.
         /// </summary>
@@ -36,7 +39,7 @@ namespace Libplanet.Action
         private InsufficientBalanceException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Address = info.GetValue<Address>(nameof(Address));
+            Address = new Address(_codec.Decode(info.GetValue<byte[]>(nameof(Address))));
             Balance = info.GetValue<FungibleAssetValue>(nameof(Balance));
         }
 
@@ -54,7 +57,7 @@ namespace Libplanet.Action
         {
             base.GetObjectData(info, context);
 
-            info.AddValue(nameof(Address), Address);
+            info.AddValue(nameof(Address), _codec.Encode(Address.Bencoded));
             info.AddValue(nameof(Balance), Balance);
         }
     }

--- a/Libplanet/Action/Sys/Mint.cs
+++ b/Libplanet/Action/Sys/Mint.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Action.Sys
         public void LoadPlainValue(IValue plainValue)
         {
             var dict = (Bencodex.Types.Dictionary)plainValue;
-            Recipient = new Address(dict.GetValue<Binary>("recipient"));
+            Recipient = new Address(dict.GetValue<IValue>("recipient"));
             Amount = new FungibleAssetValue(
                 new Currency(dict["currency"]),
                 dict.GetValue<Bencodex.Types.Integer>("amount")

--- a/Libplanet/Action/Sys/Transfer.cs
+++ b/Libplanet/Action/Sys/Transfer.cs
@@ -49,7 +49,7 @@ namespace Libplanet.Action.Sys
         public void LoadPlainValue(IValue plainValue)
         {
             var dict = (Bencodex.Types.Dictionary)plainValue;
-            Recipient = new Address(dict.GetValue<Binary>("recipient"));
+            Recipient = new Address(dict.GetValue<IValue>("recipient"));
             Amount = new FungibleAssetValue(
                 new Currency(dict["currency"]),
                 dict.GetValue<Bencodex.Types.Integer>("amount")

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -4,14 +4,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
-using Libplanet.Serialization;
 using Org.BouncyCastle.Crypto.Digests;
 
 namespace Libplanet
@@ -43,9 +41,8 @@ namespace Libplanet
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
     [JsonConverter(typeof(AddressJsonConverter))]
-    [Serializable]
     public readonly struct Address
-        : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable, IBencodable
+        : IEquatable<Address>, IComparable<Address>, IComparable, IBencodable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="Address"/> takes.
@@ -153,14 +150,6 @@ namespace Libplanet
         {
         }
 
-        private Address(
-            SerializationInfo info,
-            StreamingContext context)
-            : this(info?.GetValue<byte[]>("address") ??
-                throw new SerializationException("Missing the address field."))
-        {
-        }
-
         /// <summary>
         /// An immutable array of 20 <see cref="byte"/>s that represent this
         /// <see cref="Address"/>.
@@ -168,18 +157,10 @@ namespace Libplanet
         /// <remarks>This is immutable.  For a mutable array, call <see
         /// cref="ToByteArray()"/> method.</remarks>
         /// <seealso cref="ToByteArray()"/>
-        public ImmutableArray<byte> ByteArray
-        {
-            get
-            {
-                if (_byteArray.IsDefault)
-                {
-                    return _defaultByteArray.ToImmutableArray();
-                }
-
-                return _byteArray;
-            }
-        }
+        public ImmutableArray<byte> ByteArray =>
+            _byteArray.IsDefault
+                ? _defaultByteArray.ToImmutableArray()
+                : _byteArray;
 
         /// <inheritdoc/>
         public IValue Bencoded => new Binary(ByteArray);
@@ -252,12 +233,6 @@ namespace Libplanet
         public override string ToString()
         {
             return $"0x{ToHex()}";
-        }
-
-        /// <inheritdoc />
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("address", ToByteArray());
         }
 
         /// <inheritdoc cref="IComparable{T}.CompareTo(T)"/>

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Serialization;
@@ -44,7 +45,7 @@ namespace Libplanet
     [JsonConverter(typeof(AddressJsonConverter))]
     [Serializable]
     public readonly struct Address
-        : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable
+        : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable, IBencodable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="Address"/> takes.
@@ -135,16 +136,20 @@ namespace Libplanet
         }
 
         /// <summary>
-        /// Creates an <see cref="Address"/> instance from the given Bencodex <see cref="Binary"/>
-        /// (i.e., <paramref name="address"/>).
+        /// Creates an <see cref="Address"/> instance from given <paramref name="bencoded"/>.
         /// </summary>
-        /// <param name="address">A Bencodex <see cref="Binary"/> of 20 <see cref="byte"/>s which
+        /// <param name="bencoded">A Bencodex <see cref="Binary"/> of 20 <see cref="byte"/>s which
         /// represents an <see cref="Address"/>.
         /// </param>
-        /// <exception cref="ArgumentException">Thrown when the given <paramref name="address"/>
-        /// did not lengthen 20 bytes.</exception>
-        public Address(Binary address)
-            : this(address.ByteArray)
+        /// <exception cref="ArgumentException">Thrown when given <paramref name="bencoded"/>
+        /// is not an encoding of a <see cref="byte"/> array of length 20.</exception>
+        public Address(IValue bencoded)
+            : this((Binary)bencoded)
+        {
+        }
+
+        private Address(Binary bencoded)
+            : this(bencoded.ByteArray)
         {
         }
 
@@ -175,6 +180,9 @@ namespace Libplanet
                 return _byteArray;
             }
         }
+
+        /// <inheritdoc/>
+        public IValue Bencoded => new Binary(ByteArray);
 
         public static bool operator ==(Address left, Address right) => left.Equals(right);
 

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -139,9 +139,14 @@ namespace Libplanet
         /// represents an <see cref="Address"/>.
         /// </param>
         /// <exception cref="ArgumentException">Thrown when given <paramref name="bencoded"/>
-        /// is not an encoding of a <see cref="byte"/> array of length 20.</exception>
+        /// is not of type <see cref="Binary"/>.</exception>
         public Address(IValue bencoded)
-            : this((Binary)bencoded)
+            : this(bencoded is Binary binary
+                ? (Binary)bencoded
+                : throw new ArgumentException(
+                    $"Given {nameof(bencoded)} must be of type " +
+                    $"{typeof(Bencodex.Types.Binary)}: {bencoded.GetType()}",
+                    nameof(bencoded)))
         {
         }
 

--- a/Libplanet/Blocks/InvalidBlockTxCountPerSignerException.cs
+++ b/Libplanet/Blocks/InvalidBlockTxCountPerSignerException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using Bencodex;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Serialization;
 using Libplanet.Tx;
@@ -13,6 +14,8 @@ namespace Libplanet.Blocks
     [Serializable]
     public sealed class InvalidBlockTxCountPerSignerException : BlockPolicyViolationException
     {
+        private static Codec _codec = new Codec();
+
         /// <summary>
         /// Initializes a new instance of <see cref="InvalidBlockTxCountPerSignerException"/> class.
         /// </summary>
@@ -32,7 +35,7 @@ namespace Libplanet.Blocks
             SerializationInfo info, StreamingContext context)
             : base(info.GetString(nameof(Message)) ?? string.Empty)
         {
-            Signer = info.GetValue<Address>(nameof(Signer));
+            Signer = new Address(_codec.Decode(info.GetValue<byte[]>(nameof(Signer))));
             TxCount = info.GetInt32(nameof(TxCount));
         }
 
@@ -43,7 +46,7 @@ namespace Libplanet.Blocks
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Signer), Signer);
+            info.AddValue(nameof(Signer), _codec.Encode(Signer.Bencoded));
             info.AddValue(nameof(TxCount), TxCount);
         }
     }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -239,7 +239,7 @@ namespace Libplanet.Store
 
                 ImmutableDictionary<Address, IValue> sDelta = d.GetValue<Dictionary>("sDelta")
                     .ToImmutableDictionary(
-                        kv => new Address((Binary)kv.Key),
+                        kv => new Address((IValue)kv.Key),
                         kv => kv.Value is List l && l.Any() ? l[0] : null
                     );
                 IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>
@@ -281,7 +281,7 @@ namespace Libplanet.Store
         private static IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
         DeserializeGroupedFAVs(Bencodex.Types.Dictionary serialized) =>
             serialized.ToImmutableDictionary(
-                kv => new Address((Binary)kv.Key),
+                kv => new Address((IValue)kv.Key),
                 kv => DeserializeFAVs((List)kv.Value)
             );
 

--- a/Libplanet/Tx/TxMetadata.cs
+++ b/Libplanet/Tx/TxMetadata.cs
@@ -72,7 +72,7 @@ namespace Libplanet.Tx
                 ? new BlockHash(g.ByteArray)
                 : (BlockHash?)null;
             UpdatedAddresses = dictionary.GetValue<List>(UpdatedAddressesKey)
-                .Select(v => new Address((Binary)v))
+                .Select(v => new Address(v))
                 .ToImmutableHashSet();
             PublicKey = new PublicKey(dictionary.GetValue<Binary>(PublicKeyKey).ByteArray);
             Timestamp = DateTimeOffset.ParseExact(

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -59,7 +59,7 @@ namespace Libplanet.Tx
             var updatedStates =
                 (Dictionary)Codec.Decode(info.GetValue<byte[]>(nameof(UpdatedStates)));
             UpdatedStates = updatedStates.ToImmutableDictionary(
-                kv => new Address((Binary)kv.Key),
+                kv => new Address(kv.Key),
                 kv => kv.Value is List l && l.Any() ? l[0] : null
             );
             FungibleAssetsDelta = DecodeFungibleAssetGroups(
@@ -154,7 +154,7 @@ namespace Libplanet.Tx
         private static IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
         DecodeFungibleAssetGroups(byte[] encoded) =>
             ((Dictionary)Codec.Decode(encoded)).ToImmutableDictionary(
-                kv => new Address((Binary)kv.Key),
+                kv => new Address(kv.Key),
                 kv => (IImmutableDictionary<Currency, FAV>)((List)kv.Value)
                     .Cast<List>()
                     .Select(pair => (new Currency(pair[0]), (Bencodex.Types.Integer)pair[1]))


### PR DESCRIPTION
Baby steps. 😶
- Allows to remove `[Serializable]` attribute on our own `class`es. `[Serializable]` was being used only for the sake of having objects to be serialized as a part of custom `Exception`s that we wanted to `throw`. This can reduce the exposure to the [warning] by Microsoft.
- `Address` now explicitly accepts `IValue` type not `Binary`. This is my own design decision to have overall consistency down the line.
  - Before this PR, `Address(Binary)` is probably not even necessary as `Binary` would be implicitly casted to `Address(byte[])`. The same goes with `Address(Text)` where the parameter is implicitly casted to `Address(string)`. This makes it more error prone by allowing non-standard usage of `Address` encoding.

[warning]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/serialization/#binary-and-xml-serialization