### PR TITLE
♻️ Rename `IAccountStateView` to `IAccountState`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ To be released.
  -  Changed `TxSuccess.UpdatedStates`'s type to
     `IImmutableDictionary<Address, IValue>` from
     `IImmutableDictionary<Address, IValue?>`.  [[#3248]]
+ -  Added `IBlockChainStates.GetState()` interface method.  [[#3250]]
+ -  Added `IBlockStates.GetState()` interface method.  [[#3250]]
 
 ### Backward-incompatible network protocol changes
 
@@ -70,6 +72,7 @@ To be released.
 [#3245]: https://github.com/planetarium/libplanet/pull/3245
 [#3247]: https://github.com/planetarium/libplanet/pull/3247
 [#3248]: https://github.com/planetarium/libplanet/pull/3248
+[#3250]: https://github.com/planetarium/libplanet/pull/3250
 
 
 Version 2.2.0

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -175,6 +175,9 @@ public class StateQueryTest
 
     private class MockChainStates : IBlockChainStates
     {
+        public IValue GetState(Address address, BlockHash? offset) =>
+            GetBlockStates(offset).GetState(address);
+
         public IReadOnlyList<IValue> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>
             GetBlockStates(offset).GetStates(addresses);
@@ -200,6 +203,8 @@ public class StateQueryTest
         }
 
         public BlockHash? BlockHash { get; }
+
+        public IValue GetState(Address address) => GetStates(new[] { address }).First();
 
         public IReadOnlyList<IValue> GetStates(IReadOnlyList<Address> addresses) =>
             BlockHash is { } _

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -494,7 +494,11 @@ namespace Libplanet.Blockchain
         /// <returns>The current state of given <paramref name="address"/>.  This can be
         /// <see langword="null"/> if <paramref name="address"/> has no value.</returns>
         public IValue GetState(Address address) =>
-            GetStates(new[] { address }, Tip.Hash)[0];
+            GetState(address, Tip.Hash);
+
+        /// <inheritdoc cref="IBlockChainStates.GetState"/>
+        public IValue GetState(Address address, BlockHash? offset) =>
+            _blockChainStates.GetState(address, offset);
 
         /// <summary>
         /// Gets multiple states associated to the specified <paramref name="addresses"/>.
@@ -524,10 +528,7 @@ namespace Libplanet.Blockchain
         public FungibleAssetValue GetBalance(
             Address address,
             Currency currency) =>
-            GetBalance(
-                address,
-                currency,
-                Tip.Hash);
+            GetBalance(address, currency, Tip.Hash);
 
         /// <inheritdoc cref="IBlockChainStates.GetBalance"/>
         public FungibleAssetValue GetBalance(

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -23,6 +23,11 @@ namespace Libplanet.Blockchain
             _stateStore = stateStore;
         }
 
+        /// <inheritdoc cref="IBlockChainStates.GetState"/>
+        public IValue? GetState(
+            Address address, BlockHash? offset) =>
+            GetBlockStates(offset).GetState(address);
+
         /// <inheritdoc cref="IBlockChainStates.GetStates"/>
         public IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>

--- a/Libplanet/Blockchain/IBlockChainStates.cs
+++ b/Libplanet/Blockchain/IBlockChainStates.cs
@@ -16,6 +16,35 @@ namespace Libplanet.Blockchain
     public interface IBlockChainStates
     {
         /// <summary>
+        /// Gets a state associated to specified <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
+        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
+        /// the states from.</param>
+        /// <returns>The state associated to specified <paramref name="address"/>.
+        /// An absent state is represented as <see langword="null"/>.  The returned value
+        /// must be the same as the single element when retrieved via
+        /// <see cref="GetStates"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/> is not
+        /// <see langword="null"/> and one of the following is true.
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         Corresponding <see cref="Block"/> is not found in the <see cref="IStore"/>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         Corresponding <see cref="Block"/> is found but its state root is not found
+        ///         in the <see cref="IStateStore"/>.
+        ///     </description></item>
+        /// </list>
+        /// </exception>
+        /// <remarks>
+        /// For performance reasons, it is generally recommended to use <see cref="GetStates"/>
+        /// with a batch of <see cref="Address"/>es instead of iterating over this method.
+        /// </remarks>
+        IValue? GetState(Address address, BlockHash? offset);
+
+        /// <summary>
         /// Gets multiple states associated to specified <paramref name="addresses"/>.
         /// </summary>
         /// <param name="addresses">The <see cref="Address"/>es of the states to query.</param>
@@ -24,6 +53,8 @@ namespace Libplanet.Blockchain
         /// <returns>The states associated to specified <paramref name="addresses"/>.
         /// Associated values are ordered in the same way to the corresponding
         /// <paramref name="addresses"/>.  Absent states are represented as <see langword="null"/>.
+        /// Hence, the returned <see cref="IReadOnlyList{T}"/> is guarenteeed to be of the same
+        /// length as <paramref name="addresses"/> with possible <see langword="null"/> values.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/> is not
         /// <see langword="null"/> and one of the following is true.

--- a/Libplanet/Blockchain/NullChainStates.cs
+++ b/Libplanet/Blockchain/NullChainStates.cs
@@ -15,6 +15,10 @@ namespace Libplanet.Blockchain
         {
         }
 
+        public IValue? GetState(
+            Address address, BlockHash? offset) =>
+            GetBlockStates(offset).GetState(address);
+
         public IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>
             GetBlockStates(offset).GetStates(addresses);
@@ -42,6 +46,8 @@ namespace Libplanet.Blockchain
         }
 
         public BlockHash? BlockHash { get; }
+
+        public IValue? GetState(Address address) => null;
 
         public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses) =>
             new IValue?[addresses.Count];

--- a/Libplanet/Blocks/BlockStates.cs
+++ b/Libplanet/Blocks/BlockStates.cs
@@ -29,6 +29,9 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockStates.BlockHash"/>
         public BlockHash? BlockHash => _blockHash;
 
+        /// <inheritdoc cref="IBlockStates.GetState"/>
+        public IValue? GetState(Address address) => GetStates(new[] { address }).First();
+
         /// <inheritdoc cref="IBlockStates.GetStates"/>
         public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses)
         {

--- a/Libplanet/Blocks/IBlockStates.cs
+++ b/Libplanet/Blocks/IBlockStates.cs
@@ -19,6 +19,22 @@ namespace Libplanet.Blocks
         BlockHash? BlockHash { get; }
 
         /// <summary>
+        /// Gets the state associated to specified <paramref name="address"/>
+        /// at <see cref="BlockHash"/>.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
+        /// <returns>The state associated to specified <paramref name="address"/>.
+        /// An absent state is represented as <see langword="null"/>.  The returned value
+        /// must be the same as the single element when retrieved via
+        /// <see cref="GetStates"/>.
+        /// </returns>
+        /// <remarks>
+        /// For performance reasons, it is generally recommended to use <see cref="GetStates"/>
+        /// with a batch of <see cref="Address"/>es instead of iterating over this method.
+        /// </remarks>
+        IValue? GetState(Address address);
+
+        /// <summary>
         /// Gets multiple states associated to specified <paramref name="addresses"/>
         /// at <see cref="BlockHash"/>.
         /// </summary>

--- a/Libplanet/State/AccountStateDelta.cs
+++ b/Libplanet/State/AccountStateDelta.cs
@@ -87,7 +87,7 @@ namespace Libplanet.State
             return state;
         }
 
-        /// <inheritdoc cref="IAccountStateView.GetStates(IReadOnlyList{Address})"/>
+        /// <inheritdoc cref="IAccountState.GetStates(IReadOnlyList{Address})"/>
         [Pure]
         public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses)
         {

--- a/Libplanet/State/IAccountState.cs
+++ b/Libplanet/State/IAccountState.cs
@@ -28,7 +28,7 @@ namespace Libplanet.State
     /// </item>
     /// </list>
     /// </summary>
-    public interface IAccountStateView
+    public interface IAccountState
     {
         /// <summary>
         /// Gets the account state of the given <paramref name="address"/>.

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -38,7 +38,7 @@ namespace Libplanet.State
     /// method does not manipulate the instance, but returns a new
     /// <see cref="IAccountStateDelta"/> instance with updated states.
     /// </remarks>
-    public interface IAccountStateDelta : IAccountStateView
+    public interface IAccountStateDelta : IAccountState
     {
         /// <summary>
         /// The <see cref="IAccountDelta"/> representing the delta part of

--- a/Libplanet/State/TotalSupplyNotTrackableException.cs
+++ b/Libplanet/State/TotalSupplyNotTrackableException.cs
@@ -6,11 +6,11 @@ using Libplanet.Serialization;
 namespace Libplanet.State
 {
     /// <summary>
-    /// The exception thrown when <see cref="IAccountStateView.GetTotalSupply"/> was called on a
+    /// The exception thrown when <see cref="IAccountState.GetTotalSupply"/> was called on a
     /// legacy untracked currency with <see cref="Assets.Currency.TotalSupplyTrackable"/> set to
     /// <see langword="false"/>.
     /// </summary>
-    /// <seealso cref="IAccountStateView.GetTotalSupply"/>
+    /// <seealso cref="IAccountState.GetTotalSupply"/>
     [Serializable]
     public sealed class TotalSupplyNotTrackableException : Exception
     {


### PR DESCRIPTION
Simplifies naming and aligns APIs for consistency.