### PR TITLE
Convert custom actions lazily

### DIFF
--- a/Libplanet/Misc/Either/EitherLeft.cs
+++ b/Libplanet/Misc/Either/EitherLeft.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+
+namespace Libplanet.Misc.Either
+{
+    internal class EitherLeft<TLeft, TRight> : IEither<TLeft, TRight>
+    {
+        private readonly TLeft _value;
+
+        internal EitherLeft(TLeft value)
+        {
+            _value = value;
+        }
+
+        public TLeft GetLeftOrElse(Func<TRight, TLeft> f) => _value;
+
+        public TRight GetRightOrElse(Func<TLeft, TRight> f) => f(_value);
+    }
+}

--- a/Libplanet/Misc/Either/EitherRight.cs
+++ b/Libplanet/Misc/Either/EitherRight.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+
+namespace Libplanet.Misc.Either
+{
+    internal class EitherRight<TLeft, TRight> : IEither<TLeft, TRight>
+    {
+        private readonly TRight _value;
+
+        internal EitherRight(TRight value)
+        {
+            _value = value;
+        }
+
+        public TLeft GetLeftOrElse(Func<TRight, TLeft> f) => f(_value);
+
+        public TRight GetRightOrElse(Func<TLeft, TRight> f) => _value;
+    }
+}

--- a/Libplanet/Misc/Either/IEither.cs
+++ b/Libplanet/Misc/Either/IEither.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using System;
+
+namespace Libplanet.Misc.Either
+{
+    internal interface IEither<TLeft, TRight>
+    {
+        TLeft GetLeftOrElse(Func<TRight, TLeft> f);
+
+        TRight GetRightOrElse(Func<TLeft, TRight> f);
+    }
+}


### PR DESCRIPTION
Since https://github.com/planetarium/libplanet/pull/2539, the `Transaction<T>` became to own actions as bencodex type and to convert them to `IAction` when `Transaction<T>.CustomActions` is needed. Then, when creating transactions with `IAction`s, it converts twice time (`IAction` -> `IValue` -> `IAction`). This pull request tries to resolve the issue with wrapper type (maybe `Either` like). And it skips changelog because it doesn't change any interfaces.