### PR TITLE
Support `query.stateQuery.balance(...)` with custom currencies instead of `currencyHash`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,8 +150,12 @@ To be released.
     class.  [[#3071]]
  -  (@planetarium/account-web3-secret-storage) Added `Web3KeyMetadata`
     interface.  [[#3084]]
+<<<<<<< HEAD
  -  (Libplanet.Tools) Added `-v`/`--validator-key` option to
     `planet block generate-genesis` command.  [[#3088]]
+=======
+ -  (Libplanet.Explorer) Added `CurrencyInput` type.  [[#3085]]
+>>>>>>> fbb931d6 (Implement \`Currency\`'s input type)
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,8 @@ To be released.
     Predicate<Currency>)`.  [[#3079]]
  -  (Libplanet.Explorer) `Currency.decimalPlaces`' type became `Byte`
     from `UInt`.  [[#3085]]
+ -  (Libplanet.Explorer) `currencyHash` parameter was removed from
+    `balance` and `totalSupply` in `StateQuery` type.  [[#3085]]
 
 ### Backward-incompatible network protocol changes
 
@@ -150,12 +152,11 @@ To be released.
     class.  [[#3071]]
  -  (@planetarium/account-web3-secret-storage) Added `Web3KeyMetadata`
     interface.  [[#3084]]
-<<<<<<< HEAD
  -  (Libplanet.Tools) Added `-v`/`--validator-key` option to
     `planet block generate-genesis` command.  [[#3088]]
-=======
  -  (Libplanet.Explorer) Added `CurrencyInput` type.  [[#3085]]
->>>>>>> fbb931d6 (Implement \`Currency\`'s input type)
+ -  (Libplanet.Explorer) Added `CurrencyInput`-typed `currency` parameter to
+    `balance` and `totalSupply` in `StateQuery` type.  [[#3085]]
 
 ### Behavioral changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@ To be released.
     Predicate<Currency>)` to `BlockChain<T>.ProposeGenesisBlock(
     PrivateKey, ImmutableList<Transaction<T>>, DateTimeOffset?, IAction,
     Predicate<Currency>)`.  [[#3079]]
+ -  (Libplanet.Explorer) `Currency.decimalPlaces`' type became `Byte`
+    from `UInt`.  [[#3085]]
 
 ### Backward-incompatible network protocol changes
 
@@ -267,6 +269,7 @@ To be released.
 [#3079]: https://github.com/planetarium/libplanet/pull/3079
 [#3080]: https://github.com/planetarium/libplanet/pull/3080
 [#3084]: https://github.com/planetarium/libplanet/pull/3084
+[#3085]: https://github.com/planetarium/libplanet/pull/3085
 [#3088]: https://github.com/planetarium/libplanet/pull/3088
 
 

--- a/Libplanet.Explorer.Tests/GraphTypes/BlockPolicyTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/BlockPolicyTypeTest.cs
@@ -44,7 +44,7 @@ public class BlockPolicyTypeTest
         IDictionary<string, object>[] tokenDicts =
             nativeTokens.Cast<IDictionary<string, object>>().ToArray();
         Assert.Equal("BAR", tokenDicts[0]["ticker"]);
-        Assert.Equal(0U, tokenDicts[0]["decimalPlaces"]);
+        Assert.Equal((byte)0, tokenDicts[0]["decimalPlaces"]);
         object[] minters = Assert.IsAssignableFrom<object[]>(tokenDicts[0]["minters"]);
         Assert.All(minters, m => Assert.IsType<string>(m));
         Assert.Equal(minters.Cast<string>().ToArray(), new[]
@@ -53,7 +53,7 @@ public class BlockPolicyTypeTest
             "0xD6D639DA5a58A78A564C2cD3DB55FA7CeBE244A9",
         });
         Assert.Equal("FOO", tokenDicts[1]["ticker"]);
-        Assert.Equal(2U, tokenDicts[1]["decimalPlaces"]);
+        Assert.Equal((byte)2, tokenDicts[1]["decimalPlaces"]);
         Assert.Null(tokenDicts[1]["minters"]);
     }
 }

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Execution;
+using GraphQL.Types;
+using Libplanet.Assets;
+using Libplanet.Explorer.GraphTypes;
+using Xunit;
+using static Libplanet.Explorer.Tests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.Tests.GraphTypes;
+
+public class CurrencyInputTypeTest
+{
+    [Fact]
+    public async Task Accept()
+    {
+        var result = await ExecuteQueryAsync<TestQuery>(
+            @"query
+            {
+                currency(currency: { ticker: ""ABC"", decimalPlaces: 5, totalSupplyTrackable: false, minters: null })
+                {
+                    ticker
+                    decimalPlaces
+                    totalSupplyTrackable
+                    minters
+                }
+            }");
+        var expected = new Dictionary<string, object>
+        {
+            ["currency"] = new Dictionary<string, object>
+            {
+                ["ticker"] = "ABC",
+                ["decimalPlaces"] = (byte)5,
+                ["totalSupplyTrackable"] = false,
+                ["minters"] = null,
+            },
+        };
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        Assert.Equal(expected, resultDict);
+    }
+
+    [Fact]
+    public async Task OnlyHalfOmitted()
+    {
+        var result = await ExecuteQueryAsync<TestQuery>(
+            @"query
+            {
+                currency(currency: { ticker: ""ABC"", decimalPlaces: 5, totalSupplyTrackable: false, minters: null, maximumSupplyMajorUnit: 1 })
+                {
+                    ticker
+                    decimalPlaces
+                    totalSupplyTrackable
+                    minters
+                }
+            }");
+        var error = Assert.Single(result.Errors);
+        Assert.Contains(
+            "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be omitted",
+            error.Message);
+    }
+}
+
+class TestQuery : ObjectGraphType
+{
+    public TestQuery()
+    {
+        Field<CurrencyType>("currency", arguments: new QueryArguments(
+            new QueryArgument<CurrencyInputType>
+            {
+                Name = "currency",
+            }
+        ), resolve: context => context.GetArgument<Currency>("currency"));
+    }
+}

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
@@ -59,7 +59,7 @@ public class CurrencyInputTypeTest
             }");
         var error = Assert.Single(result.Errors);
         Assert.Contains(
-            "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be omitted",
+            "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be present or omitted",
             error.Message);
     }
 }

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
@@ -13,7 +13,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes;
 public class CurrencyInputTypeTest
 {
     [Fact]
-    public async Task Accept()
+    public async Task Input()
     {
         var result = await ExecuteQueryAsync<TestQuery>(
             @"query

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyTypeTest.cs
@@ -44,7 +44,7 @@ public class CurrencyTypeTest
         IDictionary<string, object> resultDict =
             Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
         Assert.Equal("ABC", resultDict["ticker"]);
-        Assert.Equal(2U, resultDict["decimalPlaces"]);
+        Assert.Equal((byte)2, resultDict["decimalPlaces"]);
         IDictionary<string, object> maxSupplyDict =
             Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["maximumSupply"]);
         IDictionary<string, object> currencyDict =

--- a/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
@@ -131,7 +131,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                                     new Dictionary<string, object> {
                                         ["currency"] = new Dictionary<string, object> {
                                             ["ticker"] = KRW.Ticker,
-                                            ["decimalPlaces"] = (uint)KRW.DecimalPlaces,
+                                            ["decimalPlaces"] = KRW.DecimalPlaces,
                                         },
                                         ["quantity"] = "20000",
                                     },
@@ -145,7 +145,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                                     new Dictionary<string, object> {
                                         ["currency"] = new Dictionary<string, object> {
                                             ["ticker"] = KRW.Ticker,
-                                            ["decimalPlaces"] = (uint)KRW.DecimalPlaces,
+                                            ["decimalPlaces"] = KRW.DecimalPlaces,
                                         },
                                         ["quantity"] = "10000",
                                     },

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -59,7 +59,7 @@ public class StateQueryTest
         {
             balance(
                  owner: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"",
-                 currencyHash: ""84ba810ca5ac342c122eb7ef455939a8a05d1d40"",
+                 currency: { ticker: ""ABC"", decimalPlaces: 2, totalSupplyTrackable: true },
                  offsetBlockHash:
                      ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
             ) {
@@ -87,21 +87,6 @@ public class StateQueryTest
         Assert.Equal(0, Assert.IsAssignableFrom<BigInteger>(balanceDict["minorUnit"]));
         Assert.Equal("123", balanceDict["quantity"]);
         Assert.Equal("123 ABC", balanceDict["string"]);
-
-        result = await ExecuteQueryAsync<StateQuery<NullAction>>(@"
-        {
-            balance(
-                 owner: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"",
-                 currencyHash: ""0000000000000000000000000000000000000000"",
-                 offsetBlockHash:
-                     ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
-            ) {
-                quantity
-            }
-        }
-        ", source: source);
-        Assert.Single(result.Errors);
-        Assert.Contains("native token", result.Errors[0].Message);
     }
 
     [Fact]
@@ -120,7 +105,7 @@ public class StateQueryTest
         ExecutionResult result = await ExecuteQueryAsync<StateQuery<NullAction>>(@"
         {
             totalSupply(
-                 currencyHash: ""84ba810ca5ac342c122eb7ef455939a8a05d1d40"",
+                 currency: { ticker: ""ABC"", decimalPlaces: 2, totalSupplyTrackable: true },
                  offsetBlockHash:
                      ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
             ) {
@@ -152,21 +137,7 @@ public class StateQueryTest
         result = await ExecuteQueryAsync<StateQuery<NullAction>>(@"
         {
             totalSupply(
-                 currencyHash: ""0000000000000000000000000000000000000000"",
-                 offsetBlockHash:
-                     ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
-            ) {
-                quantity
-            }
-        }
-        ", source: source);
-        Assert.Single(result.Errors);
-        Assert.Contains("native token", result.Errors[0].Message);
-
-        result = await ExecuteQueryAsync<StateQuery<NullAction>>(@"
-        {
-            totalSupply(
-                 currencyHash: ""d9d45abf192b6c337027063cda2d4a61e76e66d8"",
+                 currency: { ticker: ""LEG"", decimalPlaces: 0, totalSupplyTrackable: false },
                  offsetBlockHash:
                      ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
             ) {

--- a/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
+++ b/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Assets;
+
+namespace Libplanet.Explorer.GraphTypes
+{
+    public class CurrencyInputType : InputObjectGraphType<Currency>
+    {
+        public CurrencyInputType()
+        {
+            Name = "CurrencyInput";
+            Field<NonNullGraphType<StringGraphType>>(
+                "ticker",
+                "The ticker symbol, e.g., USD."
+            );
+            Field<NonNullGraphType<ByteGraphType>>(
+                "decimalPlaces",
+                "The number of digits to treat as minor units (i.e., exponents)."
+            );
+            Field<ListGraphType<NonNullGraphType<AddressType>>>(
+                "minters",
+                "The addresses who can mint this currency.  If this is null anyone can " +
+                "mint the currency.  On the other hand, unlike null, an empty set means no one " +
+                "can mint the currency."
+            );
+            Field<BigIntGraphType>("maximumSupplyMajorUnit");
+            Field<BigIntGraphType>("maximumSupplyMinorUnit");
+            Field<NonNullGraphType<BooleanGraphType>>(
+                "totalSupplyTrackable",
+                "Whether the total supply of this currency is trackable."
+            );
+        }
+
+        public override object ParseDictionary(IDictionary<string, object?> value)
+        {
+            IImmutableSet<Address>? minters = null;
+            var rawMinters = value.TryGetValue("minters", out object? obj) && obj is object[] o
+                ? o
+                : null;
+            if (rawMinters is not null)
+            {
+                if (rawMinters.Any())
+                {
+                    minters = ImmutableHashSet<Address>.Empty;
+                    foreach (var rawMinter in rawMinters)
+                    {
+                        minters = minters.Add((Address)rawMinter);
+                    }
+                }
+            }
+
+            bool totalSupplyTrackable = (bool)value["totalSupplyTrackable"]!;
+            (BigInteger, BigInteger)? maximumSupply = GetMaximumSupply(value);
+            if (maximumSupply is { } && !totalSupplyTrackable)
+            {
+                throw new ExecutionError(
+                    "Maximum supply is not available for legacy untracked currencies.");
+            }
+
+            string ticker = (string)value["ticker"]!;
+            byte decimalPlaces = (byte)value["decimalPlaces"]!;
+
+#pragma warning disable CS0618
+
+            if (!totalSupplyTrackable)
+            {
+                return Currency.Legacy(
+                    ticker,
+                    decimalPlaces,
+                    minters: minters);
+            }
+#pragma warning restore CS0618
+
+            return maximumSupply is { } ms
+                ? Currency.Capped(ticker, decimalPlaces, ms, minters)
+                : Currency.Uncapped(ticker, decimalPlaces, minters);
+        }
+
+        private static (BigInteger, BigInteger)? GetMaximumSupply(
+            IDictionary<string, object?> variables
+        )
+        {
+            BigInteger? nullableMajorUnit =
+                variables.TryGetValue("maximumSupplyMajorUnit", out object? nullableMajorUnitValue)
+                && nullableMajorUnitValue is BigInteger majorUnit
+                    ? majorUnit
+                    : null;
+            BigInteger? nullableMinorUnit =
+                variables.TryGetValue("maximumSupplyMinorUnit", out object? nullableMinorUnitValue)
+                && nullableMinorUnitValue is BigInteger minorUnit
+                    ? minorUnit
+                    : null;
+
+            return (nullableMajorUnit, nullableMinorUnit) switch
+            {
+                (null, null) => null,
+                (BigInteger x, BigInteger y) => (x, y),
+                _ => throw new ExecutionError(
+                    "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be omitted"
+                ),
+            };
+        }
+    }
+}

--- a/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
+++ b/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
@@ -100,7 +100,8 @@ namespace Libplanet.Explorer.GraphTypes
                 (null, null) => null,
                 (BigInteger x, BigInteger y) => (x, y),
                 _ => throw new ExecutionError(
-                    "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be omitted"
+                    "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must " +
+                    "be present or omitted"
                 ),
             };
         }

--- a/Libplanet.Explorer/GraphTypes/CurrencyType.cs
+++ b/Libplanet.Explorer/GraphTypes/CurrencyType.cs
@@ -14,7 +14,7 @@ public class CurrencyType : ObjectGraphType<Currency>
             "The ticker symbol, e.g., USD.",
             resolve: context => context.Source.Ticker
         );
-        Field<NonNullGraphType<UIntGraphType>>(
+        Field<NonNullGraphType<ByteGraphType>>(
             "decimalPlaces",
             "The number of digits to treat as minor units (i.e., exponents).",
             resolve: context => (uint)context.Source.DecimalPlaces


### PR DESCRIPTION
1. Replaced `ByteString`-typed `currencyHash` parameter with `CurrencyInput`-typed `currency` parameter in `query.stateQuery.balance`  and `query.stateQuery.totalSupply`.
2. Corrected the type of `Currency.decimalPlaces` to `byte` from `uint`.