### PR TITLE
⚡ `RocksDBStore` Concat optimization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 2.4.1
 
 To be released.
 
+ -  (Libplanet.RocksDBStore) Slight improvement for speed and memory usage.
+    [[#3298]]
+
+[#3298]: https://github.com/planetarium/libplanet/pull/3298
+
 
 Version 2.4.0
 -------------

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -1337,7 +1338,7 @@ namespace Libplanet.RocksDBStore
         {
             try
             {
-                IEnumerable<Iterator> iterators = IterateDb(_blockCommitDb, new byte[] { });
+                IEnumerable<Iterator> iterators = IterateDb(_blockCommitDb, Array.Empty<byte>());
 
                 // FIXME: Somehow key value comes with 0x76 prefix at the first index of
                 // byte array.
@@ -1383,66 +1384,114 @@ namespace Libplanet.RocksDBStore
             return (store, stateStore);
         }
 
-        private static byte[] DeletedChainKey(Guid chainId)
-            => DeletedKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] DeletedChainKey(Guid chainId) =>
+            Concat(DeletedKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] PreviousChainIndexKey(Guid chainId)
-            => PreviousChainIndexKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] PreviousChainIndexKey(Guid chainId) =>
+            Concat(PreviousChainIndexKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] PreviousChainIdKey(Guid chainId)
-            => PreviousChainIdKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] PreviousChainIdKey(Guid chainId) =>
+            Concat(PreviousChainIdKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] IndexKey(Guid chainId)
-            => IndexKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] IndexKey(Guid chainId) =>
+            Concat(IndexKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] IndexKey(Guid chainId, byte[] indexBytes)
-            => IndexKey(chainId).Concat(indexBytes).ToArray();
+        private static byte[] IndexKey(Guid chainId, byte[] indexBytes) =>
+            Concat(IndexKeyPrefix, chainId.ToByteArray(), indexBytes);
 
-        private static byte[] IndexCountKey(Guid chainId)
-            => IndexCountKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] IndexCountKey(Guid chainId) =>
+            Concat(IndexCountKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] ChainIdKey(Guid chainId)
-            => ChainIdKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] ChainIdKey(Guid chainId) =>
+            Concat(ChainIdKeyPrefix, chainId.ToByteArray());
 
         private static byte[] BlockKey(in BlockHash blockHash) =>
-            BlockKeyPrefix.Concat(blockHash.ByteArray).ToArray();
+            Concat(BlockKeyPrefix, blockHash.ByteArray);
 
         private static byte[] TxKey(in TxId txId) =>
-            TxKeyPrefix.Concat(txId.ByteArray).ToArray();
+            Concat(TxKeyPrefix, txId.ByteArray);
 
-        private static byte[] TxNonceKey(Guid chainId)
-            => TxNonceKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+        private static byte[] TxNonceKey(Guid chainId) =>
+            Concat(TxNonceKeyPrefix, chainId.ToByteArray());
 
-        private static byte[] TxNonceKey(Guid chainId, Address address)
-            => TxNonceKey(chainId, address.ToByteArray());
+        private static byte[] TxNonceKey(Guid chainId, Address address) =>
+            Concat(TxNonceKeyPrefix, chainId.ToByteArray(), address.ByteArray);
 
-        private static byte[] TxNonceKey(Guid chainId, byte[] addressBytes)
-            => TxNonceKey(chainId).Concat(addressBytes).ToArray();
+        private static byte[] TxNonceKey(Guid chainId, byte[] addressBytes) =>
+            Concat(TxNonceKeyPrefix, chainId.ToByteArray(), addressBytes);
 
         private static byte[] TxExecutionKey(in BlockHash blockHash, in TxId txId) =>
 
             // As BlockHash is not fixed size, place TxId first.
-            TxExecutionKeyPrefix.Concat(txId.ByteArray).Concat(blockHash.ByteArray).ToArray();
+            Concat(TxExecutionKeyPrefix, txId.ByteArray, blockHash.ByteArray);
 
         private static byte[] TxExecutionKey(TxExecution txExecution) =>
-            TxExecutionKey(txExecution.BlockHash, txExecution.TxId);
+            Concat(
+                TxExecutionKeyPrefix, txExecution.TxId.ByteArray, txExecution.BlockHash.ByteArray);
 
         private static byte[] TxIdBlockHashIndexKey(in TxId txId, in BlockHash blockHash) =>
-            TxIdBlockHashIndexTxIdKey(txId).Concat(blockHash.ByteArray).ToArray();
+            Concat(TxIdBlockHashIndexPrefix, txId.ByteArray, blockHash.ByteArray);
 
         private static byte[] TxIdBlockHashIndexTxIdKey(in TxId txId) =>
-            TxIdBlockHashIndexPrefix.Concat(txId.ByteArray).ToArray();
+            Concat(TxIdBlockHashIndexPrefix, txId.ByteArray);
 
         private static byte[] ForkedChainsKey(Guid chainId, Guid forkedChainId) =>
-            ForkedChainsKeyPrefix
-            .Concat(chainId.ToByteArray())
-            .Concat(forkedChainId.ToByteArray()).ToArray();
+            Concat(ForkedChainsKeyPrefix, chainId.ToByteArray(), forkedChainId.ToByteArray());
 
         private static byte[] ChainBlockCommitKey(Guid chainId) =>
-            ChainBlockCommitKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+            Concat(ChainBlockCommitKeyPrefix, chainId.ToByteArray());
 
         private static byte[] BlockCommitKey(in BlockHash blockHash) =>
-            BlockCommitKeyPrefix.Concat(blockHash.ByteArray).ToArray();
+            Concat(BlockCommitKeyPrefix, blockHash.ByteArray);
+
+        private static byte[] Concat(byte[] first, byte[] second)
+        {
+            byte[] result = new byte[first.Length + second.Length];
+            first.CopyTo(result, 0);
+            second.CopyTo(result, first.Length);
+            return result;
+        }
+
+        private static byte[] Concat(byte[] first, ImmutableArray<byte> second)
+        {
+            byte[] result = new byte[first.Length + second.Length];
+            first.CopyTo(result, 0);
+            second.CopyTo(result, first.Length);
+            return result;
+        }
+
+        private static byte[] Concat(byte[] first, byte[] second, byte[] third)
+        {
+            byte[] result = new byte[first.Length + second.Length + third.Length];
+            first.CopyTo(result, 0);
+            second.CopyTo(result, first.Length);
+            third.CopyTo(result, first.Length + second.Length);
+            return result;
+        }
+
+        private static byte[] Concat(
+            byte[] first,
+            byte[] second,
+            ImmutableArray<byte> third)
+        {
+            byte[] result = new byte[first.Length + second.Length + third.Length];
+            first.CopyTo(result, 0);
+            second.CopyTo(result, first.Length);
+            third.CopyTo(result, first.Length + second.Length);
+            return result;
+        }
+
+        private static byte[] Concat(
+            byte[] first,
+            ImmutableArray<byte> second,
+            ImmutableArray<byte> third)
+        {
+            byte[] result = new byte[first.Length + second.Length + third.Length];
+            first.CopyTo(result, 0);
+            second.CopyTo(result, first.Length);
+            third.CopyTo(result, first.Length + second.Length);
+            return result;
+        }
 
         private static IEnumerable<Iterator> IterateDb(RocksDb db, byte[] prefix)
         {
@@ -1571,7 +1620,7 @@ namespace Libplanet.RocksDBStore
         private IEnumerable<BlockHash> IterateIndexesInner(Guid chainId, long expectedCount)
         {
             long count = 0;
-            byte[] prefix = IndexKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+            byte[] prefix = Concat(IndexKeyPrefix, chainId.ToByteArray());
             foreach (Iterator it in IterateDb(_chainDb, prefix))
             {
                 if (count >= expectedCount)
@@ -1597,7 +1646,7 @@ namespace Libplanet.RocksDBStore
 
         private bool HasFork(Guid chainId)
         {
-            byte[] prefix = ForkedChainsKeyPrefix.Concat(chainId.ToByteArray()).ToArray();
+            byte[] prefix = Concat(ForkedChainsKeyPrefix, chainId.ToByteArray());
             return IterateDb(_chainDb, prefix).Any();
         }
 


### PR DESCRIPTION
Tested with 1,000,000 byte string pairs (or triples) of length `WordSize` below. Obviously as words get longer, the proportion of LINQ overhead decreases. However, for the most part, we are only concatenating small byte strings for most, if not all, cases.

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.3086)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.203
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT AVX2


|            Method | WordSize |        Mean |     Error |     StdDev |      Median |        Gen0 |  Allocated |
|------------------ |--------- |------------:|----------:|-----------:|------------:|------------:|-----------:|
|   WithConcatPairs |       10 |   243.32 ms |  4.791 ms |  10.617 ms |   244.86 ms |  25333.3333 |  160.22 MB |
|     WithCopyPairs |       10 |    94.13 ms |  1.872 ms |   5.432 ms |    93.98 ms |   7666.6667 |   53.41 MB |
| WithConcatTriples |       10 |   314.55 ms |  9.623 ms |  28.223 ms |   313.11 ms |  28000.0000 |  175.48 MB |
|   WithCopyTriples |       10 |   102.91 ms |  2.046 ms |   4.180 ms |   103.41 ms |   9000.0000 |   61.04 MB |
|   WithConcatPairs |      100 |   432.83 ms |  9.997 ms |  29.161 ms |   431.51 ms |  53000.0000 |  328.06 MB |
|     WithCopyPairs |      100 |   235.76 ms |  4.667 ms |   9.639 ms |   235.96 ms |  35666.6667 |  221.25 MB |
| WithConcatTriples |      100 |   626.57 ms | 13.426 ms |  39.377 ms |   627.25 ms |  71000.0000 |  434.88 MB |
|   WithCopyTriples |      100 |   312.88 ms | 10.005 ms |  28.705 ms |   304.96 ms |  52000.0000 |  320.43 MB |
|   WithConcatPairs |     1000 | 1,339.92 ms | 85.190 ms | 251.185 ms | 1,379.64 ms | 340000.0000 | 2044.68 MB |
|     WithCopyPairs |     1000 | 1,002.98 ms | 67.109 ms | 195.760 ms |   963.25 ms | 322000.0000 | 1937.87 MB |
| WithConcatTriples |     1000 | 2,879.15 ms | 53.529 ms |  50.071 ms | 2,876.16 ms | 502000.0000 | 3005.99 MB |
|   WithCopyTriples |     1000 | 2,209.61 ms | 42.739 ms |  59.914 ms | 2,209.95 ms | 483000.0000 | 2891.54 MB |