### PR TITLE
🔀 Port 0.50.3 to 0.51.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.51.2
 
 To be released.
 
+ -  Ported changes from [Libplanet 0.50.3] release.  [[#2937]]
+
+[Libplanet 0.50.3]: https://www.nuget.org/packages/Libplanet/0.50.3
+[#2937]: https://github.com/planetarium/libplanet/pull/2937
+
 
 Version 0.51.1
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,29 @@ and the specification might change in the near future.
 [@planetarium/account]: https://www.npmjs.com/package/@planetarium/account
 
 
+Version 0.50.3
+--------------
+
+Released on March 14, 2023.
+
+ -  Ported changes from [Libplanet 0.49.3] release.  [[#2935]]
+
+[Libplanet 0.49.3]: https://www.nuget.org/packages/Libplanet/0.49.3
+[#2935]: https://github.com/planetarium/libplanet/pull/2935
+
+
+Version 0.50.2
+--------------
+
+Released on March 9, 2023.
+
+ -  Added `PolymorphicAction<T>.ActionTypeLoader` static property to provide
+    a way to configure action type loader to be used in `PolymorphicAction<T>`.
+    [[#2875]]
+
+[#2875]: https://github.com/planetarium/libplanet/pull/2875
+
+
 Version 0.50.1
 --------------
 
@@ -213,6 +236,27 @@ Released on February 27, 2023.
 [#2845]: https://github.com/planetarium/libplanet/pull/2845
 
 
+Version 0.49.3
+--------------
+
+Released on March 14, 2023.
+
+ -  Ported changes from [Libplanet 0.48.1] release.  [[#2933]]
+
+[Libplanet 0.48.1]: https://www.nuget.org/packages/Libplanet/0.48.1
+[#2933]: https://github.com/planetarium/libplanet/pull/2933
+
+
+Version 0.49.2
+--------------
+
+Released on March 3, 2023.
+
+ -  General logging changes for better comprehension.  [[#2874]]
+
+[#2874]: https://github.com/planetarium/libplanet/pull/2874
+
+
 Version 0.49.1
 --------------
 
@@ -258,6 +302,17 @@ Released on February 20, 2023.
 [#2822]: https://github.com/planetarium/libplanet/pull/2822
 
 
+Version 0.48.1
+--------------
+
+Released on March 14, 2023.
+
+ -  Ported changes from [Libplanet 0.47.1] release.  [[#2931]]
+
+[Libplanet 0.47.1]: https://www.nuget.org/packages/Libplanet/0.47.1
+[#2931]: https://github.com/planetarium/libplanet/pull/2931
+
+
 Version 0.48.0
 --------------
 
@@ -300,6 +355,18 @@ Released on February 14, 2023.
 [#2800]: https://github.com/planetarium/libplanet/issues/2800
 [#2803]: https://github.com/planetarium/libplanet/pull/2803
 [#2805]: https://github.com/planetarium/libplanet/pull/2805
+
+
+Version 0.47.1
+--------------
+
+Released on March 14, 2023.
+
+ -  Ported changes from [Libplanet 0.46.2] and [Libplanet 0.46.3].  [[#2929]]
+
+[Libplanet 0.46.2]: https://www.nuget.org/packages/Libplanet/0.46.2
+[Libplanet 0.46.3]: https://www.nuget.org/packages/Libplanet/0.46.3
+[#2929]: https://github.com/planetarium/libplanet/pull/2929
 
 
 Version 0.47.0
@@ -407,6 +474,16 @@ Released on February 6, 2023.
 [Bencodex 0.8.0]: https://www.nuget.org/packages/Bencodex/0.8.0
 [Bencodex.Json 0.8.0]: https://www.nuget.org/packages/Bencodex.Json/0.8.0
 [System.Text.Json 6.0.7]: https://www.nuget.org/packages/System.Text.Json/6.0.7
+
+
+Version 0.46.3
+--------------
+
+Released on March 14, 2023.
+
+ -  Fixed `Validator.Encoded` to be more compact.  [[#2927]]
+
+[#2927]: https://github.com/planetarium/libplanet/pull/2927
 
 
 Version 0.46.2

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "ed3951949a2067ae66ef5c0966239df7fc460b387f0f5f282b0e17d113c07e6d")),
+                    "b54502d91645cd5430ea787003c92a0d1d5b30afab5f44f1c0280625d6fb6846")),
                 message.Id);
         }
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -363,9 +363,9 @@ namespace Libplanet.Tests.Action
             // have to be updated, since the order may change due to different PreEvaluationHash.
             (int TxIdx, int ActionIdx, string[] UpdatedStates, Address Signer)[] expectations =
             {
-                (1, 0, new[] { null, null, "C", null, null }, _txFx.Address2),
-                (0, 0, new[] { "A", null, "C", null, null }, _txFx.Address1),
-                (0, 1, new[] { "A", "B", "C", null, null }, _txFx.Address1),
+                (0, 0, new[] { "A", null, null, null, null }, _txFx.Address1),
+                (0, 1, new[] { "A", "B", null, null, null }, _txFx.Address1),
+                (1, 0, new[] { "A", "B", "C", null, null }, _txFx.Address2),
             };
             Assert.Equal(expectations.Length, evals.Length);
             foreach (var (expect, eval) in expectations.Zip(evals, (x, y) => (x, y)))
@@ -493,8 +493,8 @@ namespace Libplanet.Tests.Action
             // have to be updated, since the order may change due to different PreEvaluationHash.
             expectations = new[]
             {
-                (0, 0, new[] { "A,D", "B", "C", null, null }, _txFx.Address1),
-                (2, 0, new[] { "A,D", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address3),
+                (2, 0, new[] { "A", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address3),
+                (0, 0, new[] { "A,D", "B", "C", null, "RecordRehearsal:False" }, _txFx.Address1),
                 (
                     1,
                     0,

--- a/Libplanet.Tests/Action/Sys/SetValidatorTest.cs
+++ b/Libplanet.Tests/Action/Sys/SetValidatorTest.cs
@@ -105,8 +105,8 @@ namespace Libplanet.Tests.Action.Sys
                     ""\ufefftype_id"": ""2"",
                     ""\uFEFFvalues"": {
                         ""\uFEFFvalidator"": {
-                        ""\uFEFFpow"": ""0x01"",
-                        ""\uFEFFpubKey"": ""0x03b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a548""
+                        ""0x50"": ""0x03b5a24aa2112720423bad39a0205182379d6f2b33e3487c9ab6cc8fc496f8a548"",
+                        ""0x70"": ""0x01""
                         }
                     }
                 }

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -123,7 +123,7 @@ namespace Libplanet.Tests.Blocks
                 .Add("protocol_version", 4)
                 .Add(
                     "transaction_fingerprint",
-                    ParseHex("eae2c77210d9a1a4ce4fdd68479e5b49d91c341ac071e51f3a525030a131270b"));
+                    ParseHex("8905c623d9e4a32a6b405168e6f244d70b2dab87c6c10814d956ae4f7a44ae77"));
             AssertBencodexEqual(expectedGenesis, GenesisMetadata.MakeCandidateData(default));
             AssertBencodexEqual(
                 expectedGenesis.SetItem("nonce", new byte[] { 0x00, 0x01, 0x02 }),
@@ -239,7 +239,7 @@ namespace Libplanet.Tests.Blocks
 
             HashDigest<SHA256> hash = GenesisMetadata.DerivePreEvaluationHash(default);
             AssertBytesEqual(
-                FromHex("5a1284960596e71bd90b089741af3f44b4fc04f829acf836d52c8da5bd070166"),
+                FromHex("834ee1a2f50d5fc5376b96f94bdaa634f983bdef9de713d3985c2de7ea215bbd"),
                 hash.ByteArray);
 
             hash = Block1Metadata.DerivePreEvaluationHash(

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -67,7 +67,7 @@ namespace Libplanet.Tests.Blocks
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray)
                 .Add(
                     "transaction_fingerprint",
-                    ParseHex("eae2c77210d9a1a4ce4fdd68479e5b49d91c341ac071e51f3a525030a131270b"));
+                    ParseHex("8905c623d9e4a32a6b405168e6f244d70b2dab87c6c10814d956ae4f7a44ae77"));
             var genesis = new PreEvaluationBlockHeader(
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
@@ -204,22 +204,22 @@ namespace Libplanet.Tests.Blocks
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("164f3b65f29e7b1a2440582c31fdcf9e26277c7ac389b139ac7c1b7c0e7b880b"),
+                fromHex("362a34ef5b99b0d168342a8bfd499448e86db2dd0eb4fe938e7e178d062cc797"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("221ec2ef2c752547eae2b9f04300a3322ded62d747862e5aee9434aa8584fd68"),
+                fromHex("280a78bd0b500a6b2fd9a560a0c4802c26bad181bd1117207ceba64e51588ff5"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("edb7a84ac4ce3a7f2a11e0abe6c2deabe0583fd5a626784809f5fcf335de4ed9"),
+                fromHex("c8f123e73f94df091faf8a8021fdbcf91bc40401a7d6e4531b0cd8ab1a128917"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("775015344e34a842d00db61f3f2e427678821f882b556ec7daacd1b1e77bb34b"),
+                fromHex("4fc0d218fd88d5338591e2cd15d5ac15a7eb458008b084832965938670123911"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash))

--- a/Libplanet/Consensus/Validator.cs
+++ b/Libplanet/Consensus/Validator.cs
@@ -14,8 +14,9 @@ namespace Libplanet.Consensus
     /// </summary>
     public class Validator : IEquatable<Validator>
     {
-        private const string PublicKeyKey = "pubKey";
-        private const string PowerKey = "pow";
+        private static readonly byte[] PublicKeyKey = { 0x50 }; // 'P'
+        private static readonly byte[] PowerKey = { 0x70 }; // 'p'
+
         private static Codec _codec = new Codec();
 
         /// <summary>


### PR DESCRIPTION
🔀 Unlike #2927, #2929, #2931, #2933, #2935 this won't be immediately released. 😗
The plan is to release 0.51.2 with updated `BlockCommit` encoding similar to changes in #2927 for `Validator`.