### PR TITLE
feat(#3354): support rocksdb read-only mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ To be released.
 
 ### Added APIs
 
+ -  (Libplanet.RocksDBStore) `RocksDBStore` and `RocksDBKeyValueStore` became to
+    receive `@readonly` parameter in their constructor. If it is true, it opens
+    rocksdb as read-only mode.  [[#3354], [#3356], [RocksDB Read Only]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -27,6 +31,10 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#3354]: https://github.com/planetarium/libplanet/issues/3354
+[#3356]: https://github.com/planetarium/libplanet/pull/3356
+[RocksDB Read Only]: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
 
 
 Version 3.2.0

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -85,12 +85,13 @@ namespace Libplanet.RocksDBStore
         /// Creates a new <see cref="RocksDBKeyValueStore"/>.
         /// </summary>
         /// <param name="path">The path of the storage file will be saved.</param>
-        public RocksDBKeyValueStore(string path)
+        /// <param name="readonly">If it is true, it will open rocksdb in read-only mode.</param>
+        public RocksDBKeyValueStore(string path, bool @readonly = false)
         {
             var options = new DbOptions()
                 .SetCreateIfMissing();
 
-            _keyValueDb = RocksDBUtils.OpenRocksDb(options, path);
+            _keyValueDb = RocksDBUtils.OpenRocksDb(options, path, @readonly: @readonly);
         }
 
         /// <inheritdoc/>

--- a/Libplanet.RocksDBStore/RocksDBUtils.cs
+++ b/Libplanet.RocksDBStore/RocksDBUtils.cs
@@ -6,11 +6,21 @@ namespace Libplanet.RocksDBStore
     internal static class RocksDBUtils
     {
         internal static RocksDb OpenRocksDb(
-            DbOptions options, string dbPath, ColumnFamilies? columnFamilies = null)
+            DbOptions options,
+            string dbPath,
+            ColumnFamilies? columnFamilies = null,
+            bool @readonly = false)
         {
             if (!Directory.Exists(dbPath))
             {
                 Directory.CreateDirectory(dbPath);
+            }
+
+            if (@readonly)
+            {
+                return columnFamilies is null
+                    ? RocksDb.OpenReadOnly(options, dbPath, false)
+                    : RocksDb.OpenReadOnly(options, dbPath, columnFamilies, false);
             }
 
             return columnFamilies is null


### PR DESCRIPTION
This pull request resolves #3354.

RocksDB supports read-only mode so Libplanet's wrapper class supports it too. https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances