### PR TITLE
Dump delta key-value pairs when `InvalidBlockStateRootHashException` occurred

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ To be released.
 
 ### Behavioral changes
 
+ -  `BlockChain` became to leave a state_dump if an 
+    `InvalidBlockStateRootHashException` was thrown during block evaluation.
+    [[#3194]]
+
 ### Bug fixes
 
 ### Dependencies
@@ -29,6 +33,7 @@ To be released.
 
 [#3168]: https://github.com/planetarium/libplanet/pull/3168
 [#3193]: https://github.com/planetarium/libplanet/pull/3193
+[#3194]: https://github.com/planetarium/libplanet/pull/3194
 
 
 Version 1.3.0


### PR DESCRIPTION
This pull request's purpose is to suggest leaving a state dump when `InvalidBlockStateRootHashException` occurs. Previously, it expected to use `planet mpt diff` but it became too slow to iterate all mpt nodes. So I want to provide a way to debug the `InvalidBlockStateRootHashException` faster with the state dump.