### PR TITLE
Replace newHeightDelay with contextMinInterval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,19 @@ Version 0.53.5
 
 To be released.
 
+### Backward-incompatible API changes
+
+ -  (Libplanet.Net) Replaced parameter `newHeightDelay` with
+    `contextMinInterval` from `ConsensusContext` and `ConsensusReactor`.
+    [[#3063]]
+
+### Behavioral changes
+
+ -  (Libplanet.Net) `ConsensusContext.NewHeight()` will be suspended till
+    `contextMinInterval` arrives.  [[#3063]]
+
+[#3026]: https://github.com/planetarium/libplanet/issues/3063
+
 
 Version 0.53.4
 --------------

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -121,17 +121,18 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
         [Fact(Timeout = Timeout)]
         public async void NewHeightWhenTipChanged()
         {
-            var newHeightDelay = TimeSpan.FromSeconds(1);
+            var contextMinInterval = TimeSpan.FromSeconds(1);
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
-                newHeightDelay,
+                contextMinInterval,
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[1]);
 
             Assert.Equal(-1, consensusContext.Height);
+            consensusContext.NewHeight(1L);
             Block<DumbAction> block = blockChain.ProposeBlock(new PrivateKey());
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
-            Assert.Equal(-1, consensusContext.Height);
-            await Task.Delay(newHeightDelay + TimeSpan.FromSeconds(1));
+            Assert.Equal(1, consensusContext.Height);
+            await Task.Delay(contextMinInterval + TimeSpan.FromSeconds(1));
             Assert.Equal(2, consensusContext.Height);
         }
 
@@ -180,8 +181,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                 new PrivateKey(), lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            // Create context of index 4, check if the context of 1 and 2 are removed correctly.
-            consensusContext.NewHeight(4);
+            // Check if the context of 1 and 2 are removed correctly.
             Assert.Throws<KeyNotFoundException>(() => consensusContext.Contexts[1]);
             Assert.Throws<KeyNotFoundException>(() => consensusContext.Contexts[2]);
         }

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus
                     key: TestUtils.PrivateKeys[i],
                     consensusPort: 6000 + i,
                     validatorPeers: validatorPeers,
-                    newHeightDelayMilliseconds: PropagationDelay * 2);
+                    contextMinIntervalMilliseconds: PropagationDelay * 2);
             }
 
             try

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -217,7 +217,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> BlockChain,
             ConsensusContext<DumbAction> ConsensusContext)
             CreateDummyConsensusContext(
-                TimeSpan newHeightDelay,
+                TimeSpan contextMinInterval,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
@@ -244,7 +244,7 @@ namespace Libplanet.Net.Tests
                 broadcastMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                contextMinInterval,
                 contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, consensusContext);
@@ -293,7 +293,7 @@ namespace Libplanet.Net.Tests
             string host = "127.0.0.1",
             int consensusPort = 5101,
             List<BoundPeer>? validatorPeers = null,
-            int newHeightDelayMilliseconds = 10_000,
+            int contextMinIntervalMilliseconds = 10_000,
             ContextTimeoutOption? contextTimeoutOptions = null)
         {
             key ??= PrivateKeys[1];
@@ -313,7 +313,7 @@ namespace Libplanet.Net.Tests
                 key,
                 validatorPeers.ToImmutableList(),
                 new List<BoundPeer>().ToImmutableList(),
-                TimeSpan.FromMilliseconds(newHeightDelayMilliseconds),
+                TimeSpan.FromMilliseconds(contextMinIntervalMilliseconds),
                 contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
         }
 

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -26,7 +26,6 @@ namespace Libplanet.Net.Consensus
 
         private readonly BlockChain<T> _blockChain;
         private readonly PrivateKey _privateKey;
-        private readonly TimeSpan _newHeightDelay;
         private readonly ILogger _logger;
         private readonly Dictionary<long, Context<T>> _contexts;
 
@@ -44,8 +43,8 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
         /// </param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block. <seealso cref="OnTipChanged"/>
+        /// <param name="contextMinInterval">A time interval in starting the consensus
+        /// for the next height block. <seealso cref="OnTipChanged"/>
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
@@ -53,14 +52,14 @@ namespace Libplanet.Net.Consensus
             DelegateBroadcastMessage broadcastMessage,
             BlockChain<T> blockChain,
             PrivateKey privateKey,
-            TimeSpan newHeightDelay,
+            TimeSpan contextMinInterval,
             ContextTimeoutOption contextTimeoutOption)
         {
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
             _privateKey = privateKey;
             Height = -1;
-            _newHeightDelay = newHeightDelay;
+            ContextMinInterval = contextMinInterval;
 
             _contextTimeoutOption = contextTimeoutOption;
 
@@ -136,6 +135,11 @@ namespace Libplanet.Net.Consensus
         /// height of value, and value is the <see cref="Context{T}"/>.
         /// </summary>
         internal Dictionary<long, Context<T>> Contexts => _contexts;
+
+        /// <summary>
+        /// A minimum time interval between each <see cref="Context{T}"/> starts.
+        /// </summary>
+        internal TimeSpan ContextMinInterval { get; private set; }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>
         public void Dispose()
@@ -309,8 +313,8 @@ namespace Libplanet.Net.Consensus
 
         /// <summary>
         /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls
-        /// <see cref="NewHeight"/>.  Starting a new height will be delayed for
-        /// <see cref="_newHeightDelay"/> in order to collect remaining delayed votes
+        /// <see cref="NewHeight"/>.  Starting a new height will be delayed until reached
+        /// <see cref="ContextMinInterval"/> in order to collect remaining delayed votes
         /// and stabilize the consensus process by waiting for Global Stabilization Time.
         /// </summary>
         /// <param name="sender">The source object instance for <see cref="EventHandler"/>.
@@ -327,7 +331,24 @@ namespace Libplanet.Net.Consensus
             Task.Run(
                 async () =>
                 {
-                    await Task.Delay(_newHeightDelay, _newHeightCts.Token);
+                    var startTime = _contexts.ContainsKey(e.NewTip.Index)
+                        ? _contexts[Height].StartTime
+                        : DateTimeOffset.MinValue;
+                    var contextIntervalLacked = ContextMinInterval
+                        - (DateTime.UtcNow - startTime);
+                    if (contextIntervalLacked.Ticks > 0)
+                    {
+                        _logger.Debug(
+                            "Waiting lacked context interval {Delay}ms for " +
+                            "block #{Index} {Hash} (context: {Context})",
+                            contextIntervalLacked.TotalMilliseconds,
+                            e.NewTip.Index,
+                            e.NewTip.Hash,
+                            ToString());
+                        await Task.Delay(
+                            contextIntervalLacked, _newHeightCts.Token);
+                    }
+
                     if (!_newHeightCts.IsCancellationRequested)
                     {
                         try

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -43,8 +43,8 @@ namespace Libplanet.Net.Consensus
         /// itself.
         /// </param>
         /// <param name="seedPeers">A list of seed's <see cref="BoundPeer"/>.</param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block.
+        /// <param name="contextMinInterval">A time interval in starting the consensus
+        /// for the next height block.
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
@@ -54,7 +54,7 @@ namespace Libplanet.Net.Consensus
             PrivateKey privateKey,
             ImmutableList<BoundPeer> validatorPeers,
             ImmutableList<BoundPeer> seedPeers,
-            TimeSpan newHeightDelay,
+            TimeSpan contextMinInterval,
             ContextTimeoutOption contextTimeoutOption)
         {
             validatorPeers ??= ImmutableList<BoundPeer>.Empty;
@@ -72,7 +72,7 @@ namespace Libplanet.Net.Consensus
                 AddMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                contextMinInterval,
                 contextTimeoutOption);
 
             _logger = Log

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -18,6 +18,7 @@ namespace Libplanet.Net.Consensus
         /// or not.</param>
         public void Start(BlockCommit? lastCommit = null, bool bootstrapping = false)
         {
+            StartTime = DateTimeOffset.UtcNow;
             _logger.Information(
                 "Starting context for height #{Height}, LastCommit: {LastCommit}",
                 Height,

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -208,6 +208,11 @@ namespace Libplanet.Net.Consensus
         public Step Step { get; private set; }
 
         /// <summary>
+        /// The time when <see cref="Start(BlockCommit?, bool)"/> called.
+        /// </summary>
+        public DateTimeOffset StartTime { get; private set; }
+
+        /// <summary>
         /// A command class for receiving <see cref="ConsensusMsg"/> from or broadcasts to other
         /// validators.
         /// </summary>


### PR DESCRIPTION
### Problem to solve
Context interval is expected to be constant, but it varies.

### Changes
`newHeightDelay`, that suspends `NewHeight()` with fixed time after `OnTipChanged` will be removed, and replaced with `contextMinInterval` that suspends `NewHeight()` with dynamic time, till interval between previous `NewHeight()` call and current `NewHeight()` call reaches to it.

### Limitation
Validator that doesn't have context of new tip appends block without delay, since it doesn't know the time that context has been made.