### PR TITLE
Introduce `IStateStore.Commit()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,10 @@ To be released.
 
  -  (Libplanet.Action) Renamed `IAccountStateDelta` as `IAccount`.
     [[#3337]]
- -  (Libplanet.Store) Optimized `MerkleTrie.Get()`.  [[#3347]]
+ -  (Libplanet.Store) Added `IStateStore.Commit(ITrie)` interface method.
+    [[#3350]]
+ -  (Libplanet.Store) Removed `ITrie.Commit()` interface method.
+    [[#3350]]
 
 ### Backward-incompatible network protocol changes
 
@@ -22,6 +25,8 @@ To be released.
 
 ### Behavioral changes
 
+ -  (Libplanet.Store) Optimized `MerkleTrie.Get()`.  [[#3347]]
+
 ### Bug fixes
 
 ### Dependencies
@@ -30,6 +35,7 @@ To be released.
 
 [#3337]: https://github.com/planetarium/libplanet/pull/3337
 [#3347]: https://github.com/planetarium/libplanet/pull/3347
+[#3350]: https://github.com/planetarium/libplanet/pull/3350
 
 
 Version 3.1.0

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -501,6 +501,12 @@ If omitted (default) explorer only the local blockchain store.")]
             {
             }
 
+            public ITrie Commit(ITrie trie)
+            {
+                throw new InvalidOperationException(
+                    $"A {nameof(NoOpStateStore)} does not allow commit operation");
+            }
+
             public void Dispose()
             {
             }

--- a/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/MptCommandTest.cs
@@ -33,11 +33,13 @@ public class MptCommandTest : IDisposable
         _trieA = new MerkleTrie(stateKeyValueStoreA).Set(
             ImmutableDictionary<KeyBytes, IValue>.Empty
                 .Add(new KeyBytes("deleted"), Null.Value)
-                .Add(new KeyBytes("common"), (Text)"before")).Commit();
+                .Add(new KeyBytes("common"), (Text)"before"));
+        _trieA = ((MerkleTrie)_trieA).Commit();
         _trieB = new MerkleTrie(stateKeyValueStoreB).Set(
             ImmutableDictionary<KeyBytes, IValue>.Empty
                 .Add(new KeyBytes("created"), Null.Value)
-                .Add(new KeyBytes("common"), (Text)"after")).Commit();
+                .Add(new KeyBytes("common"), (Text)"after"));
+        _trieB = ((MerkleTrie)_trieB).Commit();
     }
 
     [Fact]

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
-using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Store.Trie;
 
@@ -33,6 +32,11 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="trie">The <see cref="ITrie"/> to commit.</param>
         /// <returns>A new committed <see cref="ITrie"/>.</returns>
+        /// <remarks>Given <paramref name="trie"/> must have been derived from an
+        /// <see cref="ITrie"/> retrieved via <see cref="GetStateRoot"/> from the same
+        /// instance of an <see cref="IStateStore"/>.  Otherwise, this does not guarentee
+        /// that <paramref name="trie"/> would be committed.
+        /// </remarks>
         ITrie Commit(ITrie trie);
     }
 }

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Store.Trie;
 
@@ -26,5 +27,12 @@ namespace Libplanet.Store
         /// <param name="survivingStateRootHashes">The state root hashes <em>not</em> to prune.
         /// These state root hashes are guaranteed to survive after pruning.</param>
         void PruneStates(IImmutableSet<HashDigest<SHA256>> survivingStateRootHashes);
+
+        /// <summary>
+        /// Cleans up and stores the <see cref="ITrie"/> in storage.
+        /// </summary>
+        /// <param name="trie">The <see cref="ITrie"/> to commit.</param>
+        /// <returns>A new committed <see cref="ITrie"/>.</returns>
+        ITrie Commit(ITrie trie);
     }
 }

--- a/Libplanet.Store/StateStoreExtensions.cs
+++ b/Libplanet.Store/StateStoreExtensions.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Store
                 trie = trie.Set(pair.Key, pair.Value);
             }
 
-            ITrie stage = trie.Commit();
+            ITrie stage = stateStore.Commit(trie);
             return stateStore.GetStateRoot(stage.Hash);
         }
 

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -41,11 +41,5 @@ namespace Libplanet.Store.Trie
         /// values are ordered in the same way to the corresponding <paramref name="keys"/>.  Absent
         /// values are represented as <see langword="null"/>.</returns>
         IReadOnlyList<IValue?> Get(IReadOnlyList<KeyBytes> keys);
-
-        /// <summary>
-        /// Cleans up and stores the <see cref="ITrie"/> in storage.
-        /// </summary>
-        /// <returns>Returns new committed <see cref="ITrie"/>.</returns>
-        ITrie Commit();
     }
 }

--- a/Libplanet.Store/TrieStateStore.cs
+++ b/Libplanet.Store/TrieStateStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -96,6 +97,21 @@ namespace Libplanet.Store
                 deleteCount,
                 stopwatch.ElapsedMilliseconds);
             stopwatch.Stop();
+        }
+
+        /// <inheritdoc cref="IStateStore.Commit(ITrie)"/>
+        public ITrie Commit(ITrie trie)
+        {
+            if (trie is MerkleTrie mTrie)
+            {
+                return mTrie.Commit();
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(trie)} must be a {nameof(MerkleTrie)}: {trie.GetType()}",
+                    nameof(trie));
+            }
         }
 
         /// <summary>

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -135,7 +135,7 @@ namespace Libplanet.Tests.Fixtures
                         var updatedRawStates = ImmutableDictionary<KeyBytes, IValue>.Empty
                             .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
                         HashDigest<SHA256> nextRootHash =
-                            prevTrie.Set(updatedRawStates).Commit().Hash;
+                            StateStore.Commit(prevTrie.Set(updatedRawStates)).Hash;
                         return (nextState, nextRootHash);
                     }
                 });
@@ -157,7 +157,7 @@ namespace Libplanet.Tests.Fixtures
                             var updatedRawStates = ImmutableDictionary<KeyBytes, IValue>.Empty
                                 .Add(rawStateKey, (Bencodex.Types.Integer)nextState);
                             HashDigest<SHA256> nextRootHash =
-                                prevTrie.Set(updatedRawStates).Commit().Hash;
+                                StateStore.Commit(prevTrie.Set(updatedRawStates)).Hash;
                             return delta.Add((nextState, nextRootHash));
                         }
                     }

--- a/Libplanet.Tests/Store/StateStoreTracker.cs
+++ b/Libplanet.Tests/Store/StateStoreTracker.cs
@@ -28,6 +28,12 @@ namespace Libplanet.Tests.Store
             _stateStore.PruneStates(survivingStateRootHashes);
         }
 
+        public ITrie Commit(ITrie trie)
+        {
+            Log(nameof(Commit), trie);
+            return _stateStore.Commit(trie);
+        }
+
         public void Dispose()
         {
             if (!_disposed)

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -17,12 +17,12 @@ namespace Libplanet.Tests.Store.Trie
 
             trieA = (MerkleTrie)trieA.Set(new KeyBytes(0x01), Null.Value)
                 .Set(new KeyBytes(0x02), Null.Value)
-                .Set(new KeyBytes(0x03), Null.Value)
-                .Commit();
+                .Set(new KeyBytes(0x03), Null.Value);
+            trieA = (MerkleTrie)trieA.Commit();
             trieB = (MerkleTrie)trieB.Set(new KeyBytes(0x01), Dictionary.Empty)
                 .Set(new KeyBytes(0x02), Null.Value)
-                .Set(new KeyBytes(0x04), Null.Value)
-                .Commit();
+                .Set(new KeyBytes(0x04), Null.Value);
+            trieB = (MerkleTrie)trieB.Commit();
 
             Dictionary<KeyBytes, (IValue OriginValue, IValue OtherValue)> differentNodes =
                 trieA.DifferentNodes(trieB).ToDictionary(

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
 
             trie = trie.Set(new KeyBytes(0xbe, 0xef), Null.Value);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString("16fc25f43edd0c2d2cb6e3cc3827576e57f4b9e04f8dc3a062c7fe59041f77bd"),
                 trie.Hash
@@ -80,7 +80,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
 
             trie = trie.Set(new KeyBytes(0xbe, 0xef), new Boolean(true));
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString("4458796f4092b5ebfc1ffb3989e72edee228501e438080a12dea45591dc66d58"),
                 trie.Hash
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
 
             trie = trie.Set(new KeyBytes(0x11, 0x22), List.Empty);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString("ab1359a2497453110a9c658dd3db45f282404fe68d8c8aca30856f395572284c"),
                 trie.Hash
@@ -108,7 +108,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
 
             trie = trie.Set(new KeyBytes(0xaa, 0xbb), new Text("hello world"));
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString("abb5759141f7af1c40f1b0993ba60073cf4227900617be9641373e5a097eaa3c"),
                 trie.Hash
@@ -126,7 +126,7 @@ namespace Libplanet.Tests.Store.Trie
 
             var longText = new Text(string.Join("\n", Range(0, 1000).Select(i => $"long str {i}")));
             trie = trie.Set(new KeyBytes(0xaa, 0xbb), longText);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
                     ? "56e5a39a726acba1f7631a6520ae92e20bb93ca3992a7b7d3542c6daee68e56d"
@@ -142,7 +142,7 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
 
             trie = trie.Set(new KeyBytes(0x12, 0x34), Dictionary.Empty);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
                     ? "88d6375097fd03e6c30a129eb0030d938caeaa796643971ca938fbd27ff5e057"
@@ -167,7 +167,7 @@ namespace Libplanet.Tests.Store.Trie
                         new List(Range(0, 1000).Select(i => new Text($"long str {i}")))))
                 .Add(new List(Range(0, 1000).Select(i => new Text($"long str {i}"))));
             trie = trie.Set(new KeyBytes(0x11, 0x22), complexList);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
                     ? "f29820df65c1d1a66b69a59b9fe3e21911bbd2d97a9f298853c529804bf84a26"
@@ -197,7 +197,7 @@ namespace Libplanet.Tests.Store.Trie
                         .Add("qrst", complexList)
                         .Add("uvwx", Dictionary.Empty));
             trie = trie.Set(new KeyBytes(0x12, 0x34), complexDict);
-            trie = commit ? trie.Commit() : trie;
+            trie = commit ? ((MerkleTrie)trie).Commit() : trie;
             AssertBytesEqual(
                 FromString(commit
                     ? "1dabec2c0fea02af0182e9fee6c7ce7ad1a9d9bcfaa2cd80c2971bbce5272655"


### PR DESCRIPTION
Kinda forcibly moves `ITrie.Commit()` to `IStateStore.Commit(ITrie)`. After working on it, I'm having doubts whether this is any better. 🙄
To be safe, we could implement `IStateStore.Commit(HashDigest<SHA256>, Dictionary<KeyBytes, IValue>)`, but then again this increases the scope of `IStateStore`. 😕