### PR TITLE
Eager TotalUpdatedFungibles update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,16 @@ To be released.
 
 ### Behavioral changes
 
+ -  Improved performance of fungible asset APIs on default
+    `IAccountStateDelta` implementation.  [[#3218]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
+
+[#3218]: https://github.com/planetarium/libplanet/pull/3218
 
 
 Version 2.0.0

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -242,8 +242,6 @@ namespace Libplanet.State
             bool allowNegativeBalance = false
         )
         {
-            var sw = new System.Diagnostics.Stopwatch();
-            sw.Start();
             if (value.Sign <= 0)
             {
                 throw new ArgumentOutOfRangeException(

--- a/Libplanet/State/AccountStateDeltaImplV0.cs
+++ b/Libplanet/State/AccountStateDeltaImplV0.cs
@@ -67,6 +67,9 @@ namespace Libplanet.State
             return UpdateFungibleAssets(
                 UpdatedFungibles
                     .SetItem((sender, currency), (senderBalance - value).RawValue)
+                    .SetItem((recipient, currency), (recipientBalance + value).RawValue),
+                TotalUpdatedFungibles
+                    .SetItem((sender, currency), (senderBalance - value).RawValue)
                     .SetItem((recipient, currency), (recipientBalance + value).RawValue)
             );
         }
@@ -84,11 +87,13 @@ namespace Libplanet.State
             {
                 UpdatedStates = updatedStates,
                 UpdatedFungibles = UpdatedFungibles,
+                TotalUpdatedFungibles = TotalUpdatedFungibles,
             };
 
         [Pure]
         protected override AccountStateDeltaImpl UpdateFungibleAssets(
-            IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets
+            IImmutableDictionary<(Address, Currency), BigInteger> updatedFungibleAssets,
+            IImmutableDictionary<(Address, Currency), BigInteger> totalUpdatedFungibles
         ) =>
             new AccountStateDeltaImplV0(
                 StateGetter,
@@ -99,6 +104,7 @@ namespace Libplanet.State
             {
                 UpdatedStates = UpdatedStates,
                 UpdatedFungibles = updatedFungibleAssets,
+                TotalUpdatedFungibles = totalUpdatedFungibles,
             };
     }
 }


### PR DESCRIPTION
This PR tweaks the codes maintaining `AccountStateDeltaImpl.TotalUpdatedFungibles`, to care performance even in the extreme case of updating many addresses in one action.