### PR TITLE
Preserve order of `Transaction<T>.UpdatedAddresses`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,6 +141,9 @@ To be released.
     custom actions.  However, it still can be deserialized from JSON when it
     contains a system action.  [[#2986]]
 
+ -  `Transaction<T>.UpdatedAddresses` now preserves the order of `Address`es
+    so that it is no more reordered during deserialization.  [[#3074]]
+
  -  The JSON representation of `Transaction<T>` now includes the `"actions"`
     field, which includes a system action or a list of custom actions and
     a `"type"` field denoting one of `"system"` or `"custom"`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,6 +208,9 @@ To be released.
 
  -  (Libplanet.Explorer.Executable) Project is now deprecated. It is currently
     nonfunctional.  [[#2243], [#2588]]
+ -  (Libplanet.Tools) Now `planet` uses *libsecp256k1* (which is the same
+    library used in Bitcoin and written in C) instead of
+    *BouncyCastle.Cryptography* (which is written in C#).  [[#3074]]
 
 [#2243]: https://github.com/planetarium/libplanet/discussions/2243
 [#2588]: https://github.com/planetarium/libplanet/discussions/2588
@@ -224,6 +227,7 @@ To be released.
 [#3067]: https://github.com/planetarium/libplanet/pull/3067
 [#3069]: https://github.com/planetarium/libplanet/pull/3069
 [#3072]: https://github.com/planetarium/libplanet/pull/3072
+[#3074]: https://github.com/planetarium/libplanet/pull/3074
 [#3077]: https://github.com/planetarium/libplanet/pull/3077
 
 

--- a/Libplanet.Tests/Tx/AddressSetTest.cs
+++ b/Libplanet.Tests/Tx/AddressSetTest.cs
@@ -1,0 +1,395 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Libplanet.Tx;
+using Xunit;
+
+namespace Libplanet.Tests.Tx
+{
+    public class AddressSetTest
+    {
+        [Fact]
+        public void Empty()
+        {
+            Assert.Empty(AddressSet.Empty);
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            Address[] addresses =
+            {
+                new Address("4000000000000000000000000000000000000000"),
+                new Address("3000000000000000000000000000000000000001"),
+                new Address("2000000000000000000000000000000000000002"),
+                new Address("1000000000000000000000000000000000000003"),
+                new Address("0000000000000000000000000000000000000004"),
+
+                // dups:
+                new Address("0000000000000000000000000000000000000004"),
+                new Address("2000000000000000000000000000000000000002"),
+                new Address("4000000000000000000000000000000000000000"),
+            };
+            var set = new AddressSet(addresses);
+            Assert.Equal(5, set.Count);
+            Assert.Equal<IEnumerable<Address>>(
+                new[]
+                {
+                    new Address("4000000000000000000000000000000000000000"),
+                    new Address("3000000000000000000000000000000000000001"),
+                    new Address("2000000000000000000000000000000000000002"),
+                    new Address("1000000000000000000000000000000000000003"),
+                    new Address("0000000000000000000000000000000000000004"),
+                },
+                set
+            );
+        }
+
+        [Fact]
+        public void TryGetValue()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool found = set.TryGetValue(
+                new Address("1000000000000000000000000000000000000001"),
+                out Address value);
+            Assert.True(found);
+            Assert.Equal(new Address("1000000000000000000000000000000000000001"), value);
+
+            found = set.TryGetValue(
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                out Address value2);
+            Assert.False(found);
+            Assert.Equal(default(Address), value2);
+        }
+
+        [Fact]
+        public void SymmetricExcept()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            IImmutableSet<Address> result = set.SymmetricExcept(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                default(Address),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("1000000000000000000000000000000000000001"),
+                default(Address),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.Equal<IEnumerable<Address>>(
+                new Address[]
+                {
+                    new Address("2000000000000000000000000000000000000000"),
+                    new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                    default(Address),
+                },
+                result
+            );
+        }
+
+        [Fact]
+        public void IsProperSubsetOf()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool result = set.IsProperSubsetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.True(result);
+
+            result = set.IsProperSubsetOf(new Address[]
+            {
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            Assert.False(result);
+
+            result = set.IsProperSubsetOf(new Address[]
+            {
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            Assert.False(result);
+
+            result = set.IsProperSubsetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsProperSupersetOf()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool result = set.IsProperSupersetOf(new Address[]
+            {
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+            });
+            Assert.True(result);
+
+            result = set.IsProperSupersetOf(new Address[]
+            {
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            Assert.False(result);
+
+            result = set.IsProperSupersetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.False(result);
+
+            result = set.IsProperSupersetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSubsetOf()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool result = set.IsSubsetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            Assert.True(result);
+
+            result = set.IsSubsetOf(new Address[]
+            {
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            Assert.True(result);
+
+            result = set.IsSubsetOf(new Address[]
+            {
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            Assert.False(result);
+
+            result = set.IsSubsetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSupersetOf()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool result = set.IsSupersetOf(new Address[]
+            {
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            Assert.True(result);
+
+            result = set.IsSupersetOf(new Address[]
+            {
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            Assert.True(result);
+
+            result = set.IsSupersetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+            });
+            Assert.False(result);
+
+            result = set.IsSupersetOf(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+            });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Overlaps()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+
+            bool result = set.Overlaps(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                default(Address),
+            });
+            Assert.True(result);
+
+            result = set.Overlaps(new Address[]
+            {
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                default(Address),
+                default(Address),
+            });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var set = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            var set2 = new AddressSet(new Address[]
+            {
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            var set3 = new AddressSet(new Address[]
+            {
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+                new Address("0000000000000000000000000000000000000002"),
+            });
+            var set4 = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+            });
+            var set5 = new AddressSet(new Address[]
+            {
+                new Address("2000000000000000000000000000000000000000"),
+                new Address("1000000000000000000000000000000000000001"),
+                new Address("0000000000000000000000000000000000000002"),
+                new Address("ffffffffffffffffffffffffffffffffffffffff"),
+            });
+            (AddressSet A, AddressSet B, bool Equal)[] truthTable =
+            {
+                (set, set, true),
+                (set, set2, true),
+                (set, set3, false),
+                (set, set4, false),
+                (set, set5, false),
+                (set2, set3, false),
+                (set2, set4, false),
+                (set2, set5, false),
+            };
+            foreach ((AddressSet a, AddressSet b, bool equal) in truthTable)
+            {
+                if (equal)
+                {
+                    Assert.Equal<AddressSet>(a, b);
+                    Assert.Equal<AddressSet>(b, a);
+                    Assert.True(a.Equals((object)b));
+                    Assert.True(b.Equals((object)a));
+                    Assert.True(a.SetEquals(b));
+                    Assert.True(b.SetEquals(a));
+                    Assert.Equal(a.GetHashCode(), b.GetHashCode());
+                }
+                else
+                {
+                    Assert.NotEqual<AddressSet>(a, b);
+                    Assert.NotEqual<AddressSet>(b, a);
+                    Assert.False(a.Equals((object)b));
+                    Assert.False(b.Equals((object)a));
+                    Assert.False(a.SetEquals(b));
+                    Assert.False(b.SetEquals(a));
+                    Assert.NotEqual(b.GetHashCode(), a.GetHashCode());
+                }
+
+                Assert.False(a.Equals((AddressSet)null));
+                Assert.False(b.Equals((AddressSet)null));
+                Assert.False(a.Equals((object)null));
+                Assert.False(b.Equals((object)null));
+            }
+        }
+    }
+}

--- a/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/Libplanet.Tools/Libplanet.Tools.csproj
@@ -91,6 +91,7 @@
     <ProjectReference Include="..\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <ProjectReference Include="..\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" />
     <!-- FIXME: We should specify the version range when the following NuGet
     issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
   </ItemGroup>

--- a/Libplanet.Tools/Program.cs
+++ b/Libplanet.Tools/Program.cs
@@ -1,3 +1,8 @@
+using System.Security.Cryptography;
+using Libplanet.Crypto;
+using Libplanet.Crypto.Secp256k1;
+using CryptoConfig = Libplanet.Crypto.CryptoConfig;
+
 namespace Libplanet.Tools;
 
 using System;
@@ -24,8 +29,10 @@ public class Program
     // Workaround for linking with Libplanet.RocksDBStore.
     private static readonly Type _rocksdb = typeof(Libplanet.RocksDBStore.RocksDBStore);
 
-    public static Task Main(string[] args) =>
-        CoconaLiteApp.CreateHostBuilder()
+    public static Task Main(string[] args)
+    {
+        CryptoConfig.CryptoBackend = new Secp256k1CryptoBackend<SHA256>();
+        return CoconaLiteApp.CreateHostBuilder()
             .ConfigureServices(services =>
             {
                 services.AddJsonConfigurationService(FileConfigurationServiceRoot);
@@ -35,6 +42,7 @@ public class Program
                 options.TreatPublicMethodsAsCommands = false;
                 options.EnableShellCompletionSupport = true;
             });
+    }
 
     [PrimaryCommand]
     public Task Help() =>

--- a/Libplanet/Tx/AddressSet.cs
+++ b/Libplanet/Tx/AddressSet.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+namespace Libplanet.Tx
+{
+    /// <summary>
+    /// Order-preserving set of <see cref="Address"/>es.
+    /// </summary>
+    internal class AddressSet : IImmutableSet<Address>, IEquatable<AddressSet>
+    {
+        /// <summary>
+        /// An empty <see cref="AddressSet"/>.
+        /// </summary>
+        public static readonly AddressSet Empty = new AddressSet(ImmutableArray<Address>.Empty);
+
+        private readonly ImmutableArray<Address> _addresses;
+
+        /// <summary>
+        /// Creates a new <see cref="AddressSet"/> instance.
+        /// </summary>
+        /// <param name="addresses"><see cref="Address"/>es to include in the set.  Duplicated
+        /// <see cref="Address"/>es are ignored, and only the first occurrence is included.
+        /// The order of <paramref name="addresses"/> is preserved.</param>
+        public AddressSet(IEnumerable<Address> addresses)
+        {
+            var elements = new HashSet<Address>();
+            var builder = ImmutableArray.CreateBuilder<Address>();
+            foreach (Address address in addresses)
+            {
+                if (elements.Add(address))
+                {
+                    builder.Add(address);
+                }
+            }
+
+            builder.Capacity = elements.Count;
+            _addresses = builder.MoveToImmutable();
+        }
+
+        private AddressSet(in ImmutableArray<Address> addresses, bool bypassCheck)
+        {
+            if (!bypassCheck)
+            {
+                throw new ArgumentException("Make sure if this call is intended.");
+            }
+
+            _addresses = addresses;
+        }
+
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
+        [Pure]
+        public int Count => _addresses.Length;
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()"/>
+        [Pure]
+        public IEnumerator<Address> GetEnumerator() =>
+            ((IEnumerable<Address>)_addresses).GetEnumerator();
+
+        /// <inheritdoc cref="IEnumerable.GetEnumerator()"/>
+        [Pure]
+        IEnumerator IEnumerable.GetEnumerator() =>
+            ((IEnumerable)_addresses).GetEnumerator();
+
+        /// <inheritdoc cref="IImmutableSet{T}.Clear()"/>
+        [Pure]
+        public IImmutableSet<Address> Clear() => Empty;
+
+        /// <inheritdoc cref="IImmutableSet{T}.Contains(T)"/>
+        [Pure]
+        public bool Contains(Address value) =>
+            _addresses.Contains(value);
+
+        /// <inheritdoc cref="IImmutableSet{T}.Add(T)"/>
+        [Pure]
+        public IImmutableSet<Address> Add(Address value) =>
+            new AddressSet(_addresses.Add(value));
+
+        /// <inheritdoc cref="IImmutableSet{T}.Remove(T)"/>
+        [Pure]
+        public IImmutableSet<Address> Remove(Address value) =>
+            new AddressSet(_addresses.Remove(value), bypassCheck: true);
+
+        /// <inheritdoc cref="IImmutableSet{T}.TryGetValue(T, out T)"/>
+        [Pure]
+        public bool TryGetValue(Address equalValue, out Address actualValue)
+        {
+            if (_addresses.Contains(equalValue))
+            {
+                actualValue = equalValue;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.Intersect(IEnumerable{T})"/>
+        [Pure]
+        public IImmutableSet<Address> Intersect(IEnumerable<Address> other) =>
+            new AddressSet(_addresses.Intersect(other).ToImmutableArray(), bypassCheck: true);
+
+        /// <inheritdoc cref="IImmutableSet{T}.Except(IEnumerable{T})"/>
+        [Pure]
+        public IImmutableSet<Address> Except(IEnumerable<Address> other) =>
+            new AddressSet(_addresses.Except(other).ToImmutableArray(), bypassCheck: true);
+
+        /// <inheritdoc cref="IImmutableSet{T}.SymmetricExcept(IEnumerable{T})"/>
+        [Pure]
+        public IImmutableSet<Address> SymmetricExcept(IEnumerable<Address> other)
+        {
+            ICollection<Address> operand = other is ICollection<Address> o
+                ? o
+                : other.ToArray();
+            return new AddressSet(_addresses.Union(operand).Except(_addresses.Intersect(operand)));
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.Union(IEnumerable{T})"/>
+        [Pure]
+        public IImmutableSet<Address> Union(IEnumerable<Address> other) =>
+            new AddressSet(_addresses.Union(other));
+
+        /// <inheritdoc cref="IImmutableSet{T}.SetEquals(IEnumerable{T})"/>
+        [Pure]
+        public bool SetEquals(IEnumerable<Address> other)
+        {
+            ICollection<Address> operand = other is ICollection<Address> o
+                ? o
+                : other.ToArray();
+            if (_addresses.Length != operand.Count)
+            {
+                return false;
+            }
+
+            return _addresses.All(operand.Contains);
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.IsProperSubsetOf(IEnumerable{T})"/>
+        [Pure]
+        public bool IsProperSubsetOf(IEnumerable<Address> other)
+        {
+            ISet<Address> operand = other is ISet<Address> o
+                ? o
+                : other.ToImmutableHashSet();
+            return operand.IsProperSupersetOf(_addresses);
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.IsProperSupersetOf(IEnumerable{T})"/>
+        [Pure]
+        public bool IsProperSupersetOf(IEnumerable<Address> other)
+        {
+            ISet<Address> operand = other is ISet<Address> o
+                ? o
+                : other.ToImmutableHashSet();
+            return operand.IsProperSubsetOf(_addresses);
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.IsSubsetOf(IEnumerable{T})"/>
+        [Pure]
+        public bool IsSubsetOf(IEnumerable<Address> other)
+        {
+            ISet<Address> operand = other is ISet<Address> o
+                ? o
+                : other.ToImmutableHashSet();
+            return operand.IsSupersetOf(_addresses);
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.IsSupersetOf(IEnumerable{T})"/>
+        [Pure]
+        public bool IsSupersetOf(IEnumerable<Address> other)
+        {
+            ISet<Address> operand = other is ISet<Address> o
+                ? o
+                : other.ToImmutableHashSet();
+            return operand.IsSubsetOf(_addresses);
+        }
+
+        /// <inheritdoc cref="IImmutableSet{T}.Overlaps(IEnumerable{T})"/>
+        [Pure]
+        public bool Overlaps(IEnumerable<Address> other)
+        {
+            ICollection<Address> operand = other is ICollection<Address> o
+                ? o
+                : other.ToArray();
+            return _addresses.Any(operand.Contains);
+        }
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        [Pure]
+        public bool Equals(AddressSet? other) =>
+            other is { } set && set.SetEquals(this);
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        [Pure]
+        public override bool Equals(object? obj) =>
+            obj is AddressSet set && Equals(set);
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        [Pure]
+        public override int GetHashCode() =>
+            _addresses.OrderBy(a => a).Aggregate(0, (h, a) => h ^ a.GetHashCode());
+    }
+}

--- a/Libplanet/Tx/TxInvoice.cs
+++ b/Libplanet/Tx/TxInvoice.cs
@@ -32,9 +32,15 @@ namespace Libplanet.Tx
             DateTimeOffset timestamp,
             TxActionList actions)
         {
+            if (updatedAddresses is null)
+            {
+                throw new ArgumentNullException(nameof(updatedAddresses));
+            }
+
             GenesisHash = genesisHash;
-            UpdatedAddresses = updatedAddresses
-                ?? throw new ArgumentNullException(nameof(updatedAddresses));
+            UpdatedAddresses = updatedAddresses is AddressSet set
+                ? set
+                : new AddressSet(updatedAddresses);
             Timestamp = timestamp;
             Actions = actions ?? throw new ArgumentNullException(nameof(actions));
         }

--- a/Libplanet/Tx/TxMarshaler.cs
+++ b/Libplanet/Tx/TxMarshaler.cs
@@ -84,9 +84,9 @@ namespace Libplanet.Tx
                 genesisHash: dictionary.TryGetValue(GenesisHashKey, out IValue v)
                     ? new BlockHash(v)
                     : (BlockHash?)null,
-                updatedAddresses: ((Bencodex.Types.List)dictionary[UpdatedAddressesKey])
-                    .Select(v => new Address(v))
-                    .ToImmutableHashSet(),
+                updatedAddresses: new AddressSet(
+                    ((Bencodex.Types.List)dictionary[UpdatedAddressesKey])
+                        .Select(v => new Address(v))),
                 timestamp: DateTimeOffset.ParseExact(
                     (Text)dictionary[TimestampKey],
                     TimestampFormat,


### PR DESCRIPTION
Previously, `Transaction<T>.UpdatedAddresses` in serialized form should have be ordered in a certain way, which depends on `ImmutableHashSet<T>`'s internals.  If a transaction payload had multiple updated addresses and they were ordered in another way, it failed to verify the signature.

This patch fixes it by letting `Transaction<T>.UpdatedAddresses` preserve the order regardless of the way to order it.  Note that it still does not allow duplicates though.  A new internal data structure named `AddressSet` is also introduced.