### PR TITLE
Add `Context.VoteSetModified` event handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@ be compatible with this version.
     `List<IReadOnlyList<string>>?` from `List<List<string>>?`.  [[#3274]]
  -  (Libplanet.Explorer) Added `BlockType.PreEvaluationHash` field.
     [[#3280], [#3281]]
+ -  (Libplanet.Net) Added `VoteSet.GetAllVotes()` method.  [[#3288]]
 
 ### Behavioral changes
 
@@ -99,6 +100,7 @@ be compatible with this version.
 [#3281]: https://github.com/planetarium/libplanet/pull/3281
 [#3282]: https://github.com/planetarium/libplanet/pull/3282
 [#3283]: https://github.com/planetarium/libplanet/pull/3283
+[#3288]: https://github.com/planetarium/libplanet/pull/3288
 
 
 Version 2.4.0

--- a/Libplanet.Net/Consensus/Context.Event.cs
+++ b/Libplanet.Net/Consensus/Context.Event.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Libplanet.Consensus;
 using Libplanet.Net.Messages;
 
 namespace Libplanet.Net.Consensus
@@ -43,5 +45,11 @@ namespace Libplanet.Net.Consensus
         /// An event that is invoked when a queued <see cref="System.Action"/> is consumed.
         /// </summary>
         internal event EventHandler<System.Action>? MutationConsumed;
+
+        /// <summary>
+        /// An event that is invoked when the <see cref="HeightVoteSet"/> is modified.
+        /// </summary>
+        internal event EventHandler<(int Round, VoteFlag Flag, IEnumerable<Vote> Votes)>?
+            VoteSetModified;
     }
 }

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
 using Libplanet.Net.Messages;
@@ -108,11 +107,22 @@ namespace Libplanet.Net.Consensus
                     switch (voteMsg)
                     {
                         case ConsensusPreVoteMsg preVote:
+                        {
                             _heightVoteSet.AddVote(preVote.PreVote);
+                            var args = (preVote.Round, VoteFlag.PreVote,
+                                _heightVoteSet.PreVotes(preVote.Round).GetAllVotes());
+                            VoteSetModified?.Invoke(this, args);
                             break;
+                        }
+
                         case ConsensusPreCommitMsg preCommit:
+                        {
                             _heightVoteSet.AddVote(preCommit.PreCommit);
+                            var args = (preCommit.Round, VoteFlag.PreCommit,
+                                _heightVoteSet.PreCommits(preCommit.Round).GetAllVotes());
+                            VoteSetModified?.Invoke(this, args);
                             break;
+                        }
                     }
 
                     _logger.Debug(

--- a/Libplanet.Net/Consensus/VoteSet.cs
+++ b/Libplanet.Net/Consensus/VoteSet.cs
@@ -120,6 +120,21 @@ namespace Libplanet.Net.Consensus
             _votesByBlock[blockHash].Votes.Values;
 
         /// <summary>
+        /// Gets all collected <see cref="Vote"/>s.
+        /// </summary>
+        /// <returns><see cref="IEnumerable{T}"/> of <see cref="Vote"/>.</returns>
+        public IEnumerable<Vote> GetAllVotes()
+        {
+            var list = new List<Vote>();
+            foreach (var votes in _votesByBlock.Values)
+            {
+                list.AddRange(votes.Votes.Values);
+            }
+
+            return list;
+        }
+
+        /// <summary>
         /// If a peer claims that it has 2/3 majority for given <see cref="BlockHash"/>,
         /// modify state by calling this method.
         /// </summary>


### PR DESCRIPTION
Added an event that invoked when the `VoteSet` is modified.

Fixed flakiness of `ConsensusContextTest.GetVoteSetBits()` test by using the added event handler.