### PR TITLE
Ignore policy checks for genesis block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,12 +18,16 @@ To be released.
 
 ### Behavioral changes
 
+ -  `IBlockPolicy` is no longer enforced for genesis `Block<T>`s.  [[#2845]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+
+[#2845]: https://github.com/planetarium/libplanet/pull/2845
 
 Version 0.49.0
 --------------

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1048,15 +1048,11 @@ namespace Libplanet.Tests.Blockchain
         public void GetStatesOnUninitializedBlockChain()
         {
             bool invoked = false;
-            IReadOnlyList<IValue> values = null;
-            IValue value = null;
             var policy = new NullPolicyForGetStatesOnUninitializedBlockChain<DumbAction>(
                 c =>
                 {
                     // ReSharper disable AccessToModifiedClosure
                     // The following method calls should not throw any exceptions:
-                    values = c?.GetStates(new[] { default(Address) });
-                    value = c?.GetState(default);
                     invoked = true;
                     // ReSharper restore AccessToModifiedClosure
                 });
@@ -1086,11 +1082,7 @@ namespace Libplanet.Tests.Blockchain
                 stateStore,
                 genesisWithTx
             );
-            Assert.True(invoked);
-            Assert.NotNull(values);
-            Assert.Single(values);
-            Assert.Null(values[0]);
-            Assert.Null(value);
+            Assert.False(invoked);
         }
 
         // This is a regression test for:

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1466,8 +1466,76 @@ namespace Libplanet.Blockchain
             }
         }
 
+        /// <summary>
+        /// Checks if given <paramref name="block"/> is a valid genesis <see cref="Block{T}"/>.
+        /// </summary>
+        /// <param name="block">The target <see cref="Block{T}"/> to validate.</param>
+        /// <returns><see langword="null"/> if given <paramref name="block"/> is valid,
+        /// otherwise an <see cref="InvalidBlockException"/>.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="block"/> has
+        /// <see cref="Block{T}.Index"/> value anything other than 0.</exception>
+        private static InvalidBlockException ValidateGenesisBlock(Block<T> block)
+        {
+            if (block.Index != 0)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(block)} must have index 0 but has index {block.Index}",
+                    nameof(block));
+            }
+
+            int actualProtocolVersion = block.ProtocolVersion;
+            const int currentProtocolVersion = Block<T>.CurrentProtocolVersion;
+            if (block.ProtocolVersion > Block<T>.CurrentProtocolVersion)
+            {
+                return new InvalidBlockProtocolVersionException(
+                    $"The protocol version ({actualProtocolVersion}) of the block " +
+                    $"#{block.Index} {block.Hash} is not supported by this node." +
+                    $"The highest supported protocol version is {currentProtocolVersion}.",
+                    actualProtocolVersion);
+            }
+
+            if (block.Difficulty != 0)
+            {
+                return new InvalidBlockDifficultyException(
+                    $"The expected difficulty of the block #{block.Index} {block.Hash} " +
+                    $"is 0, but its difficulty is {block.Difficulty}.");
+            }
+
+            if (block.Difficulty != block.TotalDifficulty)
+            {
+                return new InvalidBlockTotalDifficultyException(
+                    $"The expected total difficulty of the block #{block.Index} " +
+                    $"{block.Hash} is {block.Difficulty}, but its total difficulty is " +
+                    $"{block.TotalDifficulty}.",
+                    block.Difficulty,
+                    block.TotalDifficulty);
+            }
+
+            if (block.PreviousHash is { } previousHash)
+            {
+                return new InvalidBlockPreviousHashException(
+                    $"A genesis block should not have previous hash, " +
+                    $"but its value is {block.PreviousHash}.");
+            }
+
+            return null;
+        }
+
         private InvalidBlockException ValidateNextBlock(Block<T> block)
         {
+            if (block.Index == 0)
+            {
+                return ValidateGenesisBlock(block);
+            }
+
+            long index = Count;
+            if (block.Index != index)
+            {
+                return new InvalidBlockIndexException(
+                    $"The expected index of block {block.Hash} is #{index}, " +
+                    $"but its index is #{block.Index}.");
+            }
+
             int actualProtocolVersion = block.ProtocolVersion;
             const int currentProtocolVersion = Block<T>.CurrentProtocolVersion;
 
@@ -1484,7 +1552,7 @@ namespace Libplanet.Blockchain
                     actualProtocolVersion
                 );
             }
-            else if (Count > 0 && actualProtocolVersion < Tip.ProtocolVersion)
+            else if (actualProtocolVersion < Tip.ProtocolVersion)
             {
                 string message =
                     "The protocol version is disallowed to be downgraded from the topmost block " +
@@ -1492,30 +1560,20 @@ namespace Libplanet.Blockchain
                 return new InvalidBlockProtocolVersionException(message, actualProtocolVersion);
             }
 
-            if (block.Index > 0 && Policy.ValidateNextBlock(this, block) is { } bpve)
+            if (Policy.ValidateNextBlock(this, block) is { } bpve)
             {
                 return bpve;
             }
 
-            // FIXME: Difficulty comparison to policy should be part of ValidateNextBlock().
-            long index = this.Count;
+            // FIXME: Difficulty comparison to policy should be part of Policy.ValidateNextBlock().
             long difficulty = Policy.GetNextBlockDifficulty(this);
-            BigInteger totalDifficulty = index >= 1
-                    ? this[index - 1].TotalDifficulty + block.Difficulty
-                    : block.Difficulty;
+            BigInteger totalDifficulty = this[index - 1].TotalDifficulty + block.Difficulty;
 
-            Block<T> lastBlock = index >= 1 ? this[index - 1] : null;
+            Block<T> lastBlock = this[index - 1];
             BlockHash? prevHash = lastBlock?.Hash;
             DateTimeOffset? prevTimestamp = lastBlock?.Timestamp;
 
-            if (block.Index != index)
-            {
-                return new InvalidBlockIndexException(
-                    $"The expected index of block {block.Hash} is #{index}, " +
-                    $"but its index is #{block.Index}.");
-            }
-
-            if (block.Index > 0 && block.Difficulty < difficulty)
+            if (block.Difficulty < difficulty)
             {
                 return new InvalidBlockDifficultyException(
                     $"The expected difficulty of the block #{index} {block.Hash} " +
@@ -1535,13 +1593,6 @@ namespace Libplanet.Blockchain
 
             if (!block.PreviousHash.Equals(prevHash))
             {
-                if (prevHash is null)
-                {
-                    return new InvalidBlockPreviousHashException(
-                        $"The genesis block {block.Hash} should not have previous hash, " +
-                        $"but its value is {block.PreviousHash}.");
-                }
-
                 return new InvalidBlockPreviousHashException(
                     $"The block #{index} {block.Hash} is not continuous from the " +
                     $"block #{index - 1}; while previous block's hash is " +

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -17,6 +17,9 @@ namespace Libplanet.Blockchain.Policies
     /// such as whether a <see cref="Block{T}"/> has the right difficulty,
     /// a <see cref="Transaction{T}"/> has the right signer, etc.
     /// </para>
+    /// <para>
+    /// Note that all index dependent sub-policies are ignored for genesis <see cref="Block{T}"/>s.
+    /// </para>
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
     /// <see cref="Block{T}"/>'s type parameter.</typeparam>

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -95,9 +95,15 @@ namespace Libplanet.Blockchain.Policies
             BlockChain<T> blockChain, Block<T> nextBlock);
 
         /// <summary>
+        /// <para>
         /// Determines a right <see cref="Block{T}.Difficulty"/>
         /// for a new <see cref="Block{T}"/> to be mined
         /// right after the given <paramref name="blockChain"/>.
+        /// </para>
+        /// <para>
+        /// Any specific implementation of this method should assume a genesis
+        /// <see cref="Block{T}"/> will always have zero difficulty.
+        /// </para>
         /// </summary>
         /// <param name="blockChain">Consecutive <see cref="Block{T}"/>s to be
         /// followed by a new <see cref="Block{T}"/> to be mined.</param>


### PR DESCRIPTION
Just some preparatory work to tease out genesis block handling from `Append()`. The eventual goal is to change `Block<T>()` constructor to remove `IBlockPolicy` getting hold of a reference to an uninitialized `BlockChain<T>` "instance".

Notable changes:
- Introduces `ValidateGenesisBlock()` as a separate method. Although this violates DRY principle, I think this is better for comprehension as there are too many special `Block<T>` "fields" to consider.
- Reduced dependency for `IBlockPolicy` during genesis block validation.