### PR TITLE
⚡ Faster `Hex` for netstandard2.1 and up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,12 @@ Version 2.4.1
 
 To be released.
 
+ -  Slight speed and memory optimization for `ByteUtil.Hex()`.  [[#3297]]
  -  (Libplanet.RocksDBStore) Slight improvement for speed and memory usage.
     [[#3298]]
 
 [#3298]: https://github.com/planetarium/libplanet/pull/3298
+[#3297]: https://github.com/planetarium/libplanet/pull/3297
 
 
 Version 2.4.0


### PR DESCRIPTION
Just squeezing some micro performance improvement. 😗
Tested on batch size of `100_000`.

|      Method | ByteStringSize |      Mean |    Error |    StdDev |    Median | Allocated |
|------------ |--------------- |----------:|---------:|----------:|----------:|----------:|
|  HexWithNew |             10 |  24.02 ms | 0.474 ms |  0.680 ms |  24.03 ms |  12.97 MB |
| HexWithRent |             10 |  13.21 ms | 0.259 ms |  0.505 ms |  13.17 ms |   6.87 MB |
|  HexWithNew |            100 |  92.30 ms | 1.844 ms |  4.558 ms |  91.67 ms |  81.64 MB |
| HexWithRent |            100 |  58.31 ms | 1.151 ms |  1.758 ms |  58.21 ms |   41.2 MB |
|  HexWithNew |           1000 | 409.74 ms | 8.723 ms | 25.306 ms | 402.72 ms | 768.28 MB |
| HexWithRent |           1000 | 327.40 ms | 6.537 ms | 11.619 ms | 328.16 ms | 384.52 MB |
