### PR TITLE
Add missing commit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@ Libplanet changelog
 Version 0.53.2
 --------------
 
-To be continued.
+To be released.
 
--  Ported changes from [Libplanet 0.50.7] release.  [[#3022]]
+ -  Ported changes from [Libplanet 0.50.7] release.  [[#3022]]
 
 [Libplanet 0.50.7]: https://www.nuget.org/packages/Libplanet/0.50.7
 [#3022]: https://github.com/planetarium/libplanet/pull/3022

--- a/Libplanet/Action/ValidatorStateExtensions.cs
+++ b/Libplanet/Action/ValidatorStateExtensions.cs
@@ -3,7 +3,7 @@ using Libplanet.Consensus;
 
 namespace Libplanet.Action
 {
-    internal static class ValidatorStateExtensions
+    public static class ValidatorStateExtensions
     {
         public static ValidatorSet GetValidatorSet(this IAccountStateDelta delta)
         {


### PR DESCRIPTION
fix: make `ValidatorStateExtensions` to public

(cherry picked from commit 84da0b42fe7f01833b1c9846eca09c2a45778b34)