### PR TITLE
Fix flaky test `GossipConsensusMessageCommunicatorTest`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
 
 ### Added APIs
 
+ -  (Libplanet.Net) Added `Gossip.DeniedPeers` property.  [[#3313]]
+
 ### Behavioral changes
 
  -  `TxFailure` no longer tracks `ExceptionMetadata` and is always
@@ -42,6 +44,7 @@ To be released.
 [#3300]: https://github.com/planetarium/libplanet/pull/3300
 [#3303]: https://github.com/planetarium/libplanet/pull/3303
 [#3304]: https://github.com/planetarium/libplanet/pull/3304
+[#3313]: https://github.com/planetarium/libplanet/pull/3313
 
 
 Version 2.5.0

--- a/Libplanet.Net/Consensus/Gossip.cs
+++ b/Libplanet.Net/Consensus/Gossip.cs
@@ -118,6 +118,11 @@ namespace Libplanet.Net.Consensus
         public IEnumerable<BoundPeer> Peers => _table.Peers;
 
         /// <summary>
+        /// The list of <see cref="BoundPeer"/>s written in <see cref="_denySet"/>.
+        /// </summary>
+        public IEnumerable<BoundPeer> DeniedPeers => _denySet.ToList();
+
+        /// <summary>
         /// Start the <see cref="Gossip"/> instance.
         /// </summary>
         /// <param name="ctx">A cancellation token used to propagate notification


### PR DESCRIPTION
Fix flaky `GossipConsensusMessageCommunicatorTest` by checking `Gossip.DeniedPeers`.

### API change
- Add Gossip.DeniedPeers property

### Limitation
- Still sometimes this test cannot cover the cases when receiver couldn't received all messages within the delay. But at least, this test isn't flaky for test success any more.
(Not flaky for success, but still flaky for its coverage)