### PR TITLE
🧹 Removed unnecessary logic

### DIFF
--- a/Libplanet/Blockchain/BlockChain.MineBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.MineBlock.cs
@@ -82,7 +82,7 @@ namespace Libplanet.Blockchain
         {
             long index = Count;
             long difficulty = 1L;
-            BlockHash? prevHash = index > 0 ? Store.IndexBlockHash(Id, index - 1) : null;
+            BlockHash? prevHash = Store.IndexBlockHash(Id, index - 1);
 
             int sessionId = new System.Random().Next();
             int processId = Process.GetCurrentProcess().Id;


### PR DESCRIPTION
After #2863, `BlockChain<T>` instances are guaranteed to have at least one `Block<T>`. 😗