### PR TITLE
♻️ Refactor validate nonces

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1137,7 +1137,6 @@ namespace Libplanet.Blockchain
                 sampleAfter: threshold);
         }
 
-#pragma warning disable MEN003
         internal void Append(
             Block<T> block,
             bool evaluateActions,
@@ -1163,7 +1162,7 @@ namespace Libplanet.Blockchain
             stateCompleters ??= StateCompleterSet<T>.Recalculate;
 
             _logger.Information(
-                "Trying to append block #{BlockIndex} {BlockHash}...", block?.Index, block?.Hash);
+                "Trying to append block #{BlockIndex} {BlockHash}...", block.Index, block.Hash);
 
             block.ValidateTimestamp();
 
@@ -1321,7 +1320,6 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitUpgradeableReadLock();
             }
         }
-#pragma warning restore MEN003
 
         /// <summary>
         /// Find an approximate to the topmost common ancestor between this
@@ -1522,7 +1520,8 @@ namespace Libplanet.Blockchain
                 if (!expectedNonce.Equals(tx.Nonce))
                 {
                     throw new InvalidTxNonceException(
-                        "Transaction nonce is invalid.",
+                        $"Transaction {tx.Id} has an invalid nonce {tx.Nonce} that is different " +
+                        $"from expected nonce {expectedNonce}.",
                         tx.Id,
                         expectedNonce,
                         tx.Nonce);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1173,39 +1173,25 @@ namespace Libplanet.Blockchain
             {
                 if (ValidateNextBlock(block) is { } ibe)
                 {
-                    _logger.Error(ibe, "Failed to append invalid block {BlockHash}", block.Hash);
                     throw ibe;
                 }
 
-                var nonceDeltas = new Dictionary<Address, long>();
+                var nonceDeltas = ValidateNonces(
+                    block.Transactions
+                        .Select(tx => tx.Signer)
+                        .Distinct()
+                        .ToDictionary(signer => signer, signer => Store.GetTxNonce(Id, signer)),
+                    block);
 
-                foreach (Transaction<T> tx1 in block.Transactions.OrderBy(tx => tx.Nonce))
+                foreach (Transaction<T> tx in block.Transactions)
                 {
-                    if (block.Index > 0 && Policy.ValidateNextBlockTx(this, tx1) is { } tpve)
+                    if (block.Index > 0 && Policy.ValidateNextBlockTx(this, tx) is { } tpve)
                     {
                         throw new TxPolicyViolationException(
                             "According to BlockPolicy, this transaction is not valid.",
-                            tx1.Id,
+                            tx.Id,
                             tpve);
                     }
-
-                    Address txSigner = tx1.Signer;
-                    nonceDeltas.TryGetValue(txSigner, out var nonceDelta);
-
-                    long expectedNonce = nonceDelta + Store.GetTxNonce(Id, txSigner);
-
-                    if (!expectedNonce.Equals(tx1.Nonce))
-                    {
-                        _logger.Error("Failed to append invalid tx {TxId}", tx1.Id);
-                        throw new InvalidTxNonceException(
-                            "Transaction nonce is invalid.",
-                            tx1.Id,
-                            expectedNonce,
-                            tx1.Nonce
-                        );
-                    }
-
-                    nonceDeltas[txSigner] = nonceDelta + 1;
                 }
 
                 _rwlock.EnterWriteLock();
@@ -1519,6 +1505,33 @@ namespace Libplanet.Blockchain
             }
 
             return null;
+        }
+
+        private static Dictionary<Address, long> ValidateNonces(
+            Dictionary<Address, long> storedNonces,
+            Block<T> block)
+        {
+            var nonceDeltas = new Dictionary<Address, long>();
+            foreach (Transaction<T> tx in block.Transactions.OrderBy(tx => tx.Nonce))
+            {
+                nonceDeltas.TryGetValue(tx.Signer, out var nonceDelta);
+                storedNonces.TryGetValue(tx.Signer, out var storedNonce);
+
+                long expectedNonce = nonceDelta + storedNonce;
+
+                if (!expectedNonce.Equals(tx.Nonce))
+                {
+                    throw new InvalidTxNonceException(
+                        "Transaction nonce is invalid.",
+                        tx.Id,
+                        expectedNonce,
+                        tx.Nonce);
+                }
+
+                nonceDeltas[tx.Signer] = nonceDelta + 1;
+            }
+
+            return nonceDeltas;
         }
 
         private InvalidBlockException ValidateNextBlock(Block<T> block)

--- a/Libplanet/Tx/InvalidTxNonceException.cs
+++ b/Libplanet/Tx/InvalidTxNonceException.cs
@@ -1,13 +1,14 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Libplanet.Blockchain;
+using Libplanet.Blocks;
 
 namespace Libplanet.Tx
 {
     /// <summary>
-    /// The exception that is thrown when the <see cref="Transaction{T}.Nonce"/>
-    /// is different from <see cref="BlockChain{T}.GetNextTxNonce"/> result of
-    /// the <see cref="Transaction{T}.Signer"/>.
+    /// An exception that is thrown when the <see cref="Transaction{T}.Nonce"/>
+    /// of a <see cref="Transaction{T}"/> included in a <see cref="Block{T}"/>
+    /// is inconsistent with the expected nonce for the <see cref="Transaction{T}.Signer"/>
+    /// when appending to a <see cref="BlockChain{T}"/>.
     /// </summary>
     [Serializable]
     public sealed class InvalidTxNonceException : InvalidTxException
@@ -17,35 +18,27 @@ namespace Libplanet.Tx
         /// <see cref="InvalidTxNonceException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        /// <param name="txid">The invalid <see cref="Transaction{T}"/>'s
+        /// <param name="txId">The invalid <see cref="Transaction{T}"/>'s
         /// <see cref="Transaction{T}.Id"/>.  It is automatically included to
         /// the <see cref="Exception.Message"/> string.</param>
-        /// <param name="expectedNonce"><see cref="BlockChain{T}.GetNextTxNonce"/>
-        /// result of the <see cref="Transaction{T}.Signer"/>.</param>
-        /// <param name="improperNonce">The actual
-        /// <see cref="Transaction{T}.Nonce"/>.</param>
-        [SuppressMessage(
-            "Microsoft.StyleCop.CSharp.ReadabilityRules",
-            "SA1118",
-            Justification = "A long error message should be multiline.")]
+        /// <param name="expectedNonce">The expected <see cref="Transaction{T}.Nonce"/> value
+        /// for the <see cref="Transaction{T}"/>.</param>
+        /// <param name="improperNonce">The actual <see cref="Transaction{T}.Nonce"/>.</param>
         public InvalidTxNonceException(
             string message,
-            TxId txid,
+            TxId txId,
             long expectedNonce,
             long improperNonce)
-            : base(
-                $"{message}\n" +
-                $"Expected nonce: {expectedNonce}\n" +
-                $"Improper nonce: {improperNonce}",
-                txid)
+            : base(message, txId)
         {
             ExpectedNonce = expectedNonce;
             ImproperNonce = improperNonce;
         }
 
         /// <summary>
-        /// <see cref="BlockChain{T}.GetNextTxNonce"/> result of the
-        /// <see cref="Transaction{T}.Signer"/>.
+        /// The expected <see cref="Transaction{T}.Nonce"/> value
+        /// for the <see cref="Transaction{T}"/> with <see cref="TxId"/>
+        /// as its <see cref="Transaction{T}.Id"/>.
         /// </summary>
         public long ExpectedNonce { get; }
 


### PR DESCRIPTION
This is a follow-up to #2845.

PR size is unnecessarily large due to indentation fix in `Swarm.BlockCandidate.cs`. 🙄

- Tx nonce validation has been extracted out as a separate method.
  - There could be a slight performance degradation as we are iterating over `Block<T>.Transactions` twice.
  - This is to mainly separate policy validation and structural validation more easily.
  - Future plan is to re-use this method during genesis `Block<T>` validation.