### PR TITLE
Improve commit() perf on trie related APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,18 @@ To be released.
 
 ### Behavioral changes
 
+ -  Improved performance of `StateStoreExtensions.Commit()` extension method
+    and `MerkleTrie.Commit()` method.  [[#3165]]
+ -  Improved performance of `HashDigest<T>.DeriveFrom()` static method on
+    .NET Standard 2.1+.  [[#3165]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
+
+[#3165]: https://github.com/planetarium/libplanet/pull/3165
 
 
 Version 1.4.0


### PR DESCRIPTION
As the title suggests, this PR improves `StateStoreExtensions.Commit()` and `MerkleTrie.Commit()` methods by limiting the size of batch writes.

And more, this PR fixes `ReadOnlySpan<T>` usages in `HashDigest<T>`, to improve the performance when .NET Standard 2.1+.