### PR TITLE
🧹 Refactor to use `KeyBytes` instead of `string`s in general

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,13 @@ To be released.
     `IImmutableDictionary<string, IValue>`.  [[#3321]]
  -  Removed `EnumerableMeasurement` class.  [[#3325]]
  -  Removed `KeyValueExtensions` class.  [[#3325]]
+ -  Removed `StateStoreExtensions.EncodeKey()` and
+    `StateStoreExtensions.DecodeKey()` methods.  [[#3328]]
+ -  Removed `StateStoreExtensions.GetStates(IStateStore, HashDigest<SHA256>?,
+    IReadOnlyList<string>)` method.  [[#3328]]
+ -  Removed `TrieExtensions.Set(ITrie,
+    IEnumerable<KeyValuePair<string, IValue?>)` method.  [[#3328]]
+ -  Removed `KeyBytes(string, Encoding)` constructor.  [[#3328]]
 
 ### Backward-incompatible network protocol changes
 
@@ -30,6 +37,8 @@ To be released.
 
  -  Added `StateStoreExtensions.GetStates(IStateStore, HashDigest<SHA256>,
     IReadOnlyList<KeyBytes>)` method.  [[#3321]]
+ -  Added `KeyBytes.Encoding` static property.  [[#3328]]
+ -  Added `KeyBytes(string)` constructor.  [[#3328]]
 
 ### Behavioral changes
 
@@ -44,6 +53,7 @@ To be released.
 
 [#3321]: https://github.com/planetarium/libplanet/pull/3321
 [#3325]: https://github.com/planetarium/libplanet/pull/3325
+[#3328]: https://github.com/planetarium/libplanet/pull/3328
 
 
 Version 3.0.1

--- a/Libplanet.Action.Tests/State/KeyConvertersTest.cs
+++ b/Libplanet.Action.Tests/State/KeyConvertersTest.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
@@ -20,21 +19,20 @@ namespace Libplanet.Action.State.Tests
             var currency = Currency.Uncapped("Foo", 2, new PrivateKey().ToAddress());
 
             Assert.Equal(
-                new KeyBytes(ByteUtil.Hex(address.ByteArray), Encoding.UTF8),
+                new KeyBytes(ByteUtil.Hex(address.ByteArray)),
                 KeyConverters.ToStateKey(address));
 
             Assert.Equal(
                 new KeyBytes(
-                    $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}",
-                    Encoding.UTF8),
+                    $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}"),
                 KeyConverters.ToFungibleAssetKey(address, currency));
 
             Assert.Equal(
-                new KeyBytes($"__{ByteUtil.Hex(currency.Hash.ByteArray)}", Encoding.UTF8),
+                new KeyBytes($"__{ByteUtil.Hex(currency.Hash.ByteArray)}"),
                 KeyConverters.ToTotalSupplyKey(currency));
 
             Assert.Equal(
-                new KeyBytes("___", Encoding.UTF8),
+                new KeyBytes("___"),
                 KeyConverters.ValidatorSetKey);
         }
     }

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -32,12 +32,12 @@ public class MptCommandTest : IDisposable
         using var stateKeyValueStoreB = new DefaultKeyValueStore(_pathB);
         _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
             ImmutableDictionary<KeyBytes, IValue>.Empty
-                .Add(StateStoreExtensions.EncodeKey("deleted"), Null.Value)
-                .Add(StateStoreExtensions.EncodeKey("common"), (Text)"before")).Commit();
+                .Add(new KeyBytes("deleted"), Null.Value)
+                .Add(new KeyBytes("common"), (Text)"before")).Commit();
         _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
             ImmutableDictionary<KeyBytes, IValue>.Empty
-                .Add(StateStoreExtensions.EncodeKey("created"), Null.Value)
-                .Add(StateStoreExtensions.EncodeKey("common"), (Text)"after")).Commit();
+                .Add(new KeyBytes("created"), Null.Value)
+                .Add(new KeyBytes("common"), (Text)"after")).Commit();
     }
 
     [Fact]

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -7,6 +7,7 @@ using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Extensions.Cocona.Commands;
 using Libplanet.Extensions.Cocona.Configuration;
+using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tools.Tests.Services;
 using Xunit;
@@ -30,13 +31,13 @@ public class MptCommandTest : IDisposable
         using var stateKeyValueStoreA = new DefaultKeyValueStore(_pathA);
         using var stateKeyValueStoreB = new DefaultKeyValueStore(_pathB);
         _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
-            ImmutableDictionary<string, IValue>.Empty
-                .Add("deleted", Null.Value)
-                .Add("common", (Text)"before")).Commit();
+            ImmutableDictionary<KeyBytes, IValue>.Empty
+                .Add(StateStoreExtensions.EncodeKey("deleted"), Null.Value)
+                .Add(StateStoreExtensions.EncodeKey("common"), (Text)"before")).Commit();
         _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
-            ImmutableDictionary<string, IValue>.Empty
-                .Add("created", Null.Value)
-                .Add("common", (Text)"after")).Commit();
+            ImmutableDictionary<KeyBytes, IValue>.Empty
+                .Add(StateStoreExtensions.EncodeKey("created"), Null.Value)
+                .Add(StateStoreExtensions.EncodeKey("common"), (Text)"after")).Commit();
     }
 
     [Fact]

--- a/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
@@ -122,7 +122,7 @@ public class MptCommand
         // This assumes the original key was encoded from a sensible string.
         ImmutableDictionary<string, byte[]> decoratedStates = trie.ListAllStates()
             .ToImmutableDictionary(
-                pair => KeyBytes.DefaultEncoding.GetString(pair.Key.ToByteArray()),
+                pair => KeyBytes.Encoding.GetString(pair.Key.ToByteArray()),
                 pair => codec.Encode(pair.Value));
 
         Console.WriteLine(JsonSerializer.Serialize(decoratedStates));

--- a/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/MptCommand.cs
@@ -118,9 +118,11 @@ public class MptCommand
             keyValueStore,
             HashDigest<SHA256>.FromString(stateRootHashHex));
         var codec = new Codec();
+
+        // This assumes the original key was encoded from a sensible string.
         ImmutableDictionary<string, byte[]> decoratedStates = trie.ListAllStates()
             .ToImmutableDictionary(
-                pair => StateStoreExtensions.DecodeKey(pair.Key),
+                pair => KeyBytes.DefaultEncoding.GetString(pair.Key.ToByteArray()),
                 pair => codec.Encode(pair.Value));
 
         Console.WriteLine(JsonSerializer.Serialize(decoratedStates));
@@ -227,7 +229,7 @@ public class MptCommand
         var trie = new MerkleTrie(
             keyValueStore,
             HashDigest<SHA256>.FromString(stateRootHashHex));
-        KeyBytes stateKeyBytes = StateStoreExtensions.EncodeKey(stateKey);
+        KeyBytes stateKeyBytes = new KeyBytes(stateKey);
         IReadOnlyList<IValue?> values = trie.Get(new[] { stateKeyBytes });
         if (values.Count > 0 && values[0] is { } value)
         {

--- a/Libplanet.Store/StateStoreExtensions.cs
+++ b/Libplanet.Store/StateStoreExtensions.cs
@@ -53,28 +53,6 @@ namespace Libplanet.Store
         public static IReadOnlyList<IValue?> GetStates(
             this IStateStore stateStore,
             HashDigest<SHA256>? stateRootHash,
-            IReadOnlyList<string> rawStateKeys
-        )
-        {
-            ITrie trie = stateStore.GetStateRoot(stateRootHash);
-            KeyBytes[] keys = rawStateKeys.Select(str => new KeyBytes(str)).ToArray();
-            return trie.Get(keys);
-        }
-
-        /// <summary>
-        /// Gets multiple states at once.
-        /// </summary>
-        /// <param name="stateStore">The <see cref="IStateStore"/> to get states.</param>
-        /// <param name="stateRootHash">The root hash of the state trie to look up states from.
-        /// </param>
-        /// <param name="rawStateKeys">State keys to get.</param>
-        /// <returns>The state values associated to the specified <paramref name="rawStateKeys"/>.
-        /// The associated values are ordered in the same way to the corresponding
-        /// <paramref name="rawStateKeys"/>.  Absent values are represented as
-        /// <see langword="null"/>.</returns>
-        public static IReadOnlyList<IValue?> GetStates(
-            this IStateStore stateStore,
-            HashDigest<SHA256>? stateRootHash,
             IReadOnlyList<KeyBytes> rawStateKeys
         )
         {

--- a/Libplanet.Store/StateStoreExtensions.cs
+++ b/Libplanet.Store/StateStoreExtensions.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Store.Trie;
@@ -14,36 +13,6 @@ namespace Libplanet.Store
     /// </summary>
     public static class StateStoreExtensions
     {
-        /// <summary>
-        /// The internal bytes encoding of raw state keys.
-        /// </summary>
-        internal static readonly Encoding KeyEncoding = Encoding.UTF8;
-
-        /// <summary>
-        /// Encodes a raw state key string to internal bytes representation.
-        /// </summary>
-        /// <param name="key">The raw state key to encode.</param>
-        /// <returns>An encoded key bytes.</returns>
-        public static KeyBytes EncodeKey(string key) =>
-            new KeyBytes(key, KeyEncoding);
-
-        /// <summary>
-        /// Decodes internal <paramref name="keyBytes"/> into a raw state key string.
-        /// </summary>
-        /// <param name="keyBytes">The key bytes to decode.</param>
-        /// <returns>A decoded raw state key string.</returns>
-        public static string DecodeKey(in KeyBytes keyBytes)
-        {
-            ImmutableArray<byte> immutableBytes = keyBytes.ByteArray;
-#if NETSTANDARD2_0
-            byte[] neverChangedBytes = System.Runtime.CompilerServices.Unsafe
-                .As<ImmutableArray<byte>, byte[]>(ref immutableBytes);
-            return KeyEncoding.GetString(neverChangedBytes);
-#else
-            return KeyEncoding.GetString(immutableBytes.AsSpan());
-#endif
-        }
-
         /// <summary>
         /// Records <paramref name="rawStatesDelta"/> which is based on the previous state
         /// root, and returns the new state root.
@@ -88,7 +57,7 @@ namespace Libplanet.Store
         )
         {
             ITrie trie = stateStore.GetStateRoot(stateRootHash);
-            KeyBytes[] keys = rawStateKeys.Select(EncodeKey).ToArray();
+            KeyBytes[] keys = rawStateKeys.Select(str => new KeyBytes(str)).ToArray();
             return trie.Get(keys);
         }
 

--- a/Libplanet.Store/Trie/KeyBytes.cs
+++ b/Libplanet.Store/Trie/KeyBytes.cs
@@ -13,6 +13,12 @@ namespace Libplanet.Store.Trie
     public readonly struct KeyBytes
         : IEquatable<KeyBytes>, IEquatable<ImmutableArray<byte>>, IEquatable<byte[]>
     {
+        /// <summary>
+        /// The default <see cref="Encoding"/>, which is <see cref="Encoding.UTF8"/>, to use
+        /// when creating an instance from a <see langword="string"/>.
+        /// </summary>
+        public static readonly Encoding DefaultEncoding = Encoding.UTF8;
+
         private readonly ImmutableArray<byte> _byteArray;
 
         /// <summary>
@@ -34,14 +40,25 @@ namespace Libplanet.Store.Trie
         }
 
         /// <summary>
-        /// Creates a new <seealso cref="KeyBytes"/> instance from the given <paramref
-        /// name="string"/>.
+        /// Creates a new <seealso cref="KeyBytes"/> instance from given
+        /// <paramref name="str"/> with <see cref="DefaultEncoding"/>.
         /// </summary>
-        /// <param name="string">A key string.  This is encoded to bytes.</param>
-        /// <param name="encoding">The text encoding used for the key string.</param>
-        public KeyBytes(string @string, Encoding encoding)
+        /// <param name="str">The key <see langword="string"/> to encode into bytes.</param>
+        public KeyBytes(string str)
+            : this(str, DefaultEncoding)
         {
-            byte[] neverReusedBuffer = encoding.GetBytes(@string);
+        }
+
+        /// <summary>
+        /// Creates a new <seealso cref="KeyBytes"/> instance from given <paramref name="str"/>
+        /// with <paramref name="encoding"/>.
+        /// </summary>
+        /// <param name="str">The key <see langword="string"/> to encode into bytes.</param>
+        /// <param name="encoding">The <see cref="Encoding"/> to be used for <paramref name="str">.
+        /// </param>
+        public KeyBytes(string str, Encoding encoding)
+        {
+            byte[] neverReusedBuffer = encoding.GetBytes(str);
             ImmutableArray<byte> movedImmutable =
                 Unsafe.As<byte[], ImmutableArray<byte>>(ref neverReusedBuffer);
             _byteArray = movedImmutable;

--- a/Libplanet.Store/Trie/KeyBytes.cs
+++ b/Libplanet.Store/Trie/KeyBytes.cs
@@ -14,10 +14,10 @@ namespace Libplanet.Store.Trie
         : IEquatable<KeyBytes>, IEquatable<ImmutableArray<byte>>, IEquatable<byte[]>
     {
         /// <summary>
-        /// The default <see cref="Encoding"/>, which is <see cref="Encoding.UTF8"/>, to use
-        /// when creating an instance from a <see langword="string"/>.
+        /// The default <see cref="System.Text.Encoding"/>, which is <see cref="Encoding.UTF8"/>,
+        /// to use when creating an instance from a <see langword="string"/>.
         /// </summary>
-        public static readonly Encoding DefaultEncoding = Encoding.UTF8;
+        public static readonly Encoding Encoding = Encoding.UTF8;
 
         private readonly ImmutableArray<byte> _byteArray;
 
@@ -41,11 +41,11 @@ namespace Libplanet.Store.Trie
 
         /// <summary>
         /// Creates a new <seealso cref="KeyBytes"/> instance from given
-        /// <paramref name="str"/> with <see cref="DefaultEncoding"/>.
+        /// <paramref name="str"/> with <see cref="Encoding"/>.
         /// </summary>
         /// <param name="str">The key <see langword="string"/> to encode into bytes.</param>
         public KeyBytes(string str)
-            : this(str, DefaultEncoding)
+            : this(str, Encoding)
         {
         }
 
@@ -54,9 +54,9 @@ namespace Libplanet.Store.Trie
         /// with <paramref name="encoding"/>.
         /// </summary>
         /// <param name="str">The key <see langword="string"/> to encode into bytes.</param>
-        /// <param name="encoding">The <see cref="Encoding"/> to be used for <paramref name="str">.
-        /// </param>
-        public KeyBytes(string str, Encoding encoding)
+        /// <param name="encoding">The <see cref="System.Text.Encoding"/> to be used for
+        /// <paramref name="str">.</param>
+        private KeyBytes(string str, Encoding encoding)
         {
             byte[] neverReusedBuffer = encoding.GetBytes(str);
             ImmutableArray<byte> movedImmutable =

--- a/Libplanet.Store/Trie/TrieExtensions.cs
+++ b/Libplanet.Store/Trie/TrieExtensions.cs
@@ -26,15 +26,5 @@ namespace Libplanet.Store.Trie
 
             return trie;
         }
-
-        public static ITrie Set(this ITrie trie, IEnumerable<KeyValuePair<string, IValue?>> pairs)
-            => trie.Set(
-                pairs.Select(pair =>
-                    new KeyValuePair<KeyBytes, IValue?>(
-                        StateStoreExtensions.EncodeKey(pair.Key),
-                        pair.Value
-                    )
-                )
-            );
     }
 }

--- a/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
+++ b/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
@@ -34,11 +34,11 @@ namespace Libplanet.Tests.Store
         public static IImmutableDictionary<KeyBytes, IValue> ZeroDelta =>
             ImmutableDictionary<KeyBytes, IValue>.Empty;
 
-        public static KeyBytes KeyFoo => StateStoreExtensions.EncodeKey("foo");
+        public static KeyBytes KeyFoo => new KeyBytes("foo");
 
-        public static KeyBytes KeyBar => StateStoreExtensions.EncodeKey("bar");
+        public static KeyBytes KeyBar => new KeyBytes("bar");
 
-        public static KeyBytes KeyBaz => StateStoreExtensions.EncodeKey("baz");
+        public static KeyBytes KeyBaz => new KeyBytes("baz");
 
         public static IImmutableDictionary<KeyBytes, IValue> DeltaA => ZeroDelta
             .Add(KeyFoo, (Text)"abc")

--- a/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
+++ b/Libplanet.Tests/Store/StateStoreExtensionsTest.cs
@@ -78,13 +78,19 @@ namespace Libplanet.Tests.Store
             ITrie a = stateStore.Commit(null, DeltaA);
             ITrie b = stateStore.Commit(a.Hash, DeltaB);
 
-            AssertBencodexEqual((Text)"abc", stateStore.GetStates(a.Hash, new[] { "foo" })[0]);
-            AssertBencodexEqual((Text)"def", stateStore.GetStates(a.Hash, new[] { "bar" })[0]);
-            AssertBencodexEqual(null, stateStore.GetStates(a.Hash, new[] { "baz" })[0]);
+            AssertBencodexEqual(
+                (Text)"abc", stateStore.GetStates(a.Hash, new[] { new KeyBytes("foo") })[0]);
+            AssertBencodexEqual(
+                (Text)"def", stateStore.GetStates(a.Hash, new[] { new KeyBytes("bar") })[0]);
+            AssertBencodexEqual(
+                null, stateStore.GetStates(a.Hash, new[] { new KeyBytes("baz") })[0]);
 
-            AssertBencodexEqual((Text)"ABC", stateStore.GetStates(b.Hash, new[] { "foo" })[0]);
-            AssertBencodexEqual((Text)"def", stateStore.GetStates(b.Hash, new[] { "bar" })[0]);
-            AssertBencodexEqual((Text)"ghi", stateStore.GetStates(b.Hash, new[] { "baz" })[0]);
+            AssertBencodexEqual(
+                (Text)"ABC", stateStore.GetStates(b.Hash, new[] { new KeyBytes("foo") })[0]);
+            AssertBencodexEqual(
+                (Text)"def", stateStore.GetStates(b.Hash, new[] { new KeyBytes("bar") })[0]);
+            AssertBencodexEqual(
+                (Text)"ghi", stateStore.GetStates(b.Hash, new[] { new KeyBytes("baz") })[0]);
         }
 
         [Theory]

--- a/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyBytesTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Text;
 using Libplanet.Store.Trie;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
@@ -15,7 +14,7 @@ namespace Libplanet.Tests.Store.Trie
             AssertBytesEqual(ImmutableArray<byte>.Empty, default(KeyBytes).ByteArray);
             AssertBytesEqual(
                 ImmutableArray<byte>.Empty,
-                new KeyBytes(string.Empty, Encoding.ASCII).ByteArray
+                new KeyBytes(string.Empty).ByteArray
             );
             AssertBytesEqual(
                 ImmutableArray<byte>.Empty.Add(1).Add(2).Add(3).Add(4),
@@ -27,7 +26,7 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBytesEqual(
                 new KeyBytes(ImmutableArray.Create<byte>(0x66, 0x6f, 0x6f)).ByteArray,
-                new KeyBytes("foo", Encoding.ASCII).ByteArray
+                new KeyBytes("foo").ByteArray
             );
         }
 

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -20,15 +20,15 @@ namespace Libplanet.Tests.Store
             _stateKeyValueStore = new DefaultKeyValueStore(null);
         }
 
-        public static KeyBytes KeyFoo => StateStoreExtensions.EncodeKey("foo");
+        public static KeyBytes KeyFoo => new KeyBytes("foo");
 
-        public static KeyBytes KeyBar => StateStoreExtensions.EncodeKey("bar");
+        public static KeyBytes KeyBar => new KeyBytes("bar");
 
-        public static KeyBytes KeyBaz => StateStoreExtensions.EncodeKey("baz");
+        public static KeyBytes KeyBaz => new KeyBytes("baz");
 
-        public static KeyBytes KeyQux => StateStoreExtensions.EncodeKey("qux");
+        public static KeyBytes KeyQux => new KeyBytes("qux");
 
-        public static KeyBytes KeyQuux => StateStoreExtensions.EncodeKey("quux");
+        public static KeyBytes KeyQuux => new KeyBytes("quux");
 
         [Theory]
         [InlineData(true)]
@@ -44,10 +44,10 @@ namespace Libplanet.Tests.Store
             Assert.Null(empty.Get(new[] { KeyQux })[0]);
             Assert.Null(empty.Get(new[] { KeyQuux })[0]);
 
-            KeyBytes fooKey = StateStoreExtensions.EncodeKey("foo");
-            KeyBytes barKey = StateStoreExtensions.EncodeKey("bar");
-            KeyBytes bazKey = StateStoreExtensions.EncodeKey("baz");
-            KeyBytes quxKey = StateStoreExtensions.EncodeKey("qux");
+            KeyBytes fooKey = new KeyBytes("foo");
+            KeyBytes barKey = new KeyBytes("bar");
+            KeyBytes bazKey = new KeyBytes("baz");
+            KeyBytes quxKey = new KeyBytes("qux");
             var values = ImmutableDictionary<KeyBytes, IValue>.Empty
                 .Add(fooKey, (Binary)GetRandomBytes(32))
                 .Add(barKey, (Text)ByteUtil.Hex(GetRandomBytes(32)))
@@ -69,14 +69,14 @@ namespace Libplanet.Tests.Store
         public void PruneStates(bool secure)
         {
             var values = ImmutableDictionary<KeyBytes, IValue>.Empty
-                .Add(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096))
+                .Add(new KeyBytes("foo"), (Binary)GetRandomBytes(4096))
                 .Add(
-                    StateStoreExtensions.EncodeKey("bar"),
+                    new KeyBytes("bar"),
                     (Text)ByteUtil.Hex(GetRandomBytes(2048)))
-                .Add(StateStoreExtensions.EncodeKey("baz"), (Bencodex.Types.Boolean)false)
-                .Add(StateStoreExtensions.EncodeKey("qux"), Bencodex.Types.Dictionary.Empty)
+                .Add(new KeyBytes("baz"), (Bencodex.Types.Boolean)false)
+                .Add(new KeyBytes("qux"), Bencodex.Types.Dictionary.Empty)
                 .Add(
-                    StateStoreExtensions.EncodeKey("zzz"),
+                    new KeyBytes("zzz"),
                     Bencodex.Types.Dictionary.Empty
                         .Add("binary", GetRandomBytes(4096))
                         .Add("text", ByteUtil.Hex(GetRandomBytes(2048))));
@@ -86,7 +86,7 @@ namespace Libplanet.Tests.Store
 
             int prevStatesCount = _stateKeyValueStore.ListKeys().Count();
             ImmutableDictionary<KeyBytes, IValue> nextStates =
-                values.SetItem(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096));
+                values.SetItem(new KeyBytes("foo"), (Binary)GetRandomBytes(4096));
             ITrie second = stateStore.Commit(first.Hash, nextStates);
 
             // foo = 0x666f6f
@@ -108,14 +108,14 @@ namespace Libplanet.Tests.Store
         public void CopyStates(bool secure)
         {
             var values = ImmutableDictionary<KeyBytes, IValue>.Empty
-                .Add(StateStoreExtensions.EncodeKey("foo"), (Binary)GetRandomBytes(4096))
+                .Add(new KeyBytes("foo"), (Binary)GetRandomBytes(4096))
                 .Add(
-                    StateStoreExtensions.EncodeKey("bar"),
+                    new KeyBytes("bar"),
                     (Text)ByteUtil.Hex(GetRandomBytes(2048)))
-                .Add(StateStoreExtensions.EncodeKey("baz"), (Bencodex.Types.Boolean)false)
-                .Add(StateStoreExtensions.EncodeKey("qux"), Bencodex.Types.Dictionary.Empty)
+                .Add(new KeyBytes("baz"), (Bencodex.Types.Boolean)false)
+                .Add(new KeyBytes("qux"), Bencodex.Types.Dictionary.Empty)
                 .Add(
-                    StateStoreExtensions.EncodeKey("zzz"),
+                    new KeyBytes("zzz"),
                     Bencodex.Types.Dictionary.Empty
                         .Add("binary", GetRandomBytes(4096))
                         .Add("text", ByteUtil.Hex(GetRandomBytes(2048))));

--- a/Libplanet.Tests/Store/TrieStateStoreTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreTest.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Store;
@@ -128,10 +127,10 @@ namespace Libplanet.Tests.Store
             int prevStatesCount = _stateKeyValueStore.ListKeys().Count();
 
             _stateKeyValueStore.Set(
-                new KeyBytes("alpha", Encoding.UTF8),
+                new KeyBytes("alpha"),
                 ByteUtil.ParseHex("00"));
             _stateKeyValueStore.Set(
-                new KeyBytes("beta", Encoding.UTF8),
+                new KeyBytes("beta"),
                 ByteUtil.ParseHex("00"));
 
             Assert.Equal(prevStatesCount + 2, _stateKeyValueStore.ListKeys().Count());


### PR DESCRIPTION
Removing encoding responsibility from `StateStoreExtensions`.

- It isn't at all clear which entity should actually be responsible for the encoding scheme.
- The general codebase is already severely infected with hardcoded encoding scheme (UTF8).
  - Having `KeyBytes` to be encoding agnostic is nice and all, but in reality, there is no real way to use the library with a different encoding.
  - Technically, `IStateStore` can be responsible for tracking how `string`s are encoded into bytes, but then `IStateStore` should track the encoding scheme not an extension class.
  - On another note, allowing to mix `byte[]` and `string` to be mixed seem like a bad idea, as there is no way to determine whether a `KeyBytes` is derived from a byte string or a text string. 🙄
    - To be usable at a higher level, `KeyBytes` should've retained the encoding information (i.e. whether it was created from `byte[]` or `string`).
    - The way we are handling keys in `KeyConverters` is already a mess. 😕
  - I don't think its worth the effort to allow different encoding schemes.

Anyhow, with how assumptions have already seeped in to the codebase, might well as make it more explicit. 😶