### PR TITLE
♻️ `BlockChain<T>.ProposeBlock()` overhaul

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,13 @@ To be released.
     [[#2613]]
  -  Removed `BlockChain<T>.ProposeBlock(PrivateKey, DateTimeOffset, long, int,
     int, IComparer<Transaction<T>>, BlockCommit)` method.  [[#3072]]
+ -  Changed `BlockChain<T>.ProposeBlock(PrivateKey, DateTimeOffset,
+    BlockCommit, IComparer<Transaction<T>>)` method to
+    `BlockChain<T>.ProposeBlock(PrivateKey, BlockCommit,
+    IComparer<Transaction<T>>)`.  [[#3077]]
+ -  Added `BlockChain<T>.ProposeBlock(PrivateKey, ImmutableList<Transaction<T>>,
+    BlockCommit)` method.  [[#3077]]
+
 
 ### Backward-incompatible network protocol changes
 
@@ -220,6 +227,7 @@ To be released.
 [#3067]: https://github.com/planetarium/libplanet/pull/3067
 [#3069]: https://github.com/planetarium/libplanet/pull/3069
 [#3072]: https://github.com/planetarium/libplanet/pull/3072
+[#3077]: https://github.com/planetarium/libplanet/pull/3077
 
 
 Version 0.53.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,9 +81,6 @@ To be released.
     BlockCommit, IComparer<Transaction<T>>)` method to
     `BlockChain<T>.ProposeBlock(PrivateKey, BlockCommit,
     IComparer<Transaction<T>>)`.  [[#3077]]
- -  Added `BlockChain<T>.ProposeBlock(PrivateKey, ImmutableList<Transaction<T>>,
-    BlockCommit)` method.  [[#3077]]
-
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -108,7 +108,7 @@ namespace Libplanet.Benchmarks
         private void PrepareAppend()
         {
             _lastCommit = TestUtils.CreateBlockCommit(_blockChain.Tip);
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
             _commit = TestUtils.CreateBlockCommit(_block);
         }
     }

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -105,31 +105,31 @@ namespace Libplanet.Benchmarks
         [Benchmark]
         public void ProposeBlockEmpty()
         {
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
         }
 
         [Benchmark]
         public void ProposeBlockOneTransactionNoAction()
         {
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
         }
 
         [Benchmark]
         public void ProposeBlockTenTransactionsNoAction()
         {
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
         }
 
         [Benchmark]
         public void ProposeBlockOneTransactionWithActions()
         {
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
         }
 
         [Benchmark]
         public void ProposeBlockTenTransactionsWithActions()
         {
-            _block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+            _block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
         }
     }
 }

--- a/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
@@ -42,7 +42,7 @@ public abstract class BlockChainIndexTest
         var forkedChain = ChainFx.Chain.Fork(ChainFx.Chain.Tip.PreviousHash!.Value);
         var divergentBlock = forkedChain.ProposeBlock(
             ChainFx.PrivateKeys[0],
-            lastCommit: forkedChain.GetBlockCommit(forkedChain.Tip.Hash));
+            forkedChain.GetBlockCommit(forkedChain.Tip.Hash));
         forkedChain.Append(
             divergentBlock,
             new BlockCommit(

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryTest.cs
@@ -130,7 +130,7 @@ public class TransactionQueryTest
         Source.BlockChain.MakeTransaction(key2, ImmutableList<NullAction>.Empty.Add(new NullAction()));
         block = Source.BlockChain.ProposeBlock(
             new PrivateKey(),
-            lastCommit: Libplanet.Tests.TestUtils.CreateBlockCommit(block));
+            Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         Source.BlockChain.Append(block, Libplanet.Tests.TestUtils.CreateBlockCommit(block));
         await AssertNextNonce(1, key2.ToAddress());
         await AssertNextNonce(2, key1.ToAddress());

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextNonProposerTest.cs
@@ -224,7 +224,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
                     (Dictionary)codec.Decode(proposal.Proposal.MarshaledBlock));
             var blockHeightThree = blockChain.ProposeBlock(
                 TestUtils.PrivateKeys[3],
-                lastCommit: TestUtils.CreateBlockCommit(blockHeightTwo));
+                TestUtils.CreateBlockCommit(blockHeightTwo));
 
             // Message from higher height
             consensusContext.HandleMessage(

--- a/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContext/ConsensusContextTest.cs
@@ -74,7 +74,7 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var blockCommit = TestUtils.CreateBlockCommit(block);
             blockChain.Append(block, blockCommit);
-            block = blockChain.ProposeBlock(TestUtils.PrivateKeys[2], lastCommit: blockCommit);
+            block = blockChain.ProposeBlock(TestUtils.PrivateKeys[2], blockCommit);
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Equal(2, blockChain.Tip.Index);
 
@@ -174,10 +174,10 @@ namespace Libplanet.Net.Tests.Consensus.ConsensusContext
             var block = blockChain.ProposeBlock(new PrivateKey());
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             block = blockChain.ProposeBlock(
-                new PrivateKey(), lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
+                new PrivateKey(), TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             block = blockChain.ProposeBlock(
-                new PrivateKey(), lastCommit: TestUtils.CreateBlockCommit(blockChain.Tip));
+                new PrivateKey(), TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             // Create context of index 4, check if the context of 1 and 2 are removed correctly.

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerTest.cs
@@ -328,7 +328,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
             var block1 = blockChain.ProposeBlock(new PrivateKey());
             var block1Commit = TestUtils.CreateBlockCommit(block1);
             blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
-            var block2 = blockChain.ProposeBlock(new PrivateKey(), lastCommit: block1Commit);
+            var block2 = blockChain.ProposeBlock(new PrivateKey(), block1Commit);
             var block2Commit = TestUtils.CreateBlockCommit(block2);
             blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 

--- a/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
@@ -49,8 +49,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact]
         public void CannotAddInvalidProposer()
         {
-            var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
+            var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[0], _lastCommit);
             var proposal0 = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -83,8 +82,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact]
         public void CannotAddMultipleProposalsPerRound()
         {
-            var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
+            var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[0], _lastCommit);
             var proposal0 = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -146,8 +144,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact]
         public void GetValidatorsCount()
         {
-            var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
+            var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[0], _lastCommit);
             var proposal = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -174,8 +171,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         [Fact]
         public void GetBlockCommit()
         {
-            var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
+            var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[0], _lastCommit);
             var proposal = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,

--- a/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/MessageLogTest.cs
@@ -26,9 +26,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         {
             _blockChain = TestUtils.CreateDummyBlockChain(
                 new MemoryStoreFixture(TestUtils.Policy.BlockAction));
-            var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[1],
-                DateTimeOffset.UtcNow);
+            var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             _lastCommit = TestUtils.CreateBlockCommit(block);
             _messageLog = new MessageLog(2, TestUtils.ValidatorSet);
             _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
@@ -52,9 +50,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public void CannotAddInvalidProposer()
         {
             var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0],
-                DateTimeOffset.UtcNow,
-                lastCommit: _lastCommit);
+                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
             var proposal0 = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -88,9 +84,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public void CannotAddMultipleProposalsPerRound()
         {
             var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0],
-                DateTimeOffset.UtcNow,
-                lastCommit: _lastCommit);
+                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
             var proposal0 = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -153,9 +147,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public void GetValidatorsCount()
         {
             var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0],
-                DateTimeOffset.UtcNow,
-                lastCommit: _lastCommit);
+                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
             var proposal = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,
@@ -183,9 +175,7 @@ namespace Libplanet.Net.Tests.Consensus.Context
         public void GetBlockCommit()
         {
             var block = _blockChain.ProposeBlock(
-                TestUtils.PrivateKeys[0],
-                DateTimeOffset.UtcNow,
-                lastCommit: _lastCommit);
+                TestUtils.PrivateKeys[0], lastCommit: _lastCommit);
             var proposal = new ConsensusProposalMsg(new ProposalMetadata(
                 2,
                 0,

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -53,8 +53,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, numBlocks))
             {
                 var block = chainA.ProposeBlock(
-                    new PrivateKey(),
-                    lastCommit: TestUtils.CreateBlockCommit(chainA.Tip));
+                    new PrivateKey(), TestUtils.CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -98,7 +97,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    miner, lastCommit: CreateBlockCommit(minerChain.Tip));
+                    miner, CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -241,7 +240,7 @@ namespace Libplanet.Net.Tests
                         try
                         {
                             var block = chain.ProposeBlock(
-                                miner, lastCommit: CreateBlockCommit(chain.Tip));
+                                miner, CreateBlockCommit(chain.Tip));
                             chain.Append(block, TestUtils.CreateBlockCommit(block));
 
                             Log.Debug(
@@ -376,8 +375,7 @@ namespace Libplanet.Net.Tests
                     for (var i = 0; i < 10; i++)
                     {
                         Block<DumbAction> block = chainC.ProposeBlock(
-                            minerC,
-                            lastCommit: CreateBlockCommit(chainC.Tip));
+                            minerC, CreateBlockCommit(chainC.Tip));
                         chainC.Append(block, TestUtils.CreateBlockCommit(block));
                     }
                 });
@@ -656,14 +654,14 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = chainA.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                    keyA, CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
                 Block<DumbAction> block = chainB.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(chainB.Tip));
+                    keyB, CreateBlockCommit(chainB.Tip));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -815,7 +813,7 @@ namespace Libplanet.Net.Tests
 
                 await BootstrapAsync(swarmB, swarmA.AsPeer);
                 var block = chainA.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                    keyA, CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
                 swarmA.BroadcastBlock(chainA[-1]);
 
@@ -824,7 +822,7 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(chainB.BlockHashes, chainA.BlockHashes);
 
                 block = chainA.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(chainA.Tip));
+                    keyB, CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
                 swarmA.BroadcastBlock(chainA[-1]);
 
@@ -853,7 +851,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             var block = chainA.ProposeBlock(
-                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                keyA, CreateBlockCommit(chainA.Tip));
             BlockCommit blockCommit = TestUtils.CreateBlockCommit(block);
             chainA.Append(block, blockCommit);
             chainB.Append(block, blockCommit);
@@ -861,7 +859,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 3))
             {
                 block = chainA.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                    keyA, CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -912,7 +910,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = chainA.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                    keyA, CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -921,14 +919,14 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 5))
             {
                 Block<DumbAction> block = chainB.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(chainB.Tip));
+                    keyB, CreateBlockCommit(chainB.Tip));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             foreach (int i in Enumerable.Range(0, 3))
             {
                 Block<DumbAction> block = chainC.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(chainC.Tip));
+                    keyB, CreateBlockCommit(chainC.Tip));
                 chainC.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Net.Tests
                         }
 
                         Block<DumbAction> block = chain.ProposeBlock(
-                            miner, lastCommit: CreateBlockCommit(chain.Tip));
+                            miner, CreateBlockCommit(chain.Tip));
                         Log.Logger.Information("  #{0,2} {1}", block.Index, block.Hash);
                         chain.Append(block, CreateBlockCommit(block));
                     }

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -43,7 +43,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                    minerKey, CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -85,17 +85,17 @@ namespace Libplanet.Net.Tests
 
             minerChain.MakeTransaction(key, new[] { action });
             var block = minerChain.ProposeBlock(
-                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
             block = minerChain.ProposeBlock(
-                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
             block = minerChain.ProposeBlock(
-                minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
             try
@@ -283,8 +283,7 @@ namespace Libplanet.Net.Tests
             for (int i = 1; i <= initialSharedTipHeight; i++)
             {
                 var block = chainA.ProposeBlock(
-                    new PrivateKey(),
-                    lastCommit: TestUtils.CreateBlockCommit(chainA.Tip));
+                    new PrivateKey(), TestUtils.CreateBlockCommit(chainA.Tip));
                 chainA.Append(block, TestUtils.CreateBlockCommit(block));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
                 chainC.Append(block, TestUtils.CreateBlockCommit(block));
@@ -294,15 +293,13 @@ namespace Libplanet.Net.Tests
             for (int i = initialSharedTipHeight + 1; i < maliciousTipHeight; i++)
             {
                 var block = chainB.ProposeBlock(
-                    new PrivateKey(),
-                    lastCommit: TestUtils.CreateBlockCommit(chainB.Tip));
+                    new PrivateKey(), TestUtils.CreateBlockCommit(chainB.Tip));
                 chainB.Append(block, TestUtils.CreateBlockCommit(block));
                 chainC.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
             var specialBlock = chainB.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: TestUtils.CreateBlockCommit(chainB.Tip));
+                new PrivateKey(), TestUtils.CreateBlockCommit(chainB.Tip));
             var invalidBlockCommit = new BlockCommit(
                 maliciousTipHeight,
                 0,
@@ -323,8 +320,7 @@ namespace Libplanet.Net.Tests
             for (int i = maliciousTipHeight + 1; i <= honestTipHeight; i++)
             {
                 var block = chainC.ProposeBlock(
-                    new PrivateKey(),
-                    lastCommit: TestUtils.CreateBlockCommit(chainC.Tip));
+                    new PrivateKey(), TestUtils.CreateBlockCommit(chainC.Tip));
                 chainC.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -419,7 +415,7 @@ namespace Libplanet.Net.Tests
             {
                 sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
                 Block<DumbAction> block = sender.BlockChain.ProposeBlock(
-                    senderKey, lastCommit: CreateBlockCommit(sender.BlockChain.Tip));
+                    senderKey, CreateBlockCommit(sender.BlockChain.Tip));
                 sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -463,7 +459,7 @@ namespace Libplanet.Net.Tests
             foreach (var unused in Enumerable.Range(0, 10))
             {
                 Block<ThrowException> block = minerSwarm.BlockChain.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(minerSwarm.BlockChain.Tip));
+                    minerKey, CreateBlockCommit(minerSwarm.BlockChain.Tip));
                 minerSwarm.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -536,7 +532,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 10))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                    minerKey, CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -654,8 +650,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < blockCount; ++i)
             {
                 var block = swarm0.BlockChain.ProposeBlock(
-                    key0,
-                    lastCommit: CreateBlockCommit(swarm0.BlockChain.Tip));
+                    key0, CreateBlockCommit(swarm0.BlockChain.Tip));
                 swarm0.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 swarm1.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -832,7 +827,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 25))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                    minerKey, CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
                 receiverChain.Append(block, CreateBlockCommit(block));
             }
@@ -841,7 +836,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 20))
             {
                 Block<DumbAction> block = receiverForked.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(receiverForked.Tip));
+                    minerKey, CreateBlockCommit(receiverForked.Tip));
                 receiverForked.Append(block, CreateBlockCommit(block));
             }
 
@@ -850,7 +845,7 @@ namespace Libplanet.Net.Tests
             foreach (int i in Enumerable.Range(0, 1))
             {
                 Block<DumbAction> block = minerChain.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(minerChain.Tip));
+                    minerKey, CreateBlockCommit(minerChain.Tip));
                 minerChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -893,7 +888,7 @@ namespace Libplanet.Net.Tests
             while (forked.Count <= minerChain.Count)
             {
                 Block<DumbAction> block = forked.ProposeBlock(
-                    minerKey, lastCommit: CreateBlockCommit(forked.Tip));
+                    minerKey, CreateBlockCommit(forked.Tip));
                 forked.Append(block, CreateBlockCommit(block));
             }
 
@@ -968,10 +963,10 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> receiverChain = receiverSwarm.BlockChain;
 
             Block<DumbAction> block1 = minerChain1.ProposeBlock(
-                minerKey1, lastCommit: CreateBlockCommit(minerChain1.Tip));
+                minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block1, CreateBlockCommit(block1));
             Block<DumbAction> block2 = minerChain1.ProposeBlock(
-                minerKey1, lastCommit: CreateBlockCommit(minerChain1.Tip));
+                minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
             Block<DumbAction> block = ProposeNext(
@@ -1039,14 +1034,14 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 Block<DumbAction> block = validSeedChain.ProposeBlock(
-                    key1, lastCommit: CreateBlockCommit(validSeedChain.Tip));
+                    key1, CreateBlockCommit(validSeedChain.Tip));
                 validSeedChain.Append(block, CreateBlockCommit(block));
             }
 
             for (int i = 0; i < 20; i++)
             {
                 Block<DumbAction> block = invalidSeedChain.ProposeBlock(
-                    key1, lastCommit: CreateBlockCommit(invalidSeedChain.Tip));
+                    key1, CreateBlockCommit(invalidSeedChain.Tip));
                 invalidSeedChain.Append(block, CreateBlockCommit(block));
             }
 
@@ -1091,7 +1086,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 var block = seedChain.ProposeBlock(
-                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
+                    seedKey, CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 receiverChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
@@ -1101,7 +1096,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 10; i++)
             {
                 Block<DumbAction> block = seedChain.ProposeBlock(
-                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
+                    seedKey, CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1154,7 +1149,7 @@ namespace Libplanet.Net.Tests
                         new DumbAction(default, $"Item{i}"),
                     });
                 Block<DumbAction> block = seedChain.ProposeBlock(
-                    seedKey, lastCommit: CreateBlockCommit(seedChain.Tip));
+                    seedKey, CreateBlockCommit(seedChain.Tip));
                 seedChain.Append(block, TestUtils.CreateBlockCommit(block));
                 transactions.Add(transaction);
             }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -517,8 +517,7 @@ namespace Libplanet.Net.Tests
 
             Block<DumbAction> block1 = chainA.ProposeBlock(keyA);
             chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
-            Block<DumbAction> block2 = chainA.ProposeBlock(
-                keyA, lastCommit: CreateBlockCommit(block1));
+            Block<DumbAction> block2 = chainA.ProposeBlock(keyA, CreateBlockCommit(block1));
             chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
@@ -586,10 +585,10 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> chainB = swarmB.BlockChain;
 
             Block<DumbAction> block1 = chainA.ProposeBlock(
-                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                keyA, CreateBlockCommit(chainA.Tip));
             chainA.Append(block1, TestUtils.CreateBlockCommit(block1));
             Block<DumbAction> block2 = chainA.ProposeBlock(
-                keyA, lastCommit: CreateBlockCommit(chainA.Tip));
+                keyA, CreateBlockCommit(chainA.Tip));
             chainA.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             try
@@ -918,17 +917,17 @@ namespace Libplanet.Net.Tests
 
             miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             Block<DumbAction> block1 = miner1.BlockChain.ProposeBlock(
-                key1, lastCommit: CreateBlockCommit(miner1.BlockChain.Tip));
+                key1, CreateBlockCommit(miner1.BlockChain.Tip));
             miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             Block<DumbAction> block2 = miner2.BlockChain.ProposeBlock(
-                key2, lastCommit: CreateBlockCommit(miner2.BlockChain.Tip));
+                key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
             var latest = miner2.BlockChain.ProposeBlock(
-                key2, lastCommit: CreateBlockCommit(miner2.BlockChain.Tip));
+                key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
 
             renderer.RenderEventHandler += (_, a) =>
@@ -983,7 +982,7 @@ namespace Libplanet.Net.Tests
                 );
                 var b = miner1.BlockChain.ProposeBlock(
                     key1,
-                    lastCommit: CreateBlockCommit(
+                    CreateBlockCommit(
                         miner1.BlockChain.Tip.Hash,
                         miner1.BlockChain.Tip.Index,
                         0));
@@ -1058,13 +1057,13 @@ namespace Libplanet.Net.Tests
 
                 Log.Debug("Make minerB's chain longer than minerA's chain");
                 Block<DumbAction> blockA = minerA.BlockChain.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(minerA.BlockChain.Tip));
+                    keyA, CreateBlockCommit(minerA.BlockChain.Tip));
                 minerA.BlockChain.Append(blockA, TestUtils.CreateBlockCommit(blockA));
                 Block<DumbAction> blockB = minerB.BlockChain.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(minerB.BlockChain.Tip));
+                    keyB, CreateBlockCommit(minerB.BlockChain.Tip));
                 minerB.BlockChain.Append(blockB, TestUtils.CreateBlockCommit(blockB));
                 Block<DumbAction> blockC = minerB.BlockChain.ProposeBlock(
-                    keyB, lastCommit: CreateBlockCommit(minerB.BlockChain.Tip));
+                    keyB, CreateBlockCommit(minerB.BlockChain.Tip));
                 minerB.BlockChain.Append(blockC, TestUtils.CreateBlockCommit(blockC));
 
                 Assert.Equal((Text)dumbItem, minerA.BlockChain.GetState(targetAddress1));
@@ -1092,7 +1091,7 @@ namespace Libplanet.Net.Tests
                     minerA.BlockChain.GetStagedTransactionIds().Contains(txA.Id));
 
                 Block<DumbAction> block = minerA.BlockChain.ProposeBlock(
-                    keyA, lastCommit: CreateBlockCommit(minerA.BlockChain.Tip));
+                    keyA, CreateBlockCommit(minerA.BlockChain.Tip));
                 minerA.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
                 minerA.BroadcastBlock(minerA.BlockChain.Tip);
                 await minerB.BlockAppended.WaitAsync();

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -323,7 +323,7 @@ namespace Libplanet.Net.Consensus
         {
             try
             {
-                Block<T> block = _blockChain.ProposeBlock(_privateKey, lastCommit: _lastCommit);
+                Block<T> block = _blockChain.ProposeBlock(_privateKey, _lastCommit);
                 _blockChain.Store.PutBlock(block);
                 return block;
             }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Tests.Blockchain
             var proposerB = new PrivateKey();
             Block<DumbAction> anotherBlock = _blockChain.ProposeBlock(
                 proposerB,
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             _blockChain.Append(anotherBlock, CreateBlockCommit(anotherBlock));
             Assert.True(_blockChain.ContainsBlock(anotherBlock.Hash));
             Assert.Equal(3, _blockChain.Count);
@@ -60,7 +60,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block3 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             Assert.False(_blockChain.ContainsBlock(block3.Hash));
             Assert.Equal(3, _blockChain.Count);
             Assert.True(
@@ -95,7 +95,7 @@ namespace Libplanet.Tests.Blockchain
 
             Block<DumbAction> block4 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             Assert.False(_blockChain.ContainsBlock(block4.Hash));
             _logger.Debug(
                 $"{nameof(block4)}: {0} bytes",
@@ -295,8 +295,7 @@ namespace Libplanet.Tests.Blockchain
                 ),
             };
             StageTransactions(txs);
-            Block<DumbAction> block = _blockChain.ProposeBlock(
-                new PrivateKey());
+            Block<DumbAction> block = _blockChain.ProposeBlock(new PrivateKey());
             Assert.Equal(txs.Length, block.Transactions.Count());
         }
 
@@ -332,7 +331,7 @@ namespace Libplanet.Tests.Blockchain
             );
             Block<DumbAction> block2 = _blockChain.ProposeBlock(
                 new PrivateKey(),
-                lastCommit: CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
+                CreateBlockCommit(_blockChain.Tip.Hash, _blockChain.Tip.Index, 0));
             _blockChain.Append(block2, CreateBlockCommit(block2));
 
             Assert.Empty(block2.Transactions);
@@ -361,8 +360,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock);
 
             blockChain.MakeTransaction(privateKey2, new[] { new DumbAction(address2, "baz") });
-            var block = blockChain.ProposeBlock(
-                privateKey1, lastCommit: CreateBlockCommit(_blockChain.Tip));
+            var block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 
             var state1 = blockChain.GetState(address1);
@@ -374,8 +372,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal((Text)"baz", state2);
 
             blockChain.MakeTransaction(privateKey1, new[] { new DumbAction(address1, "bar") });
-            block = blockChain.ProposeBlock(
-                privateKey1, lastCommit: CreateBlockCommit(_blockChain.Tip));
+            block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 
             state1 = blockChain.GetState(address1);
@@ -438,9 +435,7 @@ namespace Libplanet.Tests.Blockchain
                 VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
             var blockCommit = new BlockCommit(
                 _blockChain.Tip.Index, 0, _blockChain.Tip.Hash, votes);
-            Block<DumbAction> block = _blockChain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: blockCommit);
+            Block<DumbAction> block = _blockChain.ProposeBlock(new PrivateKey(), blockCommit);
 
             Assert.NotNull(block.LastCommit);
             Assert.Equal(block.LastCommit, blockCommit);
@@ -475,8 +470,7 @@ namespace Libplanet.Tests.Blockchain
 
             // Propose only txs having higher or equal with nonce than expected nonce.
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
-                new PrivateKey(),
-                lastCommit: CreateBlockCommit(b1));
+                new PrivateKey(), CreateBlockCommit(b1));
             Assert.Single(b2.Transactions);
             Assert.Contains(txsB[3], b2.Transactions);
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Stage.cs
@@ -105,8 +105,7 @@ namespace Libplanet.Tests.Blockchain
                 txIds.OrderBy(id => id),
                 _blockChain.GetStagedTransactionIds().OrderBy(id => id)
             );
-            block = _blockChain.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(_blockChain.Tip));
+            block = _blockChain.ProposeBlock(key, TestUtils.CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block, TestUtils.CreateBlockCommit(block));
             // tx_0_1 and tx_1_x should be still staged, just filtered
             Assert.Empty(_blockChain.GetStagedTransactionIds());

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -114,13 +114,11 @@ namespace Libplanet.Tests.Blockchain
             var key = new PrivateKey();
             Block<DumbAction> block1 = chain1.ProposeBlock(key);
             chain1.Append(block1, CreateBlockCommit(block1));
-            Block<DumbAction> block2 = chain1.ProposeBlock(
-                key, lastCommit: CreateBlockCommit(chain1.Tip));
+            Block<DumbAction> block2 = chain1.ProposeBlock(key, CreateBlockCommit(chain1.Tip));
             chain1.Append(block2, CreateBlockCommit(block2));
             Assert.Equal(chain1.Id, _fx.Store.GetCanonicalChainId());
             var chain2 = chain1.Fork(chain1.Tip.Hash);
-            Block<DumbAction> block3 = chain2.ProposeBlock(
-                key, lastCommit: CreateBlockCommit(chain1.Tip));
+            Block<DumbAction> block3 = chain2.ProposeBlock(key, CreateBlockCommit(chain1.Tip));
             chain2.Append(block3, CreateBlockCommit(block3));
             Assert.Equal(chain1.Id, _fx.Store.GetCanonicalChainId());
 
@@ -148,7 +146,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(new[] { genesis.Hash, b1.Hash }, _blockChain.BlockHashes);
 
             Block<DumbAction> b2 = _blockChain.ProposeBlock(
-                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
+                key, CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b2, CreateBlockCommit(b2));
             Assert.Equal(
                 new[] { genesis.Hash, b1.Hash, b2.Hash },
@@ -156,7 +154,7 @@ namespace Libplanet.Tests.Blockchain
             );
 
             Block<DumbAction> b3 = _blockChain.ProposeBlock(
-                key, lastCommit: CreateBlockCommit(_blockChain.Tip));
+                key, CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b3, CreateBlockCommit(b3));
             Assert.Equal(
                 new[] { genesis.Hash, b1.Hash, b2.Hash, b3.Hash },
@@ -234,7 +232,7 @@ namespace Libplanet.Tests.Blockchain
 
             chain.StageTransaction(tx2);
             Block<PolymorphicAction<BaseAction>> block2 = chain.ProposeBlock(
-                new PrivateKey(), lastCommit: CreateBlockCommit(chain.Tip));
+                new PrivateKey(), CreateBlockCommit(chain.Tip));
             chain.Append(block2, CreateBlockCommit(block2));
 
             state = chain.GetState(_fx.Address1);
@@ -256,7 +254,7 @@ namespace Libplanet.Tests.Blockchain
                 }
             );
             Block<PolymorphicAction<BaseAction>> block3 = chain.ProposeBlock(
-                new PrivateKey(), lastCommit: CreateBlockCommit(chain.Tip));
+                new PrivateKey(), CreateBlockCommit(chain.Tip));
             chain.StageTransaction(tx3);
             chain.Append(block3, CreateBlockCommit(block3));
             state = chain.GetState(_fx.Address1);

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedActionRendererTest.cs
@@ -586,7 +586,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#2") });
             Block<DumbAction> block1 = chain.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
+                key, TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
             Assert.Equal(chain[0], delayedRenderer.Tip);
@@ -597,7 +597,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             var forked = chain.Fork(chain[0].Hash);
             chain.StagePolicy.Stage(chain, tx1);
             Block<DumbAction> block2 = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+                key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -607,7 +607,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 );
             chain.StagePolicy.Stage(chain, tx2);
             block2 = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+                key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -617,7 +617,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#3") });
             block2 = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+                key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -627,7 +627,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 );
             forked.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#4") });
             block2 = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+                key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block2,
                     TestUtils.CreateBlockCommit(block2),
@@ -714,7 +714,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var tx2 = chain.MakeTransaction(key, new[] { new DumbAction(fx.Address2, "#2") });
             Block<DumbAction> block2 = chain.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
+                key, TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
             Assert.Equal(chain[0], delayedRenderer.Tip);
@@ -724,8 +724,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             var forked = chain.Fork(chain[1].Hash);
             chain.StagePolicy.Stage(chain, tx2);
-            var block = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+            var block = forked.ProposeBlock(key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block,
                     TestUtils.CreateBlockCommit(block),
@@ -733,8 +732,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     renderBlocks: false,
                     renderActions: false
                 );
-            block = forked.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(forked.Tip));
+            block = forked.ProposeBlock(key, TestUtils.CreateBlockCommit(forked.Tip));
             forked.Append(
                     block,
                     TestUtils.CreateBlockCommit(block),
@@ -751,7 +749,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             Assert.Equal(2, renderLogs.Count);
 
             Block<DumbAction> block3 = chain.ProposeBlock(
-                key, lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
+                key, TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(block3, TestUtils.CreateBlockCommit(block3));
             Assert.Equal(chain[2], delayedRenderer.Tip);
             Assert.Empty(reorgLogs);

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -153,7 +153,7 @@ namespace Libplanet.Tests.Fixtures
             Sign(PrivateKeys[signerIndex], actions);
 
         public Block<Arithmetic> Propose() => Chain.ProposeBlock(
-            Miner, lastCommit: TestUtils.CreateBlockCommit(Chain.Tip));
+            Miner, TestUtils.CreateBlockCommit(Chain.Tip));
 
         public void Append(Block<Arithmetic> block) =>
             Chain.Append(block, TestUtils.CreateBlockCommit(block));

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1062,11 +1062,9 @@ namespace Libplanet.Tests.Store
                 var key = new PrivateKey();
                 var block = blocks.ProposeBlock(key);
                 blocks.Append(block, CreateBlockCommit(block));
-                block = blocks.ProposeBlock(
-                    key, lastCommit: CreateBlockCommit(blocks.Tip));
+                block = blocks.ProposeBlock(key, CreateBlockCommit(blocks.Tip));
                 blocks.Append(block, CreateBlockCommit(block));
-                block = blocks.ProposeBlock(
-                    key, lastCommit: CreateBlockCommit(blocks.Tip));
+                block = blocks.ProposeBlock(key, CreateBlockCommit(blocks.Tip));
                 blocks.Append(block, CreateBlockCommit(block));
 
                 s1.Copy(to: Fx.Store);

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -93,19 +93,17 @@ namespace Libplanet.Blockchain
         /// Proposes a next <see cref="Block{T}"/> using staged <see cref="Transaction{T}"/>s.
         /// </para>
         /// <para>
-        /// All unprovided and/or <see langword="null"/> arguments are reassigned accordingly
-        /// and redirected to a overloaded method with non-nullable parameters.  By default,
-        /// a policy adhering block is produced with current timestamp and appended immediately
-        /// to the chain.
+        /// By default, if successful, a policy adhering <see cref="Block{T}"/> is produced with
+        /// current timestamp that can be appeneded to the current chain.
         /// </para>
         /// </summary>
-        /// <param name="proposer">
-        /// The proposer's <see cref="PublicKey"/> that proposes the block.</param>
-        /// <param name="lastCommit"><see cref="BlockCommit"/> of previous <see cref="Block{T}"/>.
+        /// <param name="proposer">The proposer's <see cref="PublicKey"/> that proposes the block.
         /// </param>
+        /// <param name="lastCommit">The <see cref="BlockCommit"/> evidence of the previous
+        /// <see cref="Block{T}"/>.</param>
         /// <param name="txPriority">An optional comparer for give certain transactions to
         /// priority to belong to the block.  No certain priority by default.</param>
-        /// <returns>An awaitable task with a <see cref="Block{T}"/> that is proposed.</returns>
+        /// <returns>A <see cref="Block{T}"/> that is proposed.</returns>
         /// <exception cref="OperationCanceledException">Thrown when
         /// <see cref="BlockChain{T}.Tip"/> is changed while proposing.</exception>
         public Block<T> ProposeBlock(
@@ -147,6 +145,24 @@ namespace Libplanet.Blockchain
             return block;
         }
 
+        /// <summary>
+        /// <para>
+        /// Proposes a next <see cref="Block{T}"/> using a specified <see cref="DateTimeOffset"/>
+        /// and a specified list of <see cref="Transaction{T}"/>s.
+        /// </para>
+        /// <para>
+        /// Unlike <see cref="ProposeBlock(PrivateKey, BlockCommit, IComparer{Transaction{T}})"/>,
+        /// this may result in a <see cref="Block{T}"/> that does not conform to the
+        /// <see cref="Policy"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="proposer">The proposer's <see cref="PublicKey"/> that proposes the block.
+        /// </param>
+        /// <param name="timestamp">Goes to <see cref="Block{T}.Timestamp"/>.</param>
+        /// <param name="transactions">The list of <see cref="Transaction{T}"/>s to include.</param>
+        /// <param name="lastCommit">The <see cref="BlockCommit"/> evidence of the previous
+        /// <see cref="Block{T}"/>.</param>
+        /// <returns>A <see cref="Block{T}"/> that is proposed.</returns>
         public Block<T> ProposeBlock(
             PrivateKey proposer,
             DateTimeOffset timestamp,

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -133,7 +133,6 @@ namespace Libplanet.Blockchain
 
             var block = ProposeBlock(
                 proposer,
-                DateTimeOffset.UtcNow,
                 transactions,
                 lastCommit);
             _logger.Debug(
@@ -147,8 +146,8 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// <para>
-        /// Proposes a next <see cref="Block{T}"/> using a specified <see cref="DateTimeOffset"/>
-        /// and a specified list of <see cref="Transaction{T}"/>s.
+        /// Proposes a next <see cref="Block{T}"/> using a specified
+        /// list of <see cref="Transaction{T}"/>s.
         /// </para>
         /// <para>
         /// Unlike <see cref="ProposeBlock(PrivateKey, BlockCommit, IComparer{Transaction{T}})"/>,
@@ -158,14 +157,12 @@ namespace Libplanet.Blockchain
         /// </summary>
         /// <param name="proposer">The proposer's <see cref="PublicKey"/> that proposes the block.
         /// </param>
-        /// <param name="timestamp">Goes to <see cref="Block{T}.Timestamp"/>.</param>
         /// <param name="transactions">The list of <see cref="Transaction{T}"/>s to include.</param>
         /// <param name="lastCommit">The <see cref="BlockCommit"/> evidence of the previous
         /// <see cref="Block{T}"/>.</param>
         /// <returns>A <see cref="Block{T}"/> that is proposed.</returns>
         public Block<T> ProposeBlock(
             PrivateKey proposer,
-            DateTimeOffset timestamp,
             ImmutableList<Transaction<T>> transactions,
             BlockCommit lastCommit)
         {
@@ -179,7 +176,7 @@ namespace Libplanet.Blockchain
                 new BlockMetadata(
                     protocolVersion: BlockMetadata.CurrentProtocolVersion,
                     index: index,
-                    timestamp: timestamp,
+                    timestamp: DateTimeOffset.UtcNow,
                     miner: proposer.ToAddress(),
                     publicKey: proposer.PublicKey,
                     previousHash: prevHash,

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -161,7 +161,7 @@ namespace Libplanet.Blockchain
         /// <param name="lastCommit">The <see cref="BlockCommit"/> evidence of the previous
         /// <see cref="Block{T}"/>.</param>
         /// <returns>A <see cref="Block{T}"/> that is proposed.</returns>
-        public Block<T> ProposeBlock(
+        internal Block<T> ProposeBlock(
             PrivateKey proposer,
             ImmutableList<Transaction<T>> transactions,
             BlockCommit lastCommit)

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -117,38 +117,30 @@ namespace Libplanet.Blockchain
             long index = Count;
             BlockHash? prevHash = Store.IndexBlockHash(Id, index - 1);
 
-            int sessionId = new System.Random().Next();
-            int processId = Process.GetCurrentProcess().Id;
             _logger.Debug(
-                "{SessionId}/{ProcessId}: Starting to propose block #{Index} with " +
-                "previous hash {PreviousHash}...",
-                sessionId,
-                processId,
+                "Starting to propose block #{Index} with previous hash {PreviousHash}...",
                 index,
                 prevHash);
 
-            ImmutableList<Transaction<T>> transactionsToPropose;
+            ImmutableList<Transaction<T>> transactions;
             try
             {
-                transactionsToPropose = GatherTransactionsToPropose(index, txPriority);
+                transactions = GatherTransactionsToPropose(index, txPriority);
             }
             catch (InvalidOperationException ioe)
             {
                 throw new OperationCanceledException(
-                    "Failed to gather transactions to propose.",
+                    $"Failed to gather transactions to propose for block #{index}.",
                     ioe);
             }
 
             var block = ProposeBlock(
                 proposer,
                 DateTimeOffset.UtcNow,
-                transactionsToPropose,
+                transactions,
                 lastCommit);
             _logger.Debug(
-                "{SessionId}/{ProcessId}: Proposed block #{Index} {Hash} " +
-                "with previous hash {PreviousHash}",
-                sessionId,
-                processId,
+                "Proposed block #{Index} {Hash} with previous hash {PreviousHash}",
                 block.Index,
                 block.Hash,
                 block.PreviousHash);

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -102,7 +102,6 @@ namespace Libplanet.Blockchain
         /// </summary>
         /// <param name="proposer">
         /// The proposer's <see cref="PublicKey"/> that proposes the block.</param>
-        /// <param name="timestamp">The <see cref="DateTimeOffset"/> when proposing started.</param>
         /// <param name="txPriority">An optional comparer for give certain transactions to
         /// priority to belong to the block.  No certain priority by default.</param>
         /// <param name="lastCommit"><see cref="BlockCommit"/> of previous <see cref="Block{T}"/>.
@@ -112,7 +111,6 @@ namespace Libplanet.Blockchain
         /// <see cref="BlockChain{T}.Tip"/> is changed while proposing.</exception>
         public Block<T> ProposeBlock(
             PrivateKey proposer,
-            DateTimeOffset? timestamp = null,
             IComparer<Transaction<T>> txPriority = null,
             BlockCommit lastCommit = null)
         {
@@ -143,7 +141,7 @@ namespace Libplanet.Blockchain
 
             var block = ProposeBlock(
                 proposer,
-                timestamp ?? DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
                 transactionsToPropose,
                 lastCommit);
             _logger.Debug(

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -102,17 +101,17 @@ namespace Libplanet.Blockchain
         /// </summary>
         /// <param name="proposer">
         /// The proposer's <see cref="PublicKey"/> that proposes the block.</param>
-        /// <param name="txPriority">An optional comparer for give certain transactions to
-        /// priority to belong to the block.  No certain priority by default.</param>
         /// <param name="lastCommit"><see cref="BlockCommit"/> of previous <see cref="Block{T}"/>.
         /// </param>
+        /// <param name="txPriority">An optional comparer for give certain transactions to
+        /// priority to belong to the block.  No certain priority by default.</param>
         /// <returns>An awaitable task with a <see cref="Block{T}"/> that is proposed.</returns>
         /// <exception cref="OperationCanceledException">Thrown when
         /// <see cref="BlockChain{T}.Tip"/> is changed while proposing.</exception>
         public Block<T> ProposeBlock(
             PrivateKey proposer,
-            IComparer<Transaction<T>> txPriority = null,
-            BlockCommit lastCommit = null)
+            BlockCommit lastCommit = null,
+            IComparer<Transaction<T>> txPriority = null)
         {
             long index = Count;
             BlockHash? prevHash = Store.IndexBlockHash(Id, index - 1);


### PR DESCRIPTION
Follow-up on #3072.

Notable changes:
- Removed `Timestamp` parameter from `ProposeBlock()`. It might be nice to have, but isn't being used anywhere. Besides, there is no easy path to assign custom timestamps for a running node.
- ~~Added `ProposeBlock()` that takes a list of `Transaction<T>`s to propose a somewhat custom `Block<T>`.~~
  - On second thought, made such method `internal` only for testing.
  
Addendum:
We can also probably remove `BlockCommit` and `IComparer<Transaction<T>>`. 🙄