### PR TITLE
♻️ Streamline various getters for `ActionEvaluator`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  `IBlockChainStates` interface overhauled.  [[#3207]]
+     -  Added `IBlockChainStates.GetStateRoot()` interface method.
+     -  All `IBlockChainStates` methods now take nullable `BlockHash?`
+        instead of `BlockHash` as `offset` parameter.
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -20,9 +25,15 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `AccountStateDeltaImpl.Signer` would have an inappropraite
+    value when evaluating an `IBlockAction` if `Block` had any `Transaction`s.
+    [[#3207]]
+
 ### Dependencies
 
 ### CLI tools
+
+[#3207]: https://github.com/planetarium/libplanet/pull/3207
 
 
 Version 1.4.0

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -181,35 +181,43 @@ public class StateQueryTest
 
         public IReadOnlyList<IValue> GetStates(
             IReadOnlyList<Address> addresses,
-            BlockHash offset
+            BlockHash? offset
         ) =>
-            addresses.Select(address => address.ToString() switch
-            {
-                "0x5003712B63baAB98094aD678EA2B24BcE445D076" => (IValue)Null.Value,
-                _ => null,
-            }).ToImmutableList();
+            offset is { } _
+                ? addresses.Select(address => address.ToString() switch
+                {
+                    "0x5003712B63baAB98094aD678EA2B24BcE445D076" => (IValue)Null.Value,
+                    _ => null,
+                }).ToImmutableList()
+                : addresses.Select(address => (IValue)null).ToList();
 
         public FungibleAssetValue GetBalance(
             Address address,
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         ) =>
-            currency * 123;
+            offset is { } _
+                ? currency * 123
+                : currency * 0;
 
         public FungibleAssetValue GetTotalSupply(
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         ) =>
-            currency * 10000;
+            offset is { } _
+                ? currency * 10000
+                : currency * 0;
 
-        public ValidatorSet GetValidatorSet(BlockHash offset)
-            => new ValidatorSet(new List<Validator>
-            {
-                new(
-                    PublicKey.FromHex(
-                        "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"),
-                    new BigInteger(1)),
-            });
+        public ValidatorSet GetValidatorSet(BlockHash? offset) =>
+            offset is { } _
+                ? new ValidatorSet(new List<Validator>
+                {
+                    new(
+                        PublicKey.FromHex(
+                            "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"),
+                        new BigInteger(1)),
+                })
+                : new ValidatorSet();
 
         public ITrie GetStateRoot(BlockHash? offset) => null;
     }

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -14,6 +14,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Explorer.Queries;
+using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Xunit;
 using static Libplanet.Explorer.Tests.GraphQLTestUtils;
@@ -175,6 +176,9 @@ public class StateQueryTest
 
     private class MockChainStates : IBlockChainStates
     {
+        private static readonly IStateStore _stateStore =
+            new TrieStateStore(new MemoryKeyValueStore());
+
         public IReadOnlyList<IValue> GetStates(
             IReadOnlyList<Address> addresses,
             BlockHash offset
@@ -207,6 +211,6 @@ public class StateQueryTest
                     new BigInteger(1)),
             });
 
-        public ITrie GetTrie(BlockHash offset) => null;
+        public ITrie GetStateRoot(BlockHash? offset) => null;
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -231,13 +231,8 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent.DeriveTxHash(txs),
                     lastCommit: null),
                 transactions: txs).Propose();
-            IAccountStateDelta previousStates = AccountStateDeltaImpl.ChooseVersion(
-                genesis.ProtocolVersion,
-                ActionEvaluator.NullAccountStateGetter,
-                ActionEvaluator.NullAccountBalanceGetter,
-                ActionEvaluator.NullTotalSupplyGetter,
-                ActionEvaluator.NullValidatorSetGetter,
-                genesis.Miner);
+            IAccountStateDelta previousStates =
+                actionEvaluator.GetPreviousBlockOutputStates(genesis);
 
             Assert.Throws<OutOfMemoryException>(
                 () => actionEvaluator.EvaluateTx(
@@ -294,13 +289,8 @@ namespace Libplanet.Tests.Action
                 blockChainStates: NullChainStates.Instance,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)),
                 feeCalculator: null);
-            IAccountStateDelta previousStates = AccountStateDeltaImpl.ChooseVersion(
-                genesis.ProtocolVersion,
-                ActionEvaluator.NullAccountStateGetter,
-                ActionEvaluator.NullAccountBalanceGetter,
-                ActionEvaluator.NullTotalSupplyGetter,
-                ActionEvaluator.NullValidatorSetGetter,
-                genesis.Miner);
+            IAccountStateDelta previousStates =
+                actionEvaluator.GetPreviousBlockOutputStates(genesis);
 
             Transaction[] block1Txs =
             {
@@ -338,13 +328,7 @@ namespace Libplanet.Tests.Action
                 genesis,
                 GenesisProposer,
                 block1Txs);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                block1.ProtocolVersion,
-                ActionEvaluator.NullAccountStateGetter,
-                ActionEvaluator.NullAccountBalanceGetter,
-                ActionEvaluator.NullTotalSupplyGetter,
-                ActionEvaluator.NullValidatorSetGetter,
-                block1.Miner);
+            previousStates = actionEvaluator.GetPreviousBlockOutputStates(block1);
             var evals = actionEvaluator.EvaluateBlock(
                 block1,
                 previousStates).ToImmutableArray();
@@ -378,13 +362,7 @@ namespace Libplanet.Tests.Action
                         .Select(x => x is Text t ? t.Value : null));
             }
 
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                block1.ProtocolVersion,
-                ActionEvaluator.NullAccountStateGetter,
-                ActionEvaluator.NullAccountBalanceGetter,
-                ActionEvaluator.NullTotalSupplyGetter,
-                ActionEvaluator.NullValidatorSetGetter,
-                block1.Miner);
+            previousStates = actionEvaluator.GetPreviousBlockOutputStates(block1);
             ActionEvaluation[] evals1 =
                 actionEvaluator.EvaluateBlock(block1, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty1 = evals1.GetDirtyStates();

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -561,15 +561,19 @@ namespace Libplanet.Action
             ValidatorSetGetter validatorSetGetter = () =>
                 _blockChainStates.GetValidatorSet(
                     blockHeader.PreviousHash);
-            Address miner = blockHeader.Miner;
 
+            // FIXME: Unless we actually know the previous block,
+            // proper AccountStateDeltaImpl can't be made.
+            // This could possibly change the behavior in some edge cases
+            // depending on user's implementation of IAction Execute(),
+            // especially if MintAsset() and BurnAsset() has been used.
             return AccountStateDeltaImpl.ChooseVersion(
-                blockHeader.ProtocolVersion,
+                0,
                 accountStateGetter,
                 accountBalanceGetter,
                 totalSupplyGetter,
                 validatorSetGetter,
-                miner);
+                default(Address));
         }
 
         [Pure]

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -625,35 +625,18 @@ namespace Libplanet.Action
             InitializeAccountGettersPair(
             IPreEvaluationBlockHeader blockHeader)
         {
-            AccountStateGetter accountStateGetter;
-            AccountBalanceGetter accountBalanceGetter;
-            TotalSupplyGetter totalSupplyGetter;
-            ValidatorSetGetter validatorSetGetter;
-
-            if (blockHeader.PreviousHash is { } previousHash)
-            {
-                accountStateGetter = addresses => _blockChainStates.GetStates(
-                    addresses,
-                    previousHash
-                );
-                accountBalanceGetter = (address, currency) => _blockChainStates.GetBalance(
-                    address,
-                    currency,
-                    previousHash
-                );
-                totalSupplyGetter = currency => _blockChainStates.GetTotalSupply(
-                    currency,
-                    previousHash
-                );
-                validatorSetGetter = () => _blockChainStates.GetValidatorSet(previousHash);
-            }
-            else
-            {
-                accountStateGetter = NullAccountStateGetter;
-                accountBalanceGetter = NullAccountBalanceGetter;
-                totalSupplyGetter = NullTotalSupplyGetter;
-                validatorSetGetter = NullValidatorSetGetter;
-            }
+            AccountStateGetter accountStateGetter = addresses =>
+                _blockChainStates.GetStates(
+                    addresses, blockHeader.PreviousHash);
+            AccountBalanceGetter accountBalanceGetter = (address, currency) =>
+                _blockChainStates.GetBalance(
+                    address, currency, blockHeader.PreviousHash);
+            TotalSupplyGetter totalSupplyGetter = currency =>
+                _blockChainStates.GetTotalSupply(
+                    currency, blockHeader.PreviousHash);
+            ValidatorSetGetter validatorSetGetter = () =>
+                _blockChainStates.GetValidatorSet(
+                    blockHeader.PreviousHash);
 
             return (accountStateGetter, accountBalanceGetter, totalSupplyGetter,
                 validatorSetGetter);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -17,6 +17,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Serilog;
 using static Libplanet.Blockchain.KeyConverters;
@@ -594,6 +595,10 @@ namespace Libplanet.Blockchain
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet" />
         public ValidatorSet GetValidatorSet(BlockHash offset) =>
             _blockChainStates.GetValidatorSet(offset);
+
+        /// <inheritdoc cref="IBlockChainStates.GetStateRoot"/>
+        public ITrie GetStateRoot(BlockHash? offset) =>
+            _blockChainStates.GetStateRoot(offset);
 
         /// <summary>
         /// Queries the recorded <see cref="TxExecution"/> for a successful or failed

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -7,6 +8,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.State;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Blockchain
@@ -135,6 +137,35 @@ namespace Libplanet.Blockchain
             }
 
             throw new IncompleteBlockStatesException(offset);
+        }
+
+        /// <inheritdoc cref="IBlockChainStates.GetStateRoot"/>
+        public ITrie GetStateRoot(BlockHash? offset)
+        {
+            if (!(offset is { } hash))
+            {
+                return _stateStore.GetStateRoot(null);
+            }
+            else
+            {
+                if (_store.GetStateRootHash(hash) is { } stateRootHash)
+                {
+                    if (_stateStore.ContainsStateRoot(stateRootHash))
+                    {
+                        return _stateStore.GetStateRoot(stateRootHash);
+                    }
+                    else
+                    {
+                        throw new ArgumentException(
+                            $"Could not find state root {stateRootHash} in {nameof(IStateStore)}.");
+                    }
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"Could not find block hash {hash} in {nameof(IStore)}.");
+                }
+            }
         }
     }
 }

--- a/Libplanet/Blockchain/IBlockChainStates.cs
+++ b/Libplanet/Blockchain/IBlockChainStates.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Blockchain
         /// </returns>
         IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses,
-            BlockHash offset
+            BlockHash? offset
         );
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Libplanet.Blockchain
         FungibleAssetValue GetBalance(
             Address address,
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         );
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Libplanet.Blockchain
         /// <paramref name="offset"/> in <see cref="FungibleAssetValue"/>.</returns>
         FungibleAssetValue GetTotalSupply(
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         );
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Libplanet.Blockchain
         /// <returns>The validator set of type <see cref="ValidatorSet"/> at the
         /// <paramref name="offset"/>.
         /// </returns>
-        ValidatorSet GetValidatorSet(BlockHash offset);
+        ValidatorSet GetValidatorSet(BlockHash? offset);
 
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>

--- a/Libplanet/Blockchain/IBlockChainStates.cs
+++ b/Libplanet/Blockchain/IBlockChainStates.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Collections.Generic;
 using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
 
 namespace Libplanet.Blockchain
 {
@@ -68,5 +71,28 @@ namespace Libplanet.Blockchain
         /// <paramref name="offset"/>.
         /// </returns>
         ValidatorSet GetValidatorSet(BlockHash offset);
+
+        /// <summary>
+        /// Returns the state root associated with <see cref="BlockHash"/>
+        /// <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="offset">The <see cref="BlockHash"/> to look up in
+        /// the internally held <see cref="IStore"/>.</param>
+        /// <returns>An <see cref="ITrie"/> representing the state root associated with
+        /// <paramref name="offset"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown for one of the following reasons.
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         If <paramref name="offset"/> is not <see langword="null"/> and
+        ///         <paramref name="offset"/> cannot be found in <see cref="IStore"/>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         If <paramref name="offset"/> is not <see langword="null"/> and
+        ///         the state root hash associated with <paramref name="offset"/>
+        ///         cannot be found in <see cref="IStateStore"/>.
+        ///     </description></item>
+        /// </list>
+        /// </exception>
+        ITrie GetStateRoot(BlockHash? offset);
     }
 }

--- a/Libplanet/Blockchain/NullChainStates.cs
+++ b/Libplanet/Blockchain/NullChainStates.cs
@@ -21,20 +21,20 @@ namespace Libplanet.Blockchain
 
         public IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses,
-            BlockHash offset
+            BlockHash? offset
         ) =>
             new IValue?[addresses.Count];
 
         public FungibleAssetValue GetBalance(
             Address address,
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         ) =>
             currency * 0;
 
         public FungibleAssetValue GetTotalSupply(
             Currency currency,
-            BlockHash offset
+            BlockHash? offset
         )
         {
             if (!currency.TotalSupplyTrackable)
@@ -45,7 +45,7 @@ namespace Libplanet.Blockchain
             return currency * 0;
         }
 
-        public ValidatorSet GetValidatorSet(BlockHash offset)
+        public ValidatorSet GetValidatorSet(BlockHash? offset)
         {
             return new ValidatorSet();
         }

--- a/Libplanet/Blockchain/NullChainStates.cs
+++ b/Libplanet/Blockchain/NullChainStates.cs
@@ -4,6 +4,7 @@ using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.State;
+using Libplanet.Store;
 using Libplanet.Store.Trie;
 
 namespace Libplanet.Blockchain
@@ -11,6 +12,8 @@ namespace Libplanet.Blockchain
     internal class NullChainStates : IBlockChainStates
     {
         public static readonly NullChainStates Instance = new NullChainStates();
+        private static readonly IStateStore _stateStore =
+            new TrieStateStore(new MemoryKeyValueStore());
 
         private NullChainStates()
         {
@@ -47,6 +50,6 @@ namespace Libplanet.Blockchain
             return new ValidatorSet();
         }
 
-        public ITrie? GetTrie(BlockHash offset) => null;
+        public ITrie GetStateRoot(BlockHash? offset) => _stateStore.GetStateRoot(null);
     }
 }

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -317,19 +317,13 @@ namespace Libplanet.State
         }
 
         /// <summary>
-        /// Creates a null delta from the given <paramref name="accountStateGetter"/>,
-        /// <paramref name="accountBalanceGetter"/>, and <paramref name="totalSupplyGetter"/>,
+        /// Creates a null delta from given <paramref name="previousStates"/>
         /// with a subtype of <see cref="AccountStateDeltaImpl"/> that corresponds to the
         /// <paramref name="protocolVersion"/>.
         /// </summary>
         /// <param name="protocolVersion">The protocol version of which to create a delta.</param>
-        /// <param name="accountStateGetter">A view to the &#x201c;epoch&#x201d; states.</param>
-        /// <param name="accountBalanceGetter">A view to the &#x201c;epoch&#x201d; asset balances.
+        /// <param name="previousStates">The <see cref="IAccountStateDelta"/> to use as a basis.
         /// </param>
-        /// <param name="totalSupplyGetter">A view to the &#x201c;epoch&#x201d; total supplies of
-        /// currencies.</param>
-        /// <param name="validatorSetGetter">A view to the &#x201c;epoch&#x201d; validator
-        /// set.</param>
         /// <param name="signer">A signer address. Used for authenticating if a signer is allowed
         /// to mint a currency.</param>
         /// <returns>A instance of a subtype of <see cref="AccountStateDeltaImpl"/> which
@@ -337,22 +331,19 @@ namespace Libplanet.State
         [Pure]
         internal static AccountStateDeltaImpl ChooseVersion(
             int protocolVersion,
-            AccountStateGetter accountStateGetter,
-            AccountBalanceGetter accountBalanceGetter,
-            TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter,
+            IAccountStateDelta previousStates,
             Address signer) => protocolVersion > 0
             ? new AccountStateDeltaImpl(
-                accountStateGetter,
-                accountBalanceGetter,
-                totalSupplyGetter,
-                validatorSetGetter,
+                previousStates.GetStates,
+                previousStates.GetBalance,
+                previousStates.GetTotalSupply,
+                previousStates.GetValidatorSet,
                 signer)
             : new AccountStateDeltaImplV0(
-                accountStateGetter,
-                accountBalanceGetter,
-                totalSupplyGetter,
-                validatorSetGetter,
+                previousStates.GetStates,
+                previousStates.GetBalance,
+                previousStates.GetTotalSupply,
+                previousStates.GetValidatorSet,
                 signer);
 
         [Pure]


### PR DESCRIPTION
♻️ First step towards a long and arduous journey for overhauling state, context, and delta.

- Strictly speaking, `IBlockChainStates.GetStateRoot()` doesn't have to be exposed at this very moment as it is only used internally by `BlockChainStates`. It is merely a preparation in case we want to retrieve and inject state roots in `ActionEvaluator` and `AccountStateDeltaImpl`.
- `ActionEvaluator` only builds state getters from `IBlockChainStates` for the initial delta. Delta objects takes its previous delta directly to "inherit" previous getters.