### PR TITLE
benchmark: Benchmark for `pbft`

### DIFF
--- a/Libplanet.Benchmarks/Commit.cs
+++ b/Libplanet.Benchmarks/Commit.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Libplanet.Tests;
+
+namespace Libplanet.Benchmarks
+{
+    public class Commit
+    {
+        private const int MaxValidatorSize = 100;
+
+        private Vote[] _votes;
+        private PrivateKey[] _privateKeys;
+        private BlockHash _blockHash;
+        private BlockCommit _blockCommit;
+        private byte[] _unMarshalledBlockCommit;
+
+        [Params(4, 10, 25, 50, MaxValidatorSize)]
+        // ReSharper disable once MemberCanBePrivate.Global
+        // System.InvalidOperationException: Member "ValidatorSize" must be public if it has the
+        // [ParamsAttribute] attribute applied to it
+        public int ValidatorSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _blockHash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+            SetupKeys();
+            SetupVotes();
+        }
+
+        [IterationSetup(Target = nameof(UnmarshalBlockCommit))]
+        public void PrepareUnmarshalling()
+        {
+            _blockCommit = new BlockCommit(1, 0, _blockHash, _votes.Take(ValidatorSize).ToImmutableArray());
+            _unMarshalledBlockCommit = _blockCommit.ToByteArray();
+        }
+
+        [Benchmark]
+        public void UnmarshalBlockCommit()
+        {
+            _blockCommit = new BlockCommit(_unMarshalledBlockCommit);
+        }
+
+        private void SetupKeys()
+        {
+            _privateKeys = new PrivateKey[MaxValidatorSize];
+            for (int i = 0; i < MaxValidatorSize; i++)
+            {
+                _privateKeys[i] = new PrivateKey();
+            }
+        }
+
+        private void SetupVotes()
+        {
+            _votes = Enumerable.Range(0, MaxValidatorSize)
+                .Select(x =>
+                    new VoteMetadata(
+                        1,
+                        0,
+                        _blockHash,
+                        DateTimeOffset.UtcNow,
+                        _privateKeys[x].PublicKey,
+                        VoteFlag.PreCommit).Sign(_privateKeys[x]))
+                .ToArray();
+        }
+    }
+}

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -103,7 +103,8 @@ namespace Libplanet.Tests.Store
                     : (HashDigest<SHA256>?)null;
             Proposer = TestUtils.GenesisProposer;
             GenesisBlock = TestUtils.ProposeGenesis<DumbAction>(
-                proposer: Proposer.PublicKey
+                proposer: Proposer.PublicKey,
+                validatorSet: TestUtils.ValidatorSet
             ).Evaluate(
                 privateKey: Proposer,
                 blockAction: blockAction,


### PR DESCRIPTION
# Context
@limebell and @OnedgeLee have noticed that benchmark is failing due to the `SetValdiator` and `BlockCommit` changes. This PR finds out which tests have impact.

# Changes
- The `ProposeBlock` is now proposing and appending. We might have to see `ProposeBlock()` and `Append()` separately.
- `TestUtils.GenesisBlock` have `TestUtils.ValidatorSet`. The time of benchmark related to `GenesisBlock` has been increased due to initial `SetValidator` transaction validation.

# Benchmark results
## Propose/MineBlock
The general results increased due to the addition of `BlockCommit`, and the creation of a `LastCommit` and `Commit` for each block.
### Main
|                              Method |        Job | InvocationCount | UnrollFactor |      Mean |     Error |    StdDev |
|------------------------------------ |----------- |---------------- |------------- |----------:|----------:|----------:|
|                      MineBlockEmpty | DefaultJob |         Default |           16 |  6.820 ms | 0.3342 ms | 0.9803 ms |
|     MineBlockOneTransactionNoAction | Job-MODSWE |               1 |            1 |  7.898 ms | 0.3635 ms | 1.0661 ms |
|    MineBlockTenTransactionsNoAction | Job-MODSWE |               1 |            1 | 40.218 ms | 3.0951 ms | 9.1261 ms |
|  MineBlockOneTransactionWithActions | Job-MODSWE |               1 |            1 |  9.978 ms | 0.3575 ms | 1.0315 ms |
| MineBlockTenTransactionsWithActions | Job-MODSWE |               1 |            1 | 36.982 ms | 1.1472 ms | 3.3099 ms |
### PBFT
|                                 Method |        Job | InvocationCount | UnrollFactor |      Mean |     Error |    StdDev |
|--------------------------------------- |----------- |---------------- |------------- |----------:|----------:|----------:|
|                      ProposeBlockEmpty | DefaultJob |         Default |           16 |  2.315 ms | 0.0230 ms | 0.0216 ms |
|     ProposeBlockOneTransactionNoAction | Job-GQLCDY |               1 |            1 | 27.779 ms | 0.8095 ms | 2.3357 ms |
|    ProposeBlockTenTransactionsNoAction | Job-GQLCDY |               1 |            1 | 41.065 ms | 0.8146 ms | 1.3155 ms |
|  ProposeBlockOneTransactionWithActions | Job-GQLCDY |               1 |            1 | 27.542 ms | 0.5324 ms | 1.1231 ms |
| ProposeBlockTenTransactionsWithActions | Job-GQLCDY |               1 |            1 | 51.802 ms | 1.0343 ms | 2.3557 ms |

## Store
The time of benchmark which is related to `GenesisBlock` increased due to the verification of the `SetValidator` transaction.

### Main
|                        Method |          Mean |       Error |     StdDev |        Median |
|------------------------------ |--------------:|------------:|-----------:|--------------:|
|            PutFirstEmptyBlock |    145.001 μs |   7.0101 μs |  20.000 μs |    139.600 μs |
|          PutFirstBlockWithTxs |    377.691 μs |  11.6626 μs |  33.274 μs |    369.400 μs |
|          PutBlockOnManyBlocks |    333.493 μs |   8.9337 μs |  25.051 μs |    333.650 μs |
|    GetOldBlockOutOfManyBlocks |  3,682.359 μs |  86.3846 μs | 243.649 μs |  3,649.300 μs |
| GetRecentBlockOutOfManyBlocks | 10,942.510 μs | 328.2410 μs | 915.005 μs | 10,687.050 μs |
|    TryGetNonExistentBlockHash |     42.106 μs |   3.9448 μs |  11.318 μs |     38.800 μs |
|                    PutFirstTx |    100.275 μs |   5.9979 μs |  16.917 μs |     96.650 μs |
|                PutTxOnManyTxs |     79.306 μs |   2.2331 μs |   6.443 μs |     79.250 μs |
|          GetOldTxOutOfManyTxs |    108.938 μs |   5.6189 μs |  16.031 μs |    104.000 μs |
|       GetRecentTxOutOfManyTxs |      5.440 μs |   0.3711 μs |   1.059 μs |      5.450 μs |
|         TryGetNonExistentTxId |     37.318 μs |   3.0172 μs |   8.559 μs |     36.200 μs |

### PBFT
|                        Method |          Mean |       Error |     StdDev |        Median |
|------------------------------ |--------------:|------------:|-----------:|--------------:|
|            PutFirstEmptyBlock |    377.472 μs |  13.2417 μs |  37.564 μs |    372.400 μs |
|          PutFirstBlockWithTxs |    364.348 μs |  11.0108 μs |  30.875 μs |    358.600 μs |
|          PutBlockOnManyBlocks |    319.768 μs |   6.3215 μs |  10.904 μs |    320.200 μs |
|    GetOldBlockOutOfManyBlocks | 10,252.958 μs | 199.4623 μs | 333.257 μs | 10,119.550 μs |
| GetRecentBlockOutOfManyBlocks |  8,915.939 μs | 246.3208 μs | 686.644 μs |  8,724.400 μs |
|    TryGetNonExistentBlockHash |     60.138 μs |   4.6088 μs |  12.999 μs |     59.300 μs |
|                    PutFirstTx |    100.004 μs |   5.0476 μs |  14.237 μs |     96.550 μs |
|                PutTxOnManyTxs |     80.340 μs |   2.6524 μs |   7.524 μs |     79.300 μs |
|          GetOldTxOutOfManyTxs |    111.386 μs |   6.3296 μs |  17.853 μs |    106.650 μs |
|       GetRecentTxOutOfManyTxs |      5.790 μs |   0.4068 μs |   1.161 μs |      5.700 μs |
|         TryGetNonExistentTxId |     34.992 μs |   2.5095 μs |   7.119 μs |     33.900 μs |