### PR TITLE
🧹 Remove `PreEvaluationBlock.Evaluate()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@ To be released.
         instead.
      -  Changed `PreEvaluationBlock<T>` to `PreEvaluationBlock`.
          -  `PreEvaluationBlock.Evaluate<T>()` now requires type parameter `T`.
+ -  Removed `PreEvaluationBlock.Evaluate<T>()` method.  [[#3127]]
 
 ### Backward-incompatible network protocol changes
 
@@ -119,6 +120,7 @@ To be released.
 [#3116]: https://github.com/planetarium/libplanet/pull/3116
 [#3121]: https://github.com/planetarium/libplanet/pull/3121
 [#3123]: https://github.com/planetarium/libplanet/pull/3123
+[#3127]: https://github.com/planetarium/libplanet/pull/3127
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -228,7 +228,8 @@ public class GeneratedBlockChainFixture
     {
         var random = new System.Random(seed);
         var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
-        var block = new BlockContent(
+        var block = Chain.EvaluateAndSign(
+            new BlockContent(
                 new BlockMetadata(
                     Chain.Tip.Index + 1,
                     DateTimeOffset.UtcNow,
@@ -236,9 +237,8 @@ public class GeneratedBlockChainFixture
                     Chain.Tip.Hash,
                     BlockContent.DeriveTxHash(transactions),
                     Chain.Store.GetChainBlockCommit(Chain.Store.GetCanonicalChainId()!.Value)),
-                transactions)
-            .Propose()
-            .Evaluate<PolymorphicAction<SimpleAction>>(pk, Chain);
+                transactions).Propose(),
+            pk);
         Chain.Append(
             block,
             new BlockCommit(

--- a/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/Context/ContextProposerValidRoundTest.cs
@@ -5,7 +5,6 @@ using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
-using Libplanet.Tests.Common.Action;
 using Nito.AsyncEx;
 using Serilog;
 using Xunit;
@@ -160,17 +159,18 @@ namespace Libplanet.Net.Tests.Consensus.Context
             };
 
             var key = new PrivateKey();
-            var differentBlock = new BlockContent(
-                new BlockMetadata(
-                    protocolVersion: BlockMetadata.CurrentProtocolVersion,
-                    index: blockChain.Tip.Index + 1,
-                    timestamp: blockChain.Tip.Timestamp.Add(TimeSpan.FromSeconds(1)),
-                    miner: key.PublicKey.ToAddress(),
-                    publicKey: key.PublicKey,
-                    previousHash: blockChain.Tip.Hash,
-                    txHash: null,
-                    lastCommit: null))
-                .Propose().Evaluate<DumbAction>(key, blockChain);
+            var differentBlock = blockChain.EvaluateAndSign(
+                new BlockContent(
+                    new BlockMetadata(
+                        protocolVersion: BlockMetadata.CurrentProtocolVersion,
+                        index: blockChain.Tip.Index + 1,
+                        timestamp: blockChain.Tip.Timestamp.Add(TimeSpan.FromSeconds(1)),
+                        miner: key.PublicKey.ToAddress(),
+                        publicKey: key.PublicKey,
+                        previousHash: blockChain.Tip.Hash,
+                        txHash: null,
+                        lastCommit: null)).Propose(),
+                key);
 
             context.Start();
             await proposalSent.WaitAsync();

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -754,20 +755,15 @@ namespace Libplanet.Net.Tests
                     privateKey: privateKey),
             };
 
-            Block block1 = blockChain.EvaluateAndSign(
-                ProposeNext(
-                    blockChain.Genesis,
-                    new[] { transactions[0] },
-                    miner: GenesisProposer.PublicKey),
-                GenesisProposer);
+            Block block1 = blockChain.ProposeBlock(
+                GenesisProposer,
+                new[] { transactions[0] }.ToImmutableList(),
+                TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true);
-            Block block2 = blockChain.EvaluateAndSign(
-                ProposeNext(
-                    block1,
-                    new[] { transactions[1] },
-                    miner: GenesisProposer.PublicKey,
-                    lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)),
-                GenesisProposer);
+            Block block2 = blockChain.ProposeBlock(
+                GenesisProposer,
+                new[] { transactions[1] }.ToImmutableList(),
+                CreateBlockCommit(blockChain.Tip));
             blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true);
 
             try

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -754,18 +754,20 @@ namespace Libplanet.Net.Tests
                     privateKey: privateKey),
             };
 
-            Block block1 = ProposeNext(
-                blockChain.Genesis,
-                new[] { transactions[0] },
-                miner: GenesisProposer.PublicKey
-            ).Evaluate(GenesisProposer, blockChain);
+            Block block1 = blockChain.EvaluateAndSign(
+                ProposeNext(
+                    blockChain.Genesis,
+                    new[] { transactions[0] },
+                    miner: GenesisProposer.PublicKey),
+                GenesisProposer);
             blockChain.Append(block1, TestUtils.CreateBlockCommit(block1), true);
-            Block block2 = ProposeNext(
-                block1,
-                new[] { transactions[1] },
-                miner: GenesisProposer.PublicKey,
-                lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)
-            ).Evaluate(GenesisProposer, blockChain);
+            Block block2 = blockChain.EvaluateAndSign(
+                ProposeNext(
+                    block1,
+                    new[] { transactions[1] },
+                    miner: GenesisProposer.PublicKey,
+                    lastCommit: CreateBlockCommit(block1.Hash, block1.Index, 0)),
+                GenesisProposer);
             blockChain.Append(block2, TestUtils.CreateBlockCommit(block2), true);
 
             try

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -127,11 +127,12 @@ namespace Libplanet.Net.Tests
             var blocks = new List<Block>();
             foreach (int i in Enumerable.Range(0, 12))
             {
-                Block block = ProposeNext(
-                    previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(minerChain.Tip)
-                ).Evaluate(ChainPrivateKey, minerChain);
+                Block block = minerChain.EvaluateAndSign(
+                    ProposeNext(
+                        previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
+                        miner: ChainPrivateKey.PublicKey,
+                        lastCommit: CreateBlockCommit(minerChain.Tip)),
+                    ChainPrivateKey);
                 blocks.Add(block);
                 if (i != 11)
                 {
@@ -466,13 +467,14 @@ namespace Libplanet.Net.Tests
                     DateTimeOffset.UtcNow
                 );
 
-                Block block = ProposeNext(
-                    minerChain.Tip,
-                    new[] { tx },
-                    miner: ChainPrivateKey.PublicKey,
-                    blockInterval: TimeSpan.FromSeconds(1),
-                    lastCommit: CreateBlockCommit(minerChain.Tip)
-                ).Evaluate(ChainPrivateKey, minerChain);
+                Block block = minerChain.EvaluateAndSign(
+                    ProposeNext(
+                        minerChain.Tip,
+                        new[] { tx },
+                        miner: ChainPrivateKey.PublicKey,
+                        blockInterval: TimeSpan.FromSeconds(1),
+                        lastCommit: CreateBlockCommit(minerChain.Tip)),
+                    ChainPrivateKey);
                 minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true);
 
                 await receiverSwarm.PreloadAsync();
@@ -953,11 +955,12 @@ namespace Libplanet.Net.Tests
                 minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
-            Block block = ProposeNext(
-                minerChain2.Tip,
-                miner: ChainPrivateKey.PublicKey,
-                lastCommit: CreateBlockCommit(minerChain2.Tip)
-            ).Evaluate(ChainPrivateKey, minerChain2);
+            Block block = minerChain2.EvaluateAndSign(
+                ProposeNext(
+                    minerChain2.Tip,
+                    miner: ChainPrivateKey.PublicKey,
+                    lastCommit: CreateBlockCommit(minerChain2.Tip)),
+                ChainPrivateKey);
             minerChain2.Append(block, CreateBlockCommit(block));
 
             Assert.True(minerChain1.Count > minerChain2.Count);

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -467,14 +467,10 @@ namespace Libplanet.Net.Tests
                     DateTimeOffset.UtcNow
                 );
 
-                Block block = minerChain.EvaluateAndSign(
-                    ProposeNext(
-                        minerChain.Tip,
-                        new[] { tx },
-                        miner: ChainPrivateKey.PublicKey,
-                        blockInterval: TimeSpan.FromSeconds(1),
-                        lastCommit: CreateBlockCommit(minerChain.Tip)),
-                    ChainPrivateKey);
+                Block block = minerChain.ProposeBlock(
+                    ChainPrivateKey,
+                    new[] { tx }.ToImmutableList(),
+                    CreateBlockCommit(minerChain.Tip));
                 minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true);
 
                 await receiverSwarm.PreloadAsync();
@@ -955,12 +951,8 @@ namespace Libplanet.Net.Tests
                 minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
-            Block block = minerChain2.EvaluateAndSign(
-                ProposeNext(
-                    minerChain2.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(minerChain2.Tip)),
-                ChainPrivateKey);
+            Block block = minerChain2.ProposeBlock(
+                ChainPrivateKey, CreateBlockCommit(minerChain2.Tip));
             minerChain2.Append(block, CreateBlockCommit(block));
 
             Assert.True(minerChain1.Count > minerChain2.Count);

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1578,11 +1578,12 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block block = chain.EvaluateAndSign(
+                    ProposeNext(
+                        chain.Tip,
+                        miner: ChainPrivateKey.PublicKey,
+                        lastCommit: CreateBlockCommit(chain.Tip)),
+                    ChainPrivateKey);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1621,11 +1622,12 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block block = chain.EvaluateAndSign(
+                    ProposeNext(
+                        chain.Tip,
+                        miner: ChainPrivateKey.PublicKey,
+                        lastCommit: CreateBlockCommit(chain.Tip)),
+                    ChainPrivateKey);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1665,11 +1667,12 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = ProposeNext(
-                    chain.Tip,
-                    miner: ChainPrivateKey.PublicKey,
-                    lastCommit: CreateBlockCommit(chain.Tip)
-                ).Evaluate(ChainPrivateKey, chain);
+                Block block = chain.EvaluateAndSign(
+                    ProposeNext(
+                        chain.Tip,
+                        miner: ChainPrivateKey.PublicKey,
+                        lastCommit: CreateBlockCommit(chain.Tip)),
+                    ChainPrivateKey);
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1578,12 +1578,8 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = chain.EvaluateAndSign(
-                    ProposeNext(
-                        chain.Tip,
-                        miner: ChainPrivateKey.PublicKey,
-                        lastCommit: CreateBlockCommit(chain.Tip)),
-                    ChainPrivateKey);
+                Block block = chain.ProposeBlock(
+                    ChainPrivateKey, TestUtils.CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1622,12 +1618,8 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = chain.EvaluateAndSign(
-                    ProposeNext(
-                        chain.Tip,
-                        miner: ChainPrivateKey.PublicKey,
-                        lastCommit: CreateBlockCommit(chain.Tip)),
-                    ChainPrivateKey);
+                Block block = chain.ProposeBlock(
+                    ChainPrivateKey, TestUtils.CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1667,12 +1659,8 @@ namespace Libplanet.Net.Tests
 
             for (int i = 0; i < 6; i++)
             {
-                Block block = chain.EvaluateAndSign(
-                    ProposeNext(
-                        chain.Tip,
-                        miner: ChainPrivateKey.PublicKey,
-                        lastCommit: CreateBlockCommit(chain.Tip)),
-                    ChainPrivateKey);
+                Block block = chain.ProposeBlock(
+                    ChainPrivateKey, CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -64,14 +64,14 @@ namespace Libplanet.Tests.Action
                 chain.Genesis.Hash,
                 new[] { action }
             );
-            Block block = TestUtils.ProposeNext(
+            Block block = chain.EvaluateAndSign(
+                TestUtils.ProposeNext(
                     chain.Tip,
                     new[] { tx },
                     miner: _keys[1].PublicKey,
                     protocolVersion: ProtocolVersion,
-                    lastCommit: TestUtils.CreateBlockCommit(chain.Tip)
-                )
-                .Evaluate(_keys[1], chain);
+                    lastCommit: TestUtils.CreateBlockCommit(chain.Tip)),
+                _keys[1]);
             chain.Append(
                 block,
                 TestUtils.CreateBlockCommit(block)

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -257,7 +257,7 @@ namespace Libplanet.Tests.Action
             var hash = preEvalBlock.Header.DeriveBlockHash(stateRootHash, null);
             Block block = ProtocolVersion < 2
                 ? new Block(preEvalBlock, (stateRootHash, null, hash))
-                : preEvalBlock.Evaluate(privateKey, chain);
+                : chain.EvaluateAndSign(preEvalBlock, privateKey);
             chain.Append(
                 block,
                 TestUtils.CreateBlockCommit(block)

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -906,11 +906,12 @@ namespace Libplanet.Tests.Action
                 privateKey: ChainPrivateKey);
             (_, Transaction[] txs) = MakeFixturesForAppendTests();
             var genesis = chain.Genesis;
-            var block = ProposeNext(
-                genesis,
-                txs,
-                miner: GenesisProposer.PublicKey
-            ).Evaluate(GenesisProposer, chain);
+            var block = chain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txs,
+                    miner: GenesisProposer.PublicKey),
+                GenesisProposer);
 
             AccountStateGetter accountStateGetter =
                 ActionEvaluator.NullAccountStateGetter;

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -906,12 +906,8 @@ namespace Libplanet.Tests.Action
                 privateKey: ChainPrivateKey);
             (_, Transaction[] txs) = MakeFixturesForAppendTests();
             var genesis = chain.Genesis;
-            var block = chain.EvaluateAndSign(
-                ProposeNext(
-                    genesis,
-                    txs,
-                    miner: GenesisProposer.PublicKey),
-                GenesisProposer);
+            var block = chain.ProposeBlock(
+                GenesisProposer, txs.ToImmutableList(), CreateBlockCommit(chain.Tip));
 
             AccountStateGetter accountStateGetter =
                 ActionEvaluator.NullAccountStateGetter;

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -40,20 +40,22 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(1, _blockChain.Count);
             Assert.Empty(_renderer.ActionRecords);
             Assert.Empty(_renderer.BlockRecords);
-            var block1 = TestUtils.ProposeNext(
-                genesis,
-                miner: keys[4].PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(keys[4], _blockChain);
+            var block1 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    genesis,
+                    miner: keys[4].PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                keys[4]);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.NotNull(_blockChain.GetBlockCommit(block1.Hash));
-            Block block2 = TestUtils.ProposeNext(
-                block1,
-                txs,
-                miner: keys[4].PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block1)
-            ).Evaluate(keys[4], _blockChain);
+            Block block2 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    block1,
+                    txs,
+                    miner: keys[4].PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    lastCommit: TestUtils.CreateBlockCommit(block1)),
+                keys[4]);
             foreach (Transaction tx in txs)
             {
                 Assert.Null(getTxExecution(genesis.Hash, tx.Id));
@@ -200,12 +202,13 @@ namespace Libplanet.Tests.Blockchain
                 nonce: 2,
                 privateKey: pk
             );
-            Block block3 = TestUtils.ProposeNext(
-                block2,
-                new[] { tx1Transfer, tx2Error, tx3Transfer },
-                miner: keys[4].PublicKey,
-                lastCommit: TestUtils.CreateBlockCommit(block2)
-            ).Evaluate(keys[4], _blockChain);
+            Block block3 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    block2,
+                    new[] { tx1Transfer, tx2Error, tx3Transfer },
+                    miner: keys[4].PublicKey,
+                    lastCommit: TestUtils.CreateBlockCommit(block2)),
+                keys[4]);
             _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             var txExecution1 = getTxExecution(block3.Hash, tx1Transfer.Id);
             _logger.Verbose(nameof(txExecution1) + " = {@TxExecution}", txExecution1);
@@ -317,12 +320,13 @@ namespace Libplanet.Tests.Blockchain
             }
 
             var miner = new PrivateKey();
-            var block = TestUtils.ProposeNext(
-                _blockChain.Genesis,
-                heavyTxs,
-                miner: miner.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(miner, _blockChain);
+            var block = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    _blockChain.Genesis,
+                    heavyTxs,
+                    miner: miner.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                miner);
             long maxBytes = _blockChain.Policy.GetMaxTransactionsBytes(block.Index);
             Assert.True(block.MarshalBlock().EncodingLength > maxBytes);
 
@@ -348,12 +352,13 @@ namespace Libplanet.Tests.Blockchain
             Assert.True(manyTxs.Count > maxTxs);
 
             var miner = new PrivateKey();
-            Block block = TestUtils.ProposeNext(
-                _blockChain.Genesis,
-                manyTxs,
-                miner: miner.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(miner, _blockChain);
+            Block block = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    _blockChain.Genesis,
+                    manyTxs,
+                    miner: miner.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                miner);
             Assert.Equal(manyTxs.Count, block.Transactions.Count());
 
             var e = Assert.Throws<InvalidBlockTxCountException>(() =>
@@ -419,22 +424,24 @@ namespace Libplanet.Tests.Blockchain
 
                 var miner = new PrivateKey();
 
-                Block block1 = TestUtils.ProposeNext(
-                    fx.GenesisBlock,
-                    new[] { validTx },
-                    miner: miner.PublicKey,
-                    blockInterval: TimeSpan.FromSeconds(10)
-                ).Evaluate(miner, blockChain);
+                Block block1 = blockChain.EvaluateAndSign(
+                    TestUtils.ProposeNext(
+                        fx.GenesisBlock,
+                        new[] { validTx },
+                        miner: miner.PublicKey,
+                        blockInterval: TimeSpan.FromSeconds(10)),
+                    miner);
 
                 blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-                Block block2 = TestUtils.ProposeNext(
-                    block1,
-                    new[] { invalidTx },
-                    miner: miner.PublicKey,
-                    blockInterval: TimeSpan.FromSeconds(10),
-                    lastCommit: TestUtils.CreateBlockCommit(block1)
-                ).Evaluate(miner, blockChain);
+                Block block2 = blockChain.EvaluateAndSign(
+                    TestUtils.ProposeNext(
+                        block1,
+                        new[] { invalidTx },
+                        miner: miner.PublicKey,
+                        blockInterval: TimeSpan.FromSeconds(10),
+                        lastCommit: TestUtils.CreateBlockCommit(block1)),
+                    miner);
 
                 Assert.Throws<TxPolicyViolationException>(() => blockChain.Append(
                     block2, TestUtils.CreateBlockCommit(block2)));
@@ -451,11 +458,12 @@ namespace Libplanet.Tests.Blockchain
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
             // Mining with empty staged.
-            Block block1 = TestUtils.ProposeNext(
-                genesis,
-                miner: privateKey.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(privateKey, _blockChain);
+            Block block1 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    genesis,
+                    miner: privateKey.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                privateKey);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
 
@@ -463,13 +471,14 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
             // Tx with nonce 0 is mined.
-            Block block2 = TestUtils.ProposeNext(
-                block1,
-                ImmutableArray<Transaction>.Empty.Add(txs[0]),
-                miner: privateKey.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block1)
-            ).Evaluate(privateKey, _blockChain);
+            Block block2 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    block1,
+                    ImmutableArray<Transaction>.Empty.Add(txs[0]),
+                    miner: privateKey.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    lastCommit: TestUtils.CreateBlockCommit(block1)),
+                privateKey);
             _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
 
@@ -483,13 +492,14 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, _blockChain.GetStagedTransactionIds().Count);
 
             // Unmined tx is left intact in the stage.
-            Block block3 = TestUtils.ProposeNext(
-                block2,
-                ImmutableArray<Transaction>.Empty.Add(txs[1]),
-                miner: privateKey.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10),
-                lastCommit: TestUtils.CreateBlockCommit(block2)
-            ).Evaluate(privateKey, _blockChain);
+            Block block3 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    block2,
+                    ImmutableArray<Transaction>.Empty.Add(txs[1]),
+                    miner: privateKey.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    lastCommit: TestUtils.CreateBlockCommit(block2)),
+                privateKey);
             _blockChain.Append(block3, TestUtils.CreateBlockCommit(block3));
             Assert.Empty(_blockChain.GetStagedTransactionIds());
             Assert.Empty(_blockChain.StagePolicy.Iterate(_blockChain, filtered: true));
@@ -513,12 +523,13 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, workspace.StagePolicy.Iterate(workspace, filtered: false).Count());
 
             // Mine nonce 0 tx.
-            Block block1 = TestUtils.ProposeNext(
-                genesis,
-                miner: privateKey.PublicKey,
-                transactions: ImmutableArray<Transaction>.Empty.Add(txs[0]),
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(privateKey, _blockChain);
+            Block block1 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    genesis,
+                    miner: privateKey.PublicKey,
+                    transactions: ImmutableArray<Transaction>.Empty.Add(txs[0]),
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                privateKey);
 
             // Not actually unstaged, but lower nonce is filtered for workspace.
             workspace.Append(block1, TestUtils.CreateBlockCommit(block1));
@@ -533,13 +544,14 @@ namespace Libplanet.Tests.Blockchain
             Assert.Single(workspace.StagePolicy.Iterate(workspace, filtered: false));
 
             // Mine nonce 1 tx.
-            Block block2 = TestUtils.ProposeNext(
-                block1,
-                miner: privateKey.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10),
-                transactions: ImmutableArray<Transaction>.Empty.Add(txs[1]),
-                lastCommit: TestUtils.CreateBlockCommit(block1)
-            ).Evaluate(privateKey, _blockChain);
+            Block block2 = _blockChain.EvaluateAndSign(
+                TestUtils.ProposeNext(
+                    block1,
+                    miner: privateKey.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    transactions: ImmutableArray<Transaction>.Empty.Add(txs[1]),
+                    lastCommit: TestUtils.CreateBlockCommit(block1)),
+                privateKey);
 
             // Actually gets unstaged.
             _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -108,11 +108,12 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
-            Block block1 = ProposeNext(
-                genesis,
-                txs,
-                miner: _fx.Proposer.PublicKey
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block block1 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txs,
+                    miner: _fx.Proposer.PublicKey),
+                _fx.Proposer);
 
             _blockChain.Append(block1, CreateBlockCommit(block1), render: true);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -108,13 +108,8 @@ namespace Libplanet.Tests.Blockchain
                 MakeFixturesForAppendTests();
             var genesis = _blockChain.Genesis;
 
-            Block block1 = _blockChain.EvaluateAndSign(
-                ProposeNext(
-                    genesis,
-                    txs,
-                    miner: _fx.Proposer.PublicKey),
-                _fx.Proposer);
-
+            Block block1 = _blockChain.ProposeBlock(
+                _fx.Proposer, txs.ToImmutableList(), CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(block1, CreateBlockCommit(block1), render: true);
 
             var minerAddress = genesis.Miner;

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -67,16 +67,18 @@ namespace Libplanet.Tests.Blockchain
             _renderer.BlockChain = _blockChain;
             _renderer.ResetRecords();
 
-            _validNext = new BlockContent(
-                new BlockMetadata(
-                    protocolVersion: BlockMetadata.CurrentProtocolVersion,
-                    index: 1,
-                    timestamp: _fx.GenesisBlock.Timestamp.AddSeconds(1),
-                    miner: _fx.Proposer.PublicKey.ToAddress(),
-                    publicKey: _fx.Proposer.PublicKey,
-                    previousHash: _fx.GenesisBlock.Hash,
-                    txHash: null,
-                    lastCommit: null)).Propose().Evaluate<DumbAction>(_fx.Proposer, _blockChain);
+            _validNext = _blockChain.EvaluateAndSign(
+                new BlockContent(
+                    new BlockMetadata(
+                        protocolVersion: BlockMetadata.CurrentProtocolVersion,
+                        index: 1,
+                        timestamp: _fx.GenesisBlock.Timestamp.AddSeconds(1),
+                        miner: _fx.Proposer.PublicKey.ToAddress(),
+                        publicKey: _fx.Proposer.PublicKey,
+                        previousHash: _fx.GenesisBlock.Hash,
+                        txHash: null,
+                        lastCommit: null)).Propose(),
+                _fx.Proposer);
         }
 
         public void Dispose()
@@ -495,10 +497,8 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.Append(block, CreateBlockCommit(block));
             }
 
-            Block newBlock = ProposeNext(
-                genesis,
-                miner: key.PublicKey
-            ).Evaluate(key, _blockChain);
+            Block newBlock = _blockChain.EvaluateAndSign(
+                ProposeNext(genesis, miner: key.PublicKey), key);
 
             Assert.Throws<ArgumentException>(() =>
                 _blockChain.Fork(newBlock.Hash));
@@ -626,21 +626,23 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey),
             };
 
-            Block b1 = ProposeNext(
-                genesis,
-                txsA,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block b1 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txsA,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey),
+                _fx.Proposer);
             _blockChain.Append(b1, TestUtils.CreateBlockCommit(b1));
 
-            Block b2 = ProposeNext(
-                b1,
-                txsA,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey,
-                lastCommit: CreateBlockCommit(b1)
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block b2 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    b1,
+                    txsA,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey,
+                    lastCommit: CreateBlockCommit(b1)),
+                _fx.Proposer);
             Assert.Throws<InvalidTxNonceException>(() =>
                 _blockChain.Append(b2, CreateBlockCommit(b2)));
 
@@ -651,13 +653,14 @@ namespace Libplanet.Tests.Blockchain
                     nonce: 1,
                     privateKey: privateKey),
             };
-            b2 = ProposeNext(
-                b1,
-                txsB,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey,
-                lastCommit: CreateBlockCommit(b1)
-            ).Evaluate(_fx.Proposer, _blockChain);
+            b2 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    b1,
+                    txsB,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey,
+                    lastCommit: CreateBlockCommit(b1)),
+                _fx.Proposer);
             _blockChain.Append(b2, CreateBlockCommit(b2));
         }
 
@@ -685,12 +688,13 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(0, _blockChain.GetNextTxNonce(address));
 
-            Block b1 = ProposeNext(
-                genesis,
-                txsA,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block b1 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txsA,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey),
+                _fx.Proposer);
             _blockChain.Append(b1, CreateBlockCommit(b1));
 
             Assert.Equal(1, _blockChain.GetNextTxNonce(address));
@@ -702,13 +706,14 @@ namespace Libplanet.Tests.Blockchain
                     nonce: 1,
                     privateKey: privateKey),
             };
-            Block b2 = ProposeNext(
-                b1,
-                txsB,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey,
-                lastCommit: CreateBlockCommit(b1)
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block b2 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    b1,
+                    txsB,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey,
+                    lastCommit: CreateBlockCommit(b1)),
+                _fx.Proposer);
             _blockChain.Append(b2, CreateBlockCommit(b2));
 
             Assert.Equal(2, _blockChain.GetNextTxNonce(address));
@@ -760,12 +765,13 @@ namespace Libplanet.Tests.Blockchain
             var miner = new PrivateKey();
             var minerAddress = miner.ToAddress();
 
-            Block block1 = ProposeNext(
-                genesis,
-                txs1,
-                miner: miner.PublicKey,
-                blockInterval: TimeSpan.FromSeconds(10)
-            ).Evaluate(miner, _blockChain);
+            Block block1 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txs1,
+                    miner: miner.PublicKey,
+                    blockInterval: TimeSpan.FromSeconds(10)),
+                miner);
             _blockChain.Append(block1, CreateBlockCommit(block1));
 
             PrivateKey privateKey = new PrivateKey(new byte[]
@@ -823,13 +829,14 @@ namespace Libplanet.Tests.Blockchain
 
             foreach (Transaction[] txs in txsA)
             {
-                Block b = ProposeNext(
-                    _blockChain.Tip,
-                    txs,
-                    blockInterval: TimeSpan.FromSeconds(10),
-                    miner: miner.PublicKey,
-                    lastCommit: CreateBlockCommit(_blockChain.Tip)
-                ).Evaluate(miner, _blockChain);
+                Block b = _blockChain.EvaluateAndSign(
+                    ProposeNext(
+                        _blockChain.Tip,
+                        txs,
+                        blockInterval: TimeSpan.FromSeconds(10),
+                        miner: miner.PublicKey,
+                        lastCommit: CreateBlockCommit(_blockChain.Tip)),
+                    miner);
                 _blockChain.Append(b, CreateBlockCommit(b));
             }
 
@@ -855,13 +862,14 @@ namespace Libplanet.Tests.Blockchain
                     privateKey: privateKey),
             };
 
-            Block forkTip = ProposeNext(
-                fork.Tip,
-                txsB,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: miner.PublicKey,
-                lastCommit: CreateBlockCommit(fork.Tip)
-            ).Evaluate(miner, fork);
+            Block forkTip = fork.EvaluateAndSign(
+                ProposeNext(
+                    fork.Tip,
+                    txsB,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: miner.PublicKey,
+                    lastCommit: CreateBlockCommit(fork.Tip)),
+                miner);
             fork.Append(forkTip, CreateBlockCommit(forkTip), render: true);
 
             Guid previousChainId = _blockChain.Id;
@@ -1124,12 +1132,13 @@ namespace Libplanet.Tests.Blockchain
                 {
                     Transaction.Create<DumbAction>(0, privateKey, chain.Genesis.Hash, actions),
                 };
-                b = ProposeNext(
-                    b,
-                    txs,
-                    miner: _fx.Proposer.PublicKey,
-                    lastCommit: CreateBlockCommit(b)
-                ).Evaluate(_fx.Proposer, chain);
+                b = chain.EvaluateAndSign(
+                    ProposeNext(
+                        b,
+                        txs,
+                        miner: _fx.Proposer.PublicKey,
+                        lastCommit: CreateBlockCommit(b)),
+                    _fx.Proposer);
                 chain.Append(b, CreateBlockCommit(b));
             }
 
@@ -1164,12 +1173,13 @@ namespace Libplanet.Tests.Blockchain
             Block b = chain.Genesis;
             for (int i = 0; i < 20; ++i)
             {
-                b = ProposeNext(
-                    b,
-                    blockInterval: TimeSpan.FromSeconds(10),
-                    miner: _fx.Proposer.PublicKey,
-                    lastCommit: CreateBlockCommit(b)
-                ).Evaluate(_fx.Proposer, chain);
+                b = chain.EvaluateAndSign(
+                    ProposeNext(
+                        b,
+                        blockInterval: TimeSpan.FromSeconds(10),
+                        miner: _fx.Proposer.PublicKey,
+                        lastCommit: CreateBlockCommit(b)),
+                    _fx.Proposer);
                 chain.Append(b, CreateBlockCommit(b));
             }
 
@@ -1345,12 +1355,13 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 0),
             };
 
-            Block b1 = ProposeNext(
-                genesis,
-                txsA,
-                blockInterval: TimeSpan.FromSeconds(10),
-                miner: _fx.Proposer.PublicKey
-            ).Evaluate(_fx.Proposer, _blockChain);
+            Block b1 = _blockChain.EvaluateAndSign(
+                ProposeNext(
+                    genesis,
+                    txsA,
+                    blockInterval: TimeSpan.FromSeconds(10),
+                    miner: _fx.Proposer.PublicKey),
+                _fx.Proposer);
             _blockChain.Append(b1, CreateBlockCommit(b1));
 
             Assert.Equal(1, _blockChain.GetNextTxNonce(address));
@@ -1448,13 +1459,14 @@ namespace Libplanet.Tests.Blockchain
                 Block block,
                 IReadOnlyList<Transaction> txs
             ) =>
-                TestUtils.ProposeNext(
-                    block,
-                    txs,
-                    blockInterval: TimeSpan.FromSeconds(10),
-                    miner: _fx.Proposer.PublicKey,
-                    lastCommit: CreateBlockCommit(block)
-                ).Evaluate(_fx.Proposer, _blockChain);
+                _blockChain.EvaluateAndSign(
+                    TestUtils.ProposeNext(
+                        block,
+                        txs,
+                        blockInterval: TimeSpan.FromSeconds(10),
+                        miner: _fx.Proposer.PublicKey,
+                        lastCommit: CreateBlockCommit(block)),
+                    _fx.Proposer);
 
             Transaction[] txsA =
             {
@@ -1735,13 +1747,14 @@ namespace Libplanet.Tests.Blockchain
                         chain.Genesis.Hash,
                         new[] { new DumbAction(addresses[j], index.ToString()) }
                     );
-                    b = ProposeNext(
-                        b,
-                        new[] { tx },
-                        blockInterval: TimeSpan.FromSeconds(10),
-                        miner: GenesisProposer.PublicKey,
-                        lastCommit: CreateBlockCommit(b)
-                    ).Evaluate(GenesisProposer, chain);
+                    b = chain.EvaluateAndSign(
+                        ProposeNext(
+                            b,
+                            new[] { tx },
+                            blockInterval: TimeSpan.FromSeconds(10),
+                            miner: GenesisProposer.PublicKey,
+                            lastCommit: CreateBlockCommit(b)),
+                        GenesisProposer);
                     previousStates = AccountStateDeltaImpl.ChooseVersion(
                         b.ProtocolVersion,
                         addrs => addrs.Select(dirty.GetValueOrDefault).ToArray(),

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -72,7 +72,7 @@ namespace Libplanet.Tests.Blocks
                     transactions: txs);
                 PreEvaluationBlock preEval1 = content1.Propose();
 
-                Block block1 = preEval1.Evaluate(_contents.Block1Key, blockChain);
+                Block block1 = blockChain.EvaluateAndSign(preEval1, _contents.Block1Key);
                 AssertPreEvaluationBlocksEqual(preEval1, block1);
                 _output.WriteLine("#1: {0}", block1);
 

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -187,7 +187,7 @@ namespace Libplanet.Blockchain
         /// <exception cref="ArgumentException">Thrown when the given <paramref name="privateKey"/>
         /// does not match to the block miner's <see cref="PublicKey"/>.</exception>
         // FIXME: Remove this method.
-        public Block EvaluateAndSign(
+        internal Block EvaluateAndSign(
             PreEvaluationBlock preEvaluationBlock, PrivateKey privateKey)
         =>
             preEvaluationBlock.ProtocolVersion >= 2

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -10,6 +10,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using static Libplanet.Blockchain.KeyConverters;
@@ -167,5 +168,33 @@ namespace Libplanet.Blockchain
         [Pure]
         public IReadOnlyList<IActionEvaluation> EvaluateBlock(IPreEvaluationBlock block) =>
             ActionEvaluator.Evaluate(block);
-   }
+
+        /// <summary>
+        /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and
+        /// an optional <see cref="Blockchain.Policies.IBlockPolicy{T}.BlockAction"/>, and returns
+        /// a <see cref="Block"/> instance combined with the <see cref="Block.StateRootHash"/>
+        /// The returned <see cref="Block"/> is signed by the given <paramref name="privateKey"/>.
+        /// </summary>
+        /// <param name="preEvaluationBlock">The <see cref="PreEvaluationBlock"/> to evaluate
+        /// and sign.</param>
+        /// <param name="privateKey">The private key to be used for signing the block.
+        /// This must match to the block's <see cref="PreEvaluationBlockHeader.Miner"/> and
+        /// <see cref="PreEvaluationBlockHeader.PublicKey"/>.</param>
+        /// <returns>The block combined with the resulting <see cref="Block.StateRootHash"/>.
+        /// It is signed by the given <paramref name="privateKey"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when the block's
+        /// <see cref="PreEvaluationBlockHeader.ProtocolVersion"/> is less than 2.</exception>
+        /// <exception cref="ArgumentException">Thrown when the given <paramref name="privateKey"/>
+        /// does not match to the block miner's <see cref="PublicKey"/>.</exception>
+        // FIXME: Remove this method.
+        public Block EvaluateAndSign(
+            PreEvaluationBlock preEvaluationBlock, PrivateKey privateKey)
+        =>
+            preEvaluationBlock.ProtocolVersion >= 2
+                ? preEvaluationBlock.Sign(
+                    privateKey, DetermineBlockStateRootHash(preEvaluationBlock, out _))
+                : throw new ArgumentException(
+                    $"Given {nameof(preEvaluationBlock)} must have protocol version " +
+                    $"2 or greater: {preEvaluationBlock.ProtocolVersion}");
+    }
 }

--- a/Libplanet/Blocks/PreEvaluationBlock.cs
+++ b/Libplanet/Blocks/PreEvaluationBlock.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
-using Libplanet.Action;
-using Libplanet.Blockchain;
 using Libplanet.Crypto;
 using Libplanet.Tx;
 
@@ -82,36 +80,6 @@ namespace Libplanet.Blocks
 
         /// <inheritdoc cref="IPreEvaluationBlockHeader.PreEvaluationHash"/>
         public HashDigest<SHA256> PreEvaluationHash => _header.PreEvaluationHash;
-
-        /// <summary>
-        /// Evaluates all actions in the <see cref="Transactions"/> and an optional
-        /// <see cref="Blockchain.Policies.IBlockPolicy{T}.BlockAction"/>, and returns
-        /// a <see cref="Block"/> instance combined with the <see cref="Block.StateRootHash"/>
-        /// determined from ground zero (i.e., empty state root). The returned
-        /// <see cref="Block"/> is signed by the given <paramref name="privateKey"/>.
-        /// </summary>
-        /// <param name="privateKey">The miner's private key to be used for signing the block.
-        /// This must match to the block's <see cref="PreEvaluationBlockHeader.Miner"/> and
-        /// <see cref="PreEvaluationBlockHeader.PublicKey"/>.</param>
-        /// <param name="blockChain">The blockchain on which actions are evaluated based.</param>
-        /// <returns>The block combined with the resulting <see cref="Block.StateRootHash"/>.
-        /// It is signed by the given <paramref name="privateKey"/>.</returns>
-        /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
-        /// to <see cref="Block"/>'s type parameter.</typeparam>
-        /// <exception cref="InvalidOperationException">Thrown when the block's
-        /// <see cref="PreEvaluationBlockHeader.ProtocolVersion"/> is less than 2.</exception>
-        /// <exception cref="ArgumentException">Thrown when the given <paramref name="privateKey"/>
-        /// does not match to the block miner's <see cref="PublicKey"/>.</exception>
-        /// <remarks>As blocks have their signatures since the <see
-        /// cref="PreEvaluationBlockHeader.ProtocolVersion"/> 2, it is not usable with blocks of
-        /// the earlier <see cref="PreEvaluationBlockHeader.ProtocolVersion"/>s than 2.
-        /// To create a <see cref="Block"/> instance with <see cref="Block.ProtocolVersion"/>
-        /// less than 2, use <see cref="Block"/>'s constructors with
-        /// <see langword="null"/> signatures.</remarks>
-        // FIXME: Take narrower input instead of a whole BlockChain<T>.
-        public Block Evaluate<T>(PrivateKey privateKey, BlockChain<T> blockChain)
-            where T : IAction, new() =>
-            Sign(privateKey, blockChain.DetermineBlockStateRootHash(this, out _));
 
         /// <summary>
         /// Signs the block content with the given <paramref name="stateRootHash"/>.


### PR DESCRIPTION
- `PreEvaluationBlock.Evaluate<T>()` was only being used purely for convenience in test code.
- The name was misleading.