### PR TITLE
Adjust consensus loggins

### DIFF
--- a/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 TestUtils.PrivateKeys[0].PublicKey,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[0]));
 
-            Assert.False(_messageLog.Add(preVote));
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(preVote));
         }
 
         [Fact]
@@ -76,8 +76,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 _codec.Encode(block.MarshalBlock()),
                 -1).Sign(TestUtils.PrivateKeys[2]));
 
-            Assert.False(_messageLog.Add(proposal0));
-            Assert.True(_messageLog.Add(proposal2));
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(proposal0));
+            _messageLog.Add(proposal2);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var preVote = new ConsensusPreVoteMsg(new VoteMetadata(
                 2, 0, null, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreVote).Sign(key));
 
-            Assert.False(_messageLog.Add(preVote));
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(preVote));
         }
 
         [Fact]
@@ -115,8 +115,8 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 _codec.Encode(block.MarshalBlock()),
                 -1).Sign(TestUtils.PrivateKeys[2]));
 
-            Assert.True(_messageLog.Add(proposal0));
-            Assert.False(_messageLog.Add(proposal1));
+            _messageLog.Add(proposal0);
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(proposal1));
         }
 
         [Fact]
@@ -152,10 +152,10 @@ namespace Libplanet.Net.Tests.Consensus.Context
                 TestUtils.PrivateKeys[0].PublicKey,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[0]));
 
-            Assert.True(_messageLog.Add(preVote0));
-            Assert.False(_messageLog.Add(preVote1));
-            Assert.True(_messageLog.Add(preCommit0));
-            Assert.False(_messageLog.Add(preCommit1));
+            _messageLog.Add(preVote0);
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(preVote1));
+            _messageLog.Add(preCommit0);
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(preCommit1));
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var randomHash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
 
             // Insufficient pre-commits.
-            _messageLog.Add(proposal);
+            Assert.Throws<InvalidConsensusMessageException>(() => _messageLog.Add(proposal));
             foreach (var preCommit in preCommits.Take(2))
             {
                 _messageLog.Add(preCommit);

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -167,7 +167,7 @@ namespace Libplanet.Net.Consensus
             {
                 _newHeightCts?.Cancel();
 
-                _logger.Debug(
+                _logger.Information(
                     "Invoked {FName}() for new height #{NewHeight} from old height #{OldHeight}",
                     nameof(NewHeight),
                     height,
@@ -209,7 +209,7 @@ namespace Libplanet.Net.Consensus
                 RemoveOldContexts(height);
                 Height = height;
 
-                _logger.Debug("Start consensus for height #{Height}.", Height);
+                _logger.Information("Start consensus for height #{Height}", Height);
 
                 lock (_contextLock)
                 {

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Net.Consensus
         /// or not.</param>
         public void Start(BlockCommit? lastCommit = null, bool bootstrapping = false)
         {
-            _logger.Debug(
+            _logger.Information(
                 "Starting context for height #{Height}, LastCommit: {LastCommit}",
                 Height,
                 lastCommit);
@@ -57,7 +57,7 @@ namespace Libplanet.Net.Consensus
                 }
                 catch (Exception e)
                 {
-                    _logger.Debug(
+                    _logger.Error(
                         e,
                         "Unexpected exception occurred during {FName}",
                         nameof(ConsumeMessage));
@@ -89,7 +89,7 @@ namespace Libplanet.Net.Consensus
                 }
                 catch (Exception e)
                 {
-                    _logger.Debug(
+                    _logger.Error(
                         e,
                         "Unexpected exception occurred during {FName}",
                         nameof(ConsumeMutation));
@@ -166,7 +166,7 @@ namespace Libplanet.Net.Consensus
                 (_messageLog.GetTotalCount(), Round, Step);
             if (prevState != nextState)
             {
-                _logger.Debug(
+                _logger.Information(
                     "State (MessageLogSize, Round, Step) changed from " +
                     "({PrevMessageLogSize}, {PrevRound}, {PrevStep}) to " +
                     "({NextMessageLogSize}, {NextRound}, {NextStep})",
@@ -194,7 +194,7 @@ namespace Libplanet.Net.Consensus
         {
             TimeSpan timeout = TimeoutPropose(round);
             await Task.Delay(timeout, _cancellationTokenSource.Token);
-            _logger.Debug(
+            _logger.Information(
                 "TimeoutPropose has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());
@@ -210,7 +210,7 @@ namespace Libplanet.Net.Consensus
         {
             TimeSpan timeout = TimeoutPreVote(round);
             await Task.Delay(timeout, _cancellationTokenSource.Token);
-            _logger.Debug(
+            _logger.Information(
                 "TimeoutPreVote has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());
@@ -226,7 +226,7 @@ namespace Libplanet.Net.Consensus
         {
             TimeSpan timeout = TimeoutPreCommit(round);
             await Task.Delay(timeout, _cancellationTokenSource.Token);
-            _logger.Debug(
+            _logger.Information(
                 "TimeoutPreCommit has occurred in {Timeout}. {Info}",
                 timeout,
                 ToString());

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Net.Consensus
         /// <param name="round">The round to start.</param>
         private void StartRound(int round)
         {
-            _logger.Debug(
+            _logger.Information(
                 "Starting round {NewRound} (was {PrevRound}). (context: {Context})",
                 round,
                 Round,
@@ -27,7 +27,7 @@ namespace Libplanet.Net.Consensus
             Step = Step.Propose;
             if (IsCurrentRoundProposer())
             {
-                _logger.Debug(
+                _logger.Information(
                     "Starting round {NewRound} and is a proposer.",
                     round,
                     ToString());
@@ -45,7 +45,7 @@ namespace Libplanet.Net.Consensus
                 }
                 else
                 {
-                    _logger.Debug(
+                    _logger.Information(
                         "Failed to propose a block for round {Round}.",
                         round);
                     _ = OnTimeoutPropose(Round);
@@ -53,7 +53,7 @@ namespace Libplanet.Net.Consensus
             }
             else
             {
-                _logger.Debug(
+                _logger.Information(
                     "Starting round {NewRound} and is not a proposer.",
                     round);
                 _ = OnTimeoutPropose(Round);
@@ -261,7 +261,7 @@ namespace Libplanet.Net.Consensus
 
                 try
                 {
-                    _logger.Debug(
+                    _logger.Information(
                         "Committing block #{Index} {Hash} (context: {Context})",
                         block4.Index,
                         block4.Hash,
@@ -270,7 +270,7 @@ namespace Libplanet.Net.Consensus
                 }
                 catch (Exception e)
                 {
-                    _logger.Debug(
+                    _logger.Error(
                         e,
                         "Failed to commit block #{Index} {Hash}",
                         block4.Index,
@@ -279,7 +279,7 @@ namespace Libplanet.Net.Consensus
                     return;
                 }
 
-                _logger.Debug(
+                _logger.Information(
                     "Committed block #{Index} {Hash}",
                     block4.Index,
                     block4.Hash);

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -78,33 +78,25 @@ namespace Libplanet.Net.Consensus
         {
             try
             {
-                if (_messageLog.Add(message))
-                {
-                    _logger.Debug(
-                        "{FName}: Message: {Message} => Height: {Height}, Round: {Round}, " +
-                        "Validator Address: {VAddress}, " +
-                        "Hash: {BlockHash}, MessageCount: {Count}. (context: {Context})",
-                        nameof(AddMessage),
-                        message,
-                        message.Height,
-                        message.Round,
-                        message.ValidatorPublicKey.ToAddress(),
-                        message.BlockHash,
-                        _messageLog.GetTotalCount(),
-                        ToString());
-                }
-                else
-                {
-                    throw new InvalidConsensusMessageException(
-                        $"Given {nameof(message)} could not be added to {nameof(MessageLog)}.",
-                        message);
-                }
+                _messageLog.Add(message);
+                _logger.Debug(
+                    "{FName}: Message: {Message} => Height: {Height}, Round: {Round}, " +
+                    "Validator Address: {VAddress}, " +
+                    "Hash: {BlockHash}, MessageCount: {Count}. (context: {Context})",
+                    nameof(AddMessage),
+                    message,
+                    message.Height,
+                    message.Round,
+                    message.ValidatorPublicKey.ToAddress(),
+                    message.BlockHash,
+                    _messageLog.GetTotalCount(),
+                    ToString());
             }
             catch (InvalidConsensusMessageException icme)
             {
-                _logger.Debug(
+                _logger.Error(
                     icme,
-                    "Failed to add invalid message {Message}.",
+                    $"Failed to add invalid message {{Message}} to the {nameof(MessageLog)}",
                     message);
                 ExceptionOccurred?.Invoke(this, icme);
             }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -186,7 +186,10 @@ namespace Libplanet.Net.Consensus
 
             _contextTimeoutOption = contextTimeoutOptions ?? new ContextTimeoutOption();
 
-            _logger.Debug("Created Context for height #{Height}, round #{Round}", Height, Round);
+            _logger.Information(
+                "Created Context for height #{Height}, round #{Round}",
+                Height,
+                Round);
         }
 
         /// <summary>
@@ -364,7 +367,7 @@ namespace Libplanet.Net.Consensus
 
                 if (!isValid)
                 {
-                    _logger.Debug(
+                    _logger.Information(
                         exception,
                         "BlockHeader #{Index} {BlockHash} is invalid",
                         block.Index,
@@ -419,7 +422,7 @@ namespace Libplanet.Net.Consensus
                 }
 
                 isValid = exception is null;
-                _logger.Debug(
+                _logger.Information(
                     exception,
                     "Block #{Index} {Hash} is valid? {Bool}",
                     block.Index,

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -378,10 +378,10 @@ namespace Libplanet.Net.Consensus
             MessageId[] ids = contents.Select(c => c.Id).ToArray();
 
             _logger.Debug(
-                "WantMessage: Requests are: {Idr}, Ids are: {Id}, Messages are: {@Messages}",
+                "WantMessage: Requests are: {Idr}, Ids are: {Id}, Messages are: {Messages}",
                 wantMessage.Ids,
                 ids,
-                contents);
+                contents.Select(content => (content.Type, content.Id)));
 
             await contents.ParallelForEachAsync(
                 async c =>


### PR DESCRIPTION
This changes `MessageLog.Add()`'s return type to `void` (which was `bool`), and throws error instead if failed. Since the method was `internal`, skip changelog.