### PR TITLE
CI: fix where obj/ directory is missing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,7 @@ jobs:
       run: node scripts/determine-version.js
     - shell: bash
       run: |
+        mkdir -p obj
         echo "$VERSION_PREFIX" > obj/version_prefix.txt
         if [[ "$VERSION_SUFFIX" != "" ]]; then
           echo "$VERSION_SUFFIX" > obj/version_suffix.txt


### PR DESCRIPTION
Fix CI regression introduced with #2847: https://github.com/planetarium/libplanet/actions/runs/4259681427/jobs/7412118146#step:7:18