### PR TITLE
docs: fix docfx toc configuration

### DIFF
--- a/Docs/api/index.md
+++ b/Docs/api/index.md
@@ -1,2 +1,2 @@
-<meta http-equiv="refresh" content="0; url=Libplanet.html">
-Move to [Libplanet](Libplanet.yml)&hellip;
+<meta http-equiv="refresh" content="0; url=Libplanet.Action.html">
+Move to [Libplanet.Action](Libplanet.Action.yml)&hellip;

--- a/Docs/toc.yml
+++ b/Docs/toc.yml
@@ -6,7 +6,7 @@
   href: articles/design.md
 - name: API Reference
   href: api/
-  homepage: api/Libplanet.yml
+  homepage: api/Libplanet.Action.yml
 - name: Analyzer
   href: ../Libplanet.Analyzers/
   homepage: ../Libplanet.Analyzers/README.md


### PR DESCRIPTION
This pull request resolves https://github.com/planetarium/libplanet/issues/3301. After this pull request, the `API reference` tab will redirect to `api/Libplanet.Action.html` I chose `Libplanet.Action`because it is on the top of the left list. If you think other project should be the entry point, please leave a comment 🙏🏻 

<img width="300" alt="Screenshot 2023-07-20 at 11 45 26 AM" src="https://github.com/planetarium/libplanet/assets/26626194/dc8dd652-0ab6-4093-8bcb-cd1c6c974a99">
