### PR TITLE
♻️ Better `MockAccountState`

### DIFF
--- a/Libplanet.Tests/Action/AccountStateDeltaTest.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaTest.cs
@@ -28,10 +28,10 @@ namespace Libplanet.Tests.Action
         protected readonly Address[] _addr;
         protected readonly Currency[] _currencies;
         protected readonly IImmutableDictionary<Address, IValue> _states;
-        protected readonly IImmutableDictionary<(Address, Currency), BigInteger> _assets;
-        protected readonly IImmutableDictionary<Currency, (BigInteger, BigInteger)> _totalSupplies;
+        protected readonly IImmutableDictionary<(Address, Currency), BigInteger> _fungibles;
+        protected readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
         protected readonly ValidatorSet _validatorSet;
-        protected readonly IAccountStateDelta _initDelta;
+        protected readonly IAccountStateDelta _initStateDelta;
         protected readonly IActionContext _initContext;
 
         protected AccountStateDeltaTest(ITestOutputHelper output)
@@ -62,7 +62,7 @@ namespace Libplanet.Tests.Action
                 [_addr[1]] = (Text)"b",
             }.ToImmutableDictionary();
 
-            _assets = new Dictionary<(Address, Currency), BigInteger>
+            _fungibles = new Dictionary<(Address, Currency), BigInteger>
             {
                 [(_addr[0], _currencies[0])] = 5,
                 [(_addr[0], _currencies[1])] = -10,
@@ -71,9 +71,9 @@ namespace Libplanet.Tests.Action
                 [(_addr[1], _currencies[2])] = 20,
             }.ToImmutableDictionary();
 
-            _totalSupplies = new Dictionary<Currency, (BigInteger, BigInteger)>
+            _totalSupplies = new Dictionary<Currency, BigInteger>
             {
-                [_currencies[3]] = (5, 0),
+                [_currencies[3]] = 5,
             }.ToImmutableDictionary();
 
             _validatorSet =
@@ -101,13 +101,13 @@ namespace Libplanet.Tests.Action
                 );
             }
 
-            _initDelta = CreateInstance(
+            _initStateDelta = CreateInstance(
                 GetStates,
                 GetBalance,
                 GetTotalSupply,
                 GetValidatorSet);
             _initContext = CreateContext(
-                _initDelta, _addr[0]);
+                _initStateDelta, _addr[0]);
         }
 
         public abstract int ProtocolVersion { get; }
@@ -131,66 +131,66 @@ namespace Libplanet.Tests.Action
         [Fact]
         public virtual void NullDelta()
         {
-            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
-            Assert.Equal("a", (Text)_initDelta.GetState(_addr[0]));
-            Assert.Equal("b", (Text)_initDelta.GetState(_addr[1]));
-            Assert.Null(_initDelta.GetState(_addr[2]));
-            Assert.Equal(Value(0, 5), _initDelta.GetBalance(_addr[0], _currencies[0]));
-            Assert.Equal(Value(1, -10), _initDelta.GetBalance(_addr[0], _currencies[1]));
-            Assert.Equal(Zero(2), _initDelta.GetBalance(_addr[0], _currencies[2]));
-            Assert.Equal(Zero(0), _initDelta.GetBalance(_addr[1], _currencies[0]));
-            Assert.Equal(Value(1, 15), _initDelta.GetBalance(_addr[1], _currencies[1]));
-            Assert.Equal(Value(2, 20), _initDelta.GetBalance(_addr[1], _currencies[2]));
-            Assert.Equal(Zero(0), _initDelta.GetBalance(_addr[2], _currencies[0]));
-            Assert.Equal(Zero(1), _initDelta.GetBalance(_addr[2], _currencies[1]));
-            Assert.Equal(Zero(2), _initDelta.GetBalance(_addr[2], _currencies[2]));
+            Assert.Empty(_initStateDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.UpdatedFungibleAssets);
+            Assert.Equal("a", (Text)_initStateDelta.GetState(_addr[0]));
+            Assert.Equal("b", (Text)_initStateDelta.GetState(_addr[1]));
+            Assert.Null(_initStateDelta.GetState(_addr[2]));
+            Assert.Equal(Value(0, 5), _initStateDelta.GetBalance(_addr[0], _currencies[0]));
+            Assert.Equal(Value(1, -10), _initStateDelta.GetBalance(_addr[0], _currencies[1]));
+            Assert.Equal(Zero(2), _initStateDelta.GetBalance(_addr[0], _currencies[2]));
+            Assert.Equal(Zero(0), _initStateDelta.GetBalance(_addr[1], _currencies[0]));
+            Assert.Equal(Value(1, 15), _initStateDelta.GetBalance(_addr[1], _currencies[1]));
+            Assert.Equal(Value(2, 20), _initStateDelta.GetBalance(_addr[1], _currencies[2]));
+            Assert.Equal(Zero(0), _initStateDelta.GetBalance(_addr[2], _currencies[0]));
+            Assert.Equal(Zero(1), _initStateDelta.GetBalance(_addr[2], _currencies[1]));
+            Assert.Equal(Zero(2), _initStateDelta.GetBalance(_addr[2], _currencies[2]));
         }
 
         [Fact]
         public virtual void States()
         {
-            IAccountStateDelta a = _initDelta.SetState(_addr[0], (Text)"A");
+            IAccountStateDelta a = _initStateDelta.SetState(_addr[0], (Text)"A");
             Assert.Equal("A", (Text)a.GetState(_addr[0]));
-            Assert.Equal("a", (Text)_initDelta.GetState(_addr[0]));
+            Assert.Equal("a", (Text)_initStateDelta.GetState(_addr[0]));
             Assert.Equal("b", (Text)a.GetState(_addr[1]));
-            Assert.Equal("b", (Text)_initDelta.GetState(_addr[1]));
+            Assert.Equal("b", (Text)_initStateDelta.GetState(_addr[1]));
             Assert.Null(a.GetState(_addr[2]));
-            Assert.Null(_initDelta.GetState(_addr[2]));
+            Assert.Null(_initStateDelta.GetState(_addr[2]));
             Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.Delta.StateUpdatedAddresses);
             Assert.Equal(a.Delta.StateUpdatedAddresses, a.Delta.UpdatedAddresses);
             Assert.Empty(a.Delta.UpdatedFungibleAssets);
             Assert.Empty(a.Delta.UpdatedTotalSupplyCurrencies);
-            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
-            Assert.Empty(_initDelta.Delta.UpdatedTotalSupplyCurrencies);
+            Assert.Empty(_initStateDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.UpdatedFungibleAssets);
+            Assert.Empty(_initStateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             IAccountStateDelta b = a.SetState(_addr[0], (Text)"z");
             Assert.Equal("z", (Text)b.GetState(_addr[0]));
             Assert.Equal("A", (Text)a.GetState(_addr[0]));
-            Assert.Equal("a", (Text)_initDelta.GetState(_addr[0]));
+            Assert.Equal("a", (Text)_initStateDelta.GetState(_addr[0]));
             Assert.Equal("b", (Text)b.GetState(_addr[1]));
             Assert.Equal("b", (Text)a.GetState(_addr[1]));
             Assert.Null(b.GetState(_addr[2]));
             Assert.Null(a.GetState(_addr[2]));
             Assert.Equal(new[] { _addr[0] }.ToImmutableHashSet(), a.Delta.StateUpdatedAddresses);
             Assert.Equal(a.Delta.StateUpdatedAddresses, a.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.StateUpdatedAddresses);
 
             IAccountStateDelta c = b.SetState(_addr[0], (Text)"a");
             Assert.Equal("a", (Text)c.GetState(_addr[0]));
             Assert.Equal("z", (Text)b.GetState(_addr[0]));
-            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.StateUpdatedAddresses);
         }
 
         [Fact]
         public virtual void FungibleAssets()
         {
-            IAccountStateDelta a = _initDelta.TransferAsset(
+            IAccountStateDelta a = _initStateDelta.TransferAsset(
                 _initContext, _addr[1], _addr[2], Value(2, 5));
             Assert.Equal(Value(2, 15), a.GetBalance(_addr[1], _currencies[2]));
             Assert.Equal(Value(2, 5), a.GetBalance(_addr[2], _currencies[2]));
@@ -210,26 +210,26 @@ namespace Libplanet.Tests.Action
                 a.Delta.UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet(),
                 a.Delta.UpdatedAddresses);
             Assert.Empty(a.Delta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.UpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.StateUpdatedAddresses);
-            Assert.Empty(_initDelta.Delta.UpdatedFungibleAssets);
-            Assert.Empty(_initDelta.Delta.UpdatedTotalSupplyCurrencies);
+            Assert.Empty(_initStateDelta.Delta.UpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.StateUpdatedAddresses);
+            Assert.Empty(_initStateDelta.Delta.UpdatedFungibleAssets);
+            Assert.Empty(_initStateDelta.Delta.UpdatedTotalSupplyCurrencies);
         }
 
         [Fact]
         public virtual void TransferAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.TransferAsset(_initContext, _addr[0], _addr[1], Zero(0))
+                _initStateDelta.TransferAsset(_initContext, _addr[0], _addr[1], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.TransferAsset(_initContext, _addr[0], _addr[1], Value(0, -1))
+                _initStateDelta.TransferAsset(_initContext, _addr[0], _addr[1], Value(0, -1))
             );
             Assert.Throws<InsufficientBalanceException>(() =>
-                _initDelta.TransferAsset(_initContext, _addr[0], _addr[1], Value(0, 6))
+                _initStateDelta.TransferAsset(_initContext, _addr[0], _addr[1], Value(0, 6))
             );
 
-            IAccountStateDelta a = _initDelta.TransferAsset(
+            IAccountStateDelta a = _initStateDelta.TransferAsset(
                 _initContext,
                 _addr[0],
                 _addr[1],
@@ -291,13 +291,13 @@ namespace Libplanet.Tests.Action
         public virtual void MintAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.MintAsset(_initContext, _addr[0], Zero(0))
+                _initStateDelta.MintAsset(_initContext, _addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.MintAsset(_initContext, _addr[0], Value(0, -1))
+                _initStateDelta.MintAsset(_initContext, _addr[0], Value(0, -1))
             );
 
-            IAccountStateDelta delta0 = _initDelta;
+            IAccountStateDelta delta0 = _initStateDelta;
             IActionContext context0 = _initContext;
             // currencies[0] (FOO) allows only _addr[0] to mint
             delta0 = delta0.MintAsset(context0, _addr[0], Value(0, 10));
@@ -331,16 +331,16 @@ namespace Libplanet.Tests.Action
         public virtual void BurnAsset()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.BurnAsset(_initContext, _addr[0], Zero(0))
+                _initStateDelta.BurnAsset(_initContext, _addr[0], Zero(0))
             );
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.BurnAsset(_initContext, _addr[0], Value(0, -1))
+                _initStateDelta.BurnAsset(_initContext, _addr[0], Value(0, -1))
             );
             Assert.Throws<InsufficientBalanceException>(() =>
-                _initDelta.BurnAsset(_initContext, _addr[0], Value(0, 6))
+                _initStateDelta.BurnAsset(_initContext, _addr[0], Value(0, 6))
             );
 
-            IAccountStateDelta delta0 = _initDelta;
+            IAccountStateDelta delta0 = _initStateDelta;
             IActionContext context0 = _initContext;
             // currencies[0] (FOO) allows only _addr[0] to burn
             delta0 = delta0.BurnAsset(context0, _addr[0], Value(0, 4));
@@ -374,14 +374,14 @@ namespace Libplanet.Tests.Action
         public virtual void SetValidator()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                _initDelta.SetValidator(new Validator(new PrivateKey().PublicKey, -1))
+                _initStateDelta.SetValidator(new Validator(new PrivateKey().PublicKey, -1))
             );
 
             var initCount = _keys.Length;
             var key3 = new PrivateKey().PublicKey;
             var key4 = new PrivateKey().PublicKey;
 
-            IAccountStateDelta delta = _initDelta;
+            IAccountStateDelta delta = _initStateDelta;
             // delta already has 3 validators
             Assert.Equal(initCount, delta.GetValidatorSet().TotalCount);
 
@@ -434,7 +434,7 @@ namespace Libplanet.Tests.Action
         protected FungibleAssetValue GetBalance(Address address, Currency currency) =>
             new FungibleAssetValue(
                 currency,
-                _assets.TryGetValue((address, currency), out BigInteger balance) ? balance : 0,
+                _fungibles.TryGetValue((address, currency), out BigInteger balance) ? balance : 0,
                 0
             );
 
@@ -446,7 +446,7 @@ namespace Libplanet.Tests.Action
             }
 
             return _totalSupplies.TryGetValue(currency, out var totalSupply)
-                ? new FungibleAssetValue(currency, totalSupply.Item1, totalSupply.Item2)
+                ? FungibleAssetValue.FromRawValue(currency, totalSupply)
                 : currency * 0;
         }
 

--- a/Libplanet.Tests/Action/AccountStateDeltaV0Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaV0Test.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Tests.Action
         {
             base.TransferAsset();
 
-            IAccountStateDelta a = _initDelta.TransferAsset(
+            IAccountStateDelta a = _initStateDelta.TransferAsset(
                 _initContext,
                 _addr[0],
                 _addr[1],

--- a/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Tests.Action
         {
             base.TransferAsset();
 
-            IAccountStateDelta a = _initDelta.TransferAsset(
+            IAccountStateDelta a = _initStateDelta.TransferAsset(
                 _initContext,
                 _addr[0],
                 _addr[1],
@@ -86,41 +86,33 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void TotalSupplyTracking()
         {
-            IAccountStateDelta stateDelta = _initDelta;
+            IAccountStateDelta stateDelta = _initStateDelta;
             IActionContext context = _initContext;
 
             Assert.Empty(stateDelta.GetUpdatedTotalSupplies());
             Assert.Empty(stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             Assert.Equal(
-                new FungibleAssetValue(
+                FungibleAssetValue.FromRawValue(
                     _currencies[3],
-                    _totalSupplies[_currencies[3]].Item1,
-                    _totalSupplies[_currencies[3]].Item2),
-                _initDelta.GetTotalSupply(_currencies[3])
-            );
-            Assert.Equal(
-                new FungibleAssetValue(
-                    _currencies[3],
-                    _totalSupplies[_currencies[3]].Item1,
-                    _totalSupplies[_currencies[3]].Item2),
-                _initDelta.GetTotalSupply(_currencies[3])
+                    _totalSupplies[_currencies[3]]),
+                _initStateDelta.GetTotalSupply(_currencies[3])
             );
 
             Assert.Throws<TotalSupplyNotTrackableException>(() =>
-                _initDelta.GetTotalSupply(_currencies[0]));
+                _initStateDelta.GetTotalSupply(_currencies[0]));
             Assert.DoesNotContain(
                 new KeyValuePair<Currency, FungibleAssetValue>(
                     _currencies[0], Value(0, 5)),
                 stateDelta.GetUpdatedTotalSupplies());
             Assert.DoesNotContain(_currencies[0], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
-            Assert.Equal(Value(4, 0), _initDelta.GetTotalSupply(_currencies[4]));
+            Assert.Equal(Value(4, 0), _initStateDelta.GetTotalSupply(_currencies[4]));
             Assert.DoesNotContain(_currencies[4], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             stateDelta = stateDelta.MintAsset(context, _addr[0], Value(0, 10));
             Assert.Throws<TotalSupplyNotTrackableException>(() =>
-                _initDelta.GetTotalSupply(_currencies[0]));
+                _initStateDelta.GetTotalSupply(_currencies[0]));
             Assert.DoesNotContain(_currencies[0], stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             stateDelta = stateDelta.MintAsset(context, _addr[0], Value(4, 10));
@@ -146,13 +138,13 @@ namespace Libplanet.Tests.Action
             base.MintAsset();
 
             Assert.Throws<SupplyOverflowException>(
-                () => _initDelta.MintAsset(_initContext, _addr[0], Value(4, 200)));
+                () => _initStateDelta.MintAsset(_initContext, _addr[0], Value(4, 200)));
         }
 
         [Fact]
         public virtual void TotalUpdatedFungibleAssets()
         {
-            IAccountStateDelta delta0 = _initDelta;
+            IAccountStateDelta delta0 = _initStateDelta;
             IActionContext context0 = _initContext;
 
             // currencies[0] (FOO) allows only _addr[0] to burn

--- a/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
+++ b/Libplanet.Tests/Action/AccountStateDeltaV1Test.cs
@@ -93,11 +93,8 @@ namespace Libplanet.Tests.Action
             Assert.Empty(stateDelta.Delta.UpdatedTotalSupplyCurrencies);
 
             Assert.Equal(
-                FungibleAssetValue.FromRawValue(
-                    _currencies[3],
-                    _totalSupplies[_currencies[3]]),
-                _initStateDelta.GetTotalSupply(_currencies[3])
-            );
+                _initState.GetTotalSupply(_currencies[3]),
+                _initStateDelta.GetTotalSupply(_currencies[3]));
 
             Assert.Throws<TotalSupplyNotTrackableException>(() =>
                 _initStateDelta.GetTotalSupply(_currencies[0]));

--- a/Libplanet.Tests/Action/ActionEvaluationTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluationTest.cs
@@ -1,9 +1,6 @@
-using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
-using Libplanet.Assets;
 using Libplanet.Blocks;
-using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.State;
 using Libplanet.Tests.Common.Action;
@@ -47,13 +44,8 @@ namespace Libplanet.Tests.Action
                     false
                 ),
                 AccountStateDelta.Create(
-                    new MockAccountState(
-                        addrs => addrs
-                            .Select(a => a.Equals(address) ? (Text)"item" : (IValue)null)
-                            .ToArray(),
-                        (_, c) => new FungibleAssetValue(c),
-                        c => c * 0,
-                        () => new ValidatorSet()))
+                    MockAccountState.Empty
+                        .SetState(address, (Text)"item"))
             );
             var action = (DumbAction)evaluation.Action;
 

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -16,7 +16,6 @@ using Libplanet.Crypto;
 using Libplanet.State;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
-using Libplanet.Tests.Mocks;
 using Libplanet.Tx;
 
 namespace Libplanet.Tests.Fixtures
@@ -180,15 +179,7 @@ namespace Libplanet.Tests.Fixtures
             Chain.Append(block, TestUtils.CreateBlockCommit(block));
 
         public IAccountStateDelta CreateAccountStateDelta(Address signer, BlockHash? offset = null)
-        {
-            offset = offset ?? Tip.Hash;
-            return AccountStateDelta.Create(
-                new MockAccountState(
-                    a => Chain.GetStates(a, offset),
-                    (a, c) => Chain.GetBalance(a, c, offset),
-                    c => Chain.GetTotalSupply(c),
-                    () => Chain.GetValidatorSet()));
-        }
+            => AccountStateDelta.Create(Chain.GetBlockState(offset ?? Tip.Hash));
 
         public IAccountStateDelta CreateAccountStateDelta(int signerIndex, BlockHash? offset = null)
             => CreateAccountStateDelta(Addresses[signerIndex], offset);

--- a/Libplanet.Tests/Mocks/MockAccountState.cs
+++ b/Libplanet.Tests/Mocks/MockAccountState.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Assets;
 using Libplanet.Consensus;
@@ -8,55 +11,208 @@ using Libplanet.State;
 namespace Libplanet.Tests.Mocks
 {
     /// <summary>
-    /// A simple class for mocking an <see cref="IAccountState"/> with given various getters.
+    /// A mock implementation of <see cref="IAccountState"/> with various overloaded methods for
+    /// setting up a semi-valid <see cref="IAccountState"/> for testing.
     /// </summary>
+    /// <remarks>
+    /// All methods are pretty self-explanatory with no side-effects.  There are some caveats:
+    /// <list type="bullet">
+    ///     <item><description>
+    ///         Every balance related operation can accept a negative amount.  Each behave
+    ///         as expected.  That is, adding negative amount would decrease the balance.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Negative balance is allowed for all cases.  This includes total supply.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Total supply is not automatically tracked.  That is, changing the balance
+    ///         associated with an <see cref="Address"/> does not change the total supply
+    ///         in any way.  Total supply must be explicitly set if needed.
+    ///     </description></item>
+    ///     <item><description>
+    ///         There are only few restrictions that apply for manipulating this object, mostly
+    ///         pertaining to total supplies:
+    ///         <list type="bullet">
+    ///             <item><description>
+    ///                 It is not possible to set a total supply amount for a currency that is
+    ///                 not trackable.
+    ///             </description></item>
+    ///             <item><description>
+    ///                 It is not possible to set a total supply amount that is over the currency's
+    ///                 capped maximum total supply.
+    ///             </description></item>
+    ///         </list>
+    ///     </description></item>
+    /// </list>
+    /// </remarks>
     public class MockAccountState : IAccountState
     {
-        private AccountStateGetter _stateGetter;
-        private AccountBalanceGetter _balanceGetter;
-        private TotalSupplyGetter _totalSupplyGetter;
-        private ValidatorSetGetter _validatorSetGetter;
+        private static readonly MockAccountState _empty = new MockAccountState();
+        private readonly IImmutableDictionary<Address, IValue> _states;
+        private readonly IImmutableDictionary<(Address, Currency), BigInteger> _fungibles;
+        private readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
+        private readonly ValidatorSet _validatorSet;
 
         public MockAccountState(
-            AccountStateGetter stateGetter,
-            AccountBalanceGetter balanceGetter,
-            TotalSupplyGetter totalSupplyGetter,
-            ValidatorSetGetter validatorSetGetter)
+            IImmutableDictionary<Address, IValue> states,
+            IImmutableDictionary<(Address Address, Currency Currency), BigInteger> fungibles,
+            IImmutableDictionary<Currency, BigInteger> totalSupplies,
+            ValidatorSet validatorSet)
         {
-            _stateGetter = stateGetter;
-            _balanceGetter = balanceGetter;
-            _totalSupplyGetter = totalSupplyGetter;
-            _validatorSetGetter = validatorSetGetter;
+            _states = states;
+            _fungibles = fungibles;
+            _totalSupplies = totalSupplies;
+            _validatorSet = validatorSet;
         }
 
-        /// <summary>
-        /// An empty default state that returns <see langword="null"/> for any state,
-        /// 0 for any balance, 0 for any total supply if trackable, and
-        /// an empty <see cref="ValidatorSet"/>.
-        /// </summary>
-        public static MockAccountState Empty =>
-            new MockAccountState(
-                addrs => new IValue[addrs.Count],
-                (_, c) => c * 0,
-                c => c.TotalSupplyTrackable
-                    ? c * 0
-                    : throw new TotalSupplyNotTrackableException(
-                        $"Currency {c}'s total supply cannot be tracked", c),
-                () => new ValidatorSet());
+        private MockAccountState()
+            : this(
+                ImmutableDictionary<Address, IValue>.Empty,
+                ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
+                ImmutableDictionary<Currency, BigInteger>.Empty,
+                new ValidatorSet())
+        {
+        }
 
-        public IValue GetState(Address address) =>
-            GetStates(new[] { address }).First();
+        public static MockAccountState Empty => _empty;
+
+        public IImmutableDictionary<Address, IValue> States => _states;
+
+        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles => _fungibles;
+
+        public IImmutableDictionary<Currency, BigInteger> TotalSupplies => _totalSupplies;
+
+        public ValidatorSet ValidatorSet => _validatorSet;
+
+        public IValue GetState(Address address) => _states.TryGetValue(address, out IValue value)
+            ? value
+            : null;
 
         public IReadOnlyList<IValue> GetStates(IReadOnlyList<Address> addresses) =>
-            _stateGetter(addresses);
+            addresses.Select(GetState).ToArray();
 
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
-            _balanceGetter(address, currency);
+            _fungibles.TryGetValue((address, currency), out BigInteger rawValue)
+                ? FungibleAssetValue.FromRawValue(currency, rawValue)
+                : FungibleAssetValue.FromRawValue(currency, 0);
 
-        public FungibleAssetValue GetTotalSupply(Currency currency) =>
-            _totalSupplyGetter(currency);
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+        {
+            if (!currency.TotalSupplyTrackable)
+            {
+                var msg =
+                    $"The total supply value of the currency {currency} is not trackable " +
+                    "because it is a legacy untracked currency which might have been" +
+                    "established before the introduction of total supply tracking support.";
+                throw new TotalSupplyNotTrackableException(msg, currency);
+            }
 
-        public ValidatorSet GetValidatorSet() =>
-            _validatorSetGetter();
+            return _totalSupplies.TryGetValue(currency, out var rawValue)
+                ? FungibleAssetValue.FromRawValue(currency, rawValue)
+                : FungibleAssetValue.FromRawValue(currency, 0);
+        }
+
+        public ValidatorSet GetValidatorSet() => _validatorSet;
+
+        public MockAccountState SetState(Address address, IValue state) =>
+            new MockAccountState(
+                _states.SetItem(address, state),
+                _fungibles,
+                _totalSupplies,
+                _validatorSet);
+
+        public MockAccountState SetBalance(
+            Address address, FungibleAssetValue amount) =>
+            SetBalance((address, amount.Currency), amount.RawValue);
+
+        public MockAccountState SetBalance(
+            Address address, Currency currency, BigInteger rawAmount) =>
+            SetBalance((address, currency), rawAmount);
+
+        public MockAccountState SetBalance(
+            (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            new MockAccountState(
+                _states,
+                _fungibles.SetItem(pair, rawAmount),
+                _totalSupplies,
+                _validatorSet);
+
+        public MockAccountState AddBalance(Address address, FungibleAssetValue amount) =>
+            AddBalance((address, amount.Currency), amount.RawValue);
+
+        public MockAccountState AddBalance(
+            Address address, Currency currency, BigInteger rawAmount) =>
+            AddBalance((address, currency), rawAmount);
+
+        public MockAccountState AddBalance(
+            (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            SetBalance(
+                pair,
+                (_fungibles.TryGetValue(pair, out BigInteger amount) ? amount : 0) + rawAmount);
+
+        public MockAccountState SubtractBalance(
+            Address address, FungibleAssetValue amount) =>
+            SubtractBalance((address, amount.Currency), amount.RawValue);
+
+        public MockAccountState SubtractBalance(
+            Address address, Currency currency, BigInteger rawAmount) =>
+            SubtractBalance((address, currency), rawAmount);
+
+        public MockAccountState SubtractBalance(
+            (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            SetBalance(
+                pair,
+                (_fungibles.TryGetValue(pair, out BigInteger amount) ? amount : 0) - rawAmount);
+
+        public MockAccountState TransferBalance(
+            Address sender, Address recipient, FungibleAssetValue amount) =>
+            TransferBalance(sender, recipient, amount.Currency, amount.RawValue);
+
+        public MockAccountState TransferBalance(
+            Address sender, Address recipient, Currency currency, BigInteger rawAmount) =>
+            SubtractBalance(sender, currency, rawAmount).AddBalance(recipient, currency, rawAmount);
+
+        public MockAccountState SetTotalSupply(FungibleAssetValue amount) =>
+            SetTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockAccountState SetTotalSupply(Currency currency, BigInteger rawAmount) =>
+            currency.TotalSupplyTrackable
+                ? !(currency.MaximumSupply is FungibleAssetValue maximumSupply) ||
+                    rawAmount <= maximumSupply.RawValue
+                    ? new MockAccountState(
+                        _states,
+                        _fungibles,
+                        _totalSupplies.SetItem(currency, rawAmount),
+                        _validatorSet)
+                    : throw new ArgumentException(
+                        $"Given {currency}'s total supply is capped at {maximumSupply.RawValue} " +
+                        $"and cannot be set to {rawAmount}.")
+                : throw new ArgumentException(
+                    $"Given {currency} is not trackable.");
+
+        public MockAccountState AddTotalSupply(FungibleAssetValue amount) =>
+            AddTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockAccountState AddTotalSupply(Currency currency, BigInteger rawAmount) =>
+            SetTotalSupply(
+                currency,
+                (_totalSupplies.TryGetValue(currency, out BigInteger amount) ? amount : 0) +
+                    rawAmount);
+
+        public MockAccountState SubtractTotalSupply(FungibleAssetValue amount) =>
+            SubtractTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockAccountState SubtractTotalSupply(Currency currency, BigInteger rawAmount) =>
+            SetTotalSupply(
+                currency,
+                (_totalSupplies.TryGetValue(currency, out BigInteger amount) ? amount : 0) -
+                    rawAmount);
+
+        public MockAccountState SetValidator(Validator validator) =>
+            new MockAccountState(
+                _states,
+                _fungibles,
+                _totalSupplies,
+                _validatorSet.Update(validator));
     }
 }


### PR DESCRIPTION
Backported(?) from a lib9c [PR](https://github.com/planetarium/lib9c/pull/1996). Sticking it in `Libplanet.Tests` for now. I haven't quite decided how, but it might be better to have a separate project to provide these kinds of classes to lib9c and 9c-headless directly to reduce code duplication. 🙄

Also this prepares the project to get rid of `IAccountStateDelta`'s getter `delegates`. 