### PR TITLE
🔧 Filter malformed `Transaction`s when proposing `Block`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@ To be released.
      -  Added `IActionLoader.Load(long, IValue)` interface method.
      -  Removed `ActionTypeLoaderContext` class.  Use `long` instead.
      -  Renamed `StaticActionTypeLoader` to `StaticActionLoader`.
+ -  Added `IActionEvaluator.IActionLoader` property.  [[#3136]]
 
 ### Backward-incompatible network protocol changes
 
@@ -99,6 +100,9 @@ To be released.
     methods are no longer invoked by a `BlockChain<T>`.  [[#3087]]
 
 ### Bug fixes
+
+ -  Fixes a bug where `BlockChain<T>` could not propose if a certain type of
+    invalid `Transaction` was staged.  [[#3136]]
 
 ### Dependencies
 
@@ -126,6 +130,7 @@ To be released.
 [#3123]: https://github.com/planetarium/libplanet/pull/3123
 [#3127]: https://github.com/planetarium/libplanet/pull/3127
 [#3135]: https://github.com/planetarium/libplanet/pull/3135
+[#3136]: https://github.com/planetarium/libplanet/pull/3136
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -647,7 +647,8 @@ namespace Libplanet.Tests.Blockchain
                 new PrivateKey(), CreateBlockCommit(_blockChain.Tip));
 
             // Includes txA0, txA1, txA2, txB0; txB2 is not included due to its nonce
-            Assert.Equal(txs.Length - 2, block.Transactions.Count);
+            Assert.DoesNotContain(txs.Last(), block.Transactions);
+            Assert.DoesNotContain(invalidTx, block.Transactions);
 
             // txB1 is marked ignored and removed
             Assert.Equal(txs.Length - 1, _blockChain.ListStagedTransactions().Count);

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Action
         private readonly IBlockChainStates _blockChainStates;
         private readonly Func<BlockHash, ITrie>? _trieGetter;
         private readonly Predicate<Currency> _nativeTokenPredicate;
-        private readonly IActionLoader _actionTypeLoader;
+        private readonly IActionLoader _actionLoader;
         private readonly IFeeCalculator? _feeCalculator;
 
 #pragma warning disable MEN002
@@ -70,9 +70,13 @@ namespace Libplanet.Action
             _trieGetter = trieGetter;
             _genesisHash = genesisHash;
             _nativeTokenPredicate = nativeTokenPredicate;
-            _actionTypeLoader = actionTypeLoader;
+            _actionLoader = actionTypeLoader;
             _feeCalculator = feeCalculator;
         }
+
+        /// <inheritdoc cref="IActionEvaluator.ActionLoader"/>
+        [Pure]
+        public IActionLoader ActionLoader => _actionLoader;
 
         /// <summary>
         /// Creates a random seed.
@@ -96,13 +100,9 @@ namespace Libplanet.Action
                 ^ (signature.Any() ? BitConverter.ToInt32(hashedSignature, 0) : 0) - actionOffset;
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc cref="IActionEvaluator.Evaluate"/>
         [Pure]
-        IReadOnlyList<IActionEvaluation> IActionEvaluator.Evaluate(IPreEvaluationBlock block) =>
-            Evaluate(block);
-
-        [Pure]
-        public IReadOnlyList<ActionEvaluation> Evaluate(IPreEvaluationBlock block)
+        public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
         {
             _logger.Information(
                 "Evaluating actions in the block #{BlockIndex} " +
@@ -822,7 +822,7 @@ namespace Libplanet.Action
             {
                 foreach (IValue rawAction in actions)
                 {
-                    yield return _actionTypeLoader.LoadAction(index, rawAction);
+                    yield return _actionLoader.LoadAction(index, rawAction);
                 }
             }
         }

--- a/Libplanet/Action/IActionEvaluator.cs
+++ b/Libplanet/Action/IActionEvaluator.cs
@@ -8,6 +8,13 @@ namespace Libplanet.Action
     public interface IActionEvaluator
     {
         /// <summary>
+        /// The <see cref="IActionLoader"/> used by this <see cref="IActionEvaluator"/>
+        /// when evaluating <see cref="Block"/>s.
+        /// </summary>
+        [Pure]
+        IActionLoader ActionLoader { get; }
+
+        /// <summary>
         /// The main entry point for evaluating a <see cref="IPreEvaluationBlock"/>.
         /// </summary>
         /// <param name="block">The block to evaluate.</param>

--- a/Libplanet/Action/IActionLoader.cs
+++ b/Libplanet/Action/IActionLoader.cs
@@ -34,6 +34,9 @@ namespace Libplanet.Action
         /// <paramref name="value"/>.</param>
         /// <param name="value">The <see cref="IValue"/> to deserialize to
         /// an <see cref="IAction"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when an <see cref="IAction"/> cannot be
+        /// instantiated with given <paramref name="index"/> and <paramref name="value"/>.
+        /// </exception>
         /// <returns>An <see cref="IAction"/> instantiated with <paramref name="value"/>.</returns>
         public IAction LoadAction(long index, IValue value);
     }

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -336,6 +336,23 @@ namespace Libplanet.Blockchain
                         continue;
                     }
 
+                    try
+                    {
+                        foreach (IValue rawAction in tx.Actions)
+                        {
+                            _ = ActionEvaluator.ActionLoader.LoadAction(index, rawAction);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Error(
+                            e,
+                            "Failed to load an action in tx; marking tx {TxId} as ignored...",
+                            tx.Id);
+                        StagePolicy.Ignore(this, tx.Id);
+                        continue;
+                    }
+
                     _logger.Verbose(
                         "Adding tx {Iter}/{Total} {TxId} to the list of transactions " +
                         "to be proposed",


### PR DESCRIPTION
There should be an accompanying PR to filter malformed `Block`s containing malformed `Transaction`s received from the network.