### PR TITLE
Fix ActionExecutionState total count

### DIFF
--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -547,7 +547,7 @@ namespace Libplanet.Net
 
                 var actionExecutionState = new ActionExecutionState()
                 {
-                    TotalBlockCount = (int)(workspace.Count - (branchpoint?.Index + 1 ?? 0)),
+                    TotalBlockCount = blockChainSlice.Count,
                     ExecutedBlockCount = 0,
                 };
                 long txsCount = 0, actionsCount = 0;


### PR DESCRIPTION
Since workspace is forked blockchain of branchpoint, current `TotalBlockCount` indicates wrong counts. So, fixed it up.