### PR TITLE
@planetarium/account-web3-secret-storage: Support browser

### DIFF
--- a/@planetarium/.gitignore
+++ b/@planetarium/.gitignore
@@ -1,2 +1,3 @@
 package.tgz
 *.tsbuildinfo
+vitest.config.js

--- a/@planetarium/account-web3-secret-storage/package.json
+++ b/@planetarium/account-web3-secret-storage/package.json
@@ -8,6 +8,14 @@
     "#crypto": {
       "node": "./src/crypto/node.ts",
       "default": "./src/crypto/browser.ts"
+    },
+    "#path": {
+      "node": "./src/path/node.ts",
+      "default": "./src/path/browser.ts"
+    },
+    "#fs": {
+      "node": "./src/fs/node.ts",
+      "default": "./src/fs/browser.ts"
     }
   },
   "exports": {

--- a/@planetarium/account-web3-secret-storage/package.json
+++ b/@planetarium/account-web3-secret-storage/package.json
@@ -4,8 +4,23 @@
   "description": "Libplanet account implementation using Ethereum Web3 Secret Storage",
   "type": "module",
   "main": "./dist/index.js",
-  "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "imports": {
+    "#crypto": {
+      "node": "./src/crypto/node.ts",
+      "default": "./src/crypto/browser.ts"
+    }
+  },
+  "exports": {
+    ".": {
+      "node": {
+        "types": "./dist/index.d.ts",
+        "require": "./dist/index.cjs",
+        "import": "./dist/index.mjs"
+      },
+      "browser": "./dist/index.browser.mjs",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist/**/*"
   ],
@@ -45,5 +60,8 @@
   },
   "peerDependencies": {
     "@planetarium/account": "workspace:^"
+  },
+  "engines": {
+    "node": "20.2.0"
   }
 }

--- a/@planetarium/account-web3-secret-storage/src/KeyId.ts
+++ b/@planetarium/account-web3-secret-storage/src/KeyId.ts
@@ -1,6 +1,4 @@
-import { Crypto } from "@peculiar/webcrypto";
-
-const crypto = new Crypto();
+import { crypto } from "#crypto";
 
 export type KeyId = string;
 

--- a/@planetarium/account-web3-secret-storage/src/Web3Account.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3Account.ts
@@ -7,13 +7,11 @@ import {
   RawPrivateKey,
   Signature,
 } from "@planetarium/account";
-import { Crypto } from "@peculiar/webcrypto";
+import { crypto } from "#crypto";
 import { pbkdf2Async } from "@noble/hashes/pbkdf2";
 import { scrypt } from "scrypt-js";
 import { sha256 } from "@noble/hashes/sha256";
 import { keccak_256 } from "@noble/hashes/sha3";
-
-const crypto = new Crypto();
 
 export type Web3KeyObjectKdf =
   | {

--- a/@planetarium/account-web3-secret-storage/src/Web3KeyStore.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3KeyStore.ts
@@ -80,6 +80,44 @@ export class NodeJsFileSystem implements IFileSystem {
   }
 }
 
+export class LocalStorageFileSystem implements IFileSystem {
+  async mkdir(path: string, options?: unknown): Promise<void> {}
+
+  readFile(path: string, options?: { encoding: "utf8" }): Promise<string> {
+    const item = localStorage.getItem(path);
+    if (item == null) {
+      throw new Error("Not found");
+    }
+
+    return Promise.resolve(item);
+  }
+
+  async delete(path: string): Promise<void> {
+    localStorage.removeItem(path);
+  }
+
+  async *listFiles(directory: string): AsyncIterable<string> {
+    for (let i = 0; i < localStorage.length; ++i) {
+      const item = localStorage.key(i);
+      if (item == null) {
+        throw new Error(`Expected ${i}th item in localStorage.`);
+      }
+
+      if (item.startsWith(directory)) {
+        yield item.slice(directory.length);
+      }
+    }
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    encoding?: "utf8",
+  ): Promise<void> {
+    localStorage.setItem(path, content);
+  }
+}
+
 export interface Web3KeyStoreOptions {
   path?: string;
   passphraseEntry: PassphraseEntry;

--- a/@planetarium/account-web3-secret-storage/src/crypto/browser.ts
+++ b/@planetarium/account-web3-secret-storage/src/crypto/browser.ts
@@ -1,0 +1,1 @@
+export const crypto = window.crypto;

--- a/@planetarium/account-web3-secret-storage/src/crypto/node.ts
+++ b/@planetarium/account-web3-secret-storage/src/crypto/node.ts
@@ -1,0 +1,2 @@
+import { Crypto } from "@peculiar/webcrypto";
+export const crypto = new Crypto();

--- a/@planetarium/account-web3-secret-storage/src/fs/browser.ts
+++ b/@planetarium/account-web3-secret-storage/src/fs/browser.ts
@@ -1,0 +1,39 @@
+export async function mkdir(path: string, options?: unknown): Promise<void> {}
+
+export function readFile(
+  path: string,
+  options?: { encoding: "utf8" },
+): Promise<string> {
+  const item = localStorage.getItem(path);
+  if (item == null) {
+    throw new Error("Not found");
+  }
+
+  return Promise.resolve(item);
+}
+
+export function removeFile(path: string): Promise<void> {
+  localStorage.removeItem(path);
+  return Promise.resolve();
+}
+
+export async function* listFiles(directory: string): AsyncIterable<string> {
+  for (let i = 0; i < localStorage.length; ++i) {
+    const item = localStorage.key(i);
+    if (item == null) {
+      throw new Error(`Expected ${i}th item in localStorage.`);
+    }
+
+    if (item.startsWith(directory)) {
+      yield item.slice(directory.length);
+    }
+  }
+}
+
+export async function writeFile(
+  path: string,
+  content: string,
+  encoding?: "utf8",
+): Promise<void> {
+  localStorage.setItem(path, content);
+}

--- a/@planetarium/account-web3-secret-storage/src/fs/browser.ts
+++ b/@planetarium/account-web3-secret-storage/src/fs/browser.ts
@@ -25,7 +25,12 @@ export async function* listFiles(directory: string): AsyncIterable<string> {
     }
 
     if (item.startsWith(directory)) {
-      yield item.slice(directory.length);
+      let sliced = item.slice(directory.length);
+      if (sliced.startsWith("/")) {
+        sliced = sliced.slice(1);
+      }
+
+      yield sliced;
     }
   }
 }

--- a/@planetarium/account-web3-secret-storage/src/fs/node.ts
+++ b/@planetarium/account-web3-secret-storage/src/fs/node.ts
@@ -1,0 +1,51 @@
+import * as fs from "node:fs/promises";
+
+export async function mkdir(
+  path: string,
+  options?: { recursive: true },
+): Promise<void> {
+  await fs.mkdir(path, options);
+}
+
+export function readFile(
+  path: string,
+  options?: { encoding: "utf8" },
+): Promise<string> {
+  return fs.readFile(path, options) as Promise<string>;
+}
+
+export function removeFile(path: string): Promise<void> {
+  return fs.unlink(path);
+}
+
+export async function* listFiles(directory: string): AsyncIterable<string> {
+  let dir;
+  try {
+    dir = await fs.opendir(directory);
+  } catch (e) {
+    if (
+      typeof e === "object" &&
+      e != null &&
+      "code" in e &&
+      e.code === "ENOENT"
+    ) {
+      // In case where there is no directory at all (it's likely the first
+      // time to run this operation in a system), it should be considered
+      // it's just empty (instead of considering it an exceptional case).
+      return;
+    }
+    throw e;
+  }
+  for await (const dirEntry of dir) {
+    if (!dirEntry.isFile()) continue;
+    yield dirEntry.name;
+  }
+}
+
+export function writeFile(
+  path: string,
+  content: string,
+  encoding?: "utf8",
+): Promise<void> {
+  return fs.writeFile(path, content, encoding);
+}

--- a/@planetarium/account-web3-secret-storage/src/index.ts
+++ b/@planetarium/account-web3-secret-storage/src/index.ts
@@ -10,6 +10,4 @@ export {
 export {
   getDefaultWeb3KeyStorePath,
   Web3KeyStore,
-  LocalStorageFileSystem,
-  NodeJsFileSystem,
 } from "./Web3KeyStore.js";

--- a/@planetarium/account-web3-secret-storage/src/index.ts
+++ b/@planetarium/account-web3-secret-storage/src/index.ts
@@ -7,4 +7,9 @@ export {
   Web3Account,
   type Web3KeyObject,
 } from "./Web3Account.js";
-export { getDefaultWeb3KeyStorePath, Web3KeyStore } from "./Web3KeyStore.js";
+export {
+  getDefaultWeb3KeyStorePath,
+  Web3KeyStore,
+  LocalStorageFileSystem,
+  NodeJsFileSystem,
+} from "./Web3KeyStore.js";

--- a/@planetarium/account-web3-secret-storage/src/path/browser.ts
+++ b/@planetarium/account-web3-secret-storage/src/path/browser.ts
@@ -1,0 +1,7 @@
+export function join(...args: string[]): string {
+  return args.join("/");
+}
+
+export function getDefaultWeb3KeyStorePath(): string {
+  return "/planetarium/account/web3-secret-storage/keystore";
+}

--- a/@planetarium/account-web3-secret-storage/src/path/node.ts
+++ b/@planetarium/account-web3-secret-storage/src/path/node.ts
@@ -1,0 +1,23 @@
+export { join } from "node:path";
+
+/**
+ * Determines the default key store path.  It depends on the platform:
+ *
+ * - Linux/macOS: `$HOME/.config/planetarium/keystore`
+ * - Windows: `%AppData%\planetarium\keystore`
+ */
+export function getDefaultWeb3KeyStorePath(): string {
+  const { homedir } = require("node:os");
+  const path = require("node:path");
+  const baseDir =
+    process.platform === "win32"
+      ? process.env.AppData || path.join(homedir(), "AppData", "Roaming")
+      : process.env.XDG_CONFIG_HOME || path.join(homedir(), ".config");
+  // Note that it's not necessary to explicitly choose one of `path.win32` or
+  // `path.posix` here, but it makes unit tests less dependent on mocks:
+  return (process.platform === "win32" ? path.win32 : path.posix).join(
+    baseDir,
+    "planetarium",
+    "keystore",
+  );
+}

--- a/@planetarium/account-web3-secret-storage/test/Web3KeyStore.test.ts
+++ b/@planetarium/account-web3-secret-storage/test/Web3KeyStore.test.ts
@@ -1,4 +1,5 @@
 import {
+  NodeJsFileSystem,
   Web3KeyStore,
   getDefaultWeb3KeyStorePath,
   parseKeyFilename,
@@ -37,7 +38,7 @@ describe("getDefaultWeb3KeyStorePath", () => {
       platform: "linux",
     });
     vi.stubEnv("XDG_CONFIG_HOME", "");
-    vi.spyOn(await import("node:os"), "homedir").mockReturnValue("/home/user");
+    vi.spyOn(require("node:os"), "homedir").mockReturnValue("/home/user");
     expect(getDefaultWeb3KeyStorePath()).toBe(
       "/home/user/.config/planetarium/keystore",
     );
@@ -60,7 +61,7 @@ describe("getDefaultWeb3KeyStorePath", () => {
       platform: "win32",
     });
     vi.stubEnv("AppData", "");
-    vi.spyOn(await import("node:os"), "homedir").mockReturnValue(
+    vi.spyOn(require("node:os"), "homedir").mockReturnValue(
       "C:\\Users\\user",
     );
     expect(getDefaultWeb3KeyStorePath()).toBe(
@@ -124,6 +125,7 @@ describe("Web3KeyStore", () => {
     const store = new Web3KeyStore({
       path: tmpDir,
       passphraseEntry: new MockPassphraseEntry(),
+      fileSystem: await NodeJsFileSystem.create(),
     });
     let i = 0;
     for await (const key of store.list()) {
@@ -196,7 +198,7 @@ describe("Web3KeyStore", () => {
 
   testInTempDir("get", async (tmpDir) => {
     const passphraseEntry = new MockPassphraseEntry();
-    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry });
+    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry, fileSystem: await NodeJsFileSystem.create() });
     await copyFile(
       path.join(
         __dirname,
@@ -262,7 +264,7 @@ describe("Web3KeyStore", () => {
 
   testInTempDir("get insufficient lengthed key", async (tmpDir) => {
     const passphraseEntry = new MockPassphraseEntry("1");
-    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry });
+    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry, fileSystem: await NodeJsFileSystem.create() });
     await copyFile(
       path.join(
         __dirname,
@@ -286,6 +288,7 @@ describe("Web3KeyStore", () => {
       path: tmpDir,
       passphraseEntry,
       allowWeakPrivateKey: true,
+      fileSystem: await NodeJsFileSystem.create()
     });
     const result2 = await nonStrictStore.get(
       "b35a2647-8581-43ff-a98e-6083dc952632",
@@ -299,7 +302,7 @@ describe("Web3KeyStore", () => {
 
   testInTempDir("generate", async (tmpDir) => {
     const passphraseEntry = new MockPassphraseEntry();
-    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry });
+    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry, fileSystem: await NodeJsFileSystem.create() });
 
     const before = new Date().setMilliseconds(0);
     const result = await store.generate();
@@ -329,7 +332,7 @@ describe("Web3KeyStore", () => {
 
   testInTempDir("delete", async (tmpDir) => {
     const passphraseEntry = new MockPassphraseEntry();
-    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry });
+    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry, fileSystem: await NodeJsFileSystem.create() });
     await copyFile(
       path.join(
         __dirname,
@@ -384,7 +387,7 @@ describe("Web3KeyStore", () => {
 
   testInTempDir("import", async (tmpDir) => {
     const passphraseEntry = new MockPassphraseEntry();
-    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry });
+    const store = new Web3KeyStore({ path: tmpDir, passphraseEntry, fileSystem: await NodeJsFileSystem.create() });
 
     const privateKey = RawPrivateKey.fromHex(
       "e8b612d1126989e1b85b0b94e511bfca5eff4866bb646fc7a42275759bc2d529",
@@ -423,6 +426,7 @@ describe("Web3KeyStore", () => {
       path: tmpDir,
       passphraseEntry,
       allowWeakPrivateKey: true,
+      fileSystem: await NodeJsFileSystem.create()
     });
     const result2 = await nonStrictStore.import(insufficientLenghtedKey);
     expect(result2.result).toBe("success");

--- a/@planetarium/account-web3-secret-storage/tsconfig.json
+++ b/@planetarium/account-web3-secret-storage/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["./src", "*.d.ts", "*.ts"],
   "compilerOptions": {
+    "rootDir": "./",
     "outDir": "dist",
     "target": "ESNext",
     "strict": true,

--- a/@planetarium/account-web3-secret-storage/tsconfig.json
+++ b/@planetarium/account-web3-secret-storage/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["./src", "*.d.ts", "*.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "ES2020",
+    "target": "ESNext",
     "strict": true,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "nodenext",
     "module": "ESNext",
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ESNext", "DOM"]
   }
 }

--- a/@planetarium/account-web3-secret-storage/tsconfig.json
+++ b/@planetarium/account-web3-secret-storage/tsconfig.json
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "nodenext",
     "module": "ESNext",
-    "lib": ["ES2020"]
+    "lib": ["ES2020", "DOM"]
   }
 }

--- a/@planetarium/account-web3-secret-storage/tsconfig.json
+++ b/@planetarium/account-web3-secret-storage/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "nodenext",
+    "module": "ESNext",
     "lib": ["ES2020"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "_libplanet_build=1 yarn workspaces foreach -p run build",
     "pack-all": "yarn workspaces foreach -p --include @planetarium/\\* pack",
-    "postinstall": "env | grep -E '^_libplanet_build=1$' || yarn build && echo ran yarn build",
+    "postinstall": "yarn workspace @planetarium/account build && env | grep -E '^_libplanet_build=1$' || yarn build && echo ran yarn build",
     "prepack": "printf \"\\033[41;97mLibplanet note: `yarn pack` is not allowed on the project root level, as it produces useless empty package. use `yarn pack-all` instead.\\033[0m\n\" > /dev/stderr && false",
     "test": "yarn workspaces foreach -p run test"
   },


### PR DESCRIPTION
Resolves #3197.

It uses `localStorage` in `browser` environment by [`imports` field in the `package.json`](https://nodejs.org/api/packages.html#subpath-imports)

## Issues

 - vitest seems not to support the `imports` field 😢 