### PR TITLE
♻️ Refactor `BlockCandidateTable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `BlockCandidateTable<T>.Any()` method.  [[#2794]]
+ -  Changed the return type from `SortedList<long, Block<T>>?` to
+    `List<Block<T>>?` for `BlockCandidateTable<T>.GetCurrentRoundCandidate()`
+    method.  [[#2794]]
+ -  Changed the behavior of `BlockCandidateTable<T>.Add()` method.  [[#2794]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +29,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#2794]: https://github.com/planetarium/libplanet/pull/2794
 
 
 Version 0.47.0

--- a/Libplanet.Net.Tests/BlockCandidateTableTest.cs
+++ b/Libplanet.Net.Tests/BlockCandidateTableTest.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Xunit;
+
+namespace Libplanet.Net.Tests
+{
+    public class BlockCandidateTableTest
+    {
+        private StoreFixture _fx;
+
+        public BlockCandidateTableTest()
+        {
+            _fx = new MemoryStoreFixture();
+        }
+
+        [Fact]
+        public void Add()
+        {
+            var table = new BlockCandidateTable<DumbAction>();
+            var header = _fx.GenesisBlock.Header;
+
+            // Ignore empty
+            table.Add(header, new List<Block<DumbAction>>());
+            Assert.Equal(0, table.Count);
+
+            // Ignore duplicate
+            var duplicateSet = new List<Block<DumbAction>>() { _fx.Block1, _fx.Block1, _fx.Block2 };
+            table.Add(header, duplicateSet);
+            Assert.Equal(0, table.Count);
+
+            // Ignore non-consecutive
+            var nonConsecutiveSet = new List<Block<DumbAction>>()
+                { _fx.Block1, _fx.Block2, _fx.Block4 };
+            table.Add(header, nonConsecutiveSet);
+            Assert.Equal(0, table.Count);
+
+            // Ignore existing key
+            var firstSet = new List<Block<DumbAction>>() { _fx.Block1, _fx.Block2 };
+            var secondSet = new List<Block<DumbAction>>() { _fx.Block3, _fx.Block4 };
+            table.Add(header, firstSet);
+            Assert.Equal(1, table.Count);
+            table.Add(header, secondSet);
+            Assert.Equal(1, table.Count);
+            var stored = table.GetCurrentRoundCandidate(header)
+                ?? throw new NullReferenceException();
+            Assert.Equal(stored, firstSet);
+        }
+    }
+}

--- a/Libplanet.Net.Tests/BlockCandidateTableTest.cs
+++ b/Libplanet.Net.Tests/BlockCandidateTableTest.cs
@@ -31,14 +31,20 @@ namespace Libplanet.Net.Tests
             table.Add(header, duplicateSet);
             Assert.Equal(0, table.Count);
 
-            // Ignore non-consecutive
-            var nonConsecutiveSet = new List<Block<DumbAction>>()
+            // Ignore non-consecutive indices
+            var nonConsecutiveIndexSet = new List<Block<DumbAction>>()
                 { _fx.Block1, _fx.Block2, _fx.Block4 };
-            table.Add(header, nonConsecutiveSet);
+            table.Add(header, nonConsecutiveIndexSet);
+            Assert.Equal(0, table.Count);
+
+            // Ignore non-consecutive blocks
+            var nonConsecutiveHashSet = new List<Block<DumbAction>>()
+                { _fx.Block2, _fx.Block3Alt, _fx.Block4 };
+            table.Add(header, nonConsecutiveHashSet);
             Assert.Equal(0, table.Count);
 
             // Ignore existing key
-            var firstSet = new List<Block<DumbAction>>() { _fx.Block1, _fx.Block2 };
+            var firstSet = new List<Block<DumbAction>>() { _fx.Block2, _fx.Block3, _fx.Block4 };
             var secondSet = new List<Block<DumbAction>>() { _fx.Block3, _fx.Block4 };
             table.Add(header, firstSet);
             Assert.Equal(1, table.Count);

--- a/Libplanet.Net/BlockCandidateTable.cs
+++ b/Libplanet.Net/BlockCandidateTable.cs
@@ -23,16 +23,16 @@ namespace Libplanet.Net
     public class BlockCandidateTable<T>
         where T : IAction, new()
     {
-        private readonly ConcurrentDictionary<BlockHeader, List<Block<T>>> _blocks;
+        private readonly ConcurrentDictionary<BlockHeader, List<Block<T>>> _table;
 
         public BlockCandidateTable()
         {
-            _blocks = new ConcurrentDictionary<BlockHeader, List<Block<T>>>();
+            _table = new ConcurrentDictionary<BlockHeader, List<Block<T>>>();
         }
 
         public long Count
         {
-            get => _blocks.Count;
+            get => _table.Count;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Libplanet.Net
         /// <param name="blocks">The list of downloaded <see cref="Block{T}"/>s.</param>
         public void Add(BlockHeader blockHeader, IEnumerable<Block<T>> blocks)
         {
-            if (_blocks.ContainsKey(blockHeader))
+            if (_table.ContainsKey(blockHeader))
             {
                 Log.Debug(
                     "Given blocks will not be added as the table already contains " +
@@ -91,7 +91,7 @@ namespace Libplanet.Net
                 return;
             }
 
-            _blocks.TryAdd(blockHeader, sorted);
+            _table.TryAdd(blockHeader, sorted);
         }
 
         /// <summary>
@@ -108,19 +108,19 @@ namespace Libplanet.Net
         public List<Block<T>>? GetCurrentRoundCandidate(
             BlockHeader thisRoundTip)
         {
-            return _blocks.TryGetValue(thisRoundTip, out var blocks)
+            return _table.TryGetValue(thisRoundTip, out var blocks)
                 ? blocks
                 : null;
         }
 
         public bool TryRemove(BlockHeader header)
         {
-            return _blocks.TryRemove(header, out _);
+            return _table.TryRemove(header, out _);
         }
 
         public void Cleanup(Func<IBlockExcerpt, bool> predicate)
         {
-            foreach (var blockHeader in _blocks.Keys)
+            foreach (var blockHeader in _table.Keys)
             {
                 if (!predicate(blockHeader))
                 {

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -17,20 +17,20 @@ namespace Libplanet.Net
             var checkInterval = TimeSpan.FromMilliseconds(10);
             while (!cancellationToken.IsCancellationRequested)
             {
-                if (BlockCandidateTable.Any())
+                if (BlockCandidateTable.Count > 0)
                 {
                     BlockHeader tipHeader = BlockChain.Tip.Header;
-                    SortedList<long, Block<T>> blocks =
+                    List<Block<T>> blocks =
                         BlockCandidateTable.GetCurrentRoundCandidate(tipHeader);
-                    if (!(blocks is null) && blocks.Count > 0)
+                    if (blocks is { } && blocks.Count > 0)
                     {
                         var latest = blocks.Last();
                         _logger.Debug(
                             "{MethodName} has started. Excerpt: #{BlockIndex} {BlockHash} " +
                             "Count of {BlockCandidateTable}: {Count}",
                             nameof(ConsumeBlockCandidates),
-                            latest.Value.Index,
-                            latest.Value.Hash,
+                            latest.Index,
+                            latest.Hash,
                             nameof(BlockCandidateTable),
                             BlockCandidateTable.Count);
                         _ = BlockCandidateProcess(
@@ -50,7 +50,7 @@ namespace Libplanet.Net
         }
 
         private bool BlockCandidateProcess(
-            SortedList<long, Block<T>> candidate,
+            List<Block<T>> candidate,
             CancellationToken cancellationToken)
         {
             BlockChain<T> synced = null;
@@ -111,7 +111,7 @@ namespace Libplanet.Net
 
         private BlockChain<T> AppendPreviousBlocks(
             BlockChain<T> blockChain,
-            SortedList<long, Block<T>> candidate,
+            List<Block<T>> candidate,
             bool evaluateActions)
         {
              BlockChain<T> workspace = blockChain;
@@ -120,8 +120,8 @@ namespace Libplanet.Net
              bool renderBlocks = true;
 
              Block<T> oldTip = workspace.Tip;
-             Block<T> newTip = candidate.Last().Value;
-             List<Block<T>> blocks = candidate.Values.ToList();
+             Block<T> newTip = candidate.Last();
+             List<Block<T>> blocks = candidate.ToList();
              Block<T> branchpoint = FindBranchpoint(oldTip, newTip, blocks);
 
              if (oldTip is null || branchpoint.Equals(oldTip))

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -118,6 +118,8 @@ namespace Libplanet.Tests.Store
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
             Block3 = TestUtils.MineNextBlock(Block2, miner: Miner);
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
+            Block3Alt = TestUtils.MineNextBlock(Block2, miner: Miner);
+            stateRootHashes[Block3Alt.Hash] = Block3Alt.StateRootHash;
             Block4 = TestUtils.MineNextBlock(Block3, miner: Miner);
             stateRootHashes[Block4.Hash] = Block4.StateRootHash;
             Block5 = TestUtils.MineNextBlock(Block4, miner: Miner);
@@ -165,6 +167,8 @@ namespace Libplanet.Tests.Store
         public Block<DumbAction> Block2 { get; }
 
         public Block<DumbAction> Block3 { get; }
+
+        public Block<DumbAction> Block3Alt { get; }
 
         public Block<DumbAction> Block4 { get; }
 


### PR DESCRIPTION
Preliminary refactoring to further specify the context in which a set of `Block<T>`s gets thrown around.
I'll probably be implementing a `Branch<T>` class shortly as the contractual guarantee from `GetCurrentRoundCandidate()` is pretty weak for the returned `List<T>` of `Block<T>`s when passing it around. For that reason, the usage of `SortedList<long, Block<T>>` has been removed as it does not sufficiently guarantee the desired properties. 😶

This adds two additional constraints to the previous implementation:
- `Block<T>`s have to have consecutive indices.
- `Block<T>`s should form a linked list in the sense that a "next" `Block<T>`'s `PreviousHash` should match that of the "previous" `Block<T>`s `Hash`.

As a side note, I think it'd be also a good idea to only allow `Block<T>`s that are at least of size 2. This would require the table to always include the branchpoint and some logic change up the stack. 🙄