### PR TITLE
Move delay to `EndCommit` from `OnTipChanged`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ To be released.
  -  (Libplanet.Net) Removed optional `render` parameter from
     all `Swarm<T>.PreloadAsync()` overload methods.  No rendering is done
     during the preloading phase.  [[#3108]]
+ -  (Libplanet.Net) Removed `newHeightDelay` parameter from constructor of
+    `ConsensusReactor<T>`, `ConsensusContext<T>`.  [[#3104]]
+ -  (Libplanet.Net) Added `commitBlockDelay` parameter from constructor of
+    `ConsensusReactor<T>`, `ConsensusContext<T>`, `Context`.  [[#3104]]
 
 ### Backward-incompatible network protocol changes
 
@@ -38,6 +42,10 @@ To be released.
     `IRenderer<T>.RenderReorgEnd()`, `IActionRenderer<T>.UnrenderAction()`,
     and `IActionRenderer<T>.UnrenderActionError()`, i.e., these interface
     methods are no longer invoked by a `BlockChain<T>`.  [[#3087]]
+ -  `ConsensusContext<T>` no longer waits before `NewHeight()` calls.
+    [[#3104]]
+ -  `Context` now waits before `BlockChain<T>.Append()` after entering
+    `EndCommit` step.  [[#3104]]
 
 ### Bug fixes
 
@@ -56,6 +64,7 @@ To be released.
 [#3087]: https://github.com/planetarium/libplanet/pull/3087
 [#3092]: https://github.com/planetarium/libplanet/pull/3092
 [#3098]: https://github.com/planetarium/libplanet/pull/3098
+[#3104]: https://github.com/planetarium/libplanet/pull/3104
 [#3106]: https://github.com/planetarium/libplanet/pull/3106
 [#3108]: https://github.com/planetarium/libplanet/pull/3108
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Net.Tests.Consensus
                     key: TestUtils.PrivateKeys[i],
                     consensusPort: 6000 + i,
                     validatorPeers: validatorPeers,
-                    newHeightDelayMilliseconds: PropagationDelay * 2);
+                    commitBlockDelayMilliseconds: PropagationDelay * 2);
             }
 
             try
@@ -124,7 +124,7 @@ namespace Libplanet.Net.Tests.Consensus
                         validatorPeers[node].Address.ToString(),
                         json["node_id"].GetString());
                     Assert.Equal(1, json["height"].GetInt32());
-                    Assert.Equal(2, blockChains[node].Count);
+                    Assert.Equal(1, blockChains[node].Count);
                     Assert.Equal(0L, json["round"].GetInt32());
                     Assert.Equal("EndCommit", json["step"].GetString());
                 }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -221,13 +221,14 @@ namespace Libplanet.Net.Tests
             BlockChain<DumbAction> BlockChain,
             ConsensusContext<DumbAction> ConsensusContext)
             CreateDummyConsensusContext(
-                TimeSpan newHeightDelay,
+                TimeSpan? commitBlockDelay = null,
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ConsensusContext<DumbAction>.DelegateBroadcastMessage? broadcastMessage = null,
                 long blockCommitClearThreshold = 30,
                 ContextTimeoutOption? contextTimeoutOptions = null)
         {
+            var assignedCommitBlockDelay = commitBlockDelay ?? TimeSpan.FromSeconds(1);
             policy ??= Policy;
             var fx = new MemoryStoreFixture(policy.BlockAction);
             var blockChain = CreateDummyBlockChain(fx, policy);
@@ -248,7 +249,7 @@ namespace Libplanet.Net.Tests
                 broadcastMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                assignedCommitBlockDelay,
                 contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, consensusContext);
@@ -262,11 +263,13 @@ namespace Libplanet.Net.Tests
                 IBlockPolicy<DumbAction>? policy = null,
                 PrivateKey? privateKey = null,
                 ContextTimeoutOption? contextTimeoutOptions = null,
-                ValidatorSet? validatorSet = null)
+                ValidatorSet? validatorSet = null,
+                TimeSpan? commitBlockDelay = null)
         {
             Context<DumbAction>? context = null;
             privateKey ??= PrivateKeys[1];
             policy ??= Policy;
+            var assignedCommitBlockDelay = commitBlockDelay ?? TimeSpan.FromSeconds(1);
 
             void BroadcastMessage(ConsensusMsg message) =>
                 Task.Run(() =>
@@ -275,7 +278,7 @@ namespace Libplanet.Net.Tests
                 });
 
             var (blockChain, consensusContext) = CreateDummyConsensusContext(
-                TimeSpan.FromSeconds(1),
+                assignedCommitBlockDelay,
                 policy,
                 PrivateKeys[1],
                 broadcastMessage: BroadcastMessage);
@@ -286,6 +289,7 @@ namespace Libplanet.Net.Tests
                 height,
                 privateKey,
                 validatorSet ?? blockChain.GetValidatorSet(blockChain[height - 1].Hash),
+                assignedCommitBlockDelay,
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 
             return (blockChain, context);
@@ -297,7 +301,7 @@ namespace Libplanet.Net.Tests
             string host = "127.0.0.1",
             int consensusPort = 5101,
             List<BoundPeer>? validatorPeers = null,
-            int newHeightDelayMilliseconds = 10_000,
+            int commitBlockDelayMilliseconds = 10_000,
             ContextTimeoutOption? contextTimeoutOptions = null)
         {
             key ??= PrivateKeys[1];
@@ -317,7 +321,7 @@ namespace Libplanet.Net.Tests
                 key,
                 validatorPeers.ToImmutableList(),
                 new List<BoundPeer>().ToImmutableList(),
-                TimeSpan.FromMilliseconds(newHeightDelayMilliseconds),
+                TimeSpan.FromMilliseconds(commitBlockDelayMilliseconds),
                 contextTimeoutOption: contextTimeoutOptions ?? new ContextTimeoutOption());
         }
 

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
@@ -26,11 +24,10 @@ namespace Libplanet.Net.Consensus
 
         private readonly BlockChain<T> _blockChain;
         private readonly PrivateKey _privateKey;
-        private readonly TimeSpan _newHeightDelay;
+        private readonly TimeSpan _commitBlockDelay;
         private readonly ILogger _logger;
         private readonly Dictionary<long, Context<T>> _contexts;
 
-        private CancellationTokenSource? _newHeightCts;
         private bool _bootstrapping;
 
         /// <summary>
@@ -44,23 +41,22 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="privateKey">A <see cref="PrivateKey"/> for signing message and blocks.
         /// </param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block. <seealso cref="OnTipChanged"/>
-        /// </param>
+        /// <param name="commitBlockDelay">A time delay between <see cref="Step.EndCommit"/>
+        /// and <see cref="BlockChain{T}.Append(Block{T}, BlockCommit)"/>.</param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
         public ConsensusContext(
             DelegateBroadcastMessage broadcastMessage,
             BlockChain<T> blockChain,
             PrivateKey privateKey,
-            TimeSpan newHeightDelay,
+            TimeSpan commitBlockDelay,
             ContextTimeoutOption contextTimeoutOption)
         {
             BroadcastMessage = broadcastMessage;
             _blockChain = blockChain;
             _privateKey = privateKey;
             Height = -1;
-            _newHeightDelay = newHeightDelay;
+            _commitBlockDelay = commitBlockDelay;
 
             _contextTimeoutOption = contextTimeoutOption;
 
@@ -140,7 +136,6 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="IDisposable.Dispose"/>
         public void Dispose()
         {
-            _newHeightCts?.Cancel();
             lock (_contextLock)
             {
                 foreach (Context<T> context in _contexts.Values)
@@ -165,8 +160,6 @@ namespace Libplanet.Net.Consensus
         {
             lock (_newHeightLock)
             {
-                _newHeightCts?.Cancel();
-
                 _logger.Information(
                     "Invoked {FName}() for new height #{NewHeight} from old height #{OldHeight}",
                     nameof(NewHeight),
@@ -309,10 +302,7 @@ namespace Libplanet.Net.Consensus
 
         /// <summary>
         /// A handler for <see cref="BlockChain{T}.TipChanged"/> event that calls
-        /// <see cref="NewHeight"/>.  Starting a new height will be delayed for
-        /// <see cref="_newHeightDelay"/> in order to collect remaining delayed votes
-        /// and stabilize the consensus process by waiting for Global Stabilization Time.
-        /// </summary>
+        /// <see cref="NewHeight"/>.</summary>
         /// <param name="sender">The source object instance for <see cref="EventHandler"/>.
         /// </param>
         /// <param name="e">The event arguments given by <see cref="BlockChain{T}.TipChanged"/>
@@ -320,38 +310,17 @@ namespace Libplanet.Net.Consensus
         /// </param>
         private void OnTipChanged(object? sender, (Block<T> OldTip, Block<T> NewTip) e)
         {
-            // TODO: Should set delay by using GST.
-            _newHeightCts?.Cancel();
-            _newHeightCts?.Dispose();
-            _newHeightCts = new CancellationTokenSource();
-            Task.Run(
-                async () =>
-                {
-                    await Task.Delay(_newHeightDelay, _newHeightCts.Token);
-                    if (!_newHeightCts.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            NewHeight(e.NewTip.Index + 1);
-                        }
-                        catch (Exception exc)
-                        {
-                            _logger.Error(
-                                exc,
-                                "Unexpected exception occurred during {FName}()",
-                                nameof(NewHeight));
-                        }
-                    }
-                    else
-                    {
-                        _logger.Error(
-                            "Did not invoke {FName}() for height " +
-                            "#{Height} because cancellation is requested",
-                            nameof(NewHeight),
-                            e.NewTip.Index + 1);
-                    }
-                },
-                _newHeightCts.Token);
+            try
+            {
+                NewHeight(e.NewTip.Index + 1);
+            }
+            catch (Exception exc)
+            {
+                _logger.Error(
+                    exc,
+                    "Unexpected exception occurred during {FName}()",
+                    nameof(NewHeight));
+            }
         }
 
         /// <summary>
@@ -368,6 +337,7 @@ namespace Libplanet.Net.Consensus
                 height,
                 _privateKey,
                 _blockChain.GetValidatorSet(_blockChain[Height - 1].Hash),
+                _commitBlockDelay,
                 contextTimeoutOptions: _contextTimeoutOption);
             AttachEventHandlers(context);
             return context;

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -43,8 +43,8 @@ namespace Libplanet.Net.Consensus
         /// itself.
         /// </param>
         /// <param name="seedPeers">A list of seed's <see cref="BoundPeer"/>.</param>
-        /// <param name="newHeightDelay">A time delay in starting the consensus for the next height
-        /// block.
+        /// <param name="commitBlockDelay">A time delay between <see cref="Step.EndCommit"/>
+        /// and <see cref="BlockChain{T}.Append(Blocks.Block{T}, Blocks.BlockCommit)"/>.
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
@@ -54,7 +54,7 @@ namespace Libplanet.Net.Consensus
             PrivateKey privateKey,
             ImmutableList<BoundPeer> validatorPeers,
             ImmutableList<BoundPeer> seedPeers,
-            TimeSpan newHeightDelay,
+            TimeSpan commitBlockDelay,
             ContextTimeoutOption contextTimeoutOption)
         {
             validatorPeers ??= ImmutableList<BoundPeer>.Empty;
@@ -72,7 +72,7 @@ namespace Libplanet.Net.Consensus
                 PublishMessage,
                 blockChain,
                 privateKey,
-                newHeightDelay,
+                commitBlockDelay,
                 contextTimeoutOption);
 
             _logger = Log

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -258,38 +258,7 @@ namespace Libplanet.Net.Consensus
                 Step = Step.EndCommit;
                 _decision = block4;
                 _committedRound = round;
-
-                try
-                {
-                    _logger.Information(
-                        "Committing block #{Index} {Hash} (context: {Context})",
-                        block4.Index,
-                        block4.Hash,
-                        ToString());
-
-                    IsValid(block4, out var evaluatedActions);
-
-                    _blockChain.Append(
-                        block4,
-                        GetBlockCommit(),
-                        true,
-                        actionEvaluations: evaluatedActions);
-                }
-                catch (Exception e)
-                {
-                    _logger.Error(
-                        e,
-                        "Failed to commit block #{Index} {Hash}",
-                        block4.Index,
-                        block4.Hash);
-                    ExceptionOccurred?.Invoke(this, e);
-                    return;
-                }
-
-                _logger.Information(
-                    "Committed block #{Index} {Hash}",
-                    block4.Index,
-                    block4.Hash);
+                _ = ScheduleCommitBlock(block4);
                 return;
             }
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -85,6 +85,7 @@ namespace Libplanet.Net.Consensus
         private readonly BlockChain<T> _blockChain;
         private readonly Codec _codec;
         private readonly ValidatorSet _validatorSet;
+        private readonly TimeSpan _commitBlockDelay;
         private readonly Channel<ConsensusMsg> _messageRequests;
         private readonly Channel<System.Action> _mutationRequests;
         private readonly MessageLog _messageLog;
@@ -126,6 +127,9 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="validators">The <see cref="ValidatorSet"/> for
         /// given <paramref name="height"/>.</param>
+        /// <param name="commitBlockDelay">A time delay between <see cref="Step.EndCommit"/>
+        /// and <see cref="BlockChain{T}.Append(Block{T}, BlockCommit)"/>.
+        /// <seealso cref="ScheduleCommitBlock(Block{T})"/></param>
         /// <param name="contextTimeoutOptions">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="Step"/>.</param>
         public Context(
@@ -134,6 +138,7 @@ namespace Libplanet.Net.Consensus
             long height,
             PrivateKey privateKey,
             ValidatorSet validators,
+            TimeSpan commitBlockDelay,
             ContextTimeoutOption contextTimeoutOptions)
             : this(
                 consensusContext,
@@ -141,6 +146,7 @@ namespace Libplanet.Net.Consensus
                 height,
                 privateKey,
                 validators,
+                commitBlockDelay,
                 Step.Default,
                 -1,
                 128,
@@ -154,6 +160,7 @@ namespace Libplanet.Net.Consensus
             long height,
             PrivateKey privateKey,
             ValidatorSet validators,
+            TimeSpan commitBlockDelay,
             Step step,
             int round = -1,
             int cacheSize = 128,
@@ -190,6 +197,7 @@ namespace Libplanet.Net.Consensus
             _hasTwoThirdsPreVoteFlags = new HashSet<int>();
             _preCommitTimeoutFlags = new HashSet<int>();
             _validatorSet = validators;
+            _commitBlockDelay = commitBlockDelay;
             _cancellationTokenSource = new CancellationTokenSource();
             ConsensusContext = consensusContext;
             _blockValidationCache =


### PR DESCRIPTION
### Rationale
1. `ConsensusContext` doesn't have to be asynchronous, but it's asynchronous only due to delay before `NewHeight`.
2. For now, consensus waits after block has been committed, so `BlockCommit` only have `Vote`s before waiting period while appending.
3. Timing will be synced when validators comes to `EndCommit` step, and block appending will be executed immediately without state transition, so it doesn't matter if we move waiting period to before appending. (Timing of validators' `OnTipChanged` still will be synced)
4. If we can sync timing of `OnTipChanged`, it seems more natural not to wait after block has been committed.

### Changes
- Move `newHeightDelay` to `EndCommit` step, to be wait before block has been committed.

### Trivials
- This can be done since action evaluation caching(#3028) has been merged already.

### Related PRs
- https://github.com/planetarium/libplanet/pull/3028

### Related issues
- https://github.com/planetarium/libplanet/issues/3103