### PR TITLE
Added `BlockChain<T>.Create()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,21 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `BlockChain<T>()` no longer accepts an `IStore` where
+    `IStore.GetCanonicalChainId()` is `null`.  For on-the-fly `BlockChain<T>`
+    creation from scratch, use `BlockChain<T>.Create()` factory method instead.
+    [[#2863]]
+ -  `BlockChain<T>.Append()` no longer accepts a genesis `Block<T>` (i.e.
+    any `Block<T>` with an index of `0`).  [[#2863]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  Added `BlockChain<T>.Create()` factory method for creating a `BlockChain<T>`
+    with an empty `IStore`.  [[#2863]]
 
 ### Behavioral changes
 
@@ -23,6 +33,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#2863]: https://github.com/planetarium/libplanet/pull/2863
 
 
 Version 0.51.0

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -56,7 +56,7 @@ namespace Libplanet.Net.Tests.Consensus
                         TestUtils.PrivateKeys[i].PublicKey,
                         new DnsEndPoint("127.0.0.1", 6000 + i)));
                 stores[i] = new MemoryStore();
-                blockChains[i] = new BlockChain<DumbAction>(
+                blockChains[i] = BlockChain<DumbAction>.Create(
                     TestUtils.Policy,
                     new VolatileStagePolicy<DumbAction>(),
                     stores[i],

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -465,7 +465,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < size; i++)
             {
                 fxs[i] = new MemoryStoreFixture();
-                blockChains[i] = new BlockChain<DumbAction>(
+                blockChains[i] = BlockChain<DumbAction>.Create(
                     policy,
                     new VolatileStagePolicy<DumbAction>(),
                     fxs[i].Store,

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -76,7 +76,7 @@ namespace Libplanet.RocksDBStore.Tests
             {
                 var store = new RocksDBStore(path);
                 var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-                var blocks = new BlockChain<DumbAction>(
+                var blocks = BlockChain<DumbAction>.Create(
                     new NullBlockPolicy<DumbAction>(),
                     new VolatileStagePolicy<DumbAction>(),
                     store,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -441,7 +441,7 @@ namespace Libplanet.Tests.Blockchain
             var policy = new BlockPolicy<DumbAction>(validateNextBlockTx: IsSignerValid);
             using (var fx = new MemoryStoreFixture())
             {
-                var blockChain = new BlockChain<DumbAction>(
+                var blockChain = BlockChain<DumbAction>.Create(
                     policy,
                     new VolatileStagePolicy<DumbAction>(),
                     fx.Store,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.MineBlock.cs
@@ -240,7 +240,7 @@ namespace Libplanet.Tests.Blockchain
             var policy = new BlockPolicy<DumbAction>(validateNextBlockTx: IsSignerValid);
             using (var fx = new MemoryStoreFixture())
             {
-                var blockChain = new BlockChain<DumbAction>(
+                var blockChain = BlockChain<DumbAction>.Create(
                     policy,
                     new VolatileStagePolicy<DumbAction>(),
                     fx.Store,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -169,18 +169,17 @@ namespace Libplanet.Tests.Blockchain
                 TestUtils.GenesisProposer,
                 policy.BlockAction,
                 policy.NativeTokens.Contains,
-                stateStore
+                new TrieStateStore(new MemoryKeyValueStore())
             );
             store.PutBlock(genesisBlock);
             Assert.NotNull(store.GetStateRootHash(genesisBlock.Hash));
 
-            var chain1 = new BlockChain<DumbAction>(
+            var chain1 = BlockChain<DumbAction>.Create(
                 policy,
                 new VolatileStagePolicy<DumbAction>(),
                 store,
                 stateStore,
-                genesisBlock
-            );
+                genesisBlock);
 
             Block<DumbAction> block1 = new BlockContent<DumbAction>(
                 new BlockMetadata(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -2124,13 +2124,12 @@ namespace Libplanet.Tests.Blockchain
             var systemActions = ValidatorPrivateKeys.Select(
                 pk => new SetValidator(new Validator(pk.PublicKey, BigInteger.One)));
 
-            BlockChain<DumbAction> blockChain =
-                new BlockChain<DumbAction>(
-                    policy,
-                    new VolatileStagePolicy<DumbAction>(),
-                    storeFixture.Store,
-                    storeFixture.StateStore,
-                    BlockChain<DumbAction>.ProposeGenesisBlock(systemActions: systemActions));
+            var blockChain = BlockChain<DumbAction>.Create(
+                policy,
+                new VolatileStagePolicy<DumbAction>(),
+                storeFixture.Store,
+                storeFixture.StateStore,
+                BlockChain<DumbAction>.ProposeGenesisBlock(systemActions: systemActions));
 
             blockChain.MakeTransaction(
                 new PrivateKey(),

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 blockAction: null,
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             _stagePolicy = new VolatileStagePolicy<DumbAction>();
-            _chain = new BlockChain<DumbAction>(
+            _chain = BlockChain<DumbAction>.Create(
                 _policy,
                 _stagePolicy,
                 _fx.Store,

--- a/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -22,13 +22,12 @@ namespace Libplanet.Tests.Blockchain.Policies
         {
             _policy = new BlockPolicy<DumbAction>();
             _fx = new MemoryStoreFixture();
-            _chain = new BlockChain<DumbAction>(
+            _chain = BlockChain<DumbAction>.Create(
                 _policy,
                 StagePolicy,
                 _fx.Store,
                 _fx.StateStore,
-                _fx.GenesisBlock
-            );
+                _fx.GenesisBlock);
             _key = new PrivateKey();
             _txs = Enumerable.Range(0, 5).Select(i =>
                 Transaction<DumbAction>.Create(

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -471,7 +471,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 4
             );
 
-            var chain = new BlockChain<DumbAction>(
+            var chain = BlockChain<DumbAction>.Create(
                 policy,
                 new VolatileStagePolicy<DumbAction>(),
                 fx.Store,
@@ -558,7 +558,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 confirmations: 2
             );
 
-            var chain = new BlockChain<DumbAction>(
+            var chain = BlockChain<DumbAction>.Create(
                 policy,
                 new VolatileStagePolicy<DumbAction>(),
                 fx.Store,
@@ -686,7 +686,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 confirmations: 2
             );
 
-            var chain = new BlockChain<DumbAction>(
+            var chain = BlockChain<DumbAction>.Create(
                 policy,
                 new VolatileStagePolicy<DumbAction>(),
                 fx.Store,

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Tests.Blocks
                 AssertPreEvaluationBlocksEqual(preEvalGenesis, genesis);
                 _output.WriteLine("#1: {0}", genesis);
 
-                var blockChain = new BlockChain<Arithmetic>(
+                var blockChain = BlockChain<Arithmetic>.Create(
                     policy,
                     stagePolicy,
                     fx.Store,
@@ -109,7 +109,7 @@ namespace Libplanet.Tests.Blocks
                     preEvalGenesis.Sign(_contents.GenesisKey, genesisStateRootHash);
                 _output.WriteLine("#1: {0}", genesis);
 
-                var blockChain = new BlockChain<Arithmetic>(
+                var blockChain = BlockChain<Arithmetic>.Create(
                     policy,
                     stagePolicy,
                     fx.Store,

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Fixtures
                 blockAction: policy.BlockAction,
                 nativeTokenPredicate: policy.NativeTokens.Contains,
                 stateStore: StateStore);
-            Chain = new BlockChain<Arithmetic>(
+            Chain = BlockChain<Arithmetic>.Create(
                 policy,
                 new VolatileStagePolicy<Arithmetic>(),
                 Store,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1046,7 +1046,7 @@ namespace Libplanet.Tests.Store
             {
                 IStore s1 = fx.Store, s2 = fx2.Store;
                 var policy = new NullBlockPolicy<NullAction>();
-                var blocks = new BlockChain<NullAction>(
+                var blocks = BlockChain<NullAction>.Create(
                     policy,
                     new VolatileStagePolicy<NullAction>(),
                     s1,

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -627,7 +627,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
             ValidatingActionRenderer<T> validator = null;
 #pragma warning disable S1121
-            var chain = new BlockChain<T>(
+            var chain = BlockChain<T>.Create(
                 policy,
                 new VolatileStagePolicy<T>(),
                 store,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -447,7 +447,7 @@ namespace Libplanet.Blockchain
             IStore store,
             IStateStore stateStore,
             Block<T> genesisBlock,
-            IEnumerable<IRenderer<T>> renderers)
+            IEnumerable<IRenderer<T>> renderers = null)
 #pragma warning restore SA1611  // The documentation for parameters are missing.
         {
             if (store is null)

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -461,7 +461,7 @@ namespace Libplanet.Blockchain
             else if (store.GetCanonicalChainId() is { } canonId)
             {
                 throw new ArgumentException(
-                    $"Given {store} already has its canonical chain id set: {canonId}",
+                    $"Given {nameof(store)} already has its canonical chain id set: {canonId}",
                     nameof(store));
             }
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1322,6 +1322,7 @@ namespace Libplanet.Blockchain
         public BlockCommit GetBlockCommit(BlockHash blockHash) =>
             GetBlockCommit(this[blockHash].Index);
 
+#pragma warning disable MEN003
         internal void Append(
             Block<T> block,
             BlockCommit blockCommit,
@@ -1365,7 +1366,7 @@ namespace Libplanet.Blockchain
             block.ValidateTimestamp();
 
             _rwlock.EnterUpgradeableReadLock();
-            Block<T> prevTip = Count > 0 ? Tip : null;
+            Block<T> prevTip = Tip;
             try
             {
                 if (ValidateNextBlock(block) is { } ibe)
@@ -1533,6 +1534,7 @@ namespace Libplanet.Blockchain
                 _rwlock.ExitUpgradeableReadLock();
             }
         }
+#pragma warning restore MEN003
 
         /// <summary>
         /// Find an approximate to the topmost common ancestor between this

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1332,6 +1332,18 @@ namespace Libplanet.Blockchain
             StateCompleterSet<T>? stateCompleters = null
         )
         {
+            if (Count == 0)
+            {
+                throw new ArgumentException(
+                    "Cannot append a block to an empty chain.");
+            }
+            else if (block.Index == 0)
+            {
+                throw new ArgumentException(
+                    $"Cannot append genesis block #{block.Index} {block.Hash} to a chain.",
+                    nameof(block));
+            }
+
             if (!evaluateActions && renderActions)
             {
                 throw new ArgumentException(
@@ -1375,7 +1387,7 @@ namespace Libplanet.Blockchain
 
                 foreach (Transaction<T> tx in block.Transactions)
                 {
-                    if (block.Index > 0 && Policy.ValidateNextBlockTx(this, tx) is { } tpve)
+                    if (Policy.ValidateNextBlockTx(this, tx) is { } tpve)
                     {
                         throw new TxPolicyViolationException(
                             "According to BlockPolicy, this transaction is not valid.",


### PR DESCRIPTION
Related to #1486 and #2585.

Added `BlockChain<T>.Create()` factory method to create a `BlockChain<T>` instance with an "empty" `IStore` from scratch. The reason is twofold:

- Reduce side effects of simply instantiating a `BlockChain<T>` instance.
  - This can be further reduced by refactoring the `Fork()` method. In near future, we should be able to have `BlockChain<T>()` constructor without any side effects if all goes well. 🙃
- Reduce the usage of references to uninitialized `BlockChain<T>` instance.
  - I have only prevented calling `Append()` with a genesis `Block<T>` for now. Further `BlockChain<T>()` refactoring is in order once this is merged.

Eventually, we should be able to assume `BlockChain<T>.Tip` to be non-`null` and `Count > 0` to be `true` on any `BlockChain<T>` object.

Notable changes:
- Most, if not all, `BlockChain<T>()` for creating a new `BlockChain<T>` with an empty `IStore` has been replaced with `BlockChain<T>.Create()`.
- Removed `ShortCircuitActionEvaluationForUnrenderWithNoActionRenderers()` test. For now, the updated API does not allow such functionality (forcibly creating a new `BlockChain<T>` that is a "fork" of the original chain without directly calling `Fork()` while having a custom `IRenderer`s injected).
- I have to admit I have no idea how `ForkShouldSkipExecuteAndRenderGenesis()` should behave. I just changed the assertion constants to whatever actual values the test spat out. I'm really confused about rehearsal context. 🙄

Future to-do list:
- Check if `IStateStore` already contains given genesis `Block<T>.StateRootHash`. This might not be strictly necessary, but I'd say allowing such is prone to mistakes.
- Make `BlockChain<T>()` to be side-effect free by removing `Store.SetCanonicalChainId()`, `Append()`, and `Store.AppendIndex(Id, genesisBlock.Hash)`.