### PR TITLE
♻️ Refactor `AccountStateDelta` internal API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ To be released.
     `IImmutableDictionary<Address, IValue?>`.  [[#3248]]
  -  Added `IBlockChainStates.GetState()` interface method.  [[#3250]]
  -  Added `IBlockStates.GetState()` interface method.  [[#3250]]
+ -  Changed `IBlockStates` to inherit `IAccountState` interface.  [[#3251]]
 
 ### Backward-incompatible network protocol changes
 
@@ -73,6 +74,7 @@ To be released.
 [#3247]: https://github.com/planetarium/libplanet/pull/3247
 [#3248]: https://github.com/planetarium/libplanet/pull/3248
 [#3250]: https://github.com/planetarium/libplanet/pull/3250
+[#3251]: https://github.com/planetarium/libplanet/pull/3251
 
 
 Version 2.2.0

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -15,6 +15,7 @@ using Libplanet.State;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Mocks;
 using Libplanet.Tx;
 using Xunit;
 using Xunit.Abstractions;
@@ -116,11 +117,12 @@ namespace Libplanet.Tests.Action
             AccountBalanceGetter accountBalanceGetter,
             TotalSupplyGetter totalSupplyGetter,
             ValidatorSetGetter validatorSetGetter) =>
-            new AccountStateDelta(
-                accountStateGetter,
-                accountBalanceGetter,
-                totalSupplyGetter,
-                validatorSetGetter);
+            AccountStateDelta.Create(
+                new MockAccountState(
+                    accountStateGetter,
+                    accountBalanceGetter,
+                    totalSupplyGetter,
+                    validatorSetGetter));
 
         public abstract IActionContext CreateContext(
             IAccountStateDelta delta,

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -7,6 +7,7 @@ using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.State;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Mocks;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,22 +41,19 @@ namespace Libplanet.Tests.Action
                     address,
                     1,
                     Block.CurrentProtocolVersion,
-                    new AccountStateDelta(
-                        addrs => new IValue[addrs.Count],
-                        (_, c) => new FungibleAssetValue(c),
-                        c => c * 0,
-                        () => new ValidatorSet()),
+                    AccountStateDelta.Create(MockAccountState.Empty),
                     123,
                     0,
                     false
                 ),
-                new AccountStateDelta(
-                    addrs => addrs
-                        .Select(a => a.Equals(address) ? (Text)"item" : (IValue)null)
-                        .ToArray(),
-                    (_, c) => new FungibleAssetValue(c),
-                    c => c * 0,
-                    () => new ValidatorSet())
+                AccountStateDelta.Create(
+                    new MockAccountState(
+                        addrs => addrs
+                            .Select(a => a.Equals(address) ? (Text)"item" : (IValue)null)
+                            .ToArray(),
+                        (_, c) => new FungibleAssetValue(c),
+                        c => c * 0,
+                        () => new ValidatorSet()))
             );
             var action = (DumbAction)evaluation.Action;
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -442,8 +442,7 @@ namespace Libplanet.Tests.Action
                 lastCommit: CreateBlockCommit(block1, true));
 
             // Forcefully reset to null delta
-            previousStates = AccountStateDelta.Create(
-                evals1.Last().OutputStates);
+            previousStates = new AccountStateDelta(evals1.Last().OutputStates);
             evals = actionEvaluator.EvaluateBlock(
                 block2,
                 previousStates).ToImmutableArray();
@@ -480,8 +479,7 @@ namespace Libplanet.Tests.Action
                     (Integer)randomValue);
             }
 
-            previousStates = AccountStateDelta.Create(
-                evals1.Last().OutputStates);
+            previousStates = new AccountStateDelta(evals1.Last().OutputStates);
             var evals2 = actionEvaluator.EvaluateBlock(block2, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty2 = evals2.GetDirtyStates();
             IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances2 =
@@ -800,8 +798,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputStates.GetState(genesis.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
 
-            previousStates = AccountStateDelta.Create(
-                evaluation.OutputStates);
+            previousStates = new AccountStateDelta(evaluation.OutputStates);
             evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousStates);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -442,7 +442,7 @@ namespace Libplanet.Tests.Action
                 lastCommit: CreateBlockCommit(block1, true));
 
             // Forcefully reset to null delta
-            previousStates = new AccountStateDelta(evals1.Last().OutputStates);
+            previousStates = AccountStateDelta.Create(evals1.Last().OutputStates);
             evals = actionEvaluator.EvaluateBlock(
                 block2,
                 previousStates).ToImmutableArray();
@@ -479,7 +479,7 @@ namespace Libplanet.Tests.Action
                     (Integer)randomValue);
             }
 
-            previousStates = new AccountStateDelta(evals1.Last().OutputStates);
+            previousStates = AccountStateDelta.Create(evals1.Last().OutputStates);
             var evals2 = actionEvaluator.EvaluateBlock(block2, previousStates).ToArray();
             IImmutableDictionary<Address, IValue> dirty2 = evals2.GetDirtyStates();
             IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances2 =
@@ -798,7 +798,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputStates.GetState(genesis.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
 
-            previousStates = new AccountStateDelta(evaluation.OutputStates);
+            previousStates = AccountStateDelta.Create(evaluation.OutputStates);
             evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousStates);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);

--- a/Libplanet.Tests/Action/Sys/InitializeTest.cs
+++ b/Libplanet.Tests/Action/Sys/InitializeTest.cs
@@ -9,6 +9,7 @@ using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.State;
+using Libplanet.Tests.Mocks;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 using Random = System.Random;
@@ -46,11 +47,7 @@ namespace Libplanet.Tests.Action.Sys
         {
             var random = new Random();
             Address signer = random.NextAddress();
-            var prevStates = new AccountStateDelta(
-                accountStateGetter: _ => new List(),
-                accountBalanceGetter: (_, c) => c * 0,
-                totalSupplyGetter: c => c * 0,
-                validatorSetGetter: () => new ValidatorSet());
+            var prevStates = AccountStateDelta.Create(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,
@@ -78,11 +75,7 @@ namespace Libplanet.Tests.Action.Sys
         {
             var random = new Random();
             Address signer = random.NextAddress();
-            var prevStates = new AccountStateDelta(
-                accountStateGetter: _ => new List(),
-                accountBalanceGetter: (_, c) => c * 0,
-                totalSupplyGetter: c => c * 0,
-                validatorSetGetter: () => new ValidatorSet());
+            var prevStates = AccountStateDelta.Create(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1747,7 +1747,7 @@ namespace Libplanet.Tests.Blockchain
                             miner: GenesisProposer.PublicKey,
                             lastCommit: CreateBlockCommit(b)),
                         GenesisProposer);
-                    previousStates = new AccountStateDelta(previousStates);
+                    previousStates = AccountStateDelta.Create(previousStates);
 
                     dirty = actionEvaluator.EvaluateBlock(b, previousStates).GetDirtyStates();
                     Assert.NotEmpty(dirty);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1747,8 +1747,7 @@ namespace Libplanet.Tests.Blockchain
                             miner: GenesisProposer.PublicKey,
                             lastCommit: CreateBlockCommit(b)),
                         GenesisProposer);
-                    previousStates = AccountStateDelta.Create(
-                        previousStates);
+                    previousStates = new AccountStateDelta(previousStates);
 
                     dirty = actionEvaluator.EvaluateBlock(b, previousStates).GetDirtyStates();
                     Assert.NotEmpty(dirty);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -3,9 +3,9 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
-using Libplanet.Consensus;
 using Libplanet.State;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Mocks;
 using Xunit;
 
 namespace Libplanet.Tests.Blockchain.Renderers
@@ -15,11 +15,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static IValue _action = new DumbAction().PlainValue;
 
         private static IAccountStateDelta _stateDelta =
-            new AccountStateDelta(
-                _ => null,
-                (_, __) => default,
-                _ => default,
-                () => new ValidatorSet());
+            AccountStateDelta.Create(MockAccountState.Empty);
 
         private static IActionContext _actionContext =
             new ActionContext(

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -6,9 +6,9 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Blocks;
-using Libplanet.Consensus;
 using Libplanet.State;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Mocks;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.TestCorrelator;
@@ -23,11 +23,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         private static IValue _action = new DumbAction().PlainValue;
 
         private static IAccountStateDelta _stateDelta =
-            new AccountStateDelta(
-                _ => null,
-                (_, __) => default,
-                _ => default,
-                () => new ValidatorSet());
+            AccountStateDelta.Create(MockAccountState.Empty);
 
         private static Exception _exception = new Exception();
 

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -16,6 +16,7 @@ using Libplanet.Crypto;
 using Libplanet.State;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
+using Libplanet.Tests.Mocks;
 using Libplanet.Tx;
 
 namespace Libplanet.Tests.Fixtures
@@ -170,11 +171,12 @@ namespace Libplanet.Tests.Fixtures
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)
         {
             offset = offset ?? Tip.Hash;
-            return new AccountStateDelta(
-                a => Chain.GetStates(a, offset),
-                (a, c) => Chain.GetBalance(a, c, offset),
-                c => Chain.GetTotalSupply(c),
-                () => Chain.GetValidatorSet());
+            return AccountStateDelta.Create(
+                new MockAccountState(
+                    a => Chain.GetStates(a, offset),
+                    (a, c) => Chain.GetBalance(a, c, offset),
+                    c => Chain.GetTotalSupply(c),
+                    () => Chain.GetValidatorSet()));
         }
 
         public IAccountStateDelta CreateAccountStateDelta(int signerIndex, BlockHash? offset = null)

--- a/Libplanet.Tests/Mocks/MockAccountState.cs
+++ b/Libplanet.Tests/Mocks/MockAccountState.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Tests.Mocks
         /// </summary>
         public static MockAccountState Empty =>
             new MockAccountState(
-                _ => null,
+                addrs => new IValue[addrs.Count],
                 (_, c) => c * 0,
                 c => c.TotalSupplyTrackable
                     ? c * 0

--- a/Libplanet.Tests/Mocks/MockAccountState.cs
+++ b/Libplanet.Tests/Mocks/MockAccountState.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet.Assets;
+using Libplanet.Consensus;
+using Libplanet.State;
+
+namespace Libplanet.Tests.Mocks
+{
+    /// <summary>
+    /// A simple class for mocking an <see cref="IAccountState"/> with given various getters.
+    /// </summary>
+    public class MockAccountState : IAccountState
+    {
+        private AccountStateGetter _stateGetter;
+        private AccountBalanceGetter _balanceGetter;
+        private TotalSupplyGetter _totalSupplyGetter;
+        private ValidatorSetGetter _validatorSetGetter;
+
+        public MockAccountState(
+            AccountStateGetter stateGetter,
+            AccountBalanceGetter balanceGetter,
+            TotalSupplyGetter totalSupplyGetter,
+            ValidatorSetGetter validatorSetGetter)
+        {
+            _stateGetter = stateGetter;
+            _balanceGetter = balanceGetter;
+            _totalSupplyGetter = totalSupplyGetter;
+            _validatorSetGetter = validatorSetGetter;
+        }
+
+        /// <summary>
+        /// An empty default state that returns <see langword="null"/> for any state,
+        /// 0 for any balance, 0 for any total supply if trackable, and
+        /// an empty <see cref="ValidatorSet"/>.
+        /// </summary>
+        public static MockAccountState Empty =>
+            new MockAccountState(
+                _ => null,
+                (_, c) => c * 0,
+                c => c.TotalSupplyTrackable
+                    ? c * 0
+                    : throw new TotalSupplyNotTrackableException(
+                        $"Currency {c}'s total supply cannot be tracked", c),
+                () => new ValidatorSet());
+
+        public IValue GetState(Address address) =>
+            GetStates(new[] { address }).First();
+
+        public IReadOnlyList<IValue> GetStates(IReadOnlyList<Address> addresses) =>
+            _stateGetter(addresses);
+
+        public FungibleAssetValue GetBalance(Address address, Currency currency) =>
+            _balanceGetter(address, currency);
+
+        public FungibleAssetValue GetTotalSupply(Currency currency) =>
+            _totalSupplyGetter(currency);
+
+        public ValidatorSet GetValidatorSet() =>
+            _validatorSetGetter();
+    }
+}

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -500,8 +500,7 @@ namespace Libplanet.Action
         /// </returns>
         internal IAccountStateDelta PrepareInitialDelta(IPreEvaluationBlock block)
         {
-            IBlockStates blockStates = _blockChainStates.GetBlockStates(block.PreviousHash);
-            return new AccountStateDelta(blockStates);
+            return AccountStateDelta.Create(_blockChainStates.GetBlockStates(block.PreviousHash));
         }
 
         [Pure]

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -501,12 +501,7 @@ namespace Libplanet.Action
         internal IAccountStateDelta PrepareInitialDelta(IPreEvaluationBlock block)
         {
             IBlockStates blockStates = _blockChainStates.GetBlockStates(block.PreviousHash);
-            IAccountStateDelta delta = AccountStateDelta.Create(
-                blockStates.GetStates,
-                blockStates.GetBalance,
-                blockStates.GetTotalSupply,
-                blockStates.GetValidatorSet);
-            return delta;
+            return new AccountStateDelta(blockStates);
         }
 
         [Pure]

--- a/Libplanet/Blocks/BlockStates.cs
+++ b/Libplanet/Blocks/BlockStates.cs
@@ -29,10 +29,10 @@ namespace Libplanet.Blocks
         /// <inheritdoc cref="IBlockStates.BlockHash"/>
         public BlockHash? BlockHash => _blockHash;
 
-        /// <inheritdoc cref="IBlockStates.GetState"/>
+        /// <inheritdoc cref="IAccountState.GetState"/>
         public IValue? GetState(Address address) => GetStates(new[] { address }).First();
 
-        /// <inheritdoc cref="IBlockStates.GetStates"/>
+        /// <inheritdoc cref="IAccountState.GetStates"/>
         public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses)
         {
             // Try using cache first
@@ -76,7 +76,7 @@ namespace Libplanet.Blocks
             return result;
         }
 
-        /// <inheritdoc cref="IBlockStates.GetBalance"/>
+        /// <inheritdoc cref="IAccountState.GetBalance"/>
         public FungibleAssetValue GetBalance(Address address, Currency currency)
         {
             string[] stringKeys = new[] { ToFungibleAssetKey(address, currency) };
@@ -87,7 +87,7 @@ namespace Libplanet.Blocks
                 : currency * 0;
         }
 
-        /// <inheritdoc cref="IBlockStates.GetTotalSupply"/>
+        /// <inheritdoc cref="IAccountState.GetTotalSupply"/>
         public FungibleAssetValue GetTotalSupply(Currency currency)
         {
             if (!currency.TotalSupplyTrackable)
@@ -103,7 +103,7 @@ namespace Libplanet.Blocks
                 : currency * 0;
         }
 
-        /// <inheritdoc cref="IBlockStates.GetValidatorSet"/>
+        /// <inheritdoc cref="IAccountState.GetValidatorSet"/>
         public ValidatorSet GetValidatorSet()
         {
             string[] stringKeys = new[] { ValidatorSetKey };

--- a/Libplanet/Blocks/IBlockStates.cs
+++ b/Libplanet/Blocks/IBlockStates.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using Bencodex.Types;
-using Libplanet.Assets;
-using Libplanet.Consensus;
 using Libplanet.State;
 
 namespace Libplanet.Blocks
@@ -9,7 +5,7 @@ namespace Libplanet.Blocks
     /// <summary>
     /// A minimal interface to get states from output states of a <see cref="Block"/>.
     /// </summary>
-    public interface IBlockStates
+    public interface IBlockStates : IAccountState
     {
         /// <summary>
         /// The <see cref="Block.Hash"/> of the <see cref="Block"/> that this
@@ -17,64 +13,5 @@ namespace Libplanet.Blocks
         /// in which case represents initial default states.
         /// </summary>
         BlockHash? BlockHash { get; }
-
-        /// <summary>
-        /// Gets the state associated to specified <paramref name="address"/>
-        /// at <see cref="BlockHash"/>.
-        /// </summary>
-        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
-        /// <returns>The state associated to specified <paramref name="address"/>.
-        /// An absent state is represented as <see langword="null"/>.  The returned value
-        /// must be the same as the single element when retrieved via
-        /// <see cref="GetStates"/>.
-        /// </returns>
-        /// <remarks>
-        /// For performance reasons, it is generally recommended to use <see cref="GetStates"/>
-        /// with a batch of <see cref="Address"/>es instead of iterating over this method.
-        /// </remarks>
-        IValue? GetState(Address address);
-
-        /// <summary>
-        /// Gets multiple states associated to specified <paramref name="addresses"/>
-        /// at <see cref="BlockHash"/>.
-        /// </summary>
-        /// <param name="addresses">The <see cref="Address"/>es of the states to query.</param>
-        /// <returns>The states associated to specified <paramref name="addresses"/>.
-        /// Associated values are ordered the same to the corresponding
-        /// <paramref name="addresses"/>.  Absent states are represented as <see langword="null"/>.
-        /// </returns>
-        IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses);
-
-        /// <summary>
-        /// Gets <paramref name="address"/>'s balance for given <paramref name="currency"/>
-        /// at <see cref="BlockHash"/>.
-        /// </summary>
-        /// <param name="address">The owner <see cref="Address"/> to query.</param>
-        /// <param name="currency">The currency type to query.</param>
-        /// <returns>The <paramref name="address"/>'s balance for <paramref name="currency"/>.
-        /// If absent, returns 0 <see cref="FungibleAssetValue"/>
-        /// for <paramref name="currency"/>.
-        /// </returns>
-        FungibleAssetValue GetBalance(Address address, Currency currency);
-
-        /// <summary>
-        /// Gets the total supply of a <paramref name="currency"/> at <see cref="BlockHash"/>.
-        /// </summary>
-        /// <param name="currency">The currency type to query.</param>
-        /// <returns>The total supply value of <paramref name="currency"/>
-        /// in <see cref="FungibleAssetValue"/>.  If absent, returns 0
-        /// <see cref="FungibleAssetValue"/> for <paramref name="currency"/>.</returns>
-        /// <exception cref="TotalSupplyNotTrackableException">Thrown when
-        /// given <paramref name="currency"/>'s <see cref="Currency.TotalSupplyTrackable"/>
-        /// is <see langword="false"/>.</exception>
-        FungibleAssetValue GetTotalSupply(Currency currency);
-
-        /// <summary>
-        /// Returns the validator set.
-        /// </summary>
-        /// <returns>The validator set of type <see cref="ValidatorSet"/>
-        /// at <see cref="BlockHash"/>.
-        /// </returns>
-        ValidatorSet GetValidatorSet();
     }
 }

--- a/Libplanet/State/AccountStateDelta.cs
+++ b/Libplanet/State/AccountStateDelta.cs
@@ -27,7 +27,7 @@ namespace Libplanet.State
         /// currencies.</param>
         /// <param name="validatorSetGetter">A view to the &#x201c;epoch&#x201d; validator
         /// set.</param>
-        internal AccountStateDelta(
+        private AccountStateDelta(
             AccountStateGetter accountStateGetter,
             AccountBalanceGetter accountBalanceGetter,
             TotalSupplyGetter totalSupplyGetter,
@@ -38,21 +38,6 @@ namespace Libplanet.State
             BalanceGetter = accountBalanceGetter;
             TotalSupplyGetter = totalSupplyGetter;
             ValidatorSetGetter = validatorSetGetter;
-            TotalUpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
-        }
-
-        /// <summary>
-        /// Creates a null state delta from given <paramref name="previousState"/>.
-        /// </summary>
-        /// <param name="previousState">The previous <see cref="IAccountState"/> to use as
-        /// a basis.</param>
-        internal AccountStateDelta(IAccountState previousState)
-        {
-            Delta = new AccountDelta();
-            StateGetter = previousState.GetStates;
-            BalanceGetter = previousState.GetBalance;
-            TotalSupplyGetter = previousState.GetTotalSupply;
-            ValidatorSetGetter = previousState.GetValidatorSet;
             TotalUpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
         }
 
@@ -289,6 +274,22 @@ namespace Libplanet.State
         public IAccountStateDelta SetValidator(Validator validator)
         {
             return UpdateValidatorSet(GetValidatorSet().Update(validator));
+        }
+
+        /// <summary>
+        /// Creates a null state delta from given <paramref name="previousState"/>.
+        /// </summary>
+        /// <param name="previousState">The previous <see cref="IAccountState"/> to use as
+        /// a basis.</param>
+        /// <returns>A null state delta created from <paramref name="previousState"/>.
+        /// </returns>
+        internal static IAccountStateDelta Create(IAccountState previousState)
+        {
+            return new AccountStateDelta(
+                previousState.GetStates,
+                previousState.GetBalance,
+                previousState.GetTotalSupply,
+                previousState.GetValidatorSet);
         }
 
         /// <summary>

--- a/Libplanet/State/AccountStateDelta.cs
+++ b/Libplanet/State/AccountStateDelta.cs
@@ -41,6 +41,21 @@ namespace Libplanet.State
             TotalUpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
         }
 
+        /// <summary>
+        /// Creates a null state delta from given <paramref name="previousState"/>.
+        /// </summary>
+        /// <param name="previousState">The previous <see cref="IAccountState"/> to use as
+        /// a basis.</param>
+        internal AccountStateDelta(IAccountState previousState)
+        {
+            Delta = new AccountDelta();
+            StateGetter = previousState.GetStates;
+            BalanceGetter = previousState.GetBalance;
+            TotalSupplyGetter = previousState.GetTotalSupply;
+            ValidatorSetGetter = previousState.GetValidatorSet;
+            TotalUpdatedFungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
+        }
+
         /// <inheritdoc/>
         public IAccountDelta Delta { get; private set; }
 
@@ -275,43 +290,6 @@ namespace Libplanet.State
         {
             return UpdateValidatorSet(GetValidatorSet().Update(validator));
         }
-
-        /// <summary>
-        /// Creates a default null state delta.
-        /// </summary>
-        /// <param name="accountStateGetter">A view to the &#x201c;epoch&#x201d; states.</param>
-        /// <param name="accountBalanceGetter">A view to the &#x201c;epoch&#x201d; asset balances.
-        /// </param>
-        /// <param name="totalSupplyGetter">A view to the &#x201c;epoch&#x201d; total supplies of
-        /// currencies.</param>
-        /// <param name="validatorSetGetter">A view to the &#x201c;epoch&#x201d; validator
-        /// set.</param>
-        /// <returns>A null state delta of type <see cref="AccountStateDelta"/>.</returns>
-        internal static IAccountStateDelta Create(
-            AccountStateGetter accountStateGetter,
-            AccountBalanceGetter accountBalanceGetter,
-            TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter)
-        {
-            return new AccountStateDelta(
-                accountStateGetter,
-                accountBalanceGetter,
-                totalSupplyGetter,
-                validatorSetGetter);
-        }
-
-        /// <summary>
-        /// Creates a default null state delta from <paramref name="stateDelta"/>.
-        /// </summary>
-        /// <param name="stateDelta">The previous <see cref="IAccountStateDelta"/> to use.</param>
-        /// <returns>A null state delta made from <paramref name="stateDelta"/>.</returns>
-        internal static IAccountStateDelta Create(
-            IAccountStateDelta stateDelta) =>
-            new AccountStateDelta(
-                stateDelta.GetStates,
-                stateDelta.GetBalance,
-                stateDelta.GetTotalSupply,
-                stateDelta.GetValidatorSet);
 
         /// <summary>
         /// Creates a null state delta while inheriting <paramref name="stateDelta"/>s


### PR DESCRIPTION
Now only allows `IAccountState` as an argument. Additionally, `IBlockStates` now inherits `IAccountState`.