### PR TITLE
Fix index cache in RocksDBStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,13 @@ To be released.
  -  Fixed a bug where `BlockChain<T>.Append()` hadn't update tx executions
     even `evaluateActions` set to `true` when `actionEvaluations` are given.
     [[#3125]]
+ -  (Libplanet.Explorer) Fixed a bug where `BlockQuery.blocks` field had thrown
+    `KeyNotFoundException` when appending block simultaneously.
+    [[#3126], [#3130]]
 
 [#3125]: https://github.com/planetarium/libplanet/pull/3125
+[#3126]: https://github.com/planetarium/libplanet/issues/3126
+[#3130]: https://github.com/planetarium/libplanet/pull/3126
 
 
 Version 1.0.0

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -532,15 +532,14 @@ namespace Libplanet.RocksDBStore
                 return cached;
             }
 
-            List<BlockHash> indexes = IterateIndexes(chainId, offset, limit, false)
-                .ToList();
+            List<BlockHash> indexes = IterateIndexes(chainId, offset, limit, false).ToList();
 
             if (ic is null)
             {
-                _indexCache[chainId] = new LruCache<(int, int?), List<BlockHash>>();
+                _indexCache[chainId] = ic = new LruCache<(int, int?), List<BlockHash>>();
             }
 
-            _indexCache[chainId][(offset, limit)] = indexes;
+            ic[(offset, limit)] = indexes;
             return indexes;
         }
 


### PR DESCRIPTION
This PR fixes `KeyNotFoundException`, mentioned on #3126.

p.s. we need to revisit whether `_indexCache` on `RocksDBStore` is still needed.

