### PR TITLE
feat(@planetarium/tx): Support building unsigned transactions with custom actions

### DIFF
--- a/@planetarium/tx/README.md
+++ b/@planetarium/tx/README.md
@@ -1,7 +1,7 @@
 `@planetarium/tx`
 =================
 
-[![npm][npm-badge]][npm]
+[![npm][npm-badge]][npm] ![](https://img.shields.io/node/v-lts/@planetarium/tx)
 
 This npm package provides functions to build transactions equivalent to
 [Libplanet]:

--- a/@planetarium/tx/README.md
+++ b/@planetarium/tx/README.md
@@ -7,7 +7,7 @@ This npm package provides functions to build transactions equivalent to
 [Libplanet]:
 
  -  Creating an unsigned transaction with a system action
- - [ ] (TODO) Creating an unsigned transaction with custom actions
+ - [x] Creating an unsigned transaction with custom actions
  - [ ] Signing a transaction
 
 [npm]: https://www.npmjs.com/package/@planetarium/tx

--- a/@planetarium/tx/package.json
+++ b/@planetarium/tx/package.json
@@ -4,6 +4,9 @@
   "description": "Creating Libplanet transactions from JavaScript/TypeScript",
   "main": "dist/pkg.cjs.js",
   "module": "dist/pkg.esm.js",
+  "engines": {
+    "node" : ">=19.0.0"
+  },
   "scripts": {
     "prebuild": "npm install --include=dev",
     "build": "bunchee --target es2020 --dts src/index.ts",

--- a/@planetarium/tx/src/action.ts
+++ b/@planetarium/tx/src/action.ts
@@ -48,3 +48,5 @@ export function encodeTransfer(action: Transfer): Encodable {
     amount: action.amount.rawValue,
   };
 }
+
+export type CustomAction = Encodable;

--- a/@planetarium/tx/src/index.ts
+++ b/@planetarium/tx/src/index.ts
@@ -12,9 +12,18 @@ export {
   encodeMint,
   encodeSystemAction,
   encodeTransfer,
+  type CustomAction,
   type Mint,
   type SystemAction,
   type Transfer,
 } from "./action";
-export type { TxMetadata, UnsignedTxWithSystemAction } from "./tx";
-export { encodeTxMetadata, encodeUnsignedTxWithSystemAction } from "./tx";
+export type {
+  TxMetadata,
+  UnsignedTxWithSystemAction,
+  UnsignedTxWithCustomActions,
+} from "./tx";
+export {
+  encodeTxMetadata,
+  encodeUnsignedTxWithSystemAction,
+  encodeUnsignedTxWithCustomActions,
+} from "./tx";

--- a/@planetarium/tx/src/tx/index.ts
+++ b/@planetarium/tx/src/tx/index.ts
@@ -1,4 +1,10 @@
 export type { TxMetadata } from "./metadata";
 export { encodeTxMetadata } from "./metadata";
-export type { UnsignedTxWithSystemAction } from "./unsigned";
-export { encodeUnsignedTxWithSystemAction } from "./unsigned";
+export type {
+  UnsignedTxWithSystemAction,
+  UnsignedTxWithCustomActions,
+} from "./unsigned";
+export {
+  encodeUnsignedTxWithSystemAction,
+  encodeUnsignedTxWithCustomActions,
+} from "./unsigned";

--- a/@planetarium/tx/src/tx/unsigned.ts
+++ b/@planetarium/tx/src/tx/unsigned.ts
@@ -1,11 +1,16 @@
 import { Encodable } from "bencodex";
-import { encodeSystemAction, SystemAction } from "../action";
+import { CustomAction, encodeSystemAction, SystemAction } from "../action";
 import { encodeTxMetadata, TxMetadata } from "./metadata";
 
 const SYSTEM_ACTION_KEY = Buffer.from([0x41]); // 'A'
+const CUSTOM_ACTION_KEY = Buffer.from([0x61]); // 'a'
 
 export interface UnsignedTxWithSystemAction extends TxMetadata {
   systemAction: SystemAction;
+}
+
+export interface UnsignedTxWithCustomActions extends TxMetadata {
+  customActions: CustomAction[];
 }
 
 /**
@@ -18,5 +23,18 @@ export function encodeUnsignedTxWithSystemAction(
 ): Encodable {
   const dict = encodeTxMetadata(metadata);
   dict.set(SYSTEM_ACTION_KEY, encodeSystemAction(metadata.systemAction));
+  return dict;
+}
+
+/**
+ * Encodes an unsigned transaction with custom actions.
+ * @param tx An unsigned transaction with custom actions.
+ * @returns An encoded transaction.
+ */
+export function encodeUnsignedTxWithCustomActions(
+  metadata: UnsignedTxWithCustomActions
+): Encodable {
+  const dict = encodeTxMetadata(metadata);
+  dict.set(CUSTOM_ACTION_KEY, metadata.customActions);
   return dict;
 }

--- a/@planetarium/tx/test/tx/unsigned.test.ts
+++ b/@planetarium/tx/test/tx/unsigned.test.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { encode } from "bencodex";
 import { execa } from "execa";
 import { expect, test } from "vitest";
-import { encodeUnsignedTxWithSystemAction } from "../../src/tx/unsigned";
+import { encodeUnsignedTxWithCustomActions, encodeUnsignedTxWithSystemAction } from "../../src/tx/unsigned";
 import { FOO, key1, key2 } from "./fixtures";
 
 test("encodeUnsignedTxWithSystemAction", async () => {
@@ -56,6 +56,79 @@ test("encodeUnsignedTxWithSystemAction", async () => {
         "\ufeffrecipient": "0x8a29de186b85560d708451101c4bf02d63b25c50",
       },
     },
+    timestamp: "2022-05-23T01:02:00+00:00",
+    publicKey:
+      "0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f",
+    genesisHash: null,
+  });
+}, 30_000);
+
+test("encodeUnsignedTxWithCustomActions", async () => {
+  const encoded = encodeUnsignedTxWithCustomActions({
+    nonce: 123n,
+    publicKey: key1.public,
+    signer: key1.address,
+    timestamp: new Date("2022-05-23T01:02:00+00:00"),
+    updatedAddresses: new Set(),
+    genesisHash: null,
+    customActions: [
+      {
+        type_id: "transfer_asset",
+        values: {
+          amount: [
+            {
+              decimalPlaces: Buffer.from([0x02]),
+              minters: [Buffer.from("47d082a115c63e7b58b1532d20e631538eafadde", "hex")],
+              ticker: "NCG",
+            },
+            1000,
+          ],
+          recipient: Buffer.from("5a533067D0cBa77490268b26195EdB10B990143D", "hex"),
+          sender: Buffer.from("111CB8E18c6D70f5032000c5739c5ac36E793EDB", "hex"),
+        },
+      },
+    ],
+  });
+  const payload = encode(encoded);
+  const { stdout } = await execa(
+    "dotnet",
+    [
+      "run",
+      "--project",
+      join(__dirname, "..", "..", "..", "..", "Libplanet.Tools"),
+      "--",
+      "tx",
+      "analyze",
+      "--unsigned",
+      "-",
+    ],
+    { input: payload },
+  );
+  expect(JSON.parse(stdout)).toStrictEqual({
+    id: "f03738f2d844906e1e5f889b6445e4cef6833444c2a5fc335a15fad074da8f2e",
+    nonce: 123,
+    signer: "268344BA46e6CA2A8a5096565548b9018bc687Ce",
+    updatedAddresses: [],
+    signature: "",
+    customActions: [
+      {
+        "\ufefftype_id": "\ufefftransfer_asset",
+        "\ufeffvalues": {
+          "\ufeffamount": [
+            {
+              "\ufeffdecimalPlaces": "0x02",
+              "\ufeffminters": [
+                "0x47d082a115c63e7b58b1532d20e631538eafadde"
+              ],
+              "\ufeffticker": "\ufeffNCG",
+            },
+            "1000"
+          ],
+          "\ufeffsender": "0x111cb8e18c6d70f5032000c5739c5ac36e793edb",
+          "\ufeffrecipient": "0x5a533067d0cba77490268b26195edb10b990143d",
+        },
+      },
+    ],
     timestamp: "2022-05-23T01:02:00+00:00",
     publicKey:
       "0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@ To be released.
  -  Added `Serializable` attribute back to `Address`.  [[#2798]]
  -  (Libplanet.Net) Added `Serializable` attribute back to `BoundPeer`.
     [[#2798]]
+ -  (@planetarium/tx) Added `encodeUnsignedTxWithCustomActions()` function.
+    [[#2805]]
+ -  (@planetarium/tx) Added `CustomAction` type.  [[#2805]]
+ -  (@planetarium/tx) Added `UnsignedTxWithCustomActions` type.  [[#2805]]
 
 ### Behavioral changes
 
@@ -38,6 +42,7 @@ To be released.
 [#2794]: https://github.com/planetarium/libplanet/pull/2794
 [#2795]: https://github.com/planetarium/libplanet/pull/2795
 [#2798]: https://github.com/planetarium/libplanet/pull/2798
+[#2805]: https://github.com/planetarium/libplanet/pull/2805
 
 
 Version 0.47.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,10 @@ To be released.
 
 ### Dependencies
 
+ -  (@planetarium/tx) Because `globalThis.crypto` API is available since
+    Node.js version 19.0.0, it now explicitly requires 19.0.0 or later.
+    [[#2805]]
+
 ### CLI tools
 
 [#2794]: https://github.com/planetarium/libplanet/pull/2794


### PR DESCRIPTION
This pull request makes the `@planetarium/tx` JavaScript package support building unsigned transactions with custom actions. Also, it specifies the node's version requirement through the `package.json` file's `engines` property because `globalThis.crypto` is available since Node.js `19.0.0`. You can check it by making a `.npmrc` file with `engine-strict=true` content.
