### PR TITLE
Remove `T` from `IRender` and its implementations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  Removed type parameter `T` from `Transaction.Create<T>()` and
     `PreEvaluationBlock.Evaluate<T>()`.  [[#3122]]
+ -  Removed type parameter `T` from `IRenderer` and its all implementations.
+    [[#3147]]
 
 ### Backward-incompatible network protocol changes
 
@@ -31,6 +33,7 @@ To be released.
 ### CLI tools
 
 [#3122]: https://github.com/planetarium/libplanet/pull/3122
+[#3147]: https://github.com/planetarium/libplanet/pull/3147
 
 
 Version 1.1.0

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -717,8 +717,8 @@ namespace Libplanet.Net.Tests
             var privateKey = new PrivateKey();
             var minerSwarm = await CreateSwarm(blockChain, privateKey).ConfigureAwait(false);
             var fx2 = new MemoryStoreFixture();
-            var receiverRenderer = new RecordingActionRenderer<DumbAction>();
-            var loggedRenderer = new LoggedActionRenderer<DumbAction>(
+            var receiverRenderer = new RecordingActionRenderer();
+            var loggedRenderer = new LoggedActionRenderer(
                 receiverRenderer,
                 _logger);
             var receiverChain = MakeBlockChain(

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -377,7 +377,7 @@ namespace Libplanet.Net.Tests
         public async Task NoRenderInPreload()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var renderer = new RecordingActionRenderer<DumbAction>();
+            var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
                 new MemoryStore(),

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -887,7 +887,7 @@ namespace Libplanet.Net.Tests
         public async Task RenderInFork()
         {
             var policy = new BlockPolicy<DumbAction>(new MinerReward(1));
-            var renderer = new RecordingActionRenderer<DumbAction>();
+            var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
                 new MemoryStore(),

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.True(_blockChain.ContainsBlock(block2.Hash));
 
-            RenderRecord<DumbAction>.ActionSuccess[] renders = _renderer.ActionSuccessRecords
+            RenderRecord.ActionSuccess[] renders = _renderer.ActionSuccessRecords
                 .Where(r => r.Action is DumbAction)
                 .ToArray();
             DumbAction[] actions = renders.Select(r => (DumbAction)r.Action).ToArray();
@@ -119,7 +119,7 @@ namespace Libplanet.Tests.Blockchain
             );
 
             Address minerAddress = addresses[4];
-            RenderRecord<DumbAction>.ActionSuccess[] blockRenders = _renderer.ActionSuccessRecords
+            RenderRecord.ActionSuccess[] blockRenders = _renderer.ActionSuccessRecords
                 .Where(r => r.Action is MinerReward)
                 .ToArray();
 
@@ -346,7 +346,7 @@ namespace Libplanet.Tests.Blockchain
             var store = new MemoryStore();
             var stateStore =
                 new TrieStateStore(new MemoryKeyValueStore());
-            var renderer = new RecordingActionRenderer<ThrowException>();
+            var renderer = new RecordingActionRenderer();
             BlockChain<ThrowException> blockChain =
                 TestUtils.MakeBlockChain(policy, store, stateStore, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
@@ -361,7 +361,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, blockChain.Count);
             Assert.Empty(renderer.ActionSuccessRecords);
             Assert.Single(renderer.ActionErrorRecords);
-            RenderRecord<ThrowException>.ActionError errorRecord = renderer.ActionErrorRecords[0];
+            RenderRecord.ActionError errorRecord = renderer.ActionErrorRecords[0];
             Assert.Equal(action.PlainValue, errorRecord.Action.PlainValue);
             Assert.IsType<UnexpectedlyTerminatedActionException>(errorRecord.Exception);
             Assert.IsType<ThrowException.SomeException>(errorRecord.Exception.InnerException);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -62,7 +62,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.Store,
                 _fx.StateStore,
                 _fx.GenesisBlock,
-                renderers: new[] { new LoggedActionRenderer<DumbAction>(_renderer, Log.Logger) }
+                renderers: new[] { new LoggedActionRenderer(_renderer, Log.Logger) }
             );
             _renderer.BlockChain = _blockChain;
             _renderer.ResetRecords();
@@ -271,9 +271,9 @@ namespace Libplanet.Tests.Blockchain
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var generatedRandomValueLogs = new List<int>();
-            IActionRenderer<DumbAction>[] renderers = Enumerable.Range(0, 2).Select(i =>
-                new LoggedActionRenderer<DumbAction>(
-                    new AnonymousActionRenderer<DumbAction>
+            IActionRenderer[] renderers = Enumerable.Range(0, 2).Select(i =>
+                new LoggedActionRenderer(
+                    new AnonymousActionRenderer
                     {
                         ActionRenderer = (act, context, nextStates) =>
                             // Consuming the random state through IRandom.Next() should not
@@ -308,8 +308,8 @@ namespace Libplanet.Tests.Blockchain
             var policy = new NullBlockPolicy<DumbAction>();
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
-            var recordingRenderer = new RecordingActionRenderer<DumbAction>();
-            var renderer = new LoggedActionRenderer<DumbAction>(recordingRenderer, Log.Logger);
+            var recordingRenderer = new RecordingActionRenderer();
+            var renderer = new LoggedActionRenderer(recordingRenderer, Log.Logger);
             BlockChain<DumbAction> blockChain =
                 MakeBlockChain(policy, store, stateStore, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
@@ -323,10 +323,10 @@ namespace Libplanet.Tests.Blockchain
             blockChain.Append(block, CreateBlockCommit(block));
 
             Assert.Equal(2, blockChain.Count);
-            IReadOnlyList<RenderRecord<DumbAction>.BlockEvent> blockLogs =
+            IReadOnlyList<RenderRecord.BlockEvent> blockLogs =
                 recordingRenderer.BlockRecords;
             Assert.Equal(2, blockLogs.Count);
-            IReadOnlyList<RenderRecord<DumbAction>.ActionBase> actionLogs =
+            IReadOnlyList<RenderRecord.ActionBase> actionLogs =
                 recordingRenderer.ActionRecords;
             Assert.Single(actions);
             Assert.Equal(prevBlock, blockLogs[0].OldTip);
@@ -346,7 +346,7 @@ namespace Libplanet.Tests.Blockchain
             var store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
 
-            IActionRenderer<DumbAction> renderer = new AnonymousActionRenderer<DumbAction>
+            IActionRenderer renderer = new AnonymousActionRenderer
             {
                 ActionRenderer = (a, __, nextStates) =>
                 {
@@ -356,7 +356,7 @@ namespace Libplanet.Tests.Blockchain
                     }
                 },
             };
-            renderer = new LoggedActionRenderer<DumbAction>(renderer, Log.Logger);
+            renderer = new LoggedActionRenderer(renderer, Log.Logger);
             BlockChain<DumbAction> blockChain =
                 MakeBlockChain(policy, store, stateStore, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
@@ -577,7 +577,7 @@ namespace Libplanet.Tests.Blockchain
                     nativeTokenPredicate: _policy.NativeTokens.Contains);
 
                 store.PutBlock(genesis);
-                var renderer = new RecordingActionRenderer<DumbAction>();
+                var renderer = new RecordingActionRenderer();
                 var blockChain = BlockChain<DumbAction>.Create(
                     _policy,
                     new VolatileStagePolicy<DumbAction>(),
@@ -827,11 +827,11 @@ namespace Libplanet.Tests.Blockchain
             Assert.Empty(_blockChain.Store.IterateIndexes(previousChainId));
             Assert.Empty(_blockChain.Store.ListTxNonces(previousChainId));
 
-            RenderRecord<DumbAction>.BlockBase[] blockLevelRenders = _renderer.Records
-                .OfType<RenderRecord<DumbAction>.BlockBase>()
+            RenderRecord.BlockBase[] blockLevelRenders = _renderer.Records
+                .OfType<RenderRecord.BlockBase>()
                 .ToArray();
 
-            RenderRecord<DumbAction>.ActionBase[] actionRenders = _renderer.ActionRecords
+            RenderRecord.ActionBase[] actionRenders = _renderer.ActionRecords
                 .Where(r => r.Action is DumbAction)
                 .ToArray();
             DumbAction[] actions = actionRenders.Select(r => (DumbAction)r.Action).ToArray();
@@ -846,9 +846,9 @@ namespace Libplanet.Tests.Blockchain
             if (render)
             {
                 Assert.Equal(2, blockLevelRenders.Length);
-                Assert.IsType<RenderRecord<DumbAction>.BlockEvent>(blockLevelRenders[0]);
+                Assert.IsType<RenderRecord.BlockEvent>(blockLevelRenders[0]);
                 Assert.True(blockLevelRenders[0].Begin);
-                Assert.IsType<RenderRecord<DumbAction>.BlockEvent>(blockLevelRenders[1]);
+                Assert.IsType<RenderRecord.BlockEvent>(blockLevelRenders[1]);
                 Assert.True(blockLevelRenders[1].End);
 
                 Assert.True(blockLevelRenders[0].Index < actionRenders[0].Index);
@@ -863,7 +863,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Equal("fork-bar", actions[1].Item);
                 Assert.Equal("fork-baz", actions[2].Item);
 
-                RenderRecord<DumbAction>.ActionBase[] blockActionRenders = _renderer.ActionRecords
+                RenderRecord.ActionBase[] blockActionRenders = _renderer.ActionRecords
                     .Where(r => r.Action is MinerReward)
                     .ToArray();
 
@@ -956,7 +956,7 @@ namespace Libplanet.Tests.Blockchain
         public void SwapForSameTip(bool render)
         {
             BlockChain<DumbAction> fork = _blockChain.Fork(_blockChain.Tip.Hash);
-            IReadOnlyList<RenderRecord<DumbAction>> prevRecords = _renderer.Records;
+            IReadOnlyList<RenderRecord> prevRecords = _renderer.Records;
             _blockChain.Swap(fork, render: render)();
 
             // Render methods should be invoked if and only if the tip changes
@@ -1588,7 +1588,7 @@ namespace Libplanet.Tests.Blockchain
             MakeIncompleteBlockStates(
                 IStore store,
                 IStateStore stateStore,
-                IRenderer<DumbAction> renderer = null
+                IRenderer renderer = null
             )
         {
             List<int> presentIndices = new List<int>() { 4, 7 };
@@ -1802,9 +1802,9 @@ namespace Libplanet.Tests.Blockchain
             Assert.Empty(_renderer.BlockRecords);
             Block block = _blockChain.ProposeBlock(new PrivateKey());
             _blockChain.Append(block, CreateBlockCommit(block));
-            IReadOnlyList<RenderRecord<DumbAction>.BlockEvent> records = _renderer.BlockRecords;
+            IReadOnlyList<RenderRecord.BlockEvent> records = _renderer.BlockRecords;
             Assert.Equal(2, records.Count);
-            foreach (RenderRecord<DumbAction>.BlockEvent record in records)
+            foreach (RenderRecord.BlockEvent record in records)
             {
                 Assert.Equal(genesis, record.OldTip);
                 Assert.Equal(block, record.NewTip);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         public void ActionRenderer()
         {
             (IAction, IActionContext, IAccountStateDelta)? record = null;
-            var renderer = new AnonymousActionRenderer<DumbAction>
+            var renderer = new AnonymousActionRenderer
             {
                 ActionRenderer = (action, context, nextStates) =>
                     record = (action, context, nextStates),
@@ -60,7 +60,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         public void ActionErrorRenderer()
         {
             (IAction, IActionContext, Exception)? record = null;
-            var renderer = new AnonymousActionRenderer<DumbAction>
+            var renderer = new AnonymousActionRenderer
             {
                 ActionErrorRenderer = (action, context, exception) =>
                     record = (action, context, exception),
@@ -82,7 +82,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         public void BlockRenderer()
         {
             (Block Old, Block New)? record = null;
-            var renderer = new AnonymousActionRenderer<DumbAction>
+            var renderer = new AnonymousActionRenderer
             {
                 BlockRenderer = (oldTip, newTip) => record = (oldTip, newTip),
             };

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousRendererTest.cs
@@ -1,6 +1,5 @@
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
-using Libplanet.Tests.Common.Action;
 using Xunit;
 
 namespace Libplanet.Tests.Blockchain.Renderers
@@ -20,7 +19,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         public void BlockRenderer()
         {
             (Block Old, Block New)? record = null;
-            var renderer = new AnonymousRenderer<DumbAction>
+            var renderer = new AnonymousRenderer
             {
                 BlockRenderer = (oldTip, newTip) => record = (oldTip, newTip),
             };

--- a/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AtomicActionRendererTest.cs
@@ -12,15 +12,15 @@ namespace Libplanet.Tests.Blockchain.Renderers
 {
     public class AtomicActionRendererTest
     {
-        private readonly RecordingActionRenderer<Arithmetic> _record;
-        private readonly AtomicActionRenderer<Arithmetic> _renderer;
+        private readonly RecordingActionRenderer _record;
+        private readonly AtomicActionRenderer _renderer;
         private readonly IntegerSet _fx;
         private Transaction _successTx;
 
         public AtomicActionRendererTest()
         {
-            _record = new RecordingActionRenderer<Arithmetic>();
-            _renderer = new AtomicActionRenderer<Arithmetic>(_record);
+            _record = new RecordingActionRenderer();
+            _renderer = new AtomicActionRenderer(_record);
             _fx = new IntegerSet(new BigInteger?[] { 0 }, null, new[] { _renderer });
             (_successTx, _) = _fx.Sign(
                 0,
@@ -43,26 +43,26 @@ namespace Libplanet.Tests.Blockchain.Renderers
         public void Block()
         {
             _fx.Append(_fx.Propose());
-            IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
+            IReadOnlyList<RenderRecord> records = _record.Records;
             Assert.Equal(5, records.Count);
-            AssertTypeAnd<RenderRecord<Arithmetic>.BlockEvent>(
+            AssertTypeAnd<RenderRecord.BlockEvent>(
                 records[0], r => Assert.True(r.Begin));
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[1], r =>
+            AssertTypeAnd<RenderRecord.ActionSuccess>(records[1], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
                 Assert.Equal(_successTx.Actions[0], r.Action.PlainValue);
             });
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[2], r =>
+            AssertTypeAnd<RenderRecord.ActionSuccess>(records[2], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
                 Assert.Equal(_successTx.Actions[1], r.Action.PlainValue);
             });
-            AssertTypeAnd<RenderRecord<Arithmetic>.ActionSuccess>(records[3], r =>
+            AssertTypeAnd<RenderRecord.ActionSuccess>(records[3], r =>
             {
                 Assert.Equal(_successTx.Id, r.Context.TxId);
                 Assert.Equal(_successTx.Actions[2], r.Action.PlainValue);
             });
-            AssertTypeAnd<RenderRecord<Arithmetic>.BlockEvent>(records[4], r => Assert.True(r.End));
+            AssertTypeAnd<RenderRecord.BlockEvent>(records[4], r => Assert.True(r.End));
         }
 
         [Fact]
@@ -72,11 +72,11 @@ namespace Libplanet.Tests.Blockchain.Renderers
             _fx.Append(_fx.Propose());
             _record.ResetRecords();
             _fx.Chain.Swap(@base, true)();
-            IReadOnlyList<RenderRecord<Arithmetic>> records = _record.Records;
+            IReadOnlyList<RenderRecord> records = _record.Records;
             Assert.Equal(2, records.Count);
-            AssertTypeAnd<RenderRecord<Arithmetic>.BlockEvent>(
+            AssertTypeAnd<RenderRecord.BlockEvent>(
                 records[0], r => Assert.True(r.Begin));
-            AssertTypeAnd<RenderRecord<Arithmetic>.BlockEvent>(
+            AssertTypeAnd<RenderRecord.BlockEvent>(
                 records[1], r => Assert.True(r.End));
         }
 

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -77,7 +77,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     default, default, default, default, 123, _stateDelta, default, rehearsal
                 );
             Exception actionError = new Exception();
-            IActionRenderer<DumbAction> actionRenderer;
+            IActionRenderer actionRenderer;
             if (error)
             {
                 Action<IAction, IActionContext, Exception> render = (action, cxt, e) =>
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                         throw new ThrowException.SomeException(string.Empty);
                     }
                 };
-                actionRenderer = new AnonymousActionRenderer<DumbAction>
+                actionRenderer = new AnonymousActionRenderer
                 {
                     ActionErrorRenderer = render,
                 };
@@ -115,13 +115,13 @@ namespace Libplanet.Tests.Blockchain.Renderers
                         throw new ThrowException.SomeException(string.Empty);
                     }
                 };
-                actionRenderer = new AnonymousActionRenderer<DumbAction>
+                actionRenderer = new AnonymousActionRenderer
                 {
                     ActionRenderer = render,
                 };
             }
 
-            actionRenderer = new LoggedActionRenderer<DumbAction>(
+            actionRenderer = new LoggedActionRenderer(
                 actionRenderer,
                 _logger,
                 LogEventLevel.Information
@@ -184,7 +184,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 firstLog.Properties["BlockIndex"].ToString()
             );
             Assert.Equal(
-                $"\"{typeof(AnonymousActionRenderer<DumbAction>).FullName}\"",
+                $"\"{typeof(AnonymousActionRenderer).FullName}\"",
                 firstLog.Properties[Constants.SourceContextPropertyName].ToString()
             );
             Assert.Null(firstLog.Exception);
@@ -271,12 +271,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 }
             }
 
-            IActionRenderer<DumbAction> actionRenderer = new AnonymousActionRenderer<DumbAction>
+            IActionRenderer actionRenderer = new AnonymousActionRenderer
             {
                 BlockRenderer = end ? (Action<DumbBlock, DumbBlock>)null : Callback,
                 BlockEndRenderer = end ? Callback : (Action<DumbBlock, DumbBlock>)null,
             };
-            actionRenderer = new LoggedActionRenderer<DumbAction>(actionRenderer, _logger);
+            actionRenderer = new LoggedActionRenderer(actionRenderer, _logger);
             var invoke = end
                 ? (Action<DumbBlock, DumbBlock>)actionRenderer.RenderBlockEnd
                 : actionRenderer.RenderBlock;
@@ -325,7 +325,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             Assert.Equal($"\"{_genesis.Hash}\"", firstLog.Properties["OldHash"].ToString());
             Assert.Equal(
-                $"\"{typeof(AnonymousActionRenderer<DumbAction>).FullName}\"",
+                $"\"{typeof(AnonymousActionRenderer).FullName}\"",
                 firstLog.Properties[Constants.SourceContextPropertyName].ToString()
             );
             Assert.Null(firstLog.Exception);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedRendererTest.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             bool called = false;
             LogEvent firstLog = null;
 
-            IRenderer<DumbAction> renderer = new AnonymousRenderer<DumbAction>
+            IRenderer renderer = new AnonymousRenderer
             {
                 BlockRenderer = (oldTip, newTip) =>
                 {
@@ -69,7 +69,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     }
                 },
             };
-            renderer = new LoggedRenderer<DumbAction>(renderer, _logger);
+            renderer = new LoggedRenderer(renderer, _logger);
 
             Assert.False(called);
             Assert.Empty(LogEvents);
@@ -106,7 +106,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             );
             Assert.Equal($"\"{_genesis.Hash}\"", firstLog.Properties["OldHash"].ToString());
             Assert.Equal(
-                $"\"{typeof(AnonymousRenderer<DumbAction>).FullName}\"",
+                $"\"{typeof(AnonymousRenderer).FullName}\"",
                 firstLog.Properties[Constants.SourceContextPropertyName].ToString()
             );
             Assert.Null(firstLog.Exception);

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Tests.Fixtures
         public IntegerSet(
             IReadOnlyList<BigInteger?> initialStates,
             IBlockPolicy<Arithmetic> policy = null,
-            IEnumerable<IRenderer<Arithmetic>> renderers = null
+            IEnumerable<IRenderer> renderers = null
         )
         {
             PrivateKeys = initialStates.Select(_ => new PrivateKey()).ToImmutableArray();
@@ -95,7 +95,7 @@ namespace Libplanet.Tests.Fixtures
 
         public IBlockPolicy<Arithmetic> Policy => Chain.Policy;
 
-        public IReadOnlyList<IRenderer<Arithmetic>> Renderers => Chain.Renderers;
+        public IReadOnlyList<IRenderer> Renderers => Chain.Renderers;
 
         public Block Tip => Chain.Tip;
 

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -547,7 +547,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         /// <param name="timestamp"><see cref="DateTimeOffset"/> of the genesis block.
         /// Works only if <paramref name="genesisBlock"/> is null.</param>
         /// <param name="renderers">
-        /// An <see cref="IEnumerable{T}"/> of <see cref="IRenderer{T}"/>s.</param>
+        /// An <see cref="IEnumerable{T}"/> of <see cref="IRenderer"/>s.</param>
         /// <param name="genesisBlock">Genesis <see cref="Block"/> of the chain.
         /// If null is given, a genesis will be generated.</param>
         /// <param name="protocolVersion">Block protocol version of genesis block.</param>
@@ -561,7 +561,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             ValidatorSet validatorSet = null,
             PrivateKey privateKey = null,
             DateTimeOffset? timestamp = null,
-            IEnumerable<IRenderer<T>> renderers = null,
+            IEnumerable<IRenderer> renderers = null,
             Block genesisBlock = null,
             int protocolVersion = Block.CurrentProtocolVersion
         )
@@ -590,7 +590,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             ValidatorSet validatorSet = null,
             PrivateKey privateKey = null,
             DateTimeOffset? timestamp = null,
-            IEnumerable<IRenderer<T>> renderers = null,
+            IEnumerable<IRenderer> renderers = null,
             Block genesisBlock = null,
             int protocolVersion = Block.CurrentProtocolVersion
         )

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -200,7 +200,7 @@ namespace Libplanet.Action
         /// <see cref="Execute(IActionContext)"/> method can be called more
         /// than once, the time it's called is difficult to predict.
         /// <para>For changing in-memory game states or drawing graphics,
-        /// implement the <see cref="Blockchain.Renderers.IRenderer{T}"/> interface separately and
+        /// implement the <see cref="Blockchain.Renderers.IRenderer"/> interface separately and
         /// attach it to a <see cref="Blockchain.BlockChain{T}"/> instance.</para>
         /// <para>For randomness, <em>never</em> use <see cref="System.Random"/>
         /// nor any other PRNGs provided by other than Libplanet.

--- a/Libplanet/Action/PolymorphicAction.cs
+++ b/Libplanet/Action/PolymorphicAction.cs
@@ -116,7 +116,7 @@ namespace Libplanet.Action
     ///     }
     /// }
     /// ]]></code>
-    /// Note that when it's rendered through <see cref="Blockchain.Renderers.IRenderer{T}"/>,
+    /// Note that when it's rendered through <see cref="Blockchain.Renderers.IRenderer"/>,
     /// an instance of <see cref="PolymorphicAction{T}"/> is passed instead of its
     /// <see cref="InnerAction"/>:
     /// <code>

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -144,7 +144,7 @@ namespace Libplanet.Blockchain
         {
             if (render)
             {
-                foreach (IRenderer<T> renderer in Renderers)
+                foreach (IRenderer renderer in Renderers)
                 {
                     renderer.RenderBlock(
                         oldTip: oldTip,
@@ -189,7 +189,7 @@ namespace Libplanet.Blockchain
                     nameof(Swap),
                     count);
 
-                foreach (IActionRenderer<T> renderer in ActionRenderers)
+                foreach (IActionRenderer renderer in ActionRenderers)
                 {
                     renderer.RenderBlockEnd(oldTip, newTip);
                 }
@@ -232,7 +232,7 @@ namespace Libplanet.Blockchain
                     ? Policy.BlockAction!
                     : ToAction(evaluation.Action);
 
-                foreach (IActionRenderer<T> renderer in ActionRenderers)
+                foreach (IActionRenderer renderer in ActionRenderers)
                 {
                     if (evaluation.Exception is null)
                     {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -28,9 +28,9 @@ namespace Libplanet.Blockchain
     /// information.
     /// </para>
     /// <para>
-    /// In order to watch its state changes, implement <see cref="IRenderer{T}"/> interface
+    /// In order to watch its state changes, implement <see cref="IRenderer"/> interface
     /// and pass it to the <see cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T},
-    /// IStore, IStateStore, Block, IEnumerable{IRenderer{T}})"/> constructor.
+    /// IStore, IStateStore, Block, IEnumerable{IRenderer})"/> constructor.
     /// </para>
     /// </summary>
     /// <remarks>This object is guaranteed that it has at least one block, since it takes a genesis
@@ -81,7 +81,7 @@ namespace Libplanet.Blockchain
         /// <param name="renderers">Listens state changes on the created chain.  Listens nothing
         /// by default or if it is <see langword="null"/>.  Note that action renderers receive
         /// events made by unsuccessful transactions too; see also
-        /// <see cref="AtomicActionRenderer{T}"/> for workaround.</param>
+        /// <see cref="AtomicActionRenderer"/> for workaround.</param>
         /// <param name="stateStore"><see cref="IStateStore"/> to store states.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="store"/> does not
         /// have canonical chain id set, i.e. <see cref="IStore.GetCanonicalChainId()"/> is
@@ -97,7 +97,7 @@ namespace Libplanet.Blockchain
             IStore store,
             IStateStore stateStore,
             Block genesisBlock,
-            IEnumerable<IRenderer<T>> renderers = null
+            IEnumerable<IRenderer> renderers = null
         )
             : this(
                 policy,
@@ -113,7 +113,7 @@ namespace Libplanet.Blockchain
 
 #pragma warning disable MEN002
 #pragma warning disable CS1573
-        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block, IEnumerable{IRenderer{T}})" />
+        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block, IEnumerable{IRenderer})" />
         /// <param name="blockChainStates">The <see cref="IBlockChainStates"/> implementation to state lookup.</param>
         public BlockChain(
             IBlockPolicy<T> policy,
@@ -121,7 +121,7 @@ namespace Libplanet.Blockchain
             IStore store,
             IStateStore stateStore,
             Block genesisBlock,
-            IEnumerable<IRenderer<T>> renderers,
+            IEnumerable<IRenderer> renderers,
             IBlockChainStates blockChainStates
         )
 #pragma warning restore MEN002
@@ -150,7 +150,7 @@ namespace Libplanet.Blockchain
 
 #pragma warning disable MEN002
 #pragma warning disable CS1573
-        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block, IEnumerable{IRenderer{T}}, IBlockChainStates)" />
+        /// <inheritdoc cref="BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block, IEnumerable{IRenderer}, IBlockChainStates)" />
         /// <param name="actionEvaluator">The <see cref="ActionEvaluator" /> implementation to calculate next states when append new blocks.</param>
         public BlockChain(
             IBlockPolicy<T> policy,
@@ -158,7 +158,7 @@ namespace Libplanet.Blockchain
             IStore store,
             IStateStore stateStore,
             Block genesisBlock,
-            IEnumerable<IRenderer<T>> renderers,
+            IEnumerable<IRenderer> renderers,
             IBlockChainStates blockChainStates,
             IActionEvaluator actionEvaluator
         )
@@ -189,7 +189,7 @@ namespace Libplanet.Blockchain
             IStateStore stateStore,
             Guid id,
             Block genesisBlock,
-            IEnumerable<IRenderer<T>> renderers,
+            IEnumerable<IRenderer> renderers,
             IBlockChainStates blockChainStates,
             IActionEvaluator actionEvaluator)
         {
@@ -216,10 +216,10 @@ namespace Libplanet.Blockchain
             _blockChainStates = blockChainStates;
 
             _blocks = new BlockSet(store);
-            Renderers = renderers is IEnumerable<IRenderer<T>> r
+            Renderers = renderers is IEnumerable<IRenderer> r
                 ? r.ToImmutableArray()
-                : ImmutableArray<IRenderer<T>>.Empty;
-            ActionRenderers = Renderers.OfType<IActionRenderer<T>>().ToImmutableArray();
+                : ImmutableArray<IRenderer>.Empty;
+            ActionRenderers = Renderers.OfType<IActionRenderer>().ToImmutableArray();
             _rwlock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             _txLock = new object();
 
@@ -253,7 +253,7 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// An event which is invoked when <see cref="Tip"/> is changed.
         /// </summary>
-        // FIXME: This should be completely replaced by IRenderer<T>.RenderBlock() or any other
+        // FIXME: This should be completely replaced by IRenderer.RenderBlock() or any other
         // alternatives.
         internal event EventHandler<(Block OldTip, Block NewTip)> TipChanged;
 
@@ -264,16 +264,16 @@ namespace Libplanet.Blockchain
         /// Since this value is immutable, renderers cannot be registered after once a <see
         /// cref="BlockChain{T}"/> object is instantiated; use <c>renderers</c> option of <see cref=
         /// "BlockChain{T}(IBlockPolicy{T}, IStagePolicy{T}, IStore, IStateStore, Block,
-        /// IEnumerable{IRenderer{T}})"/>
+        /// IEnumerable{IRenderer})"/>
         /// constructor instead.
         /// </remarks>
-        public IImmutableList<IRenderer<T>> Renderers { get; }
+        public IImmutableList<IRenderer> Renderers { get; }
 
         /// <summary>
         /// A filtered list, from <see cref="Renderers"/>, which contains only <see
-        /// cref="IActionRenderer{T}"/> instances.
+        /// cref="IActionRenderer"/> instances.
         /// </summary>
-        public IImmutableList<IActionRenderer<T>> ActionRenderers { get; }
+        public IImmutableList<IActionRenderer> ActionRenderers { get; }
 
         /// <summary>
         /// The block and blockchain policy.
@@ -409,7 +409,7 @@ namespace Libplanet.Blockchain
             IStore store,
             IStateStore stateStore,
             Block genesisBlock,
-            IEnumerable<IRenderer<T>> renderers = null,
+            IEnumerable<IRenderer> renderers = null,
             IBlockChainStates blockChainStates = null,
             ActionEvaluator actionEvaluator = null)
 #pragma warning restore SA1611  // The documentation for parameters are missing.
@@ -905,9 +905,9 @@ namespace Libplanet.Blockchain
             }
 
             var forkedId = Guid.NewGuid();
-            IEnumerable<IRenderer<T>> renderers = inheritRenderers
+            IEnumerable<IRenderer> renderers = inheritRenderers
                 ? Renderers
-                : Enumerable.Empty<IRenderer<T>>();
+                : Enumerable.Empty<IRenderer>();
             try
             {
                 _rwlock.EnterReadLock();
@@ -1203,7 +1203,7 @@ namespace Libplanet.Blockchain
                         ActionRenderers.Count,
                         block.Index,
                         block.Hash);
-                    foreach (IRenderer<T> renderer in Renderers)
+                    foreach (IRenderer renderer in Renderers)
                     {
                         renderer.RenderBlock(oldTip: prevTip ?? Genesis, newTip: block);
                     }
@@ -1211,7 +1211,7 @@ namespace Libplanet.Blockchain
                     if (ActionRenderers.Any())
                     {
                         RenderActions(evaluations: actionEvaluations, block: block);
-                        foreach (IActionRenderer<T> renderer in ActionRenderers)
+                        foreach (IActionRenderer renderer in ActionRenderers)
                         {
                             renderer.RenderBlockEnd(oldTip: prevTip ?? Genesis, newTip: block);
                         }

--- a/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
@@ -5,16 +5,16 @@ using Libplanet.Blocks;
 namespace Libplanet.Blockchain.Renderers
 {
     /// <summary>
-    /// An <see cref="IActionRenderer{T}"/> that invokes its callbacks.
-    /// In other words, this is an <see cref="IActionRenderer{T}"/> version of
-    /// <see cref="AnonymousRenderer{T}"/>.
+    /// An <see cref="IActionRenderer"/> that invokes its callbacks.
+    /// In other words, this is an <see cref="IActionRenderer"/> version of
+    /// <see cref="AnonymousRenderer"/>.
     /// <para>This class is useful when you want an one-use ad-hoc implementation (i.e., Java-style
-    /// anonymous class) of <see cref="IActionRenderer{T}"/> interface.</para>
+    /// anonymous class) of <see cref="IActionRenderer"/> interface.</para>
     /// </summary>
     /// <example>
     /// With object initializers, you can easily make an one-use action renderer:
     /// <code><![CDATA[
-    /// var actionRenderer = new AnonymousActionRenderer<ExampleAction>
+    /// var actionRenderer = new AnonymousActionRenderer
     /// {
     ///     ActionRenderer = (action, context, nextStates) =>
     ///     {
@@ -23,10 +23,7 @@ namespace Libplanet.Blockchain.Renderers
     /// };
     /// ]]></code>
     /// </example>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public sealed class AnonymousActionRenderer<T> : AnonymousRenderer<T>, IActionRenderer<T>
-        where T : IAction, new()
+    public sealed class AnonymousActionRenderer : AnonymousRenderer, IActionRenderer
     {
         /// <summary>
         /// A callback function to be invoked together with
@@ -47,7 +44,7 @@ namespace Libplanet.Blockchain.Renderers
         public Action<Block, Block>? BlockEndRenderer { get; set; }
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        /// cref="IActionRenderer.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
         public void RenderAction(
             IAction action,
             IActionContext context,
@@ -56,11 +53,11 @@ namespace Libplanet.Blockchain.Renderers
             ActionRenderer?.Invoke(action, context, nextStates);
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        /// cref="IActionRenderer.RenderActionError(IAction, IActionContext, Exception)"/>
         public void RenderActionError(IAction action, IActionContext context, Exception exception)
             => ActionErrorRenderer?.Invoke(action, context, exception);
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block, Block)"/>
+        /// <inheritdoc cref="IActionRenderer.RenderBlockEnd(Block, Block)"/>
         public void RenderBlockEnd(Block oldTip, Block newTip) =>
             BlockEndRenderer?.Invoke(oldTip, newTip);
     }

--- a/Libplanet/Blockchain/Renderers/AnonymousRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using Libplanet.Action;
 using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain.Renderers
@@ -7,7 +6,7 @@ namespace Libplanet.Blockchain.Renderers
     /// <summary>
     /// A renderer that invokes its callbacks.
     /// <para>This class is useful when you want an one-use ad-hoc implementation (i.e., Java-style
-    /// anonymous class) of <see cref="IRenderer{T}"/> interface.</para>
+    /// anonymous class) of <see cref="IRenderer"/> interface.</para>
     /// </summary>
     /// <example>
     /// With object initializers, you can easily make an one-use renderer:
@@ -21,10 +20,7 @@ namespace Libplanet.Blockchain.Renderers
     /// };
     /// </code>
     /// </example>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public class AnonymousRenderer<T> : IRenderer<T>
-        where T : IAction, new()
+    public class AnonymousRenderer : IRenderer
     {
         /// <summary>
         /// A callback function to be invoked together with
@@ -32,7 +28,7 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         public Action<Block, Block>? BlockRenderer { get; set; }
 
-        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block, Block)"/>
+        /// <inheritdoc cref="IRenderer.RenderBlock(Block, Block)"/>
         public void RenderBlock(Block oldTip, Block newTip) =>
             BlockRenderer?.Invoke(oldTip, newTip);
     }

--- a/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
@@ -8,31 +8,28 @@ namespace Libplanet.Blockchain.Renderers
 {
     /// <summary>
     /// A middleware to make action render events to satisfy transactions' atomicity.
-    /// <para>Decorates an <see cref="IActionRenderer{T}"/> instance and filters out render events
+    /// <para>Decorates an <see cref="IActionRenderer"/> instance and filters out render events
     /// made by unsuccessful transactions (i.e., transactions with one or more exception-throwing
     /// actions).</para>
     /// </summary>
     /// <remarks>The wrapped <see cref="ActionRenderer"/> will not receive any
-    /// <see cref="IActionRenderer{T}.RenderActionError"/> events except for block actions,
+    /// <see cref="IActionRenderer.RenderActionError"/> events except for block actions,
     /// which do not belong to any transactions.
     /// </remarks>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public sealed class AtomicActionRenderer<T> : IActionRenderer<T>
-        where T : IAction, new()
+    public sealed class AtomicActionRenderer : IActionRenderer
     {
         private readonly List<(IAction, IActionContext, IAccountStateDelta)> _eventBuffer;
         private TxId? _lastTxId;
         private bool _errored;
 
         /// <summary>
-        /// Creates a new <see cref="AtomicActionRenderer{T}"/> instance decorating the given
+        /// Creates a new <see cref="AtomicActionRenderer"/> instance decorating the given
         /// <paramref name="actionRenderer"/>.
         /// </summary>
         /// <param name="actionRenderer">The inner action renderer which has the <em>actual</em>
         /// implementations and expects to receive no <see cref="RenderActionError"/> events.
         /// </param>
-        public AtomicActionRenderer(IActionRenderer<T> actionRenderer)
+        public AtomicActionRenderer(IActionRenderer actionRenderer)
         {
             ActionRenderer = actionRenderer;
             _lastTxId = null;
@@ -44,15 +41,15 @@ namespace Libplanet.Blockchain.Renderers
         /// The inner action renderer which has the <em>actual</em> implementations and expects to
         /// receive no <see cref="RenderActionError"/> events.
         /// </summary>
-        public IActionRenderer<T> ActionRenderer { get; }
+        public IActionRenderer ActionRenderer { get; }
 
-        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block, Block)"/>
+        /// <inheritdoc cref="IRenderer.RenderBlock(Block, Block)"/>
         public void RenderBlock(Block oldTip, Block newTip)
         {
             ActionRenderer.RenderBlock(oldTip, newTip);
         }
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block, Block)"/>
+        /// <inheritdoc cref="IActionRenderer.RenderBlockEnd(Block, Block)"/>
         public void RenderBlockEnd(Block oldTip, Block newTip)
         {
             FlushBuffer(null, ActionRenderer.RenderAction);
@@ -60,7 +57,7 @@ namespace Libplanet.Blockchain.Renderers
         }
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        /// cref="IActionRenderer.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
         public void RenderAction(
             IAction action,
             IActionContext context,
@@ -83,7 +80,7 @@ namespace Libplanet.Blockchain.Renderers
         }
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        /// cref="IActionRenderer.RenderActionError(IAction, IActionContext, Exception)"/>
         public void RenderActionError(IAction action, IActionContext context, Exception exception)
         {
             if (!context.TxId.Equals(_lastTxId))

--- a/Libplanet/Blockchain/Renderers/Debug/InvalidRenderException.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/InvalidRenderException.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Libplanet.Action;
 
 namespace Libplanet.Blockchain.Renderers.Debug
 {
     /// <summary>
     /// Exception thrown by <see cref="ValidatingActionRenderer{T}"/>.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="ValidatingActionRenderer{T}"/>'s type parameter.</typeparam>
-    public class InvalidRenderException<T> : Exception
-        where T : IAction, new()
+    public class InvalidRenderException : Exception
     {
         /// <summary>
         /// Creates a new <see cref="ValidatingActionRenderer{T}"/> instance.
@@ -20,7 +16,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <param name="records">Recorded render events.</param>
         public InvalidRenderException(
             string message,
-            IReadOnlyList<RenderRecord<T>> records
+            IReadOnlyList<RenderRecord> records
         )
             : base(message)
         {
@@ -30,7 +26,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <summary>
         /// Recorded render events.
         /// </summary>
-        public IReadOnlyList<RenderRecord<T>> Records { get; }
+        public IReadOnlyList<RenderRecord> Records { get; }
 
         /// <inheritdoc cref="Exception.Message"/>
         public override string Message
@@ -56,7 +52,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                     return pre + "\n(0 records.)";
                 }
 
-                RenderRecord<T> first = Records[Records.Count - 1];
+                RenderRecord first = Records[Records.Count - 1];
                 var firstLine = $"{pre}\n{first}";
                 if (Records.Count < 2)
                 {
@@ -86,8 +82,8 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 firstTrace =
                     MakeCompact(firstTrace.Substring(0, firstTrace.Length - commonPostfix));
                 firstLine += $"\n{firstTrace}";
-                RenderRecord<T> second = Records[Records.Count - 2];
-                IEnumerable<RenderRecord<T>> rest = Records.Reverse().Skip(2);
+                RenderRecord second = Records[Records.Count - 2];
+                IEnumerable<RenderRecord> rest = Records.Reverse().Skip(2);
                 string secondTrace = second.StackTrace;
                 string secondCompactTrace =
                     MakeCompact(secondTrace.Substring(0, secondTrace.Length - commonPostfix));

--- a/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
@@ -11,39 +11,36 @@ namespace Libplanet.Blockchain.Renderers.Debug
     /// <summary>
     /// Records every render events.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
-    public class RecordingActionRenderer<T> : IActionRenderer<T>
-        where T : IAction, new()
+    public class RecordingActionRenderer : IActionRenderer
     {
-        private readonly List<RenderRecord<T>> _records;
+        private readonly List<RenderRecord> _records;
         private long _nextIndex;
 
         /// <summary>
-        /// Creates a new <see cref="RecordingActionRenderer{T}"/> instance.
+        /// Creates a new <see cref="RecordingActionRenderer"/> instance.
         /// </summary>
         public RecordingActionRenderer()
         {
             _nextIndex = 0;
-            _records = new List<RenderRecord<T>>();
+            _records = new List<RenderRecord>();
         }
 
         /// <summary>
         /// The list of recorded render events.
         /// </summary>
-        public IReadOnlyList<RenderRecord<T>> Records => _records;
+        public IReadOnlyList<RenderRecord> Records => _records;
 
-        internal IReadOnlyList<RenderRecord<T>.ActionBase> ActionRecords =>
-            Records.OfType<RenderRecord<T>.ActionBase>().ToImmutableArray();
+        internal IReadOnlyList<RenderRecord.ActionBase> ActionRecords =>
+            Records.OfType<RenderRecord.ActionBase>().ToImmutableArray();
 
-        internal IReadOnlyList<RenderRecord<T>.ActionSuccess> ActionSuccessRecords =>
-            Records.OfType<RenderRecord<T>.ActionSuccess>().ToImmutableArray();
+        internal IReadOnlyList<RenderRecord.ActionSuccess> ActionSuccessRecords =>
+            Records.OfType<RenderRecord.ActionSuccess>().ToImmutableArray();
 
-        internal IReadOnlyList<RenderRecord<T>.ActionError> ActionErrorRecords =>
-            Records.OfType<RenderRecord<T>.ActionError>().ToImmutableArray();
+        internal IReadOnlyList<RenderRecord.ActionError> ActionErrorRecords =>
+            Records.OfType<RenderRecord.ActionError>().ToImmutableArray();
 
-        internal IReadOnlyList<RenderRecord<T>.BlockEvent> BlockRecords =>
-            Records.OfType<RenderRecord<T>.BlockEvent>().ToImmutableArray();
+        internal IReadOnlyList<RenderRecord.BlockEvent> BlockRecords =>
+            Records.OfType<RenderRecord.BlockEvent>().ToImmutableArray();
 
         internal EventHandler<IAction>? RenderEventHandler { get; set; }
 
@@ -54,10 +51,10 @@ namespace Libplanet.Blockchain.Renderers.Debug
         {
             _nextIndex = 0;
             _records.Clear();
-            Log.Logger.ForContext<RecordingActionRenderer<T>>().Debug("Reset records");
+            Log.Logger.ForContext<RecordingActionRenderer>().Debug("Reset records");
         }
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderAction"/>
+        /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public virtual void RenderAction(
             IAction action,
             IActionContext context,
@@ -65,7 +62,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         )
         {
             _records.Add(
-                new RenderRecord<T>.ActionSuccess(
+                new RenderRecord.ActionSuccess(
                     index: _nextIndex++,
                     stackTrace: RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                     action: action,
@@ -77,14 +74,14 @@ namespace Libplanet.Blockchain.Renderers.Debug
             RenderEventHandler?.Invoke(action, action);
         }
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderActionError"/>
+        /// <inheritdoc cref="IActionRenderer.RenderActionError"/>
         public virtual void RenderActionError(
             IAction action,
             IActionContext context,
             Exception exception
         ) =>
             _records.Add(
-                new RenderRecord<T>.ActionError(
+                new RenderRecord.ActionError(
                     index: _nextIndex++,
                     stackTrace: RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                     action: action,
@@ -93,10 +90,10 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 )
             );
 
-        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block, Block)"/>
+        /// <inheritdoc cref="IRenderer.RenderBlock(Block, Block)"/>
         public virtual void RenderBlock(Block oldTip, Block newTip) =>
             _records.Add(
-                new RenderRecord<T>.BlockEvent(
+                new RenderRecord.BlockEvent(
                     index: _nextIndex++,
                     stackTrace: RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                     oldTip: oldTip,
@@ -104,10 +101,10 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 )
             );
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block, Block)"/>
+        /// <inheritdoc cref="IActionRenderer.RenderBlockEnd(Block, Block)"/>
         public virtual void RenderBlockEnd(Block oldTip, Block newTip) =>
             _records.Add(
-                new RenderRecord<T>.BlockEvent(
+                new RenderRecord.BlockEvent(
                     index: _nextIndex++,
                     stackTrace: RemoveFirstLine(Environment.StackTrace).TrimEnd(),
                     end: true,

--- a/Libplanet/Blockchain/Renderers/Debug/RenderRecord.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/RenderRecord.cs
@@ -5,12 +5,9 @@ using Libplanet.Blocks;
 namespace Libplanet.Blockchain.Renderers.Debug
 {
     /// <summary>
-    /// A render event represented by <see cref="RecordingActionRenderer{T}"/>.
+    /// A render event represented by <see cref="RecordingActionRenderer"/>.
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
-    public abstract class RenderRecord<T>
-        where T : IAction, new()
+    public abstract class RenderRecord
     {
         protected RenderRecord(long index, string stackTrace)
         {
@@ -34,7 +31,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <summary>
         /// Represents an action render/unrender event.
         /// </summary>
-        public abstract class ActionBase : RenderRecord<T>
+        public abstract class ActionBase : RenderRecord
         {
             protected ActionBase(
                 long index,
@@ -70,7 +67,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             /// </summary>
             public bool Unrender => !Render;
 
-            /// <inheritdoc cref="RenderRecord{T}.ToString()"/>
+            /// <inheritdoc cref="RenderRecord.ToString()"/>
             public override string ToString() =>
                 $"{base.ToString()} #{Context.BlockIndex} " +
                 (Render ? "Render" : "Unrender") + "Action";
@@ -108,7 +105,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             /// </summary>
             public IAccountStateDelta NextStates { get; }
 
-            /// <inheritdoc cref="RenderRecord{T}.ToString()"/>
+            /// <inheritdoc cref="RenderRecord.ToString()"/>
             public override string ToString() => $"{base.ToString()} [success]";
         }
 
@@ -144,14 +141,14 @@ namespace Libplanet.Blockchain.Renderers.Debug
             /// </summary>
             public Exception Exception { get; }
 
-            /// <inheritdoc cref="RenderRecord{T}.ToString()"/>
+            /// <inheritdoc cref="RenderRecord.ToString()"/>
             public override string ToString() => $"{base.ToString()} [error]";
         }
 
         /// <summary>
         /// Represents a block event.
         /// </summary>
-        public abstract class BlockBase : RenderRecord<T>
+        public abstract class BlockBase : RenderRecord
         {
             protected BlockBase(
                 long index,
@@ -187,7 +184,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             /// </summary>
             public bool End => !Begin;
 
-            /// <inheritdoc cref="RenderRecord{T}.ToString()"/>
+            /// <inheritdoc cref="RenderRecord.ToString()"/>
             public override string ToString() =>
                 $"{base.ToString()} " +
                 $"#{OldTip.Index} {OldTip.Hash} -> #{NewTip.Index} {NewTip.Hash} Render..." +
@@ -218,7 +215,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             {
             }
 
-            /// <inheritdoc cref="RenderRecord{T}.ToString()"/>
+            /// <inheritdoc cref="RenderRecord.ToString()"/>
             public override string ToString() =>
                 base.ToString().Replace("Render...", "RenderBlock");
         }

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -7,22 +7,22 @@ namespace Libplanet.Blockchain.Renderers.Debug
 {
     /// <summary>
     /// Validates if rendering events are in the correct order according to the documented automata
-    /// (see also the docs for <see cref="IRenderer{T}"/> and <see cref="IActionRenderer{T}"/>)
+    /// (see also the docs for <see cref="IRenderer"/> and <see cref="IActionRenderer"/>)
     /// using profiling-guided analysis.
     /// </summary>
     /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
     /// <see cref="Libplanet.Blockchain.BlockChain{T}"/>'s type parameter.</typeparam>
-    public class ValidatingActionRenderer<T> : RecordingActionRenderer<T>
+    public class ValidatingActionRenderer<T> : RecordingActionRenderer
         where T : IAction, new()
     {
-        private readonly Action<InvalidRenderException<T>>? _onError;
+        private readonly Action<InvalidRenderException>? _onError;
 
         /// <summary>
         /// Creates a new <see cref="ValidatingActionRenderer{T}"/> instance.
         /// </summary>
         /// <param name="onError">An optional event handler which is triggered when invalid
         /// render events occur.</param>
-        public ValidatingActionRenderer(Action<InvalidRenderException<T>>? onError = null)
+        public ValidatingActionRenderer(Action<InvalidRenderException>? onError = null)
         {
             _onError = onError;
         }
@@ -40,7 +40,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// </summary>
         public BlockChain<T>? BlockChain { get; set; }
 
-        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block, Block)"/>
+        /// <inheritdoc cref="IRenderer.RenderBlock(Block, Block)"/>
         public override void RenderBlock(Block oldTip, Block newTip)
         {
             base.RenderBlock(oldTip, newTip);
@@ -48,7 +48,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         }
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        /// cref="IActionRenderer.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
         public override void RenderAction(
             IAction action,
             IActionContext context,
@@ -60,7 +60,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         }
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        /// cref="IActionRenderer.RenderActionError(IAction, IActionContext, Exception)"/>
         public override void RenderActionError(
             IAction action,
             IActionContext context,
@@ -71,7 +71,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             Validate();
         }
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block, Block)"/>
+        /// <inheritdoc cref="IActionRenderer.RenderBlockEnd(Block, Block)"/>
         public override void RenderBlockEnd(Block oldTip, Block newTip)
         {
             base.RenderBlockEnd(oldTip, newTip);
@@ -81,13 +81,13 @@ namespace Libplanet.Blockchain.Renderers.Debug
         private void Validate()
         {
             var state = RenderState.Ready;
-            RenderRecord<T>.BlockEvent? blockState = null;
+            RenderRecord.BlockEvent? blockState = null;
             long previousActionBlockIndex = -1L;
-            var records = new List<RenderRecord<T>>(Records.Count);
+            var records = new List<RenderRecord>(Records.Count);
 
             Exception BadRenderExc(string msg) => Error(records, msg);
 
-            foreach (RenderRecord<T> record in Records)
+            foreach (RenderRecord record in Records)
             {
                 records.Add(record);
                 switch (state)
@@ -100,10 +100,10 @@ namespace Libplanet.Blockchain.Renderers.Debug
                         {
                             throw BadRenderExc($"Unexpected block state: {blockState}.");
                         }
-                        else if (record is RenderRecord<T>.BlockBase blockBase && blockBase.Begin)
+                        else if (record is RenderRecord.BlockBase blockBase && blockBase.Begin)
                         {
 #pragma warning disable S1066
-                            if (blockBase is RenderRecord<T>.BlockEvent block)
+                            if (blockBase is RenderRecord.BlockEvent block)
 #pragma warning restore S1066
                             {
                                 blockState = block;
@@ -112,7 +112,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                             }
                         }
 
-                        throw BadRenderExc($"Expected {nameof(IRenderer<T>.RenderBlock)}.");
+                        throw BadRenderExc($"Expected {nameof(IRenderer.RenderBlock)}.");
                     }
 
                     case RenderState.Block:
@@ -121,14 +121,14 @@ namespace Libplanet.Blockchain.Renderers.Debug
                         {
                             throw BadRenderExc("Unexpected block state: null.");
                         }
-                        else if (record is RenderRecord<T>.BlockEvent block && block.End)
+                        else if (record is RenderRecord.BlockEvent block && block.End)
                         {
                             if (block.OldTip != blockState.OldTip ||
                                 block.NewTip != blockState.NewTip)
                             {
                                 throw BadRenderExc(
-                                    $"{nameof(IRenderer<T>.RenderBlock)} and " +
-                                    $"{nameof(IActionRenderer<T>.RenderBlockEnd)} which matches " +
+                                    $"{nameof(IRenderer.RenderBlock)} and " +
+                                    $"{nameof(IActionRenderer.RenderBlockEnd)} which matches " +
                                     "to it should have the same oldTip and newTip."
                                 );
                             }
@@ -139,7 +139,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                             blockState = null;
                             break;
                         }
-                        else if (record is RenderRecord<T>.ActionBase actionBase &&
+                        else if (record is RenderRecord.ActionBase actionBase &&
                                  actionBase.Render)
                         {
                             long idx = actionBase.Context.BlockIndex;
@@ -156,9 +156,9 @@ namespace Libplanet.Blockchain.Renderers.Debug
                         }
 
                         throw BadRenderExc(
-                            $"Expected {nameof(IActionRenderer<T>.RenderBlockEnd)} or " +
-                            $"{nameof(IActionRenderer<T>.RenderAction)} or " +
-                            $"{nameof(IActionRenderer<T>.RenderActionError)}"
+                            $"Expected {nameof(IActionRenderer.RenderBlockEnd)} or " +
+                            $"{nameof(IActionRenderer.RenderAction)} or " +
+                            $"{nameof(IActionRenderer.RenderActionError)}"
                         );
                     }
 
@@ -177,9 +177,9 @@ namespace Libplanet.Blockchain.Renderers.Debug
             }
         }
 
-        private InvalidRenderException<T> Error(IReadOnlyList<RenderRecord<T>> records, string msg)
+        private InvalidRenderException Error(IReadOnlyList<RenderRecord> records, string msg)
         {
-            var exception = new InvalidRenderException<T>(msg, records);
+            var exception = new InvalidRenderException(msg, records);
             _onError?.Invoke(exception);
             return exception;
         }

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -9,11 +9,11 @@ namespace Libplanet.Blockchain.Renderers
     /// <summary>
     /// Listens state changes of every step of actions, besides blocks,
     /// on a <see cref="BlockChain{T}"/>.
-    /// If you need more fine-grained events than <see cref="IRenderer{T}"/>,
+    /// If you need more fine-grained events than <see cref="IRenderer"/>,
     /// implement this interface instead.
     /// <para>The invocation order of methods for each <see cref="Block"/> are:</para>
     /// <list type="number">
-    /// <item><description><see cref="IRenderer{T}.RenderBlock(Block, Block)"/> (one time)
+    /// <item><description><see cref="IRenderer.RenderBlock(Block, Block)"/> (one time)
     /// </description></item>
     /// <item><description><see cref="RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
     /// &amp; <see cref="RenderActionError(IAction, IActionContext, Exception)"/> (zero or more
@@ -25,20 +25,17 @@ namespace Libplanet.Blockchain.Renderers
     /// </summary>
     /// <remarks>Although <see cref="Transaction"/>s affect the states in
     /// the <see cref="IStateStore"/> all or nothing at all (i.e., atomically),
-    /// <see cref="IActionRenderer{T}"/> receives all action-related events
+    /// <see cref="IActionRenderer"/> receives all action-related events
     /// (<see cref="RenderAction"/>/<see cref="RenderActionError"/>) <em>immediately</em>
     /// without buffering, which means actions are rendered <em>even before</em> whether there are
     /// any actions throwing an exception in the same transaction is determined.  In other words,
-    /// for <see cref="IActionRenderer{T}"/>s, it is not guaranteed that actions in a transaction
+    /// for <see cref="IActionRenderer"/>s, it is not guaranteed that actions in a transaction
     /// are atomic.
     /// <para>If your action renderer expects to receive only render events about actions belonging
     /// successful transactions, wrap your action renderer with
-    /// <see cref="AtomicActionRenderer{T}"/>.</para>
+    /// <see cref="AtomicActionRenderer"/>.</para>
     /// </remarks>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public interface IActionRenderer<T> : IRenderer<T>
-        where T : IAction, new()
+    public interface IActionRenderer : IRenderer
     {
         /// <summary>
         /// Does things that should be done right after an <paramref name="action"/>
@@ -60,13 +57,9 @@ namespace Libplanet.Blockchain.Renderers
         /// cref="RenderActionError(IAction, IActionContext, Exception)"/> is called instead) or
         /// once the <paramref name="action"/> has been unrendered.
         /// <para>Also note that this method is invoked after <see
-        /// cref="IRenderer{T}.RenderBlock(Block, Block)"/> method is called
+        /// cref="IRenderer.RenderBlock(Block, Block)"/> method is called
         /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
         /// name="action"/> belongs to).</para>
-        /// <para>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction.Actions"/>).</para>
         /// </remarks>
         void RenderAction(IAction action, IActionContext context, IAccountStateDelta nextStates);
 
@@ -84,13 +77,9 @@ namespace Libplanet.Blockchain.Renderers
         /// name="action"/>.</param>
         /// <remarks>
         /// Also note that this method is invoked after <see
-        /// cref="IRenderer{T}.RenderBlock(Block, Block)"/> method is called
+        /// cref="IRenderer.RenderBlock(Block, Block)"/> method is called
         /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
         /// name="action"/> belongs to).
-        /// <para>The reason why the parameter <paramref name="action"/> takes
-        /// <see cref="IAction"/> instead of <typeparamref name="T"/> is because it can take
-        /// block actions (<see cref="Policies.IBlockPolicy{T}.BlockAction"/>) besides transaction
-        /// actions (<see cref="Tx.Transaction.Actions"/>).</para>
         /// </remarks>
         void RenderActionError(IAction action, IActionContext context, Exception exception);
 

--- a/Libplanet/Blockchain/Renderers/IRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IRenderer.cs
@@ -1,4 +1,3 @@
-using Libplanet.Action;
 using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain.Renderers
@@ -14,10 +13,7 @@ namespace Libplanet.Blockchain.Renderers
     /// </item>
     /// </list>
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
-    public interface IRenderer<T>
-        where T : IAction, new()
+    public interface IRenderer
     {
         /// <summary>
         /// Does things that should be done right after a new <see cref="Block"/> is appended to

--- a/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
@@ -7,32 +7,29 @@ using Serilog.Events;
 namespace Libplanet.Blockchain.Renderers
 {
     /// <summary>
-    /// Decorates an <see cref="IActionRenderer{T}"/> so that all event messages are logged.
-    /// In other words, this is an <see cref="IActionRenderer{T}"/> version of
-    /// <see cref="LoggedRenderer{T}"/>.
+    /// Decorates an <see cref="IActionRenderer"/> so that all event messages are logged.
+    /// In other words, this is an <see cref="IActionRenderer"/> version of
+    /// <see cref="LoggedRenderer"/>.
     /// <para>Every single event message causes two log messages: one is logged <em>before</em>
     /// rendering, and other one is logged <em>after</em> rendering.  If any exception is thrown
     /// it is also logged with the log level <see cref="LogEventLevel.Error"/> (regardless of
-    /// <see cref="LoggedRenderer{T}.Level"/> configuration).</para>
+    /// <see cref="LoggedRenderer.Level"/> configuration).</para>
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
     /// <example>
     /// <code><![CDATA[
-    /// IActionRenderer<ExampleAction> actionRenderer = new SomeActionRenderer();
+    /// IActionRenderer actionRenderer = new SomeActionRenderer();
     /// // Wraps the action renderer with LoggedActionRenderer:
-    /// actionRenderer = new LoggedActionRenderer<ExampleAction>(
+    /// actionRenderer = new LoggedActionRenderer(
     ///     actionRenderer,
     ///     Log.Logger,
     ///     LogEventLevel.Information,
     /// );
     /// ]]></code>
     /// </example>
-    public class LoggedActionRenderer<T> : LoggedRenderer<T>, IActionRenderer<T>
-        where T : IAction, new()
-    {
+    public class LoggedActionRenderer : LoggedRenderer, IActionRenderer
+        {
         /// <summary>
-        /// Creates a new <see cref="LoggedActionRenderer{T}"/> instance which decorates the given
+        /// Creates a new <see cref="LoggedActionRenderer"/> instance which decorates the given
         /// action <paramref name="renderer"/>.
         /// </summary>
         /// <param name="renderer">The actual action renderer to forward all event messages to and
@@ -42,7 +39,7 @@ namespace Libplanet.Blockchain.Renderers
         /// type (with the context property <c>SourceContext</c>).</param>
         /// <param name="level">The log event level.  All log messages become this level.</param>
         public LoggedActionRenderer(
-            IActionRenderer<T> renderer,
+            IActionRenderer renderer,
             ILogger logger,
             LogEventLevel level = LogEventLevel.Debug
         )
@@ -54,9 +51,9 @@ namespace Libplanet.Blockchain.Renderers
         /// <summary>
         /// The inner action renderer to forward all event messages to and actually render things.
         /// </summary>
-        public IActionRenderer<T> ActionRenderer { get; }
+        public IActionRenderer ActionRenderer { get; }
 
-        /// <inheritdoc cref="IActionRenderer{T}.RenderBlockEnd(Block, Block)"/>
+        /// <inheritdoc cref="IActionRenderer.RenderBlockEnd(Block, Block)"/>
         public void RenderBlockEnd(
             Block oldTip,
             Block newTip
@@ -69,7 +66,7 @@ namespace Libplanet.Blockchain.Renderers
             );
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
+        /// cref="IActionRenderer.RenderAction(IAction, IActionContext, IAccountStateDelta)"/>
         public void RenderAction(
             IAction action,
             IActionContext context,
@@ -83,7 +80,7 @@ namespace Libplanet.Blockchain.Renderers
             );
 
         /// <inheritdoc
-        /// cref="IActionRenderer{T}.RenderActionError(IAction, IActionContext, Exception)"/>
+        /// cref="IActionRenderer.RenderActionError(IAction, IActionContext, Exception)"/>
         public void RenderActionError(
             IAction action,
             IActionContext context,

--- a/Libplanet/Blockchain/Renderers/LoggedRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using Libplanet.Action;
 using Libplanet.Blocks;
 using Serilog;
 using Serilog.Events;
@@ -7,35 +6,32 @@ using Serilog.Events;
 namespace Libplanet.Blockchain.Renderers
 {
     /// <summary>
-    /// Decorates an <see cref="IRenderer{T}"/> so that all event messages are logged.
+    /// Decorates an <see cref="IRenderer"/> so that all event messages are logged.
     /// <para>Every single event message causes two log messages: one is logged <em>before</em>
     /// rendering, and other one is logged <em>after</em> rendering.  If any exception is thrown
     /// it is also logged with the log level <see cref="LogEventLevel.Error"/> (regardless of
     /// <see cref="Level"/> configuration).</para>
     /// </summary>
-    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match to
-    /// <see cref="BlockChain{T}"/>'s type parameter.</typeparam>
     /// <example>
     /// <code>
-    /// IRenderer&lt;ExampleAction&gt; renderer = new SomeRenderer();
+    /// IRenderer renderer = new SomeRenderer();
     /// // Wraps the renderer with LoggedRenderer:
-    /// renderer = new LoggedRenderer&lt;ExampleAction&gt;(
+    /// renderer = new LoggedRenderer(
     ///     renderer,
     ///     Log.Logger,
     ///     LogEventLevel.Information,
     /// );
     /// </code>
     /// </example>
-    /// <remarks>Since <see cref="IActionRenderer{T}"/> is a subtype of <see cref="IRenderer{T}"/>,
-    /// <see cref="LoggedRenderer{T}(IRenderer{T}, ILogger, LogEventLevel)"/> constructor can take
-    /// an <see cref="IActionRenderer{T}"/> instance as well.  However, even it takes an action
+    /// <remarks>Since <see cref="IActionRenderer"/> is a subtype of <see cref="IRenderer"/>,
+    /// <see cref="LoggedRenderer(IRenderer, ILogger, LogEventLevel)"/> constructor can take
+    /// an <see cref="IActionRenderer"/> instance as well.  However, even it takes an action
     /// renderer, action-level fine-grained events will not be logged.  For action renderers,
-    /// please use <see cref="LoggedActionRenderer{T}"/> instead.</remarks>
-    public class LoggedRenderer<T> : IRenderer<T>
-        where T : IAction, new()
+    /// please use <see cref="LoggedActionRenderer"/> instead.</remarks>
+    public class LoggedRenderer : IRenderer
     {
         /// <summary>
-        /// Creates a new <see cref="LoggedRenderer{T}"/> instance which decorates the given
+        /// Creates a new <see cref="LoggedRenderer"/> instance which decorates the given
         /// <paramref name="renderer"/>.
         /// </summary>
         /// <param name="renderer">The actual renderer to forward all event messages to and actually
@@ -45,15 +41,15 @@ namespace Libplanet.Blockchain.Renderers
         /// type (with the context property <c>SourceContext</c>).</param>
         /// <param name="level">The log event level.  All log messages become this level.</param>
         public LoggedRenderer(
-            IRenderer<T> renderer,
+            IRenderer renderer,
             ILogger logger,
             LogEventLevel level = LogEventLevel.Debug
         )
         {
             Renderer = renderer;
             Logger = logger
-                .ForContext<LoggedRenderer<T>>()
-                .ForContext("Source", nameof(LoggedRenderer<T>))
+                .ForContext<LoggedRenderer>()
+                .ForContext("Source", nameof(LoggedRenderer))
                 .ForContext(renderer.GetType());
             Level = level;
         }
@@ -61,7 +57,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <summary>
         /// The inner renderer to forward all event messages to and actually render things.
         /// </summary>
-        public IRenderer<T> Renderer { get; }
+        public IRenderer Renderer { get; }
 
         /// <summary>
         /// The log event level.  All log messages become this level.
@@ -75,7 +71,7 @@ namespace Libplanet.Blockchain.Renderers
         /// </summary>
         protected ILogger Logger { get; }
 
-        /// <inheritdoc cref="IRenderer{T}.RenderBlock(Block, Block)"/>
+        /// <inheritdoc cref="IRenderer.RenderBlock(Block, Block)"/>
         public void RenderBlock(
             Block oldTip,
             Block newTip


### PR DESCRIPTION
This PR is a subset of #3145, (to maintain PR's size mainly 😅 ) 

As the title suggests, it removes the unnecessary `T` parameter from `IRenderer` and its implementations. (except `ValidatingActionRenderer<T>` since `ValidatingActionRenderer<T>` has `BlockChain<T>` property yet)

Also, it will cause huge API changes, so its target branch might be changed, to unify any other changes on #3145 (see also: #3146)