### PR TITLE
♻️ Remove null getters for `ActionEvaluator`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,11 +29,15 @@ To be released.
 
 ### Bug fixes
 
+ -  Fixed a bug where `BlockAction` could have unintended
+    `AccountStateDeltaImpl.Signer` during its execution.  [[#3215]]
+
 ### Dependencies
 
 ### CLI tools
 
 [#3214]: https://github.com/planetarium/libplanet/pull/3214
+[#3215]: https://github.com/planetarium/libplanet/pull/3215
 [#3218]: https://github.com/planetarium/libplanet/pull/3218
 
 

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -162,14 +162,7 @@ namespace Libplanet.Tests.Action
                 Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
 
             // Forcefully create null delta
-            delta0 = AccountStateDeltaImpl.ChooseVersion(
-                1,
-                delta0.GetStates,
-                delta0.GetBalance,
-                delta0.GetTotalSupply,
-                delta0.GetValidatorSet,
-                _addr[0],
-                ((AccountStateDeltaImpl)delta0).TotalUpdatedFungibles);
+            delta0 = AccountStateDeltaImpl.ChooseSigner(delta0, _addr[0]);
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint and burn
             delta0 = delta0.MintAsset(_addr[0], Value(1, 1));
@@ -180,14 +173,7 @@ namespace Libplanet.Tests.Action
 
             // Forcefully create null delta
             // Currently there is no way to swap signer without clearing
-            delta0 = AccountStateDeltaImpl.ChooseVersion(
-                1,
-                delta0.GetStates,
-                delta0.GetBalance,
-                delta0.GetTotalSupply,
-                delta0.GetValidatorSet,
-                _addr[1],
-                ((AccountStateDeltaImpl)delta0).TotalUpdatedFungibles);
+            delta0 = AccountStateDeltaImpl.ChooseSigner(delta0, _addr[1]);
             delta0 = delta0.BurnAsset(_addr[1], Value(1, 1));
 
             // _addr[0] burned currencies[0] & minted currencies[1]

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -231,12 +231,7 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent.DeriveTxHash(txs),
                     lastCommit: null),
                 transactions: txs).Propose();
-            IAccountStateDelta previousStates =
-                actionEvaluator.GetBlockOutputStates(block.PreviousHash);
-            previousStates =
-                AccountStateDeltaImpl.ChooseVersion(previousStates, block.ProtocolVersion);
-            previousStates =
-                AccountStateDeltaImpl.ChooseSigner(previousStates, block.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
 
             Assert.Throws<OutOfMemoryException>(
                 () => actionEvaluator.EvaluateTx(
@@ -330,12 +325,7 @@ namespace Libplanet.Tests.Action
                 genesis,
                 GenesisProposer,
                 block1Txs);
-            IAccountStateDelta previousStates = actionEvaluator.GetBlockOutputStates(
-                block1.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block1.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block1.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block1);
             var evals = actionEvaluator.EvaluateBlock(
                 block1,
                 previousStates).ToImmutableArray();
@@ -369,12 +359,7 @@ namespace Libplanet.Tests.Action
                         .Select(x => x is Text t ? t.Value : null));
             }
 
-            previousStates = actionEvaluator.GetBlockOutputStates(
-                block1.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block1.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block1.Miner);
+            previousStates = actionEvaluator.PrepareInitialDelta(block1);
             ActionEvaluation[] evals1 =
                 actionEvaluator.EvaluateBlock(block1, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty1 = evals1.GetDirtyStates();
@@ -566,12 +551,7 @@ namespace Libplanet.Tests.Action
 
             DumbAction.RehearsalRecords.Value =
                 ImmutableList<(Address, string)>.Empty;
-            IAccountStateDelta previousStates =
-                actionEvaluator.GetBlockOutputStates(block.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
             var evaluations = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
@@ -637,12 +617,7 @@ namespace Libplanet.Tests.Action
 
             DumbAction.RehearsalRecords.Value =
                 ImmutableList<(Address, string)>.Empty;
-            previousStates =
-                actionEvaluator.GetBlockOutputStates(block.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block.Miner);
+            previousStates = actionEvaluator.PrepareInitialDelta(block);
             IAccountStateDelta delta = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
@@ -686,12 +661,7 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent.DeriveTxHash(txs),
                     lastCommit: CreateBlockCommit(hash, 122, 0)),
                 transactions: txs).Propose();
-            IAccountStateDelta previousStates =
-                actionEvaluator.GetBlockOutputStates(block.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
             var nextStates = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
@@ -823,12 +793,7 @@ namespace Libplanet.Tests.Action
             var block = chain.ProposeBlock(
                 GenesisProposer, txs.ToImmutableList(), CreateBlockCommit(chain.Tip));
 
-            IAccountStateDelta previousStates = actionEvaluator.GetBlockOutputStates(
-                genesis.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, genesis.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, genesis.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(genesis);
             var evaluation = actionEvaluator.EvaluatePolicyBlockAction(genesis, previousStates);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);
@@ -852,11 +817,7 @@ namespace Libplanet.Tests.Action
             Assert.True(evaluation.InputContext.BlockAction);
 
             chain.Append(block, CreateBlockCommit(block), render: true);
-            previousStates = actionEvaluator.GetBlockOutputStates(block.PreviousHash);
-            previousStates = AccountStateDeltaImpl.ChooseVersion(
-                previousStates, block.ProtocolVersion);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block.Miner);
+            previousStates = actionEvaluator.PrepareInitialDelta(block);
             var txEvaluations = actionEvaluator.EvaluateBlock(
                 block,
                 previousStates).ToList();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1720,12 +1720,7 @@ namespace Libplanet.Tests.Blockchain
 
             // Build a store with incomplete states
             Block b = chain.Genesis;
-            IAccountStateDelta previousStates =
-                actionEvaluator.GetBlockOutputStates(b.PreviousHash);
-            previousStates =
-                AccountStateDeltaImpl.ChooseVersion(previousStates, b.ProtocolVersion);
-            previousStates =
-                AccountStateDeltaImpl.ChooseSigner(previousStates, b.Miner);
+            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(b);
             ActionEvaluation[] evals =
                 actionEvaluator.EvaluateBlock(b, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty = evals.GetDirtyStates();

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -422,34 +422,31 @@ namespace Libplanet.State
         {
             // The order is important since AccountStateDeltaImplV0 inherits from
             // AccountStateDeltaImpl
-            if (delta is AccountStateDeltaImplV0 implV0)
+            switch (delta)
             {
-                return new AccountStateDeltaImplV0(
-                    delta.GetStates,
-                    delta.GetBalance,
-                    delta.GetTotalSupply,
-                    delta.GetValidatorSet,
-                    signer)
-                    {
-                        TotalUpdatedFungibles = implV0.TotalUpdatedFungibles,
-                    };
-            }
-            else if (delta is AccountStateDeltaImpl impl)
-            {
-                return new AccountStateDeltaImpl(
-                    delta.GetStates,
-                    delta.GetBalance,
-                    delta.GetTotalSupply,
-                    delta.GetValidatorSet,
-                    signer)
-                    {
-                        TotalUpdatedFungibles = impl.TotalUpdatedFungibles,
-                    };
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"Unknown type for {nameof(delta)}: {delta.GetType()}");
+                case AccountStateDeltaImplV0 implV0:
+                    return new AccountStateDeltaImplV0(
+                        delta.GetStates,
+                        delta.GetBalance,
+                        delta.GetTotalSupply,
+                        delta.GetValidatorSet,
+                        signer)
+                        {
+                            TotalUpdatedFungibles = implV0.TotalUpdatedFungibles,
+                        };
+                case AccountStateDeltaImpl impl:
+                    return new AccountStateDeltaImpl(
+                        delta.GetStates,
+                        delta.GetBalance,
+                        delta.GetTotalSupply,
+                        delta.GetValidatorSet,
+                        signer)
+                        {
+                            TotalUpdatedFungibles = impl.TotalUpdatedFungibles,
+                        };
+                default:
+                    throw new ArgumentException(
+                        $"Unknown type for {nameof(delta)}: {delta.GetType()}");
             }
         }
 

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Libplanet.Blocks;
 using Libplanet.Consensus;
 
 namespace Libplanet.State
@@ -339,12 +340,8 @@ namespace Libplanet.State
         }
 
         /// <summary>
-        /// Creates a null delta from the given <paramref name="accountStateGetter"/>,
-        /// <paramref name="accountBalanceGetter"/>, and <paramref name="totalSupplyGetter"/>,
-        /// with a subtype of <see cref="AccountStateDeltaImpl"/> that corresponds to the
-        /// <paramref name="protocolVersion"/>.
+        /// Creates a default null delta.
         /// </summary>
-        /// <param name="protocolVersion">The protocol version of which to create a delta.</param>
         /// <param name="accountStateGetter">A view to the &#x201c;epoch&#x201d; states.</param>
         /// <param name="accountBalanceGetter">A view to the &#x201c;epoch&#x201d; asset balances.
         /// </param>
@@ -352,40 +349,109 @@ namespace Libplanet.State
         /// currencies.</param>
         /// <param name="validatorSetGetter">A view to the &#x201c;epoch&#x201d; validator
         /// set.</param>
-        /// <param name="signer">A signer address. Used for authenticating if a signer is allowed
-        /// to mint a currency.</param>
-        /// <param name="previousTotalUpdatedFungibles">The previous
-        /// <see cref="AccountStateDeltaImpl"/>'s total updated fungibles to keep track of.</param>
-        /// <returns>A instance of a subtype of <see cref="AccountStateDeltaImpl"/> which
-        /// corresponds to the <paramref name="protocolVersion"/>.</returns>
-        [Pure]
-        internal static AccountStateDeltaImpl ChooseVersion(
-            int protocolVersion,
+        /// <returns>A null delta of type <see cref="AccountStateDeltaImplV0"/>
+        /// with <see langword="default"/> <see cref="Address"/> as its
+        /// <see cref="AccountStateDeltaImpl.Signer"/>.</returns>
+        /// <remarks>
+        /// This is not immediately usable.  Choose its proper type with <see cref="ChooseVersion"/>
+        /// and signer with <see cref="ChooseSigner"/> before use.
+        /// </remarks>
+        /// <seealso cref="ChooseVersion"/>
+        /// <seealso cref="ChooseSigner"/>
+        internal static IAccountStateDelta Create(
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
             TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter,
-            Address signer,
-            IImmutableDictionary<(Address, Currency), BigInteger> previousTotalUpdatedFungibles)
-                => protocolVersion > 0
+            ValidatorSetGetter validatorSetGetter)
+        {
+            return new AccountStateDeltaImplV0(
+                accountStateGetter,
+                accountBalanceGetter,
+                totalSupplyGetter,
+                validatorSetGetter,
+                default(Address));
+        }
+
+        /// <summary>
+        /// Creates a null delta with given <paramref name="protocolVersion"/>.
+        /// </summary>
+        /// <param name="delta">The previous <see cref="IAccountStateDelta"/> to use.</param>
+        /// <param name="protocolVersion">The <see cref="Block.ProtocolVersion"/> for which
+        /// this delta will be used.</param>
+        /// <returns>A null delta with an appropriate type as <see cref="IAccountStateDelta"/>
+        /// given <paramref name="protocolVersion"/>.</returns>
+        /// <remarks>
+        /// This clears <see cref="IAccountStateDelta.TotalUpdatedFungibleAssets"/> and should be
+        /// only used right after <see cref="Create"/>.
+        /// </remarks>
+        /// <seealso cref="Create"/>
+        internal static IAccountStateDelta ChooseVersion(
+            IAccountStateDelta delta,
+            int protocolVersion) => protocolVersion > 0
                 ? new AccountStateDeltaImpl(
-                    accountStateGetter,
-                    accountBalanceGetter,
-                    totalSupplyGetter,
-                    validatorSetGetter,
-                    signer)
-                    {
-                        TotalUpdatedFungibles = previousTotalUpdatedFungibles,
-                    }
+                    delta.GetStates,
+                    delta.GetBalance,
+                    delta.GetTotalSupply,
+                    delta.GetValidatorSet,
+                    default(Address))
                 : new AccountStateDeltaImplV0(
-                    accountStateGetter,
-                    accountBalanceGetter,
-                    totalSupplyGetter,
-                    validatorSetGetter,
+                    delta.GetStates,
+                    delta.GetBalance,
+                    delta.GetTotalSupply,
+                    delta.GetValidatorSet,
+                    default(Address));
+
+        /// <summary>
+        /// Creates a null delta with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="delta">The previous <see cref="IAccountStateDelta"/> to use.</param>
+        /// <param name="signer">The <see cref="Address"/> to set.</param>
+        /// <returns>A null delta with given <paramref name="signer"/> that is of the same type
+        /// as <paramref name="delta"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="delta"/>
+        /// is neither <see cref="AccountStateDeltaImplV0"/>
+        /// nor <see cref="AccountStateDeltaImpl"/>.
+        /// </exception>
+        /// <remarks>
+        /// This inherits <paramref name="delta"/>'s
+        /// <see cref="IAccountStateDelta.TotalUpdatedFungibleAssets"/>.
+        /// </remarks>
+        internal static IAccountStateDelta ChooseSigner(
+            IAccountStateDelta delta,
+            Address signer)
+        {
+            // The order is important since AccountStateDeltaImplV0 inherits from
+            // AccountStateDeltaImpl
+            if (delta is AccountStateDeltaImplV0 implV0)
+            {
+                return new AccountStateDeltaImplV0(
+                    delta.GetStates,
+                    delta.GetBalance,
+                    delta.GetTotalSupply,
+                    delta.GetValidatorSet,
                     signer)
                     {
-                        TotalUpdatedFungibles = previousTotalUpdatedFungibles,
+                        TotalUpdatedFungibles = implV0.TotalUpdatedFungibles,
                     };
+            }
+            else if (delta is AccountStateDeltaImpl impl)
+            {
+                return new AccountStateDeltaImpl(
+                    delta.GetStates,
+                    delta.GetBalance,
+                    delta.GetTotalSupply,
+                    delta.GetValidatorSet,
+                    signer)
+                    {
+                        TotalUpdatedFungibles = impl.TotalUpdatedFungibles,
+                    };
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"Unknown type for {nameof(delta)}: {delta.GetType()}");
+            }
+        }
 
         [Pure]
         protected virtual FungibleAssetValue GetBalance(


### PR DESCRIPTION
Null getters are no longer necessary as expanded API of `IBlockChainStates` in #3214 now return "sensible" values for empty states.