### PR TITLE
Make `PolymorphicAction<T>._actionTypeLoader` configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ and the specification might change in the near future.
 
 ### Added APIs
 
+ -  Added `PolymorphicAction<T>.ActionTypeLoader` static property to provide
+    a way to configure action type loader to be used in `PolymorphicAction<T>`.
+    [[#2873]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -31,6 +35,7 @@ and the specification might change in the near future.
 ### CLI tools
 
 [#2848]: https://github.com/planetarium/libplanet/pull/2848
+[#2873]: https://github.com/planetarium/libplanet/pull/2873
 [@planetarium/account]: https://www.npmjs.com/package/@planetarium/account
 
 

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -150,13 +150,7 @@ namespace Libplanet.Action
     public sealed class PolymorphicAction<T> : IAction
         where T : IAction
     {
-        private static readonly StaticActionTypeLoader _actionTypeLoader =
-            new StaticActionTypeLoader(
-                Assembly.GetEntryAssembly() is Assembly entryAssembly
-                    ? new[] { typeof(T).Assembly, entryAssembly }
-                    : new[] { typeof(T).Assembly },
-                typeof(T)
-            );
+        private static StaticActionTypeLoader _actionTypeLoader;
 
         private static IDictionary<string, Type> _types;
 
@@ -183,6 +177,20 @@ namespace Libplanet.Action
         public PolymorphicAction(T innerAction)
         {
             InnerAction = innerAction;
+        }
+
+        /// <summary>
+        /// <see cref="StaticActionTypeLoader"/> for <see cref="PolymorphicAction{T}"/>.
+        /// </summary>
+        public static StaticActionTypeLoader ActionTypeLoader
+        {
+            get => _actionTypeLoader ??= new StaticActionTypeLoader(
+                Assembly.GetEntryAssembly() is Assembly entryAssembly
+                    ? new[] { typeof(T).Assembly, entryAssembly }
+                    : new[] { typeof(T).Assembly },
+                typeof(T)
+            );
+            set => _actionTypeLoader = value;
         }
 
         /// <summary>
@@ -260,7 +268,7 @@ namespace Libplanet.Action
 
         private static Type GetType(string typeId)
         {
-            _types ??= _actionTypeLoader.Load();
+            _types ??= ActionTypeLoader.Load();
             return _types[typeId];
         }
     }


### PR DESCRIPTION
This feature is temporary and it should be removed when removing the all `T` generic parameter.