### PR TITLE
♻️ Explicit `IActionContext` dependency for `MintAsset()` and `BurnAsset()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ To be released.
  -  Added `BlockProtocolVersion` property to `IActionContext`.  [[#3228]]
  -  Changed `IAccountStateDelta.TransferAsset()` to require additional
     `IActionContext` parameter.  [[#3229]]
+ -  Changed `IAccountStateDelta.MintAsset()` and
+    `IAccountStateDelta.BurnAsset()` to each require an additional
+    `IActionContext` parameter.  [[#3231]]
 
 ### Backward-incompatible network protocol changes
 
@@ -33,6 +36,7 @@ To be released.
 
 [#3228]: https://github.com/planetarium/libplanet/pull/3228
 [#3229]: https://github.com/planetarium/libplanet/pull/3229
+[#3231]: https://github.com/planetarium/libplanet/pull/3231
 
 
 Version 2.1.0

--- a/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaImplTest.cs
@@ -162,7 +162,7 @@ namespace Libplanet.Tests.Action
                 Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
 
             // Forcefully create null delta
-            delta0 = AccountStateDeltaImpl.ChooseSigner(delta0, _addr[0]);
+            delta0 = AccountStateDeltaImpl.Flush(delta0);
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint and burn
             delta0 = delta0.MintAsset(context0, _addr[0], Value(1, 1));
@@ -172,8 +172,7 @@ namespace Libplanet.Tests.Action
             Assert.DoesNotContain(_addr[1], delta0.TotalUpdatedFungibleAssets.Keys);
 
             // Forcefully create null delta
-            // Currently there is no way to swap signer without clearing
-            delta0 = AccountStateDeltaImpl.ChooseSigner(delta0, _addr[1]);
+            delta0 = AccountStateDeltaImpl.Flush(delta0);
             context0 = CreateContext(delta0, _addr[1]);
             delta0 = delta0.BurnAsset(context0, _addr[1], Value(1, 1));
 

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -104,8 +104,7 @@ namespace Libplanet.Tests.Action
                 GetStates,
                 GetBalance,
                 GetTotalSupply,
-                GetValidatorSet,
-                _addr[0]);
+                GetValidatorSet);
             _initContext = CreateContext(
                 _initDelta, _addr[0]);
         }
@@ -116,14 +115,12 @@ namespace Libplanet.Tests.Action
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
             TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter,
-            Address signer) =>
+            ValidatorSetGetter validatorSetGetter) =>
             new AccountStateDeltaImpl(
                 accountStateGetter,
                 accountBalanceGetter,
                 totalSupplyGetter,
-                validatorSetGetter,
-                signer);
+                validatorSetGetter);
 
         public abstract IActionContext CreateContext(
             IAccountStateDelta delta,
@@ -314,7 +311,7 @@ namespace Libplanet.Tests.Action
             Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[2], _currencies[2]));
 
             IAccountStateDelta delta1 =
-                CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet, _addr[1]);
+                CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet);
             IActionContext context1 = CreateContext(delta1, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to mint
             Assert.Throws<CurrencyPermissionException>(() =>
@@ -357,7 +354,7 @@ namespace Libplanet.Tests.Action
             Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[1], _currencies[2]));
 
             IAccountStateDelta delta1 =
-                CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet, _addr[1]);
+                CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet);
             IActionContext context1 = CreateContext(delta1, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to burn
             Assert.Throws<CurrencyPermissionException>(() =>

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -293,38 +293,39 @@ namespace Libplanet.Tests.Action
         public virtual void MintAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.MintAsset(_addr[0], Zero(0))
+                _initDelta.MintAsset(_initContext, _addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.MintAsset(_addr[0], Value(0, -1))
+                _initDelta.MintAsset(_initContext, _addr[0], Value(0, -1))
             );
 
             IAccountStateDelta delta0 = _initDelta;
+            IActionContext context0 = _initContext;
             // currencies[0] (FOO) allows only _addr[0] to mint
-            delta0 = delta0.MintAsset(_addr[0], Value(0, 10));
+            delta0 = delta0.MintAsset(context0, _addr[0], Value(0, 10));
             Assert.Equal(Value(0, 15), delta0.GetBalance(_addr[0], _currencies[0]));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
-            delta0 = delta0.MintAsset(_addr[1], Value(1, 10));
+            delta0 = delta0.MintAsset(context0, _addr[1], Value(1, 10));
             Assert.Equal(Value(1, 25), delta0.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to mint
-            delta0 = delta0.MintAsset(_addr[2], Value(2, 10));
+            delta0 = delta0.MintAsset(context0, _addr[2], Value(2, 10));
             Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[2], _currencies[2]));
 
             IAccountStateDelta delta1 =
                 CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet, _addr[1]);
+            IActionContext context1 = CreateContext(delta1, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to mint
             Assert.Throws<CurrencyPermissionException>(() =>
-                delta1.MintAsset(_addr[1], Value(0, 10))
-            );
+                delta1.MintAsset(context1, _addr[1], Value(0, 10)));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint
-            delta1 = delta1.MintAsset(_addr[0], Value(1, 20));
+            delta1 = delta1.MintAsset(context1, _addr[0], Value(1, 20));
             Assert.Equal(Value(1, 10), delta1.GetBalance(_addr[0], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to mint
-            delta1 = delta1.MintAsset(_addr[2], Value(2, 10));
+            delta1 = delta1.MintAsset(context1, _addr[2], Value(2, 10));
             Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[2], _currencies[2]));
         }
 
@@ -332,41 +333,42 @@ namespace Libplanet.Tests.Action
         public virtual void BurnAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.BurnAsset(_addr[0], Zero(0))
+                _initDelta.BurnAsset(_initContext, _addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.BurnAsset(_addr[0], Value(0, -1))
+                _initDelta.BurnAsset(_initContext, _addr[0], Value(0, -1))
             );
             Assert.Throws<InsufficientBalanceException>(() =>
-                _initDelta.BurnAsset(_addr[0], Value(0, 6))
+                _initDelta.BurnAsset(_initContext, _addr[0], Value(0, 6))
             );
 
             IAccountStateDelta delta0 = _initDelta;
+            IActionContext context0 = _initContext;
             // currencies[0] (FOO) allows only _addr[0] to burn
-            delta0 = delta0.BurnAsset(_addr[0], Value(0, 4));
+            delta0 = delta0.BurnAsset(context0, _addr[0], Value(0, 4));
             Assert.Equal(Value(0, 1), delta0.GetBalance(_addr[0], _currencies[0]));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
-            delta0 = delta0.BurnAsset(_addr[1], Value(1, 10));
+            delta0 = delta0.BurnAsset(context0, _addr[1], Value(1, 10));
             Assert.Equal(Value(1, 5), delta0.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to burn
-            delta0 = delta0.BurnAsset(_addr[1], Value(2, 10));
+            delta0 = delta0.BurnAsset(context0, _addr[1], Value(2, 10));
             Assert.Equal(Value(2, 10), delta0.GetBalance(_addr[1], _currencies[2]));
 
             IAccountStateDelta delta1 =
                 CreateInstance(GetStates, GetBalance, GetTotalSupply, GetValidatorSet, _addr[1]);
+            IActionContext context1 = CreateContext(delta1, _addr[1]);
             // currencies[0] (FOO) disallows _addr[1] to burn
             Assert.Throws<CurrencyPermissionException>(() =>
-                delta1.BurnAsset(_addr[0], Value(0, 5))
-            );
+                delta1.BurnAsset(context1, _addr[0], Value(0, 5)));
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to burn
-            delta1 = delta1.BurnAsset(_addr[1], Value(1, 10));
+            delta1 = delta1.BurnAsset(context1, _addr[1], Value(1, 10));
             Assert.Equal(Value(1, 5), delta1.GetBalance(_addr[1], _currencies[1]));
 
             // currencies[2] (BAZ) allows everyone to burn
-            delta1 = delta1.BurnAsset(_addr[1], Value(2, 10));
+            delta1 = delta1.BurnAsset(context1, _addr[1], Value(2, 10));
             Assert.Equal(Value(2, 10), delta1.GetBalance(_addr[1], _currencies[2]));
         }
 

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -204,8 +204,8 @@ namespace Libplanet.Tests.Action
                 return new ValidatorSet();
             }
 
-            public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value) =>
-                this;
+            public IAccountStateDelta MintAsset(
+                IActionContext context, Address recipient, FungibleAssetValue value) => this;
 
             public IAccountStateDelta TransferAsset(
                 IActionContext context,
@@ -215,7 +215,8 @@ namespace Libplanet.Tests.Action
                 bool allowNegativeBalance = false
             ) => this;
 
-            public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value) => this;
+            public IAccountStateDelta BurnAsset(
+                IActionContext context, Address owner, FungibleAssetValue value) => this;
 
             public IAccountStateDelta SetValidator(Validator validator) => this;
         }

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -44,9 +44,7 @@ namespace Libplanet.Tests.Action
                         addrs => new IValue[addrs.Count],
                         (_, c) => new FungibleAssetValue(c),
                         c => c * 0,
-                        () => new ValidatorSet(),
-                        address
-                    ),
+                        () => new ValidatorSet()),
                     123,
                     0,
                     false
@@ -57,9 +55,7 @@ namespace Libplanet.Tests.Action
                         .ToArray(),
                     (_, c) => new FungibleAssetValue(c),
                     c => c * 0,
-                    () => new ValidatorSet(),
-                    address
-                )
+                    () => new ValidatorSet())
             );
             var action = (DumbAction)evaluation.Action;
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -441,11 +441,9 @@ namespace Libplanet.Tests.Action
                 block2Txs,
                 lastCommit: CreateBlockCommit(block1, true));
 
-            // Forcefully reset with ChooseVersion
+            // Forcefully reset to null delta
             previousStates = AccountStateDeltaImpl.Create(
                 evals1.Last().OutputStates);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block2.Miner);
             evals = actionEvaluator.EvaluateBlock(
                 block2,
                 previousStates).ToImmutableArray();
@@ -484,8 +482,6 @@ namespace Libplanet.Tests.Action
 
             previousStates = AccountStateDeltaImpl.Create(
                 evals1.Last().OutputStates);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates, block2.Miner);
             var evals2 = actionEvaluator.EvaluateBlock(block2, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty2 = evals2.GetDirtyStates();
             IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances2 =
@@ -806,9 +802,6 @@ namespace Libplanet.Tests.Action
 
             previousStates = AccountStateDeltaImpl.Create(
                 evaluation.OutputStates);
-            previousStates = AccountStateDeltaImpl.ChooseSigner(
-                previousStates,
-                block.Miner);
             evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousStates);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1399,7 +1399,7 @@ namespace Libplanet.Tests.Action
                     .SetState(context.Signer, (Text)Memo);
                 if (!(Receiver is null) && !(MintValue is null))
                 {
-                    state = state.MintAsset(Receiver.Value, MintValue.Value);
+                    state = state.MintAsset(context, Receiver.Value, MintValue.Value);
                 }
 
                 return state;
@@ -1419,7 +1419,7 @@ namespace Libplanet.Tests.Action
 
             public IAccountStateDelta Execute(IActionContext context) =>
                 context.PreviousStates.MintAsset(
-                    context.Signer, new FungibleAssetValue(Currency, 1));
+                    context, context.Signer, new FungibleAssetValue(Currency, 1));
         }
     }
 

--- a/Libplanet.Tests/Action/Sys/InitializeTest.cs
+++ b/Libplanet.Tests/Action/Sys/InitializeTest.cs
@@ -50,9 +50,7 @@ namespace Libplanet.Tests.Action.Sys
                 accountStateGetter: _ => new List(),
                 accountBalanceGetter: (_, c) => c * 0,
                 totalSupplyGetter: c => c * 0,
-                validatorSetGetter: () => new ValidatorSet(),
-                signer: signer
-            );
+                validatorSetGetter: () => new ValidatorSet());
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,
@@ -84,9 +82,7 @@ namespace Libplanet.Tests.Action.Sys
                 accountStateGetter: _ => new List(),
                 accountBalanceGetter: (_, c) => c * 0,
                 totalSupplyGetter: c => c * 0,
-                validatorSetGetter: () => new ValidatorSet(),
-                signer: signer
-            );
+                validatorSetGetter: () => new ValidatorSet());
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1749,9 +1749,6 @@ namespace Libplanet.Tests.Blockchain
                         GenesisProposer);
                     previousStates = AccountStateDeltaImpl.Create(
                         previousStates);
-                    previousStates = AccountStateDeltaImpl.ChooseSigner(
-                        previousStates,
-                        b.Miner);
 
                     dirty = actionEvaluator.EvaluateBlock(b, previousStates).GetDirtyStates();
                     Assert.NotEmpty(dirty);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -19,8 +19,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _ => null,
                 (_, __) => default,
                 _ => default,
-                () => new ValidatorSet(),
-                default);
+                () => new ValidatorSet());
 
         private static IActionContext _actionContext =
             new ActionContext(

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -27,8 +27,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _ => null,
                 (_, __) => default,
                 _ => default,
-                () => new ValidatorSet(),
-                default);
+                () => new ValidatorSet());
 
         private static Exception _exception = new Exception();
 

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -174,9 +174,7 @@ namespace Libplanet.Tests.Fixtures
                 a => Chain.GetStates(a, offset),
                 (a, c) => Chain.GetBalance(a, c, offset),
                 c => Chain.GetTotalSupply(c),
-                () => Chain.GetValidatorSet(),
-                signer
-            );
+                () => Chain.GetValidatorSet());
         }
 
         public IAccountStateDelta CreateAccountStateDelta(int signerIndex, BlockHash? offset = null)

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -111,8 +111,6 @@ namespace Libplanet.Action
                     previousStates = evaluations.Count > 0
                         ? evaluations.Last().OutputStates
                         : previousStates;
-                    previousStates = AccountStateDeltaImpl.ChooseSigner(
-                        previousStates, block.Miner);
                     return evaluations.Add(
                         EvaluatePolicyBlockAction(block, previousStates)
                     );
@@ -394,9 +392,7 @@ namespace Libplanet.Action
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-                delta = AccountStateDeltaImpl.ChooseSigner(
-                    delta,
-                    tx.Signer);
+                delta = AccountStateDeltaImpl.Flush(delta);
 
                 IEnumerable<ActionEvaluation> evaluations = EvaluateTx(
                     blockHeader: block,
@@ -510,7 +506,6 @@ namespace Libplanet.Action
                 blockStates.GetBalance,
                 blockStates.GetTotalSupply,
                 blockStates.GetValidatorSet);
-            delta = AccountStateDeltaImpl.ChooseSigner(delta, block.Miner);
             return delta;
         }
 

--- a/Libplanet/Action/FeeCollector.cs
+++ b/Libplanet/Action/FeeCollector.cs
@@ -81,6 +81,7 @@ namespace Libplanet.Action
             }
 
             IAccountStateDelta nextState = state.BurnAsset(
+                _context,
                 _context.Signer,
                 realGasPrice * _context.GasLimit());
             _state = FeeCollectState.Mortgage;
@@ -107,6 +108,7 @@ namespace Libplanet.Action
             }
 
             IAccountStateDelta nextState = state.MintAsset(
+                _context,
                 _context.Signer,
                 (_context.GasLimit() - _context.GasUsed()) * realGasPrice);
             _state = FeeCollectState.Refund;
@@ -133,6 +135,7 @@ namespace Libplanet.Action
             }
 
             IAccountStateDelta nextState = state.MintAsset(
+                _context,
                 _context.Miner,
                 realGasPrice * _context.GasUsed());
             _state = FeeCollectState.Reward;

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -27,15 +27,11 @@ namespace Libplanet.State
         /// currencies.</param>
         /// <param name="validatorSetGetter">A view to the &#x201c;epoch&#x201d; validator
         /// set.</param>
-        /// <param name="signer">A signer address. Used for authenticating if a signer is allowed
-        /// to mint a currency.</param>
         internal AccountStateDeltaImpl(
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
             TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter,
-            Address signer
-        )
+            ValidatorSetGetter validatorSetGetter)
         {
             StateGetter = accountStateGetter;
             BalanceGetter = accountBalanceGetter;
@@ -45,7 +41,6 @@ namespace Libplanet.State
             UpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
             UpdatedTotalSupply = ImmutableDictionary<Currency, BigInteger>.Empty;
             TotalUpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
-            Signer = signer;
         }
 
         /// <inheritdoc/>
@@ -90,7 +85,7 @@ namespace Libplanet.State
 
         private ValidatorSetGetter ValidatorSetGetter { get; set; }
 
-        private Address Signer { get; set; }
+        private Address Signer => default(Address);
 
         private IImmutableDictionary<Address, IValue> UpdatedStates { get; set; }
 
@@ -197,11 +192,11 @@ namespace Libplanet.State
             }
 
             Currency currency = value.Currency;
-            if (!currency.AllowsToMint(Signer))
+            if (!currency.AllowsToMint(context.Signer))
             {
                 throw new CurrencyPermissionException(
-                    $"The account {Signer} has no permission to mint the currency {currency}.",
-                    Signer,
+                    $"The account {context.Signer} has no permission to mint currency {currency}.",
+                    context.Signer,
                     currency
                 );
             }
@@ -261,11 +256,11 @@ namespace Libplanet.State
             }
 
             Currency currency = value.Currency;
-            if (!currency.AllowsToMint(Signer))
+            if (!currency.AllowsToMint(context.Signer))
             {
-                msg = $"The account {Signer} has no permission to burn assets of " +
+                msg = $"The account {context.Signer} has no permission to burn assets of " +
                       $"the currency {currency}.";
-                throw new CurrencyPermissionException(msg, Signer, currency);
+                throw new CurrencyPermissionException(msg, context.Signer, currency);
             }
 
             FungibleAssetValue balance = GetBalance(owner, currency);
@@ -331,8 +326,7 @@ namespace Libplanet.State
                 accountStateGetter,
                 accountBalanceGetter,
                 totalSupplyGetter,
-                validatorSetGetter,
-                default(Address));
+                validatorSetGetter);
         }
 
         /// <summary>
@@ -346,8 +340,7 @@ namespace Libplanet.State
                 delta.GetStates,
                 delta.GetBalance,
                 delta.GetTotalSupply,
-                delta.GetValidatorSet,
-                default(Address));
+                delta.GetValidatorSet);
 
         /// <summary>
         /// Creates a null delta with given <paramref name="signer"/> while inheriting
@@ -374,8 +367,7 @@ namespace Libplanet.State
                     delta.GetStates,
                     delta.GetBalance,
                     delta.GetTotalSupply,
-                    delta.GetValidatorSet,
-                    signer)
+                    delta.GetValidatorSet)
                     {
                         TotalUpdatedFungibles = impl.TotalUpdatedFungibles,
                     };
@@ -404,8 +396,7 @@ namespace Libplanet.State
                 StateGetter,
                 BalanceGetter,
                 TotalSupplyGetter,
-                ValidatorSetGetter,
-                Signer)
+                ValidatorSetGetter)
             {
                 UpdatedStates = updatedStates,
                 UpdatedFungibles = UpdatedFungibles,
@@ -435,8 +426,7 @@ namespace Libplanet.State
                 StateGetter,
                 BalanceGetter,
                 TotalSupplyGetter,
-                ValidatorSetGetter,
-                Signer)
+                ValidatorSetGetter)
             {
                 UpdatedStates = UpdatedStates,
                 UpdatedFungibles = updatedFungibleAssets,
@@ -453,8 +443,7 @@ namespace Libplanet.State
                 StateGetter,
                 BalanceGetter,
                 TotalSupplyGetter,
-                ValidatorSetGetter,
-                Signer)
+                ValidatorSetGetter)
             {
                 UpdatedStates = UpdatedStates,
                 UpdatedFungibles = UpdatedFungibles,

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -313,9 +313,9 @@ namespace Libplanet.State
         /// <see cref="AccountStateDeltaImpl.Signer"/>.</returns>
         /// <remarks>
         /// This is not immediately usable.  Choose its proper signer with
-        /// <see cref="ChooseSigner"/> before use.
+        /// <see cref="Flush"/> before use.
         /// </remarks>
-        /// <seealso cref="ChooseSigner"/>
+        /// <seealso cref="Flush"/>
         internal static IAccountStateDelta Create(
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
@@ -343,13 +343,11 @@ namespace Libplanet.State
                 delta.GetValidatorSet);
 
         /// <summary>
-        /// Creates a null delta with given <paramref name="signer"/> while inheriting
-        /// <paramref name="delta"/>s total updated fungibles.
+        /// Creates a null delta while inheriting <paramref name="delta"/>s
+        /// total updated fungibles.
         /// </summary>
         /// <param name="delta">The previous <see cref="IAccountStateDelta"/> to use.</param>
-        /// <param name="signer">The <see cref="Address"/> to set.</param>
-        /// <returns>A null delta with given <paramref name="signer"/> that is of the same type
-        /// as <paramref name="delta"/>.</returns>
+        /// <returns>A null delta that is of the same type as <paramref name="delta"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if given <paramref name="delta"/>
         /// is not <see cref="AccountStateDeltaImpl"/>.
         /// </exception>
@@ -357,9 +355,8 @@ namespace Libplanet.State
         /// This inherits <paramref name="delta"/>'s
         /// <see cref="IAccountStateDelta.TotalUpdatedFungibleAssets"/>.
         /// </remarks>
-        internal static IAccountStateDelta ChooseSigner(
-            IAccountStateDelta delta,
-            Address signer)
+        internal static IAccountStateDelta Flush(
+            IAccountStateDelta delta)
         {
             if (delta is AccountStateDeltaImpl impl)
             {

--- a/Libplanet/State/AccountStateDeltaImpl.cs
+++ b/Libplanet/State/AccountStateDeltaImpl.cs
@@ -185,7 +185,8 @@ namespace Libplanet.State
 
         /// <inheritdoc/>
         [Pure]
-        public virtual IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+        public virtual IAccountStateDelta MintAsset(
+            IActionContext context, Address recipient, FungibleAssetValue value)
         {
             if (value.Sign <= 0)
             {
@@ -246,7 +247,8 @@ namespace Libplanet.State
 
         /// <inheritdoc/>
         [Pure]
-        public virtual IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+        public virtual IAccountStateDelta BurnAsset(
+            IActionContext context, Address owner, FungibleAssetValue value)
         {
             string msg;
 

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -102,6 +102,8 @@ namespace Libplanet.State
         /// Mints the fungible asset <paramref name="value"/> (i.e., in-game monetary),
         /// and give it to the <paramref name="recipient"/>.
         /// </summary>
+        /// <param name="context">The <see cref="IActionContext"/> of the <see cref="IAction"/>
+        /// executing this method.</param>
         /// <param name="recipient">The address who receives the minted asset.</param>
         /// <param name="value">The asset value to mint.</param>
         /// <returns>A new <see cref="IAccountStateDelta"/> instance that the given <paramref
@@ -116,7 +118,8 @@ namespace Libplanet.State
         /// <see cref="FungibleAssetValue.Currency"/> exceeds the
         /// <see cref="Currency.MaximumSupply"/>.</exception>
         [Pure]
-        IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value);
+        IAccountStateDelta MintAsset(
+            IActionContext context, Address recipient, FungibleAssetValue value);
 
         /// <summary>
         /// Transfers the fungible asset <paramref name="value"/> (i.e., in-game monetary)
@@ -158,6 +161,8 @@ namespace Libplanet.State
         /// Burns the fungible asset <paramref name="value"/> (i.e., in-game monetary) from
         /// <paramref name="owner"/>'s balance.
         /// </summary>
+        /// <param name="context">The <see cref="IActionContext"/> of the <see cref="IAction"/>
+        /// executing this method.</param>
         /// <param name="owner">The address who owns the fungible asset to burn.</param>
         /// <param name="value">The fungible asset <paramref name="value"/> to burn.</param>
         /// <returns>A new <see cref="IAccountStateDelta"/> instance that the given <paramref
@@ -170,6 +175,7 @@ namespace Libplanet.State
         /// <exception cref="InsufficientBalanceException">Thrown when the <paramref name="owner"/>
         /// has insufficient balance than <paramref name="value"/> to burn.</exception>
         [Pure]
-        IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value);
+        IAccountStateDelta BurnAsset(
+            IActionContext context, Address owner, FungibleAssetValue value);
     }
 }


### PR DESCRIPTION
Like #3229, this further removes context dependency from `IAccountStateDelta`. Assuming `IAccountStateDelta` is always used inside an `IAction.Execute(IActionContext)` from the client side, hopefully, there won't be much trouble updating. 😕