### PR TITLE
♻️ `IBencodable` for `BlockHash`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,9 @@ defined in *[@planetarium/account]*.
  -  Changed `BlockCommit` to implement `IBencodable`.  [[#2955]]
      -  Changed `BlockCommit(Dictionary)` to `BlockCommit(IValue)`.
      -  Changed `BlockCommit.Encoded` to `BlockCommit.Bencoded`.
+ -  Changed `BlockHash` to implement `IBencodable`.  [[#2959]]
+     -  Changed `BlockHash(Binary)` to `BlockHash(IValue)`.
+     -  Added `BlockHash.Bencoded` property.
 
 ### Backward-incompatible network protocol changes
 
@@ -85,6 +88,7 @@ defined in *[@planetarium/account]*.
 [#2915]: https://github.com/planetarium/libplanet/pull/2915
 [#2954]: https://github.com/planetarium/libplanet/pull/2954
 [#2955]: https://github.com/planetarium/libplanet/pull/2955
+[#2959]: https://github.com/planetarium/libplanet/pull/2959
 [@planetarium/account-web3-secret-storage]: https://www.npmjs.com/package/@planetarium/account-web3-secret-storage
 [@planetarium/bencodex]: https://www.npmjs.com/package/@planetarium/bencodex
 [disjukr/bencodex]: https://github.com/disjukr/bencodex

--- a/Libplanet.Tests/Blocks/BlockHashTest.cs
+++ b/Libplanet.Tests/Blocks/BlockHashTest.cs
@@ -20,12 +20,6 @@ namespace Libplanet.Tests.Blocks
         }
 
         [Fact]
-        public void DisallowNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => new BlockHash(null));
-        }
-
-        [Fact]
         public void LengthCheck()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new BlockHash(new byte[0]));

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -132,7 +132,7 @@ namespace Libplanet.Blocks
             : this(
                 bencoded.GetValue<Integer>(HeightKey),
                 bencoded.GetValue<Integer>(RoundKey),
-                new BlockHash(bencoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                new BlockHash(bencoded.GetValue<IValue>(BlockHashKey)),
                 bencoded.ContainsKey(VotesKey)
                     ? bencoded.GetValue<List>(VotesKey)
                         .Select(vote => new Vote((Binary)vote))

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -185,7 +185,7 @@ namespace Libplanet.Blocks
                 miner: miner,
                 publicKey: publicKey,
                 previousHash: marshaled.ContainsKey(PreviousHashKey)
-                    ? new BlockHash(marshaled.GetValue<Binary>(PreviousHashKey).ByteArray)
+                    ? new BlockHash(marshaled.GetValue<IValue>(PreviousHashKey))
                     : (BlockHash?)null,
                 txHash: marshaled.ContainsKey(TxHashKey)
                     ? new HashDigest<SHA256>(marshaled.GetValue<Binary>(TxHashKey).ByteArray)
@@ -214,7 +214,7 @@ namespace Libplanet.Blocks
         }
 
         public static BlockHash UnmarshalBlockHeaderHash(Dictionary marshaledBlockHeader) =>
-            new BlockHash(marshaledBlockHeader.GetValue<Binary>(HashKey).ByteArray);
+            new BlockHash(marshaledBlockHeader.GetValue<IValue>(HashKey));
 
         public static HashDigest<SHA256> UnmarshalBlockHeaderStateRootHash(
             Dictionary marshaledBlockHeader

--- a/Libplanet/Consensus/VoteMetadata.cs
+++ b/Libplanet/Consensus/VoteMetadata.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Consensus
                 height: encoded.GetValue<Integer>(HeightKey),
                 round: encoded.GetValue<Integer>(RoundKey),
                 blockHash: encoded.ContainsKey(BlockHashKey)
-                    ? new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray)
+                    ? new BlockHash(encoded.GetValue<IValue>(BlockHashKey))
                     : (BlockHash?)null,
                 timestamp: DateTimeOffset.ParseExact(
                     encoded.GetValue<Text>(TimestampKey),

--- a/Libplanet/Tx/TxMetadata.cs
+++ b/Libplanet/Tx/TxMetadata.cs
@@ -67,10 +67,9 @@ namespace Libplanet.Tx
         public TxMetadata(Bencodex.Types.Dictionary dictionary)
         {
             Nonce = dictionary.GetValue<Integer>(NonceKey);
-            GenesisHash
-                = dictionary.TryGetValue(new Binary(GenesisHashKey), out IValue v) && v is Binary g
-                ? new BlockHash(g.ByteArray)
-                : (BlockHash?)null;
+            GenesisHash = dictionary.TryGetValue(new Binary(GenesisHashKey), out IValue v)
+                    ? new BlockHash(v)
+                    : (BlockHash?)null;
             UpdatedAddresses = dictionary.GetValue<List>(UpdatedAddressesKey)
                 .Select(v => new Address(v))
                 .ToImmutableHashSet();


### PR DESCRIPTION
♻️ Of minor note: `TxMetadata` from `Dictionary` will now result in an error if there is malformed genesis hash (either by not being `Binary` or having `Null` as value) instead of ignoring it to be "null genesis hash".