### PR TITLE
pbft: Add `LastCommit` as `PreEvaluationHash` input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,6 @@ Version PBFT
  -  Removed `IBlockPolicy.GetMinBlockProtocolVersion()` interface method.
     [[#PBFT]]
 
-
 ### Backward-incompatible API changes
 
  -  Added `LastCommit` property to `IBlockMetadata`.  [[#PBFT]]
@@ -36,6 +35,10 @@ Version PBFT
  -  Added `IStore.PutBlockCommit(BlockCommit)` method.  [[#PBFT]]
  -  Added `IStore.DeleteBlockCommit(BlockHash)` method.  [[#PBFT]]
  -  Added `IStore.GetBlockCommitHashes()` method.  [[#PBFT]]
+ -  `BlockMetadata.MakeCandidateData()` now uses a SHA256 hash of `LastCommit`
+    for creating a candidate data for `PreEvaluationBlockHeader<T>`. Due to this
+    change, `PreEvaluationHash` results different with previous block hash
+    computation if the `BlockMetadata.LastCommit` is not null.  [[#PBFT]]
  -  (Libplanet.Net) Removed `SwarmOptions.StaticPeers`.  [[#PBFT]]
  -  Changed `BlockPolicy<T>()` constructor not to take
     `Func<long, int>` type parameter named `getMinBlockProtocolVersion`.

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -464,11 +464,13 @@ namespace Libplanet.Tests.Action
                 _logger.Debug("{0}[{1}] = {2}", nameof(block2Txs), i, tx.Id);
             }
 
+            // Same as above, use the same timestamp of last commit for each to get a deterministic
+            // test result.
             Block<DumbAction> block2 = ProposeNextBlock(
                 block1,
                 GenesisProposer,
                 block2Txs,
-                lastCommit: CreateBlockCommit(block1));
+                lastCommit: CreateBlockCommit(block1, true));
             AccountStateGetter accountStateGetter = addrs =>
                 addrs.Select(dirty1.GetValueOrDefault).ToArray();
             AccountBalanceGetter accountBalanceGetter = (address, currency)

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bencodex;
@@ -181,6 +182,12 @@ namespace Libplanet.Blocks
         {
             return HashCode.Combine(Height, Round, BlockHash, Votes);
         }
+
+        /// <summary>
+        /// Gets a <see cref="SHA256"/> digested <see cref="BlockCommit"/> hash value.
+        /// </summary>
+        /// <returns>Returns a <see cref="SHA256"/> digested <see cref="BlockCommit"/>.</returns>
+        public HashDigest<SHA256> ToHash() => HashDigest<SHA256>.DeriveFrom(ToByteArray());
 
         /// <inheritdoc/>
         [Pure]

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -285,6 +285,11 @@ namespace Libplanet.Blocks
                 dict = dict.Add("transaction_fingerprint", txHash.ByteArray);
             }
 
+            if (LastCommit is { } lastCommit)
+            {
+                dict = dict.Add("last_commit", lastCommit.ToHash().ByteArray);
+            }
+
             // As blocks hadn't been signed before ProtocolVersion <= 1, the PublicKey property
             // is nullable type-wise.  Blocks with ProtocolVersion <= 1 had a `reward_beneficiary`
             // field, which referred to the Miner address.  On the other hand, blocks with


### PR DESCRIPTION
(The document has originally written in Korean and translated into English.)

# Assumption

**(Correction: The `BlockHash` is being hashed with `StateRootHash`, however, the `LastCommit` is still not unique to a block.)**
https://github.com/planetarium/libplanet/blob/aa1d444f32ba468fb15186d7113078a52f164b84/Libplanet/Blocks/BlockHeader.cs#L65-L75

Afterward, when going to Proof-of-Stake and confirming that each `Validator` has participated in the consensus on the n-1th `Block`, it is confirmed using `LastCommit` of the nth `Block`, and this is used to confirm the validity of the `Validators` `Stake` is compensated when the corresponding `Block` is appended to the chain, and this information is stored in `State`.

*(Things to check: Is the value used for Power staking part of `Stake` by `Validator`, and the compensation received by participating in the consensus is applied as a change in Power value? Even if `Stake` increases, this information is Since it may be very different, the problem seems to still apply)*

If there is a way to check votes without using LastCommit, I can think of it the other way around.

## Current block validation premise

- In the network, `Block` is created through the agreement of `Context`.
- `Block` is verified through `Hash`, `LastCommit`, and `Commit`
- `Commit` must have a signature of +2/3 Power (PKI + By Quorum)
- `LastCommit` must also have the same conditions as `Commit` (PKI + By Quorum)
- `LastCommit` is not entered in `Hash` of `Block`
- `StateRootHash` is the result of `State` hash operation excluding the proposed `Block`

# Problem

`Block<T>` can have different `LastCommit`. In this case, if `State` is changed according to the above assumption by using different `LastCommit` for each node (including Validator), Power of `Validator` between nodes may result in different results.

## Network Partition

- Validator $A, B, C, D, E$
- Non-validator nodes $N_1, N_2$
- Block is `Block<T>`
- `BlockCommit` is the set of `Votes` of validators who voted for block, `PreCommit`
- `Commit` is `BlockCommit` of the block
- `LastCommit` means `BlockCommit` of previous block

Assuming the following situation,
```mermaid
graph TD
    subgraph ValidatorABCD
    P[Block #1] --> Q[Block #2] --> R[Block #3] --> S[Block #4]
    T(Commit #1) --> U(Commit #2) --> V(Commit #3) --> W[Commit #4]
    end

		subgraph ValidatorE
    G[Block #1] --> H[Block #2] --> I[Block #3] --> J[Block #4]
    K(Commit #1) --> L(Commit #2) --> M(Commit #3_) --> O[Commit #4]
    end
```

```mermaid
classDiagram
class Commit3{
ValidatorA PreCommit
ValidatorB PreCommit
ValidatorC PreCommit
ValidatorD PreCommit
ValidatorE Null
}

class Commit3_{
  ValidatorA PreCommit
  ValidatorB PreCommit
  ValidatorC PreCommit
  ValidatorD PreCommit
  ValidatorE PreCommit
}
```
There are two LastCommits for Block 4 on the network, and Validator $E$ has Block 4 that has Commit3_.

### 1. If $N_1, N_2$ receive a block from the block sync, according to the block verification premise,

- Node $N_1$ receiving a blocks from validators $A,B,C,D$ mutates the power of $A,B,C,D$, respectively.
- Node $N_2$ receiving a block from validator $E$ mutates the power of $A, B, C, D$, and $E$

⇒ $N_1$ and $N_2$ check the signature, power, and block hash and append the block. If there is one block with different LastCommits in the network, It is not known which block is determined by the proposer, in terms of implementation, the node that first appended the block.

### 2. In case Validator $D$ receives `Block #4 + LastCommit3_` from Validator $E$ through block sync

- While Validator $A,B,C$ mutates the power of $A,B,C,D$
- Validator $D, E$ mutates the power of $A, B, C, D$, $E$

### Common

When attempting to append the next `Block #5` from Validator $A, B, C$, the node receiving the block from Validator $E$ has a different `State`, so it cannot be appended. It is intended that `State` is blocked, but since `State` changes with reference to `LastCommit` for power compensation, if nodes with different `State` occur, the chain will change and fall out, and recovery in the current situation appears to be difficult.

```mermaid
graph LR
		subgraph ValidatorABC
    abcb1[Block1] --> abcb2[Block2] --> abcb3[Block3] --> abcb4[Block4] --> abcb5[Block5] 
    abcs1[Empty] --> abcs2[State1] --> abcs3[State2] --> abcs4[State3] --> abcs5[State4]
    abcl1[null] --> abcl2[LastCommit1] --> abcl3[LastCommit2] --> abcl4[LastCommit3] --> abcl5[LastCommit4]
		abcc1[Commit1] --> abcc2[Commit2] --> abcc3[Commit3] --> abcc4[Commit4] --> abcc5[Commit5]
		end
		subgraph ValidatorE
    eb1[Block1] --> eb2[Block2] --> eb3[Block3] --> eb4[Block4] --> |StateRootHash Differs| abcb5
    es1[Empty] --> es2[State1] --> es3[State2] --> es4[State3_] --> |StateRootHash Differs| abcs5
    el1[null] --> el2[LastCommit1] --> el3[LastCommit2] --> el4[LastCommit3_] --> abcl5
		ec1[Commit1] --> ec2[Commit2] --> ec3[Commit3_] --> ec4[Commit4] --> abcc5
		end
```

# Change

- Make `LastCommit` unique by including it in `Block` hash calculation. By making the `Hash` of `Block` related to `LastCommit`, it seems possible to prevent other `LastCommit` from existing at the time the corresponding `Block` is proposed.
     - Timing of change: Since this is a modification in which the `Hash` of `Block` is changed, PoW can be treated as null and passed.

Also, there might be some changes that should be covered but I didn't, PTAL. 🙏