### PR TITLE
Fixed interval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,9 @@ To be released.
     Predicate<Currency>)` to `BlockChain<T>.ProposeGenesisBlock(
     PrivateKey, ImmutableList<Transaction<T>>, DateTimeOffset?, IAction,
     Predicate<Currency>)`.  [[#3079]]
+ -  (Libplanet.Net) Replaced parameter `newHeightDelay` with
+    `contextMinInterval` from `ConsensusContext` and `ConsensusReactor`.
+    [[#3094]]
 
 ### Backward-incompatible network protocol changes
 
@@ -220,6 +223,9 @@ To be released.
  -  (@planetarium/account-web3-secret-storage) `Web3KeyStore` now supports
     Scrypt as one of KDF functions besides PBKDF2.  [[#3071]]
 
+ -  (Libplanet.Net) `ConsensusContext.NewHeight()` will be suspended till
+    `contextMinInterval` arrives.  [[#3094]]
+
 ### Bug fixes
 
  -  In `PreVote` block validation, `Context<T>.IsValid()`, validate the block
@@ -268,6 +274,7 @@ To be released.
 [#3080]: https://github.com/planetarium/libplanet/pull/3080
 [#3084]: https://github.com/planetarium/libplanet/pull/3084
 [#3088]: https://github.com/planetarium/libplanet/pull/3088
+[#3094]: https://github.com/planetarium/libplanet/pull/3094
 
 
 Version 0.53.4

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus
                     key: TestUtils.PrivateKeys[i],
                     consensusPort: 6000 + i,
                     validatorPeers: validatorPeers,
-                    newHeightDelayMilliseconds: PropagationDelay * 2);
+                    contextMinIntervalMilliseconds: PropagationDelay * 2);
             }
 
             try

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -221,7 +221,7 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> BlockChain,
             ConsensusContext<DumbAction> ConsensusContext)
             CreateDummyConsensusContext(
-                TimeSpan newHeightDelay,
+                TimeSpan contextMinInterval,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
@@ -248,7 +248,7 @@ namespace Libplanet.Net.Tests
                 broadcastMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                contextMinInterval,
                 contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, consensusContext);
@@ -297,7 +297,7 @@ namespace Libplanet.Net.Tests
             string host = "127.0.0.1",
             int consensusPort = 5101,
             List<BoundPeer>? validatorPeers = null,
-            int newHeightDelayMilliseconds = 10_000,
+            int contextMinIntervalMilliseconds = 10_000,
             ContextTimeoutOption? contextTimeoutOptions = null)
         {
             key ??= PrivateKeys[1];
@@ -317,7 +317,7 @@ namespace Libplanet.Net.Tests
                 key,
                 validatorPeers.ToImmutableList(),
                 new List<BoundPeer>().ToImmutableList(),
-                TimeSpan.FromMilliseconds(newHeightDelayMilliseconds),
+                TimeSpan.FromMilliseconds(contextMinIntervalMilliseconds),
                 contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
         }
 

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -26,10 +26,11 @@ namespace Libplanet.Net.Consensus
 
         private readonly BlockChain<T> _blockChain;
         private readonly PrivateKey _privateKey;
-        private readonly TimeSpan _newHeightDelay;
+        private readonly TimeSpan _contextMinInterval;
         private readonly ILogger _logger;
         private readonly Dictionary<long, Context<T>> _contexts;
 
+        private DateTimeOffset _lastTipChangedTime;
         private CancellationTokenSource? _newHeightCts;
         private bool _bootstrapping;
 
@@ -44,8 +45,8 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
         /// </param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block. <seealso cref="OnTipChanged"/>
+        /// <param name="contextMinInterval">A time interval in starting the consensus
+        /// for the next height block.
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
@@ -53,19 +54,20 @@ namespace Libplanet.Net.Consensus
             DelegateBroadcastMessage broadcastMessage,
             BlockChain<T> blockChain,
             PrivateKey privateKey,
-            TimeSpan newHeightDelay,
+            TimeSpan contextMinInterval,
             ContextTimeoutOption contextTimeoutOption)
         {
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
             _privateKey = privateKey;
+            _contextMinInterval = contextMinInterval;
             Height = -1;
-            _newHeightDelay = newHeightDelay;
 
             _contextTimeoutOption = contextTimeoutOption;
 
             _contexts = new Dictionary<long, Context<T>>();
             _blockChain.TipChanged += OnTipChanged;
+            _lastTipChangedTime = DateTimeOffset.UtcNow;
             _bootstrapping = true;
 
             _logger = Log
@@ -309,8 +311,8 @@ namespace Libplanet.Net.Consensus
 
         /// <summary>
         /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls
-        /// <see cref="NewHeight"/>.  Starting a new height will be delayed for
-        /// <see cref="_newHeightDelay"/> in order to collect remaining delayed votes
+        /// <see cref="NewHeight"/>.  Starting a new height will be delayed until reached
+        /// <see cref="_contextMinInterval"/> in order to collect remaining delayed votes
         /// and stabilize the consensus process by waiting for Global Stabilization Time.
         /// </summary>
         /// <param name="sender">The source object instance for <see cref="EventHandler"/>.
@@ -327,7 +329,22 @@ namespace Libplanet.Net.Consensus
             Task.Run(
                 async () =>
                 {
-                    await Task.Delay(_newHeightDelay, _newHeightCts.Token);
+                    TimeSpan contextIntervalLacked = _contextMinInterval
+                        - (DateTimeOffset.UtcNow - _lastTipChangedTime);
+                    _lastTipChangedTime = DateTimeOffset.UtcNow;
+                    if (contextIntervalLacked > TimeSpan.Zero)
+                    {
+                        _logger.Debug(
+                            "Waiting lacked context interval {Delay}ms for " +
+                            "block #{Index} {Hash} (context: {Context})",
+                            contextIntervalLacked.TotalMilliseconds,
+                            e.NewTip.Index,
+                            e.NewTip.Hash,
+                            ToString());
+                        await Task.Delay(
+                            contextIntervalLacked, _newHeightCts.Token);
+                    }
+
                     if (!_newHeightCts.IsCancellationRequested)
                     {
                         try

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -43,8 +43,8 @@ namespace Libplanet.Net.Consensus
         /// itself.
         /// </param>
         /// <param name="seedPeers">A list of seed's <see cref="BoundPeer"/>.</param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block.
+        /// <param name="contextMinInterval">A time interval in starting the consensus
+        /// for the next height block.
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
@@ -54,7 +54,7 @@ namespace Libplanet.Net.Consensus
             PrivateKey privateKey,
             ImmutableList<BoundPeer> validatorPeers,
             ImmutableList<BoundPeer> seedPeers,
-            TimeSpan newHeightDelay,
+            TimeSpan contextMinInterval,
             ContextTimeoutOption contextTimeoutOption)
         {
             validatorPeers ??= ImmutableList<BoundPeer>.Empty;
@@ -72,7 +72,7 @@ namespace Libplanet.Net.Consensus
                 PublishMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                contextMinInterval,
                 contextTimeoutOption);
 
             _logger = Log


### PR DESCRIPTION
On https://github.com/planetarium/libplanet/pull/3066, https://github.com/planetarium/libplanet/pull/3063,  https://github.com/planetarium/libplanet/pull/3064 has been reverted, since those would be permanently break time sync between validators.

Using the timing on tip changed, this harmful aspect can be resolved.

Still it's imperfect due to the state transition time, but to resolve it, block appending on consensus is needed.

I think those direction is OK, but it's not easy to decide.
So, to minimize difference, decided to use this way.