### PR TITLE
feat: cache evaluated actions in `Context<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,8 +92,6 @@ To be released.
  -  Added `UnsignedTx` class.  [[#1164], [#2986]]
  -  Added `Transaction<T>(IUnsignedTx, ImmutableArray<byte>)`.
     [[#1164], [#2986]]
- -  (Libplanet.Net) Added `Context<T>.IsCurrentRoundProposer()` method.
-    [[#2996]]
  -  Added `BlockChain<T>.DetermineGenesisStateRootHash()`,
     `BlockChain<T>.EvaluateGenesis()`,
     `BlockChain<T>.DetermineBlockStateRootHash()`,

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Consensus
                 ToString());
             Round = round;
             Step = Step.Propose;
-            if (IsCurrentRoundProposer())
+            if (_validatorSet.GetProposer(Height, Round).PublicKey == _privateKey.PublicKey)
             {
                 _logger.Information(
                     "Starting round {NewRound} and is a proposer.",

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -437,9 +437,6 @@ namespace Libplanet.Net.Consensus
             }
         }
 
-        private bool IsCurrentRoundProposer() =>
-            _validatorSet.GetProposer(Height, Round).PublicKey == _privateKey.PublicKey;
-
         /// <summary>
         /// Creates a signed <see cref="Vote"/> for a <see cref="ConsensusPreVoteMsg"/> or
         /// a <see cref="ConsensusPreCommitMsg"/>.


### PR DESCRIPTION
Following PR of #2996 and partially resolves #3045

## Context
Currently, block evaluation is done in proposing a block, which is required to get a final block from `PreEvaluationBlock`, `PreVote`, which is a stage of consensus for validating a given block, and `Commit`, which is a stage of consensus of finalizing the given block. This PR will cache an evaluated action from a block in the `PreVote` stage, and use it in the `Commit` stage.

## Changes
With this, an evaluation count will be reduced from two to one, if a node is a non-proposer, or from three to two, if a node is a proposer. From a network perspective, the evaluation will be done two times, which are from the proposer in `Propose`, and from all nodes in `PreVote`.

### Considerations
A proposer could bypass the `PreVote` evaluation by caching an evaluation created from proposing stage. This was ruled out due to complicating the logic in `Context<T>` without any positive effect or trade-off, optimization-wise and safety-wise. For example, even if a proposer bypasses the validation, the proposer has to wait for `PreVote` from +2/3 validators, therefore, the consensus time of the network stays remain. `BlockChain<T>` could have different statuses with `Context<T>`, or `BlockChain<T>` proposing an invalid block, but can be caught on validation.

## Further works
If a block synchronizes before the `Context<T>` committing, a cached action is not used because of that, `BlockChain<T>` will re-evaluate the block again.