### PR TITLE
♻️ Streamlined rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ To be released.
     `IActionRenderer<T>.UnrenderActionError()`.  [[#3092]]
  -  Removed `NonblockRenderer`, `NonblockActionRenderer`, `DelayedRenderer`,
     and `DelayedActionRenderer` classes.  [[#3098]]
+ -  (Libplanet.Net) Removed optional `render` parameter from
+    all `Swarm<T>.PreloadAsync()` overload methods.  No rendering is done
+    during the preloading phase.  [[#3108]]
 
 ### Backward-incompatible network protocol changes
 
@@ -54,6 +57,7 @@ To be released.
 [#3092]: https://github.com/planetarium/libplanet/pull/3092
 [#3098]: https://github.com/planetarium/libplanet/pull/3098
 [#3106]: https://github.com/planetarium/libplanet/pull/3106
+[#3108]: https://github.com/planetarium/libplanet/pull/3108
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -759,14 +759,14 @@ namespace Libplanet.Net.Tests
                 new[] { transactions[0] },
                 miner: GenesisProposer.PublicKey
             ).Evaluate(GenesisProposer, blockChain);
-            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true, false);
+            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true);
             Block<DumbAction> block2 = ProposeNext(
                 block1,
                 new[] { transactions[1] },
                 miner: GenesisProposer.PublicKey,
                 lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(GenesisProposer, blockChain);
-            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true, false);
+            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true);
 
             try
             {

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -759,14 +759,14 @@ namespace Libplanet.Net.Tests
                 new[] { transactions[0] },
                 miner: GenesisProposer.PublicKey
             ).Evaluate(GenesisProposer, blockChain);
-            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true, true, false);
+            blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true, false);
             Block<DumbAction> block2 = ProposeNext(
                 block1,
                 new[] { transactions[1] },
                 miner: GenesisProposer.PublicKey,
                 lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)
             ).Evaluate(GenesisProposer, blockChain);
-            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true, true, false);
+            blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true, false);
 
             try
             {

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -473,7 +473,7 @@ namespace Libplanet.Net.Tests
                     blockInterval: TimeSpan.FromSeconds(1),
                     lastCommit: CreateBlockCommit(minerChain.Tip)
                 ).Evaluate(ChainPrivateKey, minerChain);
-                minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), false, true, false);
+                minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true, false);
 
                 await receiverSwarm.PreloadAsync();
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -473,7 +473,7 @@ namespace Libplanet.Net.Tests
                     blockInterval: TimeSpan.FromSeconds(1),
                     lastCommit: CreateBlockCommit(minerChain.Tip)
                 ).Evaluate(ChainPrivateKey, minerChain);
-                minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true, false);
+                minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true);
 
                 await receiverSwarm.PreloadAsync();
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -373,28 +373,19 @@ namespace Libplanet.Net.Tests
         }
 
         [RetryFact(Timeout = Timeout)]
-        public async Task RenderInPreload()
+        public async Task NoRenderInPreload()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var renderer1 = new RecordingActionRenderer<DumbAction>();
-            var renderer2 = new RecordingActionRenderer<DumbAction>();
-            var chain1 = MakeBlockChain(
+            var renderer = new RecordingActionRenderer<DumbAction>();
+            var chain = MakeBlockChain(
                 policy,
                 new MemoryStore(),
                 new TrieStateStore(new MemoryKeyValueStore()),
-                renderers: new[] { renderer1 }
-            );
-            var chain2 = MakeBlockChain(
-                policy,
-                new MemoryStore(),
-                new TrieStateStore(new MemoryKeyValueStore()),
-                renderers: new[] { renderer2 }
-            );
+                renderers: new[] { renderer });
 
             var senderKey = new PrivateKey();
 
-            var receiver1 = await CreateSwarm(chain1).ConfigureAwait(false);
-            var receiver2 = await CreateSwarm(chain2).ConfigureAwait(false);
+            var receiver = await CreateSwarm(chain).ConfigureAwait(false);
             var sender = await CreateSwarm(
                 MakeBlockChain(
                     policy,
@@ -404,7 +395,7 @@ namespace Libplanet.Net.Tests
                 senderKey
             ).ConfigureAwait(false);
 
-            int renderCount1 = 0, renderCount2 = 0;
+            int renderCount = 0;
 
             var privKey = new PrivateKey();
             var addr = sender.Address;
@@ -419,25 +410,18 @@ namespace Libplanet.Net.Tests
                 sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
-            renderer1.RenderEventHandler += (_, a) =>
-                renderCount1 += a is DumbAction ? 1 : 0;
-            renderer2.RenderEventHandler += (_, a) =>
-                renderCount2 += a is DumbAction ? 1 : 0;
+            renderer.RenderEventHandler += (_, a) =>
+                renderCount += a is DumbAction ? 1 : 0;
 
-            await StartAsync(receiver1);
+            await StartAsync(receiver);
             await StartAsync(sender);
 
-            await BootstrapAsync(receiver1, sender.AsPeer);
-            await BootstrapAsync(receiver2, sender.AsPeer);
-            await receiver1.PreloadAsync(render: false);
-            await receiver2.PreloadAsync(render: true);
+            await BootstrapAsync(receiver, sender.AsPeer);
+            await receiver.PreloadAsync();
 
-            Assert.Equal(sender.BlockChain.Tip, receiver1.BlockChain.Tip);
-            Assert.Equal(sender.BlockChain.Count, receiver1.BlockChain.Count);
-            Assert.Equal(sender.BlockChain.Count, receiver2.BlockChain.Count);
-            Assert.Equal(sender.BlockChain.Count, receiver2.BlockChain.Count);
-            Assert.Equal(0, renderCount1);
-            Assert.Equal(1, renderCount2);
+            Assert.Equal(sender.BlockChain.Tip, receiver.BlockChain.Tip);
+            Assert.Equal(sender.BlockChain.Count, receiver.BlockChain.Count);
+            Assert.Equal(0, renderCount);
         }
 
         [Fact(Timeout = Timeout)]

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -274,7 +274,6 @@ namespace Libplanet.Net.Consensus
                         GetBlockCommit(),
                         true,
                         true,
-                        true,
                         actionEvaluations: evaluatedActions);
                 }
                 catch (Exception e)

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -273,7 +273,6 @@ namespace Libplanet.Net.Consensus
                         block4,
                         GetBlockCommit(),
                         true,
-                        true,
                         actionEvaluations: evaluatedActions);
                 }
                 catch (Exception e)

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -66,8 +66,7 @@ namespace Libplanet.Net
                     BlockChain.Tip.Hash);
                 synced = AppendPreviousBlocks(
                     blockChain: BlockChain,
-                    candidate: candidate,
-                    evaluateActions: true);
+                    candidate: candidate);
                 ProcessFillBlocksFinished.Set();
                 _logger.Debug(
                     "{MethodName}() finished appending blocks; synced tip is #{Index} {Hash}",
@@ -111,12 +110,11 @@ namespace Libplanet.Net
 
         private BlockChain<T> AppendPreviousBlocks(
             BlockChain<T> blockChain,
-            Branch<T> candidate,
-            bool evaluateActions)
+            Branch<T> candidate)
         {
             BlockChain<T> workspace = blockChain;
             List<Guid> scope = new List<Guid>();
-            bool renderActions = evaluateActions;
+            bool renderActions = true;
             bool renderBlocks = true;
 
             Block<T> oldTip = workspace.Tip;
@@ -179,7 +177,7 @@ namespace Libplanet.Net
                     workspace.Append(
                         block,
                         commit,
-                        evaluateActions: evaluateActions,
+                        evaluateActions: true,
                         renderBlocks: renderBlocks,
                         renderActions: renderActions);
                 }

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -175,11 +175,7 @@ namespace Libplanet.Net
                 foreach (var (block, commit) in blocks)
                 {
                     workspace.Append(
-                        block,
-                        commit,
-                        evaluateActions: true,
-                        renderBlocks: renderBlocks,
-                        renderActions: renderActions);
+                        block, commit, renderBlocks: renderBlocks, renderActions: renderActions);
                 }
             }
             catch (Exception e)

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -114,8 +114,7 @@ namespace Libplanet.Net
         {
             BlockChain<T> workspace = blockChain;
             List<Guid> scope = new List<Guid>();
-            bool renderActions = true;
-            bool renderBlocks = true;
+            bool render = true;
 
             Block<T> oldTip = workspace.Tip;
             Block<T> newTip = candidate.Blocks.Last().Item1;
@@ -155,8 +154,7 @@ namespace Libplanet.Net
                     nameof(AppendPreviousBlocks)
                 );
                 workspace = workspace.Fork(branchpoint.Hash);
-                renderActions = false;
-                renderBlocks = false;
+                render = false;
                 scope.Add(workspace.Id);
                 _logger.Debug(
                     "Fork finished. at {MethodName}()",
@@ -174,8 +172,7 @@ namespace Libplanet.Net
             {
                 foreach (var (block, commit) in blocks)
                 {
-                    workspace.Append(
-                        block, commit, renderBlocks: renderBlocks, renderActions: renderActions);
+                    workspace.Append(block, commit, render: render);
                 }
             }
             catch (Exception e)

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -553,8 +553,7 @@ namespace Libplanet.Net
 
                         Block<T> deltaBlock = workspace.Store.GetBlock<T>(deltaBlockHash);
                         BlockCommit deltaCommit = workspace.Store.GetBlockCommit(deltaBlockHash);
-                        workspace.Append(
-                            deltaBlock, deltaCommit, renderBlocks: false, renderActions: false);
+                        workspace.Append(deltaBlock, deltaCommit, render: false);
 
                         actionExecutionState.ExecutedBlockCount += 1;
                         actionExecutionState.ExecutedBlockHash = deltaBlock.Hash;

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -301,11 +301,10 @@ namespace Libplanet.Net
         }
 
 #pragma warning disable MEN003
-        private async Task<System.Action> CompleteBlocksAsync(
+        private async Task CompleteBlocksAsync(
             IList<(BoundPeer, IBlockExcerpt)> peersWithExcerpt,
             BlockChain<T> workspace,
             IProgress<PreloadState> progress,
-            bool render,
             CancellationToken cancellationToken)
         {
             // As preloading takes long, the blockchain data can corrupt if a program suddenly
@@ -316,13 +315,7 @@ namespace Libplanet.Net
             // Note that it does not pass any renderers here so that they render nothing
             // (because the workspace chain is for underlying).
             System.Action renderSwap = () => { };
-            var chainIds = new HashSet<Guid>
-            {
-                workspace.Id,
-            };
-            bool renderActions = render;
-            bool renderBlocks = true;
-
+            var chainIds = new HashSet<Guid> { workspace.Id };
             var complete = false;
 
             try
@@ -390,7 +383,7 @@ namespace Libplanet.Net
                 if (totalBlocksToDownload == 0)
                 {
                     _logger.Debug("No any blocks to fetch");
-                    return renderSwap;
+                    return;
                 }
 
                 IAsyncEnumerable<Tuple<Block<T>, BlockCommit, BoundPeer>> completedBlocks =
@@ -540,10 +533,8 @@ namespace Libplanet.Net
                     "Branchpoint block is #{Index} {Hash}",
                     branchpoint.Index,
                     branchpoint.Hash);
-                workspace = workspace.Fork(branchpoint.Hash, inheritRenderers: true);
+                workspace = workspace.Fork(branchpoint.Hash, inheritRenderers: false);
                 chainIds.Add(workspace.Id);
-                renderBlocks = false;
-                renderActions = false;
 
                 var actionExecutionState = new ActionExecutionState()
                 {
@@ -593,9 +584,8 @@ namespace Libplanet.Net
                             deltaBlock,
                             deltaCommit,
                             evaluateActions: false,
-                            renderBlocks: renderBlocks,
-                            renderActions: renderActions
-                        );
+                            renderBlocks: false,
+                            renderActions: false);
                         progress?.Report(
                             new BlockVerificationState
                             {
@@ -675,7 +665,7 @@ namespace Libplanet.Net
                         workspace.Tip
                     );
 
-                    renderSwap = BlockChain.Swap(workspace, render: render);
+                    renderSwap = BlockChain.Swap(workspace, render: false);
                     BlockChain.CleanupBlockCommitStore(BlockChain.Tip.Index);
                 }
 
@@ -690,8 +680,6 @@ namespace Libplanet.Net
 
                 _logger.Verbose("Remaining chains: {@ChainIds}", workspace.Store.ListChainIds());
             }
-
-            return renderSwap;
         }
 
         private void OnBlockChainTipChanged(object sender, (Block<T> OldTip, Block<T> NewTip) e)

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -554,11 +554,7 @@ namespace Libplanet.Net
                         Block<T> deltaBlock = workspace.Store.GetBlock<T>(deltaBlockHash);
                         BlockCommit deltaCommit = workspace.Store.GetBlockCommit(deltaBlockHash);
                         workspace.Append(
-                            deltaBlock,
-                            deltaCommit,
-                            evaluateActions: true,
-                            renderBlocks: false,
-                            renderActions: false);
+                            deltaBlock, deltaCommit, renderBlocks: false, renderActions: false);
 
                         actionExecutionState.ExecutedBlockCount += 1;
                         actionExecutionState.ExecutedBlockHash = deltaBlock.Hash;

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -256,7 +256,7 @@ namespace Libplanet.Net
         /// a lot of calls to methods of <see cref="BlockChain{T}.Renderers"/> in a short
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
         /// these actions in the behind blocks use
-        /// <see cref="PreloadAsync(IProgress{PreloadState}, bool, CancellationToken)"/>
+        /// <see cref="PreloadAsync(IProgress{PreloadState}, CancellationToken)"/>
         /// method too.</remarks>
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
@@ -292,7 +292,7 @@ namespace Libplanet.Net
         /// a lot of calls to methods of <see cref="BlockChain{T}.Renderers"/> in a short
         /// period of time.  This can lead a game startup slow.  If you want to omit rendering of
         /// these actions in the behind blocks use
-        /// <see cref="PreloadAsync(IProgress{PreloadState}, bool, CancellationToken)"/>
+        /// <see cref="PreloadAsync(IProgress{PreloadState}, CancellationToken)"/>
         /// method too.</remarks>
         public async Task StartAsync(
             TimeSpan dialTimeout,
@@ -491,8 +491,6 @@ namespace Libplanet.Net
         /// <param name="progress">
         /// An instance that receives progress updates for block downloads.
         /// </param>
-        /// <param name="render">
-        /// The value indicates whether to render blocks and actions while preloading.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -507,14 +505,12 @@ namespace Libplanet.Net
         /// failed.</exception>
         public async Task PreloadAsync(
             IProgress<PreloadState> progress = null,
-            bool render = false,
             CancellationToken cancellationToken = default)
         {
             await PreloadAsync(
                 Options.PreloadOptions.DialTimeout,
                 Options.PreloadOptions.TipDeltaThreshold,
                 progress,
-                render,
                 cancellationToken);
         }
 
@@ -533,8 +529,6 @@ namespace Libplanet.Net
         /// <param name="progress">
         /// An instance that receives progress updates for block downloads.
         /// </param>
-        /// <param name="render">
-        /// The value indicates whether to render blocks and actions while preloading.</param>
         /// <param name="cancellationToken">
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
@@ -551,7 +545,6 @@ namespace Libplanet.Net
             TimeSpan? dialTimeout,
             long tipDeltaThreshold,
             IProgress<PreloadState> progress = null,
-            bool render = false,
             CancellationToken cancellationToken = default)
         {
             using CancellationTokenRegistration ctr = cancellationToken.Register(() =>
@@ -624,13 +617,11 @@ namespace Libplanet.Net
 
                 _logger.Information("Preloading (trial #{Trial}) started...", i + 1);
                 BlockChain<T> workspace = BlockChain.Fork(localTip.Hash, inheritRenderers: false);
-                var renderSwap = await CompleteBlocksAsync(
+                await CompleteBlocksAsync(
                     peersWithExcerpts,
                     workspace,
                     progress,
-                    render: render,
                     cancellationToken: cancellationToken);
-                renderSwap();
             }
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -960,8 +960,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputStates.GetState(block.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
 
-            chain.Append(
-                block, CreateBlockCommit(block), renderBlocks: true, renderActions: false);
+            chain.Append(block, CreateBlockCommit(block), render: true);
             previousStates = AccountStateDeltaImpl.ChooseVersion(
                 block.ProtocolVersion,
                 addresses => chain.GetStates(addresses, block.PreviousHash),

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -961,11 +961,7 @@ namespace Libplanet.Tests.Action
             Assert.True(evaluation.InputContext.BlockAction);
 
             chain.Append(
-                block,
-                CreateBlockCommit(block),
-                evaluateActions: false,
-                renderBlocks: true,
-                renderActions: false);
+                block, CreateBlockCommit(block), renderBlocks: true, renderActions: false);
             previousStates = AccountStateDeltaImpl.ChooseVersion(
                 block.ProtocolVersion,
                 addresses => chain.GetStates(addresses, block.PreviousHash),

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -376,21 +376,16 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.Append(
                     block,
                     TestUtils.CreateBlockCommit(block),
-                    evaluateActions: false,
                     renderBlocks: true,
-                    renderActions: true
-                )
-            );
+                    renderActions: true));
             Assert.False(_blockChain.ContainsBlock(block.Hash));
             Assert.Empty(_renderer.ActionRecords);
 
             _blockChain.Append(
                 block,
                 TestUtils.CreateBlockCommit(block),
-                evaluateActions: false,
                 renderBlocks: true,
-                renderActions: false
-            );
+                renderActions: false);
             Assert.Equal(block, _blockChain.Tip);
             Assert.Empty(_renderer.ActionRecords);
         }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -362,35 +362,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [SkippableFact]
-        public void AppendWithoutEvaluateActions()
-        {
-            var miner = new PrivateKey();
-            var genesis = _blockChain.Genesis;
-
-            Block<DumbAction> block = TestUtils.ProposeNext(
-                genesis,
-                miner: miner.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(miner, _blockChain);
-            Assert.Throws<ArgumentException>(() =>
-                _blockChain.Append(
-                    block,
-                    TestUtils.CreateBlockCommit(block),
-                    renderBlocks: true,
-                    renderActions: true));
-            Assert.False(_blockChain.ContainsBlock(block.Hash));
-            Assert.Empty(_renderer.ActionRecords);
-
-            _blockChain.Append(
-                block,
-                TestUtils.CreateBlockCommit(block),
-                renderBlocks: true,
-                renderActions: false);
-            Assert.Equal(block, _blockChain.Tip);
-            Assert.Empty(_renderer.ActionRecords);
-        }
-
-        [SkippableFact]
         public void AppendWhenActionEvaluationFailed()
         {
             var policy = new NullBlockPolicy<ThrowException>();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -114,11 +114,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: _fx.Proposer.PublicKey
             ).Evaluate(_fx.Proposer, _blockChain);
 
-            _blockChain.Append(
-                block1,
-                CreateBlockCommit(block1),
-                renderBlocks: true,
-                renderActions: false);
+            _blockChain.Append(block1, CreateBlockCommit(block1), render: true);
 
             var minerAddress = genesis.Miner;
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -117,10 +117,8 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.Append(
                 block1,
                 CreateBlockCommit(block1),
-                evaluateActions: false,
                 renderBlocks: true,
-                renderActions: false
-            );
+                renderActions: false);
 
             var minerAddress = genesis.Miner;
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -865,10 +865,8 @@ namespace Libplanet.Tests.Blockchain
             fork.Append(
                 forkTip,
                 CreateBlockCommit(forkTip),
-                evaluateActions: true,
                 renderBlocks: true,
-                renderActions: false
-            );
+                renderActions: false);
 
             Guid previousChainId = _blockChain.Id;
             _renderer.ResetRecords();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -862,11 +862,7 @@ namespace Libplanet.Tests.Blockchain
                 miner: miner.PublicKey,
                 lastCommit: CreateBlockCommit(fork.Tip)
             ).Evaluate(miner, fork);
-            fork.Append(
-                forkTip,
-                CreateBlockCommit(forkTip),
-                renderBlocks: true,
-                renderActions: false);
+            fork.Append(forkTip, CreateBlockCommit(forkTip), render: true);
 
             Guid previousChainId = _blockChain.Id;
             _renderer.ResetRecords();

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -710,7 +710,6 @@ namespace Libplanet.Blockchain
             Append(
                 block,
                 blockCommit,
-                evaluateActions: true,
                 renderBlocks: true,
                 renderActions: true
             );
@@ -1091,7 +1090,6 @@ namespace Libplanet.Blockchain
         internal void Append(
             Block<T> block,
             BlockCommit blockCommit,
-            bool evaluateActions,
             bool renderBlocks,
             bool renderActions,
             IReadOnlyList<ActionEvaluation> actionEvaluations = null
@@ -1107,15 +1105,6 @@ namespace Libplanet.Blockchain
                 throw new ArgumentException(
                     $"Cannot append genesis block #{block.Index} {block.Hash} to a chain.",
                     nameof(block));
-            }
-
-            if (!evaluateActions && renderActions)
-            {
-                throw new ArgumentException(
-                    $"{nameof(renderActions)} option requires {nameof(evaluateActions)} " +
-                    "to be turned on.",
-                    nameof(renderActions)
-                );
             }
 
             renderActions = renderActions && renderBlocks && ActionRenderers.Any();
@@ -1158,7 +1147,7 @@ namespace Libplanet.Blockchain
                 _rwlock.EnterWriteLock();
                 try
                 {
-                    if (evaluateActions && actionEvaluations is null)
+                    if (actionEvaluations is null)
                     {
                         _logger.Information(
                             "Executing actions in block #{BlockIndex} {BlockHash}...",

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -707,12 +707,7 @@ namespace Libplanet.Blockchain
             Block<T> block,
             BlockCommit blockCommit
         ) =>
-            Append(
-                block,
-                blockCommit,
-                renderBlocks: true,
-                renderActions: true
-            );
+            Append(block, blockCommit, render: true);
 
         /// <summary>
         /// Adds <paramref name="transaction"/> to the pending list so that a next
@@ -1090,8 +1085,7 @@ namespace Libplanet.Blockchain
         internal void Append(
             Block<T> block,
             BlockCommit blockCommit,
-            bool renderBlocks,
-            bool renderActions,
+            bool render,
             IReadOnlyList<ActionEvaluation> actionEvaluations = null
         )
         {
@@ -1106,8 +1100,6 @@ namespace Libplanet.Blockchain
                     $"Cannot append genesis block #{block.Index} {block.Hash} to a chain.",
                     nameof(block));
             }
-
-            renderActions = renderActions && renderBlocks && ActionRenderers.Any();
 
             _logger.Information(
                 "Trying to append block #{BlockIndex} {BlockHash}...", block.Index, block.Hash);
@@ -1236,7 +1228,7 @@ namespace Libplanet.Blockchain
                     block.Index,
                     block.Hash);
 
-                if (renderBlocks)
+                if (render)
                 {
                     _logger.Information(
                         "Invoking {RendererCount} renderers and " +
@@ -1252,14 +1244,7 @@ namespace Libplanet.Blockchain
 
                     if (ActionRenderers.Any())
                     {
-                        if (renderActions)
-                        {
-                            RenderActions(
-                                evaluations: actionEvaluations,
-                                block: block
-                            );
-                        }
-
+                        RenderActions(evaluations: actionEvaluations, block: block);
                         foreach (IActionRenderer<T> renderer in ActionRenderers)
                         {
                             renderer.RenderBlockEnd(oldTip: prevTip ?? Genesis, newTip: block);


### PR DESCRIPTION
Resolves #3095.
Somewhat of a continuation of #3098.

Notable changes:
- Internal `Append()` has greatly reduced options
  - Whether to evaluate a give `Block<T>` is solely determined by whether `actionEvaluations` is provided or not.
  - There is no longer a split option for rendering `Renderer`s and `ActionRenderer`s.
- Rendering is disabled (possibly temporarily) for the preloading phase.