### PR TITLE
✨ Added `IAccountDelta` sum and raw-delta

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ To be released.
  -  (Libplanet.Net) Added
     `Gossip.PublishMessage(MessageContent, IEnumerable<BoundPeer>)` method.
     [[#3249]]
+ -  Added `IAccountDelta.OrderedSum()` extension method.  [[#3256]]
+ -  Added `IAccountDelta.ToRawDelta()` extension method.  [[#3256]]
 
 ### Behavioral changes
 
@@ -55,6 +57,7 @@ To be released.
 ### CLI tools
 
 [#3249]: https://github.com/planetarium/libplanet/pull/3249
+[#3256]: https://github.com/planetarium/libplanet/pull/3256
 
 
 Version 2.3.0

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -95,8 +95,7 @@ namespace Libplanet.Tests.Action
                     actionEvaluator,
                     noStateRootBlock,
                     out IReadOnlyList<IActionEvaluation> evals));
-            stateStore.Commit(null, evals.GetTotalDelta(
-                ToStateKey, ToFungibleAssetKey, ToTotalSupplyKey, ValidatorSetKey));
+            stateStore.Commit(null, evals.GetRawTotalDelta());
             var generatedRandomNumbers = new List<int>();
 
             AssertPreEvaluationBlocksEqual(stateRootBlock, noStateRootBlock);

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -25,7 +25,7 @@ using Libplanet.Tx;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
-using static Libplanet.Blockchain.KeyConverters;
+using static Libplanet.State.KeyConverters;
 using static Libplanet.Tests.TestUtils;
 
 namespace Libplanet.Tests.Action

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -11,6 +11,7 @@ using Libplanet.Store;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
 using Xunit;
+using static Libplanet.State.KeyConverters;
 using static Libplanet.Tests.TestUtils;
 using FAV = Libplanet.Assets.FungibleAssetValue;
 
@@ -132,7 +133,7 @@ namespace Libplanet.Tests.Blockchain
                     pair.Value,
                     _fx.StateStore.GetStates(
                         block1.StateRootHash,
-                        new[] { KeyConverters.ToStateKey(pair.Key) }
+                        new[] { ToStateKey(pair.Key) }
                     )[0]
                 );
             }

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -11,7 +11,6 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tx;
-using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Tests.Store
 {

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -114,8 +114,7 @@ namespace Libplanet.Tests.Store
                     actionEvaluator,
                     preEval,
                     out IReadOnlyList<IActionEvaluation> evals));
-            stateStore.Commit(null, evals.GetTotalDelta(
-                ToStateKey, ToFungibleAssetKey, ToTotalSupplyKey, ValidatorSetKey));
+            stateStore.Commit(null, evals.GetRawTotalDelta());
             stateRootHashes[GenesisBlock.Hash] = GenesisBlock.StateRootHash;
             Block1 = TestUtils.ProposeNextBlock(
                 GenesisBlock,

--- a/Libplanet/Action/ActionEvaluationsExtensions.cs
+++ b/Libplanet/Action/ActionEvaluationsExtensions.cs
@@ -1,71 +1,21 @@
-#nullable disable
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
-using Libplanet.Assets;
 using Libplanet.State;
 
 namespace Libplanet.Action
 {
     internal static class ActionEvaluationsExtensions
     {
-        public static ImmutableDictionary<string, IValue> GetTotalDelta(
-            this IReadOnlyList<IActionEvaluation> actionEvaluations,
-            Func<Address, string> toStateKey,
-            Func<(Address, Currency), string> toFungibleAssetKey,
-            Func<Currency, string> toTotalSupplyKey,
-            string validatorSetKey)
+        public static IImmutableDictionary<string, IValue> GetRawTotalDelta(
+            this IReadOnlyList<IActionEvaluation> actionEvaluations)
         {
-            IImmutableSet<Address> stateUpdatedAddresses = actionEvaluations
-                .SelectMany(a => a.OutputStates.Delta.StateUpdatedAddresses)
-                .ToImmutableHashSet();
-            IImmutableSet<(Address, Currency)> updatedFungibleAssets = actionEvaluations
-                .SelectMany(a => a.OutputStates.Delta.UpdatedFungibleAssets)
-                .ToImmutableHashSet();
-            IImmutableSet<Currency> updatedTotalSupplies = actionEvaluations
-                .SelectMany(a => a.OutputStates.Delta.UpdatedTotalSupplyCurrencies)
-                .ToImmutableHashSet();
-
-            IAccountStateDelta lastStates = actionEvaluations.Count > 0
-                ? actionEvaluations[actionEvaluations.Count - 1].OutputStates
-                : null;
-            ImmutableDictionary<string, IValue> totalDelta =
-                stateUpdatedAddresses.ToImmutableDictionary(
-                    toStateKey,
-                    a => lastStates?.GetState(a)
-                ).SetItems(
-                    updatedFungibleAssets.Select(pair =>
-                        new KeyValuePair<string, IValue>(
-                            toFungibleAssetKey(pair),
-                            new Bencodex.Types.Integer(
-                                lastStates?.GetBalance(pair.Item1, pair.Item2).RawValue ?? 0
-                            )
-                        )
-                    )
-                );
-
-            foreach (var currency in updatedTotalSupplies)
-            {
-                if (lastStates?.GetTotalSupply(currency).RawValue is { } rawValue)
-                {
-                    totalDelta = totalDelta.SetItem(
-                        toTotalSupplyKey(currency),
-                        new Bencodex.Types.Integer(rawValue)
-                    );
-                }
-            }
-
-            if (lastStates?.GetValidatorSet() is { } validatorSet && validatorSet.Validators.Any())
-            {
-                totalDelta = totalDelta.SetItem(
-                    validatorSetKey,
-                    validatorSet.Bencoded
-                );
-            }
-
-            return totalDelta;
+            return actionEvaluations
+                .Select(eval => eval.OutputStates.Delta)
+                .ToList()
+                .OrderedSum()
+                .ToRawDelta();
         }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -42,8 +42,7 @@ namespace Libplanet.Blockchain
             out IReadOnlyList<IActionEvaluation> evaluations)
         {
             evaluations = EvaluateGenesis(actionEvaluator, preEvaluationBlock);
-            ImmutableDictionary<string, IValue> delta = evaluations.GetTotalDelta(
-                ToStateKey, ToFungibleAssetKey, ToTotalSupplyKey, ValidatorSetKey);
+            IImmutableDictionary<string, IValue> delta = evaluations.GetRawTotalDelta();
             IStateStore stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             ITrie trie = stateStore.Commit(stateStore.GetStateRoot(null).Hash, delta);
             return trie.Hash;
@@ -107,12 +106,7 @@ namespace Libplanet.Blockchain
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
                 evaluations = EvaluateBlock(block);
-                var totalDelta =
-                    evaluations.GetTotalDelta(
-                        ToStateKey,
-                        ToFungibleAssetKey,
-                        ToTotalSupplyKey,
-                        ValidatorSetKey);
+                var totalDelta = evaluations.GetRawTotalDelta();
                 _logger.Debug(
                     "Took {DurationMs} ms to summarize the states delta with {KeyCount} key " +
                     "changes made by block #{BlockIndex} pre-evaluation hash {PreEvaluationHash}",

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -12,7 +12,6 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
-using static Libplanet.Blockchain.KeyConverters;
 
 namespace Libplanet.Blockchain
 {

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -409,8 +409,7 @@ namespace Libplanet.Blockchain
 
             store.SetCanonicalChainId(id);
 
-            var delta = evals.GetTotalDelta(
-                ToStateKey, ToFungibleAssetKey, ToTotalSupplyKey, ValidatorSetKey);
+            var delta = evals.GetRawTotalDelta();
             stateStore.Commit(null, delta);
 
             blockChainStates ??= new BlockChainStates(store, stateStore);

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -19,7 +19,7 @@ using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Tx;
 using Serilog;
-using static Libplanet.Blockchain.KeyConverters;
+using static Libplanet.State.KeyConverters;
 
 namespace Libplanet.Blockchain
 {

--- a/Libplanet/Blocks/BlockStates.cs
+++ b/Libplanet/Blocks/BlockStates.cs
@@ -6,7 +6,7 @@ using Libplanet.Consensus;
 using Libplanet.State;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
-using static Libplanet.Blockchain.KeyConverters;
+using static Libplanet.State.KeyConverters;
 
 namespace Libplanet.Blocks
 {

--- a/Libplanet/State/AccountDeltaExtensions.cs
+++ b/Libplanet/State/AccountDeltaExtensions.cs
@@ -11,16 +11,17 @@ namespace Libplanet.State
     internal static class AccountDeltaExtensions
     {
         /// <summary>
-        /// Aggregates a list of <see cref="IAccountDelta"/>s.
+        /// Aggregates a list of <see cref="IAccountDelta"/>s in order.
         /// </summary>
         /// <param name="deltas">The list of <see cref="IAccountStateDelta"/>s to aggregate.</param>
-        /// <returns>The sum of <paramref name="deltas"/> as an <see cref="IAccountStateDelta"/>.
+        /// <returns>The aggregate of <paramref name="deltas"/> as an
+        /// <see cref="IAccountStateDelta"/>.
         /// </returns>
         /// <remarks>
         /// As aggregation is done by partially overwriting previous values,
         /// the order in which <paramref name="deltas"/> is important.
         /// </remarks>
-        internal static IAccountDelta Sum(this IReadOnlyList<IAccountDelta> deltas)
+        internal static IAccountDelta OrderedSum(this IReadOnlyList<IAccountDelta> deltas)
         {
             IImmutableDictionary<Address, IValue> states = deltas.Aggregate(
                 ImmutableDictionary<Address, IValue>.Empty,

--- a/Libplanet/State/AccountDeltaExtensions.cs
+++ b/Libplanet/State/AccountDeltaExtensions.cs
@@ -6,7 +6,7 @@ using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Consensus;
 using Libplanet.Store;
-using static Libplanet.Blockchain.KeyConverters;
+using static Libplanet.State.KeyConverters;
 
 namespace Libplanet.State
 {

--- a/Libplanet/State/AccountDeltaExtensions.cs
+++ b/Libplanet/State/AccountDeltaExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Assets;
+using Libplanet.Consensus;
+
+namespace Libplanet.State
+{
+    internal static class AccountDeltaExtensions
+    {
+        /// <summary>
+        /// Aggregates a list of <see cref="IAccountDelta"/>s.
+        /// </summary>
+        /// <param name="deltas">The list of <see cref="IAccountStateDelta"/>s to aggregate.</param>
+        /// <returns>The sum of <paramref name="deltas"/> as an <see cref="IAccountStateDelta"/>.
+        /// </returns>
+        /// <remarks>
+        /// As aggregation is done by partially overwriting previous values,
+        /// the order in which <paramref name="deltas"/> is important.
+        /// </remarks>
+        internal static IAccountDelta Sum(this IReadOnlyList<IAccountDelta> deltas)
+        {
+            IImmutableDictionary<Address, IValue> states = deltas.Aggregate(
+                ImmutableDictionary<Address, IValue>.Empty,
+                (prev, next) => prev.SetItems(next.States));
+            IImmutableDictionary<(Address, Currency), BigInteger> fungibles = deltas.Aggregate(
+                ImmutableDictionary<(Address, Currency), BigInteger>.Empty,
+                (prev, next) => prev.SetItems(next.Fungibles));
+            IImmutableDictionary<Currency, BigInteger> totalSupplies = deltas.Aggregate(
+                ImmutableDictionary<Currency, BigInteger>.Empty,
+                (prev, next) => prev.SetItems(next.TotalSupplies));
+            ValidatorSet? validatorSet = deltas.Aggregate(
+                (ValidatorSet?)null,
+                (prev, next) => next.ValidatorSet is { } set ? set : prev);
+            return new AccountDelta(
+                states, fungibles, totalSupplies, validatorSet);
+        }
+    }
+}

--- a/Libplanet/State/AccountStateDeltaExtensions.cs
+++ b/Libplanet/State/AccountStateDeltaExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
 using Libplanet.Assets;
-using static Libplanet.Blockchain.KeyConverters;
+using static Libplanet.State.KeyConverters;
 
 namespace Libplanet.State
 {

--- a/Libplanet/State/KeyConverters.cs
+++ b/Libplanet/State/KeyConverters.cs
@@ -1,6 +1,6 @@
 using Libplanet.Assets;
 
-namespace Libplanet.Blockchain
+namespace Libplanet.State
 {
     internal static class KeyConverters
     {


### PR DESCRIPTION
Generally, what we are interested in is `IAccountDelta` arithmetic (at least under current implementation). I've made a purposeful decision to make these methods `public` as lib9c and 9c-headless might be interested in these methods. Hopefully these should help reduce code duplication.