### PR TITLE
Reimplement bootstrapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,14 @@ To be released.
      -  Added `VoteSetBits` class.
      -  Added `VoteSetBitsMetadata` class.
      -  (Libplanet.Net) Added `ConsensusVoteSetBitsMsg` class.
+ -  Added `Bootstrap` and its related classes.  [[#3258]]
+     -  Added `Bootstrap` class.
+     -  Added `BootstrapMetadata` class.
+     -  (Libplanet.Net) Added `ConsensusBootstrapMsg` class.
+ -  Added `VotesRecall` and its related classes.  [[#3258]]
+     -  Added `VotesRecall` class.
+     -  Added `VotesRecallMetadata` class.
+     -  (Libplanet.Net) Added `ConsensusVotesRecallMsg` class.
  -  (Libplanet.Net) Added `VoteSet` class.  [[#3249]]
  -  (Libplanet.Net) Added `HeightVoteSet` class.  [[#3249]]
  -  (Libplanet.Net) Added `ConsensusVoteMsg` abstract class.  [[#3249]]

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -23,6 +23,7 @@ namespace Libplanet.Net.Consensus
                 Height,
                 lastCommit);
             _lastCommit = lastCommit;
+            _bootstrapping = bootstrapping;
             ProduceMutation(() => StartRound(0));
 
             // FIXME: Exceptions inside tasks should be handled properly.

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -291,7 +291,7 @@ namespace Libplanet.Net.Consensus
         public void CatchupWithVotesRecall(VotesRecall votesRecall)
         {
             _logger.Debug(
-                "Catch up consensus with VotesRecall contains {count} votes : {votesRecall}",
+                "Catch up consensus with VotesRecall contains {count} votes: {votesRecall}",
                 votesRecall.Votes.Count,
                 votesRecall);
             foreach (Vote vote in votesRecall.Votes)

--- a/Libplanet.Net/Messages/ConsensusBootstrapMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusBootstrapMsg.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A message class for informing that peer is on bootstrapping.
+    /// </summary>
+    public class ConsensusBootstrapMsg : ConsensusMsg
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusBootstrapMsg"/> class.
+        /// </summary>
+        /// <param name="bootstrap">A <see cref="Bootstrap"/> information
+        /// of <see cref="Validator"/>.</param>
+        public ConsensusBootstrapMsg(Bootstrap bootstrap)
+            : base(bootstrap.ValidatorPublicKey, bootstrap.Height, bootstrap.Round)
+        {
+            Bootstrap = bootstrap;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusBootstrapMsg"/> class
+        /// with marshalled message.
+        /// </summary>
+        /// <param name="dataframes">A marshalled message.</param>
+        public ConsensusBootstrapMsg(byte[][] dataframes)
+            : this(bootstrap: new Bootstrap(dataframes[0]))
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="Bootstrap"/> of the message.
+        /// </summary>
+        public Bootstrap Bootstrap { get; }
+
+        /// <inheritdoc cref="MessageContent.DataFrames"/>
+        public override IEnumerable<byte[]> DataFrames =>
+            new List<byte[]> { Bootstrap.ToByteArray() };
+
+        /// <inheritdoc cref="MessageContent.MessageType"/>
+        public override MessageType Type => MessageType.BootstrapMsg;
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(ConsensusMsg?)"/>
+        public override bool Equals(ConsensusMsg? other)
+        {
+            return other is ConsensusBootstrapMsg message &&
+                message.Bootstrap.Equals(Bootstrap);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsensusMsg other && Equals(other);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, Bootstrap);
+        }
+    }
+}

--- a/Libplanet.Net/Messages/ConsensusVotesRecallMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusVotesRecallMsg.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Consensus;
+
+namespace Libplanet.Net.Messages
+{
+    /// <summary>
+    /// A message class for informing that peer is on bootstrapping.
+    /// </summary>
+    public class ConsensusVotesRecallMsg : ConsensusMsg
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusVotesRecallMsg"/> class.
+        /// </summary>
+        /// <param name="votesRecall">A <see cref="VotesRecall"/> information
+        /// of <see cref="Validator"/>.</param>
+        public ConsensusVotesRecallMsg(VotesRecall votesRecall)
+            : base(votesRecall.ValidatorPublicKey, votesRecall.Height, votesRecall.Round)
+        {
+            VotesRecall = votesRecall;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsensusBootstrapMsg"/> class
+        /// with marshalled message.
+        /// </summary>
+        /// <param name="dataframes">A marshalled message.</param>
+        public ConsensusVotesRecallMsg(byte[][] dataframes)
+            : this(votesRecall: new VotesRecall(dataframes[0]))
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="VotesRecall"/> of the message.
+        /// </summary>
+        public VotesRecall VotesRecall { get; }
+
+        /// <inheritdoc cref="MessageContent.DataFrames"/>
+        public override IEnumerable<byte[]> DataFrames =>
+            new List<byte[]> { VotesRecall.ToByteArray() };
+
+        /// <inheritdoc cref="MessageContent.MessageType"/>
+        public override MessageType Type => MessageType.VotesRecallMsg;
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(ConsensusMsg?)"/>
+        public override bool Equals(ConsensusMsg? other)
+        {
+            return other is ConsensusVotesRecallMsg message &&
+                message.VotesRecall.Equals(VotesRecall);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsensusMsg other && Equals(other);
+        }
+
+        /// <inheritdoc cref="ConsensusMsg.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, VotesRecall);
+        }
+    }
+}

--- a/Libplanet.Net/Messages/MessageContent.cs
+++ b/Libplanet.Net/Messages/MessageContent.cs
@@ -120,6 +120,16 @@ namespace Libplanet.Net.Messages
             /// Consensus commit message.
             /// </summary>
             ConsensusCommit = 0x52,
+
+            /// <summary>
+            /// Message that informs peer is on bootstrapping to other peer.
+            /// </summary>
+            BootstrapMsg = 0x56,
+
+            /// <summary>
+            /// Message that helps peer by recalling past votes.
+            /// </summary>
+            VotesRecallMsg = 0x57,
         }
 
         /// <summary>

--- a/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -217,6 +217,10 @@ namespace Libplanet.Net.Messages
                     return new ConsensusPreVoteMsg(dataframes);
                 case MessageContent.MessageType.ConsensusCommit:
                     return new ConsensusPreCommitMsg(dataframes);
+                case MessageContent.MessageType.BootstrapMsg:
+                    return new ConsensusBootstrapMsg(dataframes);
+                case MessageContent.MessageType.VotesRecallMsg:
+                    return new ConsensusVotesRecallMsg(dataframes);
                 default:
                     throw new InvalidCastException($"Given type {type} is not a valid message.");
             }

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -858,7 +858,7 @@ namespace Libplanet.Net
                     List<byte[]> payloads = blockMessage.Payloads;
                     _logger.Information(
                         "Received {Count} blocks from {Peer}",
-                        payloads.Count,
+                        payloads.Count / 2,
                         message.Remote);
                     for (int i = 0; i < payloads.Count; i += 2)
                     {

--- a/Libplanet/Consensus/Bootstrap.cs
+++ b/Libplanet/Consensus/Bootstrap.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A class used to bootstrap <see cref="Validator"/>.
+    /// </summary>
+    public class Bootstrap : IEquatable<Bootstrap>
+    {
+        private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        private static Codec _codec = new Codec();
+
+        private readonly BootstrapMetadata _bootstrapMetadata;
+
+        /// <summary>
+        /// Instantiates a <see cref="Bootstrap"/> with given <paramref name="bootstrapMetadata"/>
+        /// and its <paramref name="signature"/>.
+        /// </summary>
+        /// <param name="bootstrapMetadata">A <see cref="BootstrapMetadata"/> for bootstrapping.
+        /// </param>
+        /// <param name="signature">A signature signed with <paramref name="bootstrapMetadata"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="signature"/> is
+        /// empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="signature"/> is
+        /// invalid and cannot be verified with <paramref name="bootstrapMetadata"/>.</exception>
+        public Bootstrap(BootstrapMetadata bootstrapMetadata, ImmutableArray<byte> signature)
+        {
+            _bootstrapMetadata = bootstrapMetadata;
+            Signature = signature;
+
+            if (signature.IsDefaultOrEmpty)
+            {
+                throw new ArgumentNullException(
+                    nameof(signature),
+                    "Signature cannot be null or empty.");
+            }
+            else if (!Verify())
+            {
+                throw new ArgumentException("Signature is invalid.", nameof(signature));
+            }
+        }
+
+        public Bootstrap(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
+        {
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public Bootstrap(Dictionary encoded)
+            : this(
+                new BootstrapMetadata(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc cref="BootstrapMetadata.Height"/>
+        public long Height => _bootstrapMetadata.Height;
+
+        /// <inheritdoc cref="BootstrapMetadata.Round"/>
+        public int Round => _bootstrapMetadata.Round;
+
+        /// <inheritdoc cref="BootstrapMetadata.ValidatorPublicKey"/>
+        public PublicKey ValidatorPublicKey => _bootstrapMetadata.ValidatorPublicKey;
+
+        /// <inheritdoc cref="BootstrapMetadata.Timestamp"/>
+        public DateTimeOffset Timestamp => _bootstrapMetadata.Timestamp;
+
+        /// <summary>
+        /// A signature that signed with <see cref="Maj23Metadata"/>.
+        /// </summary>
+        public ImmutableArray<byte> Signature { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="Maj23"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded =>
+            !Signature.IsEmpty
+                ? _bootstrapMetadata.Encoded.Add(SignatureKey, Signature)
+                : _bootstrapMetadata.Encoded;
+
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="Maj23"/> data.
+        /// </summary>
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Verifies whether the <see cref="BootstrapMetadata"/> is properly signed by
+        /// <see cref="Validator"/>.
+        /// </summary>
+        /// <returns><see langword="true"/> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
+        [Pure]
+        public bool Verify() =>
+            !Signature.IsDefaultOrEmpty &&
+            ValidatorPublicKey.Verify(
+                _bootstrapMetadata.ByteArray.ToImmutableArray(),
+                Signature);
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(Bootstrap? other)
+        {
+            return other is { } bootstrap &&
+                   _bootstrapMetadata.Equals(bootstrap._bootstrapMetadata) &&
+                   Signature.SequenceEqual(bootstrap.Signature);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool Equals(object? obj)
+        {
+            return obj is Bootstrap other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                _bootstrapMetadata.GetHashCode(),
+                ByteUtil.CalculateHashCode(Signature.ToArray()));
+        }
+    }
+}

--- a/Libplanet/Consensus/BootstrapMetadata.cs
+++ b/Libplanet/Consensus/BootstrapMetadata.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    public class BootstrapMetadata : IEquatable<BootstrapMetadata>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
+        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
+        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
+        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
+
+        private static Codec _codec = new Codec();
+
+        /// <summary>
+        /// Instantiates a <see cref="BootstrapMetadata"/> with given condition of bootstrapping
+        /// <see cref="Validator"/>'s context.
+        /// </summary>
+        /// <param name="height">The height of bootstrapping context.
+        /// </param>
+        /// <param name="round">The round of bootstrapping context.
+        /// </param>
+        /// <param name="timestamp">The <see cref="DateTimeOffset"/>
+        /// that bootstrapping request has been made.
+        /// </param>
+        /// <param name="validatorPublicKey">The <see cref="PublicKey"/> of bootstrapping
+        /// <see cref="Validator"/> that will be signed on.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if given <paramref name="height"/>
+        /// or <paramref name="round"/> is less than zero.</exception>
+        public BootstrapMetadata(
+            long height,
+            int round,
+            DateTimeOffset timestamp,
+            PublicKey validatorPublicKey)
+        {
+            if (height < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(height),
+                    "Height must be greater than or equal to 0.");
+            }
+
+            if (round < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(round),
+                    "Round must be greater than or equal to 0.");
+            }
+
+            Height = height;
+            Round = round;
+            Timestamp = timestamp;
+            ValidatorPublicKey = validatorPublicKey;
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public BootstrapMetadata(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validatorPublicKey: new PublicKey(
+                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray))
+        {
+        }
+#pragma warning restore SA1118
+        /// <summary>
+        /// Current height of bootstrapping validator.
+        /// </summary>
+        public long Height { get; }
+
+        /// <summary>
+        /// Current round of bootstrapping validator.
+        /// </summary>
+        public int Round { get; }
+
+        /// <summary>
+        /// A <see cref="PublicKey"/> of bootstrapping validator.
+        /// </summary>
+        public PublicKey ValidatorPublicKey { get; }
+
+        /// <summary>
+        /// The time at which the bootstrapping requested.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="BootstrapMetadata"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(ValidatorPublicKeyKey, ValidatorPublicKey.Format(compress: true))
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture));
+
+                return encoded;
+            }
+        }
+
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Signs given <see cref="BootstrapMetadata"/> with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">A <see cref="PrivateKey"/> to sign.</param>
+        /// <returns>Returns a signed <see cref="Bootstrap"/>.</returns>
+        public Bootstrap Sign(PrivateKey signer) =>
+            new Bootstrap(this, signer.Sign(ByteArray).ToImmutableArray());
+
+        /// <inheritdoc/>
+        public bool Equals(BootstrapMetadata? other)
+        {
+            return other is { } metadata &&
+                Height == metadata.Height &&
+                Round == metadata.Round &&
+                ValidatorPublicKey.Equals(metadata.ValidatorPublicKey) &&
+                Timestamp
+                    .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                        metadata.Timestamp.ToString(
+                            TimestampFormat,
+                            CultureInfo.InvariantCulture));
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is BootstrapMetadata other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                ValidatorPublicKey,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/Libplanet/Consensus/VotesRecall.cs
+++ b/Libplanet/Consensus/VotesRecall.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    /// <summary>
+    /// A class used to help peer <see cref="Validator"/> to bootstrap by sending
+    /// <see cref="Vote"/>s that the peer has.
+    /// </summary>
+    public class VotesRecall : IEquatable<VotesRecall>
+    {
+        private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        private static Codec _codec = new Codec();
+
+        private readonly VotesRecallMetadata _votesRecallMetadata;
+
+        /// <summary>
+        /// Instantiates a <see cref="VotesRecall"/> with given
+        /// <paramref name="votesRecallMetadata"/> and its <paramref name="signature"/>.
+        /// </summary>
+        /// <param name="votesRecallMetadata">
+        /// A <see cref="VotesRecallMetadata"/> to help bootstrapping.</param>
+        /// <param name="signature">A signature signed with <paramref name="votesRecallMetadata"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if given <paramref name="signature"/> is
+        /// empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if given <paramref name="signature"/> is
+        /// invalid and cannot be verified with <paramref name="votesRecallMetadata"/>.</exception>
+        public VotesRecall(VotesRecallMetadata votesRecallMetadata, ImmutableArray<byte> signature)
+        {
+            _votesRecallMetadata = votesRecallMetadata;
+            Signature = signature;
+
+            if (signature.IsDefaultOrEmpty)
+            {
+                throw new ArgumentNullException(
+                    nameof(signature),
+                    "Signature cannot be null or empty.");
+            }
+            else if (!Verify())
+            {
+                throw new ArgumentException("Signature is invalid.", nameof(signature));
+            }
+        }
+
+        public VotesRecall(byte[] marshaled)
+            : this((Dictionary)_codec.Decode(marshaled))
+        {
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public VotesRecall(Dictionary encoded)
+            : this(
+                new VotesRecallMetadata(encoded),
+                encoded.ContainsKey(SignatureKey)
+                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    : ImmutableArray<byte>.Empty)
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <inheritdoc cref="VotesRecallMetadata.Height"/>
+        public long Height => _votesRecallMetadata.Height;
+
+        /// <inheritdoc cref="VotesRecallMetadata.Round"/>
+        public int Round => _votesRecallMetadata.Round;
+
+        /// <inheritdoc cref="VotesRecallMetadata.Timestamp"/>
+        public DateTimeOffset Timestamp => _votesRecallMetadata.Timestamp;
+
+        /// <inheritdoc cref="VotesRecallMetadata.ValidatorPublicKey"/>
+        public PublicKey ValidatorPublicKey => _votesRecallMetadata.ValidatorPublicKey;
+
+        /// <inheritdoc cref="VotesRecallMetadata.Votes"/>
+        public ImmutableHashSet<Vote> Votes => _votesRecallMetadata.Votes;
+
+        /// <summary>
+        /// A signature that signed with <see cref="VotesRecallMetadata"/>.
+        /// </summary>
+        public ImmutableArray<byte> Signature { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="VotesRecall"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded =>
+            !Signature.IsEmpty
+                ? _votesRecallMetadata.Encoded.Add(SignatureKey, Signature)
+                : _votesRecallMetadata.Encoded;
+
+        /// <summary>
+        /// <see cref="byte"/> encoded <see cref="VotesRecall"/> data.
+        /// </summary>
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Verifies whether the <see cref="VotesRecallMetadata"/> is properly signed by
+        /// <see cref="Validator"/>.
+        /// </summary>
+        /// <returns><see langword="true"/> if the <see cref="Signature"/> is not empty
+        /// and is a valid signature signed by <see cref="Validator"/>.</returns>
+        [Pure]
+        public bool Verify() =>
+            !Signature.IsDefaultOrEmpty &&
+            ValidatorPublicKey.Verify(
+                _votesRecallMetadata.ByteArray.ToImmutableArray(),
+                Signature);
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(VotesRecall? other)
+        {
+            return other is { } votesRecall &&
+                   _votesRecallMetadata.Equals(votesRecall._votesRecallMetadata) &&
+                   Signature.SequenceEqual(votesRecall.Signature);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool Equals(object? obj)
+        {
+            return obj is VotesRecall other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                _votesRecallMetadata.GetHashCode(),
+                ByteUtil.CalculateHashCode(Signature.ToArray()));
+        }
+
+        public override string ToString()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "validator_public_key", ValidatorPublicKey.ToString() },
+                {
+                    "votes", Votes.Aggregate(
+                        string.Empty, (current, next) => current + next.ToString())
+                },
+                { "height", Height },
+                { "round", Round },
+                { "timestamp", Timestamp.ToString(CultureInfo.InvariantCulture) },
+            };
+            return JsonSerializer.Serialize(dict);
+        }
+    }
+}

--- a/Libplanet/Consensus/VotesRecallMetadata.cs
+++ b/Libplanet/Consensus/VotesRecallMetadata.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+
+namespace Libplanet.Consensus
+{
+    public class VotesRecallMetadata : IEquatable<VotesRecallMetadata>
+    {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
+        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
+        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
+        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
+        private static readonly byte[] VotesKey = { 0x76 };                 // 'v'
+
+        private static Codec _codec = new Codec();
+
+        /// <summary>
+        /// Instantiates a <see cref="VotesRecallMetadata"/> with given context of
+        /// <see cref="Vote"/>s.
+        /// </summary>
+        /// <param name="height">The height of <paramref name="votes"/>.
+        /// </param>
+        /// <param name="round">The round of <paramref name="votes"/>.
+        /// </param>
+        /// <param name="timestamp">The <see cref="DateTimeOffset"/>
+        /// when <see cref="VotesRecallMetadata"/> has been made.
+        /// </param>
+        /// <param name="validatorPublicKey">The <see cref="PublicKey"/> of sending
+        /// <see cref="Validator"/> that will be signed on.
+        /// </param>
+        /// <param name="votes">The <see cref="Vote"/>s that <see cref="Validator"/>
+        /// of <paramref name="validatorPublicKey"/> has been collected.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if given <paramref name="height"/>
+        /// or <paramref name="round"/> is less than zero.</exception>
+        public VotesRecallMetadata(
+            long height,
+            int round,
+            DateTimeOffset timestamp,
+            PublicKey validatorPublicKey,
+            ImmutableHashSet<Vote> votes)
+        {
+            if (height < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(height),
+                    "Height must be greater than or equal to 0.");
+            }
+
+            if (round < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(round),
+                    "Round must be greater than or equal to 0.");
+            }
+
+            Height = height;
+            Round = round;
+            Timestamp = timestamp;
+            ValidatorPublicKey = validatorPublicKey;
+            Votes = votes;
+        }
+
+#pragma warning disable SA1118 // The parameter spans multiple lines
+        public VotesRecallMetadata(Dictionary encoded)
+            : this(
+                height: encoded.GetValue<Integer>(HeightKey),
+                round: encoded.GetValue<Integer>(RoundKey),
+                timestamp: DateTimeOffset.ParseExact(
+                    encoded.GetValue<Text>(TimestampKey),
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture),
+                validatorPublicKey: new PublicKey(
+                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
+                votes: encoded.GetValue<List>(VotesKey).Select(
+                    v => new Vote(v)).ToImmutableHashSet())
+        {
+        }
+#pragma warning restore SA1118
+
+        /// <summary>
+        /// The height of given votes recall.
+        /// </summary>
+        public long Height { get; }
+
+        /// <summary>
+        /// The round of given votes recall.
+        /// </summary>
+        public int Round { get; }
+
+        /// <summary>
+        /// The time at which the votes recall took place.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// A <see cref="PublicKey"/> of <see cref="Validator"/>
+        /// that helps bootstrapping with votes recall.
+        /// </summary>
+        public PublicKey ValidatorPublicKey { get; }
+
+        /// <summary>
+        /// Set of recalled <see cref="Vote"/>s.
+        /// </summary>
+        public ImmutableHashSet<Vote> Votes { get; }
+
+        /// <summary>
+        /// A Bencodex-encoded value of <see cref="VotesRecallMetadata"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary Encoded
+        {
+            get
+            {
+                Dictionary encoded = Bencodex.Types.Dictionary.Empty
+                    .Add(HeightKey, Height)
+                    .Add(RoundKey, Round)
+                    .Add(
+                        TimestampKey,
+                        Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
+                    .Add(ValidatorPublicKeyKey, ValidatorPublicKey.Format(compress: true))
+                    .Add(
+                        VotesKey,
+                        new List(
+                            Votes.OrderBy(v => v.Timestamp)
+                            .ThenBy(v => v.ValidatorPublicKey.ToAddress())
+                            .Select(v => v.Bencoded)));
+
+                return encoded;
+            }
+        }
+
+        public ImmutableArray<byte> ByteArray => ToByteArray().ToImmutableArray();
+
+        public byte[] ToByteArray() => _codec.Encode(Encoded);
+
+        /// <summary>
+        /// Signs given <see cref="VotesRecallMetadata"/> with given <paramref name="signer"/>.
+        /// </summary>
+        /// <param name="signer">A <see cref="PrivateKey"/> to sign.</param>
+        /// <returns>Returns a signed <see cref="VotesRecall"/>.</returns>
+        public VotesRecall Sign(PrivateKey signer) =>
+            new VotesRecall(this, signer.Sign(ByteArray).ToImmutableArray());
+
+        /// <inheritdoc/>
+        public bool Equals(VotesRecallMetadata? other)
+        {
+            return other is { } metadata &&
+                Height == metadata.Height &&
+                Round == metadata.Round &&
+                Timestamp
+                    .ToString(TimestampFormat, CultureInfo.InvariantCulture).Equals(
+                        metadata.Timestamp.ToString(
+                            TimestampFormat,
+                            CultureInfo.InvariantCulture)) &&
+                ValidatorPublicKey.Equals(metadata.ValidatorPublicKey) &&
+                Votes.SetEquals(metadata.Votes);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is VotesRecallMetadata other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Height,
+                Round,
+                Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture),
+                ValidatorPublicKey);
+        }
+    }
+}


### PR DESCRIPTION
Since `GetRandomMsg` has been removed, alternative method is needed for bootstrapping.
New bootstrapping acts like below.

1. When a validator participates in consensus and starts a new round, it broadcasts `ConsensusBootstrapMsg`.
2. Online peers who receives `ConsensusBootstrapMsg` collects proper votes from its `HeightVoteSet`, and replies with `ConsensusVotesRecallMsg`, which contains recalled votes.
3. If a validator receives `ConsensusVotesRecallMSg`, it checks the content of it and add those votes to its `HeightVoteSet`.

- Round of returned `ConsensusVotesRecallMsg` will be `Bootstrap.Round` + 1, if given round is smaller than replyer's round, otherwise, `Bootstrap.Round`.
- `ConsensusVotesRecallMsg` will be ignored, if its round is bigger than receiver's round + 1, to be fitted with spamming prevention logic.