### PR TITLE
ci(gh-actions): check typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: lint
+on: [pull_request, push]
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check spelling
+        uses: crate-ci/typos@v1.15.5
+        with:
+          files: ./CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -252,7 +252,7 @@ Released on June 28, 2023.
  -  Changed the type for `IAccountStateDelta.TotalUpdatedFungibleAssets`
     to `IImmutableSet<(Address, Currency)>`
     from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
- -  Added `IAccountStateDelta.Delta` propery.  [[#3245]]
+ -  Added `IAccountStateDelta.Delta` property.  [[#3245]]
  -  Removed `IValidatorSupportStateDelta` interface.  [[#3247]]
  -  Added `IAccountStateDeltaView.GetValidatorSet()` interface method.
     [[#3247]]
@@ -606,7 +606,7 @@ Released on May 9, 2023.
     `string?` to `IValue?`.  [[#3111]]
  -  Changed the return type for `IActionTypeLoader.Load()` from
     `IDictionary<string, Type>` to `IDictionary<IValue, Type>`.  [[#3111]]
- -  Changed return types and parameter types of serveral methods from
+ -  Changed return types and parameter types of several methods from
     `IReadOnlyList<ActionEvaluation>` to `IReadOnlyList<IActionEvaluation>`.
     [[#3089]]
      -  `BlockChain<T>.DetermineGenesisStateRootHash()`
@@ -962,7 +962,7 @@ Released on April 18, 2023.
     `getPublicKey()`.  [[#3061]]
  -  (Libplanet.Explorer) Now, when an `IBlockChainIndex` instance is available
     in the optional `Index` property of the injected `IBlockChainContext`
-    instance, GraphQL queries can benefit from the improved lookup performace
+    instance, GraphQL queries can benefit from the improved lookup performance
     of the index.  Applications willing to take advantage of the index should
     provide an instance of `IBlockChainIndex` to the `IBlockChainContext`
     implementation and add the `IndexingService` hosted service to sync the
@@ -1887,7 +1887,7 @@ Released on February 3, 2023.
 Version 0.46.0
 --------------
 
-Released on Janurary 18th, 2023.
+Released on January 18th, 2023.
 
 ### Backward-incompatible API changes
 
@@ -1966,7 +1966,7 @@ Released on Janurary 18th, 2023.
  -  Changed `BlockChain<T>.FindNextHashes()` to return zero `BlockHash`es
     if no branch point `BlockHash` is found instead of returning
     `BlockHash`es starting with the genesis `BlockHash`.  [[#2582], [#2584]]
- -  Chnaged the behavior of `BlockLocator` index selection and sampling when
+ -  Changed the behavior of `BlockLocator` index selection and sampling when
     creating an instance.  [[#2583], [#2584]]
  -  Changed the default `VolatileStagePolicy<T>.Lifetime` from 3 hours
     to 10 minutes.  [[#2718]]
@@ -2393,7 +2393,7 @@ a system action, its features will be added more in the future.
         or `PreEvaluationBlockHeader.Metadata`.
      -  `PreEvaluationBlockHeader` can be accessed through
         `PreEvaluationBlock<T>.Header` or `BlockHeader.Header`.
-     -  `BlockHeader` can be accessed thorugh `Block<T>.Header` (this has not
+     -  `BlockHeader` can be accessed through `Block<T>.Header` (this has not
         changed, but only listed here for completeness in narrative).
  -  (Libplanet.Explorer) Added `updatedStates`, `updatedFungibleAssets`,
     `fungibleAssetsDelta` GraphQL fields to `TxResultType`.  [[#2353]]
@@ -2732,9 +2732,9 @@ Released on August 26, 2022.
         replies as soon as it is created through `NetMQTransport.Create()`
         factory method.
      -  `NetMQTransport.StartAsync()` enables a `NetMQTransport` instance
-        to recieve requests and send replies.
+        to receive requests and send replies.
      -  `NetMQTransport.StopAsync()` only disables a `NetMQTransport` instance
-        to stop recieving requests and sending replies.
+        to stop receiving requests and sending replies.
 
 [#915]: https://github.com/planetarium/libplanet/issues/915
 [#1538]: https://github.com/planetarium/libplanet/issues/1538
@@ -3080,7 +3080,7 @@ Released on May 30th, 2022.
  -  (Libplanet.Net) Added `Swarm<T>.PreloadAsync(IProgress<PreloadState>, bool,
     CancellationToken)`.  [[#2025]]
  -  (Libplanet.Net) Changed the order of parameters from `Swarm<T>(TimeSpan,
-    IProgresss<PreloadState>, bool, long, CancellationToken)` to `Swarm<T>(
+    IProgress<PreloadState>, bool, long, CancellationToken)` to `Swarm<T>(
     TimeSpan?, long, IProgress<PreloadState>, bool, CancellationToken)`
     with default value for `tipDeltaThreshold` removed.  [[#2025]]
  -  (Libplanet.Net) Parameter name `Urls` changed to `Url` for `IceServer`
@@ -3123,15 +3123,15 @@ Released on May 25th, 2022.
  -  (Libplanet.Net) Property `SwarmOptions.BlockDownloadTimeout` removed.
     [[#1981], [#1982]]
  -  (Libplanet.Net) `Swarm<T>.BootstrapAsync(IEnumerable<Peer>, TimeSpan?,
-    TimeSpan?, int, CancellationToken)` changed to `Swarm<T>.BoostrapAsync(
+    TimeSpan?, int, CancellationToken)` changed to `Swarm<T>.BootstrapAsync(
     IEnumerable<Peer>, TimeSpan?, int, CancellationToken)`.  Parameter
     `dialTimeout` now gets used for both old `pingSeedTimeout` and
-    `findNeigborsTimeout`.  [[#1990]]
+    `findNeighborsTimeout`.  [[#1990]]
  -  (Libplanet.Net) `IProtocol.BootstrapAsync(IEnumerable<BoundPeer>, TimeSpan?,
     TimeSpan?, int, CancellationToken)` changed to `IProtocol.BootstrapAsync(
     IEnumerable<Peer>, TimeSpan?, int, CancellationToken)`.  Parameter
     `dialTimeout` now gets used for both old `pingSeedTimeout` and
-    `findNeigborsTimeout`.  [[#1990]]
+    `findNeighborsTimeout`.  [[#1990]]
 
 ### Added APIs
 
@@ -3200,7 +3200,7 @@ Released on May 20th, 2022.
 ### Backward-incompatible API changes
 
  -  `BlockCompletion<TPeer, TAction>.Complete()` no longer accepts
-    neither parmeter `TimeSpan singleSessionTimeout` nor
+    neither parameter `TimeSpan singleSessionTimeout` nor
     `int millisecondsSingleSessionTimeout` to regulate a single session length.
     [[#1961]]
  -  (Libplanet.Net) General API changes made to `Swarm<T>.BootstrapAsync()`,
@@ -4119,7 +4119,7 @@ Version 0.24.2
 Released on December 24, 2021.
 
  -  Fixed a bug of `NonblockRenderer<T>` and `NonblockActionRenderer<T>` where
-    they had thrown `ThreadStateException` when any render events occured after
+    they had thrown `ThreadStateException` when any render events occurred after
     disposed.  [[#1682]]
  -  Log output compacted by removing duplicate exception messages.
     [[#1632], [#1677]]
@@ -4184,7 +4184,7 @@ Version 0.23.4
 Released on December 24, 2021.
 
  -  Fixed a bug of `NonblockRenderer<T>` and `NonblockActionRenderer<T>` where
-    they had thrown `ThreadStateException` when any render events occured after
+    they had thrown `ThreadStateException` when any render events occurred after
     disposed.  [[#1682]]
 
 [#1682]: https://github.com/planetarium/libplanet/pull/1682
@@ -4414,7 +4414,7 @@ Released on November 16, 2021.
     `AsyncDelegate<T>` (which was `EventHandler`).  [[#1523]]
  -  Removed unused `BlockChain<T>` type parameter from
     `IStagePolicy<T>.Iterate()` method.  [[#1553], [#1556]]
- -  Removed unsued `HashAlgorithmTable` class.  [[#1600]]
+ -  Removed unused `HashAlgorithmTable` class.  [[#1600]]
  -  `BlockChain<T>.MineBlock()` and `BlockChain<T>.GatherTransactionsToMine()`
     now additionally accepts `maxBlockBytes` parameter of type `int`.  [[#1600]]
  -  Removed `BlockInsufficientTxsException` and
@@ -4765,7 +4765,7 @@ Released on October 13, 2021.
      -  Added `BlockHeader(PreEvaluationBlockHeader, HashDigest<SHA256>,
         ImmutableArray<byte>?, BlockHash)` overloaded constructor.
         [[#1457], [#1507]]
- -  `Block<T>` and `BlockHeader` have no more marshaling/unmarshaling methods.
+ -  `Block<T>` and `BlockHeader` have no more marshaling/unmarshalling methods.
      -  Removed `Block<T>(Bencodex.Types.Dictionary)` overloaded constructor.
         Use `BlockMarshaler.UnmarshalBlock()` static method instead.
      -  Removed `Block<T>.Deserialize()` static method.  Instead, use
@@ -5834,9 +5834,9 @@ Released on March 30, 2021.
  -  Added `BlockHeader.ProtocolVersion` property.  [[#1142], [#1147]]
  -  Added `IBlockExcerpt` interface.  [[#1155], [#1165], [#1170]]
  -  Added `BlockExcerpt` static class.  [[#1155], [#1165], [#1170], [#1184]]
- -  `Block<T>` became to implement `IBlockExceprt` interface.
+ -  `Block<T>` became to implement `IBlockExcerpt` interface.
     [[#1155], [#1165], [#1170]]
- -  `BlockHeader` became to implement `IBlockExceprt` interface.
+ -  `BlockHeader` became to implement `IBlockExcerpt` interface.
     [[#1155], [#1165], [#1170]]
  -  Added `BlockPerception` struct.  [[#1155], [#1184]]
  -  Added `BlockChain<T>.PerceiveBlock()` method.  [[#1155], [#1184]]

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
@@ -36,9 +36,9 @@ namespace Libplanet.Net.Tests.Consensus
 
             var timeoutProcessed = new AsyncAutoResetEvent();
 
-            consensusContext.TimeoutProcessed += (_, evnetArgs) =>
+            consensusContext.TimeoutProcessed += (_, eventArgs) =>
             {
-                if (evnetArgs.Height == 1)
+                if (eventArgs.Height == 1)
                 {
                     timeoutProcessed.Set();
                 }

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -201,9 +201,9 @@ namespace Libplanet.Net.Tests.Consensus
 
             var (blockChain, context) = TestUtils.CreateDummyContext(
                 privateKey: TestUtils.PrivateKeys[0]);
-            context.StateChanged += (_, evnetArgs) =>
+            context.StateChanged += (_, eventArgs) =>
             {
-                if (evnetArgs.Step == ConsensusStep.PreVote)
+                if (eventArgs.Step == ConsensusStep.PreVote)
                 {
                     stepChangedToPreVote.Set();
                 }
@@ -274,9 +274,9 @@ namespace Libplanet.Net.Tests.Consensus
             var (blockChain, context) = TestUtils.CreateDummyContext(
                 policy: policy,
                 privateKey: TestUtils.PrivateKeys[0]);
-            context.StateChanged += (_, evnetArgs) =>
+            context.StateChanged += (_, eventArgs) =>
             {
-                if (evnetArgs.Step == ConsensusStep.PreVote)
+                if (eventArgs.Step == ConsensusStep.PreVote)
                 {
                     stepChangedToPreVote.Set();
                 }
@@ -336,9 +336,9 @@ namespace Libplanet.Net.Tests.Consensus
             var (blockChain, context) = TestUtils.CreateDummyContext(
                 policy: policy,
                 privateKey: TestUtils.PrivateKeys[0]);
-            context.StateChanged += (_, evnetArgs) =>
+            context.StateChanged += (_, eventArgs) =>
             {
-                if (evnetArgs.Step == ConsensusStep.PreVote)
+                if (eventArgs.Step == ConsensusStep.PreVote)
                 {
                     stepChangedToPreVote.Set();
                 }

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -462,7 +462,7 @@ namespace Libplanet.Net.Consensus
             }
             else
             {
-                // Neeed to get txs from store, lock?
+                // Need to get txs from store, lock?
                 // TODO: Remove ChainId, enhancing lock management.
                 _blockChain._rwlock.EnterUpgradeableReadLock();
                 IReadOnlyList<IActionEvaluation> actionEvaluations;

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -227,7 +227,7 @@ namespace Libplanet.Net
             catch (Exception e)
             {
                 var msg =
-                    $"Unexpected exception occured during {nameof(PullBlocksAsync)}()";
+                    $"Unexpected exception occurred during {nameof(PullBlocksAsync)}()";
                 _logger.Error(e, msg);
                 FillBlocksAsyncFailed.Set();
             }

--- a/Libplanet.Net/Transports/ITransport.cs
+++ b/Libplanet.Net/Transports/ITransport.cs
@@ -16,7 +16,7 @@ namespace Libplanet.Net.Transports
     /// </summary>
     /// <remarks>
     /// An instance of a transport implementing <see cref="ITransport"/> should always be able to
-    /// send requests and recieve replies.
+    /// send requests and receive replies.
     /// </remarks>
     public interface ITransport : IDisposable
     {
@@ -47,9 +47,9 @@ namespace Libplanet.Net.Transports
         /// Whether this <see cref="ITransport"/> instance is running.
         /// </para>
         /// <para>
-        /// When the value is <see langword="true"/>, the <see cref="ITransport"/> can recieve
+        /// When the value is <see langword="true"/>, the <see cref="ITransport"/> can receive
         /// outside requests.  When the value is <see langword="false"/>,
-        /// the <see cref="ITransport"/> stops recieving outside requests.
+        /// the <see cref="ITransport"/> stops receiving outside requests.
         /// </para>
         /// </summary>
         /// <value>The value indicating whether the instance is running.</value>

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -163,9 +163,9 @@ namespace Libplanet.RocksDBStore
         /// option.</param>
         /// <param name="maxLogFileSize">The number to configure <c>max_log_file_size</c>
         /// RocksDB option.</param>
-        /// <param name="txEpochUnitSeconds">The interval between epochs of DB partions containing
+        /// <param name="txEpochUnitSeconds">The interval between epochs of DB partitions containing
         /// transactions.  86,400 seconds by default.</param>
-        /// <param name="blockEpochUnitSeconds">The interval between epochs of DB partions
+        /// <param name="blockEpochUnitSeconds">The interval between epochs of DB partitions
         /// containing blocks.  86,400 seconds by default.</param>
         /// <param name="dbConnectionCacheSize">The capacity of the block and transaction
         /// RocksDB connection cache. 100 by default.</param>

--- a/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSuccessTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/BindingRequestSuccessTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Libplanet.Stun.Tests.Messages
 {
-    public class BindingRequestSucessTest
+    public class BindingRequestSuccessTest
     {
         [Fact]
         public async Task ParseBytes()

--- a/Libplanet.Stun/Stun/TurnClient.cs
+++ b/Libplanet.Stun/Stun/TurnClient.cs
@@ -79,7 +79,7 @@ namespace Libplanet.Stun
         /// the <see cref="IceServer"/>s given.
         /// </summary>
         /// <remarks>
-        /// This is a blocking operation with a non-negligable amount of execution time as
+        /// This is a blocking operation with a non-negligible amount of execution time as
         /// each <see cref="IceServer"/> in <paramref name="iceServers"/> is checked over
         /// the network to see if it can be connected to.
         /// </remarks>

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -127,7 +127,7 @@ namespace Libplanet.Tests.Store
             Guid chainB = Guid.NewGuid();
             Guid chainC = Guid.NewGuid();
 
-            // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
+            // We need `Block<T>`s because `IStore` can't retrieve index(long) by block hash without
             // actual block...
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
@@ -225,7 +225,7 @@ namespace Libplanet.Tests.Store
             Guid chainB = Guid.NewGuid();
             Guid chainC = Guid.NewGuid();
 
-            // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
+            // We need `Block<T>`s because `IStore` can't retrieve index(long) by block hash without
             // actual block...
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
@@ -290,7 +290,7 @@ namespace Libplanet.Tests.Store
             Guid chainB = Guid.NewGuid();
             Guid chainC = Guid.NewGuid();
 
-            // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
+            // We need `Block<T>`s because `IStore` can't retrieve index(long) by block hash without
             // actual block...
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
@@ -830,7 +830,7 @@ namespace Libplanet.Tests.Store
             Guid chainB = Guid.NewGuid();
             Guid chainC = Guid.NewGuid();
 
-            // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
+            // We need `Block<T>`s because `IStore` can't retrieve index(long) by block hash without
             // actual block...
             store.PutBlock(Fx.GenesisBlock);
             store.PutBlock(Fx.Block1);
@@ -973,7 +973,7 @@ namespace Libplanet.Tests.Store
             Guid chainA = Guid.NewGuid();
             Guid chainB = Guid.NewGuid();
 
-            // We need `Block<T>`s because `IStore` can't retrive index(long) by block hash without
+            // We need `Block<T>`s because `IStore` can't retrieve index(long) by block hash without
             // actual block...
             Block anotherBlock3 = ProposeNextBlock(
                 Fx.Block2,

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Blockchain
         /// <returns>The state root hash calculated by committing <paramref name="evaluations"/> to
         /// an empty <see cref="IStateStore"/>.</returns>
         /// <remarks>
-        /// This method computes the state root hash by commiting <paramref name="evaluations"/>
+        /// This method computes the state root hash by committing <paramref name="evaluations"/>
         /// to an ephemeral empty <see cref="IStateStore"/>.
         /// </remarks>
         /// <seealso cref="EvaluateGenesis"/>
@@ -91,7 +91,7 @@ namespace Libplanet.Blockchain
         /// Since the state root hash can only be calculated by making a commit
         /// to an <see cref="IStateStore"/>, this always has a side-effect to
         /// <see cref="StateStore"/> regardless of whether the state root hash
-        /// obdatined through commiting to <see cref="StateStore"/>
+        /// obdatined through committing to <see cref="StateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
         /// <seealso cref="EvaluateBlock"/>

--- a/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
+++ b/Libplanet/Blockchain/BlockChain.ProposeBlock.cs
@@ -73,7 +73,7 @@ namespace Libplanet.Blockchain
         /// </para>
         /// <para>
         /// By default, if successful, a policy adhering <see cref="Block"/> is produced with
-        /// current timestamp that can be appeneded to the current chain.
+        /// current timestamp that can be appended to the current chain.
         /// </para>
         /// </summary>
         /// <param name="proposer">The proposer's <see cref="PublicKey"/> that proposes the block.
@@ -175,7 +175,7 @@ namespace Libplanet.Blockchain
         /// <summary>
         /// Gathers <see cref="Transaction"/>s for proposing a <see cref="Block"/> for
         /// index <pararef name="index"/>.  Gathered <see cref="Transaction"/>s are
-        /// guaranteed to satisified the following <see cref="Transaction"/> related
+        /// guaranteed to satisfied the following <see cref="Transaction"/> related
         /// policies:
         /// <list type="bullet">
         ///     <item><description>
@@ -278,7 +278,7 @@ namespace Libplanet.Blockchain
                     _logger.Information(
                         "Ignoring tx {Iter}/{Total} {TxId} and the rest of the " +
                         "staged transactions due to the maximum number of " +
-                        "transactions per block allowed hsa been reached: {Max}",
+                        "transactions per block allowed has been reached: {Max}",
                         i,
                         stagedTransactions.Count,
                         tx.Id,

--- a/Libplanet/Blockchain/BlockChain.Validate.cs
+++ b/Libplanet/Blockchain/BlockChain.Validate.cs
@@ -305,13 +305,13 @@ namespace Libplanet.Blockchain
         /// <param name="evaluations">The list of <see cref="IActionEvaluation"/>s
         /// from which to extract the states to commit.</param>
         /// <exception cref="InvalidBlockStateRootHashException">If the state root hash
-        /// calculated by commiting to the <see cref="IStateStore"/> does not match
+        /// calculated by committing to the <see cref="IStateStore"/> does not match
         /// the <paramref name="block"/>'s <see cref="Block.StateRootHash"/>.</exception>
         /// <remarks>
         /// Since the state root hash for can only be calculated from making a commit
         /// to an <see cref="IStateStore"/>, this always has a side-effect to the
         /// <see cref="IStateStore"/> regardless of whether the state root hash
-        /// obdatined through commiting to the <see cref="IStateStore"/>
+        /// obdatined through committing to the <see cref="IStateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
         /// <seealso cref="EvaluateBlock"/>

--- a/Libplanet/Blocks/BlockCommit.cs
+++ b/Libplanet/Blocks/BlockCommit.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Blocks
         /// <param name="height">The <see cref="Block.Index"/> of the last committed
         /// <see cref="Block"/>.</param>
         /// <param name="round">The round in which a consensus was reached.</param>
-        /// <param name="blockHash">The <see cref="Block.Hash"/> of the last commited
+        /// <param name="blockHash">The <see cref="Block.Hash"/> of the last committed
         /// <see cref="Block"/>.</param>
         /// <param name="votes">The set of <see cref="Vote"/>s as a proof for the commit
         /// of the last <see cref="Block"/>.</param>

--- a/Libplanet/Blocks/BlockMarshaler.cs
+++ b/Libplanet/Blocks/BlockMarshaler.cs
@@ -11,7 +11,7 @@ using Libplanet.Tx;
 namespace Libplanet.Blocks
 {
     /// <summary>
-    /// Marshaling and unmarshaling block data.
+    /// Marshaling and unmarshalling block data.
     /// </summary>
     public static class BlockMarshaler
     {

--- a/Libplanet/Blocks/BlockMetadata.cs
+++ b/Libplanet/Blocks/BlockMetadata.cs
@@ -102,7 +102,7 @@ namespace Libplanet.Blocks
         /// <see cref="BlockMetadata"/>.  All other public constructors are redirected to this one.
         /// </summary>
         /// <remarks>
-        /// Except for debuggin and/or testing purposes, this shouldn't be called directly.
+        /// Except for debugging and/or testing purposes, this shouldn't be called directly.
         /// </remarks>
         /// <param name="protocolVersion">Goes to <see cref="IBlockMetadata.ProtocolVersion"/>.
         /// </param>

--- a/Libplanet/ByteUtil.cs
+++ b/Libplanet/ByteUtil.cs
@@ -156,7 +156,7 @@ namespace Libplanet
         }
 
         /// <summary>
-        /// Timing safe comparision of two byte arrays.
+        /// Timing safe comparison of two byte arrays.
         /// </summary>
         /// <remarks>In case of two byte arrays do not have the same length, it tries to keep
         /// the timing dependent on the length of the shorter one.</remarks>


### PR DESCRIPTION
This pull request fixes some typos with the `crates-ci/typos` CLI tool. And it introduces a new GitHub Actions workflow to check the `CHANGES.md` file's spelling at least.