### PR TITLE
Dummy context generation to fill blockchain on test

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -45,8 +45,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var heightTwoProposalSent = new AsyncAutoResetEvent();
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[2]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[2]);
             blockChain.TipChanged += (_, __) => tipChanged.Set();
             consensusContext.MessageBroadcasted += (_, eventArgs) =>
             {
@@ -128,8 +128,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[2]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[2]);
 
             consensusContext.StateChanged += (_, eventArgs) =>
             {
@@ -262,8 +262,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[2]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[2]);
 
             consensusContext.MessageConsumed += (_, eventArgs) =>
             {
@@ -302,8 +302,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var heightTwoProposalSent = new AsyncAutoResetEvent();
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[2]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[2]);
             consensusContext.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 1 && eventArgs.Step == Step.EndCommit)

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextProposerTest.cs
@@ -31,8 +31,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         {
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1]);
 
             var timeoutProcessed = new AsyncAutoResetEvent();
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -41,8 +41,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var proposalMessageSent = new AsyncAutoResetEvent();
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[3]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[3]);
 
             AsyncAutoResetEvent heightThreeStepChangedToPropose = new AsyncAutoResetEvent();
             AsyncAutoResetEvent heightThreeStepChangedToEndCommit = new AsyncAutoResetEvent();
@@ -111,8 +111,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         {
             var (_, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1]);
 
             Assert.Equal(Step.Null, consensusContext.Step);
             Assert.Equal("No context", consensusContext.ToString());
@@ -124,8 +124,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var newHeightDelay = TimeSpan.FromSeconds(1);
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 newHeightDelay,
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1]);
 
             Assert.Equal(-1, consensusContext.Height);
             Block<DumbAction> block = blockChain.ProposeBlock(new PrivateKey());
@@ -140,8 +140,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         {
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1]);
 
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
             Assert.True(consensusContext.Height == 1);
@@ -157,8 +157,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         {
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1],
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1],
                 blockCommitClearThreshold: 1);
 
             // Create context of index 1.
@@ -196,8 +196,8 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
 
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
-                TestUtils.Policy,
-                TestUtils.PrivateKeys[1]);
+                policy: TestUtils.Policy,
+                privateKey: TestUtils.PrivateKeys[1]);
 
             consensusContext.StateChanged += (sender, tuple) =>
             {

--- a/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextTest.cs
@@ -74,8 +74,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             // is the proposer for height 2.
             var (blockChain, context) = TestUtils.CreateDummyContext(
                 height: 2,
-                privateKey: TestUtils.PrivateKeys[2],
-                validatorSet: Libplanet.Tests.TestUtils.ValidatorSet);
+                privateKey: TestUtils.PrivateKeys[2]);
 
             context.StateChanged += (_, eventArgs) =>
             {
@@ -93,11 +92,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 }
             };
 
-            // It needs a lastCommit to use, so we assume that index #1 block is already committed.
-            Block<DumbAction> heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
-            blockChain.Append(heightOneBlock, TestUtils.CreateBlockCommit(heightOneBlock));
-            var lastCommit = TestUtils.CreateBlockCommit(heightOneBlock);
-
+            var lastCommit = blockChain.GetBlockCommit(1);
             context.Start(lastCommit);
             await Task.WhenAll(stepChangedToPreVote.WaitAsync(), proposalSent.WaitAsync());
 
@@ -123,13 +118,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             var (blockChain, context) = TestUtils.CreateDummyContext(
                 height: 2,
-                privateKey: TestUtils.PrivateKeys[2],
-                validatorSet: TestUtils.ValidatorSet);
-
-            // Add block #1 so we can start with a last commit for height 2.
-            Block<DumbAction> heightOneBlock = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
-            blockChain.Append(heightOneBlock, TestUtils.CreateBlockCommit(heightOneBlock));
-            var lastCommit = TestUtils.CreateBlockCommit(heightOneBlock);
+                privateKey: TestUtils.PrivateKeys[2]);
 
             context.StateChanged += (_, eventArgs) =>
             {
@@ -158,6 +147,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 exceptionOccurred.Set();
             };
 
+            var lastCommit = blockChain.GetBlockCommit(1);
             context.Start(lastCommit);
 
             await Task.WhenAll(stepChangedToPreVote.WaitAsync(), proposalSent.WaitAsync());

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -227,6 +227,7 @@ namespace Libplanet.Net.Tests
             ConsensusContext<DumbAction> ConsensusContext)
             CreateDummyConsensusContext(
                 TimeSpan newHeightDelay,
+                long height = 1L,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
@@ -236,6 +237,14 @@ namespace Libplanet.Net.Tests
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
             var blockChain = CreateDummyBlockChain(fx);
+            for (int i = 1; i < height; i++)
+            {
+                var block = blockChain.ProposeBlock(
+                    Libplanet.Tests.TestUtils.GenesisProposer,
+                    lastCommit: CreateBlockCommit(blockChain[i - 1]));
+                blockChain.Append(block, CreateBlockCommit(block));
+            }
+
             ConsensusContext<DumbAction>? consensusContext = null;
 
             privateKey ??= PrivateKeys[1];
@@ -270,8 +279,7 @@ namespace Libplanet.Net.Tests
                 long height = 1,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
-                ContextTimeoutOption? contextTimeoutOptions = null,
-                ValidatorSet? validatorSet = null)
+                ContextTimeoutOption? contextTimeoutOptions = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= PrivateKeys[1];
@@ -288,16 +296,16 @@ namespace Libplanet.Net.Tests
 
             var (blockChain, consensusContext) = CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
+                height,
                 policy,
                 PrivateKeys[1],
                 broadcastMessage: BroadcastMessage);
-
             context = new Context<DumbAction>(
                 consensusContext,
                 blockChain,
                 height,
                 privateKey,
-                validatorSet ?? blockChain.GetValidatorSet(blockChain[height - 1].Hash),
+                blockChain.GetValidatorSet(blockChain[height - 1].Hash),
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, context);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -240,7 +240,9 @@ namespace Libplanet.Net.Tests
             for (int i = 1; i < height; i++)
             {
                 var block = blockChain.ProposeBlock(
-                    Libplanet.Tests.TestUtils.GenesisProposer,
+                    Libplanet.Tests.TestUtils.ValidatorPrivateKeyMap[
+                        Libplanet.Tests.TestUtils.ValidatorSet.GetProposer(i, 0).PublicKey
+                    ],
                     lastCommit: CreateBlockCommit(blockChain[i - 1]));
                 blockChain.Append(block, CreateBlockCommit(block));
             }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -53,6 +53,9 @@ namespace Libplanet.Tests
                 "91602d7091c5c7837ac8e71a8d6b1ed1355cfe311914d9a76107899add0ad56a"),
         };  // The ordering here should match the ordering by address.
 
+        public static readonly Dictionary<PublicKey, PrivateKey> ValidatorPrivateKeyMap
+            = ValidatorPrivateKeys.ToDictionary(pk => pk.PublicKey, pk => pk);
+
         public static readonly ValidatorSet ValidatorSet = new ValidatorSet(
             ValidatorPrivateKeys.Select(
                 privateKey => new Validator(privateKey.PublicKey, BigInteger.One)).ToList());


### PR DESCRIPTION
### Changes
- Make `CreateDummyConsensusContext` to fill returned `BlockChain`.
- Also, `CreateDummyContext` will fill returned `BlockChain`.
- Removed `validatorSet` parameter from `CreateDummyContext`
- Removed test : Remove `CannotProposeWithoutLastCommitWhenRequired`, since block proposal without required lastcommit will be prohibited by block appending, before proposal.

### Related issues
- #2730