### PR TITLE
🧹 Remove reorg related render calls from `BlockChain<T>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,12 +18,18 @@ To be released.
 
 ### Behavioral changes
 
+ -  Changed `BlockChain<T>` to ignore `IRenderer<T>.RenderReorg()`,
+    `IRenderer<T>.RenderReorgEnd()`, `IActionRenderer<T>.UnrenderAction()`,
+    and `IActionRenderer<T>.UnrenderActionError()`, i.e., these interface
+    methods are no longer invoked by a `BlockChain<T>`.  [[#3087]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+[#3087]: https://github.com/planetarium/libplanet/pull/3087
 
 
 Version 1.0.0

--- a/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
@@ -72,26 +72,9 @@ namespace Libplanet.Tests.Blockchain.Renderers
             _record.ResetRecords();
             _fx.Chain.Swap(@base, true)();
             IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
-            Assert.Equal(7, records.Count);
-            AssertTypeAnd<RenderRecord<Arithmetic>.Reorg>(records[0], r => Assert.True(r.Begin));
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
-            {
-                Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.CustomActions[2], r.Action);
-            });
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
-            {
-                Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.CustomActions[1], r.Action);
-            });
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
-            {
-                Assert.Equal(_successTx.Id, r.Context.TxId);
-                Assert.Equal(_successTx.CustomActions[0], r.Action);
-            });
-            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[4], r => Assert.True(r.Begin));
-            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[5], r => Assert.True(r.End));
-            AssertTypeAnd<RenderRecord<Arithmetic>.Reorg>(records[6], r => Assert.True(r.End));
+            Assert.Equal(2, records.Count);
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[0], r => Assert.True(r.Begin));
+            AssertTypeAnd<RenderRecord<Arithmetic>.Block>(records[1], r => Assert.True(r.End));
         }
 
         private static void AssertTypeAnd<T>(object obj, Action<T> callback)

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -141,20 +141,6 @@ namespace Libplanet.Blockchain
             IReadOnlyList<BlockHash> rewindPath,
             IReadOnlyList<BlockHash> fastForwardPath)
         {
-            // If there is no rewind, it is not considered as a reorg.
-            bool reorg = rewindPath.Count > 0;
-
-            if (render && reorg)
-            {
-                foreach (IRenderer<T> renderer in Renderers)
-                {
-                    renderer.RenderReorg(
-                        oldTip: oldTip,
-                        newTip: newTip,
-                        branchpoint: branchpoint);
-                }
-            }
-
             RenderRewind(
                 render: render,
                 oldTip: oldTip,
@@ -178,17 +164,6 @@ namespace Libplanet.Blockchain
                 newTip: newTip,
                 branchpoint: branchpoint,
                 fastForwardPath: fastForwardPath);
-
-            if (render && reorg)
-            {
-                foreach (IRenderer<T> renderer in Renderers)
-                {
-                    renderer.RenderReorgEnd(
-                        oldTip: oldTip,
-                        newTip: newTip,
-                        branchpoint: branchpoint);
-                }
-            }
         }
 
         internal void RenderRewind(

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -442,11 +442,11 @@ namespace Libplanet.Blockchain.Renderers.Debug
                                     );
                                 }
                             }
-                            else if (idx != blockState.NewTip.Index)
+                            else if (idx > blockState.NewTip.Index)
                             {
                                 throw BadRenderExc(
                                     "An action is from a block which has an unexpected index " +
-                                    $"#{idx} (expected: #{blockState.NewTip.Index})."
+                                    $"#{idx} (expected max: #{blockState.NewTip.Index})."
                                 );
                             }
 

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -13,12 +13,6 @@ namespace Libplanet.Blockchain.Renderers
     /// implement this interface instead.
     /// <para>The invocation order of methods for each <see cref="Block{T}"/> are:</para>
     /// <list type="number">
-    /// <item><description><see cref="IRenderer{T}.RenderReorg(Block{T}, Block{T}, Block{T})"/>
-    /// (one time)</description></item>
-    /// <item><description><see cref="UnrenderAction(IAction, IActionContext, IAccountStateDelta)"/>
-    /// &amp; <see cref="UnrenderActionError(IAction, IActionContext, Exception)"/> (zero or more
-    /// times)</description>
-    /// </item>
     /// <item><description><see cref="IRenderer{T}.RenderBlock(Block{T}, Block{T})"/> (one time)
     /// </description></item>
     /// <item><description><see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
@@ -27,8 +21,6 @@ namespace Libplanet.Blockchain.Renderers
     /// </item>
     /// <item><description><see cref="RenderBlockEnd(Block{T}, Block{T})"/> (one time)</description>
     /// </item>
-    /// <item><description><see cref="IRenderer{T}.RenderReorgEnd(Block{T}, Block{T}, Block{T})"/>
-    /// (one time)</description></item>
     /// </list>
     /// </summary>
     /// <remarks>Although <see cref="Transaction{T}"/>s affect the states in
@@ -97,10 +89,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <remarks>As a rule of thumb, this should be the inverse of
         /// <see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/> method
         /// with redrawing the graphics on the display at the finish.</remarks>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        /// <remarks>This is no longer invoked by a <see cref="BlockChain{T}"/>.</remarks>
         void UnrenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
 
         /// <summary>
@@ -141,10 +130,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <em>before</em> this action executed.</param>
         /// <param name="exception">The exception thrown during executing the <paramref
         /// name="action"/>.</param>
-        /// <remarks>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction{T}.Actions"/>).</remarks>
+        /// <remarks>This is no longer invoked by a <see cref="BlockChain{T}"/>.</remarks>
         void UnrenderActionError(IAction action, IActionContext context, Exception exception);
 
         /// <summary>

--- a/Libplanet/Blockchain/Renderers/IRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IRenderer.cs
@@ -10,12 +10,8 @@ namespace Libplanet.Blockchain.Renderers
     /// on the display is redrawn.</para>
     /// <para>The invocation order of methods for each <see cref="Block{T}"/> are:</para>
     /// <list type="number">
-    /// <item><description><see cref="RenderReorg(Block{T}, Block{T}, Block{T})"/> (one time)
-    /// </description></item>
     /// <item><description><see cref="RenderBlock(Block{T}, Block{T})"/> (one time)</description>
     /// </item>
-    /// <item><description><see cref="RenderReorgEnd(Block{T}, Block{T}, Block{T})"/> (one time)
-    /// </description></item>
     /// </list>
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
@@ -38,12 +34,7 @@ namespace Libplanet.Blockchain.Renderers
         /// Does things that should be done right before reorg happens to a <see
         /// cref="BlockChain{T}"/>.
         /// </summary>
-        /// <remarks>For every call to this method, calls to
-        /// <see cref="RenderBlock(Block{T}, Block{T})"/> and
-        /// <see cref="RenderReorgEnd(Block{T}, Block{T}, Block{T})" /> methods with the same
-        /// <paramref name="newTip"/> is made too.  Note that this method is guaranteed to be called
-        /// before <see cref="RenderBlock(Block{T}, Block{T})"/> method for the same
-        /// <paramref name="newTip"/>.</remarks>
+        /// <remarks>This is no longer invoked by a <see cref="BlockChain{T}"/>.</remarks>
         /// <param name="oldTip">The <see cref="BlockChain{T}.Tip"/> right before reorg.</param>
         /// <param name="newTip">The <see cref="BlockChain{T}.Tip"/> after reorg.</param>
         /// <param name="branchpoint">The highest common <see cref="Block{T}"/> between
@@ -54,10 +45,7 @@ namespace Libplanet.Blockchain.Renderers
         /// Does things that should be done right after reorg happens to a <see
         /// cref="BlockChain{T}"/>.
         /// </summary>
-        /// <remarks>Note that this method is guaranteed to be called after
-        /// <see cref="RenderReorg(Block{T}, Block{T}, Block{T})"/> and
-        /// <see cref="RenderBlock(Block{T}, Block{T})"/> methods for the same
-        /// <paramref name="newTip"/>.</remarks>
+        /// <remarks>This is no longer invoked by a <see cref="BlockChain{T}"/>.</remarks>
         /// <param name="oldTip">The <see cref="BlockChain{T}.Tip"/> right before reorg.</param>
         /// <param name="newTip">The <see cref="BlockChain{T}.Tip"/> after reorg.</param>
         /// <param name="branchpoint">The highest common <see cref="Block{T}"/> between


### PR DESCRIPTION
As we've moved to PBFT, reorgs should not happen. In particular, calls to reorg related methods have been dead code for quite a while. This simply removes the unused part of the `RenderSwap()` method. 🙄

Notes:
- This only removes any invocation of reorg related renderer calls from `BlockChain<T>`. The interface is left intact. I'll be dealing with this piece by piece in follow-up PRs. 🙄
- I'm too scared to touch `ValidatingActionRenderer.Validate()`. I've made the condition very loose, but I'm not even sure if it is possible to "validate" renderer calls without explicitly invoking reorg related renderers as simply forward rendering lacks a branchpoint as its context. 😥