### PR TITLE
🧹 Removed ActionsLogsList from TxExecution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ be compatible with this version.
     and `ValidatorSetGetter` delegates.  [[#3282]]
  -  Removed `IFeeCalculator` interface.  [[#3283]]
  -  Removed `IBlockPolicy.FeeCalculator` interface property.  [[#3283]]
+ -  Removed `TxExecution.ActionsLogsList`, `TxFailure.ActionsLogsList`,
+    and `TxSuccess.ActionsLogsList` properties.  [[#3291]]
+ -  (Libplanet.Explorer) Removed `TxResult.ActionsLogsList` property.  [[#3291]]
 
 ### Backward-incompatible network protocol changes
 
@@ -101,6 +104,7 @@ be compatible with this version.
 [#3282]: https://github.com/planetarium/libplanet/pull/3282
 [#3283]: https://github.com/planetarium/libplanet/pull/3283
 [#3288]: https://github.com/planetarium/libplanet/pull/3288
+[#3291]: https://github.com/planetarium/libplanet/pull/3291
 
 
 Version 2.4.0

--- a/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
@@ -75,8 +75,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                         null,
                         ImmutableDictionary<Address, Bencodex.Types.IValue>.Empty,
                         ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty,
-                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty,
-                        null
+                        ImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>.Empty
                     ),
                     new Dictionary<string, object> {
                         ["txStatus"] = "SUCCESS",
@@ -109,8 +108,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                                 address,
                                 ImmutableDictionary<Currency, FungibleAssetValue>.Empty
                                     .Add(KRW, KRW * 20000)
-                            ),
-                        null
+                            )
                     ),
                     new Dictionary<string, object> {
                         ["txStatus"] = "SUCCESS",

--- a/Libplanet.Explorer/GraphTypes/TxResult.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResult.cs
@@ -18,8 +18,7 @@ namespace Libplanet.Explorer.GraphTypes
             IImmutableDictionary<Address, IValue>? updatedStates,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>? fungibleAssetsDelta,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>?
-                updatedFungibleAssets,
-            List<IReadOnlyList<string>>? actionsLogsList
+                updatedFungibleAssets
         )
         {
             TxStatus = status;
@@ -30,7 +29,6 @@ namespace Libplanet.Explorer.GraphTypes
             UpdatedStates = updatedStates;
             FungibleAssetsDelta = fungibleAssetsDelta;
             UpdatedFungibleAssets = updatedFungibleAssets;
-            ActionsLogsList = actionsLogsList;
         }
 
         public TxStatus TxStatus { get; private set; }
@@ -50,7 +48,5 @@ namespace Libplanet.Explorer.GraphTypes
 
         public IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>?
             UpdatedFungibleAssets { get; }
-
-        public List<IReadOnlyList<string>>? ActionsLogsList { get; }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/TxResultType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResultType.cs
@@ -56,15 +56,6 @@ namespace Libplanet.Explorer.GraphTypes
                 resolve: context => context.Source.FungibleAssetsDelta?
                     .Select(pair => new FungibleAssetBalances(pair.Key, pair.Value.Values))
             );
-
-            Field<ListGraphType<
-                NonNullGraphType<ListGraphType<
-                    NonNullGraphType<StringGraphType>
-                >>
-            >>(
-                nameof(TxResult.ActionsLogsList),
-                resolve: context => context.Source.ActionsLogsList
-            );
         }
 
         public record UpdatedState(Address Address, Bencodex.Types.IValue? State);

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -248,11 +248,9 @@ namespace Libplanet.Explorer.Queries
                                 null,
                                 null,
                                 null,
-                                null,
                                 null)
                             : new TxResult(
                                 TxStatus.INVALID,
-                                null,
                                 null,
                                 null,
                                 null,
@@ -280,8 +278,7 @@ namespace Libplanet.Explorer.Queries
                                 null,
                                 txSuccess.UpdatedStates,
                                 txSuccess.FungibleAssetsDelta,
-                                txSuccess.UpdatedFungibleAssets,
-                                txSuccess.ActionsLogsList
+                                txSuccess.UpdatedFungibleAssets
                             ),
                             TxFailure txFailure => new TxResult(
                                 TxStatus.FAILURE,
@@ -291,8 +288,7 @@ namespace Libplanet.Explorer.Queries
                                 txFailure.ExceptionMetadata,
                                 null,
                                 null,
-                                null,
-                                txFailure.ActionsLogsList
+                                null
                             ),
                             _ => throw new NotSupportedException(
                                 #pragma warning disable format
@@ -305,7 +301,6 @@ namespace Libplanet.Explorer.Queries
                     {
                         return new TxResult(
                             TxStatus.INVALID,
-                            null,
                             null,
                             null,
                             null,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -179,7 +179,6 @@ namespace Libplanet.Tests.Blockchain
             var inputA = new TxSuccess(
                 _fx.Hash1,
                 _fx.TxId1,
-                null,
                 ImmutableDictionary<Address, IValue>.Empty.Add(
                     random.NextAddress(),
                     (Text)"state value"
@@ -204,14 +203,12 @@ namespace Libplanet.Tests.Blockchain
             var inputB = new TxFailure(
                 _fx.Hash1,
                 _fx.TxId2,
-                null,
                 "AnExceptionName",
                 Dictionary.Empty.Add("foo", 1).Add("bar", "baz")
             );
             var inputC = new TxFailure(
                 _fx.Hash2,
                 _fx.TxId1,
-                null,
                 "AnotherExceptionName",
                 null
             );

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -390,10 +390,8 @@ namespace Libplanet.Tests.Store
             Assert.False(Fx.Store.ContainsBlock(Fx.Block3.Hash));
         }
 
-        [SkippableTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void TxExecution(bool actionsLogsList)
+        [SkippableFact]
+        public void TxExecution()
         {
             void AssertTxSuccessesEqual(TxSuccess expected, TxExecution actual)
             {
@@ -401,7 +399,6 @@ namespace Libplanet.Tests.Store
                 var success = (TxSuccess)actual;
                 Assert.Equal(expected.TxId, success.TxId);
                 Assert.Equal(expected.BlockHash, success.BlockHash);
-                Assert.Equal(expected.ActionsLogsList, success.ActionsLogsList);
                 Assert.Equal(expected.UpdatedStates, success.UpdatedStates);
                 Assert.Equal(expected.FungibleAssetsDelta, success.FungibleAssetsDelta);
                 Assert.Equal(expected.UpdatedFungibleAssets, success.UpdatedFungibleAssets);
@@ -413,7 +410,6 @@ namespace Libplanet.Tests.Store
                 var failure = (TxFailure)actual;
                 Assert.Equal(expected.TxId, failure.TxId);
                 Assert.Equal(expected.BlockHash, failure.BlockHash);
-                Assert.Equal(expected.ActionsLogsList, failure.ActionsLogsList);
                 Assert.Equal(expected.ExceptionName, failure.ExceptionName);
                 Assert.Equal(expected.ExceptionMetadata, failure.ExceptionMetadata);
             }
@@ -427,15 +423,6 @@ namespace Libplanet.Tests.Store
             var inputA = new TxSuccess(
                 Fx.Hash1,
                 Fx.TxId1,
-                actionsLogsList
-                    ? new List<IReadOnlyList<string>>
-                    {
-                        new List<string>
-                        {
-                            "LOG",
-                        },
-                    }
-                    : null,
                 ImmutableDictionary<Address, IValue>.Empty.Add(
                     random.NextAddress(),
                     (Text)"state value"
@@ -467,7 +454,6 @@ namespace Libplanet.Tests.Store
             var inputB = new TxFailure(
                 Fx.Hash1,
                 Fx.TxId2,
-                actionsLogsList ? new List<IReadOnlyList<string>>() : null,
                 "AnExceptionName",
                 Dictionary.Empty.Add("foo", 1).Add("bar", "baz")
             );
@@ -481,7 +467,6 @@ namespace Libplanet.Tests.Store
             var inputC = new TxFailure(
                 Fx.Hash2,
                 Fx.TxId1,
-                actionsLogsList ? new List<IReadOnlyList<string>>() : null,
                 "AnotherExceptionName",
                 null
             );

--- a/Libplanet.Tests/Tx/TxFailureTest.cs
+++ b/Libplanet.Tests/Tx/TxFailureTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -15,7 +14,6 @@ namespace Libplanet.Tests.Tx
         private readonly BlockHash _blockHash;
         private readonly TxId _txid;
         private readonly TxFailure _fx;
-        private readonly TxFailure _fxWithLogs;
 
         [SuppressMessage(
             "Major Code Smell",
@@ -30,39 +28,18 @@ namespace Libplanet.Tests.Tx
             _fx = new TxFailure(
                 _blockHash,
                 _txid,
-                null,
-                new ArgumentNullException("foo"));
-            _fxWithLogs = new TxFailure(
-                _blockHash,
-                _txid,
-                new List<IReadOnlyList<string>>
-                {
-                    new List<string>
-                    {
-                        "LOG",
-                    },
-                },
                 new ArgumentNullException("foo"));
         }
 
         [Fact]
         public void ConstructorWithExceptionObject()
         {
-            var fxs = new[]
-            {
-                _fx,
-                _fxWithLogs,
-            };
-
-            foreach (var fx in fxs)
-            {
-                Assert.Equal(_blockHash, fx.BlockHash);
-                Assert.Equal(_txid, fx.TxId);
-                Assert.Equal(
-                    $"{nameof(System)}.{nameof(ArgumentNullException)}",
-                    fx.ExceptionName);
-                Assert.Equal(Dictionary.Empty.Add("parameterName", "foo"), fx.ExceptionMetadata);
-            }
+            Assert.Equal(_blockHash, _fx.BlockHash);
+            Assert.Equal(_txid, _fx.TxId);
+            Assert.Equal(
+                $"{nameof(System)}.{nameof(ArgumentNullException)}",
+                _fx.ExceptionName);
+            Assert.Equal(Dictionary.Empty.Add("parameterName", "foo"), _fx.ExceptionMetadata);
         }
 
         [Fact]
@@ -71,7 +48,6 @@ namespace Libplanet.Tests.Tx
             var f = new TxFailure(
                 _blockHash,
                 _txid,
-                null,
                 nameof(ArgumentNullException),
                 (Text)"foo"
             );
@@ -79,33 +55,22 @@ namespace Libplanet.Tests.Tx
             Assert.Equal(_txid, f.TxId);
             Assert.Equal(nameof(ArgumentNullException), f.ExceptionName);
             Assert.Equal((Text)"foo", f.ExceptionMetadata);
-            Assert.Null(f.ActionsLogsList);
         }
 
         [Fact]
         public void Serialization()
         {
-            var fxs = new[]
-            {
-                _fx,
-                _fxWithLogs,
-            };
-
-            foreach (var fx in fxs)
-            {
-                var formatter = new BinaryFormatter();
-                var stream = new MemoryStream();
-                formatter.Serialize(stream, fx);
-                stream.Seek(0, SeekOrigin.Begin);
-                object deserialized = formatter.Deserialize(stream);
-                Assert.IsType<TxFailure>(deserialized);
-                var f = (TxFailure)deserialized;
-                Assert.Equal(_blockHash, f.BlockHash);
-                Assert.Equal(_txid, f.TxId);
-                Assert.Equal(fx.ExceptionName, f.ExceptionName);
-                Assert.Equal(fx.ExceptionMetadata, f.ExceptionMetadata);
-                Assert.Equal(fx.ActionsLogsList, f.ActionsLogsList);
-            }
+            var formatter = new BinaryFormatter();
+            var stream = new MemoryStream();
+            formatter.Serialize(stream, _fx);
+            stream.Seek(0, SeekOrigin.Begin);
+            object deserialized = formatter.Deserialize(stream);
+            Assert.IsType<TxFailure>(deserialized);
+            var f = (TxFailure)deserialized;
+            Assert.Equal(_blockHash, f.BlockHash);
+            Assert.Equal(_txid, f.TxId);
+            Assert.Equal(_fx.ExceptionName, f.ExceptionName);
+            Assert.Equal(_fx.ExceptionMetadata, f.ExceptionMetadata);
         }
     }
 }

--- a/Libplanet.Tests/Tx/TxSuccessTest.cs
+++ b/Libplanet.Tests/Tx/TxSuccessTest.cs
@@ -29,11 +29,7 @@ namespace Libplanet.Tests.Tx
         private readonly ImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
             _updatedFungibleAssets;
 
-        private readonly List<IReadOnlyList<string>> _actionsLogsList;
-
         private readonly TxSuccess _fx;
-
-        private readonly TxSuccess _fxWithLogs;
 
         public TxSuccessTest()
         {
@@ -67,25 +63,9 @@ namespace Libplanet.Tests.Tx
                     fav => fav.Currency * random.Next(1, int.MaxValue)
                 ).ToImmutableDictionary()
             ).ToImmutableDictionary();
-            _actionsLogsList = new List<IReadOnlyList<string>>
-            {
-                new List<string>
-                {
-                    "LOG",
-                },
-            };
             _fx = new TxSuccess(
                 _blockHash,
                 _txid,
-                null,
-                _updatedStates,
-                _fungibleAssetsDelta,
-                _updatedFungibleAssets
-            );
-            _fxWithLogs = new TxSuccess(
-                _blockHash,
-                _txid,
-                _actionsLogsList,
                 _updatedStates,
                 _fungibleAssetsDelta,
                 _updatedFungibleAssets
@@ -100,41 +80,23 @@ namespace Libplanet.Tests.Tx
             Assert.Equal(_updatedStates, _fx.UpdatedStates);
             Assert.Equal(_fungibleAssetsDelta, _fx.FungibleAssetsDelta);
             Assert.Equal(_updatedFungibleAssets, _fx.UpdatedFungibleAssets);
-            Assert.Null(_fx.ActionsLogsList);
-
-            Assert.Equal(_blockHash, _fxWithLogs.BlockHash);
-            Assert.Equal(_txid, _fxWithLogs.TxId);
-            Assert.Equal(_updatedStates, _fxWithLogs.UpdatedStates);
-            Assert.Equal(_fungibleAssetsDelta, _fxWithLogs.FungibleAssetsDelta);
-            Assert.Equal(_updatedFungibleAssets, _fxWithLogs.UpdatedFungibleAssets);
-            Assert.Equal(_actionsLogsList, _fxWithLogs.ActionsLogsList);
         }
 
         [Fact]
         public void Serialization()
         {
-            var fxs = new[]
-            {
-                _fx,
-                _fxWithLogs,
-            };
-
-            foreach (var fx in fxs)
-            {
-                var formatter = new BinaryFormatter();
-                var stream = new MemoryStream();
-                formatter.Serialize(stream, fx);
-                stream.Seek(0, SeekOrigin.Begin);
-                object deserialized = formatter.Deserialize(stream);
-                Assert.IsType<TxSuccess>(deserialized);
-                var s = (TxSuccess)deserialized;
-                Assert.Equal(_blockHash, s.BlockHash);
-                Assert.Equal(_txid, s.TxId);
-                Assert.Equal(fx.UpdatedStates, s.UpdatedStates);
-                Assert.Equal(fx.FungibleAssetsDelta, s.FungibleAssetsDelta);
-                Assert.Equal(fx.UpdatedFungibleAssets, s.UpdatedFungibleAssets);
-                Assert.Equal(fx.ActionsLogsList, s.ActionsLogsList);
-            }
+            var formatter = new BinaryFormatter();
+            var stream = new MemoryStream();
+            formatter.Serialize(stream, _fx);
+            stream.Seek(0, SeekOrigin.Begin);
+            object deserialized = formatter.Deserialize(stream);
+            Assert.IsType<TxSuccess>(deserialized);
+            var s = (TxSuccess)deserialized;
+            Assert.Equal(_blockHash, s.BlockHash);
+            Assert.Equal(_txid, s.TxId);
+            Assert.Equal(_fx.UpdatedStates, s.UpdatedStates);
+            Assert.Equal(_fx.FungibleAssetsDelta, s.FungibleAssetsDelta);
+            Assert.Equal(_fx.UpdatedFungibleAssets, s.UpdatedFungibleAssets);
         }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.TxExecution.cs
+++ b/Libplanet/Blockchain/BlockChain.TxExecution.cs
@@ -33,14 +33,12 @@ namespace Libplanet.Blockchain
                 TxId txid = txEvals.Key;
                 IAccountStateDelta prevStates = txEvals.First().InputContext.PreviousState;
                 IActionEvaluation evalSum = txEvals.Last();
-                var actionsLogsList = txEvals.Select(ae => ae.Logs).ToList();
                 TxExecution txExecution;
                 if (evalSum.Exception is { } e)
                 {
                     txExecution = new TxFailure(
                         block.Hash,
                         txid,
-                        actionsLogsList,
                         e.InnerException ?? e);
                 }
                 else
@@ -49,7 +47,6 @@ namespace Libplanet.Blockchain
                     txExecution = new TxSuccess(
                         block.Hash,
                         txid,
-                        actionsLogsList,
                         outputStates.GetUpdatedStates(),
                         outputStates.Delta.UpdatedFungibleAssets
                             .Select(pair =>

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -195,11 +195,6 @@ namespace Libplanet.Store
                 .Add("favDelta", new Dictionary(favDelta))
                 .Add("updatedFAVs", new Dictionary(updatedFAVs));
 
-            if (txSuccess.ActionsLogsList is { } actionsLogsList)
-            {
-                serialized = serialized.Add("actionsLogsList", SerializeLogs(actionsLogsList));
-            }
-
             return serialized;
         }
 
@@ -208,11 +203,6 @@ namespace Libplanet.Store
             Dictionary d = Dictionary.Empty
                 .Add("fail", true)
                 .Add("exc", txFailure.ExceptionName);
-
-            if (txFailure.ActionsLogsList is { } actionsLogsList)
-            {
-                d = d.Add("actionsLogsList", SerializeLogs(txFailure.ActionsLogsList));
-            }
 
             return txFailure.ExceptionMetadata is { } v ? d.Add("excMeta", v) : d;
         }
@@ -236,18 +226,11 @@ namespace Libplanet.Store
             {
                 bool fail = d.GetValue<Bencodex.Types.Boolean>("fail");
 
-                List<IReadOnlyList<string>> actionsLogsList = null;
-                if (d.ContainsKey("actionsLogsList"))
-                {
-                    actionsLogsList =
-                        DeserializeLogs(d.GetValue<List>("actionsLogsList"));
-                }
-
                 if (fail)
                 {
                     string excName = d.GetValue<Text>("exc");
                     IValue excMetadata = d.ContainsKey("excMeta") ? d["excMeta"] : null;
-                    return new TxFailure(blockHash, txid, actionsLogsList, excName, excMetadata);
+                    return new TxFailure(blockHash, txid, excName, excMetadata);
                 }
 
                 ImmutableDictionary<Address, IValue> sDelta = d.GetValue<Dictionary>("sDelta")
@@ -263,7 +246,6 @@ namespace Libplanet.Store
                 return new TxSuccess(
                     blockHash,
                     txid,
-                    actionsLogsList,
                     sDelta,
                     favDelta,
                     updatedFAVs

--- a/Libplanet/Tx/TxExecution.cs
+++ b/Libplanet/Tx/TxExecution.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 using Bencodex;
@@ -24,19 +23,14 @@ namespace Libplanet.Tx
         protected TxExecution(SerializationInfo info, StreamingContext context)
             : this(
                 info.GetValue<BlockHash>(nameof(BlockHash)),
-                info.GetValue<TxId>(nameof(TxId)),
-                info.GetValue<List<IReadOnlyList<string>>>(nameof(ActionsLogsList)))
+                info.GetValue<TxId>(nameof(TxId)))
         {
         }
 
-        private protected TxExecution(
-            BlockHash blockHash,
-            TxId txId,
-            List<IReadOnlyList<string>>? actionsLogsList)
+        private protected TxExecution(BlockHash blockHash, TxId txId)
         {
             BlockHash = blockHash;
             TxId = txId;
-            ActionsLogsList = actionsLogsList;
         }
 
         /// <summary>
@@ -52,18 +46,11 @@ namespace Libplanet.Tx
         [Pure]
         public TxId TxId { get; }
 
-        /// <summary>
-        /// The logs recorded while executing <see cref="Transaction"/>'s actions.
-        /// </summary>
-        [Pure]
-        public List<IReadOnlyList<string>>? ActionsLogsList { get; }
-
         /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue(nameof(BlockHash), BlockHash);
             info.AddValue(nameof(TxId), TxId);
-            info.AddValue(nameof(ActionsLogsList), ActionsLogsList);
         }
     }
 }

--- a/Libplanet/Tx/TxFailure.cs
+++ b/Libplanet/Tx/TxFailure.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 using Bencodex.Types;
@@ -23,18 +22,16 @@ namespace Libplanet.Tx
         /// that the <see cref="Transaction"/> is executed within.</param>
         /// <param name="txId">The executed <see cref="Transaction"/>'s <see
         /// cref="Transaction.Id"/>.</param>
-        /// <param name="actionsLogsList">The logs recorded while executing actions.</param>
         /// <param name="exceptionName">The name of the exception type,
         /// e.g., <c>System.ArgumentException</c>.</param>
         /// <param name="exceptionMetadata">Optional metadata about the exception.</param>
         public TxFailure(
             BlockHash blockHash,
             TxId txId,
-            List<IReadOnlyList<string>>? actionsLogsList,
             string exceptionName,
             IValue? exceptionMetadata
         )
-            : base(blockHash, txId, actionsLogsList)
+            : base(blockHash, txId)
         {
             ExceptionName = exceptionName;
             ExceptionMetadata = exceptionMetadata;
@@ -47,18 +44,15 @@ namespace Libplanet.Tx
         /// that the <see cref="Transaction"/> is executed within.</param>
         /// <param name="txId">The executed <see cref="Transaction"/>'s <see
         /// cref="Transaction.Id"/>.</param>
-        /// <param name="actionsLogsList">The logs recorded while executing actions.</param>
         /// <param name="exception">The uncaught exception thrown by an action in the transaction.
         /// </param>
         public TxFailure(
             BlockHash blockHash,
             TxId txId,
-            List<IReadOnlyList<string>>? actionsLogsList,
             Exception exception)
             : this(
                 blockHash,
                 txId,
-                actionsLogsList,
                 exception.GetType().FullName ?? string.Empty,
                 exception.ExtractMetadata()
             )

--- a/Libplanet/Tx/TxSuccess.cs
+++ b/Libplanet/Tx/TxSuccess.cs
@@ -26,7 +26,6 @@ namespace Libplanet.Tx
         /// that the <see cref="Transaction"/> is executed within.</param>
         /// <param name="txId">The executed <see cref="Transaction"/>'s <see
         /// cref="Transaction.Id"/>.</param>
-        /// <param name="actionsLogsList">The logs recorded while executing actions.</param>
         /// <param name="updatedStates">The states delta made by the actions in
         /// the transaction within the block.</param>
         /// <param name="fungibleAssetsDelta"><see cref="Address"/>es and sets of
@@ -40,13 +39,12 @@ namespace Libplanet.Tx
         public TxSuccess(
             BlockHash blockHash,
             TxId txId,
-            List<IReadOnlyList<string>>? actionsLogsList,
             IImmutableDictionary<Address, IValue> updatedStates,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> fungibleAssetsDelta,
             IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
                 updatedFungibleAssets
         )
-            : base(blockHash, txId, actionsLogsList)
+            : base(blockHash, txId)
         {
             UpdatedStates = updatedStates;
             FungibleAssetsDelta = fungibleAssetsDelta;


### PR DESCRIPTION
Reasons for removal:
- Not in real use.
- Its source, `IActionContext.Logs`, is poorly implemented anyway. 🙄

Other than "it might be nice to have logs data flow back to libplanet and be useful somehow", I don't see a strong rationale for keeping it, at least for now.