### PR TITLE
ci(gh-actions): check typos over all files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,3 @@ jobs:
 
       - name: Check spelling
         uses: crate-ci/typos@v1.15.5
-        with:
-          files: ./CHANGES.md

--- a/@planetarium/account-web3-secret-storage/test/TtyPassphraseEntry.test.ts
+++ b/@planetarium/account-web3-secret-storage/test/TtyPassphraseEntry.test.ts
@@ -12,7 +12,7 @@ async function waitUntilRead(
     typeof dataToWrite === "string"
       ? Buffer.from(dataToWrite, "utf8")
       : dataToWrite;
-  await setTimeout(0); // mimicks I/O interrupt
+  await setTimeout(0); // mimics I/O interrupt
   input.put(dataToWrite);
   return await new Promise((resolve) => {
     input.on("data", (chunk: Buffer) => {

--- a/Libplanet.Action.Tests/Common/DumbAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbAction.cs
@@ -157,10 +157,10 @@ namespace Libplanet.Action.Tests.Common
 
             if (Idempotent)
             {
-                var splitedItems = items is null ? new[] { item } : (items + "," + item).Split(',');
+                var splitItems = items is null ? new[] { item } : (items + "," + item).Split(',');
                 items = string.Join(
                     ",",
-                    splitedItems.OrderBy(x =>
+                    splitItems.OrderBy(x =>
                         float.Parse(
                             x.Substring(4),
                             NumberStyles.Float,

--- a/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
+++ b/Libplanet.Explorer.Tests/GraphQLTestUtils.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Explorer.Tests
         {
             var documentExecutor = new DocumentExecuter();
 
-            // FIXME these codes are temporarly fix and should be replaced with unified provider.
+            // FIXME these codes are temporary fix and should be replaced with unified provider.
             // see also: https://github.com/planetarium/libplanet/discussions/2230
             var services = new ServiceCollection();
             System.Action addContext = source switch

--- a/Libplanet.Explorer.ruleset
+++ b/Libplanet.Explorer.ruleset
@@ -13,7 +13,7 @@
     <Rule Id="SA1652" Action="None" />
     <!-- Allow field name to begin with an underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Allow an expression not to declare parenthese. -->
+    <!-- Allow an expression not to declare parentheses. -->
     <Rule Id="SA1407" Action="None" />
     <!-- Allow a rich text in a XML doc comment's <summary>. -->
     <Rule Id="SA1462" Action="None" />

--- a/Libplanet.Explorer/GraphTypes/ActionType.cs
+++ b/Libplanet.Explorer/GraphTypes/ActionType.cs
@@ -55,7 +55,7 @@ namespace Libplanet.Explorer.GraphTypes
 
             Field<NonNullGraphType<StringGraphType>>(
                 name: "json",
-                description: "A JSON representaion of action data",
+                description: "A JSON representation of action data",
                 resolve: ctx =>
                 {
                     var converter = new Bencodex.Json.BencodexJsonConverter();

--- a/Libplanet.Net/Consensus/GossipConsensusMessageCommunicator.cs
+++ b/Libplanet.Net/Consensus/GossipConsensusMessageCommunicator.cs
@@ -130,7 +130,7 @@ namespace Libplanet.Net.Consensus
                 {
                     Gossip.DenyPeer(peer);
                     throw new InvalidConsensusMessageException(
-                        $"Repetitively found heigher rounds, add {peer} to deny set",
+                        $"Repetitively found higher rounds, add {peer} to deny set",
                         voteMsg);
                 }
             }

--- a/Libplanet.Net/Transports/NetMQTransport.cs
+++ b/Libplanet.Net/Transports/NetMQTransport.cs
@@ -927,7 +927,7 @@ namespace Libplanet.Net.Transports
                     catch (Exception e)
                     {
                         _logger.Error(
-                            e, "An unexpected exception ocurred during poller.Run()");
+                            e, "An unexpected exception occurred during poller.Run()");
                     }
                 },
                 CancellationToken.None,

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -25,7 +25,7 @@
     <Rule Id="SA1652" Action="None" />
     <!-- Allow field name to begin with an underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Allow an expression not to declare parenthese. -->
+    <!-- Allow an expression not to declare parentheses. -->
     <Rule Id="SA1407" Action="None" />
     <!-- Allow a rich text in a XML doc comment's <summary>. -->
     <Rule Id="SA1462" Action="None" />

--- a/Libplanet.Tests/KeyStore/Kdfs/KdfTest.cs
+++ b/Libplanet.Tests/KeyStore/Kdfs/KdfTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Tests.KeyStore.Kdfs
             T kdf = MakeInstance(randomBytes);
             ImmutableArray<byte> dFoo = kdf.Derive(passphrase);
             Assert.Equal(size, dFoo.Length);
-            ImmutableArray<byte> dBar = kdf.Derive($"diffrent-{passphrase}");
+            ImmutableArray<byte> dBar = kdf.Derive($"different-{passphrase}");
             Assert.NotEqual(dFoo, dBar);
             TestUtils.AssertBytesEqual(dFoo, kdf.Derive(passphrase));
         }

--- a/Libplanet.ruleset
+++ b/Libplanet.ruleset
@@ -13,7 +13,7 @@
     <Rule Id="SA1652" Action="None" />
     <!-- Allow field name to begin with an underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Allow an expression not to declare parenthese. -->
+    <!-- Allow an expression not to declare parentheses. -->
     <Rule Id="SA1407" Action="None" />
     <!-- Allow tuple types in signatures omit element names. -->
     <Rule Id="SA1414" Action="None" />

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,14 @@
+[default]
+extend-ignore-re = [
+    "\\\"([a-zA-Z0-9][a-zA-Z0-9])+\\\"",  # for hexadecimal string values.
+    "2nd"
+]
+
+[default.extend-words]
+ba = "ba"  # byte array
+oce = "oce"  # OperationCanceledException
+
+[files]
+extend-exclude = [
+    "hooks/*"
+]


### PR DESCRIPTION
This pull request makes the *Libplanet* repository's CI runs typos over all files, while it runs on only the `CHANGES.md` file before.

You can apply the `typos` command's check result by running it with the `-w` option. (i.e., `typos -w`).
You can see the `_typos.toml` spec in https://github.com/crate-ci/typos/blob/143cc59fab61e34b96188ba6745f902d7867bda0/docs/reference.md#config-fields.
You can see the TOML's syntax in https://toml.io/ko/v1.0.0 (Korean ver).

