### PR TITLE
Introduce @planetarium/account

### DIFF
--- a/@planetarium/account/.gitignore
+++ b/@planetarium/account/.gitignore
@@ -1,0 +1,2 @@
+coverage/
+dist/

--- a/@planetarium/account/README.md
+++ b/@planetarium/account/README.md
@@ -1,0 +1,1 @@
+# account

--- a/@planetarium/account/global.d.ts
+++ b/@planetarium/account/global.d.ts
@@ -1,0 +1,15 @@
+declare module globalThis {
+  var crypto:
+    | undefined
+    | {
+        subtle: {
+          digest: (
+            algorithm: string,
+            data: ArrayBuffer | TypedArray | DataView
+          ) => Promise<ArrayBuffer>;
+        };
+      };
+  var TextEncoder:
+    | undefined
+    | (new () => { encode: (input: string) => Uint8Array });
+}

--- a/@planetarium/account/package.json
+++ b/@planetarium/account/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@planetarium/account",
+  "private": true,
+  "description": "Libplanet accounts for JavaScript/TypeScript",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "yarn && nanobundle build",
+    "prepack": "yarn && yarn build",
+    "dev": "yarn && vitest",
+    "test": "yarn && yarn run -T tsc -p tsconfig.json && vitest run",
+    "coverage": "yarn && vitest run --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/planetarium/libplanet.git",
+    "directory": "@planetarium/account"
+  },
+  "keywords": [
+    "libplanet"
+  ],
+  "author": "Planetarium (https://planetarium.dev/)",
+  "license": "LGPL-2.1-or-later",
+  "bugs": {
+    "url": "https://github.com/planetarium/libplanet/labels/js"
+  },
+  "homepage": "https://github.com/planetarium/libplanet/tree/main/@planetarium/account",
+  "devDependencies": {
+    "@types/node": "^18.13.0",
+    "@vitest/coverage-c8": "^0.22.1",
+    "@vitest/ui": "^0.22.1",
+    "fast-check": "^3.1.2",
+    "nanobundle": "^1.5.0",
+    "vite": "^4.1.1",
+    "vitest": "^0.22.1"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.2.0",
+    "@noble/secp256k1": "^1.7.1",
+    "bencodex": "^0.1.1"
+  }
+}

--- a/@planetarium/account/src/Account.ts
+++ b/@planetarium/account/src/Account.ts
@@ -1,0 +1,15 @@
+import { type Message } from "./Message.js";
+import PublicKey from "./PublicKey.js";
+import RawPrivateKey from "./RawPrivateKey.js";
+import Signature from "./Signature.js";
+
+export interface Account {
+  publicKey: PublicKey;
+  sign(message: Message): Promise<Signature>;
+}
+
+export interface ExportableAccount extends Account {
+  exportPrivateKey(): Promise<RawPrivateKey>;
+}
+
+export default Account;

--- a/@planetarium/account/src/Address.ts
+++ b/@planetarium/account/src/Address.ts
@@ -1,0 +1,112 @@
+import { keccak_256 } from "@noble/hashes/sha3";
+import { PublicKey } from "./PublicKey.js";
+
+if (typeof globalThis.TextEncoder === "undefined") {
+  // FIXME: This is a workaround for the lack of TextEncoder in Vitest.
+  globalThis.TextEncoder = require("node:util").TextEncoder;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function checksum(hex: string): string {
+  hex = hex.toLowerCase();
+
+  const hexAsciiIntoBytes = new TextEncoder!().encode(hex);
+  const hashedAddr = toHex(keccak_256(hexAsciiIntoBytes));
+  let checksum = "";
+  for (let nibbleIdx = 0; nibbleIdx < hex.length; nibbleIdx++) {
+    const nibbleHex = hex.charAt(nibbleIdx);
+    if (nibbleHex.match(/^[0-9]$/)) {
+      checksum += nibbleHex;
+      continue;
+    } else {
+      const nibble = parseInt(hashedAddr.charAt(nibbleIdx), 16);
+      checksum += nibble > 7 ? nibbleHex.toUpperCase() : nibbleHex;
+    }
+  }
+
+  return checksum;
+}
+
+export class Address {
+  #bytes: Uint8Array;
+
+  private constructor(bytes: Uint8Array) {
+    this.#bytes = bytes;
+  }
+
+  static deriveFrom(publicKey: PublicKey): Address {
+    if (!(publicKey instanceof PublicKey)) {
+      throw new Error(`Expected PublicKey, got ${typeof publicKey}`);
+    }
+    const pub = publicKey.toRawBytes("uncompressed").slice(1);
+    const digest = keccak_256(pub);
+    const addr = digest.slice(digest.length - 20);
+    return new Address(addr);
+  }
+
+  static fromHex(hex: string, ignoreChecksum: boolean = false): Address {
+    if (typeof hex !== "string") {
+      throw new Error(`Expected a string, but ${typeof hex} was given.`);
+    } else if (!hex.match(/^(0x)?[0-9a-f]{40}$/i)) {
+      throw new Error(
+        `Expected a string of 40 hexadecimals, but ${JSON.stringify(
+          hex
+        )} was given.`
+      );
+    }
+
+    if (hex.match(/^0x/i)) {
+      hex = hex.slice(2);
+    }
+
+    const addr = new Address(new Uint8Array(Buffer.from(hex, "hex")));
+    if (ignoreChecksum) {
+      return addr;
+    }
+
+    const expectedChecksum = checksum(hex);
+    if (expectedChecksum !== hex) {
+      throw new Error(
+        `Expected checksum is 0x${expectedChecksum}, but 0x${hex} was given.`
+      );
+    }
+
+    return addr;
+  }
+
+  static fromBytes(bytes: Uint8Array) {
+    if (!(bytes instanceof Uint8Array)) {
+      throw new Error(`Expected a Uint8Array, but ${typeof bytes} was given.`);
+    }
+
+    if (bytes.length !== 20) {
+      throw new Error(
+        `Expected 20 bytes, but ${bytes.length} bytes were given.`
+      );
+    }
+
+    return new Address(bytes);
+  }
+
+  toBytes(): Uint8Array {
+    return this.#bytes;
+  }
+
+  toHex(casing: "checksum" | "lower" = "checksum"): string {
+    const hex = toHex(this.#bytes);
+    return casing === "checksum" ? checksum(hex) : hex;
+  }
+
+  toString(): string {
+    return `0x${this.toHex()}`;
+  }
+}
+
+export default Address;

--- a/@planetarium/account/src/Message.ts
+++ b/@planetarium/account/src/Message.ts
@@ -1,0 +1,11 @@
+import { sha256 } from "@noble/hashes/sha256";
+
+export type Message = Uint8Array;
+
+export async function hashMessage(message: Message): Promise<Uint8Array> {
+  // TODO: Use Web Crypto API when it is available.
+  // return new Uint8Array(await crypto!.subtle.digest("SHA-256", message));
+  return sha256(message);
+}
+
+export default Message;

--- a/@planetarium/account/src/PublicKey.ts
+++ b/@planetarium/account/src/PublicKey.ts
@@ -1,0 +1,97 @@
+import * as secp256k1 from "@noble/secp256k1";
+import { Message, hashMessage } from "./Message.js";
+import Signature from "./Signature.js";
+
+export type PublicKeyForm = "compressed" | "uncompressed";
+
+export class PublicKey {
+  readonly #point: secp256k1.Point;
+
+  private constructor(point: secp256k1.Point) {
+    this.#point = point;
+  }
+
+  static fromBytes(bytes: Uint8Array, form: PublicKeyForm): PublicKey {
+    if (!(bytes instanceof Uint8Array)) {
+      throw new Error(`Expected a Uint8Array, but got ${typeof bytes}`);
+    }
+    const header = bytes[0];
+    if (form === "compressed") {
+      if (bytes.length !== 33) {
+        throw new Error(
+          `Invalid compressed public key: expected 33 bytes, but got ${bytes.length} bytes`
+        );
+      } else if (header !== 0x02 && header !== 0x03) {
+        throw new Error(
+          `Invalid compressed public key: expected either 0x02 or 0x03 as the header, but got 0x${header
+            .toString(16)
+            .padStart(2, "0")}`
+        );
+      }
+    } else if (form === "uncompressed") {
+      if (bytes.length !== 65) {
+        throw new Error(
+          `Invalid uncompressed public key expected 65 bytes, but got ${bytes.length} bytes`
+        );
+      } else if (header !== 0x04) {
+        throw new Error(
+          `Invalid compressed public key: expected 0x04 as the header, but got 0x${header
+            .toString(16)
+            .padStart(2, "0")}`
+        );
+      }
+    } else {
+      throw new Error(
+        "Invalid public key form: choose 'compressed' or 'uncompressed'"
+      );
+    }
+    return new PublicKey(secp256k1.Point.fromHex(bytes));
+  }
+
+  // TODO: more explicit length checking
+  static fromHex(hex: string, form: PublicKeyForm): PublicKey {
+    if (typeof hex !== "string") {
+      throw new Error(`Expected a string, but got ${typeof hex}`);
+    } else if (form === "compressed" && hex.length !== 66) {
+      throw new Error(
+        `Invalid compressed public key: expected 33 hexadigits, but got ${hex.length} hexadigits`
+      );
+    } else if (form === "uncompressed" && hex.length !== 130) {
+      throw new Error(
+        `Invalid uncompressed public key expected 130 hexadigits, but got ${hex.length} hexadigits`
+      );
+    }
+    const bytes = new Uint8Array(Buffer.from(hex, "hex"));
+    return this.fromBytes(bytes, form);
+  }
+
+  async verify(message: Message, signature: Signature): Promise<boolean> {
+    if (!(message instanceof Uint8Array)) {
+      throw new Error(`Expected Uint8Array, but got ${typeof message}`);
+    } else if (!(signature instanceof Signature)) {
+      throw new Error(`Expected Signature, but got ${typeof signature}`);
+    }
+    const msgHash = await hashMessage(message);
+    return secp256k1.verify(signature.toBytes(), msgHash, this.#point);
+  }
+
+  toRawBytes(form: PublicKeyForm): Uint8Array {
+    if (form !== "compressed" && form !== "uncompressed") {
+      throw new Error(
+        "Invalid public key form: choose 'compressed' or 'uncompressed'"
+      );
+    }
+    return this.#point.toRawBytes(form === "compressed");
+  }
+
+  toHex(form: PublicKeyForm): string {
+    if (form !== "compressed" && form !== "uncompressed") {
+      throw new Error(
+        "Invalid public key form: choose 'compressed' or 'uncompressed'"
+      );
+    }
+    return this.#point.toHex(form === "compressed");
+  }
+}
+
+export default PublicKey;

--- a/@planetarium/account/src/RawPrivateKey.ts
+++ b/@planetarium/account/src/RawPrivateKey.ts
@@ -1,0 +1,81 @@
+import * as secp256k1 from "@noble/secp256k1";
+import { Message, hashMessage } from "./Message.js";
+import PublicKey from "./PublicKey.js";
+import Signature from "./Signature.js";
+
+export class RawPrivateKey {
+  readonly #privatePart: Uint8Array;
+  #publicPart?: PublicKey;
+
+  private constructor(privatePart: Uint8Array) {
+    this.#privatePart = privatePart;
+  }
+
+  static fromBytes(bytes: Uint8Array): RawPrivateKey {
+    if (!(bytes instanceof Uint8Array)) {
+      throw new Error(`Expected Uint8Array, but got ${typeof bytes}`);
+    } else if (bytes.length !== 32) {
+      throw new Error(
+        `Incorrect private key length; expected 32 bytes, but got ${bytes.length} bytes`
+      );
+    } else if (!secp256k1.utils.isValidPrivateKey(bytes)) {
+      throw new Error("Invalid private key");
+    }
+
+    // NOTE: The bytes should be copied because the original array can be
+    // mutated after the key is created.
+    return new RawPrivateKey(new Uint8Array(bytes));
+  }
+
+  static fromHex(hex: string): RawPrivateKey {
+    if (typeof hex !== "string") {
+      throw new Error(`Expected string, but got ${typeof hex}`);
+    } else if (hex.length !== 64) {
+      throw new Error(
+        `Incorrect private key length; expected 64 hexadigits, but got ${hex.length} hexadigits`
+      );
+    }
+    const bytes = new Uint8Array(Buffer.from(hex, "hex"));
+    if (!secp256k1.utils.isValidPrivateKey(bytes)) {
+      throw new Error("Invalid private key");
+    }
+
+    return new RawPrivateKey(bytes);
+  }
+
+  static generate(): RawPrivateKey {
+    return this.fromBytes(secp256k1.utils.randomPrivateKey());
+  }
+
+  get publicKey(): PublicKey {
+    if (typeof this.#publicPart === "undefined") {
+      this.#publicPart = PublicKey.fromBytes(
+        secp256k1.getPublicKey(this.#privatePart),
+        "uncompressed"
+      );
+    }
+
+    return this.#publicPart;
+  }
+
+  async sign(message: Message): Promise<Signature> {
+    const sig = await secp256k1.sign(
+      await hashMessage(message),
+      this.#privatePart,
+      { der: true }
+    );
+    return Signature.fromBytes(sig);
+  }
+
+  exportPrivateKey(): Promise<RawPrivateKey> {
+    return Promise.resolve(this);
+  }
+
+  toBytes(): Uint8Array {
+    // NOTE: The #privatePart should be copied because the returned reference
+    // can be mutated after this method is called.
+    return new Uint8Array(this.#privatePart);
+  }
+}
+
+export default RawPrivateKey;

--- a/@planetarium/account/src/Signature.ts
+++ b/@planetarium/account/src/Signature.ts
@@ -1,0 +1,41 @@
+import * as secp256k1 from "@noble/secp256k1";
+
+export class Signature {
+  readonly #signature: secp256k1.Signature;
+
+  private constructor(signature: secp256k1.Signature) {
+    this.#signature = signature;
+  }
+
+  static fromBytes(bytes: Uint8Array): Signature {
+    // NOTE: We decided to distinguish fromBytes from fromHex, although they
+    // call the same function in @noble/secp256k1 which takes both a hex string
+    // and a Uint8Array.
+    return new Signature(secp256k1.Signature.fromDER(bytes));
+  }
+
+  static fromHex(hex: string): Signature {
+    // NOTE: We decided to distinguish fromBytes from fromHex, although they
+    // call the same function in @noble/secp256k1 which takes both a hex string
+    // and a Uint8Array.
+    return new Signature(secp256k1.Signature.fromDER(hex));
+  }
+
+  toBytes(): Uint8Array {
+    return this.#signature.toDERRawBytes();
+  }
+
+  toHex(): string {
+    return this.#signature.toDERHex();
+  }
+
+  toString(): string {
+    return this.toHex();
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    return `Signature { ${this.toHex()} }`;
+  }
+}
+
+export default Signature;

--- a/@planetarium/account/src/index.ts
+++ b/@planetarium/account/src/index.ts
@@ -1,0 +1,6 @@
+export { type Account, type ExportableAccount } from "./Account.js";
+export { type Address } from "./Address.js";
+export { type Message } from "./Message.js";
+export { PublicKey, type PublicKeyForm } from "./PublicKey.js";
+export { RawPrivateKey } from "./RawPrivateKey.js";
+export { Signature } from "./Signature.js";

--- a/@planetarium/account/test/Address.test.ts
+++ b/@planetarium/account/test/Address.test.ts
@@ -1,0 +1,187 @@
+import { Address } from "../src/Address";
+import { PublicKey } from "../src/PublicKey";
+import * as fc from "fast-check";
+import { describe, expect, test } from "vitest";
+import { bytesEquals, toHex } from "./utils";
+
+describe("Address", () => {
+  test("deriveFrom()", () => {
+    var pubKey = PublicKey.fromBytes(
+      new Uint8Array([
+        0x03, 0x43, 0x8b, 0x93, 0x53, 0x89, 0xa7, 0xeb, 0xf8, 0x38, 0xb3, 0xae,
+        0x41, 0x25, 0xbd, 0x28, 0x50, 0x6a, 0xa2, 0xdd, 0x45, 0x7f, 0x20, 0xaf,
+        0xc8, 0x43, 0x72, 0x9d, 0x3e, 0x7d, 0x60, 0xd7, 0x28,
+      ]),
+      "compressed"
+    );
+    var expectedAddress = Address.fromBytes(
+      new Uint8Array([
+        0xd4, 0x1f, 0xad, 0xf6, 0x1b, 0xad, 0xf5, 0xbe, 0x2d, 0xe6, 0x0e, 0x9f,
+        0xc3, 0x23, 0x0c, 0x0a, 0x8a, 0x43, 0x90, 0xf0,
+      ])
+    );
+    expect(Address.deriveFrom(pubKey)).toHaveEqualBytes(expectedAddress);
+    expect(() => Address.deriveFrom(123 as unknown as PublicKey)).toThrowError(
+      /got number/i
+    );
+  });
+
+  test("fromHex() with ignoreChecksum: true", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("", "0x", "0X"),
+        fc.uint8Array({ minLength: 20, maxLength: 20 }),
+        (prefix, addressBytes: Uint8Array) => {
+          const hex = prefix + toHex(addressBytes);
+          return (
+            bytesEquals(Address.fromHex(hex, true).toBytes(), addressBytes) &&
+            bytesEquals(
+              Address.fromHex(hex.toUpperCase(), true).toBytes(),
+              addressBytes
+            )
+          );
+        }
+      )
+    );
+    expect(() => Address.fromHex(123 as unknown as string)).toThrowError(
+      /number was given/i
+    );
+    fc.assert(
+      fc.property(
+        fc.constantFrom("", "0x", "0X"),
+        fc.oneof(
+          fc.uint8Array({ maxLength: 19 }),
+          fc.uint8Array({ minLength: 21 })
+        ),
+        (prefix: string, addressBytes: Uint8Array) => {
+          const hex = prefix + toHex(addressBytes);
+          try {
+            Address.fromHex(hex, true);
+          } catch (e) {
+            return e.toString().includes("40 hexa");
+          }
+          return false;
+        }
+      )
+    );
+  });
+
+  test("fromBytes()", () => {
+    fc.assert(
+      fc.property(
+        fc.uint8Array({ minLength: 20, maxLength: 20 }),
+        (addressBytes: Uint8Array) => {
+          return bytesEquals(
+            Address.fromBytes(addressBytes).toBytes(),
+            addressBytes
+          );
+        }
+      )
+    );
+    expect(() => Address.fromBytes(123 as unknown as Uint8Array)).toThrowError(
+      /number was given/i
+    );
+    fc.assert(
+      fc.property(
+        fc.oneof(
+          fc.uint8Array({ maxLength: 19 }),
+          fc.uint8Array({ minLength: 21 })
+        ),
+        (addressBytes: Uint8Array) => {
+          try {
+            Address.fromBytes(addressBytes);
+          } catch (e) {
+            return e.toString().includes(`${addressBytes.length} bytes`);
+          }
+          return false;
+        }
+      )
+    );
+  });
+
+  test("fromHex() with ignoreChecksum: false", () => {
+    let expected = Address.fromBytes(
+      new Uint8Array([
+        0x5a, 0xae, 0xb6, 0x5, 0x3f, 0x3e, 0x94, 0xc9, 0xb9, 0xa0, 0x9f, 0x33,
+        0x66, 0x94, 0x35, 0xe7, 0xef, 0x1b, 0xea, 0xed,
+      ])
+    );
+    expect(
+      Address.fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", false)
+    ).toHaveEqualBytes(expected);
+
+    expected = Address.fromBytes(
+      new Uint8Array([
+        0xfb, 0x69, 0x16, 0x9, 0x5c, 0xa1, 0xdf, 0x60, 0xbb, 0x79, 0xce, 0x92,
+        0xce, 0x3e, 0xa7, 0x4c, 0x37, 0xc5, 0xd3, 0x59,
+      ])
+    );
+    expect(
+      Address.fromHex("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", false)
+    ).toHaveEqualBytes(expected);
+
+    expected = Address.fromBytes(
+      new Uint8Array([
+        0xdb, 0xf0, 0x3b, 0x40, 0x7c, 0x01, 0xe7, 0xcd, 0x3c, 0xbe, 0xa9, 0x95,
+        0x09, 0xd9, 0x3f, 0x8d, 0xdd, 0xc8, 0xc6, 0xfb,
+      ])
+    );
+    expect(
+      Address.fromHex("0XdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB")
+    ).toHaveEqualBytes(expected);
+
+    expect(() =>
+      Address.fromHex("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDB")
+    ).toThrowError(/checksum/i);
+  });
+
+  test("toBytes()", () => {
+    fc.assert(
+      fc.property(
+        fc.uint8Array({ minLength: 20, maxLength: 20 }),
+        (addressBytes: Uint8Array) => {
+          return bytesEquals(
+            Address.fromHex(toHex(addressBytes), true).toBytes(),
+            addressBytes
+          );
+        }
+      )
+    );
+  });
+
+  test("toHex('checksum')", () => {
+    const address = Address.fromBytes(
+      new Uint8Array([
+        0xdb, 0xf0, 0x3b, 0x40, 0x7c, 0x01, 0xe7, 0xcd, 0x3c, 0xbe, 0xa9, 0x95,
+        0x09, 0xd9, 0x3f, 0x8d, 0xdd, 0xc8, 0xc6, 0xfb,
+      ])
+    );
+    expect(address.toHex("checksum")).toBe(
+      "dbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"
+    );
+  });
+
+  test("toHex('lower')", () => {
+    const address = Address.fromBytes(
+      new Uint8Array([
+        0xdb, 0xf0, 0x3b, 0x40, 0x7c, 0x01, 0xe7, 0xcd, 0x3c, 0xbe, 0xa9, 0x95,
+        0x09, 0xd9, 0x3f, 0x8d, 0xdd, 0xc8, 0xc6, 0xfb,
+      ])
+    );
+    expect(address.toHex("lower")).toBe(
+      "dbf03b407c01e7cd3cbea99509d93f8dddc8c6fb"
+    );
+  });
+
+  test("toString()", () => {
+    const address = Address.fromBytes(
+      new Uint8Array([
+        0xdb, 0xf0, 0x3b, 0x40, 0x7c, 0x01, 0xe7, 0xcd, 0x3c, 0xbe, 0xa9, 0x95,
+        0x09, 0xd9, 0x3f, 0x8d, 0xdd, 0xc8, 0xc6, 0xfb,
+      ])
+    );
+    expect(address.toString()).toBe(
+      "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"
+    );
+  });
+});

--- a/@planetarium/account/test/Message.test.ts
+++ b/@planetarium/account/test/Message.test.ts
@@ -1,0 +1,24 @@
+import { hashMessage } from "../src/Message";
+import { expect, test } from "vitest";
+
+test("hashMessage()", async () => {
+  const foo = new Uint8Array([0x66, 0x6f, 0x6f]);
+  expect(await hashMessage(foo)).toStrictEqual(
+    new Uint8Array(
+      Buffer.from(
+        "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+        "hex"
+      )
+    )
+  );
+
+  const bar = new Uint8Array([0x62, 0x61, 0x72]);
+  expect(await hashMessage(bar)).toStrictEqual(
+    new Uint8Array(
+      Buffer.from(
+        "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9",
+        "hex"
+      )
+    )
+  );
+});

--- a/@planetarium/account/test/PublicKey.test.ts
+++ b/@planetarium/account/test/PublicKey.test.ts
@@ -1,0 +1,196 @@
+import { Message } from "../src/Message";
+import { PublicKey } from "../src/PublicKey";
+import { Signature } from "../src/Signature";
+import { describe, expect, test } from "vitest";
+
+describe("PublicKey", () => {
+  const compHex =
+    "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070";
+  const uncompHex =
+    "04472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed807" +
+    "0302b403f1fb65851e90ccc75838b0346d052d5431e8baa64ec677d62be463170";
+  test("fromBytes()", () => {
+    // TODO: Test with a compressed pubkey with 0x03 header
+    const compBytes = Buffer.from(compHex, "hex");
+
+    // TypedArray() constructor refers to the memory if it takes an
+    // ArrayBuffer/Buffer, but it copies the memory if it takes a view
+    // (e.g. Uint8Array).  The below code calls the constructor twice by
+    // intention (to copy the data):
+    const inputCompBytes = new Uint8Array(new Uint8Array(compBytes));
+    const pubKey = PublicKey.fromBytes(inputCompBytes, "compressed");
+
+    expect(pubKey.toHex("compressed")).toBe(compHex);
+    expect(pubKey.toHex("uncompressed")).toBe(uncompHex);
+
+    // The inputCompBytes should not affect the RawPrivateKey instance which
+    // was created from it:
+    inputCompBytes.fill(0, 0, inputCompBytes.length);
+    expect(pubKey.toHex("compressed")).toBe(compHex);
+
+    const pubKey2 = PublicKey.fromBytes(
+      pubKey.toRawBytes("uncompressed"),
+      "uncompressed"
+    );
+    expect(pubKey2.toHex("compressed")).toBe(compHex);
+
+    const invalidType = [] as unknown as Uint8Array;
+    expect(() => PublicKey.fromBytes(invalidType, "compressed")).toThrowError(
+      /got object/i
+    );
+
+    const invalidCompLength = new Uint8Array(32);
+    expect(() =>
+      PublicKey.fromBytes(invalidCompLength, "compressed")
+    ).toThrowError(/got 32 bytes/i);
+
+    const invalidCompHeader = new Uint8Array(33);
+    invalidCompHeader[0] = 0x04;
+    expect(() =>
+      PublicKey.fromBytes(invalidCompHeader, "compressed")
+    ).toThrowError(/got 0x04/i);
+
+    const invalidUncompLength = new Uint8Array(64);
+    expect(() =>
+      PublicKey.fromBytes(invalidUncompLength, "uncompressed")
+    ).toThrowError(/got 64 bytes/i);
+
+    const invalidUncompHeader = new Uint8Array(65);
+    invalidUncompHeader[0] = 0x02;
+    expect(() =>
+      PublicKey.fromBytes(invalidUncompHeader, "uncompressed")
+    ).toThrowError(/got 0x02/i);
+
+    expect(() =>
+      PublicKey.fromBytes(
+        new Uint8Array(0),
+        "invalid" as unknown as "compressed" | "uncompressed"
+      )
+    ).toThrowError(/invalid.*? form/i);
+  });
+
+  test("fromHex()", () => {
+    // TODO: Test with a compressed pubkey with 0x03 header
+    const pubKey = PublicKey.fromHex(compHex, "compressed");
+
+    expect(pubKey.toHex("compressed")).toBe(compHex);
+    expect(pubKey.toHex("uncompressed")).toBe(uncompHex);
+
+    const pubKey2 = PublicKey.fromHex(
+      pubKey.toHex("uncompressed"),
+      "uncompressed"
+    );
+    expect(pubKey2.toHex("compressed")).toBe(compHex);
+
+    const invalidType = [] as unknown as string;
+    expect(() => PublicKey.fromHex(invalidType, "compressed")).toThrowError(
+      /got object/i
+    );
+
+    const invalidCompLength = "0".repeat(65);
+    expect(() =>
+      PublicKey.fromHex(invalidCompLength, "compressed")
+    ).toThrowError(/got 65 hexadigits/i);
+
+    const invalidCompHeader = "04" + "0".repeat(64);
+    expect(() =>
+      PublicKey.fromHex(invalidCompHeader, "compressed")
+    ).toThrowError(/got 0x04/i);
+
+    const invalidUncompLength = "0".repeat(129);
+    expect(() =>
+      PublicKey.fromHex(invalidUncompLength, "uncompressed")
+    ).toThrowError(/got 129 hexadigits/i);
+
+    const invalidUncompHeader = "02" + "0".repeat(128);
+    expect(() =>
+      PublicKey.fromHex(invalidUncompHeader, "uncompressed")
+    ).toThrowError(/got 0x02/i);
+
+    expect(() =>
+      PublicKey.fromHex(
+        "",
+        "invalid" as unknown as "compressed" | "uncompressed"
+      )
+    ).toThrowError(/invalid.*? form/i);
+  });
+
+  test("verify()", async () => {
+    const pubKeyBytes = new Uint8Array([
+      0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20, 0x42, 0x3b, 0xad, 0x39,
+      0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b, 0x33, 0xe3, 0x48, 0x7c,
+      0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96, 0xf8, 0xa5, 0x48, 0x34, 0x40, 0xef,
+      0xbb, 0xef, 0x06, 0x57, 0xac, 0x2e, 0xf6, 0xc6, 0xee, 0x05, 0xdb, 0x06,
+      0xa9, 0x45, 0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a, 0x16, 0x95, 0xe5, 0xce,
+      0x1a, 0x3d, 0x3c, 0x76, 0xdb,
+    ]);
+    const pubKey = PublicKey.fromBytes(pubKeyBytes, "uncompressed");
+    const msg = new Uint8Array([
+      0x64, 0x37, 0x3a, 0x61, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x6c, 0x65,
+      0x31, 0x30, 0x3a, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x5f, 0x6b, 0x65,
+      0x79, 0x36, 0x35, 0x3a, 0x04, 0xb5, 0xa2, 0x4a, 0xa2, 0x11, 0x27, 0x20,
+      0x42, 0x3b, 0xad, 0x39, 0xa0, 0x20, 0x51, 0x82, 0x37, 0x9d, 0x6f, 0x2b,
+      0x33, 0xe3, 0x48, 0x7c, 0x9a, 0xb6, 0xcc, 0x8f, 0xc4, 0x96, 0xf8, 0xa5,
+      0x48, 0x34, 0x40, 0xef, 0xbb, 0xef, 0x06, 0x57, 0xac, 0x2e, 0xf6, 0xc6,
+      0xee, 0x05, 0xdb, 0x06, 0xa9, 0x45, 0x32, 0xfd, 0xa7, 0xdd, 0xc4, 0x4a,
+      0x16, 0x95, 0xe5, 0xce, 0x1a, 0x3d, 0x3c, 0x76, 0xdb, 0x39, 0x3a, 0x72,
+      0x65, 0x63, 0x69, 0x70, 0x69, 0x65, 0x6e, 0x74, 0x32, 0x30, 0x3a, 0x8a,
+      0xe7, 0x2e, 0xfa, 0xb0, 0x95, 0x94, 0x66, 0x51, 0x12, 0xe6, 0xd4, 0x9d,
+      0xfd, 0x19, 0x41, 0x53, 0x8c, 0xf3, 0x74, 0x36, 0x3a, 0x73, 0x65, 0x6e,
+      0x64, 0x65, 0x72, 0x32, 0x30, 0x3a, 0xb6, 0xc0, 0x3d, 0xe5, 0x7d, 0xdf,
+      0x03, 0x69, 0xc7, 0x20, 0x7d, 0x2d, 0x11, 0x3a, 0xdf, 0xf8, 0x20, 0x51,
+      0x99, 0xcf, 0x39, 0x3a, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d,
+      0x70, 0x32, 0x37, 0x3a, 0x32, 0x30, 0x31, 0x38, 0x2d, 0x30, 0x31, 0x2d,
+      0x30, 0x32, 0x54, 0x30, 0x33, 0x3a, 0x30, 0x34, 0x3a, 0x30, 0x35, 0x2e,
+      0x30, 0x30, 0x36, 0x30, 0x30, 0x30, 0x5a, 0x65,
+    ]);
+    const sigBytes = new Uint8Array([
+      0x30, 0x44, 0x02, 0x20, 0x62, 0xcf, 0x8a, 0x04, 0x41, 0x9c, 0x6a, 0x03,
+      0xba, 0xf5, 0x5d, 0xe1, 0x0d, 0x9b, 0x20, 0x0e, 0xda, 0xa9, 0xdf, 0x2b,
+      0x9b, 0xf0, 0xcf, 0x98, 0x9f, 0xd6, 0x5d, 0x71, 0xc5, 0x5c, 0x35, 0x60,
+      0x02, 0x20, 0x2a, 0xa5, 0x59, 0x69, 0xd0, 0xad, 0xb1, 0x5e, 0x9e, 0x70,
+      0x8d, 0x83, 0x00, 0xe1, 0x05, 0x31, 0x1e, 0x1a, 0x16, 0x16, 0x5d, 0xb7,
+      0x3e, 0xd8, 0xf4, 0xf0, 0x05, 0x1d, 0x9f, 0x13, 0x81, 0xfd,
+    ]);
+    const sig = Signature.fromBytes(sigBytes);
+    expect(pubKey.verify(msg, sig)).toBeTruthy();
+
+    const invalidMsgType = "" as unknown as Message;
+    await expect(() => pubKey.verify(invalidMsgType, sig)).rejects.toThrowError(
+      /got string/
+    );
+
+    const invalidSigType = "" as unknown as Signature;
+    await expect(() => pubKey.verify(msg, invalidSigType)).rejects.toThrowError(
+      /got string/
+    );
+  });
+
+  test("toRawBytes()", () => {
+    const pubKey = PublicKey.fromHex(compHex, "compressed");
+    expect(pubKey.toRawBytes("uncompressed")).toStrictEqual(
+      new Uint8Array(Buffer.from(uncompHex, "hex"))
+    );
+
+    const pubKey2 = PublicKey.fromHex(uncompHex, "uncompressed");
+    expect(pubKey2.toRawBytes("compressed")).toStrictEqual(
+      new Uint8Array(Buffer.from(compHex, "hex"))
+    );
+
+    const invalidForm = "invalid" as unknown as "compressed" | "uncompressed";
+    expect(() => pubKey.toRawBytes(invalidForm)).toThrowError(
+      /invalid .*? form/i
+    );
+  });
+
+  test("toHex()", () => {
+    const pubKey = PublicKey.fromHex(compHex, "compressed");
+    expect(pubKey.toHex("uncompressed")).toBe(uncompHex);
+
+    const pubKey2 = PublicKey.fromHex(uncompHex, "uncompressed");
+    expect(pubKey2.toHex("compressed")).toBe(compHex);
+
+    const invalidForm = "invalid" as unknown as "compressed" | "uncompressed";
+    expect(() => pubKey.toHex(invalidForm)).toThrowError(/invalid .*? form/i);
+  });
+});

--- a/@planetarium/account/test/RawPrivateKey.test.ts
+++ b/@planetarium/account/test/RawPrivateKey.test.ts
@@ -1,0 +1,139 @@
+import * as fc from "fast-check";
+import * as secp256k1 from "@noble/secp256k1";
+import { PublicKey } from "../src/PublicKey";
+import { RawPrivateKey } from "../src/RawPrivateKey";
+import { describe, expect, test } from "vitest";
+
+describe("RawPrivateKey", () => {
+  test("fromBytes()", () => {
+    const bytes = Buffer.from(
+      "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d",
+      "hex"
+    );
+
+    // TypedArray() constructor refers to the memory if it takes an
+    // ArrayBuffer/Buffer, but it copies the memory if it takes a view
+    // (e.g. Uint8Array).  The below code calls the constructor twice by
+    // intention (to copy the data):
+    const inputBytes = new Uint8Array(new Uint8Array(bytes));
+    const rawKey = RawPrivateKey.fromBytes(inputBytes);
+    expect(rawKey.toBytes()).toStrictEqual(new Uint8Array(bytes));
+
+    const pubKeyBytes = new Uint8Array(
+      Buffer.from(
+        "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070",
+        "hex"
+      )
+    );
+    expect(rawKey.publicKey.toRawBytes("compressed")).toStrictEqual(
+      pubKeyBytes
+    );
+
+    // The inputBytes should not affect the RawPrivateKey instance which
+    // was created from it:
+    inputBytes.fill(0, 0, inputBytes.length);
+    expect(rawKey.toBytes()).toStrictEqual(new Uint8Array(bytes));
+    expect(rawKey.publicKey.toRawBytes("compressed")).toStrictEqual(
+      pubKeyBytes
+    );
+
+    const invalidType = [] as unknown as Uint8Array;
+    expect(() => RawPrivateKey.fromBytes(invalidType)).toThrowError(
+      /got object/i
+    );
+
+    const invalidLength = new Uint8Array(31);
+    expect(() => RawPrivateKey.fromBytes(invalidLength)).toThrowError(
+      /got 31 bytes/i
+    );
+
+    const invalidKey = new Uint8Array(32);
+    expect(() => RawPrivateKey.fromBytes(invalidKey)).toThrowError(/invalid/i);
+  });
+
+  test("fromHex()", () => {
+    const hex =
+      "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d";
+    const rawKey = RawPrivateKey.fromHex(hex);
+    expect(rawKey.toBytes()).toStrictEqual(
+      new Uint8Array(Buffer.from(hex, "hex"))
+    );
+
+    const pubKeyBytes = new Uint8Array(
+      Buffer.from(
+        "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070",
+        "hex"
+      )
+    );
+    expect(rawKey.publicKey.toRawBytes("compressed")).toStrictEqual(
+      pubKeyBytes
+    );
+
+    const invalidType = new Uint8Array(32) as unknown as string;
+    expect(() => RawPrivateKey.fromHex(invalidType)).toThrowError(
+      /got object/i
+    );
+
+    const invalidLength = "0".repeat(62);
+    expect(() => RawPrivateKey.fromHex(invalidLength)).toThrowError(
+      /got 62 hexadigits/i
+    );
+
+    const invalidKey = "0".repeat(64);
+    expect(() => RawPrivateKey.fromHex(invalidKey)).toThrowError(/invalid/i);
+  });
+
+  test("generate()", () => {
+    const rawKey = RawPrivateKey.generate();
+    const keyBytes = rawKey.toBytes();
+    expect(keyBytes.length).toBe(32);
+    expect(keyBytes).toSatisfy(secp256k1.utils.isValidPrivateKey);
+  });
+
+  test("publicKey", () => {
+    const key = RawPrivateKey.fromHex(
+      "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d"
+    );
+    expect(key.publicKey).toBeInstanceOf(PublicKey);
+    expect(key.publicKey.toHex("compressed")).toStrictEqual(
+      "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070"
+    );
+  });
+
+  test("sign()", async () => {
+    // TODO: Compare with `planet key sign` command
+    // TODO: Turn the RawPrivateKey fixture into an arbitrary.
+    const key = RawPrivateKey.generate();
+    const pubKey = key.publicKey;
+    await fc.assert(
+      fc.asyncProperty(fc.uint8Array(), async (msg: Uint8Array) => {
+        const sig = await key.sign(msg);
+        return await pubKey.verify(msg, sig);
+      })
+    );
+  });
+
+  test("exportPrivateKey()", async () => {
+    const key = RawPrivateKey.generate();
+    const exported = await key.exportPrivateKey();
+    expect(exported).toBeInstanceOf(RawPrivateKey);
+    expect(exported).toHaveEqualBytes(key);
+  });
+
+  test("toBytes()", () => {
+    const originalBytes = new Uint8Array(
+      Buffer.from(
+        "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d",
+        "hex"
+      )
+    );
+    const rawKey = RawPrivateKey.fromBytes(originalBytes);
+    const bytes = rawKey.toBytes();
+    expect(bytes).toStrictEqual(originalBytes);
+
+    // The returned bytes should be a copy, and should not affect the original
+    // bytes in the RawPrivateKey instance:
+    bytes.fill(0, 0, bytes.length);
+    expect(rawKey.toBytes()).toStrictEqual(originalBytes);
+  });
+});

--- a/@planetarium/account/test/Signature.test.ts
+++ b/@planetarium/account/test/Signature.test.ts
@@ -1,0 +1,56 @@
+import { Signature } from "../src/Signature";
+import { describe, expect, test } from "vitest";
+import { inspect } from "node:util";
+
+describe("Signature", () => {
+  const sigBytes = new Uint8Array([
+    0x30, 0x44, 0x02, 0x20, 0x62, 0xcf, 0x8a, 0x04, 0x41, 0x9c, 0x6a, 0x03,
+    0xba, 0xf5, 0x5d, 0xe1, 0x0d, 0x9b, 0x20, 0x0e, 0xda, 0xa9, 0xdf, 0x2b,
+    0x9b, 0xf0, 0xcf, 0x98, 0x9f, 0xd6, 0x5d, 0x71, 0xc5, 0x5c, 0x35, 0x60,
+    0x02, 0x20, 0x2a, 0xa5, 0x59, 0x69, 0xd0, 0xad, 0xb1, 0x5e, 0x9e, 0x70,
+    0x8d, 0x83, 0x00, 0xe1, 0x05, 0x31, 0x1e, 0x1a, 0x16, 0x16, 0x5d, 0xb7,
+    0x3e, 0xd8, 0xf4, 0xf0, 0x05, 0x1d, 0x9f, 0x13, 0x81, 0xfd,
+  ]);
+  const sigHex =
+    "3044022062cf8a04419c6a03baf55de10d9b200edaa9df2b9bf0cf989fd65d71c55c35" +
+    "6002202aa55969d0adb15e9e708d8300e105311e1a16165db73ed8f4f0051d9f1381fd";
+
+  test("fromBytes()", () => {
+    const inputBytes = new Uint8Array(sigBytes);
+    const sig = Signature.fromBytes(inputBytes);
+    expect(sig.toBytes()).toStrictEqual(sigBytes);
+    expect(sig.toHex()).toBe(sigHex);
+
+    // The inputBytes should not affect the Signature instance which
+    // was created from it:
+    inputBytes.fill(0, 0, inputBytes.length);
+    expect(sig.toBytes()).toStrictEqual(sigBytes);
+    expect(sig.toHex()).toBe(sigHex);
+  });
+
+  test("fromHex()", () => {
+    const sig = Signature.fromHex(sigHex);
+    expect(sig.toHex()).toBe(sigHex);
+    expect(sig.toBytes()).toStrictEqual(sigBytes);
+  });
+
+  test("toBytes()", () => {
+    const sig = Signature.fromBytes(sigBytes);
+    expect(sig.toBytes()).toStrictEqual(sigBytes);
+  });
+
+  test("toHex()", () => {
+    const sig = Signature.fromBytes(sigBytes);
+    expect(sig.toHex()).toBe(sigHex);
+  });
+
+  test("toString()", () => {
+    const sig = Signature.fromBytes(sigBytes);
+    expect(sig.toString()).toBe(sigHex);
+  });
+
+  test("[nodejs.util.inspect.custom]()", () => {
+    const sig = Signature.fromBytes(sigBytes);
+    expect(inspect(sig)).toBe(`Signature { ${sig.toString()} }`);
+  });
+});

--- a/@planetarium/account/test/setup.ts
+++ b/@planetarium/account/test/setup.ts
@@ -1,0 +1,37 @@
+import { expect } from "vitest";
+
+interface HavingBytes {
+  toBytes(): Uint8Array;
+}
+
+expect.extend({
+  toHaveEqualBytes: (received: HavingBytes, expected: HavingBytes) => {
+    const actualBytes = received.toBytes();
+    const expectedBytes = expected.toBytes();
+    const actualHex = new Buffer(actualBytes).toString("hex");
+    const expectedHex = new Buffer(expectedBytes).toString("hex");
+    if (actualBytes.length !== expectedBytes.length) {
+      return {
+        message: () =>
+          `expected to have ${expectedBytes.length} bytes, ` +
+          `got ${actualBytes.length}\n` +
+          `expected: ${expectedHex}\nactual: ${actualHex}`,
+        pass: false,
+      };
+    }
+
+    for (let i = 0; i < actualBytes.length; i++) {
+      if (actualBytes[i] !== expectedBytes[i]) {
+        return {
+          message: () =>
+            `expected ${received} to have equal bytes, ` +
+            `got ${actualBytes} at index ${i}\n` +
+            `expected: ${expectedHex}\nactual: ${actualHex}`,
+          pass: false,
+        };
+      }
+    }
+
+    return { pass: true };
+  },
+});

--- a/@planetarium/account/test/utils.ts
+++ b/@planetarium/account/test/utils.ts
@@ -1,0 +1,19 @@
+export function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+export function bytesEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/@planetarium/account/tsconfig.json
+++ b/@planetarium/account/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["./src", "*.d.ts", "*.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "ES2020",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "nodenext"
+  }
+}

--- a/@planetarium/account/vitest.config.ts
+++ b/@planetarium/account/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./test/setup.ts"],
+    cache: false
+  },
+});

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.51.0
 
 To be released.
 
+Since 0.51.0, we officially provide *[@planetarium/account]*, an npm package for
+providing measures to represent accounts for apps developed with Libplanet in
+JavaScript/TypeScript.  Note that the feature set is being actively developed,
+and the specification might change in the near future.
+
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
@@ -21,8 +26,12 @@ To be released.
 ### Bug fixes
 
 ### Dependencies
+ -  Added *[@planetarium/account]* npm package.  [[#2848]]
 
 ### CLI tools
+
+[#2848]: https://github.com/planetarium/libplanet/pull/2848
+[@planetarium/account]: https://www.npmjs.com/package/@planetarium/account
 
 
 Version 0.50.0

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "packageManager": "yarn@3.4.1",
   "private": true,
   "workspaces": [
+    "@planetarium/account",
     "@planetarium/tx",
     "Libplanet.Tools"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@noble/hashes@npm:1.2.0"
+  checksum: 8ca080ce557b8f40fb2f78d3aedffd95825a415ac8e13d7ffe3643f8626a8c2d99a3e5975b555027ac24316d8b3c02a35b8358567c0c23af681e6573602aa434
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@noble/secp256k1@npm:1.7.1"
+  checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
+  languageName: node
+  linkType: hard
+
 "@npmcli/fs@npm:^2.1.0":
   version: 2.1.2
   resolution: "@npmcli/fs@npm:2.1.2"
@@ -432,6 +446,23 @@ __metadata:
   checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
   languageName: node
   linkType: hard
+
+"@planetarium/account@workspace:@planetarium/account":
+  version: 0.0.0-use.local
+  resolution: "@planetarium/account@workspace:@planetarium/account"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+    "@noble/secp256k1": ^1.7.1
+    "@types/node": ^18.13.0
+    "@vitest/coverage-c8": ^0.22.1
+    "@vitest/ui": ^0.22.1
+    bencodex: ^0.1.1
+    fast-check: ^3.1.2
+    nanobundle: ^1.5.0
+    vite: ^4.1.1
+    vitest: ^0.22.1
+  languageName: unknown
+  linkType: soft
 
 "@planetarium/cli@workspace:Libplanet.Tools":
   version: 0.0.0-use.local
@@ -546,7 +577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^18.14.0":
+"@types/node@npm:*, @types/node@npm:^18.13.0, @types/node@npm:^18.14.0":
   version: 18.14.0
   resolution: "@types/node@npm:18.14.0"
   checksum: d83fcf5e4ed544755dd9028f5cbb6b9d46235043159111bb2ad62223729aee581c0144a9f6df8ba73d74011db9ed4ebd7af2fd5e0996714e3beb508a5da8ac5c
@@ -3274,7 +3305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^4.1.3":
+"vite@npm:^4.1.1, vite@npm:^4.1.3":
   version: 4.1.4
   resolution: "vite@npm:4.1.4"
   dependencies:


### PR DESCRIPTION
Prerequisite: ~~#2847~~ satisfied
This PR introduces @planetarium/account typescript package into the typescript monorepo, which provides means to represent accounts for applications built with Libplanet.
Note that KeyStore interface is not yet ready and is not yet included in this PR. For now, RawPrivateKey constructor can be used with external code to access tx signing and account management features.

~~**Note for reviewers**: as this PR includes commits for #2847, you can examine only the latest commit for making a code review. This PR will be rebased on #2847 once it gets merged.~~ Not applicable