### PR TITLE
⚡ Optimize `KeyBytes` derivation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,17 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Changed `StateStoreExtensions.Commit()` to accept
+    `IImmutableDictionary<KeyBytes, IValue>` instead of
+    `IImmutableDictionary<string, IValue>`.  [[#3321]]
+ -  Added `StateStoreExtensions.GetStates(IStateStore, HashDigest<SHA256>,
+    IReadOnlyList<KeyBytes>)` method.  [[#3321]]
+ -  Changed `AccountDeltaExtensions.ToRawDelta()` to return
+    `IImmutableDictionary<KeyBytes, IValue>` instead of
+    `IImmutableDictionary<string, IValue>`.  [[#3321]]
+ -  Changed `ActionEvaluatorExtensions.GetRawTotalDelta()` to return
+    `IImmutableDictionary<KeyBytes, IValue>` instead of
+    `IImmutableDictionary<string, IValue>`.  [[#3321]]
  -  Removed `EnumerableMeasurement` class.  [[#3325]]
  -  Removed `KeyValueExtensions` class.  [[#3325]]
 
@@ -21,12 +32,16 @@ To be released.
 
 ### Behavioral changes
 
+ -  Optimized read and write access to `IStateStore` both for memory and speed.
+    [[#3321]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
 
+[#3321]: https://github.com/planetarium/libplanet/pull/3321
 [#3325]: https://github.com/planetarium/libplanet/pull/3325
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,6 @@ To be released.
  -  Changed `StateStoreExtensions.Commit()` to accept
     `IImmutableDictionary<KeyBytes, IValue>` instead of
     `IImmutableDictionary<string, IValue>`.  [[#3321]]
- -  Added `StateStoreExtensions.GetStates(IStateStore, HashDigest<SHA256>,
-    IReadOnlyList<KeyBytes>)` method.  [[#3321]]
  -  Changed `AccountDeltaExtensions.ToRawDelta()` to return
     `IImmutableDictionary<KeyBytes, IValue>` instead of
     `IImmutableDictionary<string, IValue>`.  [[#3321]]
@@ -29,6 +27,9 @@ To be released.
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  Added `StateStoreExtensions.GetStates(IStateStore, HashDigest<SHA256>,
+    IReadOnlyList<KeyBytes>)` method.  [[#3321]]
 
 ### Behavioral changes
 

--- a/Libplanet.Action.Tests/State/KeyConvertersTest.cs
+++ b/Libplanet.Action.Tests/State/KeyConvertersTest.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Assets;
+using Xunit;
+
+namespace Libplanet.Action.State.Tests
+{
+    public class KeyConvertersTest
+    {
+        public KeyConvertersTest()
+        {
+        }
+
+        [Fact]
+        public void ToKeysSpec()
+        {
+            var address = new PrivateKey().ToAddress();
+            var currency = Currency.Uncapped("Foo", 2, new PrivateKey().ToAddress());
+
+            Assert.Equal(
+                new KeyBytes(ByteUtil.Hex(address.ByteArray), Encoding.UTF8),
+                KeyConverters.ToStateKey(address));
+
+            Assert.Equal(
+                new KeyBytes(
+                    $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}",
+                    Encoding.UTF8),
+                KeyConverters.ToFungibleAssetKey(address, currency));
+
+            Assert.Equal(
+                new KeyBytes($"__{ByteUtil.Hex(currency.Hash.ByteArray)}", Encoding.UTF8),
+                KeyConverters.ToTotalSupplyKey(currency));
+
+            Assert.Equal(
+                new KeyBytes("___", Encoding.UTF8),
+                KeyConverters.ValidatorSetKey);
+        }
+    }
+}

--- a/Libplanet.Action/ActionEvaluationsExtensions.cs
+++ b/Libplanet.Action/ActionEvaluationsExtensions.cs
@@ -3,12 +3,13 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action.State;
+using Libplanet.Store.Trie;
 
 namespace Libplanet.Action
 {
     public static class ActionEvaluationsExtensions
     {
-        public static IImmutableDictionary<string, IValue> GetRawTotalDelta(
+        public static IImmutableDictionary<KeyBytes, IValue> GetRawTotalDelta(
             this IReadOnlyList<IActionEvaluation> actionEvaluations)
         {
             return actionEvaluations

--- a/Libplanet.Action/State/AccountDeltaExtensions.cs
+++ b/Libplanet.Action/State/AccountDeltaExtensions.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
 using Libplanet.Types.Consensus;
 using static Libplanet.Action.State.KeyConverters;
@@ -49,19 +50,19 @@ namespace Libplanet.Action.State
         /// <param name="delta">The <see cref="IAccountDelta"/> to convert.</param>
         /// <returns>A raw dictionary representation of <see cref="IAccountDelta"/> to write
         /// to an <see cref="IStateStore"/>.</returns>
-        public static IImmutableDictionary<string, IValue> ToRawDelta(this IAccountDelta delta)
+        public static IImmutableDictionary<KeyBytes, IValue> ToRawDelta(this IAccountDelta delta)
         {
             var rawStates = delta.States.Select(
-                kv => new KeyValuePair<string, IValue>(
+                kv => new KeyValuePair<KeyBytes, IValue>(
                     ToStateKey(kv.Key), kv.Value));
             var rawFungibles = delta.Fungibles.Select(
-                kv => new KeyValuePair<string, IValue>(
+                kv => new KeyValuePair<KeyBytes, IValue>(
                     ToFungibleAssetKey(kv.Key), new Integer(kv.Value)));
             var rawTotalSupplies = delta.TotalSupplies.Select(
-                kv => new KeyValuePair<string, IValue>(
+                kv => new KeyValuePair<KeyBytes, IValue>(
                     ToTotalSupplyKey(kv.Key), new Integer(kv.Value)));
 
-            var rawDelta = ImmutableDictionary<string, IValue>.Empty;
+            var rawDelta = ImmutableDictionary<KeyBytes, IValue>.Empty;
             rawDelta = rawDelta.SetItems(rawStates.Concat(rawFungibles).Concat(rawTotalSupplies));
             return delta.ValidatorSet is { } validatorSet
                 ? rawDelta.SetItem(ValidatorSetKey, validatorSet.Bencoded)

--- a/Libplanet.Action/State/AccountStateDeltaExtensions.cs
+++ b/Libplanet.Action/State/AccountStateDeltaExtensions.cs
@@ -24,43 +24,5 @@ namespace Libplanet.Action.State
             stateDelta.Delta.TotalSupplies.ToImmutableDictionary(
                 kv => kv.Key,
                 kv => FungibleAssetValue.FromRawValue(kv.Key, kv.Value));
-
-        internal static IImmutableDictionary<string, IValue?> GetUpdatedRawStates(
-            this IAccountStateDelta stateDelta)
-        {
-            var dict = stateDelta.GetUpdatedStates()
-                .Select(
-                    pair =>
-                        new KeyValuePair<string, IValue?>(
-                            ToStateKey(pair.Key),
-                            pair.Value))
-                .Union(
-                    stateDelta.GetUpdatedBalances()
-                        .Select(
-                            pair =>
-                                new KeyValuePair<string, IValue?>(
-                                    ToFungibleAssetKey(pair.Key),
-                                    (Integer)pair.Value.RawValue)))
-                .Union(
-                    stateDelta.GetUpdatedTotalSupplies()
-                        .Select(
-                            pair =>
-                                new KeyValuePair<string, IValue?>(
-                                    ToTotalSupplyKey(pair.Key),
-                                    (Integer)pair.Value.RawValue)));
-
-            if (stateDelta.GetValidatorSet().Validators.Any())
-            {
-                dict = dict.Union(
-                    new[]
-                    {
-                        new KeyValuePair<string, IValue?>(
-                            ValidatorSetKey,
-                            stateDelta.GetValidatorSet().Bencoded),
-                    });
-            }
-
-            return dict.ToImmutableDictionary();
-        }
     }
 }

--- a/Libplanet.Action/State/BlockState.cs
+++ b/Libplanet.Action/State/BlockState.cs
@@ -62,9 +62,8 @@ namespace Libplanet.Action.State
             // Fetched uncached and update cache
             IReadOnlyList<Address> uncachedAddresses =
                 uncachedIndices.Select(index => addresses[index]).ToArray();
-            string[] uncachedStringKeys = uncachedAddresses.Select(ToStateKey).ToArray();
-            IReadOnlyList<IValue?> fetched = _stateRoot.Get(
-                uncachedStringKeys.Select(StateStoreExtensions.EncodeKey).ToList()).ToArray();
+            KeyBytes[] uncachedKeys = uncachedAddresses.Select(ToStateKey).ToArray();
+            IReadOnlyList<IValue?> fetched = _stateRoot.Get(uncachedKeys).ToArray();
             foreach ((var v, var i) in uncachedIndices.Select((v, i) => (v, i)))
             {
                 result[v] = fetched[i];
@@ -80,9 +79,8 @@ namespace Libplanet.Action.State
         /// <inheritdoc cref="IAccountState.GetBalance"/>
         public FungibleAssetValue GetBalance(Address address, Currency currency)
         {
-            string[] stringKeys = new[] { ToFungibleAssetKey(address, currency) };
-            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(
-                stringKeys.Select(StateStoreExtensions.EncodeKey).ToList());
+            KeyBytes[] keys = new[] { ToFungibleAssetKey(address, currency) };
+            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(keys);
             return rawValues.Count > 0 && rawValues[0] is Bencodex.Types.Integer i
                 ? FungibleAssetValue.FromRawValue(currency, i)
                 : currency * 0;
@@ -96,9 +94,8 @@ namespace Libplanet.Action.State
                 throw TotalSupplyNotTrackableException.WithDefaultMessage(currency);
             }
 
-            string[] stringKeys = new[] { ToTotalSupplyKey(currency) };
-            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(
-                stringKeys.Select(StateStoreExtensions.EncodeKey).ToList());
+            KeyBytes[] keys = new[] { ToTotalSupplyKey(currency) };
+            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(keys);
             return rawValues.Count > 0 && rawValues[0] is Bencodex.Types.Integer i
                 ? FungibleAssetValue.FromRawValue(currency, i)
                 : currency * 0;
@@ -107,9 +104,8 @@ namespace Libplanet.Action.State
         /// <inheritdoc cref="IAccountState.GetValidatorSet"/>
         public ValidatorSet GetValidatorSet()
         {
-            string[] stringKeys = new[] { ValidatorSetKey };
-            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(
-                stringKeys.Select(StateStoreExtensions.EncodeKey).ToList());
+            KeyBytes[] keys = new[] { ValidatorSetKey };
+            IReadOnlyList<IValue?> rawValues = _stateRoot.Get(keys);
             return rawValues.Count > 0 && rawValues[0] is List list
                 ? new ValidatorSet(list)
                 : new ValidatorSet();

--- a/Libplanet.Action/State/KeyConverters.cs
+++ b/Libplanet.Action/State/KeyConverters.cs
@@ -1,23 +1,96 @@
-using Libplanet.Common;
 using Libplanet.Crypto;
+using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
 
 namespace Libplanet.Action.State
 {
     internal static class KeyConverters
     {
-        internal const string ValidatorSetKey = "___";
+        // "___"
+        internal static readonly KeyBytes ValidatorSetKey =
+            new KeyBytes(new byte[] { _underScore, _underScore, _underScore });
 
-        internal static string ToStateKey(Address address) => ByteUtil.Hex(address.ByteArray);
+        private const byte _underScore = 95;  // '_'
 
-        internal static string ToFungibleAssetKey(Address address, Currency currency) =>
-            "_" + ByteUtil.Hex(address.ByteArray) +
-            "_" + ByteUtil.Hex(currency.Hash.ByteArray);
+        private static readonly byte[] _conversionTable =
+        {
+            48,  // '0'
+            49,  // '1'
+            50,  // '2'
+            51,  // '3'
+            52,  // '4'
+            53,  // '5'
+            54,  // '6'
+            55,  // '7'
+            56,  // '8'
+            57,  // '9'
+            97,  // 'a'
+            98,  // 'b'
+            99,  // 'c'
+            100, // 'd'
+            101, // 'e'
+            102, // 'f'
+        };
 
-        internal static string ToFungibleAssetKey((Address, Currency) pair) =>
-            ToFungibleAssetKey(pair.Item1, pair.Item2);
+        // $"{ByteUtil.Hex(address.ByteArray)}"
+        internal static KeyBytes ToStateKey(Address address)
+        {
+            var addressBytes = address.ByteArray;
+            byte[] buffer = new byte[addressBytes.Length * 2];
+            for (int i = 0; i < addressBytes.Length; i++)
+            {
+                buffer[i * 2] = _conversionTable[addressBytes[i] >> 4];
+                buffer[i * 2 + 1] = _conversionTable[addressBytes[i] & 0xf];
+            }
 
-        internal static string ToTotalSupplyKey(Currency currency) =>
-            "__" + ByteUtil.Hex(currency.Hash.ByteArray);
+            return new KeyBytes(buffer);
+        }
+
+        // $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}"
+        internal static KeyBytes ToFungibleAssetKey(Address address, Currency currency)
+        {
+            var addressBytes = address.ByteArray;
+            var currencyBytes = currency.Hash.ByteArray;
+            byte[] buffer = new byte[addressBytes.Length * 2 + currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            for (int i = 0; i < addressBytes.Length; i++)
+            {
+                buffer[1 + i * 2] = _conversionTable[addressBytes[i] >> 4];
+                buffer[1 + i * 2 + 1] = _conversionTable[addressBytes[i] & 0xf];
+            }
+
+            var offset = addressBytes.Length * 2;
+            buffer[offset + 1] = _underScore;
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[offset + 2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[offset + 2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
+        }
+
+        internal static KeyBytes ToFungibleAssetKey(
+            (Address Address, Currency Currency) pair) =>
+            ToFungibleAssetKey(pair.Address, pair.Currency);
+
+        // $"__{ByteUtil.Hex(currency.Hash.ByteArray)}"
+        internal static KeyBytes ToTotalSupplyKey(Currency currency)
+        {
+            var currencyBytes = currency.Hash.ByteArray;
+            byte[] buffer = new byte[currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            buffer[1] = _underScore;
+
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
+        }
     }
 }

--- a/Libplanet.Store/StateStoreExtensions.cs
+++ b/Libplanet.Store/StateStoreExtensions.cs
@@ -57,13 +57,13 @@ namespace Libplanet.Store
         public static ITrie Commit(
             this IStateStore stateStore,
             HashDigest<SHA256>? previousStateRootHash,
-            IImmutableDictionary<string, IValue> rawStatesDelta
+            IImmutableDictionary<KeyBytes, IValue> rawStatesDelta
         )
         {
             ITrie trie = stateStore.GetStateRoot(previousStateRootHash);
-            foreach (KeyValuePair<string, IValue> pair in rawStatesDelta)
+            foreach (KeyValuePair<KeyBytes, IValue> pair in rawStatesDelta)
             {
-                trie = trie.Set(EncodeKey(pair.Key), pair.Value);
+                trie = trie.Set(pair.Key, pair.Value);
             }
 
             ITrie stage = trie.Commit();
@@ -89,6 +89,28 @@ namespace Libplanet.Store
         {
             ITrie trie = stateStore.GetStateRoot(stateRootHash);
             KeyBytes[] keys = rawStateKeys.Select(EncodeKey).ToArray();
+            return trie.Get(keys);
+        }
+
+        /// <summary>
+        /// Gets multiple states at once.
+        /// </summary>
+        /// <param name="stateStore">The <see cref="IStateStore"/> to get states.</param>
+        /// <param name="stateRootHash">The root hash of the state trie to look up states from.
+        /// </param>
+        /// <param name="rawStateKeys">State keys to get.</param>
+        /// <returns>The state values associated to the specified <paramref name="rawStateKeys"/>.
+        /// The associated values are ordered in the same way to the corresponding
+        /// <paramref name="rawStateKeys"/>.  Absent values are represented as
+        /// <see langword="null"/>.</returns>
+        public static IReadOnlyList<IValue?> GetStates(
+            this IStateStore stateStore,
+            HashDigest<SHA256>? stateRootHash,
+            IReadOnlyList<KeyBytes> rawStateKeys
+        )
+        {
+            ITrie trie = stateStore.GetStateRoot(stateRootHash);
+            KeyBytes[] keys = rawStateKeys.ToArray();
             return trie.Get(keys);
         }
 

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -108,7 +108,7 @@ namespace Libplanet.Tests.Fixtures
         public TxWithContext Sign(PrivateKey signer, params Arithmetic[] actions)
         {
             Address signerAddress = signer.ToAddress();
-            string rawStateKey = KeyConverters.ToStateKey(signerAddress);
+            KeyBytes rawStateKey = KeyConverters.ToStateKey(signerAddress);
             long nonce = Chain.GetNextTxNonce(signerAddress);
             Transaction tx =
                 Transaction.Create(nonce, signer, Genesis.Hash, actions.ToPlainValues());
@@ -132,7 +132,7 @@ namespace Libplanet.Tests.Fixtures
                     else
                     {
                         BigInteger nextState = a.Operator.ToFunc()(prev.Item1, a.Operand);
-                        var updatedRawStates = ImmutableDictionary<string, IValue>.Empty
+                        var updatedRawStates = ImmutableDictionary<KeyBytes, IValue>.Empty
                             .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
                         HashDigest<SHA256> nextRootHash =
                             prevTrie.Set(updatedRawStates).Commit().Hash;
@@ -154,7 +154,7 @@ namespace Libplanet.Tests.Fixtures
                         {
                             BigInteger nextState =
                                 a.Operator.ToFunc()(delta[delta.Length - 1].Item1, a.Operand);
-                            var updatedRawStates = ImmutableDictionary<string, IValue>.Empty
+                            var updatedRawStates = ImmutableDictionary<KeyBytes, IValue>.Empty
                                 .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
                             HashDigest<SHA256> nextRootHash =
                                 prevTrie.Set(updatedRawStates).Commit().Hash;

--- a/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
+++ b/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
@@ -31,22 +31,22 @@ namespace Libplanet.Tests.Store
         public static IEnumerable<object[]> StateStores =>
             StateStoreImpls.Select(pair => new object[] { pair.Item1, pair.Item2 });
 
-        public static IImmutableDictionary<string, IValue> ZeroDelta =>
-            ImmutableDictionary<string, IValue>.Empty;
-
-        public static IImmutableDictionary<string, IValue> DeltaA => ZeroDelta
-            .Add("foo", (Text)"abc")
-            .Add("bar", (Text)"def");
-
-        public static IImmutableDictionary<string, IValue> DeltaB => ZeroDelta
-            .Add("foo", (Text)"ABC")
-            .Add("baz", (Text)"ghi");
+        public static IImmutableDictionary<KeyBytes, IValue> ZeroDelta =>
+            ImmutableDictionary<KeyBytes, IValue>.Empty;
 
         public static KeyBytes KeyFoo => StateStoreExtensions.EncodeKey("foo");
 
         public static KeyBytes KeyBar => StateStoreExtensions.EncodeKey("bar");
 
         public static KeyBytes KeyBaz => StateStoreExtensions.EncodeKey("baz");
+
+        public static IImmutableDictionary<KeyBytes, IValue> DeltaA => ZeroDelta
+            .Add(KeyFoo, (Text)"abc")
+            .Add(KeyBar, (Text)"def");
+
+        public static IImmutableDictionary<KeyBytes, IValue> DeltaB => ZeroDelta
+            .Add(KeyFoo, (Text)"ABC")
+            .Add(KeyBaz, (Text)"ghi");
 
         [Theory]
         [MemberData(nameof(StateStores))]

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -44,18 +44,22 @@ namespace Libplanet.Tests.Store
             Assert.Null(empty.Get(new[] { KeyQux })[0]);
             Assert.Null(empty.Get(new[] { KeyQuux })[0]);
 
-            var values = ImmutableDictionary<string, IValue>.Empty
-                .Add("foo", (Binary)GetRandomBytes(32))
-                .Add("bar", (Text)ByteUtil.Hex(GetRandomBytes(32)))
-                .Add("baz", (Bencodex.Types.Boolean)false)
-                .Add("qux", Bencodex.Types.Dictionary.Empty);
+            KeyBytes fooKey = StateStoreExtensions.EncodeKey("foo");
+            KeyBytes barKey = StateStoreExtensions.EncodeKey("bar");
+            KeyBytes bazKey = StateStoreExtensions.EncodeKey("baz");
+            KeyBytes quxKey = StateStoreExtensions.EncodeKey("qux");
+            var values = ImmutableDictionary<KeyBytes, IValue>.Empty
+                .Add(fooKey, (Binary)GetRandomBytes(32))
+                .Add(barKey, (Text)ByteUtil.Hex(GetRandomBytes(32)))
+                .Add(bazKey, (Bencodex.Types.Boolean)false)
+                .Add(quxKey, Bencodex.Types.Dictionary.Empty);
             HashDigest<SHA256> hash = stateStore.Commit(null, values).Hash;
             ITrie found = stateStore.GetStateRoot(hash);
             Assert.True(found.Recorded);
-            AssertBencodexEqual(values["foo"], found.Get(new[] { KeyFoo })[0]);
-            AssertBencodexEqual(values["bar"], found.Get(new[] { KeyBar })[0]);
-            AssertBencodexEqual(values["baz"], found.Get(new[] { KeyBaz })[0]);
-            AssertBencodexEqual(values["qux"], found.Get(new[] { KeyQux })[0]);
+            AssertBencodexEqual(values[fooKey], found.Get(new[] { KeyFoo })[0]);
+            AssertBencodexEqual(values[barKey], found.Get(new[] { KeyBar })[0]);
+            AssertBencodexEqual(values[bazKey], found.Get(new[] { KeyBaz })[0]);
+            AssertBencodexEqual(values[quxKey], found.Get(new[] { KeyQux })[0]);
             Assert.Null(found.Get(new[] { KeyQuux })[0]);
         }
 
@@ -64,13 +68,15 @@ namespace Libplanet.Tests.Store
         [InlineData(false)]
         public void PruneStates(bool secure)
         {
-            var values = ImmutableDictionary<string, IValue>.Empty
-                .Add("foo", (Binary)GetRandomBytes(4096))
-                .Add("bar", (Text)ByteUtil.Hex(GetRandomBytes(2048)))
-                .Add("baz", (Bencodex.Types.Boolean)false)
-                .Add("qux", Bencodex.Types.Dictionary.Empty)
+            var values = ImmutableDictionary<KeyBytes, IValue>.Empty
+                .Add(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096))
                 .Add(
-                    "zzz",
+                    StateStoreExtensions.EncodeKey("bar"),
+                    (Text)ByteUtil.Hex(GetRandomBytes(2048)))
+                .Add(StateStoreExtensions.EncodeKey("baz"), (Bencodex.Types.Boolean)false)
+                .Add(StateStoreExtensions.EncodeKey("qux"), Bencodex.Types.Dictionary.Empty)
+                .Add(
+                    StateStoreExtensions.EncodeKey("zzz"),
                     Bencodex.Types.Dictionary.Empty
                         .Add("binary", GetRandomBytes(4096))
                         .Add("text", ByteUtil.Hex(GetRandomBytes(2048))));
@@ -79,8 +85,8 @@ namespace Libplanet.Tests.Store
             ITrie first = stateStore.Commit(null, values);
 
             int prevStatesCount = _stateKeyValueStore.ListKeys().Count();
-            ImmutableDictionary<string, IValue> nextStates =
-                values.SetItem("foo", (Binary)GetRandomBytes(4096));
+            ImmutableDictionary<KeyBytes, IValue> nextStates =
+                values.SetItem(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096));
             ITrie second = stateStore.Commit(first.Hash, nextStates);
 
             // foo = 0x666f6f
@@ -101,13 +107,15 @@ namespace Libplanet.Tests.Store
         [InlineData(false)]
         public void CopyStates(bool secure)
         {
-            var values = ImmutableDictionary<string, IValue>.Empty
-                .Add("foo", (Binary)GetRandomBytes(4096))
-                .Add("bar", (Text)ByteUtil.Hex(GetRandomBytes(2048)))
-                .Add("baz", (Bencodex.Types.Boolean)false)
-                .Add("qux", Bencodex.Types.Dictionary.Empty)
+            var values = ImmutableDictionary<KeyBytes, IValue>.Empty
+                .Add(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096))
                 .Add(
-                    "zzz",
+                    StateStoreExtensions.EncodeKey("bar"),
+                    (Text)ByteUtil.Hex(GetRandomBytes(2048)))
+                .Add(StateStoreExtensions.EncodeKey("baz"), (Bencodex.Types.Boolean)false)
+                .Add(StateStoreExtensions.EncodeKey("qux"), Bencodex.Types.Dictionary.Empty)
+                .Add(
+                    StateStoreExtensions.EncodeKey("zzz"),
                     Bencodex.Types.Dictionary.Empty
                         .Add("binary", GetRandomBytes(4096))
                         .Add("text", ByteUtil.Hex(GetRandomBytes(2048))));

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Blockchain
             out IReadOnlyList<IActionEvaluation> evaluations)
         {
             evaluations = EvaluateGenesis(actionEvaluator, preEvaluationBlock);
-            IImmutableDictionary<string, IValue> delta = evaluations.GetRawTotalDelta();
+            IImmutableDictionary<KeyBytes, IValue> delta = evaluations.GetRawTotalDelta();
             IStateStore stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             ITrie trie = stateStore.Commit(stateStore.GetStateRoot(null).Hash, delta);
             return trie.Hash;


### PR DESCRIPTION
Tested with 1,000,000 batch.
By "bypass" I mean direct `byte[]` to `byte[]` conversion without obtaining `string` representation in the middle.
Speed-wise not that great, but still reduces quite a bit in memory usage.

|                 Method |       Mean |      Error |     StdDev | Allocated |
|----------------------- |-----------:|-----------:|-----------:|----------:|
|             ToStateKey | 321.206 ms |  6.4224 ms | 13.8248 ms | 312.81 MB |
|       ToStateKeyBypass | 262.234 ms |  5.0044 ms |  5.7631 ms |  129.7 MB |
|               ToFAVKey | 536.196 ms | 10.3974 ms | 15.2403 ms | 785.83 MB |
|         ToFAVKeyBypass | 430.898 ms |  8.5690 ms | 19.5161 ms | 221.25 MB |
|       ToTotalSupplyKey | 408.493 ms |  7.9977 ms | 21.6222 ms | 427.25 MB |
| ToTotalSupplyKeyBypass | 312.920 ms |  6.1483 ms | 11.2424 ms | 144.96 MB |