### PR TITLE
Replace proposal when +2/3 valid votes are collected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,15 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Removed `ActionTypeAttribute.ValueOf()` method.  [[#3267]]
+ -  (Libplanet.Net) Added
+    `Gossip.PublishMessage(MessageContent, IEnumerable<BoundPeer>)` method.
+    [[#3206]]
+ -  (Libplanet.Net) Added `Context.GetVoteSetBits()` method.  [[#3206]]
+ -  (Libplanet.Net) Added `Context.GetVoteSetBitsResponse()` method.  [[#3206]]
+ -  (Libplanet.Net) Added `ConsensusContext.HandleVoteSetBits()` method.
+    [[#3206]]
+ -  (Libplanet.Net) Added `ConsensusContext.HandleProposalClaim()` method.
+    [[#3206]]
 
 ### Backward-incompatible network protocol changes
 
@@ -18,7 +27,24 @@ To be released.
 
 ### Added APIs
 
+ -  Added `VoteSetBits` and its related classes.  [[#3206]]
+     -  Added `VoteSetBits` class.
+     -  Added `VoteSetBitsMetadata` class.
+     -  (Libplanet.Net) Added `ConsensusVoteSetBitsMsg` class.
+ -  Added `ProposalClaim` and its related class.  [[#3206]]
+     -  Added `ProposalClaim` class.
+     -  Added `ProposalClaimMetadata` class.
+     -  (Libplanet.Net) Added `ConsensusProposalClaimMsg` class.
+ -  (Libplanet.Net) Added `ConsensusMaj23Msg` class.
+ -  (Libplanet.Net) Added enumeration items to `MessageType` enum.  [[#3206]]
+     -  Added `ConsensusMaj23Msg` of value `0x53`.
+     -  Added `ConsensusVoteSetBitsMsg` of value `0x54`.
+     -  Added `ConsensusProposalClaimMsg` of value `0x55`.
+
 ### Behavioral changes
+
+ -  (Libplanet.Net) `Context` became to remove its proposal
+    when +2/3 valid votes were collected.  [[#3206]]
 
 ### Bug fixes
 
@@ -26,6 +52,7 @@ To be released.
 
 ### CLI tools
 
+[#3206]: https://github.com/planetarium/libplanet/pull/3206
 [#3267]: https://github.com/planetarium/libplanet/pull/3267
 
 
@@ -52,6 +79,11 @@ Released on July 3, 2023.
  -  (Libplanet.Net) `ConsensusProposalMsg`, `ConsensusPreVoteMsg` and
     `ConsensusPreCommitMsg` became to inherit `ConsensusVoteMsg`.  [[#3249]]
  -  (Libplanet.Net) Removed `ConsensusMsg.BlockHash` property.  [[#3249]]
+ -  (Libplanet.Net) Some enumeration items to `MessageType` enum has modified.
+    [[#3249]]
+     -  `ConsensusProposal` changed to `0x50` (was `0x40`).
+     -  `ConsensusVote` changed to `0x51` (was `0x41`).
+     -  `ConsensusCommit` changed to `0x52` (was `0x42`).
  -  (Libplanet.Net) Added `Flag` property to `ConsensusVoteMsg` abstract class.
     [[#3260]]
  -  (Libplanet.Net) `ConsensusProposalMsg` no longer inherits
@@ -77,20 +109,12 @@ Released on July 3, 2023.
  -  Added `Maj23` and its related classes.  [[#3249]]
      -  Added `Maj23` class.
      -  Added `Maj23Metadata` class.
-     -  (Libplanet.Net) Added `ConsensusMaj23Msg` class.
- -  Added `VoteSetBits` and its related classes.  [[#3249]]
-     -  Added `VoteSetBits` class.
-     -  Added `VoteSetBitsMetadata` class.
-     -  (Libplanet.Net) Added `ConsensusVoteSetBitsMsg` class.
  -  (Libplanet.Net) Added `VoteSet` class.  [[#3249]]
  -  (Libplanet.Net) Added `HeightVoteSet` class.  [[#3249]]
  -  (Libplanet.Net) Added `ConsensusVoteMsg` abstract class.  [[#3249]]
  -  (Libplanet.Net) Added `InvalidProposalException` class.  [[#3249]]
  -  (Libplanet.Net) Added `InvalidVoteException` class.  [[#3249]]
  -  (Libplanet.Net) Added `InvalidMaj23Exception` class.  [[#3249]]
- -  (Libplanet.Net) Added
-    `Gossip.PublishMessage(MessageContent, IEnumerable<BoundPeer>)` method.
-    [[#3249]]
  -  Added `IAccountDelta.OrderedSum()` extension method.  [[#3256]]
  -  Added `IAccountDelta.ToRawDelta()` extension method.  [[#3256]]
  -  Removed several properties from `IAccountStateDelta` pertaining to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,11 @@ To be released.
  -  (Libplanet.Net) Added
     `Gossip.PublishMessage(MessageContent, IEnumerable<BoundPeer>)` method.
     [[#3206]]
+ -  (Libplanet.Net) Added `Context.AddMaj23()` method.  [[#3206]]
  -  (Libplanet.Net) Added `Context.GetVoteSetBits()` method.  [[#3206]]
  -  (Libplanet.Net) Added `Context.GetVoteSetBitsResponse()` method.  [[#3206]]
+ -  (Libplanet.Net) Added `ConsensusContext.HandleMaj23()` method.
+    [[#3206]]
  -  (Libplanet.Net) Added `ConsensusContext.HandleVoteSetBits()` method.
     [[#3206]]
  -  (Libplanet.Net) Added `ConsensusContext.HandleProposalClaim()` method.

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -531,15 +531,14 @@ namespace Libplanet.Net.Tests.Consensus
 
             // Validator 1 (key1) collected +2/3 pre-vote messages,
             // sends maj23 message to context.
-            var maj23 = new ConsensusMaj23Msg(
-                new Maj23Metadata(
-                    1,
-                    0,
-                    blockB.Hash,
-                    DateTimeOffset.UtcNow,
-                    key1.PublicKey,
-                    VoteFlag.PreVote).Sign(key1));
-            context.ProduceMessage(maj23);
+            var maj23 = new Maj23Metadata(
+                1,
+                0,
+                blockB.Hash,
+                DateTimeOffset.UtcNow,
+                key1.PublicKey,
+                VoteFlag.PreVote).Sign(key1);
+            context.AddMaj23(maj23);
 
             var preVoteB0 = new ConsensusPreVoteMsg(
                 new VoteMetadata(

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -6,6 +6,7 @@ using Bencodex;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Store;
@@ -41,6 +42,14 @@ namespace Libplanet.Net.Tests.Messages
         [InlineData(MessageContent.MessageType.GetChainStatus)]
         [InlineData(MessageContent.MessageType.ChainStatus)]
         [InlineData(MessageContent.MessageType.DifferentVersion)]
+        [InlineData(MessageContent.MessageType.HaveMessage)]
+        [InlineData(MessageContent.MessageType.WantMessage)]
+        [InlineData(MessageContent.MessageType.ConsensusProposal)]
+        [InlineData(MessageContent.MessageType.ConsensusVote)]
+        [InlineData(MessageContent.MessageType.ConsensusCommit)]
+        [InlineData(MessageContent.MessageType.ConsensusMaj23Msg)]
+        [InlineData(MessageContent.MessageType.ConsensusVoteSetBitsMsg)]
+        [InlineData(MessageContent.MessageType.ConsensusProposalClaimMsg)]
         public void CheckMessages(MessageContent.MessageType type)
         {
             var privateKey = new PrivateKey();
@@ -117,6 +126,66 @@ namespace Libplanet.Net.Tests.Messages
                         chain.Tip.Hash);
                 case MessageContent.MessageType.DifferentVersion:
                     return new DifferentVersionMsg();
+                case MessageContent.MessageType.HaveMessage:
+                    return new HaveMessage(
+                        new[] { new MessageId(TestUtils.GetRandomBytes(MessageId.Size)) });
+                case MessageContent.MessageType.WantMessage:
+                    return new WantMessage(
+                        new[] { new MessageId(TestUtils.GetRandomBytes(MessageId.Size)) });
+                case MessageContent.MessageType.ConsensusProposal:
+                    return new ConsensusProposalMsg(
+                        new ProposalMetadata(
+                            0,
+                            0,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            codec.Encode(genesis.MarshalBlock()),
+                            -1).Sign(privateKey));
+                case MessageContent.MessageType.ConsensusVote:
+                    return new ConsensusPreVoteMsg(
+                            new VoteMetadata(
+                            0,
+                            0,
+                            genesis.Hash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreVote).Sign(privateKey));
+                case MessageContent.MessageType.ConsensusCommit:
+                    return new ConsensusPreCommitMsg(
+                        new VoteMetadata(
+                            0,
+                            0,
+                            genesis.Hash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreCommit).Sign(privateKey));
+                case MessageContent.MessageType.ConsensusMaj23Msg:
+                    return new ConsensusMaj23Msg(
+                        new Maj23Metadata(
+                            0,
+                            0,
+                            genesis.Hash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreVote).Sign(privateKey));
+                case MessageContent.MessageType.ConsensusVoteSetBitsMsg:
+                    return new ConsensusVoteSetBitsMsg(
+                        new VoteSetBitsMetadata(
+                            0,
+                            0,
+                            genesis.Hash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey,
+                            VoteFlag.PreVote,
+                            new[] { true, true, false, false }).Sign(privateKey));
+                case MessageContent.MessageType.ConsensusProposalClaimMsg:
+                    return new ConsensusProposalClaimMsg(
+                        new ProposalClaimMetadata(
+                            0,
+                            0,
+                            genesis.Hash,
+                            DateTimeOffset.UtcNow,
+                            privateKey.PublicKey).Sign(privateKey));
                 default:
                     throw new Exception($"Cannot create a message of invalid type {type}");
             }

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -257,6 +257,40 @@ namespace Libplanet.Net.Consensus
         }
 
         /// <summary>
+        /// Handles a received <see cref="Maj23"/> and return message to fetch.
+        /// </summary>
+        /// <param name="maj23">The <see cref="Maj23"/> received from any validator.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{ConsensusMsg}"/> to reply back.
+        /// </returns>
+        /// <remarks>This method does not update state of the context.</remarks>
+        public VoteSetBits? HandleMaj23(Maj23 maj23)
+        {
+            long height = maj23.Height;
+            if (height < Height)
+            {
+                _logger.Debug(
+                    "Ignore a received VoteSetBits as its height " +
+                    "#{Height} is lower than the current context's height #{ContextHeight}",
+                    height,
+                    Height);
+            }
+            else
+            {
+                lock (_contextLock)
+                {
+                    if (_contexts.ContainsKey(height))
+                    {
+                        return _contexts[height].AddMaj23(maj23);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Handles a received <see cref="VoteSetBits"/> and return message to fetch.
         /// </summary>
         /// <param name="voteSetBits">The <see cref="VoteSetBits"/> received from any validator.

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Serilog;
@@ -253,6 +254,78 @@ namespace Libplanet.Net.Consensus
                 _contexts[height].ProduceMessage(consensusMessage);
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Handles a received <see cref="VoteSetBits"/> and return message to fetch.
+        /// </summary>
+        /// <param name="voteSetBits">The <see cref="VoteSetBits"/> received from any validator.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{ConsensusMsg}"/> to reply back.
+        /// </returns>
+        /// <remarks>This method does not update state of the context.</remarks>
+        public IEnumerable<ConsensusMsg> HandleVoteSetBits(VoteSetBits voteSetBits)
+        {
+            long height = voteSetBits.Height;
+            if (height < Height)
+            {
+                _logger.Debug(
+                    "Ignore a received VoteSetBits as its height " +
+                    "#{Height} is lower than the current context's height #{ContextHeight}",
+                    height,
+                    Height);
+            }
+            else
+            {
+                lock (_contextLock)
+                {
+                    if (_contexts.ContainsKey(height))
+                    {
+                        // NOTE: Should check if collected messages have same BlockHash with
+                        // VoteSetBit's BlockHash?
+                        return _contexts[height].GetVoteSetBitsResponse(voteSetBits);
+                    }
+                }
+            }
+
+            return Array.Empty<ConsensusMsg>();
+        }
+
+        public Proposal? HandleProposalClaim(ProposalClaim proposalClaim)
+        {
+            long height = proposalClaim.Height;
+            int round = proposalClaim.Round;
+            if (height != Height)
+            {
+                _logger.Debug(
+                    "Ignore a received ProposalClaim as its height " +
+                    "#{Height} does not match with the current context's height #{ContextHeight}",
+                    height,
+                    Height);
+            }
+            else if (round != Round)
+            {
+                _logger.Debug(
+                    "Ignore a received ProposalClaim as its round " +
+                    "#{Round} does not match with the current context's round #{ContextRound}",
+                    round,
+                    Round);
+            }
+            else
+            {
+                lock (_contextLock)
+                {
+                    if (_contexts.ContainsKey(height))
+                    {
+                        // NOTE: Should check if collected messages have same BlockHash with
+                        // VoteSetBit's BlockHash?
+                        return _contexts[height].Proposal;
+                    }
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -188,6 +188,12 @@ namespace Libplanet.Net.Consensus
                                     maj23Msg.Round,
                                     maj23Msg.Maj23.BlockHash,
                                     maj23Msg.Maj23.Flag);
+                            if (voteSetBits.VoteBits.All(b => b))
+                            {
+                                // No any votes to received, so no need to send reply.
+                                break;
+                            }
+
                             var sender = _gossip.Peers.First(
                                 peer => peer.PublicKey.Equals(maj23Msg.ValidatorPublicKey));
 

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -181,26 +181,17 @@ namespace Libplanet.Net.Consensus
                 case ConsensusMaj23Msg maj23Msg:
                     try
                     {
-                        if (_consensusContext.HandleMessage(maj23Msg))
+                        VoteSetBits? voteSetBits = _consensusContext.HandleMaj23(maj23Msg.Maj23);
+                        if (voteSetBits is null)
                         {
-                            VoteSetBits voteSetBits = _consensusContext.Contexts[maj23Msg.Height]
-                                .GetVoteSetBits(
-                                    maj23Msg.Round,
-                                    maj23Msg.Maj23.BlockHash,
-                                    maj23Msg.Maj23.Flag);
-                            if (voteSetBits.VoteBits.All(b => b))
-                            {
-                                // No any votes to received, so no need to send reply.
-                                break;
-                            }
-
-                            var sender = _gossip.Peers.First(
-                                peer => peer.PublicKey.Equals(maj23Msg.ValidatorPublicKey));
-
-                            _gossip.PublishMessage(
-                                new ConsensusVoteSetBitsMsg(voteSetBits),
-                                new[] { sender });
+                            break;
                         }
+
+                        var sender = _gossip.Peers.First(
+                            peer => peer.PublicKey.Equals(maj23Msg.ValidatorPublicKey));
+                        _gossip.PublishMessage(
+                            new ConsensusVoteSetBitsMsg(voteSetBits),
+                            new[] { sender });
                     }
                     catch (InvalidOperationException)
                     {

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -28,6 +28,7 @@ namespace Libplanet.Net.Consensus
 
             Round = round;
             _heightVoteSet.SetRound(round);
+
             Proposal = null;
             Step = ConsensusStep.Propose;
             if (_validatorSet.GetProposer(Height, Round).PublicKey == _privateKey.PublicKey)
@@ -126,6 +127,25 @@ namespace Libplanet.Net.Consensus
                         voteMsg.BlockHash,
                         ToString());
                 }
+                else
+                {
+                    switch (message)
+                    {
+                        case ConsensusMaj23Msg maj23:
+                            _heightVoteSet.SetPeerMaj23(maj23.Maj23);
+                            break;
+                    }
+
+                    _logger.Debug(
+                        "{FName}: Message: {Message} => Height: {Height}, Round: {Round}, " +
+                        "Validator Address: {VAddress}. (context: {Context})",
+                        nameof(AddMessage),
+                        message,
+                        message.Height,
+                        message.Round,
+                        message.ValidatorPublicKey.ToAddress(),
+                        ToString());
+                }
 
                 return true;
             }
@@ -144,6 +164,17 @@ namespace Libplanet.Net.Consensus
             {
                 var icme = new InvalidConsensusMessageException(
                     ive.Message,
+                    message);
+                var msg = $"Failed to add invalid message {message} to the " +
+                          $"{nameof(HeightVoteSet)}";
+                _logger.Error(icme, msg);
+                ExceptionOccurred?.Invoke(this, icme);
+                return false;
+            }
+            catch (InvalidMaj23Exception ime)
+            {
+                var icme = new InvalidConsensusMessageException(
+                    ime.Message,
                     message);
                 var msg = $"Failed to add invalid message {message} to the " +
                           $"{nameof(HeightVoteSet)}";
@@ -172,7 +203,33 @@ namespace Libplanet.Net.Consensus
                     proposal);
             }
 
-            // FIXME: Should apply more logic?
+            if (proposal.Round != Round)
+            {
+                throw new InvalidProposalException(
+                    $"Given proposal's round {proposal.Round} does not match" +
+                    $" with the current round {Round}",
+                    proposal);
+            }
+
+            // Should check if +2/3 votes already collected and the proposal does not match
+            if (_heightVoteSet.PreVotes(Round).TwoThirdsMajority(out var preVoteMaj23) &&
+                !proposal.BlockHash.Equals(preVoteMaj23))
+            {
+                throw new InvalidProposalException(
+                    $"Given proposal's block hash {proposal.BlockHash} does not match" +
+                    $" with the collected +2/3 preVotes' block hash {preVoteMaj23}",
+                    proposal);
+            }
+
+            if (_heightVoteSet.PreCommits(Round).TwoThirdsMajority(out var preCommitMaj23) &&
+                !proposal.BlockHash.Equals(preCommitMaj23))
+            {
+                throw new InvalidProposalException(
+                    $"Given proposal's block hash {proposal.BlockHash} does not match" +
+                    $" with the collected +2/3 preCommits' block hash {preCommitMaj23}",
+                    proposal);
+            }
+
             if (Proposal is null)
             {
                 Proposal = proposal;
@@ -286,6 +343,11 @@ namespace Libplanet.Net.Consensus
                     PublishMessage(
                         new ConsensusPreCommitMsg(
                             MakeVote(Round, p3.Block.Hash, VoteFlag.PreCommit)));
+
+                    // Maybe need to broadcast periodically?
+                    PublishMessage(
+                        new ConsensusMaj23Msg(
+                            MakeMaj23(Round, p3.Block.Hash, VoteFlag.PreVote)));
                 }
 
                 _validValue = p3.Block;
@@ -317,6 +379,14 @@ namespace Libplanet.Net.Consensus
                         hash3,
                         ToString());
                     Proposal = null;
+                    PublishMessage(
+                        new ConsensusProposalClaimMsg(
+                            new ProposalClaimMetadata(
+                                Height,
+                                Round,
+                                hash3,
+                                DateTimeOffset.UtcNow,
+                                _privateKey.PublicKey).Sign(_privateKey)));
                 }
             }
 
@@ -357,6 +427,11 @@ namespace Libplanet.Net.Consensus
                 Step = ConsensusStep.EndCommit;
                 _decision = block4;
                 _committedRound = round;
+
+                // Maybe need to broadcast periodically?
+                PublishMessage(
+                    new ConsensusMaj23Msg(
+                        MakeMaj23(round, block4.Hash, VoteFlag.PreCommit)));
 
                 try
                 {

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -126,28 +126,10 @@ namespace Libplanet.Net.Consensus
                         voteMsg.ValidatorPublicKey.ToAddress(),
                         voteMsg.BlockHash,
                         ToString());
-                }
-                else
-                {
-                    switch (message)
-                    {
-                        case ConsensusMaj23Msg maj23:
-                            _heightVoteSet.SetPeerMaj23(maj23.Maj23);
-                            break;
-                    }
-
-                    _logger.Debug(
-                        "{FName}: Message: {Message} => Height: {Height}, Round: {Round}, " +
-                        "Validator Address: {VAddress}. (context: {Context})",
-                        nameof(AddMessage),
-                        message,
-                        message.Height,
-                        message.Round,
-                        message.ValidatorPublicKey.ToAddress(),
-                        ToString());
+                    return true;
                 }
 
-                return true;
+                return false;
             }
             catch (InvalidProposalException ipe)
             {
@@ -164,17 +146,6 @@ namespace Libplanet.Net.Consensus
             {
                 var icme = new InvalidConsensusMessageException(
                     ive.Message,
-                    message);
-                var msg = $"Failed to add invalid message {message} to the " +
-                          $"{nameof(HeightVoteSet)}";
-                _logger.Error(icme, msg);
-                ExceptionOccurred?.Invoke(this, icme);
-                return false;
-            }
-            catch (InvalidMaj23Exception ime)
-            {
-                var icme = new InvalidConsensusMessageException(
-                    ime.Message,
                     message);
                 var msg = $"Failed to add invalid message {message} to the " +
                           $"{nameof(HeightVoteSet)}";

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -267,6 +267,34 @@ namespace Libplanet.Net.Consensus
                 voteBits).Sign(_privateKey);
         }
 
+        /// <summary>
+        /// Add a <see cref="ConsensusMsg"/> to the context.
+        /// </summary>
+        /// <param name="maj23">A <see cref="ConsensusMsg"/> to add.</param>
+        /// <returns>A <see cref="VoteSetBits"/> if given <paramref name="maj23"/> is valid and
+        /// required.</returns>
+        public VoteSetBits? AddMaj23(Maj23 maj23)
+        {
+            try
+            {
+                if (_heightVoteSet.SetPeerMaj23(maj23))
+                {
+                    var voteSetBits = GetVoteSetBits(maj23.Round, maj23.BlockHash, maj23.Flag);
+                    return voteSetBits.VoteBits.All(b => b) ? null : voteSetBits;
+                }
+
+                return null;
+            }
+            catch (InvalidMaj23Exception ime)
+            {
+                var msg = $"Failed to add invalid maj23 {ime} to the " +
+                          $"{nameof(HeightVoteSet)}";
+                _logger.Error(ime, msg);
+                ExceptionOccurred?.Invoke(this, ime);
+                return null;
+            }
+        }
+
         public IEnumerable<ConsensusMsg> GetVoteSetBitsResponse(VoteSetBits voteSetBits)
         {
             IEnumerable<Vote> votes = voteSetBits.Flag switch

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -245,6 +245,54 @@ namespace Libplanet.Net.Consensus
             return blockCommit;
         }
 
+        public VoteSetBits GetVoteSetBits(int round, BlockHash blockHash, VoteFlag flag)
+        {
+            bool[] voteBits = flag switch
+            {
+                VoteFlag.PreVote => _heightVoteSet.PreVotes(round).BitArrayByBlockHash(blockHash),
+                VoteFlag.PreCommit
+                    => _heightVoteSet.PreCommits(round).BitArrayByBlockHash(blockHash),
+                _ => throw new ArgumentException(
+                    "VoteFlag should be either PreVote or PreCommit.",
+                    nameof(flag)),
+            };
+
+            return new VoteSetBitsMetadata(
+                Height,
+                round,
+                blockHash,
+                DateTimeOffset.UtcNow,
+                _privateKey.PublicKey,
+                flag,
+                voteBits).Sign(_privateKey);
+        }
+
+        public IEnumerable<ConsensusMsg> GetVoteSetBitsResponse(VoteSetBits voteSetBits)
+        {
+            IEnumerable<Vote> votes = voteSetBits.Flag switch
+            {
+                VoteFlag.PreVote =>
+                _heightVoteSet.PreVotes(voteSetBits.Round).MappedList().Where(
+                    (vote, index)
+                    => !voteSetBits.VoteBits[index] && vote is { }).Select(vote => vote!),
+                VoteFlag.PreCommit =>
+                _heightVoteSet.PreCommits(voteSetBits.Round).MappedList().Where(
+                    (vote, index)
+                    => !voteSetBits.VoteBits[index] && vote is { }).Select(vote => vote!),
+                _ => throw new ArgumentException(
+                    "VoteFlag should be PreVote or PreCommit.",
+                    nameof(voteSetBits.Flag)),
+            };
+
+            return votes.Select(
+                vote => vote.Flag switch
+            {
+                VoteFlag.PreVote => (ConsensusMsg)new ConsensusPreVoteMsg(vote),
+                VoteFlag.PreCommit => (ConsensusMsg)new ConsensusPreCommitMsg(vote),
+                _ => throw new ArgumentException(),
+            });
+        }
+
         /// <summary>
         /// Returns the summary of context in JSON-formatted string.
         /// </summary>
@@ -452,6 +500,37 @@ namespace Libplanet.Net.Consensus
             }
 
             return new VoteMetadata(
+                Height,
+                round,
+                hash,
+                DateTimeOffset.UtcNow,
+                _privateKey.PublicKey,
+                flag).Sign(_privateKey);
+        }
+
+        /// <summary>
+        /// Creates a signed <see cref="Maj23"/> for a <see cref="ConsensusMaj23Msg"/>.
+        /// </summary>
+        /// <param name="round">Current context round.</param>
+        /// <param name="hash">Current context locked <see cref="BlockHash"/>.</param>
+        /// <param name="flag"><see cref="VoteFlag"/> of <see cref="Maj23"/> to create.
+        /// Set to <see cref="VoteFlag.PreVote"/> if +2/3 <see cref="ConsensusPreVoteMsg"/>
+        /// messages that votes to the same block with proposal are collected.
+        /// If +2/3 <see cref="ConsensusPreCommitMsg"/> messages that votes to the same block
+        /// with proposal are collected, Set to <see cref="VoteFlag.PreCommit"/>.</param>
+        /// <returns>Returns a signed <see cref="Maj23"/> with consensus private key.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="flag"/> is either
+        /// <see cref="VoteFlag.Null"/> or <see cref="VoteFlag.Unknown"/>.</exception>
+        private Maj23 MakeMaj23(int round, BlockHash hash, VoteFlag flag)
+        {
+            if (flag == VoteFlag.Null || flag == VoteFlag.Unknown)
+            {
+                throw new ArgumentException(
+                    $"{nameof(flag)} must be either {VoteFlag.PreVote} or {VoteFlag.PreCommit}" +
+                    $"to create a valid signed maj23.");
+            }
+
+            return new Maj23Metadata(
                 Height,
                 round,
                 hash,

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -187,12 +187,19 @@ namespace Libplanet.Net.Consensus
         /// Publish given <see cref="MessageContent"/> to peers.
         /// </summary>
         /// <param name="content">A <see cref="MessageContent"/> instance to publish.</param>
-        public void PublishMessage(MessageContent content)
+        public void PublishMessage(MessageContent content) => PublishMessage(
+            content,
+            PeersToBroadcast(_table.Peers, DLazy));
+
+        /// <summary>
+        /// Publish given <see cref="MessageContent"/> to given <paramref name="targetPeers"/>.
+        /// </summary>
+        /// <param name="content">A <see cref="MessageContent"/> instance to publish.</param>
+        /// <param name="targetPeers"><see cref="BoundPeer"/>s to publish to.</param>
+        public void PublishMessage(MessageContent content, IEnumerable<BoundPeer> targetPeers)
         {
             AddMessage(content);
-            _transport.BroadcastMessage(
-                PeersToBroadcast(_table.Peers, DLazy),
-                content);
+            _transport.BroadcastMessage(targetPeers, content);
         }
 
         /// <summary>

--- a/Libplanet.Net/Messages/ConsensusMaj23Msg.cs
+++ b/Libplanet.Net/Messages/ConsensusMaj23Msg.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A message class for claiming that the peer has +2/3 votes.
+    /// </summary>
+    public class ConsensusMaj23Msg : ConsensusMsg
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusMaj23Msg"/> class.
+        /// </summary>
+        /// <param name="maj23">A <see cref="Maj23"/> of given height and round.</param>
+        public ConsensusMaj23Msg(Maj23 maj23)
+            : base(maj23.ValidatorPublicKey, maj23.Height, maj23.Round)
+        {
+            Maj23 = maj23;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusMaj23Msg"/> class
+        /// with marshalled message.
+        /// </summary>
+        /// <param name="dataframes">A marshalled message.</param>
+        public ConsensusMaj23Msg(byte[][] dataframes)
+            : this(maj23: new Maj23(dataframes[0]))
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="Maj23"/> of the message.
+        /// </summary>
+        public Maj23 Maj23 { get; }
+
+        /// <inheritdoc cref="MessageContent.DataFrames"/>
+        public override IEnumerable<byte[]> DataFrames =>
+            new List<byte[]> { Maj23.ToByteArray() };
+
+        /// <inheritdoc cref="MessageContent.MessageType"/>
+        public override MessageType Type => MessageType.ConsensusMaj23Msg;
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(ConsensusMsg?)"/>
+        public override bool Equals(ConsensusMsg? other)
+        {
+            return other is ConsensusMaj23Msg message &&
+                   message.Maj23.Equals(Maj23);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsensusMaj23Msg other && Equals(other);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, Maj23);
+        }
+    }
+}

--- a/Libplanet.Net/Messages/ConsensusProposalClaimMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusProposalClaimMsg.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A message class for claiming a <see cref="Proposal"/>.
+    /// </summary>
+    public class ConsensusProposalClaimMsg : ConsensusMsg
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusProposalClaimMsg"/> class.
+        /// </summary>
+        /// <param name="proposalClaim">A <see cref="ProposalClaim"/> of given height,
+        /// round and <see cref="BlockHash"/>.</param>
+        public ConsensusProposalClaimMsg(ProposalClaim proposalClaim)
+            : base(proposalClaim.ValidatorPublicKey, proposalClaim.Height, proposalClaim.Round)
+        {
+            ProposalClaim = proposalClaim;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusProposalClaimMsg"/> class
+        /// with marshalled message.
+        /// </summary>
+        /// <param name="dataframes">A marshalled message.</param>
+        public ConsensusProposalClaimMsg(byte[][] dataframes)
+            : this(new ProposalClaim(dataframes[0]))
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="ProposalClaim"/> of the message.
+        /// </summary>
+        public ProposalClaim ProposalClaim { get; }
+
+        /// <inheritdoc cref="MessageContent.DataFrames"/>
+        public override IEnumerable<byte[]> DataFrames =>
+            new List<byte[]> { ProposalClaim.ToByteArray() };
+
+        /// <inheritdoc cref="MessageContent.MessageType"/>
+        public override MessageType Type => MessageType.ConsensusProposalClaimMsg;
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(ConsensusMsg?)"/>
+        public override bool Equals(ConsensusMsg? other)
+        {
+            return other is ConsensusProposalClaimMsg message &&
+                   message.ProposalClaim.Equals(ProposalClaim);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsensusMsg other && Equals(other);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, ProposalClaim);
+        }
+    }
+}

--- a/Libplanet.Net/Messages/ConsensusVoteSetBitsMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusVoteSetBitsMsg.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A message class for requesting lacking <see cref="Vote"/>s
+    /// by sending the <see cref="Vote"/>s that the peer has.
+    /// </summary>
+    public class ConsensusVoteSetBitsMsg : ConsensusMsg
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusVoteSetBitsMsg"/> class.
+        /// </summary>
+        /// <param name="voteSetBits">A <see cref="VoteSetBits"/> of given height and round.</param>
+        public ConsensusVoteSetBitsMsg(VoteSetBits voteSetBits)
+            : base(
+                voteSetBits.ValidatorPublicKey,
+                voteSetBits.Height,
+                voteSetBits.Round)
+        {
+            VoteSetBits = voteSetBits;
+            BlockHash = voteSetBits.BlockHash;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusVoteSetBitsMsg"/> class
+        /// with marshalled message.
+        /// </summary>
+        /// <param name="dataframes">A marshalled message.</param>
+        public ConsensusVoteSetBitsMsg(byte[][] dataframes)
+            : this(voteSetBits: new VoteSetBits(dataframes[0]))
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="VoteSetBits"/> of the message.
+        /// </summary>
+        public VoteSetBits VoteSetBits { get; }
+
+        /// <summary>
+        /// A <see cref="BlockHash"/> of the message.
+        /// </summary>
+        public BlockHash BlockHash { get; }
+
+        /// <inheritdoc cref="MessageContent.DataFrames"/>
+        public override IEnumerable<byte[]> DataFrames =>
+            new List<byte[]> { VoteSetBits.ToByteArray() };
+
+        /// <inheritdoc cref="MessageContent.MessageType"/>
+        public override MessageType Type => MessageType.ConsensusVoteSetBitsMsg;
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(ConsensusMsg?)"/>
+        public override bool Equals(ConsensusMsg? other)
+        {
+            return other is ConsensusVoteSetBitsMsg message &&
+                   message.VoteSetBits.Equals(VoteSetBits);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsensusVoteSetBitsMsg other && Equals(other);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, VoteSetBits);
+        }
+    }
+}

--- a/Libplanet.Net/Messages/MessageContent.cs
+++ b/Libplanet.Net/Messages/MessageContent.cs
@@ -120,6 +120,21 @@ namespace Libplanet.Net.Messages
             /// Consensus commit message.
             /// </summary>
             ConsensusCommit = 0x52,
+
+            /// <summary>
+            /// Consensus message that informs other peer that the peer has a vote of majority 2/3.
+            /// </summary>
+            ConsensusMaj23Msg = 0x53,
+
+            /// <summary>
+            /// Consensus message that informs vote sets that the peer have to other peer.
+            /// </summary>
+            ConsensusVoteSetBitsMsg = 0x54,
+
+            /// <summary>
+            /// Consensus message that informs vote sets that the peer received new maj23 block.
+            /// </summary>
+            ConsensusProposalClaimMsg = 0x55,
         }
 
         /// <summary>

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -217,6 +217,12 @@ namespace Libplanet.Net.Messages
                     return new ConsensusPreVoteMsg(dataframes);
                 case MessageContent.MessageType.ConsensusCommit:
                     return new ConsensusPreCommitMsg(dataframes);
+                case MessageContent.MessageType.ConsensusMaj23Msg:
+                    return new ConsensusMaj23Msg(dataframes);
+                case MessageContent.MessageType.ConsensusVoteSetBitsMsg:
+                    return new ConsensusVoteSetBitsMsg(dataframes);
+                case MessageContent.MessageType.ConsensusProposalClaimMsg:
+                    return new ConsensusProposalClaimMsg(dataframes);
                 default:
                     throw new InvalidCastException($"Given type {type} is not a valid message.");
             }

--- a/Libplanet.Tests/Consensus/Maj23Test.cs
+++ b/Libplanet.Tests/Consensus/Maj23Test.cs
@@ -1,0 +1,54 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class Maj23Test
+    {
+        [Fact]
+        public void InvalidSignature()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            Maj23Metadata metadata = new Maj23Metadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                VoteFlag.PreVote);
+
+            // Empty Signature
+            var emptySigBencodex = metadata.Encoded.Add(Maj23.SignatureKey, Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>(() => new Maj23(emptySigBencodex));
+
+            // Invalid Signature
+            var invSigBencodex = metadata.Encoded.Add(
+                Maj23.SignatureKey,
+                new PrivateKey().Sign(TestUtils.GetRandomBytes(20)));
+            Assert.Throws<ArgumentException>(() => new Maj23(invSigBencodex));
+        }
+
+        [Fact]
+        public void Sign()
+        {
+            var key = new PrivateKey();
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            Maj23Metadata metadata = new Maj23Metadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                VoteFlag.PreVote);
+            Maj23 maj23 = metadata.Sign(key);
+
+            TestUtils.AssertBytesEqual(maj23.Signature, key.Sign(metadata.ByteArray));
+            Assert.True(key.PublicKey.Verify(metadata.ByteArray, maj23.Signature));
+        }
+    }
+}

--- a/Libplanet.Tests/Consensus/ProposalClaimMetadataTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalClaimMetadataTest.cs
@@ -6,23 +6,20 @@ using Xunit;
 
 namespace Libplanet.Tests.Consensus
 {
-    public class VoteSetBitsMetadataTest
+    public class ProposalClaimMetadataTest
     {
         [Fact]
         public void Bencoded()
         {
             var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
             var key = new PrivateKey();
-            var voteBits = new[] { true, true, false, false };
-            var expected = new VoteSetBitsMetadata(
+            var expected = new ProposalClaimMetadata(
                 1,
                 2,
                 hash,
                 DateTimeOffset.UtcNow,
-                key.PublicKey,
-                VoteFlag.PreCommit,
-                voteBits);
-            var decoded = new VoteSetBitsMetadata(expected.Encoded);
+                key.PublicKey);
+            var decoded = new ProposalClaimMetadata(expected.Encoded);
             Assert.Equal(expected, decoded);
         }
     }

--- a/Libplanet.Tests/Consensus/ProposalClaimTest.cs
+++ b/Libplanet.Tests/Consensus/ProposalClaimTest.cs
@@ -1,0 +1,54 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class ProposalClaimTest
+    {
+        [Fact]
+        public void InvalidSignature()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            ProposalClaimMetadata metadata = new ProposalClaimMetadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey);
+
+            // Empty Signature
+            var emptySigBencodex = metadata.Encoded.Add(
+                ProposalClaim.SignatureKey,
+                Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>(() => new ProposalClaim(emptySigBencodex));
+
+            // Invalid Signature
+            var invSigBencodex = metadata.Encoded.Add(
+                ProposalClaim.SignatureKey,
+                new PrivateKey().Sign(TestUtils.GetRandomBytes(20)));
+            Assert.Throws<ArgumentException>(() => new ProposalClaim(invSigBencodex));
+        }
+
+        [Fact]
+        public void Sign()
+        {
+            var key = new PrivateKey();
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            ProposalClaimMetadata metadata = new ProposalClaimMetadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey);
+            ProposalClaim claim = metadata.Sign(key);
+
+            TestUtils.AssertBytesEqual(claim.Signature, key.Sign(metadata.ByteArray));
+            Assert.True(key.PublicKey.Verify(metadata.ByteArray, claim.Signature));
+        }
+    }
+}

--- a/Libplanet.Tests/Consensus/VoteSetBitsMetadataTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetBitsMetadataTest.cs
@@ -1,0 +1,31 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class VoteSetBitsMetadataTest
+    {
+        private static Bencodex.Codec _codec = new Bencodex.Codec();
+
+        [Fact]
+        public void Bencoded()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+            var key = new PrivateKey();
+            var voteBits = new[] { true, true, false, false };
+            var expected = new VoteSetBitsMetadata(
+                1,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                VoteFlag.PreCommit,
+                voteBits);
+            var decoded = new VoteSetBitsMetadata(expected.Encoded);
+            Assert.Equal(expected, decoded);
+        }
+    }
+}

--- a/Libplanet.Tests/Consensus/VoteSetBitsTest.cs
+++ b/Libplanet.Tests/Consensus/VoteSetBitsTest.cs
@@ -1,0 +1,58 @@
+using System;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace Libplanet.Tests.Consensus
+{
+    public class VoteSetBitsTest
+    {
+        [Fact]
+        public void InvalidSignature()
+        {
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            VoteSetBitsMetadata metadata = new VoteSetBitsMetadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                VoteFlag.PreVote,
+                new[] { true, true, false, false });
+
+            // Empty Signature
+            var emptySigBencodex = metadata.Encoded.Add(
+                VoteSetBits.SignatureKey,
+                Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>(() => new VoteSetBits(emptySigBencodex));
+
+            // Invalid Signature
+            var invSigBencodex = metadata.Encoded.Add(
+                VoteSetBits.SignatureKey,
+                new PrivateKey().Sign(TestUtils.GetRandomBytes(20)));
+            Assert.Throws<ArgumentException>(() => new VoteSetBits(invSigBencodex));
+        }
+
+        [Fact]
+        public void Sign()
+        {
+            var key = new PrivateKey();
+            var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
+
+            VoteSetBitsMetadata metadata = new VoteSetBitsMetadata(
+                1,
+                0,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                VoteFlag.PreVote,
+                new[] { true, true, false, false });
+            VoteSetBits voteSetBits = metadata.Sign(key);
+
+            TestUtils.AssertBytesEqual(voteSetBits.Signature, key.Sign(metadata.ByteArray));
+            Assert.True(key.PublicKey.Verify(metadata.ByteArray, voteSetBits.Signature));
+        }
+    }
+}

--- a/Libplanet/Consensus/ProposalClaim.cs
+++ b/Libplanet/Consensus/ProposalClaim.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// Represents a <see cref="ProposalClaim"/> from a validator for consensus.  It contains an
+    /// essential information <see cref="ProposalClaimMetadata"/> to claim a <see cref="Proposal"/>
+    /// for a consensus in a height, round, <see cref="BlockHash"/>, and its signature to verify.
+    /// The signature is verified in
+    /// constructor, so the instance of <see cref="ProposalClaim"/> should be valid.
+    /// </summary>
+    public class ProposalClaim : IEquatable<ProposalClaim>
+    {
+        // FIXME: This should be private.  Left as internal for testing reasons.
+        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        private static Codec _codec = new Codec();
+
+        private readonly ProposalClaimMetadata _metadata;
+
+        /// <summary>
+        /// Instantiates a <see cref="ProposalClaim"/> with given <paramref name="metadata"/>
+        /// and its <paramref name="signature"/>.
+        /// </summary>
+        /// <param name="metadata">A <see cref="ProposalClaimMetadata"/> to claim.</param>
+        /// <param name="signature">A signature signed with <paramref name="metadata"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="signature"/> is
+        /// empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="signature"/> is
+        /// invalid and cannot be verified with <paramref name="metadata"/>.</exception>
+        public ProposalClaim(ProposalClaimMetadata metadata, ImmutableArray<byte> signature)
+        {
+            _metadata = metadata;
+            Signature = signature;
+
+            if (signature.IsDefaultOrEmpty)
+            {
+                throw new ArgumentNullException(
+                    nameof(signature),
+                    "Signature cannot be null or empty.");
+            }
+            else if (!Verify())
+            {
+                throw new ArgumentException("Signature is invalid.", nameof(signature));
+            }
+        }
+
+        public ProposalClaim(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
+        {
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public ProposalClaim(Dictionary encoded)
+            : this(
+                new ProposalClaimMetadata(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc cref="ProposalClaimMetadata.Height"/>
+        public long Height => _metadata.Height;
+
+        /// <inheritdoc cref="ProposalClaimMetadata.Round"/>
+        public int Round => _metadata.Round;
+
+        /// <inheritdoc cref="ProposalClaimMetadata.BlockHash"/>
+        public BlockHash BlockHash => _metadata.BlockHash;
+
+        /// <inheritdoc cref="ProposalClaimMetadata.Timestamp"/>
+        public DateTimeOffset Timestamp => _metadata.Timestamp;
+
+        /// <inheritdoc cref="ProposalClaimMetadata.ValidatorPublicKey"/>
+        public PublicKey ValidatorPublicKey => _metadata.ValidatorPublicKey;
+
+        /// <summary>
+        /// A signature that signed with <see cref="ProposalMetadata"/>.
+        /// </summary>
+        public ImmutableArray<byte> Signature { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="ProposalClaim"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded =>
+            !Signature.IsEmpty
+                ? _metadata.Encoded.Add(SignatureKey, Signature)
+                : _metadata.Encoded;
+
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="Proposal"/> data.
+        /// </summary>
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Verifies whether the <see cref="ProposalMetadata"/> is properly signed by
+        /// <see cref="Validator"/>.
+        /// </summary>
+        /// <returns><see langword="true"/> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
+        [Pure]
+        public bool Verify() =>
+            !Signature.IsDefaultOrEmpty &&
+            ValidatorPublicKey.Verify(
+                _metadata.ByteArray.ToImmutableArray(),
+                Signature);
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(ProposalClaim? other)
+        {
+            return other is ProposalClaim proposalClaim &&
+                   _metadata.Equals(proposalClaim._metadata) &&
+                   Signature.SequenceEqual(proposalClaim.Signature);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool Equals(object? obj)
+        {
+            return obj is ProposalClaim other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                _metadata.GetHashCode(),
+                ByteUtil.CalculateHashCode(Signature.ToArray()));
+        }
+    }
+}

--- a/Libplanet/Consensus/ProposalClaimMetadata.cs
+++ b/Libplanet/Consensus/ProposalClaimMetadata.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A class for constructing <see cref="ProposalClaim"/>. This class contains proposal claim
+    /// information in consensus of a height, round and <see cref="BlockHash"/>.
+    /// Use <see cref="Sign"/> to create a <see cref="ProposalClaim"/>.
+    /// </summary>
+    public class ProposalClaimMetadata : IEquatable<ProposalClaimMetadata>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
+        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
+        private static readonly byte[] BlockHashKey = { 0x68 };             // 'h'
+        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
+        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
+
+        private static Codec _codec = new Codec();
+
+        /// <summary>
+        /// Instantiates <see cref="ProposalClaimMetadata"/> with given parameters.
+        /// </summary>
+        /// <param name="height">A height of given claim values.</param>
+        /// <param name="round">A round of given claim values.</param>
+        /// <param name="blockHash">A <see cref="BlockHash"/> of given proposal to claim.</param>
+        /// <param name="timestamp">The time at which the proposal took place.</param>
+        /// <param name="validatorPublicKey">a <see cref="PublicKey"/> of proposing validator.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">This can be thrown in following reasons:
+        /// <list type="bullet">
+        /// <item><description>
+        ///     Given <paramref name="height"/> is less than 0.
+        /// </description></item>
+        /// <item><description>
+        ///     Given <paramref name="round"/> is less than 0.
+        /// </description></item>
+        /// </list>
+        /// </exception>
+        public ProposalClaimMetadata(
+            long height,
+            int round,
+            BlockHash blockHash,
+            DateTimeOffset timestamp,
+            PublicKey validatorPublicKey)
+        {
+            if (height < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(height),
+                    "Height must be greater than or equal to 0.");
+            }
+            else if (round < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(round),
+                    "Round must be greater than or equal to 0.");
+            }
+
+            Height = height;
+            Round = round;
+            BlockHash = blockHash;
+            Timestamp = timestamp;
+            ValidatorPublicKey = validatorPublicKey;
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public ProposalClaimMetadata(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                blockHash: new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validatorPublicKey: new PublicKey(
+                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray))
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <summary>
+        /// A height of given proposal values.
+        /// </summary>
+        public long Height { get; }
+
+        /// <summary>
+        /// A round of given proposal values.
+        /// </summary>
+        public int Round { get; }
+
+        /// <summary>
+        /// The <see cref="Libplanet.Blocks.BlockHash"/> of <see cref="Proposal"/> to claim.
+        /// </summary>
+        public BlockHash BlockHash { get; }
+
+        /// <summary>
+        /// The time at which the proposal took place.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// A <see cref="PublicKey"/> of proposing validator.
+        /// </summary>
+        public PublicKey ValidatorPublicKey { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="ProposalMetadata"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(BlockHashKey, BlockHash.ByteArray)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorPublicKeyKey, ValidatorPublicKey.Format(compress: true));
+
+                return encoded;
+            }
+        }
+
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Signs given <see cref="ProposalMetadata"/> with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">A <see cref="PrivateKey"/> to sign.</param>
+        /// <returns>Returns a signed <see cref="Proposal"/>.</returns>
+        public ProposalClaim Sign(PrivateKey signer) =>
+            new ProposalClaim(this, signer.Sign(ByteArray).ToImmutableArray());
+
+        /// <inheritdoc/>
+        public bool Equals(ProposalClaimMetadata? other)
+        {
+            return other is ProposalClaimMetadata metadata &&
+                Height == metadata.Height &&
+                Round == metadata.Round &&
+                BlockHash.Equals(metadata.BlockHash) &&
+                Timestamp
+                    .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                        metadata.Timestamp.ToString(
+                            TimestampFormat,
+                            CultureInfo.InvariantCulture)) &&
+                ValidatorPublicKey.Equals(metadata.ValidatorPublicKey);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is ProposalMetadata other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                BlockHash,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                ValidatorPublicKey);
+        }
+    }
+}

--- a/Libplanet/Consensus/VoteSetBits.cs
+++ b/Libplanet/Consensus/VoteSetBits.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A class used to requests lacking votes by sending <see cref="Vote"/>s that the peer has.
+    /// </summary>
+    public class VoteSetBits : IEquatable<VoteSetBits>
+    {
+        // FIXME: This should be private.  Left as internal for testing reasons.
+        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        private static Codec _codec = new Codec();
+
+        private readonly VoteSetBitsMetadata _voteSetBitsMetadata;
+
+        /// <summary>
+        /// Instantiates a <see cref="VoteSetBits"/> with given
+        /// <paramref name="voteSetBitsMetadata"/> and its <paramref name="signature"/>.
+        /// </summary>
+        /// <param name="voteSetBitsMetadata">
+        /// A <see cref="VoteSetBitsMetadata"/> to request.</param>
+        /// <param name="signature">A signature signed with <paramref name="voteSetBitsMetadata"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="signature"/> is
+        /// empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="signature"/> is
+        /// invalid and cannot be verified with <paramref name="voteSetBitsMetadata"/>.</exception>
+        public VoteSetBits(VoteSetBitsMetadata voteSetBitsMetadata, ImmutableArray<byte> signature)
+        {
+            _voteSetBitsMetadata = voteSetBitsMetadata;
+            Signature = signature;
+
+            if (signature.IsDefaultOrEmpty)
+            {
+                throw new ArgumentNullException(
+                    nameof(signature),
+                    "Signature cannot be null or empty.");
+            }
+            else if (!Verify())
+            {
+                throw new ArgumentException("Signature is invalid.", nameof(signature));
+            }
+        }
+
+        public VoteSetBits(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
+        {
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public VoteSetBits(Dictionary encoded)
+            : this(
+                new VoteSetBitsMetadata(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.Height"/>
+        public long Height => _voteSetBitsMetadata.Height;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.Round"/>
+        public int Round => _voteSetBitsMetadata.Round;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.BlockHash"/>
+        public BlockHash BlockHash => _voteSetBitsMetadata.BlockHash;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.Timestamp"/>
+        public DateTimeOffset Timestamp => _voteSetBitsMetadata.Timestamp;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.ValidatorPublicKey"/>
+        public PublicKey ValidatorPublicKey => _voteSetBitsMetadata.ValidatorPublicKey;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.Flag"/>
+        public VoteFlag Flag => _voteSetBitsMetadata.Flag;
+
+        /// <inheritdoc cref="VoteSetBitsMetadata.VoteBits"/>
+        public ImmutableArray<bool> VoteBits => _voteSetBitsMetadata.VoteBits;
+
+        /// <summary>
+        /// A signature that signed with <see cref="VoteSetBitsMetadata"/>.
+        /// </summary>
+        public ImmutableArray<byte> Signature { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="VoteSetBits"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded =>
+            !Signature.IsEmpty
+                ? _voteSetBitsMetadata.Encoded.Add(SignatureKey, Signature)
+                : _voteSetBitsMetadata.Encoded;
+
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="VoteSetBits"/> data.
+        /// </summary>
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Verifies whether the <see cref="VoteSetBitsMetadata"/> is properly signed by
+        /// <see cref="Validator"/>.
+        /// </summary>
+        /// <returns><see langword="true"/> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
+        [Pure]
+        public bool Verify() =>
+            !Signature.IsDefaultOrEmpty &&
+            ValidatorPublicKey.Verify(
+                _voteSetBitsMetadata.ByteArray.ToImmutableArray(),
+                Signature);
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(VoteSetBits? other)
+        {
+            return other is { } voteSetBits &&
+                   _voteSetBitsMetadata.Equals(voteSetBits._voteSetBitsMetadata) &&
+                   Signature.SequenceEqual(voteSetBits.Signature);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool Equals(object? obj)
+        {
+            return obj is VoteSetBits other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                _voteSetBitsMetadata.GetHashCode(),
+                ByteUtil.CalculateHashCode(Signature.ToArray()));
+        }
+    }
+}

--- a/Libplanet/Consensus/VoteSetBitsMetadata.cs
+++ b/Libplanet/Consensus/VoteSetBitsMetadata.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    public class VoteSetBitsMetadata : IEquatable<VoteSetBitsMetadata>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
+        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
+        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
+        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
+        private static readonly byte[] BlockHashKey = { 0x42 };             // 'B'
+        private static readonly byte[] FlagKey = { 0x46 };                  // 'F'
+        private static readonly byte[] VoteBitsKey = { 0x56 };              // 'V'
+
+        private static Codec _codec = new Codec();
+
+        public VoteSetBitsMetadata(
+            long height,
+            int round,
+            BlockHash blockHash,
+            DateTimeOffset timestamp,
+            PublicKey validatorPublicKey,
+            VoteFlag flag,
+            IEnumerable<bool> voteBits)
+        {
+            if (height < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(height),
+                    "Height must be greater than or equal to 0.");
+            }
+            else if (round < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(round),
+                    "Round must be greater than or equal to 0.");
+            }
+
+            if (flag == VoteFlag.Null || flag == VoteFlag.Unknown)
+            {
+                throw new ArgumentException(
+                    "Vote flag should be PreVote or PreCommit.",
+                    nameof(flag));
+            }
+
+            Height = height;
+            Round = round;
+            BlockHash = blockHash;
+            Timestamp = timestamp;
+            ValidatorPublicKey = validatorPublicKey;
+            Flag = flag;
+            VoteBits = voteBits.ToImmutableArray();
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public VoteSetBitsMetadata(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                blockHash: new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validatorPublicKey: new PublicKey(
+                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
+                flag: (VoteFlag)(int)encoded.GetValue<Integer>(FlagKey).Value,
+                voteBits: encoded.GetValue<List>(VoteBitsKey)
+                    .Select(bit => (bool)(Bencodex.Types.Boolean)bit))
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <summary>
+        /// A height of the votes in the given vote set.
+        /// </summary>
+        public long Height { get; }
+
+        /// <summary>
+        /// A round of the votes in the given vote set.
+        /// </summary>
+        public int Round { get; }
+
+        /// <summary>
+        /// The <see cref="Libplanet.Blocks.BlockHash"/> of the votes in the vote sets.
+        /// </summary>
+        public BlockHash BlockHash { get; }
+
+        /// <summary>
+        /// The time at which the set is created.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// A <see cref="PublicKey"/> of the vote set.
+        /// </summary>
+        public PublicKey ValidatorPublicKey { get; }
+
+        /// <summary>
+        /// The <see cref="VoteFlag"/> of the votes in the vote set.
+        /// </summary>
+        public VoteFlag Flag { get; }
+
+        /// <summary>
+        /// <see cref="bool"/>s of the vote set to be .
+        /// </summary>
+        public ImmutableArray<bool> VoteBits { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="VoteSetBitsMetadata"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorPublicKeyKey, ValidatorPublicKey.Format(compress: true))
+                    .Add(BlockHashKey, BlockHash.ByteArray)
+                    .Add(FlagKey, (int)Flag)
+                    .Add(
+                        VoteBitsKey,
+                        new List(VoteBits.Select(bit => (Bencodex.Types.Boolean)bit)));
+
+                return encoded;
+            }
+        }
+
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Signs given <see cref="VoteSetBitsMetadata"/> with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">A <see cref="PrivateKey"/> to sign.</param>
+        /// <returns>Returns a signed <see cref="VoteSetBits"/>.</returns>
+        public VoteSetBits Sign(PrivateKey signer) =>
+            new VoteSetBits(this, signer.Sign(ByteArray).ToImmutableArray());
+
+        /// <inheritdoc/>
+        public bool Equals(VoteSetBitsMetadata? other)
+        {
+            return other is { } metadata &&
+                Height == metadata.Height &&
+                Round == metadata.Round &&
+                BlockHash.Equals(metadata.BlockHash) &&
+                Timestamp
+                    .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                        metadata.Timestamp.ToString(
+                            TimestampFormat,
+                            CultureInfo.InvariantCulture)) &&
+                ValidatorPublicKey.Equals(metadata.ValidatorPublicKey) &&
+                Flag == metadata.Flag &&
+                VoteBits.SequenceEqual(other.VoteBits);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is VoteSetBitsMetadata other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int voteBitsHashCode = VoteBits.Aggregate(
+                0,
+                (current, voteBit) => (current * 397) ^ voteBit.GetHashCode());
+
+            return HashCode.Combine(
+                Height,
+                Round,
+                BlockHash,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                ValidatorPublicKey,
+                Flag,
+                voteBitsHashCode);
+        }
+    }
+}


### PR DESCRIPTION
## Introduction
This PR introduces two new classes `Maj23`, `VoteSetBits` and its related classes to solve following problem.

## Problem

1. There exists 4 validator, where one of them (validator D) is attacker.

2. Validator D is the proposer for the round and height, and validator D sends block X's proposal to validator A, and send Y's proposal to validator B and C.

| |ValidatorA|ValidatorB|ValidatorC|ValidatorD|
|-|-|-|-|-|
|Proposal|X|Y|Y|XY|

3. Each validator broadcasts prevote vote according to received proposal. But validator D sends X's prevote to validator A and B, and sends Y's prevote to validaotr C.

| |ValidatorA|ValidatorB|ValidatorC|ValidatorD|
|-|-|-|-|-|
|Proposal|X|Y|Y|XY|
|PreVote|XYYX|XYYX|XYYY|XYYY|

4. Validator A and B failed to collect +2/3 prevote for block X, and validator C and D collected +2/3 prevote for block Y thus send precommit for block Y.

| |ValidatorA|ValidatorB|ValidatorC|ValidatorD|
|-|-|-|-|-|
|Proposal|X|Y|Y|XY|
|PreVote|XYYX|XYYX|XYYY|XYYY|
|lock|-|-|Y|Y|
|PreCommit|--YY|--YY|--YY|--YY|

5. No any block received +2/3 precommit, round increased.
6. Validator C and D cannot vote to other block that Validator A and B proposed (block X' != X and X' != Y) because block Y is already locked, so block X' cannot be committed.
7. When validator C is proposer, validator C will propose block Y with its valid round. Validator A and B's prevote for such round is `XYYX`, thus will not vote for block Y.
8. Round infinetly increased, block never created.

## Solution
When a validator has block X as the proposal for the round, and somehow detects other peer success to collect vote for block Y that is not same with proposal has, the validator replace proposal from block X's to block Y's.

When a validator success to collect +2/3 votes for a proposal (prevote or precommit), broadcasts `Maj23` message to other validators. If the receiver's proposal does not match with received `Maj23`'s block information, try to collect missing votes for the block using `VoteSetBits` message. Proposal will be replaced if the votes are collected successfully.

## Additional Tasks
- Add a unit test for `Maj23` auto broadcasting.
- Add a unit test for consensus-level scenario test.