### PR TITLE
♻️ Refactor block commit cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.52.0
 
 To be released.
 
+Due to changes in [[#2894]], under certain circumstances, a network ran with
+[Libplanet 0.51.0] may have difficulty getting up and running after an update
+to this version.  Thus, it is recommanded to skip [Libplanet 0.51.0] for
+deployment if possible.
+
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
@@ -19,6 +24,8 @@ To be released.
  -  `BlockChain<T>()` now throws an `ArgumentException` if provided `IStore`
     does not have its canonical chain id set or provided chain id is not found.
     [[#1486], [#2585], [#2889]]
+ -  Added `IStore.GetChainBlockCommit()` and `IStore.PutChainBlockCommit()`
+    interface methods.  [[#2878], [#2894]]
 
 ### Backward-incompatible network protocol changes
 
@@ -31,16 +38,22 @@ To be released.
 
 ### Behavioral changes
 
+ -  Changed `BlockChain<T>.Fork()` to copy `BlockCommit` for its newly forked
+    `BlockChain<T>.Tip`.  [[#2878], [#2894]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+[Libplanet 0.51.0]: https://www.nuget.org/packages/Libplanet/0.51.0
 [#1486]: https://github.com/planetarium/libplanet/issues/1486
 [#2585]: https://github.com/planetarium/libplanet/issues/2585
 [#2863]: https://github.com/planetarium/libplanet/pull/2863
+[#2878]: https://github.com/planetarium/libplanet/issues/2878
 [#2889]: https://github.com/planetarium/libplanet/pull/2889
+[#2894]: https://github.com/planetarium/libplanet/pull/2894
 
 
 Version 0.51.0
@@ -170,8 +183,6 @@ and the specification might change in the near future.
 
 ### Dependencies
  -  Added *[@planetarium/account]* npm package.  [[#2848]]
-
-### CLI tools
 
 [#2848]: https://github.com/planetarium/libplanet/pull/2848
 [#2872]: https://github.com/planetarium/libplanet/pull/2872

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -186,28 +186,27 @@ namespace Libplanet.Explorer.Store
         }
 
         /// <inheritdoc />
-        public BlockCommit GetBlockCommit(BlockHash blockHash)
-        {
-            return _store.GetBlockCommit(blockHash);
-        }
+        public BlockCommit GetChainBlockCommit(Guid chainId) =>
+            _store.GetChainBlockCommit(chainId);
+
+        public void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit) =>
+            _store.PutChainBlockCommit(chainId, blockCommit);
 
         /// <inheritdoc />
-        public void PutBlockCommit(BlockCommit blockCommit)
-        {
+        public BlockCommit GetBlockCommit(BlockHash blockHash) =>
+            _store.GetBlockCommit(blockHash);
+
+        /// <inheritdoc />
+        public void PutBlockCommit(BlockCommit blockCommit) =>
             _store.PutBlockCommit(blockCommit);
-        }
 
         /// <inheritdoc />
-        public void DeleteBlockCommit(BlockHash blockHash)
-        {
+        public void DeleteBlockCommit(BlockHash blockHash) =>
             _store.DeleteBlockCommit(blockHash);
-        }
 
         /// <inheritdoc />
-        public IEnumerable<BlockHash> GetBlockCommitHashes()
-        {
-            return _store.GetBlockCommitHashes();
-        }
+        public IEnumerable<BlockHash> GetBlockCommitHashes() =>
+            _store.GetBlockCommitHashes();
 
         /// <inheritdoc cref="IStore.PutBlock{T}(Block{T})"/>
         public void PutBlock<T>(Block<T> block)

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -156,28 +156,28 @@ namespace Libplanet.Explorer.Store
         }
 
         /// <inheritdoc />
-        public BlockCommit GetBlockCommit(BlockHash blockHash)
-        {
-            return _store.GetBlockCommit(blockHash);
-        }
+        public BlockCommit GetChainBlockCommit(Guid chainId) =>
+            _store.GetChainBlockCommit(chainId);
 
         /// <inheritdoc />
-        public void PutBlockCommit(BlockCommit blockCommit)
-        {
+        public void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit) =>
+            _store.PutChainBlockCommit(chainId, blockCommit);
+
+        /// <inheritdoc />
+        public BlockCommit GetBlockCommit(BlockHash blockHash) =>
+            _store.GetBlockCommit(blockHash);
+
+        /// <inheritdoc />
+        public void PutBlockCommit(BlockCommit blockCommit) =>
             _store.PutBlockCommit(blockCommit);
-        }
 
         /// <inheritdoc />
-        public void DeleteBlockCommit(BlockHash blockHash)
-        {
+        public void DeleteBlockCommit(BlockHash blockHash) =>
             _store.DeleteBlockCommit(blockHash);
-        }
 
         /// <inheritdoc />
-        public IEnumerable<BlockHash> GetBlockCommitHashes()
-        {
-            return _store.GetBlockCommitHashes();
-        }
+        public IEnumerable<BlockHash> GetBlockCommitHashes() =>
+            _store.GetBlockCommitHashes();
 
         /// <inheritdoc cref="IStore.PutBlock{T}(Block{T})"/>
         public void PutBlock<T>(Block<T> block)

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -600,8 +600,6 @@ namespace Libplanet.Net
                                 VerifiedBlockHash = deltaBlock.Hash,
                             });
                     }
-
-                    workspace.CleanupBlockCommitStore(workspace.Tip.Index);
                 }
                 catch (Exception e)
                 {
@@ -674,6 +672,7 @@ namespace Libplanet.Net
                     );
 
                     renderSwap = BlockChain.Swap(workspace, render: render);
+                    BlockChain.CleanupBlockCommitStore(BlockChain.Tip.Index);
                 }
 
                 foreach (Guid chainId in chainIds)

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Tests.Blockchain
                 blockInterval: TimeSpan.FromSeconds(10)
             ).Evaluate(keys[4], _blockChain);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
-            Assert.NotNull(_blockChain.Store.GetBlockCommit(block1.Hash));
+            Assert.NotNull(_blockChain.GetBlockCommit(block1.Hash));
             Block<DumbAction> block2 = TestUtils.ProposeNext(
                 block1,
                 txs,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -984,6 +984,27 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [Fact]
+        public void GetBlockCommitAfterFork()
+        {
+            Block<DumbAction> block1 = _blockChain.ProposeBlock(new PrivateKey());
+            _blockChain.Append(block1, CreateBlockCommit(block1));
+            Block<DumbAction> block2 = _blockChain.ProposeBlock(
+                new PrivateKey(),
+                lastCommit: CreateBlockCommit(block1));
+            _blockChain.Append(block2, CreateBlockCommit(block2));
+            Block<DumbAction> block3 = _blockChain.ProposeBlock(
+                new PrivateKey(),
+                lastCommit: CreateBlockCommit(block2));
+            _blockChain.Append(block3, CreateBlockCommit(block3));
+
+            var forked = _blockChain.Fork(block2.Hash);
+            Assert.NotNull(forked.GetBlockCommit(forked.Tip.Index));
+            Assert.Equal(
+                forked.GetBlockCommit(forked.Tip.Index),
+                block3.LastCommit);
+        }
+
+        [Fact]
         public void CleanupBlockCommitStore()
         {
             BlockCommit blockCommit1 = CreateBlockCommit(

--- a/Libplanet.Tests/Store/ProxyStore.cs
+++ b/Libplanet.Tests/Store/ProxyStore.cs
@@ -181,12 +181,20 @@ namespace Libplanet.Tests.Store
             Store.PruneOutdatedChains(noopWithoutCanon);
 
         /// <inheritdoc />
+        public BlockCommit GetChainBlockCommit(Guid chainId) =>
+            Store.GetChainBlockCommit(chainId);
+
+        /// <inheritdoc />
+        public void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit) =>
+            Store.PutChainBlockCommit(chainId, blockCommit);
+
+        /// <inheritdoc />
         public BlockCommit GetBlockCommit(BlockHash blockHash) =>
             Store.GetBlockCommit(blockHash);
 
         /// <inheritdoc />
-        public void PutBlockCommit(BlockCommit lastCommit) =>
-            Store.PutBlockCommit(lastCommit);
+        public void PutBlockCommit(BlockCommit blockCommit) =>
+            Store.PutBlockCommit(blockCommit);
 
         /// <inheritdoc />
         public void DeleteBlockCommit(BlockHash blockHash) =>

--- a/Libplanet.Tests/Store/StoreTracker.cs
+++ b/Libplanet.Tests/Store/StoreTracker.cs
@@ -204,6 +204,18 @@ namespace Libplanet.Tests.Store
             _store.PruneOutdatedChains();
         }
 
+        public BlockCommit GetChainBlockCommit(Guid chainId)
+        {
+            Log(nameof(GetChainBlockCommit), chainId);
+            return _store.GetChainBlockCommit(chainId);
+        }
+
+        public void PutChainBlockCommit(Guid chainId, BlockCommit blockCmmit)
+        {
+            Log(nameof(PutChainBlockCommit), blockCmmit);
+            _store.PutChainBlockCommit(chainId, blockCmmit);
+        }
+
         public BlockCommit GetBlockCommit(BlockHash blockHash)
         {
             Log(nameof(GetBlockCommit), blockHash);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1634,8 +1634,19 @@ namespace Libplanet.Blockchain
         /// <see cref="BlockCommit.Height"/> less than <paramref name="limit"/>.
         /// </summary>
         /// <param name="limit">A exceptional index that is not to be removed.</param>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="IsCanonical"/> is
+        /// <see langword="false"/>.</exception>
         internal void CleanupBlockCommitStore(long limit)
         {
+            // FIXME: This still isn't enough to prevent the canonical chain
+            // removing cached block commits that are needed by other non-canonical chains.
+            if (!IsCanonical)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot perform {nameof(CleanupBlockCommitStore)}() from a " +
+                    "non canonical chain.");
+            }
+
             List<BlockHash> hashes = Store.GetBlockCommitHashes().ToList();
 
             _logger.Debug("Removing old BlockCommits with heights lower than {Limit}...", limit);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1245,7 +1245,7 @@ namespace Libplanet.Blockchain
         /// <param name="index">A index value (height) of <see cref="Block{T}"/> to retrieve.
         /// </param>
         /// <returns>Returns a <see cref="BlockCommit"/> of given <see cref="Block{T}"/> index.
-        /// Following conditions will returns <see langword="null"/>:
+        /// Following conditions will return <see langword="null"/>:
         /// <list type="bullet">
         ///     <item>
         ///         Given <see cref="Block{T}"/> <see cref="Block{T}.ProtocolVersion"/> is
@@ -1271,7 +1271,7 @@ namespace Libplanet.Blockchain
             }
 
             return index == Tip.Index
-                ? Store.GetBlockCommit(block.Hash)
+                ? Store.GetChainBlockCommit(Id)
                 : this[index + 1].LastCommit;
         }
 
@@ -1412,12 +1412,7 @@ namespace Libplanet.Blockchain
 
                     if (block.Index != 0 && blockCommit is { })
                     {
-                        Store.PutBlockCommit(blockCommit);
-                    }
-
-                    if (block.PreviousHash is { } prevHash)
-                    {
-                        Store.DeleteBlockCommit(prevHash);
+                        Store.PutChainBlockCommit(Id, blockCommit);
                     }
                 }
                 finally

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1173,6 +1173,11 @@ namespace Libplanet.Blockchain
                     _blockChainStates,
                     ActionEvaluator);
                 Store.ForkBlockIndexes(Id, forkedId, point);
+                if (GetBlockCommit(point) is { } p)
+                {
+                    Store.PutChainBlockCommit(forkedId, GetBlockCommit(point));
+                }
+
                 Store.ForkTxNonces(Id, forked.Id);
                 for (Block<T> block = Tip;
                      block.PreviousHash is { } hash && !block.Hash.Equals(point);

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -165,6 +165,12 @@ namespace Libplanet.Store
         public abstract void PruneOutdatedChains(bool noopWithoutCanon = false);
 
         /// <inheritdoc/>
+        public abstract BlockCommit GetChainBlockCommit(Guid chainId);
+
+        /// <inheritdoc/>
+        public abstract void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit);
+
+        /// <inheritdoc/>
         public abstract BlockCommit GetBlockCommit(BlockHash blockHash);
 
         /// <inheritdoc/>

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -326,12 +326,34 @@ namespace Libplanet.Store
         void PruneOutdatedChains(bool noopWithoutCanon = false);
 
         /// <summary>
-        /// Gets a <see cref="BlockCommit"/> for given <see cref="BlockHash"/> from store.
+        /// Gets a <see cref="BlockCommit"/> associated with a <see cref="BlockChain{T}"/>
+        /// with <paramref name="chainId"/> as its <see cref="BlockChain{T}.Id"/>.
+        /// </summary>
+        /// <param name="chainId">The <see cref="BlockChain{T}.Id"/> of
+        /// the <see cref="BlockChain{T}"/> to retrieve <see cref="BlockCommit"/>.</param>
+        /// <returns>Returns <see cref="BlockCommit"/> if given <paramref name="chainId"/> is
+        /// stored and available, otherwise returns <see langword="null"/>.</returns>
+        BlockCommit GetChainBlockCommit(Guid chainId);
+
+        /// <summary>
+        /// Puts a <see cref="BlockCommit"/> associated with a <see cref="BlockChain{T}"/>
+        /// with <paramref name="chainId"/> as its <see cref="BlockChain{T}.Id"/>.
+        /// The given <see cref="BlockCommit"/> should have the same <see cref="BlockHash"/>
+        /// as the <see cref="BlockChain{T}.Tip"/>.
+        /// </summary>
+        /// <param name="chainId">The <see cref="BlockChain{T}.Id"/> of
+        /// the <see cref="BlockChain{T}"/> to store <see cref="BlockCommit"/>.</param>
+        /// <param name="blockCommit">The <see cref="BlockCommit"/> to store.</param>
+        void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit);
+
+        /// <summary>
+        /// Gets the <see cref="BlockCommit"/> for given <paramref name="blockHash"/> from
+        /// the store.
         /// </summary>
         /// <param name="blockHash">The <see cref="BlockHash"/> of a <see cref="BlockCommit"/>
-        /// to get.</param>
-        /// <returns>Returns <see cref="BlockCommit"/> if given <see cref="BlockHash"/> is stored
-        /// and available, otherwise returns <see langword="null"/>.</returns>
+        /// to retrieve.</param>
+        /// <returns>Returns <see cref="BlockCommit"/> if given <paramref name="blockHash"/> is
+        /// stored and available, otherwise returns <see langword="null"/>.</returns>
         BlockCommit GetBlockCommit(BlockHash blockHash);
 
         /// <summary>

--- a/Libplanet/Store/MemoryStore.cs
+++ b/Libplanet/Store/MemoryStore.cs
@@ -52,6 +52,9 @@ namespace Libplanet.Store
         private readonly ConcurrentDictionary<BlockHash, BlockCommit> _blockCommits =
             new ConcurrentDictionary<BlockHash, BlockCommit>();
 
+        private readonly ConcurrentDictionary<Guid, BlockCommit> _chainCommits =
+            new ConcurrentDictionary<Guid, BlockCommit>();
+
         private Guid? _canonicalChainId;
 
         void IDisposable.Dispose()
@@ -269,29 +272,30 @@ namespace Libplanet.Store
             }
         }
 
-        public BlockCommit GetBlockCommit(BlockHash blockHash)
-        {
-            if (!_blockCommits.ContainsKey(blockHash))
-            {
-                return null;
-            }
+        /// <inheritdoc />
+        public BlockCommit GetChainBlockCommit(Guid chainId) =>
+            _chainCommits.TryGetValue(chainId, out BlockCommit commit)
+                ? commit
+                : null;
 
-            return _blockCommits[blockHash];
-        }
+        /// <inheritdoc />
+        public void PutChainBlockCommit(Guid chainId, BlockCommit blockCommit) =>
+            _chainCommits[chainId] = blockCommit;
 
+        public BlockCommit GetBlockCommit(BlockHash blockHash) =>
+            _blockCommits.TryGetValue(blockHash, out var commit)
+                ? commit
+                : null;
+
+        /// <inheritdoc />
         public void PutBlockCommit(BlockCommit blockCommit) =>
             _blockCommits[blockCommit.BlockHash] = blockCommit;
 
-        public void DeleteBlockCommit(BlockHash blockHash)
-        {
-            if (!_blockCommits.ContainsKey(blockHash))
-            {
-                return;
-            }
-
+        /// <inheritdoc />
+        public void DeleteBlockCommit(BlockHash blockHash) =>
             _blockCommits.TryRemove(blockHash, out _);
-        }
 
+        /// <inheritdoc />
         public IEnumerable<BlockHash> GetBlockCommitHashes()
             => _blockCommits.Keys;
 


### PR DESCRIPTION
Resolves #2878.

There are numerous issues pertaining to handling "globally" cached `BlockCommit`s, but this is more of a problem with how we handle `IStore` generally. In particular, having multiple chain instances with different chain ids with access to shared state (be it stored `Block<T>`s or `Transaction<T>`s, etc.) and **deletion** operations, the root of the problem is not having a scheme/spec/etc. for managing chain ids.

In any case, this PR only further specifies that any instance of `BlockChain<T>` should have `BlockCommit` for its `BlockChain<T>.Tip`, when applicable, i.e. when it is a non-genesis PBFT `Block<T>`.