### PR TITLE
Avoid unintended blocks on NetMQTransport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,12 +23,16 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `NetMQTransport`'s overall throughput had been dropped
+    when hostname resolving for some peers was delayed.  [[#2817]]
+
 ### Dependencies
 
 ### CLI tools
 
 [#2808]: https://github.com/planetarium/libplanet/issues/2808
 [#2814]: https://github.com/planetarium/libplanet/pull/2814
+[#2817]: https://github.com/planetarium/libplanet/pull/2817
 
 
 Version 0.48.0

--- a/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
+++ b/Libplanet.Net.Tests/Transports/BoundPeerExtensionsTest.cs
@@ -86,6 +86,34 @@ namespace Libplanet.Net.Tests.Transports
             NetMQConfig.Cleanup(false);
         }
 
+        [Theory]
+        [InlineData("127.0.0.1", 3000, new[] { "tcp://127.0.0.1:3000" })]
+        [InlineData("localhost", 3000, new[] { "tcp://127.0.0.1:3000", "tcp://::1:3000" })]
+        public async Task ResolveNetMQAddressAsync(string host, int port, string[] expected)
+        {
+            var bp = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint(host, port)
+            );
+            var addr = await bp.ResolveNetMQAddressAsync();
+
+            Assert.Contains(addr, expected);
+        }
+
+        [Fact]
+        public async Task ResolveNetMQAddressAsyncFails()
+        {
+            string hostDoesNotExist = $"{Guid.NewGuid()}.com";
+            var bp = new BoundPeer(
+                new PrivateKey().PublicKey,
+                new DnsEndPoint(hostDoesNotExist, 3000)
+            );
+            await Assert.ThrowsAnyAsync<SocketException>(async () =>
+            {
+                await bp.ResolveNetMQAddressAsync();
+            });
+        }
+
         private static int FreeTcpPort()
         {
             var l = new TcpListener(IPAddress.Loopback, 0);

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -780,7 +780,7 @@ namespace Libplanet.Net.Transports
                 try
                 {
                     _logger.Debug("Trying to connect {RequestId}.", req.Id);
-                    dealer.Connect(req.Peer.ToNetMQAddress());
+                    dealer.Connect(await req.Peer.ResolveNetMQAddressAsync());
                     incrementedSocketCount = Interlocked.Increment(ref _socketCount);
                     _logger
                         .ForContext("Tag", "Metric")


### PR DESCRIPTION
This PR introduces `BoundPeer.ResolveNetMQAddressAsync()` extension method, to address unintended blocking for hostname resolvings on `NetMQTransport. ProcessRequest()`.

I'm a little bit unsure that we might need to perform these resolvings on `.ProcessRequest()` instead of `.SendMessageAsync()`. afik `NetMQRuntime` keeps synchronization context for restricting thread, but `await` might be useful when there're other tasks.