### PR TITLE
test/pbft: double vote byzantine test

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ByzantineTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ByzantineTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Libplanet.Blockchain;
+using Libplanet.Consensus;
+using Libplanet.Net.Consensus;
+using Libplanet.Net.Messages;
+using Libplanet.Tests.Common.Action;
+using Nito.AsyncEx;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Net.Tests.Consensus
+{
+    [Collection("NetMQConfiguration")]
+    public class ByzantineTest
+    {
+        private const int Timeout = 30000;
+        private readonly ILogger _logger;
+
+        public ByzantineTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message} {Exception}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<ByzantineTest>();
+
+            _logger = Log.ForContext<ByzantineTest>();
+        }
+
+        [Fact(Timeout = Timeout)]
+        public async Task DoubleVote()
+        {
+            // If a byzantine node sends two different votes in a round, by the MessageLog
+            // specification, one of the vote is ignored and keep the total quorum remains the same.
+
+            // Due to giving a BroadcastMessage delegation, here Context<T> is created in
+            // first and defined null. The initialization will be done in later.
+            const int validatorCount = 4;
+            Gossip[]? gossips = null;
+
+            var peerList = Enumerable.Range(0, 4)
+                .Select(x =>
+                    new BoundPeer(
+                        TestUtils.PrivateKeys[x].PublicKey,
+                        new DnsEndPoint("127.0.0.1", 6000 + x)))
+                .ToArray();
+
+            (BlockChain<DumbAction> BlockChain, Context<DumbAction> Context)[]?
+                validators = null;
+            var newHeightStarted = new AsyncAutoResetEvent[validatorCount];
+            for (int i = 0; i < validatorCount; ++i)
+            {
+                newHeightStarted[i] = new AsyncAutoResetEvent();
+            }
+
+            gossips = Enumerable.Range(0, 4)
+                .Select(x => TestUtils.CreateGossip(
+                    message =>
+                    {
+                        if (message is ConsensusMsg consensusMsg)
+                        {
+                            // ReSharper disable once AccessToModifiedClosure
+                            validators![x].Context.ProduceMessage(consensusMsg);
+                        }
+                    },
+                    TestUtils.PrivateKeys[x],
+                    6000 + x,
+                    peerList))
+                .ToArray();
+
+            validators = Enumerable.Range(0, validatorCount)
+                .Select(x =>
+                    TestUtils.CreateDummyContext(
+                        1,
+                        privateKey: TestUtils.PrivateKeys[x],
+                        broadcastMessage: gossips[x].AddMessage))
+                .ToArray();
+
+            try
+            {
+                // Setup next height listener.
+                for (int i = 0; i < validatorCount; i++)
+                {
+                    var nodeNo = i;
+                    validators[i].Context.StateChanged += (sender, mrs) =>
+                    {
+                        if (mrs.Step == Step.EndCommit)
+                        {
+                            newHeightStarted[nodeNo].Set();
+                        }
+                    };
+                }
+
+                var proposalCreated = new AsyncAutoResetEvent();
+                ConsensusProposalMsg? proposalMsg = null;
+                validators[1].Context.MessageBroadcasted += (sender, msg) =>
+                {
+                    if (msg is ConsensusProposalMsg proposal)
+                    {
+                        proposalMsg = proposal;
+                        proposalCreated.Set();
+                    }
+                };
+
+                foreach (var gossip in gossips)
+                {
+                    _ = gossip.StartAsync(default);
+                    await gossip.WaitForRunningAsync();
+                }
+
+                validators[1].Context.Start();
+
+                await proposalCreated.WaitAsync();
+                var proposalAPreVoteNil = TestUtils.CreateVote(
+                    TestUtils.PrivateKeys[0],
+                    1,
+                    0,
+                    proposalMsg!.BlockHash,
+                    VoteFlag.PreVote);
+
+                // Messages will be delivered in this order:
+                // proposal, preVote1Val, preVote0NIL, preVote(0|2|3)Val
+                validators[1].Context.ProduceMessage(new ConsensusPreVoteMsg(proposalAPreVoteNil));
+                validators[2].Context.ProduceMessage(new ConsensusPreVoteMsg(proposalAPreVoteNil));
+                validators[3].Context.ProduceMessage(new ConsensusPreVoteMsg(proposalAPreVoteNil));
+
+                validators[0].Context.Start();
+                validators[2].Context.Start();
+                validators[3].Context.Start();
+
+                await Task.WhenAll(newHeightStarted.Select(x => x.WaitAsync()));
+                foreach (var validator in validators)
+                {
+                    Assert.Equal(1, validator.Context.Height);
+                }
+
+                // TODO: Check the evidence is collected properly after the double vote incident.
+            }
+            finally
+            {
+                foreach (var gossip in gossips)
+                {
+                    await gossip.StopAsync(TimeSpan.FromMilliseconds(100), default);
+                    gossip.Dispose();
+                }
+
+                foreach (var validator in validators)
+                {
+                    validator.Context.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Net.Tests/Consensus/ByzantineTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ByzantineTest.cs
@@ -61,9 +61,9 @@ namespace Libplanet.Net.Tests.Consensus
 
             gossips = Enumerable.Range(0, 4)
                 .Select(x => TestUtils.CreateGossip(
-                    message =>
+                    content =>
                     {
-                        if (message is ConsensusMsg consensusMsg)
+                        if (content is ConsensusMsg consensusMsg)
                         {
                             // ReSharper disable once AccessToModifiedClosure
                             validators![x].Context.ProduceMessage(consensusMsg);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -239,11 +239,13 @@ namespace Libplanet.Net.Tests
                 PrivateKey? privateKey = null,
                 ContextTimeoutOption? contextTimeoutOptions = null,
                 ValidatorSet? validatorSet = null,
-                ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null)
+                ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
+                TimeSpan? newHeightDelay = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= PrivateKeys[1];
             policy ??= Policy;
+            var contextNewHeightDelay = newHeightDelay ?? TimeSpan.FromSeconds(1);
 
             void BroadcastMessage(ConsensusMsg message) =>
                 Task.Run(() =>
@@ -252,7 +254,7 @@ namespace Libplanet.Net.Tests
                 });
 
             var (blockChain, consensusContext) = CreateDummyConsensusContext(
-                TimeSpan.FromSeconds(1),
+                contextNewHeightDelay,
                 policy,
                 PrivateKeys[1],
                 broadcastMessage: broadcastMessage ?? BroadcastMessage);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -262,7 +262,8 @@ namespace Libplanet.Net.Tests
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ContextTimeoutOption? contextTimeoutOptions = null,
-                ValidatorSet? validatorSet = null)
+                ValidatorSet? validatorSet = null,
+                ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= PrivateKeys[1];
@@ -278,7 +279,7 @@ namespace Libplanet.Net.Tests
                 TimeSpan.FromSeconds(1),
                 policy,
                 PrivateKeys[1],
-                broadcastMessage: BroadcastMessage);
+                broadcastMessage: broadcastMessage ?? BroadcastMessage);
 
             context = new Context<DumbAction>(
                 consensusContext,
@@ -294,7 +295,7 @@ namespace Libplanet.Net.Tests
         public static ConsensusReactor<DumbAction> CreateDummyConsensusReactor(
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
-            string host = "127.0.0.1",
+            string host = "localhost",
             int consensusPort = 5101,
             List<BoundPeer>? validatorPeers = null,
             int newHeightDelayMilliseconds = 10_000,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -193,30 +193,6 @@ namespace Libplanet.Net.Tests
             }
         }
 
-        public static void HandleFourPeersPreVoteMessages(
-            ConsensusContext<DumbAction> consensusContext,
-            PrivateKey nodePrivateKey,
-            BlockHash roundBlockHash)
-        {
-            foreach (PrivateKey privateKey in PrivateKeys)
-            {
-                if (privateKey == nodePrivateKey)
-                {
-                    continue;
-                }
-
-                consensusContext.HandleMessage(
-                    new ConsensusPreVoteMsg(
-                        new VoteMetadata(
-                            consensusContext.Height,
-                            (int)consensusContext.Round,
-                            roundBlockHash,
-                            DateTimeOffset.UtcNow,
-                            privateKey.PublicKey,
-                            VoteFlag.PreVote).Sign(privateKey)));
-            }
-        }
-
         public static (
             BlockChain<DumbAction> BlockChain,
             ConsensusContext<DumbAction> ConsensusContext)

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -321,6 +321,43 @@ namespace Libplanet.Net.Tests
                 contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
         }
 
+        public static Gossip CreateGossip(
+            Action<MessageContent> processMessage,
+            PrivateKey? privateKey = null,
+            int? port = null,
+            IEnumerable<BoundPeer>? peers = null)
+        {
+            var transport = CreateTransport(privateKey, port);
+            return new Gossip(
+                transport,
+                peers?.ToImmutableArray() ?? ImmutableArray<BoundPeer>.Empty,
+                ImmutableArray<BoundPeer>.Empty,
+                processMessage,
+                TimeSpan.FromMinutes(2));
+        }
+
+        public static NetMQTransport CreateTransport(
+            PrivateKey? privateKey = null,
+            int? port = null)
+        {
+            var apvOptions = new AppProtocolVersionOptions
+                { AppProtocolVersion = AppProtocolVersion };
+            HostOptions hostOptions;
+            if (port is { } p)
+            {
+                hostOptions = new HostOptions("localhost", Array.Empty<IceServer>(), p);
+            }
+            else
+            {
+                hostOptions = new HostOptions("localhost", Array.Empty<IceServer>());
+            }
+
+            return NetMQTransport.Create(
+                privateKey ?? new PrivateKey(),
+                apvOptions,
+                hostOptions).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
         public static byte[] GetRandomBytes(int size)
         {
             var bytes = new byte[size];


### PR DESCRIPTION
## Context
This is a part of the byzantine tests which is a node commits a double vote.

## Double vote
If a node commits a double vote, by the `MessageLog` specification, other validator nodes will accept one of the votes and discard one. Additionally, When the evidence is added this test should check whether a node has caught the evidence.

## Double proposal
There is another byzantine case, a double proposal, solely `Context<T>` does not guarantee the recovery but it is covered by `Swarm<T>` block synchronization. 
- Even if the 2 nodes couldn't catch up with the consensus, (byzantine and the minority proposal received node), another majority received 2 nodes will able to commit the block, so the down node will recover while the block synchronization and `TipChange`. (I will try to cover this case in follow-up PR.)
- The failing `Context<T>` test is not included for the ease of managing test code. 
- Note that the current implementation would work in a double proposal scenario, however, any situation that uses only  `Context<T>` cannot recover from the double proposal byzantine case.

```csharp
[Fact(
    Timeout = Timeout,
    Skip = "If one of validators sees the +2/3 votes, new context will be created by " +
            "block sync. If the context need to be more stable, this should be fixed.")]
public async Task DoubleProposal()
{
    const int validatorCount = 4;
    Gossip[]? gossips = null;

    // Due to giving a BroadcastMessage delegation, here Context<T> is created in
    // first and defined null. The initialization will be done in later.
    var peerList = Enumerable.Range(0, 4)
        .Select(x =>
            new BoundPeer(
                TestUtils.PrivateKeys[x].PublicKey,
                new DnsEndPoint("127.0.0.1", 6000 + x)))
        .ToArray();

    (BlockChain<DumbAction> BlockChain, Context<DumbAction> Context)[]?
        validators = null;
    var newHeightStarted = new AsyncAutoResetEvent[validatorCount];
    for (int i = 0; i < validatorCount; ++i)
    {
        newHeightStarted[i] = new AsyncAutoResetEvent();
    }

    gossips = Enumerable.Range(0, 4)
        .Select(x => CreateGossip(
            message =>
            {
                if (message is ConsensusMsg consensusMsg)
                {
                    // ReSharper disable once AccessToModifiedClosure
                    validators![x].Context.ProduceMessage(consensusMsg);
                }
            },
            TestUtils.PrivateKeys[x],
            6000 + x,
            peerList))
        .ToArray();

    validators = Enumerable.Range(0, validatorCount)
        .Select(x =>
            TestUtils.CreateDummyContext(
                1,
                privateKey: TestUtils.PrivateKeys[x],
                broadcastMessage: gossips[x].AddMessage,
                contextTimeoutOptions: new ContextTimeoutOption(
                    preVoteSecondBase: 1,
                    preCommitSecondBase: 1)))
        .ToArray();

    try
    {
        // If a proposer sends two split proposals in a round, one of the node cannot see
        // the +2/3 votes from other nodes due to locking into "canonical" proposal, which
        // is the first seen proposal. A node might need to track all proposals and known
        // votes of blocks in a round for switching to the proposal with +2/3 votes to
        // keep itself into consensus.
        // Note that this is separate case with the validity of the proposed value.

        // Setup next height listener.
        for (int i = 0; i < validatorCount; i++)
        {
            var nodeNo = i;
            validators[i].Context.StateChanged += (sender, mrs) =>
            {
                if (mrs.Step == Step.EndCommit)
                {
                    newHeightStarted[nodeNo].Set();
                }
            };
        }

        // Byzantine will propose a multiple block in a round, and split out to other nodes.
        var blockB = validators[1].BlockChain.ProposeBlock(TestUtils.PrivateKeys[1]);

        // A proposal for that actually will get the +2/3 and canonical proposal.
        var proposalB = TestUtils.CreateConsensusPropose(blockB, TestUtils.PrivateKeys[1]);

        var proposalBPreVote = TestUtils.CreateVote(
            TestUtils.PrivateKeys[1],
            1,
            0,
            blockB.Hash,
            VoteFlag.PreVote);

        var proposalBPreCommit = TestUtils.CreateVote(
            TestUtils.PrivateKeys[1],
            1,
            0,
            blockB.Hash,
            VoteFlag.PreCommit);

        // And other validator 2, 3 will see the proposalB as canonical proposal.
        // The total votes for proposalB is +2/3 (by proposer, 2, and 3), so the value will
        // be committed in the perspective of validator 2, 3.
        validators[2].Context.ProduceMessage(proposalB);
        validators[3].Context.ProduceMessage(proposalB);

        // Proposer will send the proposal, preVote, and preCommit for all split blocks.
        // This is the setup before sending the proposal.
        validators[2].Context.ProduceMessage(new ConsensusPreVoteMsg(proposalBPreVote));
        validators[2].Context.ProduceMessage(new ConsensusPreCommitMsg(proposalBPreCommit));
        validators[3].Context.ProduceMessage(new ConsensusPreVoteMsg(proposalBPreVote));
        validators[3].Context.ProduceMessage(new ConsensusPreCommitMsg(proposalBPreCommit));

        foreach (var gossip in gossips)
        {
            _ = gossip.StartAsync(default);
            await gossip.WaitForRunningAsync();
        }

        AsyncAutoResetEvent proposalACreated = new AsyncAutoResetEvent();
        validators[1].Context.MessageBroadcasted += (sender, msg) =>
        {
            if (msg is ConsensusProposalMsg)
            {
                proposalACreated.Set();
            }
        };

        // Messages will be delivered in this order:
        // Validator 2, 3 : proposalB, preVoteB, preCommitB, proposalA ...
        // Validator 0 : proposalA, proposalB, preVoteA ...
        validators[1].Context.Start();
        await proposalACreated.WaitAsync();
        validators[0].Context.Start();
        validators[2].Context.Start();
        validators[3].Context.Start();

        // Validator 2, 3 reaches the PreCommit and add the block to the chain. However, the
        // validator 0 will not commit the proposalB, because it has ignored the proposalB
        // so the validator 0 will move to the next round. With that so, The next height
        // consensus can't be started.

        // From our current implementation of Swarm, even if the validator 0 and proposer
        // failed, the consensus resumed by synchronization. Context<T> cannot recover
        // solely.
        await Task.WhenAll(newHeightStarted.Select(x => x.WaitAsync()));
        foreach (var validator in validators)
        {
            Assert.Equal(1, validator.Context.Height);
        }
    }
    finally
    {
        foreach (var gossip in gossips)
        {
            await gossip.StopAsync(TimeSpan.FromMilliseconds(100), default);
            gossip.Dispose();
        }

        foreach (var validator in validators)
        {
            validator.Context.Dispose();
        }
    }
}
```