### PR TITLE
Add Static Factory Methods to TxResult Class

### DIFF
--- a/Libplanet.Explorer/GraphTypes/TxResult.cs
+++ b/Libplanet.Explorer/GraphTypes/TxResult.cs
@@ -47,5 +47,59 @@ namespace Libplanet.Explorer.GraphTypes
 
         public IImmutableDictionary<Address, IImmutableDictionary<Currency, FungibleAssetValue>>?
             UpdatedFungibleAssets { get; }
+
+        public static TxResult Success(
+            long blockIndex,
+            string blockHash,
+            IImmutableDictionary<Address, IValue> updatedStates,
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>> fungibleAssetsDelta,
+            IImmutableDictionary<Address, IImmutableDictionary<Currency, FAV>>
+                updatedFungibleAssets
+        )
+        {
+            return new TxResult(
+                TxStatus.SUCCESS,
+                blockIndex,
+                blockHash,
+                null,
+                null,
+                updatedStates,
+                fungibleAssetsDelta,
+                updatedFungibleAssets
+            );
+        }
+
+        public static TxResult Failure(
+            long blockIndex,
+            string blockHash,
+            string exceptionName,
+            IValue exceptionMetadata
+        )
+        {
+            return new TxResult(
+                TxStatus.FAILURE,
+                blockIndex,
+                blockHash,
+                exceptionName,
+                exceptionMetadata,
+                null,
+                null,
+                null
+            );
+        }
+
+        public static TxResult FromStatus(TxStatus status)
+        {
+            return new TxResult(
+                status,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+            );
+        }
     }
 }


### PR DESCRIPTION
This PR introduces `Success`, `Failure`, and `FromStatus` static factory methods to the `TxResult` class. These can be particularly beneficial in parts of the codebase such as [TransactionQuery.cs](https://github.com/planetarium/libplanet/blob/e74fb5a87684d8831b8ca42f80318bfced1494ed/Libplanet.Explorer/Queries/TransactionQuery.cs#L247C40-L247C40).
