### PR TITLE
🔧 Evaluate all `IAction`s regardless of errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Version 2.5.0
 
 To be released.
 
+Due to changes in [[#3272]], a network ran with a prior version may not
+be compatible with this version.
+
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
@@ -54,6 +57,9 @@ To be released.
 
  -  (Libplanet.Net) `Context` became to remove its proposal
     when +2/3 valid votes were collected.  [[#3206]]
+ -  Changed `ActionEvaluator` to evaluate all `IAction`s in a `Transaction`
+    without early termination even if an `IAction` throws an `Exception`.
+    [[#3272]]
  -  `Gossip.HandleMessageAsync()` now executes `_validateMessageToReceive`
     on given message received.  [[#3273]]
  -  `Gossip.SendWantAsync()` now executes `_validateMessageToReceive`
@@ -73,6 +79,7 @@ To be released.
 
 [#3206]: https://github.com/planetarium/libplanet/pull/3206
 [#3267]: https://github.com/planetarium/libplanet/pull/3267
+[#3272]: https://github.com/planetarium/libplanet/pull/3272
 [#3273]: https://github.com/planetarium/libplanet/pull/3273
 
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -691,6 +691,10 @@ namespace Libplanet.Tests.Action
                     .ToImmutableArray()).ToArray();
 
             Assert.Equal(evalsA.Length, deltaA.Count - 1);
+            Assert.Equal(
+                new Integer(15),
+                evalsA.Last().OutputState.GetState(txA.Signer));
+
             for (int i = 0; i < evalsA.Length; i++)
             {
                 IActionEvaluation eval = evalsA[i];
@@ -715,8 +719,8 @@ namespace Libplanet.Tests.Action
                 Assert.Null(eval.Exception);
             }
 
-            // txB: error(10 - 3) + -3 =
-            //           (10 - 3)      = 7  (only input of error() is left)
+            // txB: error(10 - 3) + -1 =
+            //           (10 - 3) + -1 = 6  (error() does nothing)
             (Transaction txB, var deltaB) = fx.Sign(
                 1,
                 Arithmetic.Sub(3),
@@ -739,6 +743,9 @@ namespace Libplanet.Tests.Action
                     .ToImmutableArray()).ToArray();
 
             Assert.Equal(evalsB.Length, deltaB.Count - 1);
+            Assert.Equal(
+                new Integer(6),
+                evalsB.Last().OutputState.GetState(txB.Signer));
 
             for (int i = 0; i < evalsB.Length; i++)
             {

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -318,11 +318,6 @@ namespace Libplanet.Action
                     exception: exc,
                     logs: context.Logs);
 
-                if (exc is { })
-                {
-                    yield break;
-                }
-
                 states = nextStates;
                 gasLimit = nextGasLimit;
                 unchecked


### PR DESCRIPTION
🔧 