### PR TITLE
🧹 Removed `json` syntax highlighting in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -666,7 +666,7 @@ Released on April 18, 2023.
 
     For example:
 
-    ~~~~ json
+    ~~~~
     {
        // ... other fields
        "actions": {
@@ -680,7 +680,7 @@ Released on April 18, 2023.
 
     Instead of:
 
-    ~~~~ json
+    ~~~~
     {
        // ... other fields
       "systemAction": {


### PR DESCRIPTION
Since JSONs technically don't allow comments, GitHub's parser was acting up in #3238 due to having code snippets for `json` **with comments**. This should resolve the issue.