### PR TITLE
Provide logs from ActionRenderer APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,13 @@ Released on February 20, 2023.
  -  (Libplanet.Net) Changed the return type of
     `BlockCandidateTable<T>.GetCurrentRoundCandidate()` from `List<Block<T>>?`
     to `Branch<T>?`.  [[#2822]]
+ -  Added a `logs` parameter to the below methods in `IActionRenderer<T>`
+    interface and its implementations.  [[#2826]]
+
+     - `IActionRenderer<T>.RenderAction()`.
+     - `IActionRenderer<T>.UnrenderAction()`.
+     - `IActionRenderer<T>.RenderActionError()`.
+     - `IActionRenderer<T>.UnrenderActionError()`.
 
 ### Added APIs
 
@@ -94,6 +101,7 @@ Released on February 20, 2023.
 [#2814]: https://github.com/planetarium/libplanet/pull/2814
 [#2817]: https://github.com/planetarium/libplanet/pull/2817
 [#2822]: https://github.com/planetarium/libplanet/pull/2822
+[#2826]: https://github.com/planetarium/libplanet/pull/2826
 
 
 Version 0.48.0

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -319,7 +319,7 @@ namespace Libplanet.Tests.Blockchain
                 new LoggedActionRenderer<DumbAction>(
                     new AnonymousActionRenderer<DumbAction>
                     {
-                        ActionRenderer = (act, context, nextStates) =>
+                        ActionRenderer = (act, context, nextStates, logs) =>
                             // Consuming the random state through IRandom.Next() should not
                             // affect contexts passed to other action renderers.
                             generatedRandomValueLogs.Add(context.Random.Next()),
@@ -392,7 +392,7 @@ namespace Libplanet.Tests.Blockchain
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             IActionRenderer<DumbAction> renderer = new AnonymousActionRenderer<DumbAction>
             {
-                ActionRenderer = (_, __, nextStates) =>
+                ActionRenderer = (_, __, nextStates, logs) =>
                     throw new SomeException("thrown by renderer"),
             };
             renderer = new LoggedActionRenderer<DumbAction>(renderer, Log.Logger);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
@@ -20,6 +21,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 () => new ValidatorSet(),
                 default);
 
+        private static List<string> _logs = new List<string>();
+
         private static IActionContext _actionContext =
             new ActionContext(default, default, default, default, default, _stateDelta, default);
 
@@ -37,18 +40,18 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionRenderer()
         {
-            (IAction, IActionContext, IAccountStateDelta)? record = null;
+            (IAction, IActionContext, IAccountStateDelta, List<string>)? record = null;
             var renderer = new AnonymousActionRenderer<DumbAction>
             {
-                ActionRenderer = (action, context, nextStates) =>
-                    record = (action, context, nextStates),
+                ActionRenderer = (action, context, nextStates, logs) =>
+                    record = (action, context, nextStates, logs),
             };
 
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
@@ -57,7 +60,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
             Assert.Null(record);
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.NotNull(record);
             Assert.Same(_action, record?.Item1);
             Assert.Same(_actionContext, record?.Item2);
@@ -67,18 +70,18 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionUnrenderer()
         {
-            (IAction, IActionContext, IAccountStateDelta)? record = null;
+            (IAction, IActionContext, IAccountStateDelta, List<string>)? record = null;
             var renderer = new AnonymousActionRenderer<DumbAction>
             {
-                ActionUnrenderer = (action, context, nextStates) =>
-                    record = (action, context, nextStates),
+                ActionUnrenderer = (action, context, nextStates, logs) =>
+                    record = (action, context, nextStates, logs),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
@@ -87,7 +90,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
             Assert.Null(record);
 
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.NotNull(record);
             Assert.Same(_action, record?.Item1);
             Assert.Same(_actionContext, record?.Item2);
@@ -97,18 +100,18 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionErrorRenderer()
         {
-            (IAction, IActionContext, Exception)? record = null;
+            (IAction, IActionContext, Exception, List<string>)? record = null;
             var renderer = new AnonymousActionRenderer<DumbAction>
             {
-                ActionErrorRenderer = (action, context, exception) =>
-                    record = (action, context, exception),
+                ActionErrorRenderer = (action, context, exception, logs) =>
+                    record = (action, context, exception, logs),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
@@ -117,7 +120,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
             Assert.Null(record);
 
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.NotNull(record);
             Assert.Same(_action, record?.Item1);
             Assert.Same(_actionContext, record?.Item2);
@@ -127,18 +130,18 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionErrorUnrenderer()
         {
-            (IAction, IActionContext, Exception)? record = null;
+            (IAction, IActionContext, Exception, List<string>)? record = null;
             var renderer = new AnonymousActionRenderer<DumbAction>
             {
-                ActionErrorUnrenderer = (action, context, exception) =>
-                    record = (action, context, exception),
+                ActionErrorUnrenderer = (action, context, exception, logs) =>
+                    record = (action, context, exception, logs),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
@@ -147,7 +150,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
             Assert.Null(record);
 
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.NotNull(record);
             Assert.Same(_action, record?.Item1);
             Assert.Same(_actionContext, record?.Item2);
@@ -163,13 +166,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 BlockRenderer = (oldTip, newTip) => record = (oldTip, newTip),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderReorg(_blockA, _blockB, _genesis);
             Assert.Null(record);
@@ -191,13 +194,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 ReorgRenderer = (oldTip, newTip, bp) => record = (oldTip, newTip, bp),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);
@@ -220,13 +223,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 ReorgEndRenderer = (oldTip, newTip, bp) => record = (oldTip, newTip, bp),
             };
 
-            renderer.RenderAction(_action, _actionContext, _stateDelta);
+            renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+            renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
             Assert.Null(record);
-            renderer.RenderActionError(_action, _actionContext, _exception);
+            renderer.RenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
-            renderer.UnrenderActionError(_action, _actionContext, _exception);
+            renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
             Assert.Null(record);
             renderer.RenderBlock(_genesis, _blockA);
             Assert.Null(record);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -27,6 +27,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 () => new ValidatorSet(),
                 default);
 
+        private static List<string> _logs = new List<string>();
+
         private static Exception _exception = new Exception();
 
         private static DumbBlock _genesis =
@@ -88,20 +90,21 @@ namespace Libplanet.Tests.Blockchain.Renderers
             IActionRenderer<DumbAction> actionRenderer;
             if (error)
             {
-                Action<IAction, IActionContext, Exception> render = (action, cxt, e) =>
-                {
-                    LogEvent[] logs = LogEvents.ToArray();
-                    Assert.Single(logs);
-                    firstLog = logs[0];
-                    Assert.Same(_action, action);
-                    Assert.Same(actionContext, cxt);
-                    Assert.Same(actionError, e);
-                    called = true;
-                    if (exception)
+                Action<IAction, IActionContext, Exception, List<string>> render =
+                    (action, cxt, e, logs) =>
                     {
-                        throw new ThrowException.SomeException(string.Empty);
-                    }
-                };
+                        LogEvent[] events = LogEvents.ToArray();
+                        Assert.Single(events);
+                        firstLog = events[0];
+                        Assert.Same(_action, action);
+                        Assert.Same(actionContext, cxt);
+                        Assert.Same(actionError, e);
+                        called = true;
+                        if (exception)
+                        {
+                            throw new ThrowException.SomeException(string.Empty);
+                        }
+                    };
                 actionRenderer = new AnonymousActionRenderer<DumbAction>
                 {
                     ActionErrorRenderer = unrender ? null : render,
@@ -110,20 +113,21 @@ namespace Libplanet.Tests.Blockchain.Renderers
             }
             else
             {
-                Action<IAction, IActionContext, IAccountStateDelta> render = (action, cxt, next) =>
-                {
-                    LogEvent[] logs = LogEvents.ToArray();
-                    Assert.Single(logs);
-                    firstLog = logs[0];
-                    Assert.Same(_action, action);
-                    Assert.Same(actionContext, cxt);
-                    Assert.Same(_stateDelta, next);
-                    called = true;
-                    if (exception)
+                Action<IAction, IActionContext, IAccountStateDelta, List<string>> render =
+                    (action, cxt, next, logs) =>
                     {
-                        throw new ThrowException.SomeException(string.Empty);
-                    }
-                };
+                        LogEvent[] events = LogEvents.ToArray();
+                        Assert.Single(events);
+                        firstLog = events[0];
+                        Assert.Same(_action, action);
+                        Assert.Same(actionContext, cxt);
+                        Assert.Same(_stateDelta, next);
+                        called = true;
+                        if (exception)
+                        {
+                            throw new ThrowException.SomeException(string.Empty);
+                        }
+                    };
                 actionRenderer = new AnonymousActionRenderer<DumbAction>
                 {
                     ActionRenderer = unrender ? null : render,
@@ -151,22 +155,32 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 {
                     if (unrender)
                     {
-                        actionRenderer.UnrenderActionError(_action, actionContext, actionError);
+                        actionRenderer.UnrenderActionError(
+                            _action,
+                            actionContext,
+                            actionError,
+                            _logs
+                        );
                     }
                     else
                     {
-                        actionRenderer.RenderActionError(_action, actionContext, actionError);
+                        actionRenderer.RenderActionError(
+                            _action,
+                            actionContext,
+                            actionError,
+                            _logs
+                        );
                     }
                 }
                 else
                 {
                     if (unrender)
                     {
-                        actionRenderer.UnrenderAction(_action, actionContext, _stateDelta);
+                        actionRenderer.UnrenderAction(_action, actionContext, _stateDelta, _logs);
                     }
                     else
                     {
-                        actionRenderer.RenderAction(_action, actionContext, _stateDelta);
+                        actionRenderer.RenderAction(_action, actionContext, _stateDelta, _logs);
                     }
                 }
             }

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
@@ -23,6 +23,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 () => new ValidatorSet(),
                 default);
 
+        private static List<string> _logs = new List<string>();
+
         private static IActionContext _actionContext =
             new ActionContext(default, default, default, default, 1, _stateDelta, default);
 
@@ -72,22 +74,22 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     Thread.Sleep(sleepSeconds * 1000);
                     log.Add($"ReorgEnd({oldTip.Index}, {newTip.Index}, {branchpoint.Index})");
                 },
-                ActionRenderer = (IAction act, IActionContext ctx, IAccountStateDelta delta) =>
+                ActionRenderer = (act, ctx, delta, logs) =>
                 {
                     Thread.Sleep(sleepSeconds * 1000);
                     log.Add($"Action({act.GetType().Name}, {ctx.BlockIndex})");
                 },
-                ActionErrorRenderer = (IAction act, IActionContext ctx, Exception e) =>
+                ActionErrorRenderer = (act, ctx, e, logs) =>
                 {
                     Thread.Sleep(sleepSeconds * 1000);
                     log.Add($"ActionError({act.GetType().Name}, {ctx.BlockIndex}, {e.Message})");
                 },
-                ActionUnrenderer = (IAction act, IActionContext ctx, IAccountStateDelta delta) =>
+                ActionUnrenderer = (act, ctx, delta, logs) =>
                 {
                     Thread.Sleep(sleepSeconds * 1000);
                     log.Add($"~Action({act.GetType().Name}, {ctx.BlockIndex})");
                 },
-                ActionErrorUnrenderer = (IAction act, IActionContext ctx, Exception e) =>
+                ActionErrorUnrenderer = (act, ctx, e, logs) =>
                 {
                     Thread.Sleep(sleepSeconds * 1000);
                     log.Add($"~ActionError({act.GetType().Name}, {ctx.BlockIndex}, {e.Message})");
@@ -99,13 +101,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 DateTimeOffset start = DateTimeOffset.UtcNow;
                 renderer.RenderReorg(_blockA, _blockB, _genesis);
                 Assert.Empty(log);
-                renderer.UnrenderAction(_action, _actionContext, _stateDelta);
+                renderer.UnrenderAction(_action, _actionContext, _stateDelta, _logs);
                 Assert.Empty(log);
-                renderer.UnrenderActionError(_action, _actionContext, _exception);
+                renderer.UnrenderActionError(_action, _actionContext, _exception, _logs);
                 Assert.Empty(log);
                 renderer.RenderBlock(_blockA, _blockB);
-                renderer.RenderActionError(_action, _actionContext, _exception);
-                renderer.RenderAction(_action, _actionContext, _stateDelta);
+                renderer.RenderActionError(_action, _actionContext, _exception, _logs);
+                renderer.RenderAction(_action, _actionContext, _stateDelta, _logs);
                 renderer.RenderBlockEnd(_blockA, _blockB);
                 renderer.RenderReorgEnd(_blockA, _blockB, _genesis);
                 DateTimeOffset end = DateTimeOffset.UtcNow;

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -306,14 +306,18 @@ namespace Libplanet.Blockchain
                         renderer.RenderAction(
                             evaluation.Action,
                             evaluation.InputContext.GetUnconsumedContext(),
-                            evaluation.OutputStates);
+                            evaluation.OutputStates,
+                            evaluation.Logs
+                        );
                     }
                     else
                     {
                         renderer.RenderActionError(
                             evaluation.Action,
                             evaluation.InputContext.GetUnconsumedContext(),
-                            evaluation.Exception);
+                            evaluation.Exception,
+                            evaluation.Logs
+                        );
                     }
 
                     count++;
@@ -359,14 +363,18 @@ namespace Libplanet.Blockchain
                         renderer.UnrenderAction(
                             evaluation.Action,
                             evaluation.InputContext.GetUnconsumedContext(),
-                            evaluation.OutputStates);
+                            evaluation.OutputStates,
+                            evaluation.Logs
+                        );
                     }
                     else
                     {
                         renderer.UnrenderActionError(
                             evaluation.Action,
                             evaluation.InputContext.GetUnconsumedContext(),
-                            evaluation.Exception);
+                            evaluation.Exception,
+                            evaluation.Logs
+                        );
                     }
                 }
 

--- a/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
 
@@ -16,7 +17,7 @@ namespace Libplanet.Blockchain.Renderers
     /// <code><![CDATA[
     /// var actionRenderer = new AnonymousActionRenderer<ExampleAction>
     /// {
-    ///     ActionRenderer = (action, context, nextStates) =>
+    ///     ActionRenderer = (action, context, nextStates, logs) =>
     ///     {
     ///         // Implement RenderAction() here.
     ///     };
@@ -30,27 +31,43 @@ namespace Libplanet.Blockchain.Renderers
     {
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
+        /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>.
         /// </summary>
-        public Action<IAction, IActionContext, IAccountStateDelta>? ActionRenderer { get; set; }
+        public Action<IAction, IActionContext, IAccountStateDelta, List<string>>? ActionRenderer
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>.
+        /// <see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>.
         /// </summary>
-        public Action<IAction, IActionContext, IAccountStateDelta>? ActionUnrenderer { get; set; }
+        public Action<IAction, IActionContext, IAccountStateDelta, List<string>>? ActionUnrenderer
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="RenderActionError(IAction, IActionContext, Exception)"/>.
+        /// <see cref="RenderActionError(IAction, IActionContext, Exception, List{string})"/>.
         /// </summary>
-        public Action<IAction, IActionContext, Exception>? ActionErrorRenderer { get; set; }
+        public Action<IAction, IActionContext, Exception, List<string>>? ActionErrorRenderer
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="UnrenderActionError(IAction, IActionContext, Exception)"/>.
+        /// <see cref="UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>.
         /// </summary>
-        public Action<IAction, IActionContext, Exception>? ActionErrorUnrenderer { get; set; }
+        public Action<IAction, IActionContext, Exception, List<string>>? ActionErrorUnrenderer
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// A callback function to be invoked together with
@@ -58,33 +75,47 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         public Action<Block<T>, Block<T>>? BlockEndRenderer { get; set; }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            ActionRenderer?.Invoke(action, context, nextStates);
+            ActionRenderer?.Invoke(action, context, nextStates, logs);
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            ActionUnrenderer?.Invoke(action, context, nextStates);
+            ActionUnrenderer?.Invoke(action, context, nextStates, logs);
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
-        public void RenderActionError(IAction action, IActionContext context, Exception exception)
-            => ActionErrorRenderer?.Invoke(action, context, exception);
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
+        public void RenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception,
+            List<string> logs
+        ) => ActionErrorRenderer?.Invoke(action, context, exception, logs);
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
-        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
-            => ActionErrorUnrenderer?.Invoke(action, context, exception);
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
+        public void UnrenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception,
+            List<string> logs
+        ) => ActionErrorUnrenderer?.Invoke(action, context, exception, logs);
 
         /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block{T}, Block{T})"/>
         public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip) =>

--- a/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
@@ -64,7 +64,8 @@ namespace Libplanet.Blockchain.Renderers.Debug
         public virtual void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         )
         {
             _records.Add(
@@ -84,7 +85,8 @@ namespace Libplanet.Blockchain.Renderers.Debug
         public virtual void RenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
             _records.Add(
                 new RenderRecord<T>.ActionError(
@@ -100,7 +102,8 @@ namespace Libplanet.Blockchain.Renderers.Debug
         public virtual void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
             _records.Add(
                 new RenderRecord<T>.ActionSuccess(
@@ -117,7 +120,8 @@ namespace Libplanet.Blockchain.Renderers.Debug
         public virtual void UnrenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
             _records.Add(
                 new RenderRecord<T>.ActionError(

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -53,27 +53,31 @@ namespace Libplanet.Blockchain.Renderers.Debug
             Validate();
         }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public override void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         )
         {
-            base.UnrenderAction(action, context, nextStates);
+            base.UnrenderAction(action, context, nextStates, logs);
             Validate();
         }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public override void UnrenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         )
         {
-            base.UnrenderActionError(action, context, exception);
+            base.UnrenderActionError(action, context, exception, logs);
             Validate();
         }
 
@@ -84,27 +88,31 @@ namespace Libplanet.Blockchain.Renderers.Debug
             Validate();
         }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public override void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         )
         {
-            base.RenderAction(action, context, nextStates);
+            base.RenderAction(action, context, nextStates, logs);
             Validate();
         }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public override void RenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         )
         {
-            base.RenderActionError(action, context, exception);
+            base.RenderActionError(action, context, exception, logs);
             Validate();
         }
 

--- a/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/DelayedActionRenderer.cs
@@ -164,39 +164,63 @@ namespace Libplanet.Blockchain.Renderers
             _localRenderBuffer.Value = new Dictionary<BlockHash, List<ActionEvaluation>>();
         }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            DelayUnrenderingAction(new ActionEvaluation(action, context, nextStates));
+            DelayUnrenderingAction(new ActionEvaluation(action, context, nextStates, logs: logs));
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
-        public void UnrenderActionError(IAction action, IActionContext context, Exception exception)
-        {
-            var eval = new ActionEvaluation(action, context, context.PreviousStates, exception);
-            DelayUnrenderingAction(eval);
-        }
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
+        public void UnrenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception,
+            List<string> logs
+        ) => DelayUnrenderingAction(
+                new ActionEvaluation(
+                    action,
+                    context,
+                    context.PreviousStates,
+                    exception,
+                    logs: logs
+                )
+            );
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            DelayRenderingAction(new ActionEvaluation(action, context, nextStates));
+            DelayRenderingAction(new ActionEvaluation(action, context, nextStates, logs: logs));
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
-        public void RenderActionError(IAction action, IActionContext context, Exception exception)
-        {
-            var eval = new ActionEvaluation(action, context, context.PreviousStates, exception);
-            DelayRenderingAction(eval);
-        }
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
+        public void RenderActionError(
+            IAction action,
+            IActionContext context,
+            Exception exception,
+            List<string> logs
+        ) => DelayRenderingAction(
+                new ActionEvaluation(
+                    action,
+                    context,
+                    context.PreviousStates,
+                    exception,
+                    logs: logs
+                )
+            );
 
         /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block{T}, Block{T})"/>
         public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip)
@@ -475,11 +499,21 @@ namespace Libplanet.Blockchain.Renderers
                 {
                     if (unrender)
                     {
-                        ActionRenderer.UnrenderActionError(eval.Action, eval.InputContext, e);
+                        ActionRenderer.UnrenderActionError(
+                            eval.Action,
+                            eval.InputContext,
+                            e,
+                            eval.Logs
+                        );
                     }
                     else
                     {
-                        ActionRenderer.RenderActionError(eval.Action, eval.InputContext, e);
+                        ActionRenderer.RenderActionError(
+                            eval.Action,
+                            eval.InputContext,
+                            e,
+                            eval.Logs
+                        );
                     }
                 }
                 else
@@ -489,7 +523,8 @@ namespace Libplanet.Blockchain.Renderers
                         ActionRenderer.UnrenderAction(
                             eval.Action,
                             eval.InputContext,
-                            eval.OutputStates
+                            eval.OutputStates,
+                            eval.Logs
                         );
                     }
                     else
@@ -497,7 +532,8 @@ namespace Libplanet.Blockchain.Renderers
                         ActionRenderer.RenderAction(
                             eval.Action,
                             eval.InputContext,
-                            eval.OutputStates
+                            eval.OutputStates,
+                            eval.Logs
                         );
                     }
                 }

--- a/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Serilog;
@@ -68,60 +69,68 @@ namespace Libplanet.Blockchain.Renderers
                 ActionRenderer.RenderBlockEnd
             );
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
             LogActionRendering(
                 nameof(RenderAction),
                 action,
                 context,
-                () => ActionRenderer.RenderAction(action, context, nextStates)
+                () => ActionRenderer.RenderAction(action, context, nextStates, logs)
             );
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
             LogActionRendering(
                 nameof(UnrenderAction),
                 action,
                 context,
-                () => ActionRenderer.UnrenderAction(action, context, nextStates)
+                () => ActionRenderer.UnrenderAction(action, context, nextStates, logs)
             );
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public void RenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
             LogActionRendering(
                 nameof(RenderActionError),
                 action,
                 context,
-                () => ActionRenderer.RenderActionError(action, context, exception)
+                () => ActionRenderer.RenderActionError(action, context, exception, logs)
             );
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
             LogActionRendering(
                 nameof(UnrenderActionError),
                 action,
                 context,
-                () => ActionRenderer.UnrenderActionError(action, context, exception)
+                () => ActionRenderer.UnrenderActionError(action, context, exception, logs)
             );
 
         private void LogActionRendering(

--- a/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/NonblockActionRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blocks;
 
@@ -76,41 +77,49 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         public IActionRenderer<T> ActionRenderer { get; }
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void RenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            Queue(() => ActionRenderer.RenderAction(action, context, nextStates));
+            Queue(() => ActionRenderer.RenderAction(action, context, nextStates, logs));
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderAction(IAction, IActionContext, IAccountStateDelta, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderAction(
             IAction action,
             IActionContext context,
-            IAccountStateDelta nextStates
+            IAccountStateDelta nextStates,
+            List<string> logs
         ) =>
-            Queue(() => ActionRenderer.UnrenderAction(action, context, nextStates));
+            Queue(() => ActionRenderer.UnrenderAction(action, context, nextStates, logs));
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public void RenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
-            Queue(() => ActionRenderer.RenderActionError(action, context, exception));
+            Queue(() => ActionRenderer.RenderActionError(action, context, exception, logs));
 
-        /// <inheritdoc
-        /// cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception)"/>
+#pragma warning disable MEN002
+        /// <inheritdoc cref="IActionRenderer{T}.UnrenderActionError(IAction, IActionContext, Exception, List{string})"/>
+#pragma warning restore MEN002
         public void UnrenderActionError(
             IAction action,
             IActionContext context,
-            Exception exception
+            Exception exception,
+            List<string> logs
         ) =>
-            Queue(() => ActionRenderer.UnrenderActionError(action, context, exception));
+            Queue(() => ActionRenderer.UnrenderActionError(action, context, exception, logs));
 
         /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block{T}, Block{T})"/>
         public void RenderBlockEnd(Block<T> oldTip, Block<T> newTip) =>


### PR DESCRIPTION
This PR extends (un)rendering APIs in `IActionRenderer`, to access `ActionEvaluation.Logs` data from the application side on action rendering.

it might look like that solves the same problem already covered in #2505 in a different way, and to some extent it does. However, from the application's perspective, if ephemeral execution logs generated during action execution can be obtained at rendering time, it has the advantage that it can be abstracted in a similar way to other action execution results without the need for separate access to `TxExecution`. (also there is a small performance gain because it doesn't require additional disk access 😅 )

Another approach that could be suggested would be to extend rendering API, to get whole`TxExecution` at render time as well as `logs`. but, since `TxExecution` doesn't seem to fit well with the hierarchy of the current rendering API, I think this approach needs a little different consideration.

Feel free to comment on the strategy as well as the implementation itself.