### PR TITLE
Removed `IActionContext.GenesisHash`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@ To be released.
      - (Libplanet.Explorer) Removed `BlockPolicyType<T>` class.
  -  Removed generic type parameter `T` from `IRenderer<T>` and all its
     implementations.  [[#3163]]
+ -  Removed `IActionContext.GenesisHash` property.  [[#3164]]
+ -  Removed `genesisHash` parameter from `ActionEvaluator()`.  [[#3164]]
 
 ### Backward-incompatible network protocol changes
 
@@ -76,6 +78,7 @@ To be released.
 [#3158]: https://github.com/planetarium/libplanet/pull/3158
 [#3159]: https://github.com/planetarium/libplanet/pull/3159
 [#3163]: https://github.com/planetarium/libplanet/pull/3163
+[#3164]: https://github.com/planetarium/libplanet/pull/3164
 
 
 Version 1.1.1

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -31,7 +31,6 @@ namespace Libplanet.Benchmarks
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
                     blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                    genesisHash: fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
                     feeCalculator: null
                 )

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -41,10 +41,8 @@ namespace Libplanet.Benchmarks
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
                     blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
-                    genesisHash: _fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
+                    feeCalculator: null)
             );
             var key = new PrivateKey();
             for (var i = 0; i < 500; i++)

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -30,11 +30,8 @@ namespace Libplanet.Benchmarks
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
                     blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                    genesisHash: fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
             _privateKey = new PrivateKey();
         }
 

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -108,11 +108,8 @@ public class GeneratedBlockChainFixture
             new ActionEvaluator(
                 policyBlockActionGetter: _ => policy.BlockAction,
                 blockChainStates: new BlockChainStates(store, stateStore),
-                genesisHash: genesisBlock.Hash,
                 actionTypeLoader: new SingleActionLoader(typeof(PolymorphicAction<SimpleAction>)),
-                feeCalculator: null
-            )
-        );
+                feeCalculator: null));
 
         MinedBlocks = MinedBlocks.SetItem(
             Chain.Genesis.Miner,

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -68,11 +68,8 @@ namespace Libplanet.Net.Tests.Consensus
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => TestUtils.Policy.BlockAction,
                         blockChainStates: new BlockChainStates(stores[i], stateStore),
-                        genesisHash: fx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
             }
 
             for (var i = 0; i < 4; i++)

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -476,11 +476,8 @@ namespace Libplanet.Net.Tests
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fxs[i].Store, fxs[i].StateStore),
-                        genesisHash: fxs[i].GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 swarms[i] = await CreateSwarm(blockChains[i]).ConfigureAwait(false);
             }
 

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -87,11 +87,8 @@ namespace Libplanet.RocksDBStore.Tests
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => null,
                         blockChainStates: new BlockChainStates(store, stateStore),
-                        genesisHash: Fx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 store.Dispose();
 
                 store = new RocksDBStore(path);

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -36,7 +36,6 @@ namespace Libplanet.Tests.Action
             foreach (var (seed, expected) in testCases)
             {
                 var context = new ActionContext(
-                    genesisHash: null,
                     signer: _address,
                     txid: _txid,
                     miner: _address,
@@ -54,7 +53,6 @@ namespace Libplanet.Tests.Action
         public void GuidShouldBeDeterministic()
         {
             var context1 = new ActionContext(
-                genesisHash: null,
                 signer: _address,
                 txid: _txid,
                 miner: _address,
@@ -65,7 +63,6 @@ namespace Libplanet.Tests.Action
             );
 
             var context2 = new ActionContext(
-                genesisHash: null,
                 signer: _address,
                 txid: _txid,
                 miner: _address,
@@ -76,7 +73,6 @@ namespace Libplanet.Tests.Action
             );
 
             var context3 = new ActionContext(
-                genesisHash: null,
                 signer: _address,
                 txid: _txid,
                 miner: _address,
@@ -112,7 +108,6 @@ namespace Libplanet.Tests.Action
             for (var i = 0; i < 100; i++)
             {
                 var context = new ActionContext(
-                    genesisHash: null,
                     signer: _address,
                     txid: _txid,
                     miner: _address,
@@ -132,7 +127,6 @@ namespace Libplanet.Tests.Action
         public void GetUnconsumedContext()
         {
             var original = new ActionContext(
-                genesisHash: null,
                 signer: _address,
                 txid: _txid,
                 miner: _address,
@@ -167,7 +161,6 @@ namespace Libplanet.Tests.Action
             ITrie previousBlockStatesTrie = new MerkleTrie(keyValueStore);
             previousBlockStatesTrie = previousBlockStatesTrie.Set(new KeyBytes(0x01), Null.Value);
             var actionContext = new ActionContext(
-                genesisHash: null,
                 signer: _address,
                 txid: _txid,
                 miner: _address,

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -34,7 +34,6 @@ namespace Libplanet.Tests.Action
             var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(
-                    null,
                     address,
                     txid,
                     address,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -95,10 +95,8 @@ namespace Libplanet.Tests.Action
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
                     blockChainStates: NullChainStates.Instance,
-                    genesisHash: null,
                     actionTypeLoader: new SingleActionLoader(typeof(RandomAction)),
-                    feeCalculator: null
-                );
+                    feeCalculator: null);
             var generatedRandomNumbers = new List<int>();
 
             AssertPreEvaluationBlocksEqual(stateRootBlock, noStateRootBlock);
@@ -294,7 +292,6 @@ namespace Libplanet.Tests.Action
             var actionEvaluator = new ActionEvaluator(
                 policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates.Instance,
-                genesisHash: null,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
                 feeCalculator: null);
             IAccountStateDelta previousStates = AccountStateDeltaImpl.ChooseVersion(
@@ -592,10 +589,8 @@ namespace Libplanet.Tests.Action
             var actionEvaluator = new ActionEvaluator(
                 policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates.Instance,
-                genesisHash: tx.GenesisHash,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                feeCalculator: null
-            );
+                feeCalculator: null);
 
             DumbAction.RehearsalRecords.Value =
                 ImmutableList<(Address, string)>.Empty;
@@ -707,7 +702,6 @@ namespace Libplanet.Tests.Action
             var actionEvaluator = new ActionEvaluator(
                 policyBlockActionGetter: _ => null,
                 blockChainStates: NullChainStates.Instance,
-                genesisHash: tx.GenesisHash,
                 actionTypeLoader: new SingleActionLoader(typeof(ThrowException)),
                 feeCalculator: null
             );
@@ -750,7 +744,6 @@ namespace Libplanet.Tests.Action
             Block blockA = fx.Propose();
             fx.Append(blockA);
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
-                txA.GenesisHash,
                 blockA.PreEvaluationHash,
                 blockIndex: blockA.Index,
                 txid: txA.Id,
@@ -802,7 +795,6 @@ namespace Libplanet.Tests.Action
             Block blockB = fx.Propose();
             fx.Append(blockB);
             ActionEvaluation[] evalsB = ActionEvaluator.EvaluateActions(
-                txB.GenesisHash,
                 blockB.PreEvaluationHash,
                 blockIndex: blockB.Index,
                 txid: txB.Id,
@@ -1075,34 +1067,6 @@ namespace Libplanet.Tests.Action
         }
 
         [Fact]
-        private void CheckGenesisHashInAction()
-        {
-            var chain = MakeBlockChain<EvaluateTestAction>(
-                    policy: new BlockPolicy<EvaluateTestAction>(),
-                    store: _storeFx.Store,
-                    stateStore: _storeFx.StateStore);
-            var privateKey = new PrivateKey();
-            var action = new EvaluateTestAction()
-            {
-                BlockIndexKey = new PrivateKey().ToAddress(),
-                MinerKey = new PrivateKey().ToAddress(),
-                SignerKey = new PrivateKey().ToAddress(),
-            };
-
-            var tx = Transaction.Create(
-                nonce: 0,
-                privateKey: privateKey,
-                genesisHash: chain.Genesis.Hash,
-                actions: new[] { action });
-            chain.StageTransaction(tx);
-            var miner = new PrivateKey();
-            Block block = chain.ProposeBlock(miner);
-            chain.Append(block, CreateBlockCommit(block));
-            var evaluations = chain.ActionEvaluator.Evaluate(chain.Tip);
-            Assert.Equal(chain.Genesis.Hash, evaluations[0].InputContext.GenesisHash);
-        }
-
-        [Fact]
         private void GenerateRandomSeed()
         {
             byte[] preEvaluationHashBytes =
@@ -1146,7 +1110,6 @@ namespace Libplanet.Tests.Action
 
             Block blockA = fx.Propose();
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
-                txA.GenesisHash,
                 blockA.PreEvaluationHash,
                 blockIndex: blockA.Index,
                 txid: txA.Id,

--- a/Libplanet.Tests/Action/Sys/InitializeTest.cs
+++ b/Libplanet.Tests/Action/Sys/InitializeTest.cs
@@ -63,8 +63,7 @@ namespace Libplanet.Tests.Action.Sys
                 gasLimit: 0,
                 rehearsal: false,
                 previousBlockStatesTrie: null,
-                blockAction: false,
-                genesisHash: genesisHash
+                blockAction: false
             );
             var initialize = new Initialize(
                 states: _states,
@@ -100,8 +99,7 @@ namespace Libplanet.Tests.Action.Sys
                 gasLimit: long.MaxValue,
                 rehearsal: false,
                 previousBlockStatesTrie: null,
-                blockAction: false,
-                genesisHash: genesisHash
+                blockAction: false
             );
             var initialize = new Initialize(
                 states: _states,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -395,11 +395,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: fx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
 
                 var validTx = blockChain.MakeTransaction(validKey, new DumbAction[] { });
                 var invalidTx = blockChain.MakeTransaction(invalidKey, new DumbAction[] { });

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -146,11 +146,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: genesis.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                ));
+                        feeCalculator: null)));
             }
         }
 
@@ -169,11 +166,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: fx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 var txs = new[]
                 {
                     Transaction.Create(
@@ -328,11 +322,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: fx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
 
                 var validTx = blockChain.MakeTransaction(validKey, new DumbAction[] { });
                 var invalidTx = blockChain.MakeTransaction(invalidKey, new DumbAction[] { });

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -196,11 +196,8 @@ namespace Libplanet.Tests.Blockchain
                 new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: new BlockChainStates(store, stateStore),
-                    genesisHash: genesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
 
             Block block1 = chain1.EvaluateAndSign(
                 new BlockContent(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -66,10 +66,8 @@ namespace Libplanet.Tests.Blockchain
                 new ActionEvaluator(
                     _ => _policy.BlockAction,
                     blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
-                    genesisHash: _fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                ),
+                    feeCalculator: null),
                 renderers: new[] { new LoggedActionRenderer(_renderer, Log.Logger) }
             );
             _renderer.ResetRecords();
@@ -593,10 +591,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => _policy.BlockAction,
                         blockChainStates: new BlockChainStates(store, stateStore),
-                        genesisHash: genesis.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    ),
+                        feeCalculator: null),
                     renderers: new[] { renderer }
                 );
 
@@ -998,11 +994,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => _policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx2.Store, fx2.StateStore),
-                        genesisHash: genesis2.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 var key = new PrivateKey();
                 for (int i = 0; i < 5; i++)
                 {
@@ -1066,11 +1059,8 @@ namespace Libplanet.Tests.Blockchain
                 new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: new BlockChainStates(store, stateStore),
-                    genesisHash: genesisWithTx.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
             Assert.False(invoked);
         }
 
@@ -1276,11 +1266,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => _blockChain.Policy.BlockAction,
                         blockChainStates: new BlockChainStates(emptyFx.Store, emptyFx.StateStore),
-                        genesisHash: emptyFx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 var fork = BlockChain<DumbAction>.Create(
                     _blockChain.Policy,
                     new VolatileStagePolicy<DumbAction>(),
@@ -1290,11 +1277,8 @@ namespace Libplanet.Tests.Blockchain
                     new ActionEvaluator(
                         _ => _blockChain.Policy.BlockAction,
                         blockChainStates: new BlockChainStates(forkFx.Store, forkFx.StateStore),
-                        genesisHash: forkFx.GenesisBlock.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 fork.Append(b1, CreateBlockCommit(b1));
                 fork.Append(b2, CreateBlockCommit(b2));
                 Block b5 = fork.ProposeBlock(
@@ -1648,10 +1632,8 @@ namespace Libplanet.Tests.Blockchain
             var actionEvaluator = new ActionEvaluator(
                 _ => blockPolicy.BlockAction,
                 blockChainStates: chainStates,
-                genesisHash: genesisBlock.Hash,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                feeCalculator: null
-            );
+                feeCalculator: null);
             var chain = BlockChain<DumbAction>.Create(
                 blockPolicy,
                 new VolatileStagePolicy<DumbAction>(),
@@ -1919,13 +1901,9 @@ namespace Libplanet.Tests.Blockchain
                     _ => policy.BlockAction,
                     blockChainStates: new BlockChainStates(
                         storeFixture.Store,
-                        storeFixture.StateStore
-                    ),
-                    genesisHash: storeFixture.GenesisBlock.Hash,
+                        storeFixture.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
 
             var validator = blockChain.GetValidatorSet()[0];
             Assert.Equal(validatorPrivKey.PublicKey, validator.PublicKey);
@@ -1963,11 +1941,8 @@ namespace Libplanet.Tests.Blockchain
                 new ActionEvaluator(
                     _ => _blockChain.Policy.BlockAction,
                     blockChainStates: new BlockChainStates(store, stateStore),
-                    genesisHash: genesisBlockA.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
 
             Assert.Throws<InvalidGenesisBlockException>(() =>
             {
@@ -2045,11 +2020,8 @@ namespace Libplanet.Tests.Blockchain
                 new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: new BlockChainStates(store, stateStore),
-                    genesisHash: genesisWithTx.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
 
             var blockTx = Transaction.Create(
                 0,
@@ -2112,11 +2084,8 @@ namespace Libplanet.Tests.Blockchain
                     blockChainStates: new BlockChainStates(
                         storeFixture.Store,
                         storeFixture.StateStore),
-                    genesisHash: genesis.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(SetValidator)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
 
             blockChain.MakeTransaction(
                 new PrivateKey(),

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -45,11 +45,8 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new ActionEvaluator(
                     _ => _policy.BlockAction,
                     blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
-                    genesisHash: _fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
         }
 
         public void Dispose()

--- a/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -33,11 +33,8 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new ActionEvaluator(
                     _ => _policy.BlockAction,
                     blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
-                    genesisHash: _fx.GenesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                    feeCalculator: null
-                )
-            );
+                    feeCalculator: null));
             _key = new PrivateKey();
             _txs = Enumerable.Range(0, 5).Select(i =>
                 Transaction.Create(

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -27,7 +27,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 default,
                 default,
                 default,
-                default,
                 _stateDelta,
                 default,
                 0);

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -78,7 +78,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     default,
                     default,
                     default,
-                    default,
                     123,
                     _stateDelta,
                     default,

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -55,11 +55,8 @@ namespace Libplanet.Tests.Blocks
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: genesis.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 AssertBencodexEqual((Bencodex.Types.Integer)123, blockChain.GetState(address));
 
                 HashDigest<SHA256> identicalGenesisStateRootHash =
@@ -122,11 +119,8 @@ namespace Libplanet.Tests.Blocks
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
-                        genesisHash: genesis.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
                 AssertBencodexEqual((Bencodex.Types.Integer)123, blockChain.GetState(address));
 
                 HashDigest<SHA256> identicalGenesisStateRootHash =

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -89,12 +89,9 @@ namespace Libplanet.Tests.Fixtures
                 new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: new BlockChainStates(Store, StateStore),
-                    genesisHash: Genesis.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)),
-                    feeCalculator: null
-                ),
-                renderers: renderers ?? new[] { new ValidatingActionRenderer() }
-            );
+                    feeCalculator: null),
+                renderers: renderers ?? new[] { new ValidatingActionRenderer() });
         }
 
         public int Count => Addresses.Count;

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1061,11 +1061,8 @@ namespace Libplanet.Tests.Store
                     new ActionEvaluator(
                         _ => policy.BlockAction,
                         blockChainStates: new BlockChainStates(s1, fx.StateStore),
-                        genesisHash: genesis.Hash,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
-                        feeCalculator: null
-                    )
-                );
+                        feeCalculator: null));
 
                 // FIXME: Need to add more complex blocks/transactions.
                 var key = new PrivateKey();

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -633,10 +633,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: blockChainStates,
-                    genesisHash: genesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(T)),
-                    feeCalculator: null
-            );
+                    feeCalculator: null);
 #pragma warning disable S1121
             var chain = BlockChain<T>.Create(
                 policy,

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using System.Threading;
-using Libplanet.Blocks;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
 
@@ -22,7 +21,6 @@ namespace Libplanet.Action
         private HashDigest<SHA256>? _previousStateRootHash;
 
         public ActionContext(
-            BlockHash? genesisHash,
             Address signer,
             TxId? txid,
             Address miner,
@@ -35,7 +33,6 @@ namespace Libplanet.Action
             bool blockAction = false,
             List<string>? logs = null)
         {
-            GenesisHash = genesisHash;
             Signer = signer;
             TxId = txid;
             Miner = miner;
@@ -53,8 +50,6 @@ namespace Libplanet.Action
             GetStateCount.Value = 0;
             GetGasMeter.Value = new GasMeter(_gasLimit);
         }
-
-        public BlockHash? GenesisHash { get; }
 
         public Address Signer { get; }
 
@@ -91,7 +86,6 @@ namespace Libplanet.Action
         [Pure]
         public IActionContext GetUnconsumedContext() =>
             new ActionContext(
-                GenesisHash,
                 Signer,
                 TxId,
                 Miner,

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -25,7 +25,6 @@ namespace Libplanet.Action
     /// </summary>
     public class ActionEvaluator : IActionEvaluator
     {
-        private readonly BlockHash? _genesisHash;
         private readonly ILogger _logger;
         private readonly PolicyBlockActionGetter _policyBlockActionGetter;
         private readonly IBlockChainStates _blockChainStates;
@@ -41,14 +40,11 @@ namespace Libplanet.Action
         /// at the end for each <see cref="IPreEvaluationBlock"/> that gets evaluated.</param>
         /// <param name="blockChainStates">The <see cref="IBlockChainStates"/> to use to retrieve
         /// the states for a provided <see cref="Address"/>.</param>
-        /// <param name="genesisHash"> A <see cref="BlockHash"/> value of the genesis block.
-        /// </param>
         /// <param name="actionTypeLoader"> A <see cref="IActionLoader"/> implementation using action type lookup.</param>
         /// <param name="feeCalculator">Fee calculator.</param>
         public ActionEvaluator(
             PolicyBlockActionGetter policyBlockActionGetter,
             IBlockChainStates blockChainStates,
-            BlockHash? genesisHash,
             IActionLoader actionTypeLoader,
             IFeeCalculator? feeCalculator
         )
@@ -59,7 +55,6 @@ namespace Libplanet.Action
                 .ForContext("Source", nameof(ActionEvaluator));
             _policyBlockActionGetter = policyBlockActionGetter;
             _blockChainStates = blockChainStates;
-            _genesisHash = genesisHash;
             _actionLoader = actionTypeLoader;
             _feeCalculator = feeCalculator;
         }
@@ -182,8 +177,6 @@ namespace Libplanet.Action
         /// Executes <see cref="IAction"/>s in <paramref name="actions"/>.  All other evaluation
         /// calls resolve to this method.
         /// </summary>
-        /// <param name="genesisHash"> A <see cref="BlockHash"/> value of the genesis block.
-        /// </param>
         /// <param name="preEvaluationHash">The
         /// <see cref="IPreEvaluationBlockHeader.PreEvaluationHash"/> of
         /// the <see cref="IPreEvaluationBlock"/> that <paramref name="actions"/> belong to.</param>
@@ -229,7 +222,6 @@ namespace Libplanet.Action
         /// </remarks>
         [Pure]
         internal static IEnumerable<ActionEvaluation> EvaluateActions(
-            BlockHash? genesisHash,
             HashDigest<SHA256> preEvaluationHash,
             long blockIndex,
             TxId? txid,
@@ -251,7 +243,6 @@ namespace Libplanet.Action
             )
             {
                 return new ActionContext(
-                    genesisHash: genesisHash,
                     signer: signer,
                     txid: txid,
                     miner: miner,
@@ -514,7 +505,6 @@ namespace Libplanet.Action
             ImmutableList<IAction> actions =
                 ImmutableList.CreateRange(LoadActions(blockHeader.Index, tx));
             return EvaluateActions(
-                genesisHash: _genesisHash,
                 preEvaluationHash: blockHeader.PreEvaluationHash,
                 blockIndex: blockHeader.Index,
                 txid: tx.Id,
@@ -561,7 +551,6 @@ namespace Libplanet.Action
                 $"{ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray)}");
 
             return EvaluateActions(
-                genesisHash: _genesisHash,
                 preEvaluationHash: blockHeader.PreEvaluationHash,
                 blockIndex: blockHeader.Index,
                 txid: null,

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -12,12 +12,6 @@ namespace Libplanet.Action
     public interface IActionContext
     {
         /// <summary>
-        /// The genesis block's hash.
-        /// </summary>
-        [Pure]
-        BlockHash? GenesisHash { get; }
-
-        /// <summary>
         /// <see cref="Address"/> of an account who made and signed
         /// a transaction that an executed <see cref="IAction"/> belongs to.
         /// </summary>

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -74,7 +74,6 @@ namespace Libplanet.Blockchain
             var actionEvaluator = new ActionEvaluator(
                 _ => blockAction,
                 blockChainStates: NullChainStates.Instance,
-                genesisHash: null,
                 actionTypeLoader: new SingleActionLoader(typeof(T)),
                 feeCalculator: null);
             return actionEvaluator.Evaluate(preEvaluationBlock);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -139,11 +139,8 @@ namespace Libplanet.Blockchain
                 new ActionEvaluator(
                     _ => policy.BlockAction,
                     blockChainStates: blockChainStates,
-                    genesisHash: genesisBlock.Hash,
                     actionTypeLoader: new SingleActionLoader(typeof(T)),
-                    feeCalculator: null
-                )
-            )
+                    feeCalculator: null))
         {
         }
 


### PR DESCRIPTION
See #1972.

The property isn't being used in any meaningful way. On the other hand, it clashes with the changing design of requiring an `IActionEvaluator` before creating a `BlockChain<T>`. It isn't at all intuitive how to properly use an `IActionEvaluator` that creates a proper `IActionContext.GenesisHash`. I see this more of as a hinderance to the client-side developers. 🙄