### PR TITLE
Use BFT time as block timestamp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ To be released.
         `Dictionary` to `IValue`.
 
 ### Backward-incompatible network protocol changes
+ -  The `Block<T>.CurrentProtocolVersion` is bumped from 4 to 5.
+    [[#3093]]
+ -  From block protocol version 5, `BlockMetadata<T>.Timestamp` is restricted
+    to be generated via `BlockChain<T>.GetBftTime(BlockCommit)`.  [[#3093]]
 
 ### Backward-incompatible storage format changes
 
@@ -37,6 +41,7 @@ To be released.
 
 [#3083]: https://github.com/planetarium/libplanet/pull/3083
 [#3087]: https://github.com/planetarium/libplanet/pull/3087
+[#3093]: https://github.com/planetarium/libplanet/pull/3093
 
 
 Version 1.0.0

--- a/Libplanet.Benchmarks/Store.cs
+++ b/Libplanet.Benchmarks/Store.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Benchmarks
                     blockTxs.Add(Transaction<DumbAction>.Create(
                         nonce++, key, genesis.Hash, new DumbAction[0]));
                 }
-                block = TestUtils.ProposeNextBlock(
+                block = TestUtils.MockupBlockFromPreviousBlock(
                     block, TestUtils.GenesisProposer, blockTxs);
                 blocks.Add(block);
                 txs.AddRange(blockTxs);

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -226,14 +226,17 @@ public class GeneratedBlockChainFixture
     {
         var random = new System.Random(seed);
         var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+        var lastCommit = Chain.Store.GetChainBlockCommit(Chain.Store.GetCanonicalChainId()!.Value);
+        var bftTime = lastCommit?.MedianTime(Chain.GetValidatorSet(lastCommit.BlockHash))
+            ?? DateTimeOffset.UtcNow;
         var block = new BlockContent<PolymorphicAction<SimpleAction>>(
                 new BlockMetadata(
                     Chain.Tip.Index + 1,
-                    DateTimeOffset.UtcNow,
+                    bftTime,
                     pk.PublicKey,
                     Chain.Tip.Hash,
                     BlockContent<PolymorphicAction<SimpleAction>>.DeriveTxHash(transactions),
-                    Chain.Store.GetChainBlockCommit(Chain.Store.GetCanonicalChainId()!.Value)),
+                    lastCommit),
                 transactions)
             .Propose()
             .Evaluate(pk, Chain);

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -57,27 +57,27 @@ public class StoreCommandTest : IDisposable
         _transaction3 = DummyTransaction();
         _transaction4 = DummyTransaction();
 
-        _block1 = TestUtils.ProposeNextBlock(
+        _block1 = TestUtils.MockupBlockFromPreviousBlock(
                 _genesisBlock,
                 TestUtils.GenesisProposer,
                 new[] { _transaction1 },
                 lastCommit: null);
-        _block2 = TestUtils.ProposeNextBlock(
+        _block2 = TestUtils.MockupBlockFromPreviousBlock(
                 _block1,
                 TestUtils.GenesisProposer,
                 new[] { _transaction2 },
                 lastCommit: TestUtils.CreateBlockCommit(_block1));
-        _block3 = TestUtils.ProposeNextBlock(
+        _block3 = TestUtils.MockupBlockFromPreviousBlock(
                 _block2,
                 TestUtils.GenesisProposer,
                 new[] { _transaction3 },
                 lastCommit: TestUtils.CreateBlockCommit(_block2));
-        _block4 = TestUtils.ProposeNextBlock(
+        _block4 = TestUtils.MockupBlockFromPreviousBlock(
                 _block3,
                 TestUtils.GenesisProposer,
                 new[] { _transaction3 },
                 lastCommit: TestUtils.CreateBlockCommit(_block3));
-        _block5 = TestUtils.ProposeNextBlock(
+        _block5 = TestUtils.MockupBlockFromPreviousBlock(
                 _block4,
                 TestUtils.GenesisProposer,
                 lastCommit: TestUtils.CreateBlockCommit(_block4));

--- a/Libplanet.Net.Tests/BlockCompletionTest.cs
+++ b/Libplanet.Net.Tests/BlockCompletionTest.cs
@@ -300,9 +300,9 @@ namespace Libplanet.Net.Tests
         public async Task CompleteWithBlockFetcherGivingWrongBlocks()
         {
             Block<DumbAction> genesis = ProposeGenesisBlock<DumbAction>(GenesisProposer);
-            Block<DumbAction> demand = ProposeNextBlock(genesis, new PrivateKey());
+            Block<DumbAction> demand = MockupBlockFromPreviousBlock(genesis, new PrivateKey());
             BlockCommit demandCommit = TestUtils.CreateBlockCommit(demand);
-            Block<DumbAction> wrong = ProposeNextBlock(genesis, new PrivateKey());
+            Block<DumbAction> wrong = MockupBlockFromPreviousBlock(genesis, new PrivateKey());
             BlockCommit wrongCommit = TestUtils.CreateBlockCommit(wrong);
             _logger.Debug("Genesis: #{Index} {Hash}", genesis.Index, genesis.Hash);
             _logger.Debug("Demand:  #{Index} {Hash}", demand.Index, demand.Hash);
@@ -418,7 +418,7 @@ namespace Libplanet.Net.Tests
 
                 for (int i = 1; i < count; i++)
                 {
-                    block = ProposeNextBlock(
+                    block = MockupBlockFromPreviousBlock(
                         block,
                         GenesisProposer,
                         lastCommit: CreateBlockCommit(block));

--- a/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextNonProposerTest.cs
@@ -291,11 +291,12 @@ namespace Libplanet.Net.Tests.Consensus.Context
 
             var invalidTx = diffPolicyBlockChain.MakeTransaction(invalidKey, new DumbAction[] { });
 
-            Block<DumbAction> invalidBlock = Libplanet.Tests.TestUtils.ProposeNext(
+            Block<DumbAction> invalidBlock = Libplanet.Tests.TestUtils.MockupFromPreviousBlock(
                     blockChain.Genesis,
                     new[] { invalidTx },
                     miner: TestUtils.PrivateKeys[1].PublicKey,
-                    blockInterval: TimeSpan.FromSeconds(10)
+                    timestamp: blockChain[blockChain.Tip.Index]
+                        .Timestamp.Add(TimeSpan.FromSeconds(10))
                 )
                 .Evaluate(TestUtils.PrivateKeys[1], diffPolicyBlockChain);
 

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "171013efec9807237b793df73d8625281e8f6b0c0e28f7b5ec4211f227be5b88")),
+                    "11f0cbc26211106a23735b66487848cc03d47963b552ca85120992a0975a9e30")),
                 message.Id);
         }
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -754,18 +754,16 @@ namespace Libplanet.Net.Tests
                     privateKey: privateKey),
             };
 
-            Block<DumbAction> block1 = ProposeNext(
-                blockChain.Genesis,
-                new[] { transactions[0] },
-                miner: GenesisProposer.PublicKey
-            ).Evaluate(GenesisProposer, blockChain);
+            Block<DumbAction> block1 = ProposeBlockFromBlockChain(
+                blockChain,
+                GenesisProposer,
+                new[] { transactions[0] });
             blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true, true, false);
-            Block<DumbAction> block2 = ProposeNext(
-                block1,
+            Block<DumbAction> block2 = ProposeBlockFromBlockChain(
+                blockChain,
+                GenesisProposer,
                 new[] { transactions[1] },
-                miner: GenesisProposer.PublicKey,
-                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)
-            ).Evaluate(GenesisProposer, blockChain);
+                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0));
             blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true, true, false);
 
             try
@@ -1048,11 +1046,11 @@ namespace Libplanet.Net.Tests
 
             mockTransport.ProcessMessageHandler.Register(MessageHandler);
 
-            Block<DumbAction> block1 = ProposeNextBlock(
+            Block<DumbAction> block1 = MockupBlockFromPreviousBlock(
                 receiver.BlockChain.Genesis,
                 key,
                 new Transaction<DumbAction>[] { });
-            Block<DumbAction> block2 = ProposeNextBlock(
+            Block<DumbAction> block2 = MockupBlockFromPreviousBlock(
                 block1,
                 key,
                 new Transaction<DumbAction>[] { });

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -127,11 +127,10 @@ namespace Libplanet.Net.Tests
             var blocks = new List<Block<DumbAction>>();
             foreach (int i in Enumerable.Range(0, 12))
             {
-                Block<DumbAction> block = ProposeNext(
-                    previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip)
-                ).Evaluate(ChainPrivateKey, minerChain);
+                Block<DumbAction> block = ProposeBlockFromBlockChain(
+                    minerChain,
+                    ChainPrivateKey,
+                    lastCommit: CreateBlockCommit(minerChain.Tip));
                 blocks.Add(block);
                 if (i != 11)
                 {
@@ -482,13 +481,11 @@ namespace Libplanet.Net.Tests
                     DateTimeOffset.UtcNow
                 );
 
-                Block<ThrowException> block = ProposeNext(
-                    minerChain.Tip,
+                Block<ThrowException> block = ProposeBlockFromBlockChain(
+                    minerChain,
+                    ChainPrivateKey,
                     new[] { tx },
-                    miner: ChainPrivateKey.PublicKey,
-                    blockInterval: TimeSpan.FromSeconds(1),
-                    lastCommit: CreateBlockCommit(minerChain.Tip)
-                ).Evaluate(ChainPrivateKey, minerChain);
+                    lastCommit: CreateBlockCommit(minerChain.Tip));
                 minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), false, true, false);
 
                 await receiverSwarm.PreloadAsync();
@@ -969,7 +966,7 @@ namespace Libplanet.Net.Tests
                 minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
-            Block<DumbAction> block = ProposeNext(
+            Block<DumbAction> block = MockupFromPreviousBlock(
                 minerChain2.Tip,
                 miner: ChainPrivateKey.PublicKey,
                 lastCommit: CreateBlockCommit(minerChain2.Tip)

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1252,29 +1252,35 @@ namespace Libplanet.Net.Tests
             var policyB = new NullBlockPolicy<DumbAction>();
             var fx = new DefaultStoreFixture();
             var genesis = fx.GenesisBlock;
-            Block<DumbAction> aBlock1 = ProposeNextBlock(
+            Block<DumbAction> aBlock1 = MockupBlockFromPreviousBlock(
                 genesis,
                 keyA,
                 stateRootHash: genesis.StateRootHash);
-            Block<DumbAction> aBlock2 = ProposeNextBlock(
+            BlockCommit aCommit1 = CreateBlockCommit(aBlock1);
+            Block<DumbAction> aBlock2 = MockupBlockFromPreviousBlock(
                 aBlock1,
                 keyA,
                 stateRootHash: genesis.StateRootHash,
-                lastCommit: CreateBlockCommit(aBlock1));
-            Block<DumbAction> aBlock3 = ProposeNextBlock(
+                lastCommit: aCommit1,
+                timestamp: aCommit1.MedianTime(ValidatorSet));
+            BlockCommit aCommit2 = CreateBlockCommit(aBlock2);
+            Block<DumbAction> aBlock3 = MockupBlockFromPreviousBlock(
                 aBlock2,
                 keyA,
                 stateRootHash: genesis.StateRootHash,
-                lastCommit: CreateBlockCommit(aBlock2));
-            Block<DumbAction> bBlock1 = ProposeNextBlock(
+                lastCommit: aCommit2,
+                timestamp: aCommit2.MedianTime(ValidatorSet));
+            Block<DumbAction> bBlock1 = MockupBlockFromPreviousBlock(
                 genesis,
                 keyB,
                 stateRootHash: genesis.StateRootHash);
-            Block<DumbAction> bBlock2 = ProposeNextBlock(
+            BlockCommit bCommit1 = CreateBlockCommit(bBlock1);
+            Block<DumbAction> bBlock2 = MockupBlockFromPreviousBlock(
                 bBlock1,
                 keyB,
                 stateRootHash: genesis.StateRootHash,
-                lastCommit: CreateBlockCommit(bBlock1));
+                lastCommit: bCommit1,
+                timestamp: bCommit1.MedianTime(ValidatorSet));
 
             policyA.BlockedMiners.Add(keyB.ToAddress());
             policyB.BlockedMiners.Add(keyA.ToAddress());
@@ -1579,11 +1585,10 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block<DumbAction> block = ProposeBlockFromBlockChain(
+                    chain,
+                    ChainPrivateKey,
+                    lastCommit: CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1622,11 +1627,10 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block<DumbAction> block = ProposeBlockFromBlockChain(
+                    chain,
+                    ChainPrivateKey,
+                    lastCommit: CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1666,11 +1670,10 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block<DumbAction> block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block<DumbAction> block = ProposeBlockFromBlockChain(
+                    chain,
+                    ChainPrivateKey,
+                    lastCommit: CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -112,8 +112,10 @@ namespace Libplanet.Net.Tests
                     validRound).Sign(privateKey));
         }
 
-        public static BlockCommit CreateBlockCommit<T>(Block<T> block)
-            where T : IAction, new() => Libplanet.Tests.TestUtils.CreateBlockCommit(block);
+        public static BlockCommit CreateBlockCommit<T>(
+            Block<T> block, DateTimeOffset? timestamp = null)
+            where T : IAction, new() => Libplanet.Tests.TestUtils.CreateBlockCommit(
+                block, timestamp);
 
         public static BlockCommit CreateBlockCommit(BlockHash blockHash, long height, int round) =>
             Libplanet.Tests.TestUtils.CreateBlockCommit(blockHash, height, round);

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -64,14 +64,11 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            Block<DumbAction> block = TestUtils.ProposeNext(
-                    chain.Tip,
-                    new[] { tx },
-                    miner: _keys[1].PublicKey,
-                    protocolVersion: ProtocolVersion,
-                    lastCommit: TestUtils.CreateBlockCommit(chain.Tip)
-                )
-                .Evaluate(_keys[1], chain);
+            Block<DumbAction> block = TestUtils.ProposeBlockFromBlockChain(
+                chain,
+                _keys[1],
+                new[] { tx },
+                lastCommit: TestUtils.CreateBlockCommit(chain.Tip));
             chain.Append(
                 block,
                 TestUtils.CreateBlockCommit(block)

--- a/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplV0Test.cs
@@ -62,12 +62,8 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            PreEvaluationBlock<DumbAction> preEval = TestUtils.ProposeNext(
-                chain.Tip,
-                new[] { tx },
-                miner: _keys[1].PublicKey,
-                protocolVersion: ProtocolVersion
-            );
+            var preEval = TestUtils.ProposePreEvalFromBlockChain(
+                chain, _keys[0], new[] { tx }, protocolVersion: ProtocolVersion);
             var stateRootHash = chain.DetermineBlockStateRootHash(preEval, out _);
             var hash = preEval.Header.DeriveBlockHash(stateRootHash, null);
             Block<DumbAction> block = new Block<DumbAction>(preEval, (stateRootHash, null, hash));

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -248,10 +248,10 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            var preEvalBlock = TestUtils.ProposeNext(
-                chain.Tip,
+            var preEvalBlock = TestUtils.ProposePreEvalFromBlockChain(
+                chain,
+                privateKey,
                 new[] { tx },
-                miner: privateKey.PublicKey,
                 protocolVersion: ProtocolVersion);
             var stateRootHash = chain.DetermineBlockStateRootHash(preEvalBlock, out _);
             var hash = preEvalBlock.Header.DeriveBlockHash(stateRootHash, null);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -108,11 +108,7 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
-            Block<DumbAction> block1 = ProposeNext(
-                genesis,
-                txs,
-                miner: _fx.Proposer.PublicKey
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block<DumbAction> block1 = ProposeBlockFromBlockChain(_blockChain, _fx.Proposer, txs);
 
             _blockChain.Append(
                 block1,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -481,7 +481,7 @@ namespace Libplanet.Tests.Blockchain
         [SkippableFact]
         public void ProposeBlockWithLastCommit()
         {
-            var keys = Enumerable.Range(0, 3).Select(_ => new PrivateKey()).ToList();
+            var keys = ValidatorPrivateKeys;
             var votes = keys.Select(key => new VoteMetadata(
                 _blockChain.Tip.Index,
                 0,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -236,7 +236,7 @@ namespace Libplanet.Tests.Blockchain
             Block<DumbAction> block2 = new BlockContent<DumbAction>(
                 new BlockMetadata(
                     index: 2L,
-                    timestamp: DateTimeOffset.UtcNow,
+                    timestamp: _blockChain.GetBftTime(blockCommit),
                     publicKey: _fx.Proposer.PublicKey,
                     previousHash: block1.Hash,
                     txHash: null,

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -29,10 +29,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         [Fact]
         public void ActionRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -11,10 +11,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         [Fact]
         public void BlockRenderer()

--- a/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/DelayedRendererTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
             for (int i = 1; i < chainA.Length / 2; i++)
             {
-                _branchpoint = chainA[i] = chainB[i] = TestUtils.ProposeNextBlock(
+                _branchpoint = chainA[i] = chainB[i] = TestUtils.MockupBlockFromPreviousBlock(
                     chainA[i - 1],
                     TestUtils.GenesisProposer,
                     lastCommit: TestUtils.CreateBlockCommit(
@@ -41,11 +41,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
             for (int i = chainA.Length / 2; i < chainA.Length; i++)
             {
-                chainA[i] = TestUtils.ProposeNextBlock(
+                chainA[i] = TestUtils.MockupBlockFromPreviousBlock(
                     chainA[i - 1],
                     TestUtils.GenesisProposer,
                     lastCommit: TestUtils.CreateBlockCommit(chainA[i - 1]));
-                chainB[i] = TestUtils.ProposeNextBlock(
+                chainB[i] = TestUtils.MockupBlockFromPreviousBlock(
                     chainB[i - 1],
                     TestUtils.GenesisProposer,
                     lastCommit: TestUtils.CreateBlockCommit(chainB[i - 1]));

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -33,10 +33,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static DumbBlock _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static DumbBlock _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -19,10 +19,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static DumbBlock _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static DumbBlock _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private ILogger _logger;
 

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockActionRendererTest.cs
@@ -32,10 +32,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         [RetryFact]
         public void Test()

--- a/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/NonblockRendererTest.cs
@@ -16,10 +16,10 @@ namespace Libplanet.Tests.Blockchain.Renderers
             TestUtils.ProposeGenesisBlock<DumbAction>(TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockA =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         private static Block<DumbAction> _blockB =
-            TestUtils.ProposeNextBlock(_genesis, TestUtils.GenesisProposer);
+            TestUtils.MockupBlockFromPreviousBlock(_genesis, TestUtils.GenesisProposer);
 
         [SuppressMessage(
             "SonarQube",

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.Blocks
                     "e2e938f9d8af0a20d16d1c233fc4e8f39157145d003565807e4055ce6b5a0121")
             );
             TxFixture = new TxFixture(Genesis.Hash);
-            Next = TestUtils.ProposeNextBlock(
+            Next = TestUtils.MockupBlockFromPreviousBlock(
                 Genesis,
                 miner: Miner,
                 protocolVersion: ProtocolVersion,
@@ -33,7 +33,7 @@ namespace Libplanet.Tests.Blocks
                     "6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa"),
                 lastCommit: null
             );
-            HasTx = TestUtils.ProposeNextBlock(
+            HasTx = TestUtils.MockupBlockFromPreviousBlock(
                 Next,
                 miner: Miner,
                 txs: new List<Transaction<PolymorphicAction<BaseAction>>>

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", 5)
                 .Add(
                     "transaction_fingerprint",
                     ParseHex("7786de6a7c745f9628b44f58df1882fbae30763d3515b2c81ad34a27c81f8845"));
@@ -146,7 +146,7 @@ namespace Libplanet.Tests.Blocks
                     "transaction_fingerprint",
                     ParseHex("654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0")
                 )
-                .Add("protocol_version", 4);
+                .Add("protocol_version", 5);
             AssertBencodexEqual(
                 expectedBlock1,
                 Block1Metadata.MakeCandidateData(new Nonce(new byte[] { 0xff, 0xef, 0x01, 0xcc }))
@@ -239,13 +239,13 @@ namespace Libplanet.Tests.Blocks
 
             HashDigest<SHA256> hash = GenesisMetadata.DerivePreEvaluationHash(default);
             AssertBytesEqual(
-                FromHex("7607398b11ae6d2f30ad988e019d4b7ac5d65035bd1397c61ca72bfae42a562e"),
+                FromHex("161e0d298185e9231426bf15c50d035dc796112fa0e5c1c3746e9ace4c18d1f2"),
                 hash.ByteArray);
 
             hash = Block1Metadata.DerivePreEvaluationHash(
                 new Nonce(FromHex("e7c1adf92c65d35aaae5")));
             AssertBytesEqual(
-                FromHex("9ae70453c854c69c03e9841e117d269b97615dcf4f580fb99577d981d3f61ebf"),
+                FromHex("68ee32560911ed89c89e0adf9eceec2a388d9aba165cd5387055fdfd9e5ee85e"),
                 hash.ByteArray);
         }
 

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -63,7 +63,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", 5)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray)
                 .Add(
                     "transaction_fingerprint",
@@ -98,7 +98,7 @@ namespace Libplanet.Tests.Blocks
                         "654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0"
                     )
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", 5)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray);
             var block1 = new PreEvaluationBlockHeader(
                 _contents.Block1Metadata,
@@ -168,13 +168,13 @@ namespace Libplanet.Tests.Blocks
 
             // Same as block1.MakeSignature(_contents.Block1Key, arbitraryHash)
             ImmutableArray<byte> validSig = ByteUtil.ParseHexToImmutable(
-                "3044022100b285f684fe94524aa725c6b69cb858370f85af56420d275410e148b0ad18" +
-                "b3d9021f324c828b1dd949ebf73591bc0ac8858debae7c5aabc420fd4a1cec53d61e60"
+                "3044022070295135bbe705ca79723cbad8bc8c958c6d2e8a8a17d77ecde23135757779" +
+                "e402207ba382b665c7960b3c036ddde850641b8782db6042eb74f68b65c16fdb06b146"
             );
 
             AssertBytesEqual(
-                block1.MakeSignature(_contents.Block1Key, arbitraryHash),
-                validSig);
+                validSig,
+                block1.MakeSignature(_contents.Block1Key, arbitraryHash));
             Assert.True(block1.VerifySignature(validSig, arbitraryHash));
             Assert.False(block1.VerifySignature(null, arbitraryHash));
             Assert.False(block1.VerifySignature(validSig, default));
@@ -204,22 +204,22 @@ namespace Libplanet.Tests.Blocks
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("c0e3e1da26dfbeee5ebd5195312590f99142ac019e8d324e5dd937ef486be861"),
+                fromHex("cea0c9ac3fa56829e7e1a7fb566803588f0407d95b45b1c0e7265d8dd27101c1"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("1ad4c14600c1a96494f0d3dde39eda51523d6df2adcbef4e06342a88880e4c55"),
+                fromHex("1eaf76b6f4c6a6418884ac52330c125231a4e55ec7eb21fd71345d2e9844c085"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("0f35fc967e562c6c36a6f3379191043347e876f05443b68e11cc0f380a473200"),
+                fromHex("a756ba9de50b2f09d90021b5825a1cf451ca5373ad036359e547dd8653c1fa94"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("186e46b26f43652ac11e314a81900637094747e5add0940881a5c74cf5fc72d3"),
+                fromHex("28c6e023f30597815e37b341c9b83385e0d52f555488979ee44a1d128a9ed6cf"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash))
@@ -229,19 +229,19 @@ namespace Libplanet.Tests.Blocks
                 _contents.Block1Metadata,
                 _contents.Block1Metadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("9c999d048603c32369bcd982ac2488f8d2782f339f0296ad537d4f039984dc47"),
+                fromHex("4b6b0261d090214093bb9f00c545370500aded8f632a0ae058238f67a786ae36"),
                 block1.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("1ff0ca42037e91a07db6b42a2f0aadc7fc1249900033718d783334a90a333892"),
+                fromHex("f1a1b865f56103798fe6df04dac39378de70094dd79b7a5f5114db12bb4b20a0"),
                 block1.DeriveBlockHash(default, block1.MakeSignature(_contents.Block1Key, default))
             );
             AssertBytesEqual(
-                fromHex("5e63ed240742d7dac4b7f290f5a7afc51e2d410b13d2ad9690e56ac66486b23d"),
+                fromHex("119d9e28fc4feb5756da29d3e0dd40f92d03c54e2b7b7ff0d3b2b01751623ce6"),
                 block1.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("54f7572223e4d642ca8772378528120392a9997655860a6ec108f3e4d8c1cc14"),
+                fromHex("df2d543374588f4e869d3c77c47b2200a0bca2729d904b349090afe919afef1c"),
                 block1.DeriveBlockHash(
                     arbitraryHash, block1.MakeSignature(_contents.Block1Key, arbitraryHash)
                 )

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -116,26 +116,26 @@ namespace Libplanet.Tests.Store
             stateStore.Commit(null, evals.GetTotalDelta(
                 ToStateKey, ToFungibleAssetKey, ToTotalSupplyKey, ValidatorSetKey));
             stateRootHashes[GenesisBlock.Hash] = GenesisBlock.StateRootHash;
-            Block1 = TestUtils.ProposeNextBlock(
+            Block1 = TestUtils.MockupBlockFromPreviousBlock(
                 GenesisBlock,
                 miner: Proposer,
                 lastCommit: null);
             stateRootHashes[Block1.Hash] = Block1.StateRootHash;
-            Block2 = TestUtils.ProposeNextBlock(
+            Block2 = TestUtils.MockupBlockFromPreviousBlock(
                 Block1,
                 miner: Proposer,
                 lastCommit: TestUtils.CreateBlockCommit(Block1));
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
-            Block3 = TestUtils.ProposeNextBlock(
+            Block3 = TestUtils.MockupBlockFromPreviousBlock(
                 Block2,
                 miner: Proposer,
                 lastCommit: TestUtils.CreateBlockCommit(Block2));
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
-            Block3Alt = TestUtils.ProposeNextBlock(Block2, miner: Proposer);
+            Block3Alt = TestUtils.MockupBlockFromPreviousBlock(Block2, miner: Proposer);
             stateRootHashes[Block3Alt.Hash] = Block3Alt.StateRootHash;
-            Block4 = TestUtils.ProposeNextBlock(Block3, miner: Proposer);
+            Block4 = TestUtils.MockupBlockFromPreviousBlock(Block3, miner: Proposer);
             stateRootHashes[Block4.Hash] = Block4.StateRootHash;
-            Block5 = TestUtils.ProposeNextBlock(Block4, miner: Proposer);
+            Block5 = TestUtils.MockupBlockFromPreviousBlock(Block4, miner: Proposer);
             stateRootHashes[Block5.Hash] = Block5.StateRootHash;
 
             Transaction1 = MakeTransaction(new List<DumbAction>(), ImmutableHashSet<Address>.Empty);

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Tests.Store
         [SkippableFact]
         public void DeleteChainId()
         {
-            Block<DumbAction> block1 = ProposeNextBlock(
+            Block<DumbAction> block1 = MockupBlockFromPreviousBlock(
                 ProposeGenesisBlock<DumbAction>(GenesisProposer),
                 GenesisProposer,
                 new[] { Fx.Transaction1 });
@@ -986,7 +986,7 @@ namespace Libplanet.Tests.Store
 
             // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
             // actual block...
-            Block<DumbAction> anotherBlock3 = ProposeNextBlock(
+            Block<DumbAction> anotherBlock3 = MockupBlockFromPreviousBlock(
                 Fx.Block2,
                 Fx.Proposer,
                 lastCommit: CreateBlockCommit(Fx.Block2.Hash, 2, 0));
@@ -1095,7 +1095,7 @@ namespace Libplanet.Tests.Store
             using (StoreFixture fx = FxConstructor())
             {
                 Block<DumbAction> genesisBlock = fx.GenesisBlock;
-                Block<DumbAction> block = ProposeNextBlock(
+                Block<DumbAction> block = MockupBlockFromPreviousBlock(
                     genesisBlock,
                     miner: fx.Proposer);
 

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -157,6 +157,11 @@ namespace Libplanet.Blockchain
         {
             long index = Count;
             BlockHash? prevHash = Store.IndexBlockHash(Id, index - 1);
+            DateTimeOffset? bftTime = null;
+            if (lastCommit is { } commit)
+            {
+                bftTime = GetBftTime(commit);
+            }
 
             // FIXME: Should use automated public constructor.
             // Manual internal constructor is used purely for testing custom timestamps.
@@ -165,7 +170,7 @@ namespace Libplanet.Blockchain
                 new BlockMetadata(
                     protocolVersion: BlockMetadata.CurrentProtocolVersion,
                     index: index,
-                    timestamp: DateTimeOffset.UtcNow,
+                    timestamp: bftTime ?? DateTimeOffset.UtcNow,
                     miner: proposer.ToAddress(),
                     publicKey: proposer.PublicKey,
                     previousHash: prevHash,

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -18,12 +18,17 @@ namespace Libplanet.Blocks
         /// <summary>
         /// The latest protocol version.
         /// </summary>
-        public const int CurrentProtocolVersion = 4;
+        public const int CurrentProtocolVersion = 5;
 
         /// <summary>
         /// The last PoW protocol version.
         /// </summary>
         public const int PoWProtocolVersion = 3;
+
+        /// <summary>
+        /// The last protocol version that does not restrict block timestamp.
+        /// </summary>
+        public const int FreeTimestampProtocolVersion = 4;
 
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();

--- a/Libplanet/Consensus/ValidatorSet.cs
+++ b/Libplanet/Consensus/ValidatorSet.cs
@@ -131,7 +131,11 @@ namespace Libplanet.Consensus
         public Validator this[int index] => Validators[index];
 
         public Validator GetValidator(PublicKey publicKey)
-            => Validators.Find(validator => validator.PublicKey == publicKey);
+            => Validators.Find(validator => validator.PublicKey == publicKey)
+                ?? throw new ArgumentOutOfRangeException(
+                    nameof(publicKey),
+                    publicKey,
+                    "Given public key does not exist on validator set");
 
         public ImmutableList<Validator> GetValidators(IEnumerable<PublicKey> publicKeys)
             => (from publicKey in publicKeys select GetValidator(publicKey)).ToImmutableList();


### PR DESCRIPTION
Implement a timestamp based on the last commit to make it difficult for validators to manipulate timestamps.

To apply this change, **block protocol version have to be upgraded**, since new timestamp validation logic won't be proper to previous block protocol version.

There seems to be several more options to restrict timestamp, and this is just one of them.