### PR TITLE
Periodic `MessageId` handling in `Gossip`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,18 @@ To be released.
 
 ### Behavioral changes
 
+ -  `Gossip` became to store the `MessageId`s received through the
+    `HaveMessage` instead of immediately replying to them, and send the
+    `WantMessage` requests all at once during each `HeartbeatTask`.
+    [#3152]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
+
+[#3152]: https://github.com/planetarium/libplanet/pull/3152
 
 
 Version 1.2.0

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -278,10 +278,10 @@ namespace Libplanet.Net.Tests.Consensus
                 await Task.CompletedTask;
             }
 
-            Gossip gossip = CreateGossip(_ => { });
-
             ITransport seed = CreateTransport();
             seed.ProcessMessageHandler.Register(ProcessMessage);
+            Gossip gossip = CreateGossip(_ => { }, seeds: new[] { seed.AsPeer });
+
             try
             {
                 _ = seed.StartAsync();


### PR DESCRIPTION
This PR delays reply of `HaveMessage`, to remove total amount of message in the network.

You may concern that this patch may delay the network, but gossip broadcasts messages via `Publish()` method at first, and than gossips through `HaveMessage` if any peer fails to receive published message. If a peer failed to receive published message, it means the message is already delayed, so this PR does not significantly affect delay.