### PR TITLE
introduce: IAccount

### DIFF
--- a/Libplanet/State/Account.cs
+++ b/Libplanet/State/Account.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+using Bencodex.Types;
+
+namespace Libplanet.State
+{
+    /// <summary>
+    /// An implementation of <see cref="IAccount"/> interface.
+    /// </summary>
+    public class Account : IAccount
+    {
+        public Account(
+            Address id,
+            string? memo,
+            HashDigest<SHA256> stateRootHash)
+        {
+            Id = id;
+            Memo = memo;
+            StateRootHash = stateRootHash;
+        }
+
+        public Account(Bencodex.Types.List serialized)
+        {
+            Nonce = (Integer)serialized[0];
+            Id = new Address(serialized[1]);
+            StateRootHash = new HashDigest<SHA256>((Binary)serialized[2]);
+            Memo = serialized.Count > 3 ? (Text?)serialized[3] : null;
+        }
+
+        public long Nonce { get; }
+
+        public Address Id { get; }
+
+        public string? Memo { get; }
+
+        public HashDigest<SHA256> StateRootHash { get; }
+
+        public IValue Serialize()
+        {
+             var list = Bencodex.Types.List.Empty
+                .Add(Id.Bencoded)
+                .Add(StateRootHash.ByteArray);
+             if (Memo is { } memo)
+             {
+                 list.Add(memo);
+             }
+
+             return list;
+        }
+    }
+}

--- a/Libplanet/State/AccountDeltaImpl.cs
+++ b/Libplanet/State/AccountDeltaImpl.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bencodex.Types;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.State
+{
+    internal class AccountDeltaImpl : IAccountDelta
+    {
+        private readonly ITrie _trie;
+
+        public AccountDeltaImpl(IAccount account, ITrie trie)
+        {
+            Account = account;
+            _trie = trie;
+        }
+
+        public HashDigest<SHA256> StateRootHash => _trie.Hash;
+
+        public IAccount Account { get; }
+
+        public IValue? GetState(Address key) =>
+            _trie.Get(new[] { ToStateKey(key) })[0];
+
+        public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> keys) =>
+            _trie.Get(keys.Select(ToStateKey).ToArray());
+
+        public IAccountDelta SetState(Address key, IValue value) =>
+            new AccountDeltaImpl(Account, _trie.Set(ToStateKey(key), value));
+
+        public IAccountDelta SetAccountMemo(string memo) =>
+            new AccountDeltaImpl(new Account(Account.Id, memo, Account.StateRootHash), _trie);
+
+        ITrie IAccountDelta.Commit() => _trie.Commit();
+
+        private KeyBytes ToStateKey(Address address) =>
+            new KeyBytes(ByteUtil.Hex(address.ByteArray), Encoding.UTF8);
+    }
+}

--- a/Libplanet/State/IAccount.cs
+++ b/Libplanet/State/IAccount.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+
+namespace Libplanet.State
+{
+    /// <summary>
+    /// An interface for account.
+    /// <see cref="IAccount"/> is a represent of an account in Libplanet.
+    /// It contains the account's nonce, address, state root hash, and memo.
+    /// </summary>
+    public interface IAccount
+    {
+        /// <summary>
+        /// Account's address.
+        /// </summary>
+        public Address Id { get; }
+
+        /// <summary>
+        /// Account's memo.
+        /// </summary>
+        public string? Memo { get; }
+
+        /// <summary>
+        /// Account's state root hash.
+        /// </summary>
+        public HashDigest<SHA256> StateRootHash { get; }
+    }
+}

--- a/Libplanet/State/IAccountDelta.cs
+++ b/Libplanet/State/IAccountDelta.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.State
+{
+    public interface IAccountDelta
+    {
+        public HashDigest<SHA256> StateRootHash { get; }
+
+        public IAccount Account { get; }
+
+        public IValue? GetState(Address key);
+
+        public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> keys);
+
+        public IAccountDelta SetState(Address key, IValue value);
+
+        public IAccountDelta SetAccountMemo(string memo);
+
+        internal ITrie Commit();
+    }
+}

--- a/Libplanet/Store/StateStoreExtensions.cs
+++ b/Libplanet/Store/StateStoreExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Bencodex.Types;
+using Libplanet.State;
 using Libplanet.Store.Trie;
 
 namespace Libplanet.Store
@@ -105,5 +106,34 @@ namespace Libplanet.Store
             HashDigest<SHA256> stateRootHash
         ) =>
             stateStore.GetStateRoot(stateRootHash).Recorded;
+
+        public static IAccount GetAccount(
+            this IStateStore stateStore,
+            HashDigest<SHA256>? stateRootHash,
+            string key
+        )
+        {
+            ITrie trie = stateStore.GetStateRoot(stateRootHash);
+            if (trie.Get(new[] { EncodeKey(key) })[0] is Bencodex.Types.List rawAddress)
+            {
+                return new Account(rawAddress);
+            }
+            else
+            {
+                return new Account(
+                    new Address(key),
+                    null,
+                    stateStore.GetStateRoot(null).Commit().Hash);
+            }
+        }
+
+        public static IAccountDelta GetAccountDelta(
+            this IStateStore stateStore,
+            IAccount account
+        )
+        {
+            ITrie trie = stateStore.GetStateRoot(account.StateRootHash);
+            return new AccountDeltaImpl(account, trie);
+        }
     }
 }


### PR DESCRIPTION
## Rationale
We need to own the state by each address for the next step about PoS. (I'll describe this background on the issue later.)

## Describe
This PR is introducing `IAccount`. It will make the use `MPT` more effective.