### PR TITLE
♻️ Reroute `IAccountDelta` access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,13 @@ To be released.
     [[#3249]]
  -  Added `IAccountDelta.OrderedSum()` extension method.  [[#3256]]
  -  Added `IAccountDelta.ToRawDelta()` extension method.  [[#3256]]
+ -  Removed several properties from `IAccountStateDelta` pertaining to
+    the delta part of `IAccountStateDelta`.  Access the equivalent data
+    through `IAccountStateDelta.Delta` instead.  [[#3257]]
+     -  Removed `IAccountStateDelta.UpdatedAddresses` property.
+     -  Removed `IAccountStateDelta.StateUpdatedAddresses` property.
+     -  Removed `IAccountStateDelta.UpdatedFungibleAssets` property.
+     -  Removed `IAccountStateDelta.UpdatedTotalSupplyCurrencies` property.
 
 ### Behavioral changes
 
@@ -58,6 +65,7 @@ To be released.
 
 [#3249]: https://github.com/planetarium/libplanet/pull/3249
 [#3256]: https://github.com/planetarium/libplanet/pull/3256
+[#3257]: https://github.com/planetarium/libplanet/pull/3257
 
 
 Version 2.3.0

--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -131,9 +131,9 @@ namespace Libplanet.Tests.Action
         [Fact]
         public virtual void NullDelta()
         {
-            Assert.Empty(_initDelta.UpdatedAddresses);
-            Assert.Empty(_initDelta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.UpdatedFungibleAssets);
+            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
             Assert.Equal("a", (Text)_initDelta.GetState(_addr[0]));
             Assert.Equal("b", (Text)_initDelta.GetState(_addr[1]));
             Assert.Null(_initDelta.GetState(_addr[2]));
@@ -158,14 +158,14 @@ namespace Libplanet.Tests.Action
             Assert.Equal("b", (Text)_initDelta.GetState(_addr[1]));
             Assert.Null(a.GetState(_addr[2]));
             Assert.Null(_initDelta.GetState(_addr[2]));
-            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.StateUpdatedAddresses);
-            Assert.Equal(a.StateUpdatedAddresses, a.UpdatedAddresses);
-            Assert.Empty(a.UpdatedFungibleAssets);
-            Assert.Empty(a.UpdatedTotalSupplyCurrencies);
-            Assert.Empty(_initDelta.UpdatedAddresses);
-            Assert.Empty(_initDelta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.UpdatedFungibleAssets);
-            Assert.Empty(_initDelta.UpdatedTotalSupplyCurrencies);
+            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.Delta.StateUpdatedAddresses);
+            Assert.Equal(a.Delta.StateUpdatedAddresses, a.Delta.UpdatedAddresses);
+            Assert.Empty(a.Delta.UpdatedFungibleAssets);
+            Assert.Empty(a.Delta.UpdatedTotalSupplyCurrencies);
+            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
+            Assert.Empty(_initDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             IAccountStateDelta b = a.SetState(_addr[0], (Text)"z");
             Assert.Equal("z", (Text)b.GetState(_addr[0]));
@@ -175,16 +175,16 @@ namespace Libplanet.Tests.Action
             Assert.Equal("b", (Text)a.GetState(_addr[1]));
             Assert.Null(b.GetState(_addr[2]));
             Assert.Null(a.GetState(_addr[2]));
-            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.StateUpdatedAddresses);
-            Assert.Equal(a.StateUpdatedAddresses, a.UpdatedAddresses);
-            Assert.Empty(_initDelta.UpdatedAddresses);
-            Assert.Empty(_initDelta.StateUpdatedAddresses);
+            Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.Delta.StateUpdatedAddresses);
+            Assert.Equal(a.Delta.StateUpdatedAddresses, a.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
 
             IAccountStateDelta c = b.SetState(_addr[0], (Text)"a");
             Assert.Equal("a", (Text)c.GetState(_addr[0]));
             Assert.Equal("z", (Text)b.GetState(_addr[0]));
-            Assert.Empty(_initDelta.UpdatedAddresses);
-            Assert.Empty(_initDelta.StateUpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
         }
 
         [Fact]
@@ -205,15 +205,15 @@ namespace Libplanet.Tests.Action
                 ImmutableHashSet<(Address, Currency)>.Empty
                     .Add((_addr[1], _currencies[2]))
                     .Add((_addr[2], _currencies[2])),
-                a.UpdatedFungibleAssets);
+                a.Delta.UpdatedFungibleAssets);
             Assert.Equal(
-                a.UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet(),
-                a.UpdatedAddresses);
-            Assert.Empty(a.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.UpdatedAddresses);
-            Assert.Empty(_initDelta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.UpdatedFungibleAssets);
-            Assert.Empty(_initDelta.UpdatedTotalSupplyCurrencies);
+                a.Delta.UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet(),
+                a.Delta.UpdatedAddresses);
+            Assert.Empty(a.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
+            Assert.Empty(_initDelta.Delta.UpdatedTotalSupplyCurrencies);
         }
 
         [Fact]

--- a/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
@@ -86,11 +86,11 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void TotalSupplyTracking()
         {
-            IAccountStateDelta delta = _initDelta;
+            IAccountStateDelta stateDelta = _initDelta;
             IActionContext context = _initContext;
 
-            Assert.Empty(delta.GetUpdatedTotalSupplies());
-            Assert.Empty(delta.UpdatedTotalSupplyCurrencies);
+            Assert.Empty(stateDelta.GetUpdatedTotalSupplies());
+            Assert.Empty(stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             Assert.Equal(
                 new FungibleAssetValue(
@@ -112,32 +112,32 @@ namespace Libplanet.Tests.Action
             Assert.DoesNotContain(
                 new KeyValuePair<Currency, FungibleAssetValue>(
                     _currencies[0], Value(0, 5)),
-                delta.GetUpdatedTotalSupplies());
-            Assert.DoesNotContain(_currencies[0], delta.UpdatedTotalSupplyCurrencies);
+                stateDelta.GetUpdatedTotalSupplies());
+            Assert.DoesNotContain(_currencies[0], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             Assert.Equal(Value(4, 0), _initDelta.GetTotalSupply(_currencies[4]));
-            Assert.DoesNotContain(_currencies[4], delta.UpdatedTotalSupplyCurrencies);
+            Assert.DoesNotContain(_currencies[4], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
-            delta = delta.MintAsset(context, _addr[0], Value(0, 10));
+            stateDelta = stateDelta.MintAsset(context, _addr[0], Value(0, 10));
             Assert.Throws<TotalSupplyNotTrackableException>(() =>
                 _initDelta.GetTotalSupply(_currencies[0]));
-            Assert.DoesNotContain(_currencies[0], delta.UpdatedTotalSupplyCurrencies);
+            Assert.DoesNotContain(_currencies[0], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
-            delta = delta.MintAsset(context, _addr[0], Value(4, 10));
-            Assert.Equal(Value(4, 10), delta.GetTotalSupply(_currencies[4]));
+            stateDelta = stateDelta.MintAsset(context, _addr[0], Value(4, 10));
+            Assert.Equal(Value(4, 10), stateDelta.GetTotalSupply(_currencies[4]));
             Assert.Contains(
                 new KeyValuePair<Currency, FungibleAssetValue>(
                     _currencies[4], Value(4, 10)),
-                delta.GetUpdatedTotalSupplies());
-            Assert.Contains(_currencies[4], delta.UpdatedTotalSupplyCurrencies);
+                stateDelta.GetUpdatedTotalSupplies());
+            Assert.Contains(_currencies[4], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
-            delta = delta.BurnAsset(context, _addr[0], Value(4, 5));
-            Assert.Equal(Value(4, 5), delta.GetTotalSupply(_currencies[4]));
+            stateDelta = stateDelta.BurnAsset(context, _addr[0], Value(4, 5));
+            Assert.Equal(Value(4, 5), stateDelta.GetTotalSupply(_currencies[4]));
             Assert.Contains(
                 new KeyValuePair<Currency, FungibleAssetValue>(
                     _currencies[4], Value(4, 5)),
-                delta.GetUpdatedTotalSupplies());
-            Assert.Contains(_currencies[4], delta.UpdatedTotalSupplyCurrencies);
+                stateDelta.GetUpdatedTotalSupplies());
+            Assert.Contains(_currencies[4], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
         }
 
         [Fact]

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -708,9 +708,9 @@ namespace Libplanet.Tests.Action
                 Assert.False(context.BlockAction);
                 Assert.Equal(
                     i > 0 ? new[] { txA.Signer } : new Address[0],
-                    prevStates.UpdatedAddresses);
+                    prevStates.Delta.UpdatedAddresses);
                 Assert.Equal((Integer)deltaA[i].Value, prevStates.GetState(txA.Signer));
-                Assert.Equal(new[] { txA.Signer }, outputStates.UpdatedAddresses);
+                Assert.Equal(new[] { txA.Signer }, outputStates.Delta.UpdatedAddresses);
                 Assert.Equal((Integer)deltaA[i + 1].Value, outputStates.GetState(txA.Signer));
                 Assert.Null(eval.Exception);
             }
@@ -758,9 +758,9 @@ namespace Libplanet.Tests.Action
                 Assert.False(context.BlockAction);
                 Assert.Equal(
                     i > 0 ? new[] { txB.Signer } : new Address[0],
-                    prevStates.UpdatedAddresses);
+                    prevStates.Delta.UpdatedAddresses);
                 Assert.Equal((Integer)deltaB[i].Value, prevStates.GetState(txB.Signer));
-                Assert.Equal(new[] { txB.Signer }, outputStates.UpdatedAddresses);
+                Assert.Equal(new[] { txB.Signer }, outputStates.Delta.UpdatedAddresses);
                 Assert.Equal((Integer)deltaB[i + 1].Value, outputStates.GetState(txB.Signer));
                 if (i == 1)
                 {

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -166,15 +166,21 @@ namespace Libplanet.Action
         /// <para>
         /// The returned enumeration has the following properties:
         /// <list type="bullet">
-        /// <item><description>The first <see cref="ActionEvaluation"/> in the enumerated result,
-        /// if any, has <see cref="ActionEvaluation.OutputStates"/> with
-        /// <see cref="IAccountStateDelta.UpdatedAddresses"/> that is a
-        /// superset of <paramref name="previousStates"/>'s
-        /// <see cref="IAccountStateDelta.UpdatedAddresses"/>.</description></item>
-        /// <item><description>Each <see cref="ActionEvaluation"/> in the enumerated result
-        /// has <see cref="ActionEvaluation.OutputStates"/> with
-        /// <see cref="IAccountStateDelta.UpdatedAddresses"/> that is a super set
-        /// of the previous one, if any.</description></item>
+        /// <item><description>
+        ///     The first <see cref="ActionEvaluation"/> in the enumerated result,
+        ///     if any, has <see cref="ActionEvaluation.OutputStates"/> with
+        ///     <see cref="IAccountStateDelta.Delta"/> that is a
+        ///     "superset" of <paramref name="previousStates"/>'s
+        ///     <see cref="IAccountStateDelta.Delta"/> (possibly except for
+        ///     <see cref="IAccountDelta.ValidatorSet"/>).
+        /// </description></item>
+        /// <item><description>
+        ///     Each <see cref="ActionEvaluation"/> in the enumerated result
+        ///     has <see cref="ActionEvaluation.OutputStates"/> with
+        ///     <see cref="IAccountStateDelta.Delta"/> that is a "superset"
+        ///     of the previous one, if any (possibly except for
+        ///     <see cref="IAccountDelta.ValidatorSet"/>).
+        /// </description></item>
         /// </list>
         /// </para>
         /// </remarks>

--- a/Libplanet/Blockchain/BlockChain.TxExecution.cs
+++ b/Libplanet/Blockchain/BlockChain.TxExecution.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Blockchain
                         txid,
                         actionsLogsList,
                         outputStates.GetUpdatedStates(),
-                        outputStates.UpdatedFungibleAssets
+                        outputStates.Delta.UpdatedFungibleAssets
                             .Select(pair =>
                                 (
                                     pair.Item1,
@@ -66,7 +66,7 @@ namespace Libplanet.Blockchain
                                     .ToImmutableDictionary(
                                         triple => triple.Item2,
                                         triple => triple.Item3)),
-                        outputStates.UpdatedFungibleAssets
+                        outputStates.Delta.UpdatedFungibleAssets
                             .Select(pair =>
                                 (
                                     pair.Item1,

--- a/Libplanet/State/AccountStateDelta.cs
+++ b/Libplanet/State/AccountStateDelta.cs
@@ -45,25 +45,8 @@ namespace Libplanet.State
         public IAccountDelta Delta { get; private set; }
 
         /// <inheritdoc/>
-        [Pure]
-        public IImmutableSet<Address> UpdatedAddresses =>
-            Delta.UpdatedAddresses;
-
-        /// <inheritdoc/>
-        public IImmutableSet<Address> StateUpdatedAddresses =>
-            Delta.StateUpdatedAddresses;
-
-        /// <inheritdoc/>
-        public IImmutableSet<(Address, Currency)> UpdatedFungibleAssets =>
-            Delta.UpdatedFungibleAssets;
-
-        /// <inheritdoc/>
         public IImmutableSet<(Address, Currency)> TotalUpdatedFungibleAssets =>
             TotalUpdatedFungibles.Keys.ToImmutableHashSet();
-
-        [Pure]
-        public IImmutableSet<Currency> UpdatedTotalSupplyCurrencies =>
-            Delta.UpdatedTotalSupplyCurrencies;
 
         public IImmutableDictionary<(Address, Currency), BigInteger> TotalUpdatedFungibles
             { get; protected set; }

--- a/Libplanet/State/IAccountStateDelta.cs
+++ b/Libplanet/State/IAccountStateDelta.cs
@@ -11,8 +11,8 @@ using Libplanet.Consensus;
 namespace Libplanet.State
 {
     /// <summary>
-    /// An interface to manipulate account states with
-    /// maintaining the set of <see cref="UpdatedAddresses"/>.
+    /// An interface to manipulate an account state with
+    /// maintaining <see cref="Delta"/>.
     /// <para>It is like a map which is virtually initialized such
     /// that every possible <see cref="Address"/> exists and
     /// is mapped to <see langword="null"/>.  That means that:</para>
@@ -48,50 +48,12 @@ namespace Libplanet.State
         IAccountDelta Delta { get; }
 
         /// <summary>
-        /// <seealso cref="Address"/>es of the accounts that have
-        /// been updated since then.
-        /// </summary>
-        [Pure]
-        IImmutableSet<Address> UpdatedAddresses { get; }
-
-        /// <summary>
-        /// <see cref="Address"/>es of the accounts whose states have been updated since then.
-        /// </summary>
-        [Pure]
-        IImmutableSet<Address> StateUpdatedAddresses { get; }
-
-        /// <summary>
-        /// <para>
-        /// A set of <see cref="Address"/> and <see cref="Currency"/> pairs where
-        /// each pair has its asoociated <see cref="FungibleAssetValue"/> changed.
-        /// </para>
-        /// <para>
-        /// For example, if A transfers 10 FOO to B and B transfers 20 BAR to C,
-        /// <see cref="UpdatedFungibleAssets"/> become likes
-        /// <c>{ (A, FOO), (B, FOO), (B, BAR), (C, BAR) }</c>.
-        /// </para>
-        /// <para>
-        /// Furthermore, this represents any pair that has been "touched", i.e.,
-        /// if A transfers 10 FOO to B and B transfers 10 FOO back to A,
-        /// this becomes <c>{ (A, FOO), (B, BAR) }</c> not an empty set.
-        /// </para>
-        /// </summary>
-        [Pure]
-        IImmutableSet<(Address, Currency)> UpdatedFungibleAssets { get; }
-
-        /// <summary>
         /// A set of <see cref="Address"/> and <see cref="Currency"/> pairs where
         /// each pair has its asoociated <see cref="FungibleAssetValue"/> changed
         /// since the previous <see cref="Block"/>'s output states.
         /// </summary>
         [Pure]
         IImmutableSet<(Address, Currency)> TotalUpdatedFungibleAssets { get; }
-
-        /// <summary>
-        /// <seealso cref="Currency">Currencies</seealso> with their total supplies updated.
-        /// </summary>
-        [Pure]
-        IImmutableSet<Currency> UpdatedTotalSupplyCurrencies { get; }
 
         /// <summary>
         /// Gets a new instance that the account state of the given


### PR DESCRIPTION
Generally to reduce dependency scope (and hopefully discourage using delta data in general). 🙄