### PR TITLE
🧹 Remove `ActionTypeAttribute.ValueOf()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `ActionTypeAttribute.ValueOf()` method.  [[#3267]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +25,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#3267]: https://github.com/planetarium/libplanet/pull/3267
 
 
 Version 2.4.0

--- a/Libplanet.Tests/Action/ActionTypeAttributeTest.cs
+++ b/Libplanet.Tests/Action/ActionTypeAttributeTest.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Bencodex.Types;
 using Libplanet.Action;
 using Xunit;
@@ -11,14 +12,19 @@ namespace Libplanet.Tests.Action
         {
             Assert.Equal(
                 new Text("test_action"),
-                ActionTypeAttribute.ValueOf(typeof(TestAction))
-            );
+                typeof(TestAction1).GetCustomAttribute<ActionTypeAttribute>()?.TypeIdentifier);
+            Assert.Null(
+                typeof(TestAction2).GetCustomAttribute<ActionTypeAttribute>()?.TypeIdentifier);
         }
     }
 
 #pragma warning disable SA1402 // File may only contain a single class
     [ActionType("test_action")]
-    internal class TestAction
+    internal class TestAction1
+    {
+    }
+
+    internal class TestAction2
     {
     }
 #pragma warning restore SA1402 // File may only contain a single class

--- a/Libplanet/Action/ActionTypeAttribute.cs
+++ b/Libplanet/Action/ActionTypeAttribute.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Reflection;
 using Bencodex.Types;
 
 namespace Libplanet.Action
@@ -35,21 +33,5 @@ namespace Libplanet.Action
         /// deserialization.
         /// </summary>
         public IValue TypeIdentifier { get; }
-
-        /// <summary>
-        /// Gets the <see cref="TypeIdentifier"/> for a given action class.
-        /// </summary>
-        /// <param name="actionType">A <see cref="Type"/> object of an action
-        /// class to know its annotated <see cref="TypeIdentifier"/>.</param>
-        /// <returns>The <see cref="TypeIdentifier"/> of the given
-        /// <paramref name="actionType"/> if it's annotated with
-        /// <see cref="ActionTypeAttribute"/>.  If it's not annotated returns
-        /// <see langword="null"/>.</returns>
-        public static IValue? ValueOf(Type actionType) =>
-            actionType
-                .GetCustomAttributes()
-                .OfType<ActionTypeAttribute>()
-                .Select(attr => attr.TypeIdentifier)
-                .FirstOrDefault();
     }
 }

--- a/Libplanet/Action/Loader/TypedActionLoader.cs
+++ b/Libplanet/Action/Loader/TypedActionLoader.cs
@@ -137,29 +137,29 @@ namespace Libplanet.Action.Loader
         {
             var types = new Dictionary<IValue, Type>();
             var actionType = typeof(IAction);
-            foreach (Type t in LoadAllActionTypes(assembly))
+            foreach (Type type in LoadAllActionTypes(assembly))
             {
-                if (baseType is { } type && !baseType.IsAssignableFrom(t))
+                if (baseType is { } bType && !bType.IsAssignableFrom(type))
                 {
                     continue;
                 }
 
-                if (ActionTypeAttribute.ValueOf(t) is IValue typeId)
+                if (type.GetCustomAttribute<ActionTypeAttribute>()?.TypeIdentifier is { } typeId)
                 {
                     if (types.TryGetValue(typeId, out Type? existing))
                     {
-                        if (existing != t)
+                        if (existing != type)
                         {
                             throw new DuplicateActionTypeIdentifierException(
                                 "Multiple action types are associated with the same type ID.",
                                 typeId.ToString() ?? "null",
-                                ImmutableHashSet.Create(existing, t));
+                                ImmutableHashSet.Create(existing, type));
                         }
 
                         continue;
                     }
 
-                    types[typeId] = t;
+                    types[typeId] = type;
                 }
             }
 


### PR DESCRIPTION
~~Not sure we even need `ValueOf()` as it can be a simple one liner. In any case, I think there would be an infinitesimal amount of performance improvement. 😗~~

Came back after working on [lib9c](https://github.com/planetarium/lib9c) a little. I think having `ValueOf()` just adds more confusion. 😐