### PR TITLE
⏪ Revert set state cache

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -944,8 +944,6 @@ namespace Libplanet.Blockchain
                         rootHash);
                 }
 
-                ((BlockChainStates<T>)_blockChainStates).CacheStates(block, evaluations);
-
                 _logger
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "StateUpdateDuration")

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
@@ -211,37 +210,6 @@ namespace Libplanet.Blockchain
             }
 
             throw new IncompleteBlockStatesException(offset);
-        }
-
-        internal void CacheStates(Block<T> block, IReadOnlyList<ActionEvaluation> evaluations)
-        {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-            int count = 0;
-            IImmutableSet<Address> addresses = evaluations
-                .SelectMany(a => a.OutputStates.StateUpdatedAddresses)
-                .ToImmutableHashSet();
-            IAccountStateDelta? lastStates = evaluations.Count > 0
-                ? evaluations[evaluations.Count - 1].OutputStates
-                : null;
-            foreach (Address address in addresses)
-            {
-                if (lastStates?.GetState(address) is { } value)
-                {
-                    _stateCache.AddOrUpdate(new CacheKey(block.Hash, address), value);
-                    count++;
-                }
-            }
-
-            Log
-                .ForContext("Source", nameof(BlockChainStates<T>))
-                .Debug(
-                    "Took {DurationMs} ms to cache {ValueCount} values " +
-                    "for {AddressCount} addresses for {MethodName}()",
-                    stopwatch.ElapsedMilliseconds,
-                    count,
-                    addresses.Count,
-                    nameof(CacheStates));
         }
 
         internal void Bind(BlockChain<T> blockChain)


### PR DESCRIPTION
This reverts commit 49a8555cfbbb28ac03f9b44e572fee87963625ab.

Set state cache didn't seem to help much with cache filling up too quickly and crashing a node. 🙄
Probably also need to reduce the cache size back down to 1,000.