### PR TITLE
ci/bench: missing cherry pick in 2908

### DIFF
--- a/.github/workflows/benchmarks-merged.yml
+++ b/.github/workflows/benchmarks-merged.yml
@@ -34,5 +34,5 @@ jobs:
         tool: 'benchmarkdotnet'
         output-file-path: BenchmarkDotNet.Artifacts/results/Combined.Benchmarks.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        benchmark-data-dir-path: dev/bench/${{ github.base_ref }}/${{ matrix.os }}
+        benchmark-data-dir-path: dev/bench/${{ github.ref_name }}/${{ matrix.os }}
         auto-push: true


### PR DESCRIPTION
I'm sorry for the mess 😓
(cherry picked from commit b4cbe99d9e0fdedd5545f939ea0c8d90fd220f3c)