### PR TITLE
Bump `Bencodex` to `0.9.0`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,12 @@ To be released.
 
 ### Dependencies
 
+ -  Upgrade *Bencodex* from [0.8.0][Bencodex 0.8.0] to
+    [0.9.0][Bencodex 0.9.0].  [[#3102]]
+ -  Upgrade *Bencodex.Json* from [0.8.0][Bencodex.Json 0.8.0] to
+    [0.9.0][Bencodex.Json 0.9.0].  [[#3102]]
+
+
 ### CLI tools
 
 [#3082]: https://github.com/planetarium/libplanet/pull/3082
@@ -47,6 +53,9 @@ To be released.
 [#3087]: https://github.com/planetarium/libplanet/pull/3087
 [#3092]: https://github.com/planetarium/libplanet/pull/3092
 [#3098]: https://github.com/planetarium/libplanet/pull/3098
+[#3102]: https://github.com/planetarium/libplanet/pull/3102
+[Bencodex 0.9.0]: https://www.nuget.org/packages/Bencodex/0.9.0
+[Bencodex.Json 0.9.0]: https://www.nuget.org/packages/Bencodex.Json/0.9.0
 
 
 Version 1.0.0

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -63,7 +63,7 @@
     <ProjectReference Include="..\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
-    <PackageReference Include="Bencodex.Json" Version="0.8.0" />
+    <PackageReference Include="Bencodex.Json" Version="0.9.0" />
     <!-- FIXME: We should specify the version range when the following NuGet
     issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
   </ItemGroup>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -62,8 +62,8 @@ https://docs.libplanet.io/</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bencodex" Version="0.8.0" />
-    <PackageReference Include="Bencodex.Json" Version="0.8.0" />
+    <PackageReference Include="Bencodex" Version="0.9.0" />
+    <PackageReference Include="Bencodex.Json" Version="0.9.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />


### PR DESCRIPTION
### Changes
- Bump bencodex to 0.9.0.
- `GetHashCode()` of `Bencodex.Types.Dictionary` and `Bencodex.Types.List` returns hash code derived from its content from now on.

### Related PR
- https://github.com/planetarium/libplanet/pull/2520