### PR TITLE
🧹 Elevated `NetMQTransport` log levels

### DIFF
--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -333,13 +333,6 @@ namespace Libplanet.Net.Transports
                     AsPeer,
                     DateTimeOffset.UtcNow
                 );
-                _logger.Verbose(
-                    "Enqueue a request {RequestId} to {Peer}: {@Message}",
-                    reqId,
-                    peer,
-                    message
-                );
-                Interlocked.Increment(ref _requestCount);
                 var req = new MessageRequest(
                     reqId,
                     rawMessage,
@@ -347,12 +340,11 @@ namespace Libplanet.Net.Transports
                     now,
                     expectedResponses,
                     channel,
-                    linkedCt
-                );
+                    linkedCt);
                 await _requests.Writer.WriteAsync(
                     req,
-                    linkedCt
-                ).ConfigureAwait(false);
+                    linkedCt).ConfigureAwait(false);
+                Interlocked.Increment(ref _requestCount);
                 _logger.Verbose(
                     "Enqueued a request {RequestId} to the peer {Peer}: {@Message}; " +
                     "{LeftRequests} left",
@@ -369,13 +361,12 @@ namespace Libplanet.Net.Transports
                         .ConfigureAwait(false);
                     Message reply = _messageCodec.Decode(raw, true);
 
-                    _logger.Debug(
-                        "A reply to request {Message} {RequestId} from {Peer} " +
-                        "has parsed: {Reply}",
+                    _logger.Information(
+                        "Received {Reply} as a reply to request {Message} {RequestId} from {Peer}",
+                        reply,
                         message,
                         req.Id,
-                        reply.Remote,
-                        reply);
+                        reply.Remote);
                     try
                     {
                         _messageValidator.ValidateTimestamp(reply);
@@ -413,11 +404,13 @@ namespace Libplanet.Net.Transports
                     replies.Add(reply);
                 }
 
-                const string dbgMsg =
+                _logger.Information(
                     "Received {ReplyMessageCount} reply messages to {RequestId} " +
-                    "from {Peer}: {ReplyMessages}";
-                _logger.Debug(dbgMsg, replies.Count, reqId, peer, replies);
-
+                    "from {Peer}: {ReplyMessages}",
+                    replies.Count,
+                    reqId,
+                    peer,
+                    replies);
                 return replies;
             }
             catch (OperationCanceledException oce) when (timerCts.IsCancellationRequested)
@@ -606,7 +599,7 @@ namespace Libplanet.Net.Transports
                                 _logger
                                     .ForContext("Tag", "Metric")
                                     .ForContext("Subtag", "InboundMessageReport")
-                                    .Debug(
+                                    .Information(
                                         "Received Request {RequestId} {Message} from {Peer}",
                                         reqId,
                                         message,
@@ -723,7 +716,7 @@ namespace Libplanet.Net.Transports
                 MessageRequest req = await reader.ReadAsync(cancellationToken);
 #endif
                 long left = Interlocked.Decrement(ref _requestCount);
-                _logger.Debug("Request taken; {Count} requests left", left);
+                _logger.Information("Request taken; {Count} requests left", left);
 
                 _ = SynchronizationContext.Current.PostAsync(
                     () => ProcessRequest(req, req.CancellationToken)
@@ -774,10 +767,11 @@ namespace Libplanet.Net.Transports
                         .ForContext("Tag", "Metric")
                         .ForContext("Subtag", "SocketCount")
                         .Debug(
-                        "{SocketCount} sockets open for processing request {Message} {RequestId}",
-                        incrementedSocketCount,
-                        messageType,
-                        req.Id);
+                            "{SocketCount} sockets open for processing request " +
+                            "{Message} {RequestId}",
+                            incrementedSocketCount,
+                            messageType,
+                            req.Id);
                 }
                 catch (NetMQException nme)
                 {
@@ -788,11 +782,11 @@ namespace Libplanet.Net.Transports
                         .ForContext("Tag", "Metric")
                         .ForContext("Subtag", "SocketCount")
                         .Debug(
-                        nme,
-                        logMsg,
-                        Interlocked.Read(ref _socketCount),
-                        messageType,
-                        req.Id);
+                            nme,
+                            logMsg,
+                            Interlocked.Read(ref _socketCount),
+                            messageType,
+                            req.Id);
                     throw;
                 }
 
@@ -861,7 +855,7 @@ namespace Libplanet.Net.Transports
                 _logger
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "OutboundMessageReport")
-                    .Debug(
+                    .Information(
                         "Request {RequestId} {Message} " +
                         "processed in {DurationMs:F0}ms with {ReceivedCount} replies received " +
                         "out of {ExpectedCount} expected replies",


### PR DESCRIPTION
🧹 