### PR TITLE
fix: validate block content in PreVote step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@ To be released.
  -  Added `UnsignedTx` class.  [[#1164], [#2986]]
  -  Added `Transaction<T>(IUnsignedTx, ImmutableArray<byte>)`.
     [[#1164], [#2986]]
+ -  (Libplanet.Net) Added `Context<T>.IsCurrentRoundProposer()` method.
+    [[#2996]]
  -  Added `BlockChain<T>.DetermineGenesisStateRootHash()`,
     `BlockChain<T>.EvaluateGenesis()`,
     `BlockChain<T>.DetermineBlockStateRootHash()`,
@@ -109,9 +111,15 @@ To be released.
 
 ### Bug fixes
 
+ -  In `PreVote` block validation, `Context<T>.IsValid()`, validate the block
+    header and also the block content (e.g., Tx nonces, Policy defined
+    validation rules, or state root hash.)  [[#2973], [#2996]]
+
 ### CLI tools
 
 [#2986]: https://github.com/planetarium/libplanet/pull/2986
+[#2973]: https://github.com/planetarium/libplanet/issues/2973
+[#2996]: https://github.com/planetarium/libplanet/pull/2995
 
 
 Version 0.53.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -276,8 +276,6 @@ deployment if possible.
  -  Removed *Libplanet.Node* package.  *Libplanet.Node* 0.52.0 was its last
     minor release.  [[#2971]]
 
-### CLI tools
-
 [Libplanet 0.52.0]: https://www.nuget.org/packages/Libplanet/0.52.0
 [#1997]: https://github.com/planetarium/libplanet/issues/1997
 [#2566]: https://github.com/planetarium/libplanet/pull/2566

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -186,7 +186,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task EnterPreVoteNilOnInvalidBlock()
+        public async Task EnterPreVoteNilOnInvalidBlockHeader()
         {
             var stepChangedToPreVote = new AsyncAutoResetEvent();
             var timeoutProcessed = false;
@@ -212,11 +212,15 @@ namespace Libplanet.Net.Tests.Consensus.Context
                     nilPreVoteSent.Set();
                 }
             };
-            var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
+
+            // 1. ProtocolVersion should be matched.
+            // 2. Index should be increased monotonically.
+            // 3. Timestamp should be increased monotonically.
+            // 4. PreviousHash should be matched with Tip hash.
             var invalidBlock = new BlockContent<DumbAction>(
                 new BlockMetadata(
-                    protocolVersion: BlockMetadata.CurrentProtocolVersion,
-                    index: blockChain.Tip.Index + 1,
+                    protocolVersion: BlockMetadata.CurrentProtocolVersion - 1,
+                    index: blockChain.Tip.Index + 2,
                     timestamp: blockChain.Tip.Timestamp.Subtract(TimeSpan.FromSeconds(1)),
                     miner: TestUtils.PrivateKeys[1].PublicKey.ToAddress(),
                     publicKey: TestUtils.PrivateKeys[1].PublicKey,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -80,12 +80,16 @@ namespace Libplanet.Net.Tests
             return privateKey;
         }
 
-        public static BlockChain<DumbAction> CreateDummyBlockChain(MemoryStoreFixture fx)
+        public static BlockChain<DumbAction> CreateDummyBlockChain(
+            MemoryStoreFixture fx,
+            IBlockPolicy<DumbAction>? policy = null,
+            Block<DumbAction>? genesisBlock = null)
         {
             var blockChain = Libplanet.Tests.TestUtils.MakeBlockChain(
-                Policy,
+                policy ?? Policy,
                 fx.Store,
-                new TrieStateStore(new MemoryKeyValueStore()));
+                new TrieStateStore(new MemoryKeyValueStore()),
+                genesisBlock: genesisBlock);
 
             return blockChain;
         }
@@ -226,7 +230,7 @@ namespace Libplanet.Net.Tests
         {
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
-            var blockChain = CreateDummyBlockChain(fx);
+            var blockChain = CreateDummyBlockChain(fx, policy);
             ConsensusContext<DumbAction>? consensusContext = null;
 
             privateKey ??= PrivateKeys[1];

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Consensus
                 ToString());
             Round = round;
             Step = Step.Propose;
-            if (_validatorSet.GetProposer(Height, Round).PublicKey == _privateKey.PublicKey)
+            if (IsCurrentRoundProposer())
             {
                 _logger.Debug(
                     "Starting round {NewRound} and is a proposer.",

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -307,7 +307,7 @@ namespace Libplanet.Net.Consensus
         private Block<T>? GetValue()
         {
             Block<T> block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
-            if (_blockChain.ValidateNextBlock(block) is { } e)
+            if (_blockChain.ValidateNextBlockHeader(block) is { } e)
             {
                 _logger.Error(
                     e, "Could not propose a valid block");

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -372,6 +372,9 @@ namespace Libplanet.Net.Consensus
             }
         }
 
+        private bool IsCurrentRoundProposer() =>
+            _validatorSet.GetProposer(Height, Round).PublicKey == _privateKey.PublicKey;
+
         /// <summary>
         /// Creates a signed <see cref="Vote"/> for a <see cref="ConsensusPreVoteMsg"/> or
         /// a <see cref="ConsensusPreCommitMsg"/>.

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1201,7 +1201,7 @@ namespace Libplanet.Blockchain
             Block<T> prevTip = Tip;
             try
             {
-                if (ValidateNextBlock(block) is { } ibe)
+                if (ValidateNextBlockHeader(block) is { } ibe)
                 {
                     throw ibe;
                 }
@@ -1608,7 +1608,7 @@ namespace Libplanet.Blockchain
             return null;
         }
 
-        internal InvalidBlockException ValidateNextBlock(Block<T> block)
+        internal InvalidBlockException ValidateNextBlockHeader(Block<T> block)
         {
             if (block.Index == 0)
             {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1159,6 +1159,34 @@ namespace Libplanet.Blockchain
         public BlockCommit GetBlockCommit(BlockHash blockHash) =>
             GetBlockCommit(this[blockHash].Index);
 
+        internal static Dictionary<Address, long> ValidateNonces(
+            Dictionary<Address, long> storedNonces,
+            Block<T> block)
+        {
+            var nonceDeltas = new Dictionary<Address, long>();
+            foreach (Transaction<T> tx in block.Transactions.OrderBy(tx => tx.Nonce))
+            {
+                nonceDeltas.TryGetValue(tx.Signer, out var nonceDelta);
+                storedNonces.TryGetValue(tx.Signer, out var storedNonce);
+
+                long expectedNonce = nonceDelta + storedNonce;
+
+                if (!expectedNonce.Equals(tx.Nonce))
+                {
+                    throw new InvalidTxNonceException(
+                        $"Transaction {tx.Id} has an invalid nonce {tx.Nonce} that is different " +
+                        $"from expected nonce {expectedNonce}.",
+                        tx.Id,
+                        expectedNonce,
+                        tx.Nonce);
+                }
+
+                nonceDeltas[tx.Signer] = nonceDelta + 1;
+            }
+
+            return nonceDeltas;
+        }
+
 #pragma warning disable MEN003
         internal void Append(
             Block<T> block,
@@ -1800,34 +1828,6 @@ namespace Libplanet.Blockchain
             }
 
             return null;
-        }
-
-        private static Dictionary<Address, long> ValidateNonces(
-            Dictionary<Address, long> storedNonces,
-            Block<T> block)
-        {
-            var nonceDeltas = new Dictionary<Address, long>();
-            foreach (Transaction<T> tx in block.Transactions.OrderBy(tx => tx.Nonce))
-            {
-                nonceDeltas.TryGetValue(tx.Signer, out var nonceDelta);
-                storedNonces.TryGetValue(tx.Signer, out var storedNonce);
-
-                long expectedNonce = nonceDelta + storedNonce;
-
-                if (!expectedNonce.Equals(tx.Nonce))
-                {
-                    throw new InvalidTxNonceException(
-                        $"Transaction {tx.Id} has an invalid nonce {tx.Nonce} that is different " +
-                        $"from expected nonce {expectedNonce}.",
-                        tx.Id,
-                        expectedNonce,
-                        tx.Nonce);
-                }
-
-                nonceDeltas[tx.Signer] = nonceDelta + 1;
-            }
-
-            return nonceDeltas;
         }
     }
 }


### PR DESCRIPTION
Closes #2973 

## Context
Current block validation in PBFT consensus guarantees the sanity of a block header but the block content (e.g., Tx nonces, Policy defined validation rules or state root hash.) This could lead `Context<T>` to being locked in an invalid block and committed by consensus, even though the block is invalid.

## Changes
- Rename `BlockChain<T>.ValidateNextBlock()` to `ValidateNextBlockHeader()`
- Refactor Tx nonce/policy validation and calculate and commit the state root hash to the `BlockChain<T>.ValidateNextBlockContent()` method.
- `Context<T>` validates the block with `ValidateNextBlockContext()` and if a node is a proposer, bypass the actions evaluation.
- Added `Context<T>.IsCurrentRoundProposer()` method due to SA1113.

## Further work
This fix will resolve the problem, however, lengthen the consensus time by evaluating the block twice, in the PreVote and Commit step, and the PreVote step timeout might not be triggered accurately while validating block content.