### PR TITLE
Update gossip to forget only with NewRound

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,6 @@ To be released.
 
 ### Deprecated APIs
 
- -  (Libplanet.Net) Removed `MessageCache` class.  [[#3260]]
  -  (Libplanet.Net) Removed `ConsensusContext.BroadcastMessage` property.
     [[#3260]]
 
@@ -40,6 +39,7 @@ To be released.
     `Context`.  [[#3260]]
  -  (Libplanet.Net) Renamed `Context.BroadcastMessage(ConsensusMsg)`
     as `Context.PublishMessage(ConsensusMsg)`.  [[#3260]]
+ -  (Libplanet.Net) Removed constructor of `MessageCache` class.  [[#3260]]
  -  (Libplanet.Explorer) Changed `TxResult.UpdatedStates`'s type to
     `IImmutableDictionary<Address, IValue>` from
     `IImmutableDictionary<Address, IValue?>`.  [[#3262]]
@@ -100,9 +100,9 @@ To be released.
     any more. Instead, logic change on `Gossip` solves bootstrapping
     problem.  [[#3260]]
  -  (Libplanet.Net) `Context.Start()` now triggers
-    `IConsensusMessageCommunicator.ClearDenySet()`.  [[#3260]]
- -  (Libplanet.Net) Spam filter logic now denies messages by
-    `Message.ValidatorPublicKey`.  [[#3260]]
+    `IConsensusMessageCommunicator.OnStartHeight()`.  [[#3260]]
+ -  (Libplanet.Net) `Context.StartRound()` now triggers
+    `IConsensusMessageCommunicator.OnStartRound()`.  [[#3260]]
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ To be released.
 
 ### Deprecated APIs
 
+ -  (Libplanet.Net) Removed `MessageCache` class.  [[#3260]]
+ -  (Libplanet.Net) Removed `ConsensusContext.BroadcastMessage` property.
+    [[#3260]]
+
 ### Backward-incompatible API changes
 
  -  `Vote.BlockHash` property became `BlockHash` type. (was `BlockHash?`)
@@ -21,6 +25,21 @@ To be released.
  -  (Libplanet.Net) `ConsensusProposalMsg`, `ConsensusPreVoteMsg` and
     `ConsensusPreCommitMsg` became to inherit `ConsensusVoteMsg`.  [[#3249]]
  -  (Libplanet.Net) Removed `ConsensusMsg.BlockHash` property.  [[#3249]]
+ -  (Libplanet.Net) Added `Flag` property to `ConsensusVoteMsg` abstract class.
+    [[#3260]]
+ -  (Libplanet.Net) `ConsensusProposalMsg` no longer inherits
+    `ConsensusVoteMsg`. Instead, inherits `ConsensusMsg`.  [[#3260]]
+ -  (Libplanet.Net) Added parameter
+    `IConsensusMessageCommunicator consensusMessageCommunicator` to
+    `ConsensusContext`.  [[#3260]]
+ -  (Libplanet.Net) Removed parameter
+    `DelegateBroadcastMessage broadcastMessage` from `ConsensusContext`.
+    [[#3260]]
+ -  (Libplanet.Net) Added parameter
+    `IConsensusMessageCommunicator consensusMessageCommunicator` to
+    `Context`.  [[#3260]]
+ -  (Libplanet.Net) Renamed `Context.BroadcastMessage(ConsensusMsg)`
+    as `Context.PublishMessage(ConsensusMsg)`.  [[#3260]]
  -  (Libplanet.Explorer) Changed `TxResult.UpdatedStates`'s type to
     `IImmutableDictionary<Address, IValue>` from
     `IImmutableDictionary<Address, IValue?>`.  [[#3262]]
@@ -63,8 +82,27 @@ To be released.
  -  Changes `IActionContext.PreviousStates` to `IActionContext.PreviousState`.
  -  Changed `IActionEvaluation.OutputStates` to `IActionEvaluation.OutputState`.
     [[#3259]]
+ -  (Libplanet.Net) Added `IConsensusMessageCommunicator` interface
+    and its related classes.  [[#3260]]
+     -  (Libplanet.Net) Added `GossipConsensusMessageCommunicator` class.
+        [[#3260]]
+ -  (Libplanet.Net) Added `Gossip.DenyPeer(BoundPeer)` method.  [[#3260]]
+ -  (Libplanet.Net) Added `Gossip.AllowPeer(BoundPeer)` method.  [[#3260]]
+ -  (Libplanet.Net) Added `Gossip.ClearCache()` method.  [[#3260]]
+ -  (Libplanet.Net) Added `Gossip.ClearDenySet(BoundPeer)` method.  [[#3260]]
 
 ### Behavioral changes
+
+ -  (Libplanet.Net) `Gossip` now maintains single message cache,
+    and contents of this cache does not decayed by time or new messages.
+    This cache is cleared only by `Gossip.ClearCache()` method.  [[#3260]]
+ -  (Libplanet.Net) There are no mechanism for bootstrapping conensus
+    any more. Instead, logic change on `Gossip` solves bootstrapping
+    problem.  [[#3260]]
+ -  (Libplanet.Net) `Context.Start()` now triggers
+    `IConsensusMessageCommunicator.ClearDenySet()`.  [[#3260]]
+ -  (Libplanet.Net) Spam filter logic now denies messages by
+    `Message.ValidatorPublicKey`.  [[#3260]]
 
 ### Bug fixes
 
@@ -76,6 +114,7 @@ To be released.
 [#3256]: https://github.com/planetarium/libplanet/pull/3256
 [#3257]: https://github.com/planetarium/libplanet/pull/3257
 [#3259]: https://github.com/planetarium/libplanet/pull/3259
+[#3260]: https://github.com/planetarium/libplanet/pull/3260
 [#3262]: https://github.com/planetarium/libplanet/pull/3262
 
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
@@ -46,7 +46,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.PrivateKeys[2]);
             blockChain.TipChanged += (_, __) => tipChanged.Set();
-            consensusContext.MessageBroadcasted += (_, eventArgs) =>
+            consensusContext.MessagePublished += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 2 && eventArgs.Message is ConsensusProposalMsg proposalMsg)
                 {
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Tests.Consensus
                     }
                 }
             };
-            consensusContext.MessageBroadcasted += (_, eventArgs) =>
+            consensusContext.MessagePublished += (_, eventArgs) =>
             {
                 if (eventArgs.Message is ConsensusProposalMsg proposalMsg)
                 {
@@ -295,7 +295,7 @@ namespace Libplanet.Net.Tests.Consensus
                     heightOneEndCommit.Set();
                 }
             };
-            consensusContext.MessageBroadcasted += (_, eventArgs) =>
+            consensusContext.MessagePublished += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 2 && eventArgs.Message is ConsensusProposalMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Net.Tests.Consensus
                     heightFourStepChangedToPropose.Set();
                 }
             };
-            consensusContext.MessageBroadcasted += (_, eventArgs) =>
+            consensusContext.MessagePublished += (_, eventArgs) =>
             {
                 if (eventArgs.Message is ConsensusProposalMsg proposalMsg)
                 {
@@ -204,7 +204,7 @@ namespace Libplanet.Net.Tests.Consensus
                     heightOneEndCommit.Set();
                 }
             };
-            consensusContext.MessageBroadcasted += (_, eventArgs) =>
+            consensusContext.MessagePublished += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 1 && eventArgs.Message is ConsensusProposalMsg proposalMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -157,8 +157,7 @@ namespace Libplanet.Net.Tests.Consensus
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
                 TimeSpan.FromSeconds(1),
                 TestUtils.Policy,
-                TestUtils.PrivateKeys[1],
-                blockCommitClearThreshold: 1);
+                TestUtils.PrivateKeys[1]);
 
             // Create context of index 1.
             consensusContext.NewHeight(1);

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -91,7 +91,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg)
                 {
@@ -161,7 +161,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg &&
                     preCommitMsg.BlockHash.Equals(default))
@@ -212,7 +212,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -285,7 +285,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -347,7 +347,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -465,7 +465,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg)
                 {
@@ -88,7 +88,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -189,7 +189,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToEndCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -239,7 +239,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -271,7 +271,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -309,7 +309,7 @@ namespace Libplanet.Net.Tests.Consensus
                 privateKey: TestUtils.PrivateKeys[2],
                 height: 2,
                 validatorSet: TestUtils.ValidatorSet);
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
@@ -49,7 +49,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
             context.TimeoutProcessed += (_, __) => timeoutProcessed = true;
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
             context.TimeoutProcessed += (_, __) => timeoutProcessed = true;
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg)
                 {
@@ -90,7 +90,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -148,7 +148,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToEndCommit.Set();
                 }
             };
-            context.MessageBroadcasted += (_, message) =>
+            context.MessagePublished += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -303,15 +303,14 @@ namespace Libplanet.Net.Tests.Consensus
                 });
 
             var consensusContext = new ConsensusContext(
-                BroadcastMessage,
-                () => { },
+                new TestUtils.DummyConsensusMessageHandler(BroadcastMessage),
                 blockChain,
                 TestUtils.PrivateKeys[0],
                 newHeightDelay,
                 new ContextTimeoutOption());
 
             context = new Context(
-                consensusContext,
+                new TestUtils.DummyConsensusMessageHandler(BroadcastMessage),
                 blockChain,
                 1L,
                 TestUtils.PrivateKeys[0],

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -304,6 +304,7 @@ namespace Libplanet.Net.Tests.Consensus
 
             var consensusContext = new ConsensusContext(
                 BroadcastMessage,
+                () => { },
                 blockChain,
                 TestUtils.PrivateKeys[0],
                 newHeightDelay,

--- a/Libplanet.Net.Tests/Consensus/GossipTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipTest.cs
@@ -236,7 +236,7 @@ namespace Libplanet.Net.Tests.Consensus
                 ImmutableArray<BoundPeer>.Empty,
                 ImmutableArray<BoundPeer>.Empty,
                 _ => { },
-                TimeSpan.FromMinutes(2));
+                _ => { });
             var transport2 = CreateTransport(key2, 6002);
             try
             {
@@ -371,8 +371,8 @@ namespace Libplanet.Net.Tests.Consensus
                 transport,
                 peers?.ToImmutableArray() ?? ImmutableArray<BoundPeer>.Empty,
                 seeds?.ToImmutableArray() ?? ImmutableArray<BoundPeer>.Empty,
-                processMessage,
-                TimeSpan.FromMinutes(2));
+                _ => { },
+                processMessage);
         }
 
         private NetMQTransport CreateTransport(

--- a/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
+++ b/Libplanet.Net.Tests/Consensus/MessageCacheTest.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 using Libplanet.Net.Messages;
-using Libplanet.Tests.Store;
 using Xunit;
 
 namespace Libplanet.Net.Tests.Consensus
@@ -11,20 +9,9 @@ namespace Libplanet.Net.Tests.Consensus
     public class MessageCacheTest
     {
         [Fact]
-        public void Constructor()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>("len", () => new MessageCache(-1, 3));
-            Assert.Throws<ArgumentOutOfRangeException>("len", () => new MessageCache(0, 3));
-            Assert.Throws<ArgumentOutOfRangeException>("gossip", () => new MessageCache(3, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("gossip", () => new MessageCache(3, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("gossip", () => new MessageCache(3, 4));
-            _ = new MessageCache(3, 3);
-        }
-
-        [Fact]
         public void Put()
         {
-            var cache = new MessageCache(3, 3);
+            var cache = new MessageCache();
             var msg = new PingMsg();
             cache.Put(msg);
             Assert.Throws<ArgumentException>("message", () => cache.Put(msg));
@@ -33,7 +20,7 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void Get()
         {
-            var cache = new MessageCache(3, 3);
+            var cache = new MessageCache();
             var messageId = TestUtils.GetRandomBytes(MessageId.Size);
             // Had to use HaveMessage for testing the persistent dataFrame.
             var msg = new HaveMessage(new[] { messageId });
@@ -45,51 +32,6 @@ namespace Libplanet.Net.Tests.Consensus
             // Message data is persistent
             Assert.Equal(msg.Type, ret.Type);
             Assert.Equal(msg.Ids, ((HaveMessage)ret).Ids);
-        }
-
-        [Fact]
-        public void GetGossipIds_Shift()
-        {
-            MemoryStoreFixture fx = new MemoryStoreFixture();
-            var cache = new MessageCache(2, 1);
-            var key = new PrivateKey();
-            var msg0 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 0);
-            var msg1 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 1);
-            var msg2 = TestUtils.CreateConsensusPropose(fx.Block1, key, 0, 2);
-            cache.Put(msg0);
-            cache.Put(msg1);
-            var ids = cache.GetGossipIds();
-            Assert.Equal(2, ids.Length);
-
-            // NOTE: For linux-mono-build compatibility.
-            Assert.Equal(
-                new HashSet<MessageId>(new[] { msg0.Id, msg1.Id }),
-                new HashSet<MessageId>(ids));
-            Assert.Equal(msg0, cache.Get(msg0.Id));
-            Assert.Equal(msg1, cache.Get(msg1.Id));
-
-            cache.Shift();
-            cache.Put(msg2);
-            ids = cache.GetGossipIds();
-            Assert.Single(ids);
-            Assert.Equal(msg2.Id, ids[0]);
-            Assert.Equal(msg0, cache.Get(msg0.Id));
-            Assert.Equal(msg1, cache.Get(msg1.Id));
-            Assert.Equal(msg2, cache.Get(msg2.Id));
-
-            cache.Shift();
-            ids = cache.GetGossipIds();
-            Assert.Empty(ids);
-            Assert.Throws<KeyNotFoundException>(() => cache.Get(msg0.Id));
-            Assert.Throws<KeyNotFoundException>(() => cache.Get(msg1.Id));
-            Assert.Equal(msg2, cache.Get(msg2.Id));
-
-            cache.Shift();
-            ids = cache.GetGossipIds();
-            Assert.Empty(ids);
-            Assert.Throws<KeyNotFoundException>(() => cache.Get(msg0.Id));
-            Assert.Throws<KeyNotFoundException>(() => cache.Get(msg1.Id));
-            Assert.Throws<KeyNotFoundException>(() => cache.Get(msg2.Id));
         }
     }
 }

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -479,7 +479,7 @@ namespace Libplanet.Net.Tests
                 // After swarm[1] comes online, eventually it'll catch up to vote PreCommit,
                 // at which point the round will move to 1 where swarm[2] is the proposer.
                 _ = swarms[1].StartAsync();
-                swarms[2].ConsensusReactor.ConsensusContext.MessageBroadcasted += (_, eventArgs) =>
+                swarms[2].ConsensusReactor.ConsensusContext.MessagePublished += (_, eventArgs) =>
                 {
                     if (eventArgs.Message is ConsensusProposalMsg proposalMsg &&
                         proposalMsg.Round == 1 &&

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -244,6 +244,7 @@ namespace Libplanet.Net.Tests
 
             consensusContext = new ConsensusContext(
                 broadcastMessage,
+                () => { },
                 blockChain,
                 privateKey,
                 newHeightDelay,

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -329,24 +329,16 @@ namespace Libplanet.Net.Tests
                 _publishMessage = publishMessage;
             }
 
-            public void AllowPublicKey(PublicKey publicKey)
-            {
-            }
-
-            public void ClearCache()
-            {
-            }
-
-            public void ClearDenySet()
-            {
-            }
-
-            public void DenyPublicKey(PublicKey publicKey)
-            {
-            }
-
             public void PublishMessage(ConsensusMsg message)
                 => _publishMessage(message);
+
+            public void OnStartHeight(long height)
+            {
+            }
+
+            public void OnStartRound(int round)
+            {
+            }
         }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -37,12 +37,6 @@ namespace Libplanet.Net.Consensus
                 MessageConsumed?.Invoke(this, (context.Height, message));
             context.MutationConsumed += (sender, action) =>
                 MutationConsumed?.Invoke(this, (context.Height, action));
-
-            if (_bootstrapping)
-            {
-                context.StateChanged += (sender, eventArgs) =>
-                    OnContextStateChanged(sender, eventArgs);
-            }
         }
     }
 }

--- a/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -14,8 +14,8 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="Context.StateChanged"/>
         internal event EventHandler<Context.ContextState>? StateChanged;
 
-        /// <inheritdoc cref="Context.MessageBroadcasted"/>
-        internal event EventHandler<(long Height, ConsensusMsg Message)>? MessageBroadcasted;
+        /// <inheritdoc cref="Context.MessagePublished"/>
+        internal event EventHandler<(long Height, ConsensusMsg Message)>? MessagePublished;
 
         /// <inheritdoc cref="Context.MessageConsumed"/>
         internal event EventHandler<(long Height, ConsensusMsg Message)>? MessageConsumed;
@@ -31,8 +31,8 @@ namespace Libplanet.Net.Consensus
                 TimeoutProcessed?.Invoke(this, (context.Height, eventArgs.Round, eventArgs.Step));
             context.StateChanged += (sender, eventArgs) =>
                 StateChanged?.Invoke(this, eventArgs);
-            context.MessageBroadcasted += (sender, message) =>
-                MessageBroadcasted?.Invoke(this, (context.Height, message));
+            context.MessagePublished += (sender, message) =>
+                MessagePublished?.Invoke(this, (context.Height, message));
             context.MessageConsumed += (sender, message) =>
                 MessageConsumed?.Invoke(this, (context.Height, message));
             context.MutationConsumed += (sender, action) =>

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Net.Consensus
         private readonly object _contextLock;
         private readonly object _newHeightLock;
         private readonly ContextTimeoutOption _contextTimeoutOption;
-        private readonly IConsensusMessageCommunicator _consensusMessageHandler;
+        private readonly IConsensusMessageCommunicator _consensusMessageCommunicator;
         private readonly BlockChain _blockChain;
         private readonly PrivateKey _privateKey;
         private readonly TimeSpan _newHeightDelay;
@@ -50,7 +50,7 @@ namespace Libplanet.Net.Consensus
             TimeSpan newHeightDelay,
             ContextTimeoutOption contextTimeoutOption)
         {
-            _consensusMessageHandler = consensusMessageCommunicator;
+            _consensusMessageCommunicator = consensusMessageCommunicator;
             _blockChain = blockChain;
             _privateKey = privateKey;
             Height = -1;
@@ -327,7 +327,7 @@ namespace Libplanet.Net.Consensus
         {
             // blockchain may not contain block of Height - 1?
             var context = new Context(
-                _consensusMessageHandler,
+                _consensusMessageCommunicator,
                 _blockChain,
                 height,
                 _privateKey,

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -66,6 +66,7 @@ namespace Libplanet.Net.Consensus
 
             _consensusContext = new ConsensusContext(
                 PublishMessage,
+                ClearGossip,
                 blockChain,
                 privateKey,
                 newHeightDelay,
@@ -151,6 +152,11 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="message">A <see cref="ConsensusMsg"/> to add.</param>
         private void PublishMessage(ConsensusMsg message) => _gossip.PublishMessage(message);
+
+        /// <summary>
+        /// Clears to gossip message cache.
+        /// </summary>
+        private void ClearGossip() => _gossip.Clear();
 
         /// <summary>
         /// A handler for received <see cref="Message"/>s.

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -13,10 +13,7 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="lastCommit">A <see cref="Block.LastCommit"/> from previous block.
         /// </param>
-        /// <param name="bootstrapping">A <see langword="bool"/> flag indicating whether
-        /// this <see cref="Context"/> should run as a bootstrapping <see cref="Context"/>
-        /// or not.</param>
-        public void Start(BlockCommit? lastCommit = null, bool bootstrapping = false)
+        public void Start(BlockCommit? lastCommit = null)
         {
             _logger.Information(
                 "Starting context for height #{Height}, LastCommit: {LastCommit}",

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -20,6 +20,7 @@ namespace Libplanet.Net.Consensus
                 Height,
                 lastCommit);
             _lastCommit = lastCommit;
+            _consensusMessageCommunicator.ClearDenySet();
             ProduceMutation(() => StartRound(0));
 
             // FIXME: Exceptions inside tasks should be handled properly.

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Net.Consensus
                 Height,
                 lastCommit);
             _lastCommit = lastCommit;
-            _consensusMessageCommunicator.ClearDenySet();
+            _consensusMessageCommunicator.OnStartHeight(Height);
             ProduceMutation(() => StartRound(0));
 
             // FIXME: Exceptions inside tasks should be handled properly.

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Net.Consensus
         internal event EventHandler<ContextState>? StateChanged;
 
         /// <summary>
-        /// An event that is invoked when a <see cref="ConsensusMsg"/> is broadcasted.
+        /// An event that is invoked when a <see cref="ConsensusMsg"/> is published.
         /// </summary>
         internal event EventHandler<ConsensusMsg>? MessageBroadcasted;
 

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -26,7 +26,7 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// An event that is invoked when a <see cref="ConsensusMsg"/> is published.
         /// </summary>
-        internal event EventHandler<ConsensusMsg>? MessageBroadcasted;
+        internal event EventHandler<ConsensusMsg>? MessagePublished;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMsg"/> is consumed.

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -18,6 +18,7 @@ namespace Libplanet.Net.Consensus
         /// <param name="round">The round to start.</param>
         private void StartRound(int round)
         {
+            ConsensusContext.ClearGossip();
             _logger.Information(
                 "Starting round {NewRound} (was {PrevRound}). (context: {Context})",
                 round,

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -341,7 +341,7 @@ namespace Libplanet.Net.Consensus
         private void PublishMessage(ConsensusMsg message)
         {
             _consensusMessageCommunicator.PublishMessage(message);
-            MessageBroadcasted?.Invoke(this, message);
+            MessagePublished?.Invoke(this, message);
         }
 
         /// <summary>

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -336,8 +336,8 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// Publish <see cref="ConsensusMsg"/> to validators.
         /// </summary>
-        /// <param name="message">A <see cref="ConsensusMsg"/> to broadcast.</param>
-        /// <remarks><see cref="ConsensusMsg"/> should be broadcasted to itself.</remarks>
+        /// <param name="message">A <see cref="ConsensusMsg"/> to publish.</param>
+        /// <remarks><see cref="ConsensusMsg"/> should be published to itself.</remarks>
         private void PublishMessage(ConsensusMsg message)
         {
             _consensusMessageCommunicator.PublishMessage(message);

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -105,7 +105,6 @@ namespace Libplanet.Net.Consensus
         private Block? _decision;
         private int _committedRound;
         private BlockCommit? _lastCommit;
-        private Dictionary<PublicKey, List<int>> _peerCatchupRounds;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Context"/> class.
@@ -180,7 +179,6 @@ namespace Libplanet.Net.Consensus
             _validRound = -1;
             _decision = null;
             _committedRound = -1;
-            _peerCatchupRounds = new Dictionary<PublicKey, List<int>>();
             _blockChain = blockChain;
             _codec = new Codec();
             _messageRequests = Channel.CreateUnbounded<ConsensusMsg>();

--- a/Libplanet.Net/Consensus/GossipConsensusMessageCommunicator.cs
+++ b/Libplanet.Net/Consensus/GossipConsensusMessageCommunicator.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+using Libplanet.Net.Transports;
+
+namespace Libplanet.Net.Consensus
+{
+    /// <summary>
+    /// An <see cref="IConsensusMessageCommunicator"/> implementation using <see cref="Gossip"/>.
+    /// </summary>
+    public class GossipConsensusMessageCommunicator : IConsensusMessageCommunicator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GossipConsensusMessageCommunicator"/>
+        /// class.
+        /// </summary>
+        /// <param name="consensusTransport">An <see cref="ITransport"/> for sending the
+        /// <see cref="ConsensusMsg"/>s to validators.</param>
+        /// <param name="validatorPeers">A list of validator's <see cref="BoundPeer"/>,
+        /// including itself.
+        /// </param>
+        /// <param name="seedPeers">A list of seed's <see cref="BoundPeer"/>.</param>
+        /// <param name="processMessage">Action to be called when receiving a new
+        /// <see cref="ConsensusMsg"/>.</param>
+        public GossipConsensusMessageCommunicator(
+            ITransport consensusTransport,
+            ImmutableArray<BoundPeer> validatorPeers,
+            ImmutableArray<BoundPeer> seedPeers,
+            Action<MessageContent> processMessage)
+        {
+            Gossip = new Gossip(
+                consensusTransport, validatorPeers, seedPeers, ValidateMessage, processMessage);
+        }
+
+        /// <summary>
+        /// <see cref="Gossip"/> of <see cref="GossipConsensusMessageCommunicator"/>.
+        /// </summary>
+        internal Gossip Gossip { get; }
+
+        /// <inheritdoc/>
+        public void PublishMessage(ConsensusMsg message)
+            => Gossip.PublishMessage(message);
+
+        /// <inheritdoc/>
+        public void DenyPublicKey(PublicKey publicKey)
+        {
+            IEnumerable<BoundPeer> peers = Gossip.Peers.Where(p => p.PublicKey == publicKey);
+            foreach (BoundPeer peer in peers)
+            {
+                Gossip.DenyPeer(peer);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void AllowPublicKey(PublicKey publicKey)
+        {
+            IEnumerable<BoundPeer> peers = Gossip.Peers.Where(p => p.PublicKey == publicKey);
+            foreach (BoundPeer peer in peers)
+            {
+                Gossip.AllowPeer(peer);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void ClearCache() => Gossip.ClearCache();
+
+        /// <inheritdoc/>
+        public void ClearDenySet() => Gossip.ClearDenySet();
+
+        private void ValidateMessage(Message message)
+        {
+            if (message.Content is ConsensusMsg consensusMsg
+                && message.Remote.PublicKey.Equals(consensusMsg.ValidatorPublicKey))
+            {
+                throw new InvalidConsensusMessageException(
+                    $"Public key of ConsensusMessage is different from" +
+                    $"Peer's public key that has been sent : {message.Remote.PublicKey}",
+                    consensusMsg);
+            }
+        }
+    }
+}

--- a/Libplanet.Net/Consensus/HeightVoteSet.cs
+++ b/Libplanet.Net/Consensus/HeightVoteSet.cs
@@ -146,15 +146,18 @@ namespace Libplanet.Net.Consensus
                         vote);
                 }
 
+                VoteSet voteSet;
                 try
                 {
-                    GetVoteSet(vote.Round, vote.Flag).AddVote(vote);
+                    voteSet = GetVoteSet(vote.Round, vote.Flag);
                 }
                 catch (KeyNotFoundException)
                 {
-                    throw new InvalidVoteException(
-                        $"Got vote from unwanted round {vote.Round}", vote);
+                    AddRound(vote.Round);
+                    voteSet = GetVoteSet(vote.Round, vote.Flag);
                 }
+
+                voteSet.AddVote(vote);
             }
         }
 

--- a/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
+++ b/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
@@ -1,0 +1,39 @@
+using Libplanet.Crypto;
+using Libplanet.Net.Messages;
+
+namespace Libplanet.Net.Consensus
+{
+    /// <summary>
+    /// Interface for communicating <see cref="ConsensusMsg"/>s with peers.
+    /// </summary>
+    public interface IConsensusMessageCommunicator
+    {
+        /// <summary>
+        /// Publish given <paramref name="message"/> to peers.
+        /// </summary>
+        /// <param name="message"><see cref="ConsensusMsg"/> to publish.</param>
+        public void PublishMessage(ConsensusMsg message);
+
+        /// <summary>
+        /// Deny <see cref="ConsensusMsg"/>s from given <paramref name="publicKey"/>.
+        /// </summary>
+        /// <param name="publicKey"><see cref="PublicKey"/> to deny.</param>
+        public void DenyPublicKey(PublicKey publicKey);
+
+        /// <summary>
+        /// Allow <see cref="ConsensusMsg"/>s from given <paramref name="publicKey"/>.
+        /// </summary>
+        /// <param name="publicKey"><see cref="PublicKey"/> to allow.</param>
+        public void AllowPublicKey(PublicKey publicKey);
+
+        /// <summary>
+        /// Clear cache of consensus message communicator.
+        /// </summary>
+        public void ClearCache();
+
+        /// <summary>
+        /// Clear deny set to allow messages from any peers.
+        /// </summary>
+        public void ClearDenySet();
+    }
+}

--- a/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
+++ b/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
@@ -1,4 +1,3 @@
-using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -15,25 +14,19 @@ namespace Libplanet.Net.Consensus
         public void PublishMessage(ConsensusMsg message);
 
         /// <summary>
-        /// Deny <see cref="ConsensusMsg"/>s from given <paramref name="publicKey"/>.
+        /// Method that will be called on the
+        /// <see cref="Context.Start(Blocks.BlockCommit?)"/> call.
         /// </summary>
-        /// <param name="publicKey"><see cref="PublicKey"/> to deny.</param>
-        public void DenyPublicKey(PublicKey publicKey);
+        /// <param name="height"><see cref="Context.Height"/>
+        /// to trigger this method.</param>
+        public void OnStartHeight(long height);
 
         /// <summary>
-        /// Allow <see cref="ConsensusMsg"/>s from given <paramref name="publicKey"/>.
+        /// Method that will be called on the
+        /// <see cref="Context.StartRound(int)"/> call.
         /// </summary>
-        /// <param name="publicKey"><see cref="PublicKey"/> to allow.</param>
-        public void AllowPublicKey(PublicKey publicKey);
-
-        /// <summary>
-        /// Clear cache of consensus message communicator.
-        /// </summary>
-        public void ClearCache();
-
-        /// <summary>
-        /// Clear deny set to allow messages from any peers.
-        /// </summary>
-        public void ClearDenySet();
+        /// <param name="round"><see cref="Context.Round"/>
+        /// to trigger this method.</param>
+        public void OnStartRound(int round);
     }
 }

--- a/Libplanet.Net/Messages/ConsensusPreCommitMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusPreCommitMsg.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Net.Messages
         /// <exception cref="ArgumentException">Thrown when given <paramref name="vote"/>'s
         /// <see cref="Vote.Flag"/> is not <see cref="VoteFlag.PreCommit"/>.</exception>
         public ConsensusPreCommitMsg(Vote vote)
-            : base(vote.ValidatorPublicKey, vote.Height, vote.Round, vote.BlockHash)
+            : base(vote.ValidatorPublicKey, vote.Height, vote.Round, vote.BlockHash, vote.Flag)
         {
             if (vote.Flag != VoteFlag.PreCommit)
             {

--- a/Libplanet.Net/Messages/ConsensusPreVoteMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusPreVoteMsg.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Net.Messages
         /// <exception cref="ArgumentException">Thrown when given <paramref name="vote"/>'s
         /// <see cref="Vote.Flag"/> is not <see cref="VoteFlag.PreVote"/>.</exception>
         public ConsensusPreVoteMsg(Vote vote)
-            : base(vote.ValidatorPublicKey, vote.Height, vote.Round, vote.BlockHash)
+            : base(vote.ValidatorPublicKey, vote.Height, vote.Round, vote.BlockHash, vote.Flag)
         {
             if (vote.Flag != VoteFlag.PreVote)
             {

--- a/Libplanet.Net/Messages/ConsensusProposalMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusProposalMsg.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Consensus;
 
@@ -8,7 +9,7 @@ namespace Libplanet.Net.Messages
     /// <summary>
     /// A message class for <see cref="ConsensusStep.Propose"/>.
     /// </summary>
-    public class ConsensusProposalMsg : ConsensusVoteMsg
+    public class ConsensusProposalMsg : ConsensusMsg
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsensusProposalMsg"/> class.
@@ -16,9 +17,10 @@ namespace Libplanet.Net.Messages
         /// <param name="proposal">A <see cref="Proposal"/> of given height and round.</param>
         public ConsensusProposalMsg(
             Proposal proposal)
-            : base(proposal.ValidatorPublicKey, proposal.Height, proposal.Round, proposal.BlockHash)
+            : base(proposal.ValidatorPublicKey, proposal.Height, proposal.Round)
         {
             Proposal = proposal;
+            BlockHash = proposal.BlockHash;
         }
 
         /// <summary>
@@ -35,6 +37,11 @@ namespace Libplanet.Net.Messages
         /// A <see cref="Proposal"/> of the message.
         /// </summary>
         public Proposal Proposal { get; }
+
+        /// <summary>
+        /// A <see cref="BlockHash"/> the message is written for.
+        /// </summary>
+        public BlockHash BlockHash { get; }
 
         /// <inheritdoc cref="MessageContent.DataFrames"/>
         public override IEnumerable<byte[]> DataFrames =>

--- a/Libplanet.Net/Messages/ConsensusVoteMsg.cs
+++ b/Libplanet.Net/Messages/ConsensusVoteMsg.cs
@@ -1,4 +1,5 @@
 using Libplanet.Blocks;
+using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
 
@@ -17,19 +18,27 @@ namespace Libplanet.Net.Messages
         /// <param name="height">A <see cref="Context.Height"/> the message is for.</param>
         /// <param name="round">A <see cref="Context.Round"/> the message is written for.</param>
         /// <param name="blockHash">A <see cref="BlockHash"/> the message is written for.</param>
+        /// <param name="flag">A <see cref="VoteFlag"/>.</param>
         protected ConsensusVoteMsg(
             PublicKey validatorPublicKey,
             long height,
             int round,
-            BlockHash blockHash)
+            BlockHash blockHash,
+            VoteFlag flag)
             : base(validatorPublicKey, height, round)
         {
             BlockHash = blockHash;
+            Flag = flag;
         }
 
         /// <summary>
         /// A <see cref="BlockHash"/> the message is written for.
         /// </summary>
         public BlockHash BlockHash { get; }
+
+        /// <summary>
+        /// A <see cref="VoteFlag"/> of message's vote.
+        /// </summary>
+        public VoteFlag Flag { get; }
     }
 }


### PR DESCRIPTION
### Rationale
Instead of using additional bootstrapping logic for consensus,
Maintaining round-life gossip cache would solve bootstrapping problem.

### Changes
- Introduced `IConsensusMessageCommunicator` interface for `Context`.
- Gossip cache no longer forgets message by time or adding of new message. Instead, explicit call of `Gossip.ClearCache()` would trigger to forget all messages at one time.
- `Gossip.ClearCache()` will be explicitly called on the start of new context round.
- Spam filter logic now add peer to denylist, with message's public key.