### PR TITLE
Introduce `RemoteBlockChainStates`

### DIFF
--- a/Libplanet.Extensions.Remote/Libplanet.Extensions.Remote.csproj
+++ b/Libplanet.Extensions.Remote/Libplanet.Extensions.Remote.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>8.0</LangVersion>
+    <RootNamespace>Libplanet.Extensions.Remote</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GraphQL.Client" Version="5.1.1"/>
+    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.1"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Extensions.Remote/RemoteBlockChainStates.cs
+++ b/Libplanet.Extensions.Remote/RemoteBlockChainStates.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Numerics;
+using Bencodex;
+using Bencodex.Types;
+using GraphQL;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.SystemTextJson;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+
+namespace Libplanet.Extensions.Remote
+{
+    public class RemoteBlockChainStates : IBlockChainStates
+    {
+        private readonly Uri _explorerEndpoint;
+        private readonly GraphQLHttpClient _graphQlHttpClient;
+
+        public RemoteBlockChainStates(Uri explorerEndpoint)
+        {
+            _explorerEndpoint = explorerEndpoint;
+            _graphQlHttpClient =
+                new GraphQLHttpClient(_explorerEndpoint, new SystemTextJsonSerializer());
+        }
+
+        public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses, BlockHash offset)
+        {
+            var response = _graphQlHttpClient.SendQueryAsync<GetStatesResponseType>(
+                new GraphQLRequest(
+                    @"query GetStates($addresses: [Address]!, $offsetBlockHash: ID!)
+                {
+                    stateQuery
+                    {
+                        states(addresses: addresses, offsetBlockHash: $offsetBlockHash)
+                    }
+                }",
+                    operationName: "GetStates",
+                    variables: new
+                    {
+                        addresses = addresses.Select(x => x.ToString()).ToArray(),
+                        offsetBlockHash = ByteUtil.Hex(offset.ByteArray),
+                    })).Result;
+            var codec = new Codec();
+            Console.WriteLine(response.Errors[0].Message);
+            return response.Data.StateQuery.States.Select(codec.Decode).ToList();
+        }
+
+        public FungibleAssetValue GetBalance(Address address, Currency currency, BlockHash offset)
+        {
+            var response = _graphQlHttpClient.SendQueryAsync<GetBalanceResponseType>(
+                new GraphQLRequest(
+            @"query GetBalance($owner: Address!, $currencyHash: ByteString!, $offsetBlockHash: ID!)
+                {
+                    stateQuery
+                    {
+                        balance(owner: $owner, currencyHash: $currencyHash, offsetBlockHash: $offsetBlockHash)
+                        {
+                            string
+                        }
+                    }
+                }",
+                operationName: "GetBalance",
+                variables: new
+                {
+                    owner = address.ToString(),
+                    currencyHash = ByteUtil.Hex(currency.Hash.ByteArray),
+                    offsetBlockHash = ByteUtil.Hex(offset.ByteArray),
+                })).Result;
+
+            Console.WriteLine(response.Errors[0].Message);
+
+            return FungibleAssetValue.Parse(currency, response.Data.StateQuery.Balance.String);
+        }
+
+        public FungibleAssetValue GetTotalSupply(Currency currency, BlockHash offset)
+        {
+            var response = _graphQlHttpClient.SendQueryAsync<GetTotalSupplyResponseType>(
+                new GraphQLRequest(
+                    @"query GetTotalSupply($currencyHash: ByteString!, $offsetBlockHash: ID!)
+                {
+                    stateQuery
+                    {
+                        totalSupply(currencyHash: $currencyHash, offsetBlockHash: $offsetBlockHash)
+                        {
+                            string
+                        }
+                    }
+                }",
+                    operationName: "GetTotalSupply",
+                    variables: new
+                    {
+                        currencyHash = ByteUtil.Hex(currency.Hash.ByteArray),
+                        offsetBlockHash = ByteUtil.Hex(offset.ByteArray),
+                    })).Result;
+
+            return FungibleAssetValue.Parse(currency, response.Data.StateQuery.TotalSupply.String);
+        }
+
+        public ValidatorSet GetValidatorSet(BlockHash offset)
+        {
+            var response = _graphQlHttpClient.SendQueryAsync<GetValidatorsResponseType>(
+                new GraphQLRequest (
+                    @"query GetValidators($offsetBlockHash: ID!)
+                {
+                    stateQuery
+                    {
+                        validators(offsetBlockHash: $offsetBlockHash)
+                        {
+                            publicKey
+                            power
+                        }
+                    }
+                }",
+                    operationName: "GetValidators",
+                    variables: new
+                    {
+                        offsetBlockHash = ByteUtil.Hex(offset.ByteArray),
+                    })).Result;
+            return new ValidatorSet(response.Data.StateQuery.Validators
+                .Select(x =>
+                    new Validator(new PublicKey(ByteUtil.ParseHex(x.PublicKey)), x.Power))
+                .ToList());
+        }
+
+        private class GetStatesResponseType
+        {
+            public StateQueryWithStatesType StateQuery { get; set; }
+        }
+
+        private class StateQueryWithStatesType
+        {
+            public byte[][] States { get; set; }
+        }
+
+        private class GetBalanceResponseType
+        {
+            public StateQueryWithBalanceType StateQuery { get; set; }
+        }
+
+        private class StateQueryWithBalanceType
+        {
+            public FungibleAssetValueWithStringType Balance { get; set; }
+        }
+
+        private class FungibleAssetValueWithStringType
+        {
+            public string String { get; set; }
+        }
+
+        private class GetTotalSupplyResponseType
+        {
+            public StateQueryWithTotalSupplyType StateQuery { get; set; }
+        }
+
+        private class StateQueryWithTotalSupplyType
+        {
+            public FungibleAssetValueWithStringType TotalSupply { get; set; }
+        }
+
+        private class GetValidatorsResponseType
+        {
+            public StateQueryWithValidatorsType StateQuery { get; set; }
+        }
+
+        private class StateQueryWithValidatorsType
+        {
+            public ValidatorType[] Validators { get; set; }
+        }
+
+        private class ValidatorType
+        {
+            public string PublicKey { get; set; }
+            public long Power { get; set; }
+        }
+    }
+}

--- a/Libplanet.sln
+++ b/Libplanet.sln
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Explorer.Cocona",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Explorer.Cocona.Tests", "Libplanet.Explorer.Cocona.Tests\Libplanet.Explorer.Cocona.Tests.csproj", "{F782BC86-9CE6-4F69-8F77-710A399CB54F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Remote", "Libplanet.Extensions.Remote\Libplanet.Extensions.Remote.csproj", "{103CA71F-2FC7-400C-87B2-309FCB859914}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -427,6 +429,24 @@ Global
 		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x64.Build.0 = Debug|Any CPU
 		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x86.ActiveCfg = Debug|Any CPU
 		{F782BC86-9CE6-4F69-8F77-710A399CB54F}.ReleaseMono|x86.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|x64.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Debug|x86.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|x64.ActiveCfg = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|x64.Build.0 = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|x86.ActiveCfg = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.Release|x86.Build.0 = Release|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|Any CPU.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|Any CPU.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|x64.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|x64.Build.0 = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|x86.ActiveCfg = Debug|Any CPU
+		{103CA71F-2FC7-400C-87B2-309FCB859914}.ReleaseMono|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request depends on #3080. This pull request introduces `RemoteBlockChainStates`, a new `IBlockChainStates` implementation, which gets states, balances, total supplies, and validator-set from remote `Libplanet.Explorer`'s `StateQuery` API.

```csharp
// See https://aka.ms/new-console-template for more information
using Libplanet;
using Libplanet.Blocks;
using Libplanet.Extensions.Remote;

var blockChainStates = new RemoteBlockChainStates(new Uri("https://9c-main-full-state.planetarium.dev/graphql/explorer"));

var validatorSet = blockChainStates.GetValidatorSet(BlockHash.FromString("0f1d9067c4907e1d115cdf9d0a33ff48a5f7c20fc25b7441c1c41371f48b9799"));
Console.WriteLine(string.Join(", ", validatorSet.Validators.Select(x => x.ToString())));

// It supports only native tokens yet. :thinking_face:
// This issue can be resolved in https://github.com/planetarium/libplanet/pull/3085.
// var ncg = Libplanet.Assets.Currency.Legacy("NCG", 2, ImmutableHashSet<Address>.Empty.Add(new Address("47d082a115c63e7b58b1532d20e631538eafadde")));
// var bridgeBalance = blockChainStates.GetBalance(
//     new Address("9093dd96c4bb6b44a9e0a522e2de49641f146223"),
//     ncg,
//     BlockHash.FromString("0f1d9067c4907e1d115cdf9d0a33ff48a5f7c20fc25b7441c1c41371f48b9799"));
// Console.WriteLine(bridgeBalance.ToString());

// Currently,  the `query.stateQuery.states` API didn't apply in 9c-main-full-state node yet.
// Randomly picked address from the 9cscan.
// var state = blockChainStates.GetStates(
//     new [] { new Address("56ce485b791846854013d78d6260a3bb0ee32db1") },
//     BlockHash.FromString("0f1d9067c4907e1d115cdf9d0a33ff48a5f7c20fc25b7441c1c41371f48b9799"))[0];
// Console.WriteLine(state.Inspection);

```