### PR TITLE
Update return type for `IActionEvaluator.Evaluate()` to `IReadOnlyList<IActionEvaluation>`

### DIFF
--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -98,6 +98,10 @@ namespace Libplanet.Action
 
         /// <inheritdoc/>
         [Pure]
+        IReadOnlyList<IActionEvaluation> IActionEvaluator.Evaluate(IPreEvaluationBlock block) =>
+            Evaluate(block);
+
+        [Pure]
         public IReadOnlyList<ActionEvaluation> Evaluate(IPreEvaluationBlock block)
         {
             _logger.Information(

--- a/Libplanet/Action/IActionEvaluator.cs
+++ b/Libplanet/Action/IActionEvaluator.cs
@@ -22,6 +22,6 @@ namespace Libplanet.Action
         /// the end.</para>
         /// </remarks>
         [Pure]
-        IReadOnlyList<ActionEvaluation> Evaluate(IPreEvaluationBlock block);
+        IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block);
     }
 }

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -176,7 +176,7 @@ namespace Libplanet.Blockchain
                 {
                     Block<T> block = Store.GetBlock<T>(hash);
                     ImmutableList<IActionEvaluation> evaluations =
-                        ActionEvaluator.Evaluate(block).Cast<IActionEvaluation>().ToImmutableList();
+                        ActionEvaluator.Evaluate(block).ToImmutableList();
 
                     count += RenderActions(
                         evaluations: evaluations,


### PR DESCRIPTION
This pull request changes the return type of `IActionEvalutor.Evaluate()` to `IReadOnlyList<IActionEvaluation>`.

Skip changelog because `IActionEvaluator` is not released yet.