### PR TITLE
Fix `VolatileStagePolicy<T>`'s `Expired()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,9 @@ To be released.
     [[#2761]]
  -  Fixed where `Address(string)` could accept 42 chars with a wrong prefix.
     [[#2781]]
+ -  Fixed where `VolatileStagePolicy<T>(TimeSpan)` created with
+    `TimeSpan.MaxValue` as its argument would not behave properly and throw an
+    `ArgumentOutOfRangeException`.  [[#2783], [#2784]]
 
 ### Dependencies
 
@@ -106,6 +109,8 @@ To be released.
 [#2778]: https://github.com/planetarium/libplanet/pull/2778
 [#2780]: https://github.com/planetarium/libplanet/pull/2780
 [#2781]: https://github.com/planetarium/libplanet/pull/2781
+[#2783]: https://github.com/planetarium/libplanet/issues/2783
+[#2784]: https://github.com/planetarium/libplanet/pull/2784
 [Bencodex 0.8.0]: https://www.nuget.org/packages/Bencodex/0.8.0
 [Bencodex.Json 0.8.0]: https://www.nuget.org/packages/Bencodex.Json/0.8.0
 [System.Text.Json 6.0.7]: https://www.nuget.org/packages/System.Text.Json/6.0.7

--- a/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/VolatileStagePolicyTest.cs
@@ -15,11 +15,10 @@ namespace Libplanet.Tests.Blockchain.Policies
 
         protected override IStagePolicy<DumbAction> StagePolicy => _stagePolicy;
 
-        [SkippableFact]
+        [Fact]
         public void Lifetime()
         {
-            TimeSpan timeBuffer = TimeSpan.FromSeconds(2.5);
-
+            TimeSpan timeBuffer = TimeSpan.FromSeconds(1);
             Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
                 0,
                 _key,
@@ -27,7 +26,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 Enumerable.Empty<DumbAction>(),
                 timestamp: (DateTimeOffset.UtcNow - _stagePolicy.Lifetime) + timeBuffer
             );
-            _stagePolicy.Stage(_chain, tx);
+            Assert.True(_stagePolicy.Stage(_chain, tx));
             Assert.Equal(tx, _stagePolicy.Get(_chain, tx.Id));
             Assert.Contains(tx, _stagePolicy.Iterate(_chain));
 
@@ -38,7 +37,20 @@ namespace Libplanet.Tests.Blockchain.Policies
             Assert.DoesNotContain(tx, _stagePolicy.Iterate(_chain));
         }
 
-        [SkippableFact]
+        [Fact]
+        public void MaxLifetime()
+        {
+            var stagePolicy = new VolatileStagePolicy<DumbAction>(TimeSpan.MaxValue);
+            Transaction<DumbAction> tx = Transaction<DumbAction>.Create(
+                0,
+                _key,
+                _fx.GenesisBlock.Hash,
+                Enumerable.Empty<DumbAction>(),
+                timestamp: DateTimeOffset.UtcNow);
+            Assert.True(stagePolicy.Stage(_chain, tx));
+        }
+
+        [Fact]
         public void StageUnstage()
         {
             TimeSpan timeBuffer = TimeSpan.FromSeconds(1);

--- a/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
+++ b/Libplanet/Blockchain/Policies/VolatileStagePolicy.cs
@@ -249,7 +249,7 @@ namespace Libplanet.Blockchain.Policies
         }
 
         private bool Expired(Transaction<T> transaction) =>
-            transaction.Timestamp + Lifetime < DateTimeOffset.UtcNow;
+            Lifetime < DateTimeOffset.UtcNow - transaction.Timestamp;
 
         /// <remarks>
         /// It has been intended to avoid recursive lock, hence doesn't hold any synchronous scope.


### PR DESCRIPTION
Closes #2783 
Performing `+` operation on `TimeSpan.MaxValue` results in an `Exception`.