### PR TITLE
Expose `Logs` for `ActionContext`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,13 @@ be compatible with this version.
      -  Added `ConsensusMaj23Msg` of value `0x53`.
      -  Added `ConsensusVoteSetBitsMsg` of value `0x54`.
      -  Added `ConsensusProposalClaimMsg` of value `0x55`.
+ -  Added `IActionContext.Logs` interface property.  [[#3274]]
+ -  Changed the type for `IActionEvaluation.Logs` to
+    `IReadOnlyList<string>` from `List<string>`.  [[#3274]]
+ -  Changed the type for `TxExecution.ActionsLogList` to
+    `List<IReadOnlyList<string>>?` from `List<List<string>>?`.  [[#3274]]
+ -  (Libplanet.Explorer) Changed the type for `TxResult.ActionsLogList` to
+    `List<IReadOnlyList<string>>?` from `List<List<string>>?`.  [[#3274]]
 
 ### Behavioral changes
 
@@ -81,6 +88,7 @@ be compatible with this version.
 [#3267]: https://github.com/planetarium/libplanet/pull/3267
 [#3272]: https://github.com/planetarium/libplanet/pull/3272
 [#3273]: https://github.com/planetarium/libplanet/pull/3273
+[#3274]: https://github.com/planetarium/libplanet/pull/3274
 
 
 Version 2.4.0

--- a/Libplanet.Explorer/GraphTypes/TxResult.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResult.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Explorer.GraphTypes
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>? fungibleAssetsDelta,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>?
                 updatedFungibleAssets,
-            List<List<string>>? actionsLogsList
+            List<IReadOnlyList<string>>? actionsLogsList
         )
         {
             TxStatus = status;
@@ -51,6 +51,6 @@ namespace Libplanet.Explorer.GraphTypes
         public IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>?
             UpdatedFungibleAssets { get; }
 
-        public List<List<string>>? ActionsLogsList { get; }
+        public List<IReadOnlyList<string>>? ActionsLogsList { get; }
     }
 }

--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -136,8 +136,7 @@ namespace Libplanet.Tests.Action
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: AccountStateDelta.Create(MockAccountState.Empty),
                 randomSeed: _random.Next(),
-                gasLimit: 0,
-                logs: new List<string>()
+                gasLimit: 0
             );
 
             // Consume original's random state...
@@ -153,6 +152,31 @@ namespace Libplanet.Tests.Action
                 values,
                 new[] { clone.Random.Next(), clone.Random.Next(), clone.Random.Next() }
             );
+        }
+
+        [Fact]
+        public void ActionContextLogs()
+        {
+            var context = new ActionContext(
+                signer: _address,
+                txid: _txid,
+                miner: _address,
+                blockIndex: 1,
+                blockProtocolVersion: Block.CurrentProtocolVersion,
+                previousState: AccountStateDelta.Create(MockAccountState.Empty),
+                randomSeed: _random.Next(),
+                gasLimit: 0);
+
+            string[] logs = new[] { "foo", "bar" };
+            context.PutLog(logs[0]);
+            context.PutLog(logs[1]);
+            Assert.Equal(2, context.Logs.Count);
+            Assert.Equal("foo", context.Logs[0]);
+            Assert.Equal("bar", context.Logs[1]);
+
+            // Unconsumed context should have empty logs.
+            var unconsumed = context.GetUnconsumedContext();
+            Assert.Empty(unconsumed.Logs);
         }
     }
 }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -428,7 +428,7 @@ namespace Libplanet.Tests.Store
                 Fx.Hash1,
                 Fx.TxId1,
                 actionsLogsList
-                    ? new List<List<string>>
+                    ? new List<IReadOnlyList<string>>
                     {
                         new List<string>
                         {
@@ -467,7 +467,7 @@ namespace Libplanet.Tests.Store
             var inputB = new TxFailure(
                 Fx.Hash1,
                 Fx.TxId2,
-                actionsLogsList ? new List<List<string>>() : null,
+                actionsLogsList ? new List<IReadOnlyList<string>>() : null,
                 "AnExceptionName",
                 Dictionary.Empty.Add("foo", 1).Add("bar", "baz")
             );
@@ -481,7 +481,7 @@ namespace Libplanet.Tests.Store
             var inputC = new TxFailure(
                 Fx.Hash2,
                 Fx.TxId1,
-                actionsLogsList ? new List<List<string>>() : null,
+                actionsLogsList ? new List<IReadOnlyList<string>>() : null,
                 "AnotherExceptionName",
                 null
             );

--- a/Libplanet.Tests/Tx/TxFailureTest.cs
+++ b/Libplanet.Tests/Tx/TxFailureTest.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Tests.Tx
             _fxWithLogs = new TxFailure(
                 _blockHash,
                 _txid,
-                new List<List<string>>
+                new List<IReadOnlyList<string>>
                 {
                     new List<string>
                     {

--- a/Libplanet.Tests/Tx/TxSuccessTest.cs
+++ b/Libplanet.Tests/Tx/TxSuccessTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Tests.Tx
         private readonly ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
             _updatedFungibleAssets;
 
-        private readonly List<List<string>> _actionsLogsList;
+        private readonly List<IReadOnlyList<string>> _actionsLogsList;
 
         private readonly TxSuccess _fx;
 
@@ -67,7 +67,7 @@ namespace Libplanet.Tests.Tx
                     fav => fav.Currency * random.Next(1, int.MaxValue)
                 ).ToImmutableDictionary()
             ).ToImmutableDictionary();
-            _actionsLogsList = new List<List<string>>
+            _actionsLogsList = new List<IReadOnlyList<string>>
             {
                 new List<string>
                 {

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -16,6 +16,7 @@ namespace Libplanet.Action
 
         private readonly int _randomSeed;
         private readonly long _gasLimit;
+        private readonly List<string> _logs;
 
         public ActionContext(
             Address signer,
@@ -26,8 +27,7 @@ namespace Libplanet.Action
             IAccountStateDelta previousState,
             int randomSeed,
             long gasLimit,
-            bool rehearsal = false,
-            List<string>? logs = null)
+            bool rehearsal = false)
         {
             Signer = signer;
             TxId = txid;
@@ -39,7 +39,7 @@ namespace Libplanet.Action
             Random = new Random(randomSeed);
             _randomSeed = randomSeed;
             _gasLimit = gasLimit;
-            Logs = logs ?? new List<string>();
+            _logs = new List<string>();
 
             GetStateTimer.Value = new Stopwatch();
             GetStateCount.Value = 0;
@@ -73,10 +73,11 @@ namespace Libplanet.Action
         /// <inheritdoc cref="IActionContext.BlockAction"/>
         public bool BlockAction => TxId is null;
 
-        internal List<string> Logs { get; }
+        /// <inheritdoc cref="IActionContext.Logs"/>
+        public IReadOnlyList<string> Logs => _logs;
 
         /// <inheritdoc cref="IActionContext.PutLog(string)"/>
-        public void PutLog(string log) => Logs.Add(log);
+        public void PutLog(string log) => _logs.Add(log);
 
         /// <inheritdoc cref="IActionContext.UseGas(long)"/>
         public void UseGas(long gas) => GetGasMeter.Value?.UseGas(gas);
@@ -92,8 +93,7 @@ namespace Libplanet.Action
                 PreviousState,
                 _randomSeed,
                 _gasLimit,
-                Rehearsal,
-                new List<string>());
+                Rehearsal);
 
         /// <summary>
         /// Returns the elapsed gas of the current action.

--- a/Libplanet/Action/ActionEvaluation.cs
+++ b/Libplanet/Action/ActionEvaluation.cs
@@ -28,7 +28,7 @@ namespace Libplanet.Action
             IActionContext inputContext,
             IAccountStateDelta outputState,
             Exception? exception = null,
-            List<string>? logs = null)
+            IReadOnlyList<string>? logs = null)
         {
             Action = action;
             InputContext = inputContext;
@@ -63,9 +63,9 @@ namespace Libplanet.Action
         public Exception? Exception { get; }
 
         /// <summary>
-        /// Logs recorded while executing an action through
+        /// Logs recorded while executing an <see cref="IAction"/> through
         /// <see cref="IActionContext.PutLog(string)"/>.
         /// </summary>
-        public List<string> Logs { get; }
+        public IReadOnlyList<string> Logs { get; }
     }
 }

--- a/Libplanet/Action/ActionEvaluator.cs
+++ b/Libplanet/Action/ActionEvaluator.cs
@@ -202,8 +202,7 @@ namespace Libplanet.Action
             ActionContext CreateActionContext(
                 IAccountStateDelta prevState,
                 int randomSeed,
-                long actionGasLimit = long.MaxValue,
-                List<string>? logs = null
+                long actionGasLimit = long.MaxValue
             )
             {
                 return new ActionContext(
@@ -214,8 +213,7 @@ namespace Libplanet.Action
                     blockProtocolVersion: blockProtocolVersion,
                     previousState: prevState,
                     randomSeed: randomSeed,
-                    gasLimit: actionGasLimit,
-                    logs: logs);
+                    gasLimit: actionGasLimit);
             }
 
             byte[] hashedSignature;

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -89,6 +90,13 @@ namespace Libplanet.Action
         /// </summary>
         [Pure]
         bool BlockAction { get; }
+
+        /// <summary>
+        /// Logs recorded while executing an <see cref="IAction"/> through
+        /// <see cref="IActionContext.PutLog(string)"/>.
+        /// </summary>
+        [Pure]
+        IReadOnlyList<string> Logs { get; }
 
         /// <summary>
         /// Record a log in <see cref="TxExecution"/>.

--- a/Libplanet/Action/IActionEvaluation.cs
+++ b/Libplanet/Action/IActionEvaluation.cs
@@ -37,6 +37,6 @@ namespace Libplanet.Action
         /// Logs recorded while executing an action through
         /// <see cref="IActionContext.PutLog(string)"/>.
         /// </summary>
-        public List<string> Logs { get; }
+        public IReadOnlyList<string> Logs { get; }
     }
 }

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -236,7 +236,7 @@ namespace Libplanet.Store
             {
                 bool fail = d.GetValue<Bencodex.Types.Boolean>("fail");
 
-                List<List<string>> actionsLogsList = null;
+                List<IReadOnlyList<string>> actionsLogsList = null;
                 if (d.ContainsKey("actionsLogsList"))
                 {
                     actionsLogsList =
@@ -298,13 +298,16 @@ namespace Libplanet.Store
             );
 
         private static Bencodex.Types.List SerializeLogs(
-            List<List<string>> logs
+            List<IReadOnlyList<string>> logs
         ) =>
             new List(logs.Select(l => new List(l.Select(x => (Text)x))));
 
-        private static List<List<string>> DeserializeLogs(
+        private static List<IReadOnlyList<string>> DeserializeLogs(
             Bencodex.Types.List serialized) =>
-            serialized.Cast<List>().Select(l => l.Select(x => (string)(Text)x).ToList()).ToList();
+            serialized
+                .Cast<List>()
+                .Select(l => (IReadOnlyList<string>)l.Select(e => (string)(Text)e).ToList())
+                .ToList();
 
         private static Bencodex.Types.List SerializeFAVs(
             IImmutableDictionary<Currency, FungibleAssetValue> favs

--- a/Libplanet/Tx/TxExecution.cs
+++ b/Libplanet/Tx/TxExecution.cs
@@ -25,14 +25,14 @@ namespace Libplanet.Tx
             : this(
                 info.GetValue<BlockHash>(nameof(BlockHash)),
                 info.GetValue<TxId>(nameof(TxId)),
-                info.GetValue<List<List<string>>>(nameof(ActionsLogsList)))
+                info.GetValue<List<IReadOnlyList<string>>>(nameof(ActionsLogsList)))
         {
         }
 
         private protected TxExecution(
             BlockHash blockHash,
             TxId txId,
-            List<List<string>>? actionsLogsList)
+            List<IReadOnlyList<string>>? actionsLogsList)
         {
             BlockHash = blockHash;
             TxId = txId;
@@ -56,7 +56,7 @@ namespace Libplanet.Tx
         /// The logs recorded while executing <see cref="Transaction"/>'s actions.
         /// </summary>
         [Pure]
-        public List<List<string>>? ActionsLogsList { get; }
+        public List<IReadOnlyList<string>>? ActionsLogsList { get; }
 
         /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/Libplanet/Tx/TxFailure.cs
+++ b/Libplanet/Tx/TxFailure.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Tx
         public TxFailure(
             BlockHash blockHash,
             TxId txId,
-            List<List<string>>? actionsLogsList,
+            List<IReadOnlyList<string>>? actionsLogsList,
             string exceptionName,
             IValue? exceptionMetadata
         )
@@ -53,7 +53,7 @@ namespace Libplanet.Tx
         public TxFailure(
             BlockHash blockHash,
             TxId txId,
-            List<List<string>>? actionsLogsList,
+            List<IReadOnlyList<string>>? actionsLogsList,
             Exception exception)
             : this(
                 blockHash,

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Tx
         public TxSuccess(
             BlockHash blockHash,
             TxId txId,
-            List<List<string>>? actionsLogsList,
+            List<IReadOnlyList<string>>? actionsLogsList,
             IImmutableDictionary<Address, IValue> updatedStates,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> fungibleAssetsDelta,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>


### PR DESCRIPTION
There's probably no reason for `TxExecution.ActionsLogList` to be `nullable`. Left as it is just in case things break. 😶