### PR TITLE
Implement `Gossip.PublishMessage()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@ To be released.
     and `BlockChain<T>.EvaluateBlock()`.  [[#3037]]
  -  Added `PublicKey.FromHex()` static method.  [[#2709], [#3044]]
  -  Added `PublicKey.ToHex()` method.  [[#2709], [#3044]]
+ -  (Libplanet.Net) Added `Gossip.PublishMessage()` method.  [[#3054], [#3060]]
 
 ### Behavioral changes
 
@@ -137,6 +138,8 @@ To be released.
 [#2973]: https://github.com/planetarium/libplanet/issues/2973
 [#2996]: https://github.com/planetarium/libplanet/pull/2995
 [#3044]: https://github.com/planetarium/libplanet/pull/3044
+[#3054]: https://github.com/planetarium/libplanet/issues/3054
+[#3060]: https://github.com/planetarium/libplanet/pull/3060
 
 
 Version 0.53.4

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -50,9 +50,9 @@ namespace Libplanet.Net.Tests.Consensus
             var key2 = new PrivateKey();
             var receivedEvent = new AsyncAutoResetEvent();
             var gossip1 = CreateGossip(
-                message =>
+                content =>
                 {
-                    if (message.Content is ConsensusProposalMsg)
+                    if (content is ConsensusProposalMsg)
                     {
                         received1 = true;
                     }
@@ -61,9 +61,9 @@ namespace Libplanet.Net.Tests.Consensus
                 6001,
                 new[] { new BoundPeer(key2.PublicKey, new DnsEndPoint("127.0.0.1", 6002)) });
             var gossip2 = CreateGossip(
-                message =>
+                content =>
                 {
-                    if (message.Content is ConsensusProposalMsg)
+                    if (content is ConsensusProposalMsg)
                     {
                         received2 = true;
                         receivedEvent.Set();
@@ -103,9 +103,9 @@ namespace Libplanet.Net.Tests.Consensus
             var key2 = new PrivateKey();
             var receivedEvent = new AsyncAutoResetEvent();
             var gossip1 = CreateGossip(
-                message =>
+                content =>
                 {
-                    if (message.Content is ConsensusProposalMsg)
+                    if (content is ConsensusProposalMsg)
                     {
                         received1++;
                     }
@@ -114,9 +114,9 @@ namespace Libplanet.Net.Tests.Consensus
                 6001,
                 new[] { new BoundPeer(key2.PublicKey, new DnsEndPoint("127.0.0.1", 6002)) });
             var gossip2 = CreateGossip(
-                message =>
+                content =>
                 {
-                    if (message.Content is ConsensusProposalMsg)
+                    if (content is ConsensusProposalMsg)
                     {
                         received2++;
                     }
@@ -209,7 +209,7 @@ namespace Libplanet.Net.Tests.Consensus
         }
 
         private Gossip CreateGossip(
-            Action<Message> processMessage,
+            Action<MessageContent> processMessage,
             PrivateKey? privateKey = null,
             int? port = null,
             IEnumerable<BoundPeer>? peers = null)

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -41,8 +41,63 @@ namespace Libplanet.Net.Tests.Consensus
         }
 
         [Fact(Timeout = Timeout)]
+        public async void PublishMessage()
+        {
+            MemoryStoreFixture fx = new MemoryStoreFixture();
+            bool received1 = false;
+            bool received2 = false;
+            var key1 = new PrivateKey();
+            var key2 = new PrivateKey();
+            var receivedEvent = new AsyncAutoResetEvent();
+            var gossip1 = CreateGossip(
+                content =>
+                {
+                    if (content is ConsensusProposalMsg)
+                    {
+                        received1 = true;
+                    }
+                },
+                key1,
+                6001,
+                new[] { new BoundPeer(key2.PublicKey, new DnsEndPoint("127.0.0.1", 6002)) });
+            var gossip2 = CreateGossip(
+                content =>
+                {
+                    if (content is ConsensusProposalMsg)
+                    {
+                        received2 = true;
+                        receivedEvent.Set();
+                    }
+                },
+                key2,
+                6002,
+                new[] { new BoundPeer(key1.PublicKey, new DnsEndPoint("127.0.0.1", 6001)) });
+            try
+            {
+                _ = gossip1.StartAsync(default);
+                _ = gossip2.StartAsync(default);
+                await gossip1.WaitForRunningAsync();
+                await gossip2.WaitForRunningAsync();
+                gossip1.PublishMessage(
+                    TestUtils.CreateConsensusPropose(fx.Block1, new PrivateKey(), 0));
+                await receivedEvent.WaitAsync();
+                Assert.True(received1);
+                Assert.True(received2);
+            }
+            finally
+            {
+                await gossip1.StopAsync(TimeSpan.FromMilliseconds(100), default);
+                await gossip2.StopAsync(TimeSpan.FromMilliseconds(100), default);
+                gossip1.Dispose();
+                gossip2.Dispose();
+            }
+        }
+
+        [Fact(Timeout = Timeout)]
         public async void AddMessage()
         {
+            // It has no difference with PublishMessage() test,
+            // since two methods only has timing difference.
             MemoryStoreFixture fx = new MemoryStoreFixture();
             bool received1 = false;
             bool received2 = false;

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -156,10 +156,10 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// A handler for received <see cref="Message"/>s.
         /// </summary>
-        /// <param name="message">A message to process.</param>
-        private void ProcessMessage(Message message)
+        /// <param name="content">A message to process.</param>
+        private void ProcessMessage(MessageContent content)
         {
-            switch (message.Content)
+            switch (content)
             {
                 case ConsensusMsg consensusMsg:
                     _consensusContext.HandleMessage(consensusMsg);

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Net.Consensus
             _blockChain = blockChain;
 
             _consensusContext = new ConsensusContext<T>(
-                AddMessage,
+                PublishMessage,
                 blockChain,
                 privateKey,
                 newHeightDelay,
@@ -151,7 +151,7 @@ namespace Libplanet.Net.Consensus
         /// Adds <see cref="ConsensusMsg"/> to gossip.
         /// </summary>
         /// <param name="message">A <see cref="ConsensusMsg"/> to add.</param>
-        private void AddMessage(ConsensusMsg message) => _gossip.AddMessage(message);
+        private void PublishMessage(ConsensusMsg message) => _gossip.PublishMessage(message);
 
         /// <summary>
         /// A handler for received <see cref="Message"/>s.

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Net.Consensus
         private readonly ITransport _transport;
         private readonly MessageCache _cache;
         private readonly MemoryCache _seen;
-        private readonly Action<Message> _processMessage;
+        private readonly Action<MessageContent> _processMessage;
         private readonly IEnumerable<BoundPeer> _seeds;
         private readonly ILogger _logger;
 
@@ -51,7 +51,7 @@ namespace Libplanet.Net.Consensus
             ITransport transport,
             ImmutableArray<BoundPeer> peers,
             ImmutableArray<BoundPeer> seeds,
-            Action<Message> processMessage,
+            Action<MessageContent> processMessage,
             TimeSpan seenTtl,
             long? seenCacheLimit = null)
         {
@@ -185,33 +185,19 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="content">A <see cref="MessageContent"/> instance to
         /// process and gossip.</param>
-        public void AddMessage(MessageContent content) =>
-            AddMessage(
-                new Message(
-                    content,
-                    _transport.AppProtocolVersion,
-                    AsPeer,
-                    DateTimeOffset.UtcNow,
-                    null));
-
-        /// <summary>
-        /// Process a <see cref="Message"/> and add it to the gossip.
-        /// </summary>
-        /// <param name="message">A <see cref="Message"/> instance to
-        /// process and gossip.</param>
-        public void AddMessage(Message message)
+        public void AddMessage(MessageContent content)
         {
-            if (_seen.TryGetValue(message.Content.Id, out _))
+            if (_seen.TryGetValue(content.Id, out _))
             {
                 _logger.Verbose(
                     "Message of content {Content} with id {Id} seen recently, ignored",
-                    message.Content,
-                    message.Content.Id);
+                    content,
+                    content.Id);
             }
 
             try
             {
-                _cache.Put(message.Content);
+                _cache.Put(content);
             }
             catch (Exception)
             {
@@ -219,10 +205,10 @@ namespace Libplanet.Net.Consensus
             }
 
             // Message instance does not have to be stored.
-            _seen.Set(message.Content.Id, message.Content.Id, _seenTtl);
+            _seen.Set(content.Id, content.Id, _seenTtl);
             try
             {
-                _processMessage(message);
+                _processMessage(content);
             }
             catch (Exception)
             {
@@ -239,17 +225,6 @@ namespace Libplanet.Net.Consensus
         public void AddMessages(IEnumerable<MessageContent> contents)
         {
             contents.AsParallel().ForAll(AddMessage);
-        }
-
-        /// <summary>
-        /// Adds multiple <see cref="Message"/>s in parallel.
-        /// <seealso cref="AddMessage(Message)"/>
-        /// </summary>
-        /// <param name="messages">
-        /// An enumerable <see cref="Message"/> instance to process and gossip.</param>
-        public void AddMessages(IEnumerable<Message> messages)
-        {
-            messages.AsParallel().ForAll(AddMessage);
         }
 
         /// <summary>
@@ -290,7 +265,7 @@ namespace Libplanet.Net.Consensus
                     await HandleWantAsync(msg, ctx);
                     break;
                 default:
-                    AddMessage(msg);
+                    AddMessage(msg.Content);
                     break;
             }
         };
@@ -359,7 +334,7 @@ namespace Libplanet.Net.Consensus
                 replies.Length,
                 replies,
                 replies.Select(m => m.Content.Id).ToArray());
-            AddMessages(replies);
+            AddMessages(replies.Select(m => m.Content));
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -181,6 +181,18 @@ namespace Libplanet.Net.Consensus
         public Task WaitForRunningAsync() => _runningEvent.Task;
 
         /// <summary>
+        /// Publish given <see cref="MessageContent"/> to peers.
+        /// </summary>
+        /// <param name="content">A <see cref="MessageContent"/> instance to publish.</param>
+        public void PublishMessage(MessageContent content)
+        {
+            AddMessage(content);
+            _transport.BroadcastMessage(
+                PeersToBroadcast(_table.Peers, DLazy),
+                content);
+        }
+
+        /// <summary>
         /// Process a <see cref="MessageContent"/> and add it to the gossip.
         /// </summary>
         /// <param name="content">A <see cref="MessageContent"/> instance to


### PR DESCRIPTION
`Gossip` used to broadcast messages via `HeartbeatTask`, which is called every second. Message can be delayed at most 1 second and it may hurt consensus health.

This patch implements `Gossip.PublishMessage()` method that broadcasts message immediately, and gossips it after it sent.

closes #3054 