### PR TITLE
Use @noble/hashes/scrypt instead of scrypt-js

### DIFF
--- a/@planetarium/account-web3-secret-storage/package.json
+++ b/@planetarium/account-web3-secret-storage/package.json
@@ -62,9 +62,8 @@
     "vitest": "^0.29.2"
   },
   "dependencies": {
-    "@noble/hashes": "^1.3.0",
-    "@peculiar/webcrypto": "^1.4.3",
-    "scrypt-js": "^3.0.1"
+    "@noble/hashes": "^1.3.1",
+    "@peculiar/webcrypto": "^1.4.3"
   },
   "peerDependencies": {
     "@planetarium/account": "workspace:^"

--- a/@planetarium/account-web3-secret-storage/src/Web3Account.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3Account.ts
@@ -320,7 +320,7 @@ async function deriveKey(
     const { dklen, n, p, r, salt } = kdf.kdfparams;
     const derivedKey = await scryptAsync(passphrase, salt, { N: n, r, p, dkLen: dklen});
     if (derivedKey.length < dklen) {
-      throw new Error(`Too Short key: ${toHex(derivedKey)}`);
+      throw new Error(`Key too short: ${toHex(derivedKey)}`);
     }
     return derivedKey;
   }

--- a/@planetarium/account-web3-secret-storage/src/Web3Account.ts
+++ b/@planetarium/account-web3-secret-storage/src/Web3Account.ts
@@ -313,7 +313,7 @@ async function deriveKey(
       },
     );
     if (derivedKey.length < dklen) {
-      throw new Error(`Too short key: ${toHex(derivedKey)}`);
+      throw new Error(`Key too short: ${toHex(derivedKey)}`);
     }
     return derivedKey;
   } else if (kdf.kdf === "scrypt") {

--- a/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
+++ b/@planetarium/account-web3-secret-storage/test/Web3Account.test.ts
@@ -41,19 +41,19 @@ const scryptKeyObject: Web3KeyObject = {
   crypto: {
     cipher: "aes-128-ctr",
     cipherparams: {
-      iv: "83dbcc02d8ccb40e466191a123791e0e",
+      iv: "740770fce12ce862af21264dab25f1da",
     },
     ciphertext:
-      "d172bf743a674da9cdad04534d56926ef8358534d458fffccd4e6ad2fbde479c",
+      "dd8a1132cf57db67c038c6763afe2cbe6ea1949a86abc5843f8ca656ebbb1ea2",
     kdf: "scrypt",
     kdfparams: {
       dklen: 32,
       n: 262144,
-      p: 8,
-      r: 1,
-      salt: "ab0c7876052600dd703518d6fc3fe8984592145b591fc8fb5c6d43190334ba19",
+      p: 1,
+      r: 8,
+      salt: "25710c2ccd7c610b24d068af83b959b7a0e5f40641f0c82daeb1345766191034",
     },
-    mac: "2103ac29920d71da29f15d75b4a16dbe95cfd7ff8faea1056c33131d846e3097",
+    mac: "337aeb86505d2d0bb620effe57f18381377d67d76dac1090626aa5cd20886a7c",
   },
   id: "3198bc9c-6672-5ab3-d995-4942343ae5b6",
   address: "008aeeda4d805471df9b2a5b0f38a0c3bcba786b",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,10 +1241,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@noble/hashes@npm:1.3.0"
-  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
+"@noble/hashes@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@noble/hashes@npm:1.3.1"
+  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
   languageName: node
   linkType: hard
 
@@ -1359,7 +1359,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@planetarium/account-web3-secret-storage@workspace:@planetarium/account-web3-secret-storage"
   dependencies:
-    "@noble/hashes": ^1.3.0
+    "@noble/hashes": ^1.3.1
     "@peculiar/webcrypto": ^1.4.3
     "@planetarium/account": "workspace:^"
     "@types/node": ^18.13.0
@@ -1368,7 +1368,6 @@ __metadata:
     "@vitest/ui": ^0.29.2
     fast-check: ^3.8.0
     nanobundle: ^1.5.0
-    scrypt-js: ^3.0.1
     stream-buffers: ^3.0.2
     vite: ^4.1.4
     vitest: ^0.29.2
@@ -4466,13 +4465,6 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
-  languageName: node
-  linkType: hard
-
-"scrypt-js@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "scrypt-js@npm:3.0.1"
-  checksum: b7c7d1a68d6ca946f2fbb0778e0c4ec63c65501b54023b2af7d7e9f48fdb6c6580d6f7675cd53bda5944c5ebc057560d5a6365079752546865defb3b79dea454
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since @noble/hashes includes Scrypt, which is very reliable and fast,
I replaced scrypt-js with it. this also removes unnecessary dependency.

Quite surprisingly, while replacing this, I found out test vector for Web3 Secret Storage using Scrypt provided by ethereum official documentation was incorrectly generated. so I generated new correct test vector for Scrypt. you can find about this issue from https://github.com/ethereum/ethereum-org-website/pull/10825 