### PR TITLE
Fix mutation to be consumed sequentially

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,9 @@ To be released.
     `IRenderer<T>.RenderReorgEnd()`, `IActionRenderer<T>.UnrenderAction()`,
     and `IActionRenderer<T>.UnrenderActionError()`, i.e., these interface
     methods are no longer invoked by a `BlockChain<T>`.  [[#3087]]
+ -  Changed `Context<T>.ConsumeMutation()` to iteratively call
+    `Context<T>.ProcessGenericUponRules()` itself, instead of producing
+    submutations of it.  [[#3137]]
 
 ### Bug fixes
 
@@ -131,6 +134,7 @@ To be released.
 [#3127]: https://github.com/planetarium/libplanet/pull/3127
 [#3135]: https://github.com/planetarium/libplanet/pull/3135
 [#3136]: https://github.com/planetarium/libplanet/pull/3136
+[#3137]: https://github.com/planetarium/libplanet/pull/3137
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -164,7 +164,7 @@ namespace Libplanet.Net.Consensus
             mutation();
             (int MessageLogSize, int Round, Step Step) nextState =
                 (_messageLog.GetTotalCount(), Round, Step);
-            if (prevState != nextState)
+            while (prevState != nextState)
             {
                 _logger.Information(
                     "State (MessageLogSize, Round, Step) changed from " +
@@ -178,8 +178,9 @@ namespace Libplanet.Net.Consensus
                     nextState.Step);
                 StateChanged?.Invoke(
                     this, (nextState.MessageLogSize, nextState.Round, nextState.Step));
-
-                ProduceMutation(() => ProcessGenericUponRules());
+                prevState = (_messageLog.GetTotalCount(), Round, Step);
+                ProcessGenericUponRules();
+                nextState = (_messageLog.GetTotalCount(), Round, Step);
             }
 
             MutationConsumed?.Invoke(this, mutation);

--- a/Libplanet.Tests/Common/Action/DelayAction.cs
+++ b/Libplanet.Tests/Common/Action/DelayAction.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using Bencodex.Types;
+using Libplanet.Action;
+using Serilog;
+
+namespace Libplanet.Tests.Common.Action
+{
+    public sealed class DelayAction : IAction
+    {
+        public static readonly Address TrivialUpdatedAddress =
+            new Address("3d94abf05556fdae0755ff4427869f80afd06b58");
+
+        public DelayAction()
+        {
+        }
+
+        public DelayAction(int milliSecond)
+        {
+            MilliSecond = milliSecond;
+        }
+
+        public int MilliSecond { get; private set; }
+
+        public IValue PlainValue
+        {
+            get
+            {
+                var plainValue = Bencodex.Types.Dictionary.Empty.Add(
+                    "milisecond", new Bencodex.Types.Integer(MilliSecond));
+                return plainValue;
+            }
+        }
+
+        public IAccountStateDelta Execute(IActionContext context)
+        {
+            var state = context.PreviousStates;
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug(
+                "{MethodName} exec started. Delay target: {MilliSecond}",
+                nameof(DelayAction),
+                MilliSecond);
+            Thread.Sleep(MilliSecond);
+            var ended = DateTimeOffset.UtcNow;
+            state = state.SetState(TrivialUpdatedAddress, new Bencodex.Types.Integer(MilliSecond));
+            Log.Debug(
+                "{MethodName} Total Executed Time: {Elapsed}. Delay target: {MilliSecond}",
+                nameof(DelayAction),
+                ended - started,
+                MilliSecond);
+            return state;
+        }
+
+        public void LoadPlainValue(IValue plainValue)
+        {
+            var asDict = (Dictionary)plainValue;
+            MilliSecond = (int)((Bencodex.Types.Integer)asDict["milisecond"]);
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- Mutation does not produce subsequent mutation any more.
- Instead, mutation will handle subsequent mutation with iteration.
- So, mutation produced from later messages will be consumed after every subsequent mutations has been consumed.
- This will secure `upon rules` to be performed as expected order.

### Related issue
- Resolves https://github.com/planetarium/libplanet/issues/3134

### Restriction
- `TimeoutPreVote` and `TimeoutPreCommit` can be called on inaccurate time, due to `IsValid` operation.
- But, I don't think it's so harmful, and negligible.
- According to PBFT spec, `upon rules` have to be executed `atomically`, so this seems to be a part of spec rather than restriction.
- This restriction exists from 1.0.0.