### PR TITLE
⚡ Introduce `StateCache`

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -944,6 +944,8 @@ namespace Libplanet.Blockchain
                         rootHash);
                 }
 
+                ((BlockChainStates<T>)_blockChainStates).CacheStates(block, evaluations);
+
                 _logger
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "StateUpdateDuration")

--- a/Libplanet/Blockchain/StateCache.cs
+++ b/Libplanet/Blockchain/StateCache.cs
@@ -1,0 +1,217 @@
+using System;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using LruCacheNet;
+using Serilog;
+
+namespace Libplanet.Blockchain
+{
+    internal class StateCache
+    {
+        /// <summary>
+        /// Determines how deep the cache can be formed.
+        /// </summary>
+        private const int CacheDepth = 4;
+
+        private BlockStateCache? _tip;
+
+        private object _newTipLock;
+
+        public StateCache()
+        {
+            _newTipLock = new object();
+        }
+
+        public bool TryGetValue(BlockHash blockHash, Address address, out IValue? value)
+        {
+            if (_tip is { } tip)
+            {
+                return _tip.TryGetValue(blockHash, address, out value);
+            }
+            else
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        public void AddOrUpdate(BlockHash blockHash, Address address, IValue? value)
+        {
+            if (_tip is { } tip)
+            {
+                tip.AddOrUpdate(blockHash, address, value);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new tip and replaces the old tip.
+        /// This is done in the following way:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         If <paramref name="blockHash"/> is equal to the <see cref="BlockHash"/> of
+        ///         the old tip, nothing is changed.
+        ///     </description></item>
+        ///     <item><description>
+        ///         If <paramref name="previousHash"/> is equal to the <see cref="BlockHash"/> of
+        ///         the old tip, the old tip is attached to the new tip as its previous.
+        ///     </description></item>
+        ///     <item><description>
+        ///         If neither of the above is true, the old tip is discarded.
+        ///     </description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="blockHash">The <see cref="BlockHash"/> of the new tip.</param>
+        /// <param name="previousHash">The <see cref="Block{T}.PreviousHash"/> of
+        /// the <see cref="Block{T}"/> associated with <paramref name="blockHash"/>.</param>
+        public void NewTip(
+            BlockHash blockHash,
+            BlockHash? previousHash)
+        {
+            lock (_newTipLock)
+            {
+                BlockStateCache? previous = null;
+                if (_tip is { } tip)
+                {
+                    if (tip.BlockHash.Equals(blockHash))
+                    {
+                        Log.Debug(
+                            "Given BlockHash {Hash} is the same as the existing " +
+                            "tip's BlockHash; no changes will be made");
+                        return;
+                    }
+                    else if (tip.BlockHash.Equals(previousHash))
+                    {
+                        Log.Debug(
+                            "Given previous BlockHash {Hash} is the same as the existing " +
+                            "tip's BlockHash; appending to the existing tip");
+                        previous = tip;
+                    }
+                    else
+                    {
+                        Log.Debug(
+                            "No relation could be found with the existing tip; " +
+                            "discarding the old tip");
+                    }
+                }
+
+                _tip = new BlockStateCache(blockHash, CacheDepth, previous);
+                _tip.PushDown();
+            }
+        }
+
+        public void Report()
+        {
+            if (_tip is { } tip)
+            {
+                tip.Report();
+            }
+        }
+    }
+
+#pragma warning disable SA1402  // File may only contain a single type
+    internal class BlockStateCache
+#pragma warning restore SA1402
+    {
+        private const int CacheSize = 1_000;
+
+        private int _height;
+        private int _getAttemptCount;
+        private int _getSuccessCount;
+        private int _addCount;
+
+        private BlockStateCache? _previous;
+        private LruCache<Address, IValue?> _cache;
+
+        public BlockStateCache(BlockHash blockHash, int height, BlockStateCache? previous = null)
+        {
+            if (height <= 0)
+            {
+                throw new ArgumentException($"Given {nameof(height)} must be positive: {height}");
+            }
+
+            BlockHash = blockHash;
+            _height = height;
+            _previous = previous;
+            _cache = new LruCache<Address, IValue?>(CacheSize);
+            _getAttemptCount = 0;
+            _getSuccessCount = 0;
+            _addCount = 0;
+        }
+
+        public BlockHash BlockHash { get; }
+
+        public bool TryGetValue(BlockHash blockHash, Address address, out IValue? value)
+        {
+            if (blockHash.Equals(BlockHash))
+            {
+                _getAttemptCount++;
+                if (_cache.TryGetValue(address, out value))
+                {
+                    _getSuccessCount++;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+            else if (_previous is { } previous)
+            {
+                return previous.TryGetValue(blockHash, address, out value);
+            }
+            else
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        public void AddOrUpdate(BlockHash blockHash, Address address, IValue? value)
+        {
+            if (blockHash.Equals(BlockHash))
+            {
+                _cache.AddOrUpdate(address, value);
+                _addCount++;
+            }
+            else if (_previous is { } previous)
+            {
+                previous.AddOrUpdate(blockHash, address, value);
+            }
+        }
+
+        /// <summary>
+        /// Pushes down by decreasing the height of the <see cref="BlockStateCache"/>.
+        /// Once the height reaches zero, its previous is removed by setting it to
+        /// <see langword="null"/>.
+        /// </summary>
+        public void PushDown()
+        {
+            _height -= 1;
+            if (_height == 0)
+            {
+                _previous = null;
+            }
+            else if (_previous is { } previous)
+            {
+                previous.PushDown();
+            }
+        }
+
+        public void Report()
+        {
+            Log
+                .ForContext("Tag", "Metric")
+                .ForContext("Subtag", "BlockStateCacheReport")
+                .Debug(
+                    "BlockHash: {BlockHash}, GetAttempts: {GetAttemptCount}, " +
+                    "GetSuccesses: {GetSuccessCount}, Adds: {AddCount}",
+                    BlockHash,
+                    _getAttemptCount,
+                    _getSuccessCount,
+                    _addCount);
+            if (_previous is { } previous)
+            {
+                previous.Report();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reintroduces "set-state-caching" removed by #2993. Uses a customized scheme to mange cache values. Probably could be tuned further. However, the underlying LRU cache scheme does not fit perfectly well as a solution to the problem we are having. Also needs more documentation as wrong calls to `StateCache.AddOrUpdate()` would result in improper execution of a `Block<T>`.