### PR TITLE
✨ Introduce `IAccountDelta`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,6 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  Changed the type for `IAccountStateDelta.UpdatedFungibleAssets`
-    to `IImmutableSet<(Address, Currency)>`
-    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
- -  Changed the type for `IAccountStateDelta.TotalUpdatedFungibleAssets`
-    to `IImmutableSet<(Address, Currency)>`
-    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
  -  (@planetarium/tx) Removed some types and functions related to actions
     because the concept of `SystemAction` and `CustomAction` was removed
     since 1.1.0 and some system actions were removed since 1.2.0.  [[#3230]]
@@ -35,14 +29,24 @@ To be released.
      -  `signTx(UnsignedTxWithCustomActions | UnsignedTxWithSystemAction)`
         function's signature became `signTx(UnsignedTx)`.
      -  `SignedTx<T extends UnsignedTxWithCustomActions |
-         UnsignedTxWithSystemAction>`'s signature became 
+         UnsignedTxWithSystemAction>`'s signature became
          `SignedTx<T extends UnsignedTx>`.
+ -  Changed the type for `IAccountStateDelta.UpdatedFungibleAssets`
+    to `IImmutableSet<(Address, Currency)>`
+    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
+ -  Changed the type for `IAccountStateDelta.TotalUpdatedFungibleAssets`
+    to `IImmutableSet<(Address, Currency)>`
+    from `IImmutableDictionary<Address, IImmutableSet<Currency>>`.  [[#3244]]
+ -  Added `IAccountStateDelta.Delta` propery.  [[#3245]]
 
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  Added `IAccountDelta` interface and its default implementation
+    `AccountDelta` class.  [[#3245]]
 
 ### Behavioral changes
 
@@ -54,6 +58,7 @@ To be released.
 
 [#3230]: https://github.com/planetarium/libplanet/pull/3230
 [#3244]: https://github.com/planetarium/libplanet/pull/3244
+[#3245]: https://github.com/planetarium/libplanet/pull/3245
 
 
 Version 2.2.0

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -162,6 +162,8 @@ namespace Libplanet.Tests.Action
             IValidatorSupportStateDelta,
             IAccountStateDelta
         {
+            public IAccountDelta Delta => new AccountDelta();
+
             public IImmutableSet<Address> UpdatedAddresses =>
                 ImmutableHashSet<Address>.Empty;
 

--- a/Libplanet/State/AccountDelta.cs
+++ b/Libplanet/State/AccountDelta.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Assets;
+using Libplanet.Consensus;
+
+namespace Libplanet.State
+{
+    internal class AccountDelta : IAccountDelta
+    {
+        internal AccountDelta()
+        {
+            States = ImmutableDictionary<Address, IValue>.Empty;
+            Fungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
+            TotalSupplies = ImmutableDictionary<Currency, BigInteger>.Empty;
+            ValidatorSet = null;
+        }
+
+        internal AccountDelta(
+            IImmutableDictionary<Address, IValue> statesDelta,
+            IImmutableDictionary<(Address, Currency), BigInteger> fungiblesDelta,
+            IImmutableDictionary<Currency, BigInteger> totalSuppliesDelta,
+            ValidatorSet? validatorSetDelta)
+        {
+            States = statesDelta;
+            Fungibles = fungiblesDelta;
+            TotalSupplies = totalSuppliesDelta;
+            ValidatorSet = validatorSetDelta;
+        }
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedAddresses"/>
+        public IImmutableSet<Address> UpdatedAddresses =>
+            StateUpdatedAddresses.Union(FungibleUpdatedAddresses);
+
+        /// <inheritdoc cref="IAccountDelta.StateUpdatedAddresses"/>
+        public IImmutableSet<Address> StateUpdatedAddresses =>
+            States.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.States"/>
+        public IImmutableDictionary<Address, IValue> States { get; }
+
+        /// <inheritdoc cref="IAccountDelta.FungibleUpdatedAddresses"/>
+        public IImmutableSet<Address> FungibleUpdatedAddresses =>
+            Fungibles.Keys.Select(pair => pair.Item1).ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedFungibleAssets"/>
+        public IImmutableSet<(Address, Currency)> UpdatedFungibleAssets =>
+            Fungibles.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.Fungibles"/>
+        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles { get; }
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedTotalSupplyCurrencies"/>
+        public IImmutableSet<Currency> UpdatedTotalSupplyCurrencies =>
+            TotalSupplies.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.TotalSupplies"/>
+        public IImmutableDictionary<Currency, BigInteger> TotalSupplies { get; }
+
+        /// <inheritdoc cref="IAccountDelta.ValidatorSet"/>
+        public ValidatorSet? ValidatorSet { get; }
+    }
+}

--- a/Libplanet/State/IAccountDelta.cs
+++ b/Libplanet/State/IAccountDelta.cs
@@ -1,0 +1,119 @@
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Assets;
+using Libplanet.Consensus;
+
+namespace Libplanet.State
+{
+    public interface IAccountDelta
+    {
+        /// <summary>
+        /// <para>
+        /// A set of <seealso cref="Address"/>es where each <see cref="Address"/> has
+        /// either its state changed or its <see cref="FungibleAssetValue"/> changed.
+        /// </para>
+        /// <para>
+        /// This is equivalent to the union of <see cref="StateUpdatedAddresses"/> and
+        /// <see cref="FungibleUpdatedAddresses"/>.
+        /// </para>
+        /// </summary>
+        /// <seealso cref="StateUpdatedAddresses"/>
+        /// <seealso cref="FungibleUpdatedAddresses"/>
+        [Pure]
+        IImmutableSet<Address> UpdatedAddresses { get; }
+
+        /// <summary>
+        /// <para>
+        /// A set of <seealso cref="Address"/>es where each <see cref="Address"/> has
+        /// its state changed.
+        /// </para>
+        /// <para>
+        /// This is equivalent to the set of keys in <see cref="States"/>.
+        /// </para>
+        /// </summary>
+        /// <seealso cref="States"/>
+        [Pure]
+        IImmutableSet<Address> StateUpdatedAddresses { get; }
+
+        /// <summary>
+        /// A dictionary representing changed states for each <see cref="Address"/>.
+        /// </summary>
+        [Pure]
+        IImmutableDictionary<Address, IValue> States { get; }
+
+        /// <summary>
+        /// <para>
+        /// A set of <see cref="Address"/>es where each <see cref="Address"/> has
+        /// its <see cref="FungibleAssetValue"/> changed.
+        /// </para>
+        /// <para>
+        /// This is equivalent to the set of <see cref="Address"/>es that appear in
+        /// <see cref="UpdatedFungibleAssets"/>, and in turn those that appear in
+        /// <see cref="Fungibles"/>.
+        /// </para>
+        /// </summary>
+        /// <seealso cref="UpdatedFungibleAssets"/>
+        /// <seealso cref="Fungibles"/>
+        [Pure]
+        IImmutableSet<Address> FungibleUpdatedAddresses { get; }
+
+        /// <summary>
+        /// <para>
+        /// A set of <see cref="Address"/> and <see cref="Currency"/> pairs where
+        /// each pair has its asoociated <see cref="FungibleAssetValue"/> changed.
+        /// </para>
+        /// <para>
+        /// For example, if A transfers 10 FOO to B and B transfers 20 BAR to C,
+        /// <see cref="UpdatedFungibleAssets"/> become likes
+        /// <c>{ (A, FOO), (B, FOO), (B, BAR), (C, BAR) }</c>.
+        /// </para>
+        /// <para>
+        /// Furthermore, this represents any pair that has been "touched", i.e.,
+        /// if A transfers 10 FOO to B and B transfers 10 FOO back to A,
+        /// this becomes <c>{ (A, FOO), (B, BAR) }</c> not an empty set.
+        /// </para>
+        /// <para>
+        /// This is equivalent to the keys of <see cref="Fungibles"/>.
+        /// </para>
+        /// </summary>
+        /// <seealso cref="FungibleUpdatedAddresses"/>
+        /// <seealso cref="Fungibles"/>
+        [Pure]
+        IImmutableSet<(Address, Currency)> UpdatedFungibleAssets { get; }
+
+        /// <summary>
+        /// A dictionary representing the changed <see cref="FungibleAssetValue"/>s for each
+        /// <see cref="Address"/> and <see cref="Currency"/> pair.
+        /// </summary>
+        /// <seealso cref="UpdatedFungibleAssets"/>
+        [Pure]
+        IImmutableDictionary<(Address, Currency), BigInteger> Fungibles { get; }
+
+        /// <summary>
+        /// <para>
+        /// The set of <see cref="Currency">Currencies</see> with their total supplies updated.
+        /// </para>
+        /// <para>
+        /// This is equivalent to the set of keys in <see cref="TotalSupplies"/>.
+        /// </para>
+        /// </summary>
+        /// <seealso cref="TotalSupplies"/>
+        [Pure]
+        IImmutableSet<Currency> UpdatedTotalSupplyCurrencies { get; }
+
+        /// <summary>
+        /// A dictionary representing the changed total supply for each <see cref="Currency"/>.
+        /// </summary>
+        /// <seealso cref="UpdatedTotalSupplyCurrencies"/>
+        [Pure]
+        IImmutableDictionary<Currency, BigInteger> TotalSupplies { get; }
+
+        /// <summary>
+        /// A <see cref="Consensus.ValidatorSet"/> representing a change in
+        /// <see cref="Consensus.ValidatorSet"/>, if not <see langword="null"/>.
+        /// </summary>
+        ValidatorSet? ValidatorSet { get; }
+    }
+}

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -40,6 +40,13 @@ namespace Libplanet.State
     public interface IAccountStateDelta : IAccountStateView
     {
         /// <summary>
+        /// The <see cref="IAccountDelta"/> representing the delta part of
+        /// this <see cref="IAccountStateDelta"/>.
+        /// </summary>
+        [Pure]
+        IAccountDelta Delta { get; }
+
+        /// <summary>
         /// <seealso cref="Address"/>es of the accounts that have
         /// been updated since then.
         /// </summary>


### PR DESCRIPTION
Reworked #3220. Decided to rename `IDelta` to `IAccountDelta` to be more concise as we might need something like `IWorldDelta` in the future. 😗

There are some inconsistencies between `IAccountDelta` and `IAccountStateDelta` on handling `ValidatorSet` data. This will be addressed one way or another in a follow-up PR.