### PR TITLE
♻️ General name changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@ To be released.
  -  Changed `IBlockStates` to `IBlockState`.  [[#3259]]
  -  Changed `IBlockChainStates.GetBlockStates()` to
     `IBlockChainStates.GetBlockState()`.  [[#3259]]
+ -  Changes `IActionContext.PreviousStates` to `IActionContext.PreviousState`.
  -  Changed `IActionEvaluation.OutputStates` to `IActionEvaluation.OutputState`.
     [[#3259]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,11 @@ To be released.
      -  Removed `IAccountStateDelta.StateUpdatedAddresses` property.
      -  Removed `IAccountStateDelta.UpdatedFungibleAssets` property.
      -  Removed `IAccountStateDelta.UpdatedTotalSupplyCurrencies` property.
+ -  Changed `IBlockStates` to `IBlockState`.  [[#3259]]
+ -  Changed `IBlockChainStates.GetBlockStates()` to
+    `IBlockChainStates.GetBlockState()`.  [[#3259]]
+ -  Changed `IActionEvaluation.OutputStates` to `IActionEvaluation.OutputState`.
+    [[#3259]]
 
 ### Behavioral changes
 
@@ -66,6 +71,7 @@ To be released.
 [#3249]: https://github.com/planetarium/libplanet/pull/3249
 [#3256]: https://github.com/planetarium/libplanet/pull/3256
 [#3257]: https://github.com/planetarium/libplanet/pull/3257
+[#3259]: https://github.com/planetarium/libplanet/pull/3259
 
 
 Version 2.3.0

--- a/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
+++ b/Libplanet.Analyzers.Tests/ActionAnalyzerTest.cs
@@ -33,7 +33,7 @@ namespace Libplanet.Analyzers.Tests
                         public void LoadPlainValue(IValue plainValue) {}
                         public IAccountStateDelta Execute(IActionContext context) {
                             new Random().Next();
-                            return context.PreviousStates;
+                            return context.PreviousState;
                         }
                         public static void Main() {}
                     }
@@ -148,7 +148,7 @@ namespace Libplanet.Analyzers.Tests
                             v.ToImmutableHashSet();
                             var newSet = new HashSet<" + elemType + @">(v);
                             " + dictCode + @"
-                            return context.PreviousStates;
+                            return context.PreviousState;
                         }
                         public void ConsumeEnumerable(IEnumerable<" + elemType + @"> it) {}
                         public static void Main() {}

--- a/Libplanet.Analyzers/rules/LAA1001.md
+++ b/Libplanet.Analyzers/rules/LAA1001.md
@@ -13,7 +13,7 @@ The following code is warned by the rule LAA1001:
 ~~~~ csharp
 public IAccountStateDelta Execute(IActionContext context)
 {
-    var states = context.PreviousStates;
+    var states = context.PreviousState;
     System.Random random = new System.Random();  // LAA1001
     states.SetState(_targetAddress, (Bencodex.Types.Integer)random.Next());
     return states;
@@ -25,7 +25,7 @@ This can be addressed like below:
 ~~~~ csharp
 public IAccountStateDelta Execute(IActionContext context)
 {
-    var states = context.PreviousStates;
+    var states = context.PreviousState;
     IRandom random = context.Random;  // Fixed
     states.SetState(_targetAddress, (Bencodex.Types.Integer)random.Next());
     return states;

--- a/Libplanet.Analyzers/rules/LAA1002.md
+++ b/Libplanet.Analyzers/rules/LAA1002.md
@@ -34,7 +34,7 @@ The following code is warned by the rule LAA1002:
 ~~~~ csharp
 public IAccountStateDelta Execute(IActionContext context)
 {
-    var states = context.PreviousStates;
+    var states = context.PreviousState;
     if (states.GetState(_address) is Bencodex.Types.Dictionary d)
     {
         string list = d.Keys
@@ -51,7 +51,7 @@ This can be addressed like below:
 ~~~~ csharp
 public IAccountStateDelta Execute(IActionContext context)
 {
-    var states = context.PreviousStates;
+    var states = context.PreviousState;
     if (states.GetState(_address) is Bencodex.Types.Dictionary d)
     {
         string list = d.Keys

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -176,28 +176,28 @@ public class StateQueryTest
     private class MockChainStates : IBlockChainStates
     {
         public IValue GetState(Address address, BlockHash? offset) =>
-            GetBlockStates(offset).GetState(address);
+            GetBlockState(offset).GetState(address);
 
         public IReadOnlyList<IValue> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>
-            GetBlockStates(offset).GetStates(addresses);
+            GetBlockState(offset).GetStates(addresses);
 
         public FungibleAssetValue GetBalance(
             Address address, Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetBalance(address, currency);
+            GetBlockState(offset).GetBalance(address, currency);
 
         public FungibleAssetValue GetTotalSupply(Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetTotalSupply(currency);
+            GetBlockState(offset).GetTotalSupply(currency);
 
         public ValidatorSet GetValidatorSet(BlockHash? offset) =>
-            GetBlockStates(offset).GetValidatorSet();
+            GetBlockState(offset).GetValidatorSet();
 
-        public IBlockStates GetBlockStates(BlockHash? offset) => new MockBlockStates(offset);
+        public IBlockState GetBlockState(BlockHash? offset) => new MockBlockState(offset);
     }
 
-    private class MockBlockStates : IBlockStates
+    private class MockBlockState : IBlockState
     {
-        public MockBlockStates(BlockHash? blockHash)
+        public MockBlockState(BlockHash? blockHash)
         {
             BlockHash = blockHash;
         }

--- a/Libplanet.Explorer.Tests/SimpleAction.cs
+++ b/Libplanet.Explorer.Tests/SimpleAction.cs
@@ -23,7 +23,7 @@ public abstract class SimpleAction : IAction
     {
     }
 
-    public virtual IAccountStateDelta Execute(IActionContext context) => context.PreviousStates;
+    public virtual IAccountStateDelta Execute(IActionContext context) => context.PreviousState;
 
     public static SimpleAction GetAction(int seed) =>
         (seed % 10) switch

--- a/Libplanet.Extensions.Cocona/Utils.cs
+++ b/Libplanet.Extensions.Cocona/Utils.cs
@@ -262,7 +262,7 @@ public static class Utils
 
         /// <inheritdoc/>
         public IAccountStateDelta Execute(IActionContext context) =>
-            context.PreviousStates;
+            context.PreviousState;
 
         /// <inheritdoc/>
         public void LoadPlainValue(IValue plainValue)

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -2043,7 +2043,7 @@ namespace Libplanet.Net.Tests
             public IAccountStateDelta Execute(IActionContext context)
             {
                 Thread.Sleep(10);
-                return context.PreviousStates;
+                return context.PreviousState;
             }
 
             public void LoadPlainValue(IValue plainValue)

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Tests.Action
                     miner: _address,
                     blockIndex: 1,
                     blockProtocolVersion: Block.CurrentProtocolVersion,
-                    previousStates: new DumbAccountStateDelta(),
+                    previousState: new DumbAccountStateDelta(),
                     randomSeed: seed,
                     gasLimit: 0
                 );
@@ -59,7 +59,7 @@ namespace Libplanet.Tests.Action
                 miner: _address,
                 blockIndex: 1,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: new DumbAccountStateDelta(),
+                previousState: new DumbAccountStateDelta(),
                 randomSeed: 0,
                 gasLimit: 0
             );
@@ -70,7 +70,7 @@ namespace Libplanet.Tests.Action
                 miner: _address,
                 blockIndex: 1,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: new DumbAccountStateDelta(),
+                previousState: new DumbAccountStateDelta(),
                 randomSeed: 0,
                 gasLimit: 0
             );
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Action
                 miner: _address,
                 blockIndex: 1,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: new DumbAccountStateDelta(),
+                previousState: new DumbAccountStateDelta(),
                 randomSeed: 1,
                 gasLimit: 0
             );
@@ -117,7 +117,7 @@ namespace Libplanet.Tests.Action
                     miner: _address,
                     blockIndex: 1,
                     blockProtocolVersion: Block.CurrentProtocolVersion,
-                    previousStates: new DumbAccountStateDelta(),
+                    previousState: new DumbAccountStateDelta(),
                     randomSeed: i,
                     gasLimit: 0
                 );
@@ -137,7 +137,7 @@ namespace Libplanet.Tests.Action
                 miner: _address,
                 blockIndex: 1,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: new DumbAccountStateDelta(),
+                previousState: new DumbAccountStateDelta(),
                 randomSeed: _random.Next(),
                 gasLimit: 0,
                 logs: new List<string>()

--- a/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationExtensions.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Tests.Action
         ) =>
             evaluations.Aggregate(
                 ImmutableDictionary<Address, IValue>.Empty,
-                (dirty, ev) => dirty.SetItems(ev.OutputStates.GetUpdatedStates())
+                (dirty, ev) => dirty.SetItems(ev.OutputState.GetUpdatedStates())
             );
 
         public static IImmutableDictionary<(Address, Currency), FungibleAssetValue>
@@ -24,14 +24,14 @@ namespace Libplanet.Tests.Action
         ) =>
             evaluations.Aggregate(
                 ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty,
-                (dirty, ev) => dirty.SetItems(ev.OutputStates.GetUpdatedBalances())
+                (dirty, ev) => dirty.SetItems(ev.OutputState.GetUpdatedBalances())
             );
 
         public static IImmutableDictionary<Currency, FungibleAssetValue>
         GetDirtyTotalSupplies(this IEnumerable<IActionEvaluation> evaluations) =>
             evaluations.Aggregate(
                 ImmutableDictionary<Currency, FungibleAssetValue>.Empty,
-                (dirty, ev) => dirty.SetItems(ev.OutputStates.GetUpdatedTotalSupplies())
+                (dirty, ev) => dirty.SetItems(ev.OutputState.GetUpdatedTotalSupplies())
             );
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -64,11 +64,11 @@ namespace Libplanet.Tests.Action
             Assert.Equal(address, evaluation.InputContext.Miner);
             Assert.Equal(1, evaluation.InputContext.BlockIndex);
             Assert.Null(
-                evaluation.InputContext.PreviousStates.GetState(address)
+                evaluation.InputContext.PreviousState.GetState(address)
             );
             Assert.Equal(
                 (Text)"item",
-                evaluation.OutputStates.GetState(address)
+                evaluation.OutputState.GetState(address)
             );
         }
     }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -230,13 +230,13 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent.DeriveTxHash(txs),
                     lastCommit: null),
                 transactions: txs).Propose();
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(block);
 
             Assert.Throws<OutOfMemoryException>(
                 () => actionEvaluator.EvaluateTx(
                     blockHeader: block,
                     tx: tx,
-                    previousStates: previousStates).ToList());
+                    previousState: previousState).ToList());
             Assert.Throws<OutOfMemoryException>(
                 () => chain.ActionEvaluator.Evaluate(block).ToList());
         }
@@ -324,10 +324,10 @@ namespace Libplanet.Tests.Action
                 genesis,
                 GenesisProposer,
                 block1Txs);
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block1);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(block1);
             var evals = actionEvaluator.EvaluateBlock(
                 block1,
-                previousStates).ToImmutableArray();
+                previousState).ToImmutableArray();
             int randomValue = 0;
             // Once the BlockMetadata.CurrentProtocolVersion gets bumped, expectations may also
             // have to be updated, since the order may change due to different PreEvaluationHash.
@@ -358,9 +358,9 @@ namespace Libplanet.Tests.Action
                         .Select(x => x is Text t ? t.Value : null));
             }
 
-            previousStates = actionEvaluator.PrepareInitialDelta(block1);
+            previousState = actionEvaluator.PrepareInitialDelta(block1);
             ActionEvaluation[] evals1 =
-                actionEvaluator.EvaluateBlock(block1, previousStates).ToArray();
+                actionEvaluator.EvaluateBlock(block1, previousState).ToArray();
             IImmutableDictionary<Address, IValue> dirty1 = evals1.GetDirtyStates();
             IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances1 =
                 evals1.GetDirtyBalances();
@@ -441,10 +441,10 @@ namespace Libplanet.Tests.Action
                 lastCommit: CreateBlockCommit(block1, true));
 
             // Forcefully reset to null delta
-            previousStates = AccountStateDelta.Create(evals1.Last().OutputState);
+            previousState = AccountStateDelta.Create(evals1.Last().OutputState);
             evals = actionEvaluator.EvaluateBlock(
                 block2,
-                previousStates).ToImmutableArray();
+                previousState).ToImmutableArray();
 
             // Once the BlockMetadata.CurrentProtocolVersion gets bumped, expectations may also
             // have to be updated, since the order may change due to different PreEvaluationHash.
@@ -478,8 +478,8 @@ namespace Libplanet.Tests.Action
                     (Integer)randomValue);
             }
 
-            previousStates = AccountStateDelta.Create(evals1.Last().OutputState);
-            var evals2 = actionEvaluator.EvaluateBlock(block2, previousStates).ToArray();
+            previousState = AccountStateDelta.Create(evals1.Last().OutputState);
+            var evals2 = actionEvaluator.EvaluateBlock(block2, previousState).ToArray();
             IImmutableDictionary<Address, IValue> dirty2 = evals2.GetDirtyStates();
             IImmutableDictionary<(Address, Currency), FungibleAssetValue> balances2 =
                 evals2.GetDirtyBalances();
@@ -544,11 +544,11 @@ namespace Libplanet.Tests.Action
 
             DumbAction.RehearsalRecords.Value =
                 ImmutableList<(Address, string)>.Empty;
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(block);
             var evaluations = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
-                previousStates: previousStates).ToImmutableArray();
+                previousState: previousState).ToImmutableArray();
 
             Assert.Equal(actions.Length, evaluations.Length);
             string[][] expectedStates =
@@ -610,11 +610,11 @@ namespace Libplanet.Tests.Action
 
             DumbAction.RehearsalRecords.Value =
                 ImmutableList<(Address, string)>.Empty;
-            previousStates = actionEvaluator.PrepareInitialDelta(block);
+            previousState = actionEvaluator.PrepareInitialDelta(block);
             IAccountStateDelta delta = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
-                previousStates: previousStates).Last().OutputState;
+                previousState: previousState).Last().OutputState;
             Assert.Equal(
                 evaluations[3].OutputState.GetUpdatedStates(),
                 delta.GetUpdatedStates());
@@ -654,11 +654,11 @@ namespace Libplanet.Tests.Action
                     txHash: BlockContent.DeriveTxHash(txs),
                     lastCommit: CreateBlockCommit(hash, 122, 0)),
                 transactions: txs).Propose();
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(block);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(block);
             var nextStates = actionEvaluator.EvaluateTx(
                 blockHeader: block,
                 tx: tx,
-                previousStates: previousStates).Last().OutputState;
+                previousState: previousState).Last().OutputState;
 
             Assert.Empty(nextStates.GetUpdatedStates());
         }
@@ -682,7 +682,7 @@ namespace Libplanet.Tests.Action
                 blockIndex: blockA.Index,
                 blockProtocolVersion: blockA.ProtocolVersion,
                 txid: txA.Id,
-                previousStates: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
+                previousState: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
                 miner: blockA.Miner,
                 signer: txA.Signer,
                 signature: txA.Signature,
@@ -730,7 +730,7 @@ namespace Libplanet.Tests.Action
                 blockIndex: blockB.Index,
                 blockProtocolVersion: blockB.ProtocolVersion,
                 txid: txB.Id,
-                previousStates: fx.CreateAccountStateDelta(0, blockB.PreviousHash),
+                previousState: fx.CreateAccountStateDelta(0, blockB.PreviousHash),
                 miner: blockB.Miner,
                 signer: txB.Signer,
                 signature: txB.Signature,
@@ -788,8 +788,8 @@ namespace Libplanet.Tests.Action
             var block = chain.ProposeBlock(
                 GenesisProposer, txs.ToImmutableList(), CreateBlockCommit(chain.Tip));
 
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(genesis);
-            var evaluation = actionEvaluator.EvaluatePolicyBlockAction(genesis, previousStates);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(genesis);
+            var evaluation = actionEvaluator.EvaluatePolicyBlockAction(genesis, previousState);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);
             Assert.Equal(
@@ -797,8 +797,8 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputState.GetState(genesis.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
 
-            previousStates = AccountStateDelta.Create(evaluation.OutputState);
-            evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousStates);
+            previousState = AccountStateDelta.Create(evaluation.OutputState);
+            evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousState);
 
             Assert.Equal(chain.Policy.BlockAction, evaluation.Action);
             Assert.Equal(
@@ -807,12 +807,12 @@ namespace Libplanet.Tests.Action
             Assert.True(evaluation.InputContext.BlockAction);
 
             chain.Append(block, CreateBlockCommit(block), render: true);
-            previousStates = actionEvaluator.PrepareInitialDelta(block);
+            previousState = actionEvaluator.PrepareInitialDelta(block);
             var txEvaluations = actionEvaluator.EvaluateBlock(
                 block,
-                previousStates).ToList();
-            previousStates = txEvaluations.Last().OutputState;
-            evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousStates);
+                previousState).ToList();
+            previousState = txEvaluations.Last().OutputState;
+            evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousState);
 
             Assert.Equal(
                 (Integer)2,
@@ -1293,7 +1293,7 @@ namespace Libplanet.Tests.Action
                 blockIndex: blockA.Index,
                 blockProtocolVersion: blockA.ProtocolVersion,
                 txid: txA.Id,
-                previousStates: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
+                previousState: fx.CreateAccountStateDelta(0, blockA.PreviousHash),
                 miner: blockA.Miner,
                 signer: txA.Signer,
                 signature: txA.Signature,

--- a/Libplanet.Tests/Action/Sys/InitializeTest.cs
+++ b/Libplanet.Tests/Action/Sys/InitializeTest.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Action.Sys
         {
             var random = new Random();
             Address signer = random.NextAddress();
-            var prevStates = AccountStateDelta.Create(MockAccountState.Empty);
+            var prevState = AccountStateDelta.Create(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,
@@ -55,7 +55,7 @@ namespace Libplanet.Tests.Action.Sys
                 miner: random.NextAddress(),
                 blockIndex: 0,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: prevStates,
+                previousState: prevState,
                 randomSeed: 123,
                 gasLimit: 0,
                 rehearsal: false);
@@ -75,7 +75,7 @@ namespace Libplanet.Tests.Action.Sys
         {
             var random = new Random();
             Address signer = random.NextAddress();
-            var prevStates = AccountStateDelta.Create(MockAccountState.Empty);
+            var prevState = AccountStateDelta.Create(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
                 signer: signer,
@@ -83,7 +83,7 @@ namespace Libplanet.Tests.Action.Sys
                 miner: random.NextAddress(),
                 blockIndex: 10,
                 blockProtocolVersion: Block.CurrentProtocolVersion,
-                previousStates: prevStates,
+                previousState: prevState,
                 randomSeed: 123,
                 gasLimit: long.MaxValue,
                 rehearsal: false);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -79,7 +79,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, renders[0].Context.BlockIndex);
             Assert.Equal(
                 new IValue[] { null, null, null, null, (Integer)1 },
-                addresses.Select(renders[0].Context.PreviousStates.GetState)
+                addresses.Select(renders[0].Context.PreviousState.GetState)
             );
             Assert.Equal(
                 new IValue[] { (Text)"foo", null, null, null, (Integer)1 },
@@ -89,7 +89,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, renders[1].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(renders[0].NextStates.GetState),
-                addresses.Select(renders[1].Context.PreviousStates.GetState)
+                addresses.Select(renders[1].Context.PreviousState.GetState)
             );
             Assert.Equal(
                 new IValue[] { (Text)"foo", (Text)"bar", null, null, (Integer)1 },
@@ -99,7 +99,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, renders[2].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(renders[1].NextStates.GetState),
-                addresses.Select(renders[2].Context.PreviousStates.GetState)
+                addresses.Select(renders[2].Context.PreviousState.GetState)
             );
             Assert.Equal(
                 new IValue[] { (Text)"foo", (Text)"bar", (Text)"baz", null, (Integer)1 },
@@ -109,7 +109,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(2, renders[3].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(renders[2].NextStates.GetState),
-                addresses.Select(renders[3].Context.PreviousStates.GetState)
+                addresses.Select(renders[3].Context.PreviousState.GetState)
             );
             Assert.Equal(
                 new IValue[]
@@ -136,7 +136,7 @@ namespace Libplanet.Tests.Blockchain
             );
             Assert.Equal(
                 (Integer)1,
-                (Integer)blockRenders[1].Context.PreviousStates.GetState(minerAddress)
+                (Integer)blockRenders[1].Context.PreviousState.GetState(minerAddress)
             );
             Assert.Equal(
                 (Integer)2,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1720,9 +1720,9 @@ namespace Libplanet.Tests.Blockchain
 
             // Build a store with incomplete states
             Block b = chain.Genesis;
-            IAccountStateDelta previousStates = actionEvaluator.PrepareInitialDelta(b);
+            IAccountStateDelta previousState = actionEvaluator.PrepareInitialDelta(b);
             ActionEvaluation[] evals =
-                actionEvaluator.EvaluateBlock(b, previousStates).ToArray();
+                actionEvaluator.EvaluateBlock(b, previousState).ToArray();
             IImmutableDictionary<Address, IValue> dirty = evals.GetDirtyStates();
             const int accountsCount = 5;
             Address[] addresses = Enumerable.Repeat<object>(null, accountsCount)
@@ -1747,9 +1747,9 @@ namespace Libplanet.Tests.Blockchain
                             miner: GenesisProposer.PublicKey,
                             lastCommit: CreateBlockCommit(b)),
                         GenesisProposer);
-                    previousStates = AccountStateDelta.Create(previousStates);
+                    previousState = AccountStateDelta.Create(previousState);
 
-                    dirty = actionEvaluator.EvaluateBlock(b, previousStates).GetDirtyStates();
+                    dirty = actionEvaluator.EvaluateBlock(b, previousState).GetDirtyStates();
                     Assert.NotEmpty(dirty);
                     store.PutBlock(b);
                     BuildIndex(chain.Id, b);

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -33,7 +33,7 @@ namespace Libplanet.Tests.Common.Action
         {
             IImmutableSet<string> usedWeapons = ImmutableHashSet<string>.Empty;
             IImmutableSet<string> targets = ImmutableHashSet<string>.Empty;
-            IAccountStateDelta previousStates = context.PreviousStates;
+            IAccountStateDelta previousStates = context.PreviousState;
 
             object value = previousStates.GetState(TargetAddress);
             if (!ReferenceEquals(value, null))

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -33,9 +33,9 @@ namespace Libplanet.Tests.Common.Action
         {
             IImmutableSet<string> usedWeapons = ImmutableHashSet<string>.Empty;
             IImmutableSet<string> targets = ImmutableHashSet<string>.Empty;
-            IAccountStateDelta previousStates = context.PreviousState;
+            IAccountStateDelta previousState = context.PreviousState;
 
-            object value = previousStates.GetState(TargetAddress);
+            object value = previousState.GetState(TargetAddress);
             if (!ReferenceEquals(value, null))
             {
                 var previousResult = BattleResult.FromBencodex((Bencodex.Types.Dictionary)value);
@@ -47,7 +47,7 @@ namespace Libplanet.Tests.Common.Action
             targets = targets.Add(Target);
             var result = new BattleResult(usedWeapons, targets);
 
-            return previousStates.SetState(TargetAddress, result.ToBencodex());
+            return previousState.SetState(TargetAddress, result.ToBencodex());
         }
     }
 }

--- a/Libplanet.Tests/Common/Action/DelayAction.cs
+++ b/Libplanet.Tests/Common/Action/DelayAction.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Tests.Common.Action
 
         public IAccountStateDelta Execute(IActionContext context)
         {
-            var state = context.PreviousStates;
+            var state = context.PreviousState;
             var started = DateTimeOffset.UtcNow;
             Log.Debug(
                 "{MethodName} exec started. Delay target: {MilliSecond}",

--- a/Libplanet.Tests/Common/Action/DetectRehearsal.cs
+++ b/Libplanet.Tests/Common/Action/DetectRehearsal.cs
@@ -24,9 +24,9 @@ namespace Libplanet.Tests.Common.Action
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
-            IAccountStateDelta previousStates = context.PreviousState;
+            IAccountStateDelta previousState = context.PreviousState;
             ResultState = context.Rehearsal;
-            return previousStates.SetState(
+            return previousState.SetState(
                 TargetAddress,
                 new Bencodex.Types.Boolean(context.Rehearsal)
             );

--- a/Libplanet.Tests/Common/Action/DetectRehearsal.cs
+++ b/Libplanet.Tests/Common/Action/DetectRehearsal.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Tests.Common.Action
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
-            IAccountStateDelta previousStates = context.PreviousStates;
+            IAccountStateDelta previousStates = context.PreviousState;
             ResultState = context.Rehearsal;
             return previousStates.SetState(
                 TargetAddress,

--- a/Libplanet.Tests/Common/Action/DumbAction.cs
+++ b/Libplanet.Tests/Common/Action/DumbAction.cs
@@ -149,7 +149,7 @@ namespace Libplanet.Tests.Common.Action
                     RehearsalRecords.Value.Add((TargetAddress, Item));
             }
 
-            IAccountStateDelta states = context.PreviousStates;
+            IAccountStateDelta states = context.PreviousState;
             if (Item is null)
             {
                 return states;

--- a/Libplanet.Tests/Common/Action/MinerReward.cs
+++ b/Libplanet.Tests/Common/Action/MinerReward.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Tests.Common.Action
 
         public IAccountStateDelta Execute(IActionContext ctx)
         {
-            IAccountStateDelta states = ctx.PreviousStates;
+            IAccountStateDelta states = ctx.PreviousState;
 
             string rewardRecord = (Text?)states.GetState(RewardRecordAddress);
 

--- a/Libplanet.Tests/Common/Action/RandomAction.cs
+++ b/Libplanet.Tests/Common/Action/RandomAction.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Common.Action
 
         public IAccountStateDelta Execute(IActionContext context)
         {
-            IAccountStateDelta states = context.PreviousStates;
+            IAccountStateDelta states = context.PreviousState;
             if (context.Rehearsal)
             {
                 return states.SetState(Address, Null.Value);

--- a/Libplanet.Tests/Common/Action/SetStatesAtBlock.cs
+++ b/Libplanet.Tests/Common/Action/SetStatesAtBlock.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Tests.Common.Action
 
         public IAccountStateDelta Execute(IActionContext context)
         {
-            IAccountStateDelta states = context.PreviousStates;
+            IAccountStateDelta states = context.PreviousState;
             if (context.BlockIndex == _blockIndex)
             {
                 states = states.SetState(_address, _value);

--- a/Libplanet.Tests/Common/Action/SetValidator.cs
+++ b/Libplanet.Tests/Common/Action/SetValidator.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Tests.Common.Action
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public IAccountStateDelta Execute(IActionContext context)
         {
-            return context.PreviousStates.SetValidator(Validator);
+            return context.PreviousState.SetValidator(Validator);
         }
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>

--- a/Libplanet.Tests/Common/Action/Sleep.cs
+++ b/Libplanet.Tests/Common/Action/Sleep.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Tests.Common.Action
         public override IAccountStateDelta Execute(IActionContext context)
         {
             // No-op.
-            return context.PreviousStates;
+            return context.PreviousState;
         }
 
         public override void LoadPlainValue(IValue plainValue)

--- a/Libplanet.Tests/Common/Action/ThrowException.cs
+++ b/Libplanet.Tests/Common/Action/ThrowException.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Tests.Common.Action
                 }
             }
 
-            return context.PreviousStates;
+            return context.PreviousState;
         }
 
         public class SomeException : Exception

--- a/Libplanet.Tests/Fixtures/Arithmetic.cs
+++ b/Libplanet.Tests/Fixtures/Arithmetic.cs
@@ -114,7 +114,7 @@ namespace Libplanet.Tests.Fixtures
                 throw new InvalidOperationException(Error);
             }
 
-            IValue v = context.PreviousStates.GetState(context.Signer) ?? (Bencodex.Types.Integer)0;
+            IValue v = context.PreviousState.GetState(context.Signer) ?? (Bencodex.Types.Integer)0;
             if (!(v is Bencodex.Types.Integer value))
             {
                 throw new InvalidOperationException(
@@ -124,7 +124,7 @@ namespace Libplanet.Tests.Fixtures
 
             Func<BigInteger, BigInteger, BigInteger> func = Operator.ToFunc();
             BigInteger result = func(value, Operand);
-            return context.PreviousStates.SetState(context.Signer, (Bencodex.Types.Integer)result);
+            return context.PreviousState.SetState(context.Signer, (Bencodex.Types.Integer)result);
         }
 
         public bool Equals(Arithmetic other)

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1312,7 +1312,7 @@ namespace Libplanet.Tests.Store
 
             public IAccountStateDelta Execute(IActionContext context)
             {
-                return context.PreviousStates;
+                return context.PreviousState;
             }
         }
     }

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Action
             Address miner,
             long blockIndex,
             int blockProtocolVersion,
-            IAccountStateDelta previousStates,
+            IAccountStateDelta previousState,
             int randomSeed,
             long gasLimit,
             bool rehearsal = false,
@@ -35,7 +35,7 @@ namespace Libplanet.Action
             BlockIndex = blockIndex;
             BlockProtocolVersion = blockProtocolVersion;
             Rehearsal = rehearsal;
-            PreviousStates = previousStates;
+            PreviousState = previousState;
             Random = new Random(randomSeed);
             _randomSeed = randomSeed;
             _gasLimit = gasLimit;
@@ -64,8 +64,8 @@ namespace Libplanet.Action
         /// <inheritdoc cref="IActionContext.Rehearsal"/>
         public bool Rehearsal { get; }
 
-        /// <inheritdoc cref="IActionContext.PreviousStates"/>
-        public IAccountStateDelta PreviousStates { get; }
+        /// <inheritdoc cref="IActionContext.PreviousState"/>
+        public IAccountStateDelta PreviousState { get; }
 
         /// <inheritdoc cref="IActionContext.Random"/>
         public IRandom Random { get; }
@@ -89,7 +89,7 @@ namespace Libplanet.Action
                 Miner,
                 BlockIndex,
                 BlockProtocolVersion,
-                PreviousStates,
+                PreviousState,
                 _randomSeed,
                 _gasLimit,
                 Rehearsal,

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Action
         /// <param name="action">An action to evaluate.</param>
         /// <param name="inputContext">An input <see cref="IActionContext"/> to
         /// evaluate <paramref name="action"/>.</param>
-        /// <param name="outputStates">The result states that
+        /// <param name="outputState">The result states that
         /// <paramref name="action"/> makes.</param>
         /// <param name="logs">The logs recorded while executing action.</param>
         /// <param name="exception">An exception that has risen during evaluating a given
@@ -26,13 +26,13 @@ namespace Libplanet.Action
         public ActionEvaluation(
             IAction action,
             IActionContext inputContext,
-            IAccountStateDelta outputStates,
+            IAccountStateDelta outputState,
             Exception? exception = null,
             List<string>? logs = null)
         {
             Action = action;
             InputContext = inputContext;
-            OutputStates = outputStates;
+            OutputState = outputState;
             Logs = logs ?? new List<string>();
             Exception = exception;
         }
@@ -55,7 +55,7 @@ namespace Libplanet.Action
         /// <summary>
         /// The result states that <see cref="Action"/> makes.
         /// </summary>
-        public IAccountStateDelta OutputStates { get; }
+        public IAccountStateDelta OutputState { get; }
 
         /// <summary>
         /// An exception that had risen during evaluation.

--- a/Libplanet/Action/ActionEvaluationsExtensions.cs
+++ b/Libplanet/Action/ActionEvaluationsExtensions.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Action
             this IReadOnlyList<IActionEvaluation> actionEvaluations)
         {
             return actionEvaluations
-                .Select(eval => eval.OutputStates.Delta)
+                .Select(eval => eval.OutputState.Delta)
                 .ToList()
                 .OrderedSum()
                 .ToRawDelta();

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -109,7 +109,7 @@ namespace Libplanet.Action
                 else
                 {
                     previousStates = evaluations.Count > 0
-                        ? evaluations.Last().OutputStates
+                        ? evaluations.Last().OutputState
                         : previousStates;
                     return evaluations.Add(
                         EvaluatePolicyBlockAction(block, previousStates)
@@ -168,7 +168,7 @@ namespace Libplanet.Action
         /// <list type="bullet">
         /// <item><description>
         ///     The first <see cref="ActionEvaluation"/> in the enumerated result,
-        ///     if any, has <see cref="ActionEvaluation.OutputStates"/> with
+        ///     if any, has <see cref="ActionEvaluation.OutputState"/> with
         ///     <see cref="IAccountStateDelta.Delta"/> that is a
         ///     "superset" of <paramref name="previousStates"/>'s
         ///     <see cref="IAccountStateDelta.Delta"/> (possibly except for
@@ -176,7 +176,7 @@ namespace Libplanet.Action
         /// </description></item>
         /// <item><description>
         ///     Each <see cref="ActionEvaluation"/> in the enumerated result
-        ///     has <see cref="ActionEvaluation.OutputStates"/> with
+        ///     has <see cref="ActionEvaluation.OutputState"/> with
         ///     <see cref="IAccountStateDelta.Delta"/> that is a "superset"
         ///     of the previous one, if any (possibly except for
         ///     <see cref="IAccountDelta.ValidatorSet"/>).
@@ -200,7 +200,7 @@ namespace Libplanet.Action
             ILogger? logger = null)
         {
             ActionContext CreateActionContext(
-                IAccountStateDelta prevStates,
+                IAccountStateDelta prevState,
                 int randomSeed,
                 long actionGasLimit = long.MaxValue,
                 List<string>? logs = null
@@ -212,7 +212,7 @@ namespace Libplanet.Action
                     miner: miner,
                     blockIndex: blockIndex,
                     blockProtocolVersion: blockProtocolVersion,
-                    previousStates: prevStates,
+                    previousState: prevState,
                     randomSeed: randomSeed,
                     gasLimit: actionGasLimit,
                     logs: logs);
@@ -314,7 +314,7 @@ namespace Libplanet.Action
                 yield return new ActionEvaluation(
                     action: action,
                     inputContext: equivalentContext,
-                    outputStates: nextStates,
+                    outputState: nextStates,
                     exception: exc,
                     logs: context.Logs);
 
@@ -409,7 +409,7 @@ namespace Libplanet.Action
                 foreach (ActionEvaluation evaluation in evaluations)
                 {
                     yield return evaluation;
-                    delta = evaluation.OutputStates;
+                    delta = evaluation.OutputState;
                     actions.Add(evaluation.Action);
                 }
 
@@ -506,7 +506,7 @@ namespace Libplanet.Action
         /// </returns>
         internal IAccountStateDelta PrepareInitialDelta(IPreEvaluationBlock block)
         {
-            return AccountStateDelta.Create(_blockChainStates.GetBlockStates(block.PreviousHash));
+            return AccountStateDelta.Create(_blockChainStates.GetBlockState(block.PreviousHash));
         }
 
         [Pure]

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -24,9 +24,9 @@ namespace Libplanet.Action
     /// their own action code it won't affect other honest nodes in
     /// the network.</para>
     /// <para>For example, where honest nodes share the common action
-    /// <c>Heal(Target) => PreviousStates[Target] + 1</c>, suppose a malicious
+    /// <c>Heal(Target) => PreviousState[Target] + 1</c>, suppose a malicious
     /// node <c>m</c> changes their own <c>Heal</c> action code to
-    /// <c>Heal(Target) => PreviousStates[Target] + 2</c> (2 instead of 1),
+    /// <c>Heal(Target) => PreviousState[Target] + 2</c> (2 instead of 1),
     /// and then send an action <c>Heal(m)</c>.
     /// Fortunately, this action does not work as <c>m</c>'s intention,
     /// because the changed code in itself is not used by other honest nodes,
@@ -75,7 +75,7 @@ namespace Libplanet.Action
     ///         // As far as it is serializable, you can store any types.
     ///         // (We recommend to use immutable types though.)
     ///         var state =
-    ///             context.PreviousStates.GetState(TargetAddress);
+    ///             context.PreviousState.GetState(TargetAddress);
     ///         Dictionary dictionary;
     ///         // This variable purposes to store the state
     ///         // right after this action finishes.
@@ -123,7 +123,7 @@ namespace Libplanet.Action
     ///         }
     ///         // Builds a delta (dirty) from previous to next states, and
     ///         // returns it.
-    ///         return context.PreviousStates.SetState(TargetAddress,
+    ///         return context.PreviousState.SetState(TargetAddress,
     ///             (Dictionary)nextState);
     ///     }
     ///     // Serializes its "bound arguments" so that they are transmitted

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Action
         /// <summary>
         /// Whether an <see cref="IAction"/> is being executed during
         /// &#x201c;rehearsal mode&#x201d;, that there is nothing
-        /// in <see cref="PreviousStates"/>.
+        /// in <see cref="PreviousState"/>.
         /// </summary>
         [Pure]
         bool Rehearsal { get; }
@@ -70,7 +70,7 @@ namespace Libplanet.Action
         /// cref="IAction.Execute(IActionContext)"/> method.</para>
         /// </summary>
         [Pure]
-        IAccountStateDelta PreviousStates { get; }
+        IAccountStateDelta PreviousState { get; }
 
         /// <summary>
         /// An initialized pseudorandom number generator.  Its seed (state)

--- a/Libplanet/Action/IActionEvaluation.cs
+++ b/Libplanet/Action/IActionEvaluation.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Action
         /// <summary>
         /// The result states that <see cref="Action"/> makes.
         /// </summary>
-        public IAccountStateDelta OutputStates { get; }
+        public IAccountStateDelta OutputState { get; }
 
         /// <summary>
         /// An exception that had risen during evaluation.

--- a/Libplanet/Action/NullAction.cs
+++ b/Libplanet/Action/NullAction.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Action
 
         public IAccountStateDelta Execute(IActionContext context)
         {
-            return context.PreviousStates;
+            return context.PreviousState;
         }
     }
 }

--- a/Libplanet/Action/Sys/Initialize.cs
+++ b/Libplanet/Action/Sys/Initialize.cs
@@ -67,7 +67,7 @@ namespace Libplanet.Action.Sys
                 );
             }
 
-            IAccountStateDelta states = context.PreviousStates;
+            IAccountStateDelta states = context.PreviousState;
             if (ValidatorSet is { } vs)
             {
                 foreach (Validator v in vs.Validators)

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -233,7 +233,7 @@ namespace Libplanet.Blockchain
                         renderer.RenderAction(
                             evaluation.Action,
                             evaluation.InputContext.GetUnconsumedContext(),
-                            evaluation.OutputStates);
+                            evaluation.OutputState);
                     }
                     else
                     {

--- a/Libplanet/Blockchain/BlockChain.TxExecution.cs
+++ b/Libplanet/Blockchain/BlockChain.TxExecution.cs
@@ -31,7 +31,7 @@ namespace Libplanet.Blockchain
             foreach (IGrouping<TxId, IActionEvaluation> txEvals in evaluationsPerTxs)
             {
                 TxId txid = txEvals.Key;
-                IAccountStateDelta prevStates = txEvals.First().InputContext.PreviousStates;
+                IAccountStateDelta prevStates = txEvals.First().InputContext.PreviousState;
                 IActionEvaluation evalSum = txEvals.Last();
                 var actionsLogsList = txEvals.Select(ae => ae.Logs).ToList();
                 TxExecution txExecution;
@@ -45,7 +45,7 @@ namespace Libplanet.Blockchain
                 }
                 else
                 {
-                    IAccountStateDelta outputStates = evalSum.OutputStates;
+                    IAccountStateDelta outputStates = evalSum.OutputState;
                     txExecution = new TxSuccess(
                         block.Hash,
                         txid,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -556,11 +556,11 @@ namespace Libplanet.Blockchain
         public ValidatorSet GetValidatorSet(BlockHash? offset) =>
             _blockChainStates.GetValidatorSet(offset);
 
-        public IBlockStates GetBlockStates() => GetBlockStates(Tip.Hash);
+        public IBlockState GetBlockStates() => GetBlockState(Tip.Hash);
 
-        /// <inheritdoc cref="IBlockChainStates.GetBlockStates" />
-        public IBlockStates GetBlockStates(BlockHash? offset) =>
-            _blockChainStates.GetBlockStates(offset);
+        /// <inheritdoc cref="IBlockChainStates.GetBlockState" />
+        public IBlockState GetBlockState(BlockHash? offset) =>
+            _blockChainStates.GetBlockState(offset);
 
         /// <summary>
         /// Queries the recorded <see cref="TxExecution"/> for a successful or failed

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -26,29 +26,29 @@ namespace Libplanet.Blockchain
         /// <inheritdoc cref="IBlockChainStates.GetState"/>
         public IValue? GetState(
             Address address, BlockHash? offset) =>
-            GetBlockStates(offset).GetState(address);
+            GetBlockState(offset).GetState(address);
 
         /// <inheritdoc cref="IBlockChainStates.GetStates"/>
         public IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>
-            GetBlockStates(offset).GetStates(addresses);
+            GetBlockState(offset).GetStates(addresses);
 
         /// <inheritdoc cref="IBlockChainStates.GetBalance"/>
         public FungibleAssetValue GetBalance(
             Address address, Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetBalance(address, currency);
+            GetBlockState(offset).GetBalance(address, currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetTotalSupply"/>
         public FungibleAssetValue GetTotalSupply(Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetTotalSupply(currency);
+            GetBlockState(offset).GetTotalSupply(currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet"/>
         public ValidatorSet GetValidatorSet(BlockHash? offset) =>
-            GetBlockStates(offset).GetValidatorSet();
+            GetBlockState(offset).GetValidatorSet();
 
-        /// <inheritdoc cref="IBlockChainStates.GetBlockStates"/>
-        public IBlockStates GetBlockStates(BlockHash? offset) =>
-            new BlockStates(offset, GetStateRoot(offset));
+        /// <inheritdoc cref="IBlockChainStates.GetBlockState"/>
+        public IBlockState GetBlockState(BlockHash? offset) =>
+            new BlockState(offset, GetStateRoot(offset));
 
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>

--- a/Libplanet/Blockchain/IBlockChainStates.cs
+++ b/Libplanet/Blockchain/IBlockChainStates.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Blockchain
         /// at <paramref name="offset"/>.  If absent, returns 0 <see cref="FungibleAssetValue"/>
         /// for <paramref name="currency"/>.
         /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockStates"/> at
+        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockState"/> at
         /// <paramref name="offset"/> cannot be created.</exception>
         FungibleAssetValue GetBalance(
             Address address,
@@ -102,12 +102,12 @@ namespace Libplanet.Blockchain
         /// <paramref name="offset"/> in <see cref="FungibleAssetValue"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/>
         /// for <paramref name="currency"/>.</returns>
-        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockStates"/> at
+        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockState"/> at
         /// <paramref name="offset"/> cannot be created.</exception>
         /// <exception cref="TotalSupplyNotTrackableException">Thrown when
         /// given <paramref name="currency"/>'s <see cref="Currency.TotalSupplyTrackable"/>
         /// is <see langword="false"/>.</exception>
-        /// <seealso cref="GetBlockStates"/>
+        /// <seealso cref="GetBlockState"/>
         FungibleAssetValue GetTotalSupply(
             Currency currency,
             BlockHash? offset);
@@ -121,19 +121,19 @@ namespace Libplanet.Blockchain
         /// <returns>The validator set of type <see cref="ValidatorSet"/> at
         /// <paramref name="offset"/>.
         /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockStates"/> at
+        /// <exception cref="ArgumentException">Thrown when <see cref="IBlockState"/> at
         /// <paramref name="offset"/> cannot be created.</exception>
-        /// <seealso cref="GetBlockStates"/>
+        /// <seealso cref="GetBlockState"/>
         ValidatorSet GetValidatorSet(BlockHash? offset);
 
         /// <summary>
-        /// Returns the <see cref="IBlockStates"/> in the <see cref="BlockChain"/>
+        /// Returns the <see cref="IBlockState"/> in the <see cref="BlockChain"/>
         /// at <paramref name="offset"/>.
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
-        /// for which to create an <see cref="IBlockStates"/>.</param>
+        /// for which to create an <see cref="IBlockState"/>.</param>
         /// <returns>
-        /// The <see cref="IBlockStates"/> at <paramref name="offset"/>.
+        /// The <see cref="IBlockState"/> at <paramref name="offset"/>.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/> is not
         /// <see langword="null"/> and one of the following is true.
@@ -147,7 +147,7 @@ namespace Libplanet.Blockchain
         ///     </description></item>
         /// </list>
         /// </exception>
-        /// <seealso cref="IBlockStates"/>
-        IBlockStates GetBlockStates(BlockHash? offset);
+        /// <seealso cref="IBlockState"/>
+        IBlockState GetBlockState(BlockHash? offset);
     }
 }

--- a/Libplanet/Blockchain/NullChainStates.cs
+++ b/Libplanet/Blockchain/NullChainStates.cs
@@ -17,30 +17,30 @@ namespace Libplanet.Blockchain
 
         public IValue? GetState(
             Address address, BlockHash? offset) =>
-            GetBlockStates(offset).GetState(address);
+            GetBlockState(offset).GetState(address);
 
         public IReadOnlyList<IValue?> GetStates(
             IReadOnlyList<Address> addresses, BlockHash? offset) =>
-            GetBlockStates(offset).GetStates(addresses);
+            GetBlockState(offset).GetStates(addresses);
 
         public FungibleAssetValue GetBalance(
             Address address, Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetBalance(address, currency);
+            GetBlockState(offset).GetBalance(address, currency);
 
         public FungibleAssetValue GetTotalSupply(Currency currency, BlockHash? offset) =>
-            GetBlockStates(offset).GetTotalSupply(currency);
+            GetBlockState(offset).GetTotalSupply(currency);
 
         public ValidatorSet GetValidatorSet(BlockHash? offset) =>
-            GetBlockStates(offset).GetValidatorSet();
+            GetBlockState(offset).GetValidatorSet();
 
-        public IBlockStates GetBlockStates(BlockHash? offset) => new NullBlockStates(offset);
+        public IBlockState GetBlockState(BlockHash? offset) => new NullBlockState(offset);
     }
 
 #pragma warning disable SA1402  // File may only contain a single type
-    internal class NullBlockStates : IBlockStates
+    internal class NullBlockState : IBlockState
 #pragma warning restore SA1402
     {
-        public NullBlockStates(BlockHash? blockHash)
+        public NullBlockState(BlockHash? blockHash)
         {
             BlockHash = blockHash;
         }

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <param name="action">An executed action.</param>
         /// <param name="context">The equivalent context object to an object passed to
         /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// That means <see cref="IActionContext.PreviousState"/> are the states right
         /// <em>before</em> this action executed.  For the states after this action executed,
         /// use the <paramref name="nextStates"/> argument instead.</param>
         /// <param name="nextStates">The states right <em>after</em> this action executed,
@@ -73,7 +73,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <param name="action">An action which threw an exception during execution.</param>
         /// <param name="context">The equivalent context object to an object passed to
         /// the <paramref name="action"/>'s <see cref="IAction.Execute(IActionContext)"/> method.
-        /// That means <see cref="IActionContext.PreviousStates"/> are the states right
+        /// That means <see cref="IActionContext.PreviousState"/> are the states right
         /// <em>before</em> this action executed.</param>
         /// <param name="exception">The exception thrown during executing the <paramref
         /// name="action"/>.</param>

--- a/Libplanet/Blocks/BlockState.cs
+++ b/Libplanet/Blocks/BlockState.cs
@@ -11,22 +11,22 @@ using static Libplanet.State.KeyConverters;
 namespace Libplanet.Blocks
 {
     /// <summary>
-    /// A default implementation of <see cref="IBlockStates"/> interface.
+    /// A default implementation of <see cref="IBlockState"/> interface.
     /// </summary>
-    public class BlockStates : IBlockStates
+    public class BlockState : IBlockState
     {
         private BlockHash? _blockHash;
         private ITrie _stateRoot;
-        private BlockStatesCache _cache;
+        private BlockStateCache _cache;
 
-        internal BlockStates(BlockHash? blockHash, ITrie stateRoot)
+        internal BlockState(BlockHash? blockHash, ITrie stateRoot)
         {
             _blockHash = blockHash;
             _stateRoot = stateRoot;
-            _cache = new BlockStatesCache();
+            _cache = new BlockStateCache();
         }
 
-        /// <inheritdoc cref="IBlockStates.BlockHash"/>
+        /// <inheritdoc cref="IBlockState.BlockHash"/>
         public BlockHash? BlockHash => _blockHash;
 
         /// <inheritdoc cref="IAccountState.GetState"/>

--- a/Libplanet/Blocks/BlockStateCache.cs
+++ b/Libplanet/Blocks/BlockStateCache.cs
@@ -6,7 +6,7 @@ using Serilog;
 
 namespace Libplanet.Blocks
 {
-    internal class BlockStatesCache
+    internal class BlockStateCache
     {
         public const int CacheSize = 1_000;
         public const int ReportPeriod = 1_000;
@@ -15,7 +15,7 @@ namespace Libplanet.Blocks
         private int _getAttempts;
         private int _getSuccesses;
 
-        public BlockStatesCache()
+        public BlockStateCache()
         {
             _cache = new LruCache<Address, IValue?>(CacheSize);
             _getAttempts = 0;
@@ -41,7 +41,7 @@ namespace Libplanet.Blocks
             {
                 // NOTE: This is only an estimation due to concurrency (or lack there of).
                 Log
-                    .ForContext("Source", nameof(BlockStatesCache))
+                    .ForContext("Source", nameof(BlockStateCache))
                     .ForContext("Tag", "Metric")
                     .ForContext("Subtag", "StatesCacheReport")
                     .Debug(

--- a/Libplanet/Blocks/IBlockState.cs
+++ b/Libplanet/Blocks/IBlockState.cs
@@ -3,13 +3,13 @@ using Libplanet.State;
 namespace Libplanet.Blocks
 {
     /// <summary>
-    /// A minimal interface to get states from output states of a <see cref="Block"/>.
+    /// A minimal interface to get states from the output state of a <see cref="Block"/>.
     /// </summary>
-    public interface IBlockStates : IAccountState
+    public interface IBlockState : IAccountState
     {
         /// <summary>
         /// The <see cref="Block.Hash"/> of the <see cref="Block"/> that this
-        /// <see cref="IBlockStates"/> represents.  This can be <see langword="null"/>
+        /// <see cref="IBlockState"/> represents.  This can be <see langword="null"/>
         /// in which case represents initial default states.
         /// </summary>
         BlockHash? BlockHash { get; }


### PR DESCRIPTION
For consistency. Seems like singular "state" is more apt for describing the "state" of an "account".