### PR TITLE
introduce: `ActionEvaluatorEventHandler`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ To be released.
 
 ### Added APIs
 
+ -  Added `ActionEvaluatorEventHander` class.  [[#3221]]
+ -  Added `beginBlock` parameter from `ActionEvaluator`.  [[#3221]]
+ -  Added `endBlock` parameter from `ActionEvaluator`.  [[#3221]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -24,6 +28,8 @@ To be released.
 
 ### CLI tools
 
+
+[#3221]: https://github.com/planetarium/libplanet/pull/3221
 
 Version 2.0.0
 -------------

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -546,6 +546,12 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         /// An <see cref="IEnumerable{T}"/> of <see cref="IRenderer"/>s.</param>
         /// <param name="genesisBlock">Genesis <see cref="Block"/> of the chain.
         /// If null is given, a genesis will be generated.</param>
+        /// <param name="beginBlock">
+        /// An <see cref="ActionEvaluatorEventHandler"/> to be invoked at the beginning of
+        /// block evaluation.</param>
+        /// <param name="endBlock">
+        /// An <see cref="ActionEvaluatorEventHandler"/> to be invoked at the end of
+        /// block evaluation.</param>
         /// <param name="protocolVersion">Block protocol version of genesis block.</param>
         /// <typeparam name="T">An <see cref="IAction"/> type.</typeparam>
         /// <returns>A <see cref="BlockChain"/> instance.</returns>
@@ -559,6 +565,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             DateTimeOffset? timestamp = null,
             IEnumerable<IRenderer> renderers = null,
             Block genesisBlock = null,
+            ActionEvaluatorEventHandler beginBlock = null,
+            ActionEvaluatorEventHandler endBlock = null,
             int protocolVersion = Block.CurrentProtocolVersion
         )
             where T : IAction, new()
@@ -573,6 +581,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 timestamp,
                 renderers,
                 genesisBlock,
+                beginBlock,
+                endBlock,
                 protocolVersion
             ).BlockChain;
         }
@@ -588,6 +598,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             DateTimeOffset? timestamp = null,
             IEnumerable<IRenderer> renderers = null,
             Block genesisBlock = null,
+            ActionEvaluatorEventHandler beginBlock = null,
+            ActionEvaluatorEventHandler endBlock = null,
             int protocolVersion = Block.CurrentProtocolVersion
         )
             where T : IAction, new()
@@ -610,7 +622,9 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                     _ => policy.BlockAction,
                     blockChainStates: blockChainStates,
                     actionTypeLoader: new SingleActionLoader(typeof(T)),
-                    feeCalculator: null);
+                    feeCalculator: null,
+                    beginBlock: beginBlock,
+                    endBlock: endBlock);
 
             if (genesisBlock is null)
             {

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -448,6 +448,7 @@ namespace Libplanet.Action
                 beginBlockResult.IsSuccess
                     ? beginBlockResult.Value
                     : new List<ActionEvaluation>();
+            delta = evaluations.Any() ? evaluations.Last().OutputStates : delta;
 
             List<(ITransaction, IAction, long)> metrics =
                 new List<(ITransaction, IAction, long)>();

--- a/Libplanet/Action/ActionEvaluatorEventHandler.cs
+++ b/Libplanet/Action/ActionEvaluatorEventHandler.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentResults;
+using Libplanet.State;
+
+namespace Libplanet.Action
+{
+    public class ActionEvaluatorEventHandler
+    {
+        private readonly List<IAction> _operations = new List<IAction>();
+
+        public delegate IActionContext Next(IAccountStateDelta state);
+
+        public ActionEvaluatorEventHandler Add(IAction operation)
+        {
+            _operations.Add(operation);
+            return this;
+        }
+
+        public Result<IEnumerable<ActionEvaluation>> Execute(
+            IActionContext context,
+            Next next)
+        {
+            ActionEvaluation CreateActionEvaluation(
+                IAction op,
+                IActionContext input,
+                IAccountStateDelta output,
+                Exception? exc,
+                List<string>? logs = null) => new ActionEvaluation(
+                action: op,
+                inputContext: input,
+                outputStates: output,
+                exception: exc,
+                logs: logs);
+
+            List<ActionEvaluation> result = new List<ActionEvaluation>();
+            IActionContext nextContext = context;
+            foreach (var operation in _operations)
+            {
+                Result<IAccountStateDelta> stateDelta = Result.Try(
+                    () => operation.Execute(nextContext));
+
+                switch (stateDelta)
+                {
+                    case { IsSuccess: true }:
+                        result.Add(CreateActionEvaluation(
+                            operation,
+                            nextContext,
+                            stateDelta.Value,
+                            null));
+                        break;
+                    default:
+                        var exc = stateDelta
+                            .Errors
+                            .First()
+                            .Reasons
+                            .OfType<ExceptionalError>()
+                            .First()
+                            .Exception;
+                        result.Add(CreateActionEvaluation(
+                            operation,
+                            nextContext,
+                            nextContext.PreviousStates,
+                            exc));
+                        break;
+                }
+
+                nextContext = stateDelta switch
+                {
+                    { IsSuccess: true } => next(stateDelta.Value),
+                    _ => nextContext,
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -67,6 +67,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
+    <PackageReference Include="FluentResults" Version="3.15.2" />
     <PackageReference Include="ImmutableTrie" Version="1.0.0-alpha" />
     <PackageReference Include="LiteDB" Version="4.1.4" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />


### PR DESCRIPTION
## Rationale
We need to provide a network-wide action execution interface that will be executed when a block is executed or ended. For example, F1 Fee Distribution stores the fees collected during Transaction execution in a specific address and then distributes them at the next block execution. Introducing `ActionEvaluatorEventHandler` to provide this.
