### PR TITLE
ci/bench: use trigger branch/tag name as directory [skip changelog]

### DIFF
--- a/.github/workflows/benchmarks-merged.yml
+++ b/.github/workflows/benchmarks-merged.yml
@@ -34,5 +34,5 @@ jobs:
         tool: 'benchmarkdotnet'
         output-file-path: BenchmarkDotNet.Artifacts/results/Combined.Benchmarks.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        benchmark-data-dir-path: dev/bench/${{ github.base_ref }}/${{ matrix.os }}
+        benchmark-data-dir-path: dev/bench/${{ github.ref_name }}/${{ matrix.os }}
         auto-push: true


### PR DESCRIPTION
Follow-up PR of #2903 and #2902. Merged commits benchmark is not stored with branch name due to using `ref_name` in `on.push` actions.