### PR TITLE
Make `CurrencyInputType.totalSupplyTrackable` optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,8 @@ Released on May 9, 2023.
  -  Changed `Context<T>.ConsumeMutation()` to iteratively call
     `Context<T>.ProcessGenericUponRules()` itself, instead of producing
     submutations of it.  [[#3137]]
+ -  (Libplanet.Explorer) The `CurrencyInputType`'s `totalSupplyTrackable` field
+    became nullable with `false` as its default value.  [[#3151]]
 
 ### Bug fixes
 
@@ -177,6 +179,7 @@ Released on May 9, 2023.
 [#3136]: https://github.com/planetarium/libplanet/pull/3136
 [#3137]: https://github.com/planetarium/libplanet/pull/3137
 [#3140]: https://github.com/planetarium/libplanet/pull/3140
+[#3151]: https://github.com/planetarium/libplanet/pull/3151
 [Bencodex 0.10.0]: https://www.nuget.org/packages/Bencodex/0.10.0
 [Bencodex.Json 0.10.0]: https://www.nuget.org/packages/Bencodex.Json/0.10.0
 

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
@@ -12,30 +12,11 @@ namespace Libplanet.Explorer.Tests.GraphTypes;
 
 public class CurrencyInputTypeTest
 {
-    [Fact]
-    public async Task Input()
+    [Theory]
+    [MemberData(nameof(InputTestCases))]
+    public async Task Input(string query, Dictionary<string, object> expected)
     {
-        var result = await ExecuteQueryAsync<TestQuery>(
-            @"query
-            {
-                currency(currency: { ticker: ""ABC"", decimalPlaces: 5, totalSupplyTrackable: false, minters: null })
-                {
-                    ticker
-                    decimalPlaces
-                    totalSupplyTrackable
-                    minters
-                }
-            }");
-        var expected = new Dictionary<string, object>
-        {
-            ["currency"] = new Dictionary<string, object>
-            {
-                ["ticker"] = "ABC",
-                ["decimalPlaces"] = (byte)5,
-                ["totalSupplyTrackable"] = false,
-                ["minters"] = null,
-            },
-        };
+        var result = await ExecuteQueryAsync<TestQuery>(query);
         Assert.Null(result.Errors);
         ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
         IDictionary<string, object> resultDict =
@@ -61,6 +42,34 @@ public class CurrencyInputTypeTest
         Assert.Contains(
             "Both \"maximumSupplyMajorUnit\" and \"maximumSupplyMinorUnit\" must be present or omitted",
             error.Message);
+    }
+
+    public static IEnumerable<object[]> InputTestCases()
+    {
+        return new object[][] {
+            new object[] {
+                @"query
+                {
+                    currency(currency: { ticker: ""ABC"", decimalPlaces: 5, totalSupplyTrackable: false, minters: null })
+                    {
+                        ticker
+                        decimalPlaces
+                        totalSupplyTrackable
+                        minters
+                    }
+                }",
+                new Dictionary<string, object>
+                {
+                    ["currency"] = new Dictionary<string, object>
+                    {
+                        ["ticker"] = "ABC",
+                        ["decimalPlaces"] = (byte)5,
+                        ["totalSupplyTrackable"] = false,
+                        ["minters"] = null,
+                    },
+                }
+            },
+        };
     }
 }
 

--- a/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/CurrencyInputTypeTest.cs
@@ -69,6 +69,28 @@ public class CurrencyInputTypeTest
                     },
                 }
             },
+            new object[] {
+                @"query
+                {
+                    currency(currency: { ticker: ""ABC"", decimalPlaces: 5, minters: null })
+                    {
+                        ticker
+                        decimalPlaces
+                        totalSupplyTrackable
+                        minters
+                    }
+                }",
+                new Dictionary<string, object>
+                {
+                    ["currency"] = new Dictionary<string, object>
+                    {
+                        ["ticker"] = "ABC",
+                        ["decimalPlaces"] = (byte)5,
+                        ["totalSupplyTrackable"] = false,
+                        ["minters"] = null,
+                    },
+                }
+            },
         };
     }
 }

--- a/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
+++ b/Libplanet.Explorer/GraphTypes/CurrencyInputType.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Explorer.GraphTypes
             );
             Field<BigIntGraphType>("maximumSupplyMajorUnit");
             Field<BigIntGraphType>("maximumSupplyMinorUnit");
-            Field<NonNullGraphType<BooleanGraphType>>(
+            Field<BooleanGraphType>(
                 "totalSupplyTrackable",
                 "Whether the total supply of this currency is trackable."
             );
@@ -53,7 +53,15 @@ namespace Libplanet.Explorer.GraphTypes
                 }
             }
 
-            bool totalSupplyTrackable = (bool)value["totalSupplyTrackable"]!;
+            const bool DefaultTotalSupplyTrackable = false;
+            bool totalSupplyTrackable = value.TryGetValue(
+                "totalSupplyTrackable", out object? booleanValue)
+                ? (
+                    booleanValue is bool boolean
+                        ? boolean
+                        : throw new ExecutionError("totalSupplyTrackable must be boolean value.")
+                  )
+                : DefaultTotalSupplyTrackable;
             (BigInteger, BigInteger)? maximumSupply = GetMaximumSupply(value);
             if (maximumSupply is { } && !totalSupplyTrackable)
             {


### PR DESCRIPTION
This pull request suggests making `CurrencyInputType`'s `totalSupplyTrackable` field optional. This doesn't break the previous users' GraphQL usage because it was required.

p.s. I was worried that using a default value, `false`, would recommend `Currency.Legacy`, but fortunately that's not the case as `Currency.Uncapped` does as well.

p.s. I'm not sure where to write these changes in changelog 🤔 (e.g., Backward-compatible API changes...)