### PR TITLE
♻️ Returned data structures for `IAccountStateDelta` changed for more consistency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Changed the type for `IAccountStateDelta.UpdatedFungibleAssets`
+    to `IImmutableSet<(Address, Currency)>`
+    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
+ -  Changed the type for `IAccountStateDelta.TotalUpdatedFungibleAssets`
+    to `IImmutableSet<(Address, Currency)>`
+    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +30,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#3244]: https://github.com/planetarium/libplanet/pull/3244
 
 
 Version 2.2.0

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -200,14 +200,13 @@ namespace Libplanet.Tests.Action
             Assert.Equal(Zero(0), a.GetBalance(_addr[2], _currencies[0]));
             Assert.Equal(Zero(1), a.GetBalance(_addr[2], _currencies[1]));
             Assert.Equal(
-                new Dictionary<Address, IImmutableSet<Currency>>
-                {
-                    [_addr[1]] = ImmutableHashSet.Create(_currencies[2]),
-                    [_addr[2]] = ImmutableHashSet.Create(_currencies[2]),
-                }.ToImmutableDictionary(),
-                a.UpdatedFungibleAssets
-            );
-            Assert.Equal(a.UpdatedFungibleAssets.Keys.ToImmutableHashSet(), a.UpdatedAddresses);
+                ImmutableHashSet<(Address, Currency)>.Empty
+                    .Add((_addr[1], _currencies[2]))
+                    .Add((_addr[2], _currencies[2])),
+                a.UpdatedFungibleAssets);
+            Assert.Equal(
+                a.UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet(),
+                a.UpdatedAddresses);
             Assert.Empty(a.StateUpdatedAddresses);
             Assert.Empty(_initDelta.UpdatedAddresses);
             Assert.Empty(_initDelta.StateUpdatedAddresses);

--- a/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
@@ -156,20 +157,22 @@ namespace Libplanet.Tests.Action
 
             // currencies[0] (FOO) allows only _addr[0] to burn
             delta0 = delta0.BurnAsset(context0, _addr[0], Value(0, 1));
-            Assert.Contains(_addr[0], delta0.TotalUpdatedFungibleAssets.Keys);
-            Assert.Contains(Value(0, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
+            Assert.Contains(
+                (_addr[0], Value(0, 0).Currency), delta0.TotalUpdatedFungibleAssets);
             Assert.DoesNotContain(
-                Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
+                (_addr[0], Value(1, 0).Currency), delta0.TotalUpdatedFungibleAssets);
 
             // Forcefully create null delta
             delta0 = AccountStateDelta.Flush(delta0);
 
             // currencies[1] (BAR) allows _addr[0] & _addr[1] to mint and burn
             delta0 = delta0.MintAsset(context0, _addr[0], Value(1, 1));
-            Assert.Contains(_addr[0], delta0.TotalUpdatedFungibleAssets.Keys);
-            Assert.Contains(Value(0, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
-            Assert.Contains(Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
-            Assert.DoesNotContain(_addr[1], delta0.TotalUpdatedFungibleAssets.Keys);
+            Assert.Contains(
+                (_addr[0], Value(0, 0).Currency), delta0.TotalUpdatedFungibleAssets);
+            Assert.Contains(
+                (_addr[0], Value(1, 0).Currency), delta0.TotalUpdatedFungibleAssets);
+            Assert.DoesNotContain(
+                _addr[1], delta0.TotalUpdatedFungibleAssets.Select(pair => pair.Item1));
 
             // Forcefully create null delta
             delta0 = AccountStateDelta.Flush(delta0);
@@ -178,13 +181,14 @@ namespace Libplanet.Tests.Action
 
             // _addr[0] burned currencies[0] & minted currencies[1]
             // _addr[1] burned currencies[1]
-            Assert.Contains(_addr[0], delta0.TotalUpdatedFungibleAssets.Keys);
-            Assert.Contains(Value(0, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
-            Assert.Contains(Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[0]]);
-            Assert.Contains(_addr[1], delta0.TotalUpdatedFungibleAssets.Keys);
+            Assert.Contains(
+                (_addr[0], Value(0, 0).Currency), delta0.TotalUpdatedFungibleAssets);
+            Assert.Contains(
+                (_addr[0], Value(1, 0).Currency), delta0.TotalUpdatedFungibleAssets);
             Assert.DoesNotContain(
-                Value(0, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[1]]);
-            Assert.Contains(Value(1, 0).Currency, delta0.TotalUpdatedFungibleAssets[_addr[1]]);
+                (_addr[1], Value(0, 0).Currency), delta0.TotalUpdatedFungibleAssets);
+            Assert.Contains(
+                (_addr[1], Value(1, 0).Currency), delta0.TotalUpdatedFungibleAssets);
         }
     }
 }

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -171,13 +171,11 @@ namespace Libplanet.Tests.Action
             public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
                 ImmutableHashSet<Currency>.Empty;
 
-            public IImmutableDictionary<Address, IImmutableSet<Currency>>
-            UpdatedFungibleAssets =>
-                ImmutableDictionary<Address, IImmutableSet<Currency>>.Empty;
+            public IImmutableSet<(Address, Currency)> UpdatedFungibleAssets =>
+                ImmutableHashSet<(Address, Currency)>.Empty;
 
-            public IImmutableDictionary<Address, IImmutableSet<Currency>>
-            TotalUpdatedFungibleAssets =>
-                ImmutableDictionary<Address, IImmutableSet<Currency>>.Empty;
+            public IImmutableSet<(Address, Currency)> TotalUpdatedFungibleAssets =>
+                ImmutableHashSet<(Address, Currency)>.Empty;
 
             public IValue GetState(Address address) => null;
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -947,9 +947,11 @@ namespace Libplanet.Tests.Action
 
             // Only addresses[0] and addresses[1] succeeded in minting
             Assert.Equal(2, latest.TotalUpdatedFungibleAssets.Count);
-            Assert.Contains(addresses[0], latest.TotalUpdatedFungibleAssets.Keys);
-            Assert.Contains(addresses[1], latest.TotalUpdatedFungibleAssets.Keys);
-            Assert.DoesNotContain(addresses[2], latest.TotalUpdatedFungibleAssets.Keys);
+            Assert.Contains((addresses[0], currency), latest.TotalUpdatedFungibleAssets);
+            Assert.Contains((addresses[1], currency), latest.TotalUpdatedFungibleAssets);
+            Assert.DoesNotContain(
+                addresses[2],
+                latest.TotalUpdatedFungibleAssets.Select(pair => pair.Item1));
         }
 
         [Fact]

--- a/Libplanet/Action/ActionEvaluationsExtensions.cs
+++ b/Libplanet/Action/ActionEvaluationsExtensions.cs
@@ -22,8 +22,7 @@ namespace Libplanet.Action
                 .SelectMany(a => a.OutputStates.StateUpdatedAddresses)
                 .ToImmutableHashSet();
             IImmutableSet<(Address, Currency)> updatedFungibleAssets = actionEvaluations
-                .SelectMany(a => a.OutputStates.UpdatedFungibleAssets
-                    .SelectMany(kv => kv.Value.Select(c => (kv.Key, c))))
+                .SelectMany(a => a.OutputStates.UpdatedFungibleAssets)
                 .ToImmutableHashSet();
             IImmutableSet<Currency> updatedTotalSupplies = actionEvaluations
                 .SelectMany(a => a.OutputStates.TotalSupplyUpdatedCurrencies)

--- a/Libplanet/Blockchain/BlockChain.TxExecution.cs
+++ b/Libplanet/Blockchain/BlockChain.TxExecution.cs
@@ -51,24 +51,35 @@ namespace Libplanet.Blockchain
                         txid,
                         actionsLogsList,
                         outputStates.GetUpdatedStates(),
-                        outputStates.UpdatedFungibleAssets.ToImmutableDictionary(
-                            kv => kv.Key,
-                            kv => (IImmutableDictionary<Currency, FungibleAssetValue>)kv.Value
-                                .ToImmutableDictionary(
-                                    currency => currency,
-                                    currency => outputStates.GetBalance(kv.Key, currency) -
-                                        prevStates.GetBalance(kv.Key, currency)
-                                )
-                        ),
-                        outputStates.UpdatedFungibleAssets.ToImmutableDictionary(
-                            kv => kv.Key,
-                            kv => (IImmutableDictionary<Currency, FungibleAssetValue>)kv.Value
-                                .ToImmutableDictionary(
-                                    currency => currency,
-                                    currency => outputStates.GetBalance(kv.Key, currency)
-                                )
-                        )
-                    );
+                        outputStates.UpdatedFungibleAssets
+                            .Select(pair =>
+                                (
+                                    pair.Item1,
+                                    pair.Item2,
+                                    outputStates.GetBalance(pair.Item1, pair.Item2) -
+                                        prevStates.GetBalance(pair.Item1, pair.Item2)
+                                ))
+                            .GroupBy(triple => triple.Item1)
+                            .ToImmutableDictionary(
+                                group => group.Key,
+                                group => (IImmutableDictionary<Currency, FungibleAssetValue>)group
+                                    .ToImmutableDictionary(
+                                        triple => triple.Item2,
+                                        triple => triple.Item3)),
+                        outputStates.UpdatedFungibleAssets
+                            .Select(pair =>
+                                (
+                                    pair.Item1,
+                                    pair.Item2,
+                                    outputStates.GetBalance(pair.Item1, pair.Item2)
+                                ))
+                            .GroupBy(triple => triple.Item1)
+                            .ToImmutableDictionary(
+                                group => group.Key,
+                                group => (IImmutableDictionary<Currency, FungibleAssetValue>)group
+                                    .ToImmutableDictionary(
+                                        triple => triple.Item2,
+                                        triple => triple.Item3)));
                 }
 
                 yield return txExecution;

--- a/Libplanet/State/AccountStateDelta.cs
+++ b/Libplanet/State/AccountStateDelta.cs
@@ -55,20 +55,12 @@ namespace Libplanet.State
             UpdatedStates.Keys.ToImmutableHashSet();
 
         /// <inheritdoc/>
-        IImmutableDictionary<Address, IImmutableSet<Currency>>
-            IAccountStateDelta.UpdatedFungibleAssets => UpdatedFungibles
-                .GroupBy(kv => kv.Key.Item1, kv => kv.Key.Item2)
-                .ToImmutableDictionary(
-                    group => group.Key,
-                    group => (IImmutableSet<Currency>)group.ToImmutableHashSet());
+        IImmutableSet<(Address, Currency)> IAccountStateDelta.UpdatedFungibleAssets =>
+            UpdatedFungibles.Keys.ToImmutableHashSet();
 
         /// <inheritdoc/>
-        IImmutableDictionary<Address, IImmutableSet<Currency>>
-            IAccountStateDelta.TotalUpdatedFungibleAssets => TotalUpdatedFungibles
-                .GroupBy(kv => kv.Key.Item1, kv => kv.Key.Item2)
-                .ToImmutableDictionary(
-                    group => group.Key,
-                    group => (IImmutableSet<Currency>)group.ToImmutableHashSet());
+        IImmutableSet<(Address, Currency)> IAccountStateDelta.TotalUpdatedFungibleAssets =>
+            TotalUpdatedFungibles.Keys.ToImmutableHashSet();
 
         [Pure]
         IImmutableSet<Currency> IAccountStateDelta.TotalSupplyUpdatedCurrencies =>

--- a/Libplanet/State/AccountStateDeltaExtensions.cs
+++ b/Libplanet/State/AccountStateDeltaExtensions.cs
@@ -23,14 +23,12 @@ namespace Libplanet.State
 
         internal static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
             GetUpdatedBalances(this IAccountStateDelta delta) =>
-            delta.UpdatedFungibleAssets.SelectMany(kv =>
-                kv.Value.Select(currency =>
+            delta.UpdatedFungibleAssets
+                .Select(key =>
                     new KeyValuePair<(Address, Currency), FungibleAssetValue>(
-                        (kv.Key, currency),
-                        delta.GetBalance(kv.Key, currency)
-                    )
-                )
-            ).ToImmutableDictionary();
+                        key,
+                        delta.GetBalance(key.Item1, key.Item2)))
+                .ToImmutableDictionary();
 
         internal static IImmutableDictionary<Currency, FungibleAssetValue>
             GetUpdatedTotalSupplies(this IAccountStateDelta delta) =>

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -60,7 +60,7 @@ namespace Libplanet.State
         /// <c>{ [A] = { FOO }, [B] = { FOO, BAR }, [C] = { BAR } }</c>.</para>
         /// </summary>
         [Pure]
-        IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets { get; }
+        IImmutableSet<(Address, Currency)> UpdatedFungibleAssets { get; }
 
         /// <summary>
         /// The set of <see cref="Address"/>es and associated sets of <see cref="Currency"/>
@@ -71,7 +71,7 @@ namespace Libplanet.State
         /// <see cref="Block.ProtocolVersion"/> zero.
         /// </remarks>
         [Pure]
-        IImmutableDictionary<Address, IImmutableSet<Currency>> TotalUpdatedFungibleAssets { get; }
+        IImmutableSet<(Address, Currency)> TotalUpdatedFungibleAssets { get; }
 
         /// <summary>
         /// <seealso cref="Currency">Currencies</seealso> with their total supplies updated.

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -53,23 +53,29 @@ namespace Libplanet.State
         IImmutableSet<Address> StateUpdatedAddresses { get; }
 
         /// <summary>
-        /// <see cref="Address"/>es and sets of <see cref="Currency"/> whose fungible assets have
-        /// been updated since then.
-        /// <para>For example, if A transfers 10 FOO to B and B transfers 20 BAR to C,
+        /// <para>
+        /// A set of <see cref="Address"/> and <see cref="Currency"/> pairs where
+        /// each pair has its asoociated <see cref="FungibleAssetValue"/> changed.
+        /// </para>
+        /// <para>
+        /// For example, if A transfers 10 FOO to B and B transfers 20 BAR to C,
         /// <see cref="UpdatedFungibleAssets"/> become likes
-        /// <c>{ [A] = { FOO }, [B] = { FOO, BAR }, [C] = { BAR } }</c>.</para>
+        /// <c>{ (A, FOO), (B, FOO), (B, BAR), (C, BAR) }</c>.
+        /// </para>
+        /// <para>
+        /// Furthermore, this represents any pair that has been "touched", i.e.,
+        /// if A transfers 10 FOO to B and B transfers 10 FOO back to A,
+        /// this becomes <c>{ (A, FOO), (B, BAR) }</c> not an empty set.
+        /// </para>
         /// </summary>
         [Pure]
         IImmutableSet<(Address, Currency)> UpdatedFungibleAssets { get; }
 
         /// <summary>
-        /// The set of <see cref="Address"/>es and associated sets of <see cref="Currency"/>
-        /// that have been updated since the previous <see cref="Block"/>'s output states.
+        /// A set of <see cref="Address"/> and <see cref="Currency"/> pairs where
+        /// each pair has its asoociated <see cref="FungibleAssetValue"/> changed
+        /// since the previous <see cref="Block"/>'s output states.
         /// </summary>
-        /// <remarks>
-        /// Due to a bug in old implementation, this does not work properly under
-        /// <see cref="Block.ProtocolVersion"/> zero.
-        /// </remarks>
         [Pure]
         IImmutableSet<(Address, Currency)> TotalUpdatedFungibleAssets { get; }
 


### PR DESCRIPTION
Rationale:
- Internally, the actual data is held as `Dictionary<(Address, Currency), BigInteger>`.
- There are unnecessary parsing/data transformation happening at various levels due to this discrepancy.
- As flatter structure, it'd be easier to aggregate for `Currency` as well.
- Probably faster in most cases.