### PR TITLE
fix/test: more deterministic `ConsensusReactor` test

### DIFF
--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -158,8 +158,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
-                TestUtils.PrivateKeys[1],
-                blockCommitClearThreshold: 1);
+                TestUtils.PrivateKeys[1]);
 
             // Create context of index 1.
             consensusContext.NewHeight(1);

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Net.Tests.Consensus
     [Collection("NetMQConfiguration")]
     public class ConsensusReactorTest : IDisposable
     {
-        private const int Timeout = 60 * 1000;
+        private const int Timeout = 30 * 1000;
         private ILogger _logger;
 
         public ConsensusReactorTest(ITestOutputHelper output)

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -55,7 +55,10 @@ namespace Libplanet.Net.Tests.Consensus
                 validatorPeers.Add(
                     new BoundPeer(
                         TestUtils.PrivateKeys[i].PublicKey,
-                        new DnsEndPoint("127.0.0.1", 6000 + i)));
+                        new DnsEndPoint(
+                            "127.0.0.1",
+                            TestUtils.GetAvailablePort(
+                                validatorPeers.Select(x => x.EndPoint.Port)))));
                 stores[i] = new MemoryStore();
                 blockChains[i] = new BlockChain<DumbAction>(
                     TestUtils.Policy,
@@ -70,7 +73,7 @@ namespace Libplanet.Net.Tests.Consensus
                 consensusReactors[i] = TestUtils.CreateDummyConsensusReactor(
                     blockChain: blockChains[i],
                     key: TestUtils.PrivateKeys[i],
-                    consensusPort: 6000 + i,
+                    consensusPort: validatorPeers[i].EndPoint.Port,
                     validatorPeers: validatorPeers,
                     newHeightDelayMilliseconds: 1000);
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -13,6 +13,7 @@ using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using NetMQ;
+using Nito.AsyncEx;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +23,6 @@ namespace Libplanet.Net.Tests.Consensus
     [Collection("NetMQConfiguration")]
     public class ConsensusReactorTest : IDisposable
     {
-        private const int PropagationDelay = 25_000;
         private const int Timeout = 60 * 1000;
         private ILogger _logger;
 
@@ -45,12 +45,14 @@ namespace Libplanet.Net.Tests.Consensus
             var consensusReactors = new ConsensusReactor<DumbAction>[4];
             var stores = new IStore[4];
             var blockChains = new BlockChain<DumbAction>[4];
-            var fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
+            using var fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
             var validatorPeers = new List<BoundPeer>();
             var cancellationTokenSource = new CancellationTokenSource();
+            var heightChanged = new AsyncAutoResetEvent[4];
 
             for (var i = 0; i < 4; i++)
             {
+                heightChanged[i] = new AsyncAutoResetEvent();
                 validatorPeers.Add(
                     new BoundPeer(
                         TestUtils.PrivateKeys[i].PublicKey,
@@ -71,62 +73,40 @@ namespace Libplanet.Net.Tests.Consensus
                     key: TestUtils.PrivateKeys[i],
                     consensusPort: 6000 + i,
                     validatorPeers: validatorPeers,
-                    newHeightDelayMilliseconds: PropagationDelay * 2);
+                    newHeightDelayMilliseconds: 1000);
+
+                var capture = i;
+                consensusReactors[i].ConsensusContext.StateChanged += (sender, hmrs) =>
+                {
+                    if (hmrs.Height == 2)
+                    {
+                        heightChanged[capture].Set();
+                    }
+                };
             }
 
             try
             {
+                // Prevents from non-stopping reactor. 1000 is arbitrary value which is considered
+                // as preparation time.
+                cancellationTokenSource.CancelAfter(Timeout - 1000);
                 consensusReactors.AsParallel().ForAll(
                     reactor => _ = reactor.StartAsync(cancellationTokenSource.Token));
 
-                Dictionary<string, JsonElement> json;
+                await Task.WhenAll(heightChanged.Select(x =>
+                    x.WaitAsync(cancellationTokenSource.Token)));
 
-                await Task.Delay(PropagationDelay, cancellationTokenSource.Token);
                 foreach (var reactor in consensusReactors)
                 {
                     await reactor.StopAsync(cancellationTokenSource.Token);
                 }
 
-                var isPolka = new bool[4];
-
-                for (var node = 0; node < 4; ++node)
+                foreach (var i in Enumerable.Range(0, 4))
                 {
-                    json = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
-                               consensusReactors[node].ToString())
-                           ?? throw new NullReferenceException(
-                               $"Failed to deserialize consensus reactor");
-
-                    // Genesis block exists, add 1 to the height.
-                    if (json["step"].GetString() == "EndCommit")
-                    {
-                        isPolka[node] = true;
-                    }
-                    else
-                    {
-                        Log.Error(
-                            "[Failed]: {0} {1}",
-                            json["step"].GetString(),
-                            blockChains[node].Count);
-                        isPolka[node] = false;
-                    }
-                }
-
-                Assert.Equal(4, isPolka.Sum(x => x ? 1 : 0));
-
-                for (var node = 0; node < 4; ++node)
-                {
-                    json = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
-                               consensusReactors[node].ToString())
-                           ?? throw new NullReferenceException(
-                               $"Failed to deserialize consensus reactor");
-
-                    Assert.Equal(
-                        validatorPeers[node].Address.ToString(),
-                        json["node_id"].GetString());
-                    Assert.Equal(1, json["height"].GetInt32());
-                    Assert.Equal(2, blockChains[node].Count);
-                    Assert.Equal(0L, json["round"].GetInt32());
-                    Assert.Equal("EndCommit", json["step"].GetString());
+                    // One height will be eventually consent.
+                    Assert.Equal(2, consensusReactors[i].Height);
+                    Assert.Equal(2, blockChains[i].Count);
+                    Assert.Equal(0, consensusReactors[i].ConsensusContext.Round);
                 }
             }
             finally
@@ -134,8 +114,7 @@ namespace Libplanet.Net.Tests.Consensus
                 cancellationTokenSource.Cancel();
                 for (int i = 0; i < 4; ++i)
                 {
-                    await consensusReactors[i].StopAsync(cancellationTokenSource.Token);
-                    consensusReactors[i].Dispose();
+                    await consensusReactors[i].DisposeAsync();
                 }
             }
         }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -12,7 +12,6 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
-using NetMQ;
 using Nito.AsyncEx;
 using Serilog;
 using Xunit;
@@ -21,7 +20,7 @@ using Xunit.Abstractions;
 namespace Libplanet.Net.Tests.Consensus
 {
     [Collection("NetMQConfiguration")]
-    public class ConsensusReactorTest : IDisposable
+    public class ConsensusReactorTest
     {
         private const int Timeout = 30 * 1000;
         private ILogger _logger;
@@ -158,11 +157,6 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.Equal(1, blockChain.Count);
             Assert.Equal(0L, json["round"].GetInt32());
             Assert.Equal("Propose", json["step"].GetString());
-        }
-
-        public void Dispose()
-        {
-            NetMQConfig.Cleanup(false);
         }
     }
 }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -290,7 +290,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> blockChain,
             PrivateKey? key = null,
             string host = "127.0.0.1",
-            int consensusPort = 5101,
+            int consensusPort = 0,
             List<BoundPeer>? validatorPeers = null,
             int newHeightDelayMilliseconds = 10_000,
             ContextTimeoutOption? contextTimeoutOptions = null)

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -221,7 +221,6 @@ namespace Libplanet.Net.Tests
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
-                long blockCommitClearThreshold = 30,
                 ContextTimeoutOption? contextTimeoutOptions = null)
         {
             policy ??= Policy;

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -147,6 +147,16 @@ namespace Libplanet.Net.Consensus
             return JsonSerializer.Serialize(dict);
         }
 
+        public async ValueTask DisposeAsync()
+        {
+            if (Running)
+            {
+                await StopAsync(CancellationToken.None);
+            }
+
+            Dispose();
+        }
+
         /// <summary>
         /// Adds <see cref="ConsensusMsg"/> to gossip.
         /// </summary>

--- a/Libplanet.Net/Consensus/IReactor.cs
+++ b/Libplanet.Net/Consensus/IReactor.cs
@@ -7,7 +7,7 @@ namespace Libplanet.Net.Consensus
     /// <summary>
     /// A interface of consensus reactors.
     /// </summary>
-    public interface IReactor : IDisposable
+    public interface IReactor : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Starts a reactor.


### PR DESCRIPTION
## Context
The `ConsensusReactorTest.StartAsync()` is a test for whether the consensus and its components are "booting" up correctly, and are able to reach a consensus for the next height. The previous method for checking the next height was checking in time, however, this could result non-deterministically. This PR tries to fix the flakiness of the test with an alternative method.

## Change
- Using `EventHandler` to watch for whether a node has been changed to the next height
- Split `ToString` test from the `StartAsync()` test
- Add `IAsyncDisposable()` to implements the asynchronous disposal (`StopAsync` + `Disposal`)
- Cleanup unused value