### PR TITLE
♻️ Refactor `TxActionList` encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Changed the encoding scheme and related methods for `TxActionList`.
+    [[#3083]]
+     -  Removed `TxActionList.FromBencodex<T>()` method.
+     -  Changed the return type for `TxActionList.ToBencodex()` from
+        `Dictionary` to `IValue`.
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -29,6 +35,7 @@ To be released.
 
 ### CLI tools
 
+[#3083]: https://github.com/planetarium/libplanet/pull/3083
 [#3087]: https://github.com/planetarium/libplanet/pull/3087
 
 

--- a/Libplanet.Tests/Tx/TxActionListTest.cs
+++ b/Libplanet.Tests/Tx/TxActionListTest.cs
@@ -25,13 +25,10 @@ namespace Libplanet.Tests.Tx
                 new DumbAction(default, "foo"),
                 new DumbAction(AddressA, "bar"),
             };
-            var input = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x61 },
-                Bencodex.Types.List.Empty
-                    .Add(customActions[0].PlainValue)
-                    .Add(customActions[1].PlainValue));
-            var list = Assert.IsType<TxCustomActionList>(
-                TxActionList.FromBencodex<DumbAction>(input));
+            var input = Bencodex.Types.List.Empty
+                .Add(customActions[0].PlainValue)
+                .Add(customActions[1].PlainValue);
+            var list = TxCustomActionList.FromBencodex<DumbAction>(input);
             Assert.Equal(2, list.Count);
             Assert.Equal(customActions[0], list[0]);
             Assert.Equal(customActions[1], list[1]);
@@ -40,29 +37,19 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void SystemActionListFromBencodex()
         {
-            var input = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x41 },
-                Bencodex.Types.Dictionary.Empty
-                    .Add("type_id", 0)
-                    .Add("values", Bencodex.Types.Dictionary.Empty
-                        .Add(
-                            "recipient",
-                            Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
-                        .Add("currency", FOO.Serialize())
-                        .Add("amount", (FOO * 100).RawValue)));
+            var input = Bencodex.Types.Dictionary.Empty
+                .Add("type_id", 0)
+                .Add("values", Bencodex.Types.Dictionary.Empty
+                    .Add(
+                        "recipient",
+                        Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
+                    .Add("currency", FOO.Serialize())
+                    .Add("amount", (FOO * 100).RawValue));
 
-            var list = Assert.IsType<TxSystemActionList>(
-                TxActionList.FromBencodex<DumbAction>(input));
+            var list = TxSystemActionList.FromBencodex(input);
             var sysAction = Assert.IsType<Mint>(list.SystemAction);
             var expected = new Mint(AddressA, FOO * 100);
             Assert.Equal(expected, sysAction);
-        }
-
-        [Fact]
-        public void FromBencodexError()
-        {
-            Assert.Throws<DecodingException>(() =>
-                TxActionList.FromBencodex<DumbAction>(Bencodex.Types.Dictionary.Empty));
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TxCustomActionListTest.cs
+++ b/Libplanet.Tests/Tx/TxCustomActionListTest.cs
@@ -19,12 +19,8 @@ namespace Libplanet.Tests.Tx
             Assert.Equal(0, TxCustomActionList.Empty.Count);
             Assert.Throws<IndexOutOfRangeException>(() => TxCustomActionList.Empty[0]);
             AssertBencodexEqual(
-                Bencodex.Types.Dictionary.Empty.Add(
-                    new byte[] { 0x61 },
-                    Bencodex.Types.List.Empty
-                ),
-                TxCustomActionList.Empty.ToBencodex()
-            );
+                Bencodex.Types.List.Empty,
+                TxCustomActionList.Empty.ToBencodex());
         }
 
         [Fact]
@@ -82,11 +78,8 @@ namespace Libplanet.Tests.Tx
         {
             var emptyList = new TxCustomActionList(new IAction[0]);
             AssertBencodexEqual(
-                Bencodex.Types.Dictionary.Empty.Add(
-                    new byte[] { 0x61 },
-                    Bencodex.Types.List.Empty),
-                emptyList.ToBencodex()
-            );
+                Bencodex.Types.List.Empty,
+                emptyList.ToBencodex());
 
             // TODO: We should introduce snapshot testing.
             IAction[] actions =
@@ -96,21 +89,16 @@ namespace Libplanet.Tests.Tx
             };
             var list = new TxCustomActionList(actions);
             AssertBencodexEqual(
-                Bencodex.Types.Dictionary.Empty.Add(
-                    new byte[] { 0x61 },
-                    Bencodex.Types.List.Empty
-                        .Add(actions[0].PlainValue)
-                        .Add(actions[1].PlainValue)),
-                list.ToBencodex()
-            );
+                Bencodex.Types.List.Empty
+                    .Add(actions[0].PlainValue)
+                    .Add(actions[1].PlainValue),
+                list.ToBencodex());
         }
 
         [Fact]
         public void FromBencodex()
         {
-            var emptyInput = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x61 },
-                Bencodex.Types.List.Empty);
+            var emptyInput = Bencodex.Types.List.Empty;
             Assert.Equal(
                 TxCustomActionList.Empty,
                 TxCustomActionList.FromBencodex<DumbAction>(emptyInput));
@@ -120,19 +108,15 @@ namespace Libplanet.Tests.Tx
                 new DumbAction(default, "foo"),
                 new DumbAction(default, "bar"),
             };
-            var input = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x61 },
-                Bencodex.Types.List.Empty
-                    .Add(actions[0].PlainValue)
-                    .Add(actions[1].PlainValue));
+            var input = Bencodex.Types.List.Empty
+                .Add(actions[0].PlainValue)
+                .Add(actions[1].PlainValue);
             var list = TxCustomActionList.FromBencodex<DumbAction>(input);
             Assert.Equal(2, list.Count);
             Assert.Equal(actions[0], list[0]);
             Assert.Equal(actions[1], list[1]);
 
-            var invalidInput = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x41 },
-                Bencodex.Types.Dictionary.Empty);
+            var invalidInput = Bencodex.Types.Dictionary.Empty;
             Assert.Throws<DecodingException>(
                 () => TxCustomActionList.FromBencodex<DumbAction>(invalidInput));
         }

--- a/Libplanet.Tests/Tx/TxSystemActionListTest.cs
+++ b/Libplanet.Tests/Tx/TxSystemActionListTest.cs
@@ -58,41 +58,35 @@ namespace Libplanet.Tests.Tx
             var list = new TxSystemActionList(sysAction);
 
             // TODO: We should introduce snapshot testing.
-            var expected = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x41 },
-                Bencodex.Types.Dictionary.Empty
-                    .Add("type_id", 0)
-                    .Add("values", Bencodex.Types.Dictionary.Empty
-                        .Add(
-                            "recipient",
-                            Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
-                        .Add("currency", FOO.Serialize())
-                        .Add("amount", (FOO * 100).RawValue)));
+            var expected = Bencodex.Types.Dictionary.Empty
+                .Add("type_id", 0)
+                .Add("values", Bencodex.Types.Dictionary.Empty
+                    .Add(
+                        "recipient",
+                        Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
+                    .Add("currency", FOO.Serialize())
+                    .Add("amount", (FOO * 100).RawValue));
             AssertBencodexEqual(expected, list.ToBencodex());
         }
 
         [Fact]
         public void FromBencodex()
         {
-            var input = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x41 },
-                Bencodex.Types.Dictionary.Empty
-                    .Add("type_id", 0)
-                    .Add("values", Bencodex.Types.Dictionary.Empty
-                        .Add(
-                            "recipient",
-                            Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
-                        .Add("currency", FOO.Serialize())
-                        .Add("amount", (FOO * 100).RawValue)));
+            var input = Bencodex.Types.Dictionary.Empty
+                .Add("type_id", 0)
+                .Add("values", Bencodex.Types.Dictionary.Empty
+                    .Add(
+                        "recipient",
+                        Binary.FromHex("D6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9"))
+                    .Add("currency", FOO.Serialize())
+                    .Add("amount", (FOO * 100).RawValue));
 
             var list = TxSystemActionList.FromBencodex(input);
             var sysAction = Assert.IsType<Mint>(list.SystemAction);
             var expected = new Mint(AddressA, FOO * 100);
             Assert.Equal(expected, sysAction);
 
-            var invalidInput = Bencodex.Types.Dictionary.Empty.Add(
-                new byte[] { 0x61 },
-                Bencodex.Types.List.Empty);
+            var invalidInput = Bencodex.Types.List.Empty;
             Assert.Throws<DecodingException>(
                 () => TxSystemActionList.FromBencodex(invalidInput));
         }

--- a/Libplanet/Tx/TxActionList.cs
+++ b/Libplanet/Tx/TxActionList.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bencodex;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Sys;
 
@@ -35,42 +36,6 @@ namespace Libplanet.Tx
         [Pure]
         public abstract IAction this[int index] { get; }
 
-        /// <summary>
-        /// Decodes a <see cref="TxActionList"/> from a Bencodex dictionary.
-        /// </summary>
-        /// <param name="dictionary">A Bencodex dictionary to decode.</param>
-        /// <typeparam name="T">An <see cref="IAction"/> type to decode.  It must be a concrete
-        /// type, not an interface or an abstract class.</typeparam>
-        /// <returns>A decoded <see cref="TxActionList"/>.</returns>
-        /// <exception cref="DecodingException">Thrown when the given <paramref name="dictionary"/>
-        /// does not contain either <see cref="TxSystemActionList"/> or
-        /// <see cref="TxCustomActionList"/>.</exception>
-        /// <seealso cref="ToBencodex()"/>
-        [Pure]
-        public static TxActionList FromBencodex<T>(Bencodex.Types.Dictionary dictionary)
-            where T : IAction, new()
-        {
-            try
-            {
-                return TxSystemActionList.FromBencodex(dictionary);
-            }
-            catch (DecodingException sysActionError)
-            {
-                try
-                {
-                    return TxCustomActionList.FromBencodex<T>(dictionary);
-                }
-                catch (DecodingException customActionError)
-                {
-                    string msg =
-                        $"Expected either {nameof(TxSystemActionList)} or " +
-                        $"{nameof(TxCustomActionList)}, but both were missing.  " +
-                        $"Here are the errors:\n\n\t{sysActionError}\n\t{customActionError}";
-                    throw new DecodingException(msg, customActionError);
-                }
-            }
-        }
-
         /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()"/>
         [Pure]
         public abstract IEnumerator<IAction> GetEnumerator();
@@ -83,9 +48,8 @@ namespace Libplanet.Tx
         /// Encodes the <see cref="TxActionList"/> into a Bencodex dictionary.
         /// </summary>
         /// <returns>A Bencodex dictionary that encodes the <see cref="TxActionList"/>.</returns>
-        /// <seealso cref="FromBencodex{T}(Bencodex.Types.Dictionary)"/>
         [Pure]
-        public abstract Bencodex.Types.Dictionary ToBencodex();
+        public abstract IValue ToBencodex();
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         [Pure]

--- a/Libplanet/Tx/TxCustomActionList.cs
+++ b/Libplanet/Tx/TxCustomActionList.cs
@@ -20,8 +20,6 @@ namespace Libplanet.Tx
         public static readonly TxCustomActionList Empty =
             new TxCustomActionList(ImmutableList<IAction>.Empty);
 
-        internal static readonly Binary CustomActionsKey = new byte[] { 0x61 }; // 'a'
-
         /// <summary>
         /// Creates a new <see cref="TxCustomActionList"/> instance with the given
         /// <paramref name="customActions"/>.
@@ -80,43 +78,33 @@ namespace Libplanet.Tx
 
         /// <inheritdoc cref="TxActionList.ToBencodex()"/>
         [Pure]
-        public override Dictionary ToBencodex() =>
-            Bencodex.Types.Dictionary.Empty
-                .Add(CustomActionsKey, new List(CustomActions.Select(a => a.PlainValue)));
+        public override IValue ToBencodex() =>
+            new List(CustomActions.Select(a => a.PlainValue));
 
         /// <summary>
         /// Decodes a <see cref="TxCustomActionList"/> from a Bencodex dictionary.
         /// </summary>
-        /// <param name="dictionary">A Bencodex dictionary to decode.</param>
+        /// <param name="value">A Bencodex dictionary to decode.</param>
         /// <typeparam name="T">An <see cref="IAction"/> type to decode.  It must be a concrete
         /// type, not an interface or an abstract class.</typeparam>
         /// <returns>A decoded <see cref="TxCustomActionList"/>.</returns>
-        /// <exception cref="DecodingException">Thrown when the given <paramref name="dictionary"/>
-        /// does not contain <see cref="CustomActionsKey"/> key.</exception>
+        /// <exception cref="DecodingException">Thrown when the given <paramref name="value"/>
+        /// is not a <see cref="List"/>.</exception>
         /// <seealso cref="ToBencodex()"/>
         [Pure]
-        internal static new TxCustomActionList FromBencodex<T>(Bencodex.Types.Dictionary dictionary)
+        internal static TxCustomActionList FromBencodex<T>(IValue value)
             where T : IAction, new()
         {
-            if (dictionary.TryGetValue(CustomActionsKey, out IValue v))
+            if (value is List list)
             {
-                if (v is Bencodex.Types.List customActions)
-                {
-                    return new TxCustomActionList(
-                        customActions.Select(ToAction<T>).ToImmutableList());
-                }
-
-                throw new DecodingException(
-                    $"Expected {CustomActionsKey} key to have a " +
-                    $"{typeof(Bencodex.Types.Dictionary).FullName}, " +
-                    $"but a {v.GetType().Name} was found."
-                );
+                return new TxCustomActionList(
+                    list.Select(ToAction<T>).ToImmutableList());
             }
-
-            throw new DecodingException(
-                $"Expected {CustomActionsKey} key to have a " +
-                $"{typeof(Bencodex.Types.Dictionary).FullName}, but it was missing."
-            );
+            else
+            {
+                throw new DecodingException(
+                    $"Given value must be a {nameof(List)}: {value.GetType()}");
+            }
         }
 
         [Pure]

--- a/Libplanet/Tx/TxCustomActionList.cs
+++ b/Libplanet/Tx/TxCustomActionList.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Tx
         /// <summary>
         /// Decodes a <see cref="TxCustomActionList"/> from a Bencodex dictionary.
         /// </summary>
-        /// <param name="value">A Bencodex dictionary to decode.</param>
+        /// <param name="value">A Bencodex list to decode.</param>
         /// <typeparam name="T">An <see cref="IAction"/> type to decode.  It must be a concrete
         /// type, not an interface or an abstract class.</typeparam>
         /// <returns>A decoded <see cref="TxCustomActionList"/>.</returns>

--- a/Libplanet/Tx/TxInvoice.cs
+++ b/Libplanet/Tx/TxInvoice.cs
@@ -63,10 +63,10 @@ namespace Libplanet.Tx
             TxActionList? actions = null
         )
             : this(
-              genesisHash,
-              updatedAddresses?.ToImmutableHashSet() ?? ImmutableHashSet<Address>.Empty,
-              timestamp ?? DateTimeOffset.UtcNow,
-              actions ?? TxCustomActionList.Empty
+                genesisHash,
+                updatedAddresses?.ToImmutableHashSet() ?? ImmutableHashSet<Address>.Empty,
+                timestamp ?? DateTimeOffset.UtcNow,
+                actions ?? TxCustomActionList.Empty
             )
         {
         }

--- a/Libplanet/Tx/TxMarshaler.cs
+++ b/Libplanet/Tx/TxMarshaler.cs
@@ -105,9 +105,10 @@ namespace Libplanet.Tx
                     (Text)dictionary[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture).ToUniversalTime(),
-                actions: dictionary.TryGetValue(SystemActionKey, out IValue av)
-                    ? (TxActionList)TxSystemActionList.FromBencodex(av)
-                    : (TxActionList)TxCustomActionList.FromBencodex<T>(av));
+                actions: dictionary.TryGetValue(SystemActionKey, out IValue sav)
+                    ? (TxActionList)TxSystemActionList.FromBencodex(sav)
+                    : (TxActionList)TxCustomActionList.FromBencodex<T>(
+                        dictionary[CustomActionsKey]));
 #pragma warning restore SA1118
 
         [Pure]

--- a/Libplanet/Tx/TxSystemActionList.cs
+++ b/Libplanet/Tx/TxSystemActionList.cs
@@ -15,8 +15,6 @@ namespace Libplanet.Tx
     /// <seealso cref="Libplanet.Action.Sys"/>
     public sealed class TxSystemActionList : TxActionList
     {
-        internal static readonly Binary SystemActionKey = new byte[] { 0x41 }; // 'A'
-
         /// <summary>
         /// Creates a new <see cref="TxSystemActionList"/> instance with the given
         /// <paramref name="systemAction"/>.
@@ -81,29 +79,20 @@ namespace Libplanet.Tx
 
         /// <inheritdoc cref="TxActionList.ToBencodex()"/>
         [Pure]
-        public override Dictionary ToBencodex() =>
-            Bencodex.Types.Dictionary.Empty.Add(SystemActionKey, Registry.Serialize(SystemAction));
+        public override IValue ToBencodex() => Registry.Serialize(SystemAction);
 
         [Pure]
-        internal static TxSystemActionList FromBencodex(Bencodex.Types.Dictionary dictionary)
+        internal static TxSystemActionList FromBencodex(IValue value)
         {
-            if (dictionary.TryGetValue(SystemActionKey, out IValue v))
+            if (value is Dictionary dict)
             {
-                if (v is Bencodex.Types.Dictionary sysAction)
-                {
-                    return new TxSystemActionList(Registry.Deserialize(sysAction));
-                }
-
-                throw new DecodingException(
-                    $"Expected {SystemActionKey} key to have a " +
-                    $"{typeof(Bencodex.Types.Dictionary).FullName}, " +
-                    $"but it is a {v.GetType().FullName}.");
+                return new TxSystemActionList(Registry.Deserialize(dict));
             }
-
-            throw new DecodingException(
-                $"Expected {SystemActionKey} key to have a " +
-                $"{typeof(Bencodex.Types.Dictionary).FullName}, but it was missing."
-            );
+            else
+            {
+                throw new DecodingException(
+                    $"Given value must be a {nameof(Dictionary)}: {value.GetType()}");
+            }
         }
     }
 }


### PR DESCRIPTION
My own general design opinions:
- Owning class generally should not care about *how* its member class is encoded.
- Similarly, a member class should not care about what its property name (dictionary key?) should be from the perspective of an owning class.

I have no idea whether `JsonConverters` still works with this change. 🙄