### PR TITLE
♻️ Revert to add `Serializabe` attribute back into `Address` and `BoundPeer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ To be released.
 
 ### Added APIs
 
+ -  Added `Serializable` attribute back to `Address`.  [[#2798]]
+ -  (Libplanet.Net) Added `Serializable` attribute back to `BoundPeer`.
+    [[#2798]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -33,6 +37,7 @@ To be released.
 
 [#2794]: https://github.com/planetarium/libplanet/pull/2794
 [#2795]: https://github.com/planetarium/libplanet/pull/2795
+[#2798]: https://github.com/planetarium/libplanet/pull/2798
 
 
 Version 0.47.0

--- a/Libplanet.Net.Tests/BoundPeerTest.cs
+++ b/Libplanet.Net.Tests/BoundPeerTest.cs
@@ -1,6 +1,4 @@
-#nullable disable
 using System;
-using System.Collections.Generic;
 using System.Net;
 using Libplanet.Crypto;
 using Xunit;
@@ -9,33 +7,23 @@ namespace Libplanet.Net.Tests
 {
     public class BoundPeerTest
     {
-        public static IEnumerable<object[]> GetBoundPeers => new[]
+        [Fact]
+        public void Bencoded()
         {
-            new object[]
-            {
-                new BoundPeer(
-                    new PublicKey(new byte[]
-                    {
-                        0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20, 0x42, 0x3b,
-                        0xad, 0x39, 0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b,
-                        0x33, 0xe3, 0x48, 0x7c, 0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96,
-                        0xf8, 0xa5, 0x48, 0x34, 0x40, 0xef, 0xbb, 0xef, 0x06, 0x57,
-                        0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45,
-                        0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
-                        0x1a, 0x3d, 0x3c, 0x76, 0xdb,
-                    }),
-                    new DnsEndPoint("0.0.0.0", 1234)),
-            },
-        };
+            var expected = new BoundPeer(
+                new PrivateKey().PublicKey, new DnsEndPoint("0.0.0.0", 1234));
+            var deserialized = new BoundPeer(expected.Bencoded);
+            Assert.Equal(expected, deserialized);
+        }
 
-        [Theory]
-        [MemberData(nameof(GetBoundPeers))]
-        public void Bencode(BoundPeer peer)
+        [Fact]
+        public void Serializable()
         {
-            Bencodex.Types.IValue bencoded = peer.Bencoded;
-            var decoded = new BoundPeer(bencoded);
-
-            Assert.Equal(peer, decoded);
+            var expected = new BoundPeer(
+                new PrivateKey().PublicKey, new DnsEndPoint("0.0.0.0", 1234));
+            var deserialized = Libplanet.Tests.TestUtils.BinarySerializeDeserialize<BoundPeer>(
+                expected);
+            Assert.Equal(expected, deserialized);
         }
 
         [Fact]
@@ -67,7 +55,6 @@ namespace Libplanet.Net.Tests
         [Fact]
         public void ParsePeerException()
         {
-            Assert.Throws<ArgumentNullException>(() => { BoundPeer.ParsePeer(null); });
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer(string.Empty));
 #pragma warning disable MEN002 // Line is too long
             Assert.Throws<ArgumentException>(() => BoundPeer.ParsePeer("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"));

--- a/Libplanet.Net/Transports/CommunicationFailException.cs
+++ b/Libplanet.Net/Transports/CommunicationFailException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using Bencodex;
 using Libplanet.Net.Messages;
 using Libplanet.Serialization;
 
@@ -14,8 +13,6 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class CommunicationFailException : Exception
     {
-        private static Codec _codec = new Codec();
-
         public CommunicationFailException(
             string message,
             Message.MessageType messageType,
@@ -40,7 +37,7 @@ namespace Libplanet.Net.Transports
         public CommunicationFailException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
+            Peer = info.GetValue<BoundPeer>(nameof(Peer));
             MessageType = info.GetValue(nameof(MessageType), typeof(Message.MessageType))
                 is Message.MessageType messageType
                 ? messageType
@@ -54,7 +51,7 @@ namespace Libplanet.Net.Transports
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
+            info.AddValue(nameof(Peer), Peer);
             info.AddValue(nameof(MessageType), MessageType, typeof(Message.MessageType));
         }
     }

--- a/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
+++ b/Libplanet.Net/Transports/InvalidMessageSignatureException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using Bencodex;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Serialization;
@@ -14,8 +13,6 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class InvalidMessageSignatureException : Exception
     {
-        private static Codec _codec = new Codec();
-
         internal InvalidMessageSignatureException(
             string message,
             BoundPeer peer,
@@ -35,7 +32,7 @@ namespace Libplanet.Net.Transports
             StreamingContext context)
             : base(info, context)
         {
-            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
+            Peer = info.GetValue<BoundPeer>(nameof(Peer));
             PublicKey = new PublicKey(info.GetValue<byte[]>(nameof(PublicKey)));
             MessageToVerify = info.GetValue<byte[]>(nameof(MessageToVerify));
             Signature = info.GetValue<byte[]>(nameof(Signature));
@@ -53,7 +50,7 @@ namespace Libplanet.Net.Transports
             SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
+            info.AddValue(nameof(Peer), Peer);
             info.AddValue(nameof(PublicKey), PublicKey.Format(true));
             info.AddValue(nameof(MessageToVerify), MessageToVerify);
             info.AddValue(nameof(Signature), Signature);

--- a/Libplanet.Net/Transports/SendMessageFailException.cs
+++ b/Libplanet.Net/Transports/SendMessageFailException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using Bencodex;
 using Libplanet.Net.Messages;
 using Libplanet.Serialization;
 
@@ -12,20 +11,13 @@ namespace Libplanet.Net.Transports
     [Serializable]
     public class SendMessageFailException : Exception
     {
-        private static Codec _codec = new Codec();
-
-        internal SendMessageFailException(
-            string message,
-            BoundPeer peer)
+        internal SendMessageFailException(string message, BoundPeer peer)
             : base(message)
         {
             Peer = peer;
         }
 
-        internal SendMessageFailException(
-            string message,
-            BoundPeer peer,
-            Exception innerException)
+        internal SendMessageFailException(string message, BoundPeer peer, Exception innerException)
             : base(message, innerException)
         {
             Peer = peer;
@@ -34,7 +26,7 @@ namespace Libplanet.Net.Transports
         protected SendMessageFailException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Peer = new BoundPeer(_codec.Decode(info.GetValue<byte[]>(nameof(Peer))));
+            Peer = info.GetValue<BoundPeer>(nameof(Peer));
         }
 
         public BoundPeer Peer { get; }
@@ -42,7 +34,7 @@ namespace Libplanet.Net.Transports
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Peer), _codec.Encode(Peer.Bencoded));
+            info.AddValue(nameof(Peer), Peer);
         }
     }
 }

--- a/Libplanet.Tests/AddressTest.cs
+++ b/Libplanet.Tests/AddressTest.cs
@@ -233,21 +233,6 @@ namespace Libplanet.Tests
         }
 
         [Fact]
-        public void Bencodable()
-        {
-            // Serialize and deserialize to and from memory
-            var expectedAddress = new Address(
-                new byte[]
-                {
-                    0x45, 0xa2, 0x21, 0x87, 0xe2, 0xd8, 0x85, 0x0b, 0xb3, 0x57,
-                    0x88, 0x69, 0x58, 0xbc, 0x3e, 0x85, 0x60, 0x92, 0x9c, 0xcc,
-                }
-            );
-            Address deserializedAddress = new Address(expectedAddress.Bencoded);
-            Assert.Equal(deserializedAddress, expectedAddress);
-        }
-
-        [Fact]
         public void SerializeAndDeserializeWithDefault()
         {
             var defaultAddress = default(Address);
@@ -302,6 +287,28 @@ namespace Libplanet.Tests
             Assert.Throws<ArgumentException>(() =>
                  new Address("0X0123456789ABcdefABcdEfABcdEFabcDEFabCDEF")
             );
+        }
+
+        [Fact]
+        public void Bencoded()
+        {
+            var expected = new Address(TestUtils.GetRandomBytes(Address.Size));
+            var deserialized = new Address(expected.Bencoded);
+            Assert.Equal(expected, deserialized);
+            expected = default(Address);
+            deserialized = new Address(expected.Bencoded);
+            Assert.Equal(expected, deserialized);
+        }
+
+        [Fact]
+        public void Serializable()
+        {
+            var expected = new Address(TestUtils.GetRandomBytes(Address.Size));
+            Address deserialized = TestUtils.BinarySerializeDeserialize<Address>(expected);
+            Assert.Equal(expected, deserialized);
+            expected = default(Address);
+            deserialized = TestUtils.BinarySerializeDeserialize<Address>(expected);
+            Assert.Equal(expected, deserialized);
         }
 
         [SkippableFact]

--- a/Libplanet/Action/InsufficientBalanceException.cs
+++ b/Libplanet/Action/InsufficientBalanceException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using Bencodex;
 using Libplanet.Assets;
 using Libplanet.Serialization;
 
@@ -15,8 +14,6 @@ namespace Libplanet.Action
     [Serializable]
     public sealed class InsufficientBalanceException : Exception
     {
-        private static Codec _codec = new Codec();
-
         /// <summary>
         /// Creates a new <see cref="InsufficientBalanceException"/> object.
         /// </summary>
@@ -39,7 +36,7 @@ namespace Libplanet.Action
         private InsufficientBalanceException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Address = new Address(_codec.Decode(info.GetValue<byte[]>(nameof(Address))));
+            Address = info.GetValue<Address>(nameof(Address));
             Balance = info.GetValue<FungibleAssetValue>(nameof(Balance));
         }
 
@@ -57,7 +54,7 @@ namespace Libplanet.Action
         {
             base.GetObjectData(info, context);
 
-            info.AddValue(nameof(Address), _codec.Encode(Address.Bencoded));
+            info.AddValue(nameof(Address), Address);
             info.AddValue(nameof(Balance), Balance);
         }
     }

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -40,15 +41,18 @@ namespace Libplanet
     /// </summary>
     /// <remarks>Every <see cref="Address"/> value is immutable.</remarks>
     /// <seealso cref="PublicKey"/>
+    [Serializable]
     [JsonConverter(typeof(AddressJsonConverter))]
     public readonly struct Address
-        : IEquatable<Address>, IComparable<Address>, IComparable, IBencodable
+        : ISerializable, IEquatable<Address>, IComparable<Address>, IComparable, IBencodable
     {
         /// <summary>
         /// The <see cref="byte"/>s size that each <see cref="Address"/> takes.
         /// <para>It is 20 <see cref="byte"/>s.</para>
         /// </summary>
         public const int Size = 20;
+
+        private static readonly Codec _codec = new Codec();
 
         private static readonly ImmutableArray<byte> _defaultByteArray =
             ImmutableArray.Create<byte>(new byte[Size]);
@@ -155,6 +159,15 @@ namespace Libplanet
         {
         }
 
+        private Address(SerializationInfo info, StreamingContext context)
+            : this(_codec.Decode(info.GetValue(nameof(Bencoded), typeof(byte[])) is
+                byte[] bytes
+                    ? bytes
+                    : throw new SerializationException(
+                        $"Invalid type for {nameof(Bencoded)} in {nameof(info)}.")))
+        {
+        }
+
         /// <summary>
         /// An immutable array of 20 <see cref="byte"/>s that represent this
         /// <see cref="Address"/>.
@@ -229,6 +242,12 @@ namespace Libplanet
         /// <seealso cref="ToHex()"/>
         [Pure]
         public override string ToString() => $"0x{ToHex()}";
+
+        /// <inheritdoc />
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Bencoded), _codec.Encode(Bencoded));
+        }
 
         /// <inheritdoc cref="IComparable{T}.CompareTo(T)"/>
         public int CompareTo(Address other)

--- a/Libplanet/Address.cs
+++ b/Libplanet/Address.cs
@@ -243,7 +243,7 @@ namespace Libplanet
         [Pure]
         public override string ToString() => $"0x{ToHex()}";
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue(nameof(Bencoded), _codec.Encode(Bencoded));

--- a/Libplanet/Blocks/BlockPolicyViolationException.cs
+++ b/Libplanet/Blocks/BlockPolicyViolationException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Libplanet.Blockchain.Policies;
 
 namespace Libplanet.Blocks
@@ -18,6 +19,11 @@ namespace Libplanet.Blocks
         /// </param>
         public BlockPolicyViolationException(string message)
             : base(message)
+        {
+        }
+
+        protected BlockPolicyViolationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/Libplanet/Blocks/InvalidBlockTxCountPerSignerException.cs
+++ b/Libplanet/Blocks/InvalidBlockTxCountPerSignerException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using Bencodex;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Serialization;
 using Libplanet.Tx;
@@ -14,8 +13,6 @@ namespace Libplanet.Blocks
     [Serializable]
     public sealed class InvalidBlockTxCountPerSignerException : BlockPolicyViolationException
     {
-        private static Codec _codec = new Codec();
-
         /// <summary>
         /// Initializes a new instance of <see cref="InvalidBlockTxCountPerSignerException"/> class.
         /// </summary>
@@ -33,9 +30,9 @@ namespace Libplanet.Blocks
 
         private InvalidBlockTxCountPerSignerException(
             SerializationInfo info, StreamingContext context)
-            : base(info.GetString(nameof(Message)) ?? string.Empty)
+                : base(info, context)
         {
-            Signer = new Address(_codec.Decode(info.GetValue<byte[]>(nameof(Signer))));
+            Signer = info.GetValue<Address>(nameof(Signer));
             TxCount = info.GetInt32(nameof(TxCount));
         }
 
@@ -46,7 +43,7 @@ namespace Libplanet.Blocks
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Signer), _codec.Encode(Signer.Bencoded));
+            info.AddValue(nameof(Signer), Signer);
             info.AddValue(nameof(TxCount), TxCount);
         }
     }


### PR DESCRIPTION
Follow up on #2778 and #2795.