### PR TITLE
Implement `query.stateQuery.states`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,6 +130,7 @@ To be released.
  -  (Libplanet.Explorer.Cocona) New project was added to provide Cocona
     commands related to *Libplanet.Explorer* project.  [[#2613]]
      -  Added `IndexCommand` Cocona command class.
+ -  (Libplanet.Explorer) Added `states` query in `StateQuery`.  [[#3080]]
 
 ### Behavioral changes
 
@@ -238,6 +239,7 @@ To be released.
 [#3074]: https://github.com/planetarium/libplanet/pull/3074
 [#3077]: https://github.com/planetarium/libplanet/pull/3077
 [#3079]: https://github.com/planetarium/libplanet/pull/3079
+[#3080]: https://github.com/planetarium/libplanet/pull/3080
 
 
 Version 0.53.4

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -22,6 +22,32 @@ namespace Libplanet.Explorer.Tests.Queries;
 public class StateQueryTest
 {
     [Fact]
+    public async Task States()
+    {
+        var currency = Currency.Uncapped("ABC", 2, minters: null);
+        (IBlockChainStates, IBlockPolicy<NullAction>) source = (
+            new MockChainStates(),
+            new BlockPolicy<NullAction>(nativeTokens: ImmutableHashSet.Create(currency))
+        );
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery<NullAction>>(@"
+        {
+            states(
+                 addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""],
+                 offsetBlockHash:
+                     ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
+            )
+        }
+        ", source: source);
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        object[] states =
+            Assert.IsAssignableFrom<object[]>(resultDict["states"]);
+        Assert.Equal(new[] { new byte[] { 110, }, null }, states);
+    }
+
+    [Fact]
     public async Task Balance()
     {
         var currency = Currency.Uncapped("ABC", 2, minters: null);
@@ -187,7 +213,11 @@ public class StateQueryTest
             IReadOnlyList<Address> addresses,
             BlockHash offset
         ) =>
-            new IValue[addresses.Count];
+            addresses.Select(address => address.ToString() switch
+            {
+                "0x5003712B63baAB98094aD678EA2B24BcE445D076" => (IValue)Null.Value,
+                _ => null,
+            }).ToImmutableList();
 
         public FungibleAssetValue GetBalance(
             Address address,


### PR DESCRIPTION
This pull request introduced the `states` query in the `StateQuery` GraphQL type.