### PR TITLE
♻️ Cleanup and optimize `MerkleTrie.Get()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ To be released.
 
  -  (Libplanet.Action) Renamed `IAccountStateDelta` as `IAccount`.
     [[#3337]]
+ -  (Libplanet.Store) Optimized `MerkleTrie.Get()`.  [[#3347]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +29,7 @@ To be released.
 ### CLI tools
 
 [#3337]: https://github.com/planetarium/libplanet/pull/3337
+[#3347]: https://github.com/planetarium/libplanet/pull/3347
 
 
 Version 3.1.0


### PR DESCRIPTION
Aside from unnecessarily being complicated and requiring more overhead, the previous version iterated over unnecessary elements.

Below was tested with a `MerkleTrie` with `Commit` number of commits where each commit has `Batch` number of fixed size random `Text`s and reading everything back.

|          Method | Commit | Batch |       Mean |      Error |     StdDev | Allocated |
|---------------- |------- |------ |-----------:|-----------:|-----------:|----------:|
|        GetBatch |    100 |     4 |   6.313 ms |  0.3403 ms |  0.3919 ms |   9.43 MB |
| GetBatchUpdated |    100 |     4 |   5.652 ms |  0.3036 ms |  0.3496 ms |   8.93 MB |
|        GetBatch |    100 |    16 |  30.940 ms |  1.5592 ms |  1.7956 ms |  43.85 MB |
| GetBatchUpdated |    100 |    16 |  27.860 ms |  1.3925 ms |  1.6036 ms |   42.1 MB |
|        GetBatch |    100 |    64 | 164.981 ms |  5.6950 ms |  6.3300 ms | 203.71 MB |
| GetBatchUpdated |    100 |    64 | 136.630 ms |  5.5986 ms |  6.4473 ms | 197.37 MB |
|        GetBatch |    400 |     4 |  31.833 ms |  0.9290 ms |  1.0326 ms |  44.54 MB |
| GetBatchUpdated |    400 |     4 |  27.785 ms |  1.7314 ms |  1.9939 ms |  41.99 MB |
|        GetBatch |    400 |    16 | 162.121 ms |  7.5600 ms |  8.7061 ms | 204.47 MB |
| GetBatchUpdated |    400 |    16 | 136.374 ms |  5.2204 ms |  5.8025 ms | 197.76 MB |
|        GetBatch |    400 |    64 | 815.020 ms | 22.2388 ms | 23.7953 ms | 916.86 MB |
| GetBatchUpdated |    400 |    64 | 698.497 ms | 32.9300 ms | 37.9222 ms | 890.19 MB |