### PR TITLE
@planetarium/account: `Account.getAddress()`

### DIFF
--- a/@planetarium/account-aws-kms/src/AwsKmsAccount.ts
+++ b/@planetarium/account-aws-kms/src/AwsKmsAccount.ts
@@ -2,6 +2,7 @@ import { AwsKmsKeyId } from "./AwsKmsKeyId.js";
 import { KMSClient, SignCommand } from "@aws-sdk/client-kms";
 import { Signature as NobleSignature } from "@noble/secp256k1";
 import {
+  Address,
   type Account,
   type Message,
   PublicKey,
@@ -24,6 +25,10 @@ export class AwsKmsAccount implements Account {
     this.keyId = keyId;
     this.publicKey = publicKey;
     this.#client = client;
+  }
+
+  getAddress(): Promise<Address> {
+    return Promise.resolve(Address.deriveFrom(this.publicKey));
   }
 
   getPublicKey(): Promise<PublicKey> {

--- a/@planetarium/account-aws-kms/test/AwsKmsKeyStore.test.ts
+++ b/@planetarium/account-aws-kms/test/AwsKmsKeyStore.test.ts
@@ -12,7 +12,7 @@ import {
   OriginType,
   ScheduleKeyDeletionCommand,
 } from "@aws-sdk/client-kms";
-import { PublicKey } from "@planetarium/account";
+import { Address, PublicKey } from "@planetarium/account";
 import { AggregateError } from "es-aggregate-error";
 import { randomUUID } from "node:crypto";
 import { hostname, userInfo } from "node:os";
@@ -176,6 +176,9 @@ describe.runIf(envsConfigured)("AwsKmsKeyStore", async () => {
       },
       createdAt: metadata.CreationDate,
     });
+    expect((await account.getAddress()).toHex()).toStrictEqual(
+      Address.deriveFrom(publicKey).toHex(),
+    );
     expect((await account.getPublicKey()).toHex("compressed")).toStrictEqual(
       publicKey.toHex("compressed"),
     );

--- a/@planetarium/account-web3-secret-storage/src/Web3Account.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3Account.ts
@@ -99,6 +99,10 @@ export class Web3Account implements ExportableAccount {
     return this.#exportPrivateKey({ allowWeakPrivateKey: true });
   }
 
+  getAddress(): Promise<Address> {
+    return Promise.resolve(Address.fromHex(this.#keyObject.address, true));
+  }
+
   async getPublicKey(): Promise<PublicKey> {
     const key = await this.#exportPrivateKey({ allowWeakPrivateKey: true });
     return await key.getPublicKey();

--- a/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
+++ b/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
@@ -116,6 +116,17 @@ const testVectors: Record<string, TestVector> = {
 };
 
 describe("Web3Account", () => {
+  describe("getAddress()", () => {
+    for (const [kdf, { keyObject, passphrase, options }] of Object.entries(
+      testVectors,
+    )) {
+      test(kdf, async () => {
+        const passphraseEntry = new MockPassphraseEntry(passphrase);
+        const key = new Web3Account(keyObject, passphraseEntry, options);
+        expect((await key.getAddress()).toHex("lower")).toBe(keyObject.address);
+      });
+    }
+  });
   describe("getPublicKey()", () => {
     test("fastcheck", async () => {
       const passphraseEntry = new MockPassphraseEntry();

--- a/@planetarium/account/src/Account.ts
+++ b/@planetarium/account/src/Account.ts
@@ -1,17 +1,25 @@
 import { type Message } from "./Message.js";
+import Address from "./Address.js";
 import PublicKey from "./PublicKey.js";
 import RawPrivateKey from "./RawPrivateKey.js";
 import Signature from "./Signature.js";
 
 export interface Account {
+  getAddress(): Promise<Address>;
   getPublicKey(): Promise<PublicKey>;
   sign(message: Message): Promise<Signature>;
 }
 
 export function isAccount(account: unknown): account is Account {
   return (
-    (account as { getPublicKey: unknown }).getPublicKey instanceof Function &&
-    (account as { sign: unknown }).sign instanceof Function
+    typeof account === "object" &&
+    account != null &&
+    "getAddress" in account &&
+    account.getAddress instanceof Function &&
+    "getPublicKey" in account &&
+    account.getPublicKey instanceof Function &&
+    "sign" in account &&
+    account.sign instanceof Function
   );
 }
 

--- a/@planetarium/account/src/RawPrivateKey.ts
+++ b/@planetarium/account/src/RawPrivateKey.ts
@@ -1,4 +1,5 @@
 import * as secp256k1 from "@noble/secp256k1";
+import Address from "./Address.js";
 import { Message, hashMessage } from "./Message.js";
 import PublicKey from "./PublicKey.js";
 import Signature from "./Signature.js";
@@ -45,6 +46,10 @@ export class RawPrivateKey {
 
   static generate(): RawPrivateKey {
     return this.fromBytes(secp256k1.utils.randomPrivateKey());
+  }
+
+  getAddress(): Promise<Address> {
+    return Promise.resolve(Address.deriveFrom(this.publicKey));
   }
 
   /**

--- a/@planetarium/account/test/Account.test.ts
+++ b/@planetarium/account/test/Account.test.ts
@@ -5,13 +5,17 @@ import { RawPrivateKey } from "../src/RawPrivateKey";
 test("isAccount", async () => {
   expect(isAccount(RawPrivateKey.generate())).toBeTruthy();
   const key = RawPrivateKey.generate();
-  expect(
-    isAccount({
-      getPublicKey: key.getPublicKey,
-      sign: key.sign.bind(key),
-    }),
-  ).toBeTruthy();
-  expect(isAccount({ publicKey: key.publicKey, sign: 1 })).toBeFalsy();
-  expect(isAccount({ publicKey: key.publicKey })).toBeFalsy();
-  expect(isAccount({ sign: key.sign.bind(key) })).toBeFalsy();
+  const validAccount = {
+    getAddress: key.getAddress,
+    getPublicKey: key.getPublicKey,
+    sign: key.sign.bind(key),
+  };
+  expect(isAccount(validAccount)).toBeTruthy();
+  for (const key of Object.keys(validAccount)) {
+    const invalidAccount = { ...validAccount, [key]: 1 };
+    expect(isAccount(invalidAccount)).toBeFalsy();
+    // rome-ignore lint/performance/noDelete: delete is needed
+    delete invalidAccount[key];
+    expect(isAccount(invalidAccount)).toBeFalsy();
+  }
 });

--- a/@planetarium/account/test/RawPrivateKey.test.ts
+++ b/@planetarium/account/test/RawPrivateKey.test.ts
@@ -1,5 +1,6 @@
 import * as fc from "fast-check";
 import * as secp256k1 from "@noble/secp256k1";
+import { Address } from "../src/Address";
 import { PublicKey } from "../src/PublicKey";
 import { RawPrivateKey } from "../src/RawPrivateKey";
 import { describe, expect, test } from "vitest";
@@ -82,6 +83,15 @@ describe("RawPrivateKey", () => {
     const keyBytes = rawKey.toBytes();
     expect(keyBytes.length).toBe(32);
     expect(keyBytes).toSatisfy(secp256k1.utils.isValidPrivateKey);
+  });
+
+  test("getAddress()", async () => {
+    const key = RawPrivateKey.fromHex(
+      "5760ea321bdd7ac302469e192aa527b6458e3a1e0ddf6c76d9618aca6f653b4d",
+    );
+    const address = await key.getAddress();
+    expect(address).toBeInstanceOf(Address);
+    expect(address.toHex()).toBe("8f64a97ACABB267B29854FdA9e6B1397A8991135");
   });
 
   test("publicKey [deprecated]", () => {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,8 @@ To be released.
     `Address` when a `PublicKey` is given.  [[#3061]]
  -  (@planetarium/account-web3-secret-storage) `Web3KeyStore` no more implements
     `ImportableKeyStore<KeyId, RawPrivateKey>`.  Instead, it now implements
-    `ImportableKeyStore<KeyId, Web3Account>`.  [[#3061]]
+    `ImportableKeyStore<KeyId, Web3Account, Web3KeyMetadata>`.
+    [[#3061], [#3084]]
  -  (Libplanet.Explorer) Added `Index` field to `IBlockChainContext` interface.
     [[#2613]]
  -  Removed `BlockChain<T>.ProposeBlock(PrivateKey, DateTimeOffset, long, int,
@@ -145,6 +146,8 @@ To be released.
      -  Added `Web3KeyStoreOptions.decryptionOptions` attribute.
  -  (@planetarium/account-web3-secret-storage) Added `WeakPrivateKeyError`
     class.  [[#3071]]
+ -  (@planetarium/account-web3-secret-storage) Added `Web3KeyMetadata`
+    interface.  [[#3084]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ To be released.
  -  Removed `HashCash` class.  [[#3067]]
  -  (@planetarium/account) Replaced `Account.publicKey` property with
     `Account.getPublicKey()` async method.  [[#3061]]
+ -  (@planetarium/account) Added `Account.getAddress()` async method.  [[#3084]]
  -  (@planetarium/account) `Address.deriveFrom()` method now returns
     `Promise<Address>` when an `Account` is given.  However, it still returns
     `Address` when a `PublicKey` is given.  [[#3061]]
@@ -110,12 +111,17 @@ To be released.
  -  (Libplanet.Net) Added `Gossip.PublishMessage()` method.  [[#3054], [#3060]]
  -  (@planetarium/account) Added `Account.getPublicKey()` async method.
     [[#3061]]
+ -  (@planetarium/account) Added `Account.getAddress()` async method.  [[#3084]]
  -  (@planetarium/account) Added `RawPrivateKey.getPublicKey()` async method.
     [[#3061]]
+ -  (@planetarium/account) Added `RawPrivateKey.getAddress()` async method.
+    [[#3084]]
  -  (@planetarium/account-aws-kms) Added `AwsKmsAccount.getPublicKey()` async
     method.  [[#3061]]
+ -  (@planetarium/account-aws-kms) Added `AwsKmsAccount.getAddress()` async
+    method.  [[#3084]]
  -  (@planetarium/account-web3-secret-storage) Added `Web3Account` class.
-    [[#3061]]
+    [[#3061], [#3084]]
  -  (@planetarium/account-web3-secret-storage) Added `Web3KeyObject` interface.
     [[#3061]]
  -  (Libplanet.Explorer) Added several interfaces and classes that pertain to
@@ -255,6 +261,7 @@ To be released.
 [#3077]: https://github.com/planetarium/libplanet/pull/3077
 [#3079]: https://github.com/planetarium/libplanet/pull/3079
 [#3080]: https://github.com/planetarium/libplanet/pull/3080
+[#3084]: https://github.com/planetarium/libplanet/pull/3084
 
 
 Version 0.53.4


### PR DESCRIPTION
Now, `Account` has `getAddress()` async method that can get the address of the given account directly. Also, `Web3KeyStore` now uses `Web3KeyMetadata` which contains `address` field.