### PR TITLE
Optimized `ParseHex()`

### DIFF
--- a/Libplanet.Node/NodeUtils.cs
+++ b/Libplanet.Node/NodeUtils.cs
@@ -193,8 +193,10 @@ namespace Libplanet.Node
         {
             using (StreamReader stream = new StreamReader(path, Encoding.UTF8))
             {
-                string privateKeyString = stream.ReadLine();
-                return new PrivateKey(ByteUtil.ParseHex(privateKeyString));
+                string? privateKeyString = stream.ReadLine();
+                return new PrivateKey(ByteUtil.ParseHex(privateKeyString
+                    ?? throw new ArgumentNullException(
+                        nameof(privateKeyString), "Expected a string")));
             }
         }
 

--- a/Libplanet.Tests/ByteUtilTest.cs
+++ b/Libplanet.Tests/ByteUtilTest.cs
@@ -33,7 +33,6 @@ namespace Libplanet.Tests
                 ByteUtil.ParseHex(hex)
             );
 
-            Assert.Throws<ArgumentNullException>(() => ByteUtil.ParseHex(null));
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => ByteUtil.ParseHex("abc")
             );

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -29,9 +30,6 @@ namespace Libplanet
         /// <paramref name="hex"/> string represented in hexadecimal.
         /// It lengthens the half of the given <paramref name="hex"/> string.
         /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown when the given
-        /// <paramref name="hex"/> string is <see langword="null"/>.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the length
         /// of the given <paramref name="hex"/> string is an odd number.
         /// </exception>
@@ -43,11 +41,6 @@ namespace Libplanet
         [Pure]
         public static byte[] ParseHex(string hex)
         {
-            if (hex == null)
-            {
-                throw new ArgumentNullException(nameof(hex));
-            }
-
             if (hex.Length % 2 > 0)
             {
                 throw new ArgumentOutOfRangeException(
@@ -59,7 +52,8 @@ namespace Libplanet
             var bytes = new byte[hex.Length / 2];
             for (var i = 0; i < hex.Length / 2; i++)
             {
-                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+                bytes[i] = byte.Parse(
+                    hex.Substring(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             }
 
             return bytes;


### PR DESCRIPTION
A sister PR to #2789.

Only about twice as fast than before. 😶

|   Method |     Mean |    Error |   StdDev |   Median |
|--------- |---------:|---------:|---------:|---------:|
| Original | 909.8 us | 18.03 us | 46.86 us | 934.0 us |
|    Parse | 454.6 us |  8.79 us | 23.16 us | 442.6 us |