### PR TITLE
@planetarium/account-web3-secret-storage: `Web3Account` (deferred unlock) & asyncify `getPublicKey()`

### DIFF
--- a/@planetarium/account-aws-kms/package.json
+++ b/@planetarium/account-aws-kms/package.json
@@ -13,7 +13,7 @@
     "build": "yarn && nanobundle build",
     "prepack": "yarn && yarn build",
     "dev": "yarn test",
-    "test": "bash -c 'yarn && yarn run -T tsc -p tsconfig.json && vitest run; status=$?; printf \"\\033[41;97mNOTE: running this test suite too many times may be costly, as this creates and deletes AWS KMS keys during testing. KMS keys are prorated per hour for the price of \\$1.00 per key.\\033[0m\n\" > /dev/stderr; exit $status'",
+    "test": "bash -c 'yarn && yarn run -T tsc -p tsconfig.json && vitest run; status=$?; printf \"\\033[41;97mNOTE: running this test suite too many times may be costly, as this creates and deletes AWS KMS keys during testing. KMS keys are prorated per hour for the price of \\$1.00 per month per key.\\033[0m\n\" > /dev/stderr; exit $status'",
     "coverage": "yarn && vitest run --coverage"
   },
   "repository": {

--- a/@planetarium/account-aws-kms/src/AwsKmsAccount.ts
+++ b/@planetarium/account-aws-kms/src/AwsKmsAccount.ts
@@ -12,12 +12,22 @@ export class AwsKmsAccount implements Account {
   readonly #client: KMSClient;
 
   readonly keyId: AwsKmsKeyId;
+
+  // TODO: This attribute is deprecated.  We should remove it and make
+  // getPublicKey() method the only choice in the future.
+  /**
+   * @deprecated Use {@link getPublicKey()} instead.
+   */
   readonly publicKey: PublicKey;
 
   constructor(keyId: AwsKmsKeyId, publicKey: PublicKey, client: KMSClient) {
     this.keyId = keyId;
     this.publicKey = publicKey;
     this.#client = client;
+  }
+
+  getPublicKey(): Promise<PublicKey> {
+    return Promise.resolve(this.publicKey);
   }
 
   async sign(message: Message): Promise<Signature> {

--- a/@planetarium/account-aws-kms/test/AwsKmsKeyStore.test.ts
+++ b/@planetarium/account-aws-kms/test/AwsKmsKeyStore.test.ts
@@ -176,7 +176,7 @@ describe.runIf(envsConfigured)("AwsKmsKeyStore", async () => {
       },
       createdAt: metadata.CreationDate,
     });
-    expect(account.publicKey.toHex("compressed")).toStrictEqual(
+    expect((await account.getPublicKey()).toHex("compressed")).toStrictEqual(
       publicKey.toHex("compressed"),
     );
 

--- a/@planetarium/account-web3-secret-storage/package.json
+++ b/@planetarium/account-web3-secret-storage/package.json
@@ -31,6 +31,7 @@
     "@types/stream-buffers": "^3",
     "@vitest/coverage-c8": "^0.29.2",
     "@vitest/ui": "^0.29.2",
+    "fast-check": "^3.8.0",
     "nanobundle": "^1.5.0",
     "stream-buffers": "^3.0.2",
     "vite": "^4.1.4",

--- a/@planetarium/account-web3-secret-storage/src/Web3Account.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3Account.ts
@@ -1,0 +1,92 @@
+import { KeyId } from "./KeyId.js";
+import { PassphraseEntry } from "./PassphraseEntry.js";
+import {
+  ExportableAccount,
+  PublicKey,
+  RawPrivateKey,
+  Signature,
+} from "@planetarium/account";
+import { type KeystoreAccount, decryptKeystoreJson } from "ethers";
+
+export type Web3KeyObjectKdf =
+  | {
+      kdf: "pbkdf2";
+      kdfparams: {
+        c: number;
+        dklen: number;
+        prf: "hmac-sha256";
+        salt: string;
+      };
+    }
+  | {
+      kdf: "scrypt";
+      kdfparams: {
+        dklen: number;
+        n: number;
+        p: number;
+        r: number;
+        salt: string;
+      };
+    };
+
+export interface Web3KeyObject {
+  version: 3;
+  id: KeyId;
+  address: string;
+  crypto: {
+    cipher: "aes-128-ctr" | "aes-128-cbc";
+    cipherparams: {
+      iv: string;
+    };
+    ciphertext: string;
+    mac: string;
+  } & Web3KeyObjectKdf;
+}
+
+export class Web3Account implements ExportableAccount {
+  #keyObject: Web3KeyObject;
+  #passphraseEntry: PassphraseEntry;
+
+  constructor(keyObject: Web3KeyObject, passphraseEntry: PassphraseEntry) {
+    this.#keyObject = keyObject;
+    this.#passphraseEntry = passphraseEntry;
+  }
+
+  async exportPrivateKey(): Promise<RawPrivateKey> {
+    let firstAttempt = true;
+    let account: KeystoreAccount;
+    while (true) {
+      const passphrase = await this.#passphraseEntry.authenticate(
+        this.#keyObject.id,
+        firstAttempt,
+      );
+      let currentProgress = 0;
+      const json = JSON.stringify(this.#keyObject);
+      try {
+        // TODO: ethers does not support scrypt yet, however Libplanet.KeyStore.Web3KeyStore does.
+        // We need to support scrypt in the future.
+        account = await decryptKeystoreJson(json, passphrase, (progress) => {
+          currentProgress = progress;
+        });
+      } catch (e) {
+        if (currentProgress <= 0) {
+          throw e;
+        }
+        firstAttempt = false;
+        continue;
+      }
+      break;
+    }
+    return RawPrivateKey.fromHex(account.privateKey.replace(/^0x/i, ""));
+  }
+
+  async getPublicKey(): Promise<PublicKey> {
+    const key = await this.exportPrivateKey();
+    return await key.getPublicKey();
+  }
+
+  async sign(message: Uint8Array): Promise<Signature> {
+    const key = await this.exportPrivateKey();
+    return await key.sign(message);
+  }
+}

--- a/@planetarium/account-web3-secret-storage/src/Web3KeyStore.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3KeyStore.ts
@@ -196,7 +196,7 @@ export class Web3KeyStore implements ImportableKeyStore<KeyId, RawPrivateKey> {
     const passphrase = await this.#passphraseEntry.configurePassphrase();
     const json = await encryptKeystoreJson(
       {
-        address: Address.deriveFrom(privateKey).toString(),
+        address: (await Address.deriveFrom(privateKey)).toString(),
         privateKey: "0x" + Buffer.from(privateKey.toBytes()).toString("hex"),
       },
       passphrase,

--- a/@planetarium/account-web3-secret-storage/src/index.ts
+++ b/@planetarium/account-web3-secret-storage/src/index.ts
@@ -2,3 +2,4 @@ export { KeyId } from "./KeyId.js";
 export { PassphraseEntry } from "./PassphraseEntry.js";
 export { TtyPassphraseEntry } from "./TtyPassphraseEntry.js";
 export { getDefaultWeb3KeyStorePath, Web3KeyStore } from "./Web3KeyStore.js";
+export { Web3Account, type Web3KeyObject } from "./Web3Account.js";

--- a/@planetarium/account-web3-secret-storage/test/MockPassphraseEntry.ts
+++ b/@planetarium/account-web3-secret-storage/test/MockPassphraseEntry.ts
@@ -1,0 +1,29 @@
+import { KeyId } from "../src/KeyId";
+import { Passphrase, PassphraseEntry } from "../src/PassphraseEntry";
+
+export class MockPassphraseEntry implements PassphraseEntry {
+  authenticateCalls: { keyId: KeyId; firstAttempt: boolean }[] = [];
+  configurePassphraseCalls: number = 0;
+  temporaryAuthenticateResult: { passphrase: Passphrase; times: number } = {
+    passphrase: "passphrase",
+    times: 0,
+  };
+
+  setTemporaryAuthenticateResult(passphrase: Passphrase, times: number) {
+    this.temporaryAuthenticateResult = { passphrase, times };
+  }
+
+  async authenticate(keyId: KeyId, firstAttempt: boolean): Promise<Passphrase> {
+    this.authenticateCalls.push({ keyId, firstAttempt });
+    if (this.temporaryAuthenticateResult.times > 0) {
+      this.temporaryAuthenticateResult.times--;
+      return this.temporaryAuthenticateResult.passphrase;
+    }
+    return "passphrase";
+  }
+
+  async configurePassphrase(): Promise<string> {
+    this.configurePassphraseCalls++;
+    return "passphrase";
+  }
+}

--- a/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
+++ b/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
@@ -1,0 +1,82 @@
+import * as fc from "fast-check";
+import { PublicKey, RawPrivateKey } from "@planetarium/account";
+import { Web3Account, Web3KeyObject } from "../src/Web3Account";
+import { describe, expect, test } from "vitest";
+import { MockPassphraseEntry } from "./MockPassphraseEntry";
+
+const keyObject: Web3KeyObject = {
+  version: 3,
+  id: "3c7bec5e-1f1d-4754-a1ce-3644ce1130f1",
+  address: "98a253783288c3971cf7960157b8e053bd263da7",
+  crypto: {
+    ciphertext:
+      "da63b632d3e48de4099e32e3664741fa60880547ab8740854abb77a8c5183638",
+    cipherparams: {
+      iv: "59b8523ebeaa3f37ea06898ff0860340",
+    },
+    cipher: "aes-128-ctr",
+    kdfparams: {
+      c: 10240,
+      dklen: 32,
+      prf: "hmac-sha256",
+      salt: "debd6928cf96f23e3cd5580aebd911c8ea4eb7c29d4db10c251ce8f29c2f32f6",
+    },
+    kdf: "pbkdf2",
+    mac: "5ea19f4c94faa5c698dbbcdd55390f72dac8b6383b2c1010328dfc9248eac2fc",
+  },
+};
+
+describe("Web3Account", () => {
+  test("getPublicKey()", async () => {
+    const passphraseEntry = new MockPassphraseEntry();
+    const key = new Web3Account(keyObject, passphraseEntry);
+
+    expect(passphraseEntry.authenticateCalls).toStrictEqual([]);
+    expect(passphraseEntry.configurePassphraseCalls).toBe(0);
+    const publicKey = await key.getPublicKey();
+    expect(passphraseEntry.authenticateCalls).toStrictEqual([
+      { keyId: "3c7bec5e-1f1d-4754-a1ce-3644ce1130f1", firstAttempt: true },
+    ]);
+    expect(passphraseEntry.configurePassphraseCalls).toBe(0);
+
+    expect(publicKey).toBeInstanceOf(PublicKey);
+    expect(publicKey.toHex("compressed")).toStrictEqual(
+      "03dfd25cea92d828d5c3b2836ffe5a843854285027b9de2dcca0920c0ff0beb5c4",
+    );
+  });
+
+  test("sign()", async () => {
+    const pubKey = PublicKey.fromHex(
+      "03dfd25cea92d828d5c3b2836ffe5a843854285027b9de2dcca0920c0ff0beb5c4",
+      "compressed",
+    );
+    await fc.assert(
+      fc.asyncProperty(fc.uint8Array(), async (msg: Uint8Array) => {
+        const passphraseEntry = new MockPassphraseEntry();
+        const key = new Web3Account(keyObject, passphraseEntry);
+        const sig = await key.sign(msg);
+        expect(passphraseEntry.authenticateCalls).toStrictEqual([
+          { keyId: "3c7bec5e-1f1d-4754-a1ce-3644ce1130f1", firstAttempt: true },
+        ]);
+        expect(passphraseEntry.configurePassphraseCalls).toBe(0);
+        return await pubKey.verify(msg, sig);
+      }),
+    );
+  });
+
+  test("exportPrivateKey()", async () => {
+    const passphraseEntry = new MockPassphraseEntry();
+    const key = new Web3Account(keyObject, passphraseEntry);
+
+    expect(passphraseEntry.authenticateCalls).toStrictEqual([]);
+    expect(passphraseEntry.configurePassphraseCalls).toBe(0);
+    const exported = await key.exportPrivateKey();
+    expect(passphraseEntry.authenticateCalls).toStrictEqual([
+      { keyId: "3c7bec5e-1f1d-4754-a1ce-3644ce1130f1", firstAttempt: true },
+    ]);
+    expect(passphraseEntry.configurePassphraseCalls).toBe(0);
+
+    expect(exported).toBeInstanceOf(RawPrivateKey);
+    expect(exported.toBytes()).toMatchSnapshot();
+  });
+});

--- a/@planetarium/account-web3-secret-storage/test/__snapshots__/Web3Account.test.ts.snap
+++ b/@planetarium/account-web3-secret-storage/test/__snapshots__/Web3Account.test.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Web3Account > exportPrivateKey() 1`] = `
+Uint8Array [
+  42,
+  248,
+  218,
+  36,
+  177,
+  119,
+  246,
+  114,
+  61,
+  139,
+  153,
+  118,
+  43,
+  65,
+  111,
+  195,
+  5,
+  2,
+  137,
+  181,
+  114,
+  184,
+  129,
+  158,
+  187,
+  176,
+  166,
+  177,
+  67,
+  177,
+  213,
+  93,
+]
+`;

--- a/@planetarium/account/src/Account.ts
+++ b/@planetarium/account/src/Account.ts
@@ -4,13 +4,13 @@ import RawPrivateKey from "./RawPrivateKey.js";
 import Signature from "./Signature.js";
 
 export interface Account {
-  publicKey: PublicKey;
+  getPublicKey(): Promise<PublicKey>;
   sign(message: Message): Promise<Signature>;
 }
 
 export function isAccount(account: unknown): account is Account {
   return (
-    (account as { publicKey: unknown }).publicKey instanceof PublicKey &&
+    (account as { getPublicKey: unknown }).getPublicKey instanceof Function &&
     (account as { sign: unknown }).sign instanceof Function
   );
 }

--- a/@planetarium/account/src/RawPrivateKey.ts
+++ b/@planetarium/account/src/RawPrivateKey.ts
@@ -47,7 +47,12 @@ export class RawPrivateKey {
     return this.fromBytes(secp256k1.utils.randomPrivateKey());
   }
 
+  /**
+   * @deprecated Use {@link getPublicKey()} instead.
+   */
   get publicKey(): PublicKey {
+    // TODO: This attribute is deprecated.  We should remove it and make
+    // getPublicKey() method the only choice in the future.
     if (typeof this.#publicPart === "undefined") {
       this.#publicPart = PublicKey.fromBytes(
         secp256k1.getPublicKey(this.#privatePart),
@@ -56,6 +61,10 @@ export class RawPrivateKey {
     }
 
     return this.#publicPart;
+  }
+
+  getPublicKey(): Promise<PublicKey> {
+    return Promise.resolve(this.publicKey);
   }
 
   async sign(message: Message): Promise<Signature> {

--- a/@planetarium/account/src/RawPrivateKey.ts
+++ b/@planetarium/account/src/RawPrivateKey.ts
@@ -16,7 +16,7 @@ export class RawPrivateKey {
       throw new Error(`Expected Uint8Array, but got ${typeof bytes}`);
     } else if (bytes.length !== 32) {
       throw new Error(
-        `Incorrect private key length; expected 32 bytes, but got ${bytes.length} bytes`
+        `Incorrect private key length; expected 32 bytes, but got ${bytes.length} bytes`,
       );
     } else if (!secp256k1.utils.isValidPrivateKey(bytes)) {
       throw new Error("Invalid private key");
@@ -32,7 +32,7 @@ export class RawPrivateKey {
       throw new Error(`Expected string, but got ${typeof hex}`);
     } else if (hex.length !== 64) {
       throw new Error(
-        `Incorrect private key length; expected 64 hexadigits, but got ${hex.length} hexadigits`
+        `Incorrect private key length; expected 64 hexadigits, but got ${hex.length} hexadigits`,
       );
     }
     const bytes = new Uint8Array(Buffer.from(hex, "hex"));
@@ -51,7 +51,7 @@ export class RawPrivateKey {
     if (typeof this.#publicPart === "undefined") {
       this.#publicPart = PublicKey.fromBytes(
         secp256k1.getPublicKey(this.#privatePart),
-        "uncompressed"
+        "uncompressed",
       );
     }
 
@@ -62,7 +62,7 @@ export class RawPrivateKey {
     const sig = await secp256k1.sign(
       await hashMessage(message),
       this.#privatePart,
-      { der: true }
+      { der: true },
     );
     return Signature.fromBytes(sig);
   }

--- a/@planetarium/account/test/Account.test.ts
+++ b/@planetarium/account/test/Account.test.ts
@@ -7,7 +7,7 @@ test("isAccount", async () => {
   const key = RawPrivateKey.generate();
   expect(
     isAccount({
-      publicKey: key.publicKey,
+      getPublicKey: key.getPublicKey,
       sign: key.sign.bind(key),
     }),
   ).toBeTruthy();

--- a/@planetarium/account/test/Address.test.ts
+++ b/@planetarium/account/test/Address.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, test } from "vitest";
 import { bytesEquals, toHex } from "./utils";
 
 describe("Address", () => {
-  test("deriveFrom()", () => {
-    var pubKey = PublicKey.fromBytes(
+  test("deriveFrom()", async () => {
+    const pubKey = PublicKey.fromBytes(
       new Uint8Array([
         0x03, 0x43, 0x8b, 0x93, 0x53, 0x89, 0xa7, 0xeb, 0xf8, 0x38, 0xb3, 0xae,
         0x41, 0x25, 0xbd, 0x28, 0x50, 0x6a, 0xa2, 0xdd, 0x45, 0x7f, 0x20, 0xaf,
@@ -15,7 +15,7 @@ describe("Address", () => {
       ]),
       "compressed",
     );
-    var expectedAddress = Address.fromBytes(
+    const expectedAddress = Address.fromBytes(
       new Uint8Array([
         0xd4, 0x1f, 0xad, 0xf6, 0x1b, 0xad, 0xf5, 0xbe, 0x2d, 0xe6, 0x0e, 0x9f,
         0xc3, 0x23, 0x0c, 0x0a, 0x8a, 0x43, 0x90, 0xf0,
@@ -23,7 +23,7 @@ describe("Address", () => {
     );
     expect(Address.deriveFrom(pubKey)).toHaveEqualBytes(expectedAddress);
     const account = RawPrivateKey.generate();
-    expect(Address.deriveFrom(account)).toHaveEqualBytes(
+    expect(await Address.deriveFrom(account)).toHaveEqualBytes(
       Address.deriveFrom(account.publicKey),
     );
     expect(() => Address.deriveFrom(123 as unknown as PublicKey)).toThrowError(

--- a/@planetarium/account/test/RawPrivateKey.test.ts
+++ b/@planetarium/account/test/RawPrivateKey.test.ts
@@ -84,12 +84,23 @@ describe("RawPrivateKey", () => {
     expect(keyBytes).toSatisfy(secp256k1.utils.isValidPrivateKey);
   });
 
-  test("publicKey", () => {
+  test("publicKey [deprecated]", () => {
     const key = RawPrivateKey.fromHex(
       "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d",
     );
     expect(key.publicKey).toBeInstanceOf(PublicKey);
     expect(key.publicKey.toHex("compressed")).toStrictEqual(
+      "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070",
+    );
+  });
+
+  test("getPublicKey()", async () => {
+    const key = RawPrivateKey.fromHex(
+      "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d",
+    );
+    const publicKey = await key.getPublicKey();
+    expect(publicKey).toBeInstanceOf(PublicKey);
+    expect(publicKey.toHex("compressed")).toStrictEqual(
       "02472a659c7e655cbcf688997863fb9c7a7139635929429bdc9f75f10c60ed8070",
     );
   });

--- a/@planetarium/tx/src/tx/signed.ts
+++ b/@planetarium/tx/src/tx/signed.ts
@@ -19,11 +19,17 @@ export async function signTx(
   signAccount: Account,
 ): Promise<SignedTx<typeof tx>> {
   if (
-    !bytesEqual(tx.publicKey, signAccount.publicKey.toBytes("uncompressed"))
+    !bytesEqual(
+      tx.publicKey,
+      (await signAccount.getPublicKey()).toBytes("uncompressed"),
+    )
   ) {
     throw new Error("Public keys in the tx and the signAccount are mismatched");
   } else if (
-    !bytesEqual(tx.signer, Address.deriveFrom(signAccount.publicKey).toBytes())
+    !bytesEqual(
+      tx.signer,
+      Address.deriveFrom(await signAccount.getPublicKey()).toBytes(),
+    )
   ) {
     throw new Error("The transaction signer does not match to the signAccount");
   }

--- a/@planetarium/tx/test/tx/fixtures.ts
+++ b/@planetarium/tx/test/tx/fixtures.ts
@@ -14,12 +14,12 @@ export const account1 = RawPrivateKey.fromHex(
   "9bf4664ba09a89faeb684b94e69ffde01d26ae14b556204d3f6ab58f61f78418",
 );
 
-export const address1 = Address.deriveFrom(account1);
+export const address1 = await Address.deriveFrom(account1);
 
 // FIXME: Replace this with account1/address1:
 export const key1 = {
   private: account1.toBytes(),
-  public: account1.publicKey.toBytes("compressed"),
+  public: (await account1.getPublicKey()).toBytes("compressed"),
   address: address1.toBytes(),
 };
 
@@ -27,11 +27,11 @@ export const account2 = RawPrivateKey.fromHex(
   "fcf30b333d04ccfeb562f000a32df488e7154949d31ddcac3cf9278acb5786c7",
 );
 
-export const address2 = Address.deriveFrom(account2);
+export const address2 = await Address.deriveFrom(account2);
 
 // FIXME: Replace this with account2/address2:
 export const key2 = {
   private: account2.toBytes(),
-  public: account2.publicKey.toBytes("compressed"),
+  public: (await account2.getPublicKey()).toBytes("compressed"),
   address: address2.toBytes(),
 };

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.54.0
 
 To be released.
 
+### Deprecated APIs
+
+ -  (@planerarium/account)  Deprecated `RawPrivateKey.publicKey` property in
+    favour of `RawPrivateKey.getPublicKey()` async method.  [[#3061]]
+ -  (@planetarium/account-aws-kms)  Deprecated `AwsKmsAccount.publicKey` in
+    favour of `AwsKmsAccount.getPublicKey()` async method.  [[#3061]]
+
 ### Backward-incompatible API changes
 
  -  Removed `TxMetadata` class.  [[#1164], [#2986]]
@@ -58,6 +65,11 @@ To be released.
  -  Removed `PreEvaluationBlock<T>.Mine()` and `BlockMetadata.MineNonce()`
     methods.  [[#3067]]
  -  Removed `HashCash` class.  [[#3067]]
+ -  (@planetarium/account) Replaced `Account.publicKey` property with
+    `Account.getPublicKey()` async method.  [[#3061]]
+ -  (@planetarium/account) `Address.deriveFrom()` method now returns
+    `Promise<Address>` when an `Account` is given.  However, it still returns
+    `Address` when a `PublicKey` is given.  [[#3061]]
 
 ### Backward-incompatible network protocol changes
 
@@ -82,6 +94,12 @@ To be released.
  -  Added `PublicKey.FromHex()` static method.  [[#2709], [#3044]]
  -  Added `PublicKey.ToHex()` method.  [[#2709], [#3044]]
  -  (Libplanet.Net) Added `Gossip.PublishMessage()` method.  [[#3054], [#3060]]
+ -  (@planetarium/account) Added `Account.getPublicKey()` async method.
+    [[#3061]]
+ -  (@planetarium/account) Added `RawPrivateKey.getPublicKey()` async method.
+    [[#3061]]
+ -  (@planetarium/account-aws-kms) Added `AwsKmsAccount.getPublicKey()` async
+    method.  [[#3061]]
 
 ### Behavioral changes
 
@@ -143,6 +161,7 @@ To be released.
 [#3044]: https://github.com/planetarium/libplanet/pull/3044
 [#3054]: https://github.com/planetarium/libplanet/issues/3054
 [#3060]: https://github.com/planetarium/libplanet/pull/3060
+[#3061]: https://github.com/planetarium/libplanet/pull/3061
 [#3067]: https://github.com/planetarium/libplanet/pull/3067
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,9 @@ To be released.
  -  (@planetarium/account) `Address.deriveFrom()` method now returns
     `Promise<Address>` when an `Account` is given.  However, it still returns
     `Address` when a `PublicKey` is given.  [[#3061]]
+ -  (@planetarium/account-web3-secret-storage) `Web3KeyStore` no more implements
+    `ImportableKeyStore<KeyId, RawPrivateKey>`.  Instead, it now implements
+    `ImportableKeyStore<KeyId, Web3Account>`.  [[#3061]]
 
 ### Backward-incompatible network protocol changes
 
@@ -100,6 +103,10 @@ To be released.
     [[#3061]]
  -  (@planetarium/account-aws-kms) Added `AwsKmsAccount.getPublicKey()` async
     method.  [[#3061]]
+ -  (@planetarium/account-web3-secret-storage) Added `Web3Account` class.
+    [[#3061]]
+ -  (@planetarium/account-web3-secret-storage) Added `Web3KeyObject` interface.
+    [[#3061]]
 
 ### Behavioral changes
 
@@ -144,6 +151,13 @@ To be released.
       }
     }
     ~~~~
+
+ -  (@planetarium/account-web3-secret-storage) `Web3KeyStore.get()` method now
+    defers `PassphraseEntry.authenticate()` call and account unlocking so that
+    `AccountRetrieval` instance can be gathered without unlocking the account.
+    Instead, `PassphraseEntry.authenticate()` is called when operations that
+    require unlocking `Web3Account` are called, such as `sign()` or
+    `getPublicKey()`.  [[#3061]]
 
 ### Bug fixes
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,6 +1337,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.29.2
     "@vitest/ui": ^0.29.2
     ethers: ^6.1.0
+    fast-check: ^3.8.0
     nanobundle: ^1.5.0
     stream-buffers: ^3.0.2
     vite: ^4.1.4
@@ -2586,6 +2587,15 @@ __metadata:
   dependencies:
     pure-rand: ^6.0.0
   checksum: c3732011ceef2c3a999678a932cf051946a484d564a73bac695066a255510b2e6a1102bd5cacc189919326ea5c7a515e0247b376416f348c3bc323ee4f4ec7c8
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "fast-check@npm:3.8.0"
+  dependencies:
+    pure-rand: ^6.0.0
+  checksum: 49b4f7bfb1514a2087fa5b42b77af89866f3e55170683597a45f5619b22fb007287316982ae9e2c4962cf28fa3ec4cf3947fb3c38fc780f9448a2a858667d024
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now, *@planetarium/account-web3-secret-storage* uses `Web3Account` instead of `RawPrivateKey`. This change enables the users to interact with an instance of `Account` before unlocking the account, and defers the authentication (`PassphraseEntry.authenticate()`) to when the operation that requires unlocked account is requested.

Additionally, since some backends (web3) require accounts to be unlocked before publickey can be shown, Account.publicKey property is now changed to async Account.getPublicKey() method.