### PR TITLE
Update txexecution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 1.0.1
 
 To be released.
 
+### Bug fixes
+
+ -  Fixed a bug where `BlockChain<T>.Append()` hadn't update tx executions
+    even `evaluateActions` set to `true` when `actionEvaluations` are given.
+    [[#3125]]
+
+[#3125]: https://github.com/planetarium/libplanet/pull/3125
+
 
 Version 1.0.0
 -------------

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -1158,21 +1158,24 @@ namespace Libplanet.Blockchain
                 _rwlock.EnterWriteLock();
                 try
                 {
-                    if (evaluateActions && actionEvaluations is null)
+                    if (evaluateActions)
                     {
-                        _logger.Information(
-                            "Executing actions in block #{BlockIndex} {BlockHash}...",
-                            block.Index,
-                            block.Hash);
-                        ValidateBlockStateRootHash(block, out actionEvaluations);
+                        if (actionEvaluations is null)
+                        {
+                            _logger.Information(
+                                "Executing actions in block #{BlockIndex} {BlockHash}...",
+                                block.Index,
+                                block.Hash);
+                            ValidateBlockStateRootHash(block, out actionEvaluations);
+                            _logger.Information(
+                                "Executed actions in block #{BlockIndex} {BlockHash}",
+                                block.Index,
+                                block.Hash);
+                        }
+
                         IEnumerable<TxExecution> txExecutions =
                             MakeTxExecutions(block, actionEvaluations);
                         UpdateTxExecutions(txExecutions);
-
-                        _logger.Information(
-                            "Executed actions in block #{BlockIndex} {BlockHash}",
-                            block.Index,
-                            block.Hash);
 
                         // FIXME: Using evaluateActions as a proxy flag for preloading status.
                         const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";


### PR DESCRIPTION
Fixed a bug where `BlockChain<T>.Append()` hadn't update tx executions even `evaluateActions` set to `true` when `actionEvaluations` are given.