### PR TITLE
🔧 Filter malformed `Block`s from `BlockChain<T>.Append()` and `Context<T>.IsValid()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@ To be released.
      -  Removed `ActionTypeLoaderContext` class.  Use `long` instead.
      -  Renamed `StaticActionTypeLoader` to `StaticActionLoader`.
  -  Added `IActionEvaluator.IActionLoader` property.  [[#3136]]
+ -  Changed `IActionLoader.LoadAction()` to throw `InvalidActionException`
+    instead of `ArgumentException` when an action cannot be instantiated.
+    [[#3140]]
 
 ### Backward-incompatible network protocol changes
 
@@ -91,6 +94,7 @@ To be released.
  -  Added `IActionEvaluation` interface.  [[#3089]]
  -  Added parameterless constructor to `Mint`, `Transfer`, and `Initialize`.
     [[#3112]]
+ -  Added `InvalidActionException` class.  [[#3140]]
 
 ### Behavioral changes
 
@@ -106,6 +110,9 @@ To be released.
 
  -  Fixes a bug where `BlockChain<T>` could not propose if a certain type of
     invalid `Transaction` was staged.  [[#3136]]
+ -  Fixes a bug where `Context<T>` would completely halt if a `Block`
+    with an `IValue` as one of its action that cannot be instantiated via
+    its `IActionLoader`.  [[#3140]]
 
 ### Dependencies
 
@@ -135,6 +142,7 @@ To be released.
 [#3135]: https://github.com/planetarium/libplanet/pull/3135
 [#3136]: https://github.com/planetarium/libplanet/pull/3136
 [#3137]: https://github.com/planetarium/libplanet/pull/3137
+[#3140]: https://github.com/planetarium/libplanet/pull/3140
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -415,7 +415,8 @@ namespace Libplanet.Net.Consensus
                 }
                 catch (Exception e) when (
                     e is InvalidBlockException ||
-                    e is InvalidTxException)
+                    e is InvalidTxException ||
+                    e is InvalidActionException)
                 {
                     _logger.Debug(
                         e,

--- a/Libplanet.Tests/Action/StaticActionTypeLoaderTest.cs
+++ b/Libplanet.Tests/Action/StaticActionTypeLoaderTest.cs
@@ -33,6 +33,26 @@ namespace Libplanet.Tests.Action
         }
 
         [Fact]
+        public void LoadAction()
+        {
+            var actionTypeLoader = new StaticActionLoader(
+                new[] { typeof(Attack).Assembly }, typeof(Attack));
+            actionTypeLoader.Load();
+
+            var plainValue = Dictionary.Empty
+                .Add("weapon", "foo")
+                .Add("target", "bar")
+                .Add("target_address", new Binary(TestUtils.GetRandomBytes(Address.Size)));
+            var action = new Attack();
+            action.LoadPlainValue(plainValue);
+
+            var loadedAction = actionTypeLoader.LoadAction(0, action.PlainValue);
+            Assert.Equal(plainValue, loadedAction.PlainValue);
+            Assert.Throws<InvalidActionException>(
+                () => actionTypeLoader.LoadAction(0, new Text("baz")));
+        }
+
+        [Fact]
         public void DuplicateIds()
         {
             var actionTypeLoader = new StaticActionLoader(

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -610,8 +610,8 @@ namespace Libplanet.Action
             bool rehearsal = false,
             ITrie? previousBlockStatesTrie = null)
         {
-            IEnumerable<IAction> customActions = CreateCustomActions(blockHeader.Index, tx);
-            ImmutableList<IAction> actions = ImmutableList.CreateRange(customActions);
+            ImmutableList<IAction> actions =
+                ImmutableList.CreateRange(LoadActions(blockHeader.Index, tx));
             return EvaluateActions(
                 genesisHash: _genesisHash,
                 preEvaluationHash: blockHeader.PreEvaluationHash,
@@ -816,7 +816,7 @@ namespace Libplanet.Action
                 validatorSetGetter);
         }
 
-        private IEnumerable<IAction> CreateCustomActions(long index, ITransaction tx)
+        private IEnumerable<IAction> LoadActions(long index, ITransaction tx)
         {
             if (tx.Actions is { } actions)
             {

--- a/Libplanet/Action/IActionLoader.cs
+++ b/Libplanet/Action/IActionLoader.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Action
         /// <paramref name="value"/>.</param>
         /// <param name="value">The <see cref="IValue"/> to deserialize to
         /// an <see cref="IAction"/>.</param>
-        /// <exception cref="ArgumentException">Thrown when an <see cref="IAction"/> cannot be
+        /// <exception cref="InvalidActionException">Thrown when an <see cref="IAction"/> cannot be
         /// instantiated with given <paramref name="index"/> and <paramref name="value"/>.
         /// </exception>
         /// <returns>An <see cref="IAction"/> instantiated with <paramref name="value"/>.</returns>

--- a/Libplanet/Action/InvalidActionException.cs
+++ b/Libplanet/Action/InvalidActionException.cs
@@ -1,0 +1,34 @@
+using System;
+using Bencodex.Types;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// The <see cref="Exception"/> that is thrown when an <see cref="IValue"/> that is
+    /// supposedly a serialized <see cref="IAction"/> cannot be deserialized via an
+    /// <see cref="IActionLoader"/>.
+    /// </summary>
+    /// <seealso cref="IActionLoader"/>
+    [Serializable]
+    public sealed class InvalidActionException : Exception
+    {
+        /// <summary>
+        /// Creates a new <see cref="InvalidActionException"/> object.
+        /// </summary>
+        /// <param name="message">Specifies an <see cref="Exception.Message"/>.</param>
+        /// <param name="plainValue">The <see cref="IValue"/> that cannot be loaded
+        /// to an <see cref="IAction"/>.</param>
+        /// <param name="innerException">The <see cref="Exception"/> for
+        /// <see cref="Exception.InnerException"/>.</param>
+        public InvalidActionException(string message, IValue plainValue, Exception innerException)
+            : base(message, innerException)
+        {
+            PlainValue = plainValue;
+        }
+
+        /// <summary>
+        /// The <see cref="IValue"/> that cannot be deserialized to an <see cref="IAction"/>.
+        /// </summary>
+        public IValue PlainValue { get; }
+    }
+}

--- a/Libplanet/Action/StaticActionLoader.cs
+++ b/Libplanet/Action/StaticActionLoader.cs
@@ -74,8 +74,9 @@ namespace Libplanet.Action
             }
             catch (Exception e)
             {
-                throw new ArgumentException(
+                throw new InvalidActionException(
                     $"Failed to instantiate an action from {value} for index {index}",
+                    value,
                     e);
             }
         }

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -99,6 +99,8 @@ namespace Libplanet.Blockchain
         /// <paramref name="evaluations"/>.</param>
         /// <param name="evaluations">The list of <see cref="IActionEvaluation"/>s
         /// from which to extract the states to commit.</param>
+        /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
+        /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
         /// <returns>The state root hash given <paramref name="block"/> and
         /// its <paramref name="evaluations"/>.
         /// </returns>
@@ -164,6 +166,8 @@ namespace Libplanet.Blockchain
         /// <param name="block">The <see cref="IPreEvaluationBlock"/> to execute.</param>
         /// <returns>An <see cref="IReadOnlyList{T}"/> of <ses cref="IActionEvaluation"/>s for
         /// given <paramref name="block"/>.</returns>
+        /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
+        /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
         /// <seealso cref="ValidateBlockStateRootHash"/>
         [Pure]
         public IReadOnlyList<IActionEvaluation> EvaluateBlock(IPreEvaluationBlock block) =>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -696,6 +696,8 @@ namespace Libplanet.Blockchain
         /// </exception>
         /// <exception cref="InvalidBlockException">Thrown when the given <paramref name="block"/>
         /// is invalid, in itself or according to the <see cref="Policy"/>.</exception>
+        /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
+        /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
         /// <exception cref="InvalidTxNonceException">Thrown when the
         /// <see cref="Transaction.Nonce"/> is different from
         /// <see cref="GetNextTxNonce"/> result of the


### PR DESCRIPTION
A companion PR to #3136.