### PR TITLE
test(@planetarium/tx): correct tx test data

### DIFF
--- a/@planetarium/tx/test/tx/signed.test.ts
+++ b/@planetarium/tx/test/tx/signed.test.ts
@@ -64,7 +64,6 @@ describe("signTx", () => {
             "\ufeffrecipient": "0x8a29de186b85560d708451101c4bf02d63b25c50",
           },
         },
-        type: "system",
       },
       timestamp: "2022-05-23T01:02:00+00:00",
       publicKey:
@@ -162,7 +161,6 @@ describe("signTx", () => {
             },
           },
         ],
-        type: "custom",
       },
       timestamp: "2022-05-23T01:02:00+00:00",
       publicKey:

--- a/@planetarium/tx/test/tx/unsigned.test.ts
+++ b/@planetarium/tx/test/tx/unsigned.test.ts
@@ -59,7 +59,6 @@ test("encodeUnsignedTxWithSystemAction", async () => {
           "\ufeffrecipient": "0x8a29de186b85560d708451101c4bf02d63b25c50",
         },
       },
-      type: "system",
     },
     timestamp: "2022-05-23T01:02:00+00:00",
     publicKey:
@@ -151,7 +150,6 @@ test("encodeUnsignedTxWithCustomActions", async () => {
           },
         },
       ],
-      type: "custom",
     },
     timestamp: "2022-05-23T01:02:00+00:00",
     publicKey:


### PR DESCRIPTION
Currently, tests in `@planetarium/tx` are failing because the test data is not updated correctly. Since #3110 PR, the `type` property was removed but it was not applied to the `@planetarium/tx` package's test data yet.

https://github.com/planetarium/libplanet/pull/3110/files#diff-6bef7475a39e1cf3932feaac7dcb733711a27edde2e0f6a851ab8552b9087c48L188