### PR TITLE
🧹 Changed method name logging for more consistency

### DIFF
--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -598,15 +598,16 @@ namespace Libplanet.Net.Tests
             {
                 await receiverSwarm.PreloadAsync(cancellationToken: cts.Token);
                 canceled = false;
-                Log.Logger.Debug($"{nameof(receiverSwarm.PreloadAsync)}() normally finished");
+                Log.Logger.Debug(
+                    "{MethodName}() normally finished", nameof(receiverSwarm.PreloadAsync));
             }
             catch (OperationCanceledException)
             {
-                Log.Logger.Debug($"{nameof(receiverSwarm.PreloadAsync)}() aborted");
+                Log.Logger.Debug("{MethodName}() aborted", nameof(receiverSwarm.PreloadAsync));
             }
             catch (AggregateException ae) when (ae.InnerException is TaskCanceledException)
             {
-                Log.Logger.Debug($"{nameof(receiverSwarm.PreloadAsync)}() aborted");
+                Log.Logger.Debug("{MethodName}() aborted", nameof(receiverSwarm.PreloadAsync));
             }
 
             cts.Dispose();

--- a/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -156,12 +156,14 @@ namespace Libplanet.Net.Protocols
             catch (TaskCanceledException e)
             {
                 _logger.Debug(
-                    e, "Task cancelled during {FName}()", nameof(AddPeersAsync));
+                    e, "Task cancelled during {MethodName}()", nameof(AddPeersAsync));
             }
             catch (Exception e)
             {
                 _logger.Error(
-                    e, "Unexpected exception occurred during {FName}()", nameof(AddPeersAsync));
+                    e,
+                    "Unexpected exception occurred during {MethodName}()",
+                    nameof(AddPeersAsync));
                 throw;
             }
         }
@@ -312,8 +314,8 @@ namespace Libplanet.Net.Protocols
             CancellationToken cancellationToken)
         {
             _logger.Verbose(
-                $"{nameof(FindSpecificPeerAsync)}() with {{Target}}. " +
-                "(depth: {Depth})",
+                "{MethodName}() with {Target}. (depth: {Depth})",
+                nameof(FindSpecificPeerAsync),
                 target,
                 depth);
 
@@ -545,8 +547,8 @@ namespace Libplanet.Net.Protocols
             CancellationToken cancellationToken)
         {
             _logger.Verbose(
-                $"{nameof(FindPeerAsync)}() with {{Target}} to {{Peer}}. " +
-                "(depth: {Depth})",
+                "{MethodName}() with {Target} to {Peer}. (depth: {Depth})",
+                nameof(FindPeerAsync),
                 target,
                 viaPeer,
                 depth);

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Net
                     {
                         var latest = blocks.Last();
                         _logger.Debug(
-                            "{MethodName} has started. Excerpt: #{BlockIndex} {BlockHash} " +
+                            "{MethodName}() has started. Excerpt: #{BlockIndex} {BlockHash} " +
                             "Count of {BlockCandidateTable}: {Count}",
                             nameof(ConsumeBlockCandidates),
                             latest.Index,
@@ -127,7 +127,7 @@ namespace Libplanet.Net
              if (oldTip is null || branchpoint.Equals(oldTip))
              {
                  _logger.Debug(
-                     "No need to fork. at {MethodName}",
+                     "No need to fork. at {MethodName}()",
                      nameof(AppendPreviousBlocks)
                  );
              }
@@ -151,7 +151,7 @@ namespace Libplanet.Net
              else
              {
                  _logger.Debug(
-                     "Trying to fork... at {MethodName}",
+                     "Trying to fork... at {MethodName}()",
                      nameof(AppendPreviousBlocks)
                  );
                  workspace = workspace.Fork(branchpoint.Hash);
@@ -159,7 +159,7 @@ namespace Libplanet.Net
                  renderBlocks = false;
                  scope.Add(workspace.Id);
                  _logger.Debug(
-                     "Fork finished. at {MethodName}",
+                     "Fork finished. at {MethodName}()",
                      nameof(AppendPreviousBlocks)
                  );
              }
@@ -203,7 +203,8 @@ namespace Libplanet.Net
                  }
 
                  _logger.Debug(
-                     "Completed (chain ID: {ChainId}, tip: #{TipIndex} {TipHash}). at {MethodName}",
+                     "Completed (chain ID: {ChainId}, tip: #{TipIndex} {TipHash}). " +
+                     "at {MethodName}()",
                      workspace?.Id,
                      workspace?.Tip?.Index,
                      workspace?.Tip?.Hash,
@@ -291,11 +292,9 @@ namespace Libplanet.Net
                 return false;
             }
 
-            const string downloadStartLogMsg =
-                "{SessionId}: Downloading blocks from {Peer}; started " +
-                "to fetch the block #{BlockIndex} {BlockHash} at {MethodName}";
             _logger.Debug(
-                downloadStartLogMsg,
+                "{SessionId}: Downloading blocks from {Peer}; started " +
+                "to fetch the block #{BlockIndex} {BlockHash} at {MethodName}()",
                 sessionId,
                 peer,
                 demand.Header.Index,
@@ -316,10 +315,11 @@ namespace Libplanet.Net
             }
             catch (TimeoutException)
             {
-                const string msg =
-                    "{SessionId}: Timeout occurred during " + nameof(ProcessBlockDemandAsync) +
-                    "() from {Peer}";
-                _logger.Debug(msg, sessionId, peer);
+                _logger.Debug(
+                    "{SessionId}: Timeout occurred during {MethodName}() from {Peer}",
+                    sessionId,
+                    nameof(ProcessBlockDemandAsync),
+                    peer);
                 return false;
             }
             catch (InvalidBlockIndexException)

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -221,7 +221,7 @@ namespace Libplanet.Net
                 }
 
                 ProcessFillBlocksFinished.Set();
-                _logger.Debug($"{nameof(PullBlocksAsync)}() has finished successfully");
+                _logger.Debug("{MethodName}() has finished successfully", nameof(PullBlocksAsync));
             }
         }
 
@@ -235,7 +235,7 @@ namespace Libplanet.Net
                 if (BlockDemandTable.Any())
                 {
                     _logger.Debug(
-                        "{MethodName} blockDemand count: {BlockDemandCount}",
+                        "{MethodName}() blockDemand count: {BlockDemandCount}",
                         nameof(FillBlocksAsync),
                         BlockDemandTable.Demands.Count);
                     foreach (var blockDemand in BlockDemandTable.Demands.Values)
@@ -255,7 +255,7 @@ namespace Libplanet.Net
                 BlockDemandTable.Cleanup(BlockChain, IsBlockNeeded);
             }
 
-            _logger.Debug($"{nameof(FillBlocksAsync)} has finished");
+            _logger.Debug("{MethodName}() has finished", nameof(FillBlocksAsync));
         }
 
         private async Task PollBlocksAsync(
@@ -317,7 +317,7 @@ namespace Libplanet.Net
 
             try
             {
-                _logger.Debug($"Start to {nameof(CompleteBlocksAsync)}()");
+                _logger.Debug("Start to {MethodName}()", nameof(CompleteBlocksAsync));
                 FillBlocksAsyncStarted.Set();
 
                 var blockCompletion = new BlockCompletion<BoundPeer, T>(
@@ -575,7 +575,7 @@ namespace Libplanet.Net
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Information($"{nameof(CompleteBlocksAsync)}() is canceled");
+                    _logger.Information("{MethodName}() is canceled", nameof(CompleteBlocksAsync));
                 }
 
                 IComparer<IBlockExcerpt> canonComparer = BlockChain.Policy.CanonicalChainComparer;
@@ -585,9 +585,11 @@ namespace Libplanet.Net
                     || cancellationToken.IsCancellationRequested)
                 {
                     _logger.Debug(
-                        $"{nameof(CompleteBlocksAsync)}() is aborted. Complete? {complete}; " +
+                        "{MethodName}() is aborted. Complete? {Complete}; " +
                         "delete the temporary working chain ({TId}: #{TIndex} {THash}), " +
                         "and make the existing chain ({EId}: #{EIndex} {EHash}) remains",
+                        nameof(CompleteBlocksAsync),
+                        complete,
                         workspace.Id,
                         workspace.Tip.Index,
                         workspace.Tip.Hash,
@@ -599,9 +601,10 @@ namespace Libplanet.Net
                 else if (canonComparer.Compare(workspace.Tip, BlockChain.Tip) < 0)
                 {
                     _logger.Debug(
-                        $"{nameof(CompleteBlocksAsync)}() is aborted since existing chain " +
+                        "{MethodName}() is aborted since existing chain " +
                         "({EId}: #{EIndex} {EHash}) already has proper tip than " +
                         "temporary working chain ({TId}: #{TIndex} {THash})",
+                        nameof(CompleteBlocksAsync),
                         BlockChain.Id,
                         BlockChain.Tip.Index,
                         BlockChain.Tip.Hash,
@@ -613,9 +616,10 @@ namespace Libplanet.Net
                 else
                 {
                     _logger.Debug(
-                        $"{nameof(CompleteBlocksAsync)} finished; " +
+                        "{MethodName}() finished; " +
                         "replace the existing chain ({0}: {1}) with " +
                         "the working chain ({2}: {3})",
+                        nameof(CompleteBlocksAsync),
                         BlockChain.Id,
                         BlockChain.Tip,
                         workspace.Id,

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -340,15 +340,15 @@ namespace Libplanet.Net
             }
             catch (OperationCanceledException e)
             {
-                _logger.Warning(e, $"{nameof(StartAsync)}() is canceled");
+                _logger.Warning(e, "{MethodName}() is canceled", nameof(StartAsync));
                 throw;
             }
             catch (Exception e)
             {
                 _logger.Error(
                     e,
-                    $"An unexpected exception occurred during {nameof(StartAsync)}()"
-                );
+                    "An unexpected exception occurred during {MethodName}()",
+                    nameof(StartAsync));
                 throw;
             }
         }
@@ -1243,15 +1243,13 @@ namespace Libplanet.Net
                 }
                 catch (OperationCanceledException e)
                 {
-                    _logger.Warning(e, $"{fname}() is canceled");
+                    _logger.Warning(e, "{MethodName}() was canceled", fname);
                     throw;
                 }
                 catch (Exception e)
                 {
                     _logger.Error(
-                        e,
-                        $"An unexpected exception occurred during {fname}()"
-                    );
+                        e, "An unexpected exception occurred during {MethodName}()", fname);
                 }
             }
         }
@@ -1284,15 +1282,15 @@ namespace Libplanet.Net
                 }
                 catch (OperationCanceledException e)
                 {
-                    _logger.Warning(e, $"{nameof(BroadcastTxAsync)}() is canceled");
+                    _logger.Warning(e, "{MethodName}() was canceled", nameof(BroadcastTxAsync));
                     throw;
                 }
                 catch (Exception e)
                 {
                     _logger.Error(
                         e,
-                        $"An unexpected exception occurred during {nameof(BroadcastTxAsync)}()"
-                    );
+                        "An unexpected exception occurred during {MethodName}()",
+                        nameof(BroadcastTxAsync));
                 }
             }
         }
@@ -1332,14 +1330,15 @@ namespace Libplanet.Net
                 }
                 catch (OperationCanceledException e)
                 {
-                    _logger.Warning(e, $"{nameof(RefreshTableAsync)}() is cancelled");
+                    _logger.Warning(e, "{MethodName}() was cancelled", nameof(RefreshTableAsync));
                     throw;
                 }
                 catch (Exception e)
                 {
-                    var msg = "Unexpected exception occurred during " +
-                              $"{nameof(RefreshTableAsync)}(): {{0}}";
-                    _logger.Warning(e, msg, e);
+                    _logger.Warning(
+                        e,
+                        "An unexpected exception occurred during {MethodName}()",
+                        nameof(RefreshTableAsync));
                 }
             }
         }
@@ -1364,9 +1363,10 @@ namespace Libplanet.Net
                 }
                 catch (Exception e)
                 {
-                    var msg = "Unexpected exception occurred during " +
-                              $"{nameof(RebuildConnectionAsync)}(): {{0}}";
-                    _logger.Warning(e, msg, e);
+                    _logger.Warning(
+                        e,
+                        "Unexpected exception occurred during {MethodName}()",
+                        nameof(RebuildConnectionAsync));
                 }
             }
         }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -440,7 +440,7 @@ namespace Libplanet.Net.Transports
             catch (OperationCanceledException oce2)
             {
                 const string dbgMsg =
-                    "{FName}() was cancelled while waiting for a reply to " +
+                    "{MethodName}() was cancelled while waiting for a reply to " +
                     "{Message} {RequestId} from {Peer}";
                 _logger.Debug(
                     oce2, dbgMsg, nameof(SendMessageAsync), message, reqId, peer);
@@ -455,8 +455,8 @@ namespace Libplanet.Net.Transports
             catch (Exception e)
             {
                 const string errMsg =
-                    "{FName}() encountered an unexpected exception while waiting for a reply to " +
-                    "{Message} {RequestId} from {Peer}";
+                    "{MethodName}() encountered an unexpected exception while waiting for " +
+                    "a reply to {Message} {RequestId} from {Peer}";
                 _logger.Error(
                     e, errMsg, nameof(SendMessageAsync), message, reqId, peer.Address);
                 throw;
@@ -676,7 +676,8 @@ namespace Libplanet.Net.Transports
             {
                 _logger.Error(
                     ex,
-                    $"An unexpected exception occurred during " + nameof(ReceiveMessage) + "()");
+                    "An unexpected exception occurred during {MethodName}()",
+                    nameof(ReceiveMessage));
             }
         }
 

--- a/Libplanet.Net/TxCompletion.cs
+++ b/Libplanet.Net/TxCompletion.cs
@@ -196,7 +196,7 @@ namespace Libplanet.Net
             {
                 _logger.Error(
                     e,
-                    "An error occurred during {FName} from {Peer}",
+                    "An error occurred during {MethodName}() from {Peer}",
                     nameof(ProcessFetchedTxIds),
                     peer);
                 throw;
@@ -204,7 +204,7 @@ namespace Libplanet.Net
             finally
             {
                 _logger.Debug(
-                    "End of {FName} from {Peer}",
+                    "End of {MethodName}() from {Peer}",
                     nameof(ProcessFetchedTxIds),
                     peer);
             }
@@ -337,7 +337,7 @@ namespace Libplanet.Net
                 {
                     _logger.Error(
                         e,
-                        "An error occurred during {FName} from {Peer}",
+                        "An error occurred during {MethodName}() from {Peer}",
                         nameof(RequestAsync),
                         _peer);
                     throw;
@@ -345,7 +345,7 @@ namespace Libplanet.Net
                 finally
                 {
                     _logger.Debug(
-                        "End of {FName} from {Peer}",
+                        "End of {MethodName}() from {Peer}",
                         nameof(RequestAsync),
                         _peer);
                 }

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1332,8 +1332,7 @@ namespace Libplanet.RocksDBStore
 
         private void LogUnexpectedException(string methodName, Exception e)
         {
-            string msg = $"An unexpected exception occurred on {methodName}";
-            _logger.Error(e, msg);
+            _logger.Error(e, "An unexpected exception occurred on {MethodName}()", methodName);
         }
 
         private (Guid, long)? GetPreviousChainInfo(Guid chainId)

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -408,7 +408,7 @@ namespace Libplanet.Stun
                 }
                 catch (OperationCanceledException e)
                 {
-                    _logger.Warning(e, $"{nameof(RefreshAllocate)}() is cancelled");
+                    _logger.Warning(e, "{MethodName}() was cancelled", nameof(RefreshAllocate));
                     throw;
                 }
                 catch (Exception e)

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -228,7 +228,8 @@ namespace Libplanet.Blockchain
                 }
 
                 _logger.Debug(
-                    $"{nameof(Swap)}() completed unrendering {{Actions}} actions",
+                    "{MethodName}() completed unrendering {Actions} actions",
+                    nameof(Swap),
                     count);
             }
         }
@@ -259,7 +260,8 @@ namespace Libplanet.Blockchain
                 }
 
                 _logger.Debug(
-                    $"{nameof(Swap)}() completed rendering {{Count}} actions",
+                    "{MethodName}() completed rendering {Count} actions",
+                    nameof(Swap),
                     count);
 
                 foreach (IActionRenderer<T> renderer in ActionRenderers)

--- a/Libplanet/Store/TrieStateStore.cs
+++ b/Libplanet/Store/TrieStateStore.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Store
             // Bencodex values), it needs to be fixed so that it can prune offloaded Bencodex
             // values too.  https://github.com/planetarium/libplanet/issues/1653
             var stopwatch = new Stopwatch();
-            _logger.Verbose($"Started {nameof(PruneStates)}()");
+            _logger.Verbose("Started {MethodName}()", nameof(PruneStates));
             var survivalNodes = new HashSet<HashDigest<SHA256>>();
             foreach (HashDigest<SHA256> stateRootHash in survivingStateRootHashes)
             {
@@ -108,7 +108,7 @@ namespace Libplanet.Store
         {
             IKeyValueStore targetKeyValueStore = targetStateStore.StateKeyValueStore;
             var stopwatch = new Stopwatch();
-            _logger.Verbose($"Started {nameof(CopyStates)}()");
+            _logger.Verbose("Started {MethodName}()", nameof(CopyStates));
             stopwatch.Start();
 
             foreach (HashDigest<SHA256> stateRootHash in stateRootHashes)
@@ -129,7 +129,7 @@ namespace Libplanet.Store
             _logger.Debug(
                 "Finished to copy all states {ElapsedMilliseconds}ms",
                 stopwatch.ElapsedMilliseconds);
-            _logger.Verbose($"Finished {nameof(CopyStates)}()");
+            _logger.Verbose("Finished {MethodName}()", nameof(CopyStates));
         }
 
         /// <inheritdoc cref="IStateStore.GetStateRoot(HashDigest{SHA256}?)"/>


### PR DESCRIPTION
Although a case could be made whether method names should be handled as properties, I've decided to include method names as logged property. The reason is twofold:

- Cleaner codebase
- Easier parsing through property

Also, added `()` for missing cases. These are mainly for comprehension.

In the long run, a better solution would be to automatically generate the method name and line number as context at some point. 🙄