### PR TITLE
♻️ Added single `Get()` to `ITrie`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ To be released.
  -  (Libplanet.Types) Removed `TxSuccess.FungibleAssetsDelta`  [[#3357]]
  -  (Libplanet.Explorer) Removed `TxResult.ExceptionMetadata` and
     `TxResult.FungibleAssetsDelta`.  [[#3357]]
+ -  (Libplanet.Store) Added `ITrie.Get(KeyBytes)` interface method.  [[#3359]]
+ -  (Libplanet.Store) Optimized `MerkleTrie.Get()` by allowing parallel
+    processing when more than 4 `KeyBytes` keys are given.  [[#3359]]
 
 ### Backward-incompatible network protocol changes
 
@@ -34,6 +37,7 @@ To be released.
 [#3337]: https://github.com/planetarium/libplanet/pull/3337
 [#3347]: https://github.com/planetarium/libplanet/pull/3347
 [#3357]: https://github.com/planetarium/libplanet/pull/3357
+[#3359]: https://github.com/planetarium/libplanet/pull/3359
 
 
 Version 3.1.0

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -34,6 +34,14 @@ namespace Libplanet.Store.Trie
         ITrie Set(in KeyBytes key, IValue value);
 
         /// <summary>
+        /// Gets the values stored with <paramref name="key"/> in <see cref="Set"/>.
+        /// </summary>
+        /// <param name="keys">The key used in <see cref="Set"/> to store a value.</param>
+        /// <returns>The value associated to the specified <paramref name="key"/>.  Absent
+        /// value is represented as <see langword="null"/>.</returns>
+        public IValue? Get(KeyBytes key);
+
+        /// <summary>
         /// Gets the values stored with <paramref name="keys"/> in <see cref="Set"/>.
         /// </summary>
         /// <param name="keys">The keys used in <see cref="Set"/> to store a value.</param>

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Store.Trie
         /// <summary>
         /// Gets the values stored with <paramref name="key"/> in <see cref="Set"/>.
         /// </summary>
-        /// <param name="keys">The key used in <see cref="Set"/> to store a value.</param>
+        /// <param name="key">The key used in <see cref="Set"/> to store a value.</param>
         /// <returns>The value associated to the specified <paramref name="key"/>.  Absent
         /// value is represented as <see langword="null"/>.</returns>
         public IValue? Get(KeyBytes key);

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -63,10 +63,10 @@ namespace Libplanet.Tests.Store.Trie
                 FromString("1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"),
                 trie.Hash
             );
-            Assert.Null(trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            Assert.Null(trie.Get(new KeyBytes(0xbe, 0xef)));
+            Assert.Null(trie.Get(new KeyBytes(0x11, 0x22)));
+            Assert.Null(trie.Get(new KeyBytes(0xaa, 0xbb)));
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             trie = trie.Set(new KeyBytes(0xbe, 0xef), Null.Value);
             trie = commit ? trie.Commit() : trie;
@@ -74,10 +74,10 @@ namespace Libplanet.Tests.Store.Trie
                 FromString("16fc25f43edd0c2d2cb6e3cc3827576e57f4b9e04f8dc3a062c7fe59041f77bd"),
                 trie.Hash
             );
-            AssertBencodexEqual(Null.Value, trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(Null.Value, trie.Get(new KeyBytes(0xbe, 0xef)));
+            Assert.Null(trie.Get(new KeyBytes(0x11, 0x22)));
+            Assert.Null(trie.Get(new KeyBytes(0xaa, 0xbb)));
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             trie = trie.Set(new KeyBytes(0xbe, 0xef), new Boolean(true));
             trie = commit ? trie.Commit() : trie;
@@ -87,11 +87,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            Assert.Null(trie.Get(new KeyBytes(0x11, 0x22)));
+            Assert.Null(trie.Get(new KeyBytes(0xaa, 0xbb)));
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             trie = trie.Set(new KeyBytes(0x11, 0x22), List.Empty);
             trie = commit ? trie.Commit() : trie;
@@ -101,11 +101,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(List.Empty, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(List.Empty, trie.Get(new KeyBytes(0x11, 0x22)));
+            Assert.Null(trie.Get(new KeyBytes(0xaa, 0xbb)));
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             trie = trie.Set(new KeyBytes(0xaa, 0xbb), new Text("hello world"));
             trie = commit ? trie.Commit() : trie;
@@ -115,14 +115,14 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(List.Empty, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
+            AssertBencodexEqual(List.Empty, trie.Get(new KeyBytes(0x11, 0x22)));
             AssertBencodexEqual(
                 new Text("hello world"),
-                trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]
+                trie.Get(new KeyBytes(0xaa, 0xbb))
             );
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             var longText = new Text(string.Join("\n", Range(0, 1000).Select(i => $"long str {i}")));
             trie = trie.Set(new KeyBytes(0xaa, 0xbb), longText);
@@ -135,11 +135,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(List.Empty, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            AssertBencodexEqual(longText, trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            Assert.Null(trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(List.Empty, trie.Get(new KeyBytes(0x11, 0x22)));
+            AssertBencodexEqual(longText, trie.Get(new KeyBytes(0xaa, 0xbb)));
+            Assert.Null(trie.Get(new KeyBytes(0x12, 0x34)));
 
             trie = trie.Set(new KeyBytes(0x12, 0x34), Dictionary.Empty);
             trie = commit ? trie.Commit() : trie;
@@ -151,11 +151,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(List.Empty, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            AssertBencodexEqual(longText, trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            AssertBencodexEqual(Dictionary.Empty, trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(List.Empty, trie.Get(new KeyBytes(0x11, 0x22)));
+            AssertBencodexEqual(longText, trie.Get(new KeyBytes(0xaa, 0xbb)));
+            AssertBencodexEqual(Dictionary.Empty, trie.Get(new KeyBytes(0x12, 0x34)));
 
             List complexList = List.Empty
                 .Add("Hello world")
@@ -176,11 +176,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(complexList, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            AssertBencodexEqual(longText, trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            AssertBencodexEqual(Dictionary.Empty, trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(complexList, trie.Get(new KeyBytes(0x11, 0x22)));
+            AssertBencodexEqual(longText, trie.Get(new KeyBytes(0xaa, 0xbb)));
+            AssertBencodexEqual(Dictionary.Empty, trie.Get(new KeyBytes(0x12, 0x34)));
 
             Dictionary complexDict = Dictionary.Empty
                 .Add("foo", 123)
@@ -206,11 +206,11 @@ namespace Libplanet.Tests.Store.Trie
             );
             AssertBencodexEqual(
                 new Boolean(true),
-                trie.Get(new[] { new KeyBytes(0xbe, 0xef) })[0]
+                trie.Get(new KeyBytes(0xbe, 0xef))
             );
-            AssertBencodexEqual(complexList, trie.Get(new[] { new KeyBytes(0x11, 0x22) })[0]);
-            AssertBencodexEqual(longText, trie.Get(new[] { new KeyBytes(0xaa, 0xbb) })[0]);
-            AssertBencodexEqual(complexDict, trie.Get(new[] { new KeyBytes(0x12, 0x34) })[0]);
+            AssertBencodexEqual(complexList, trie.Get(new KeyBytes(0x11, 0x22)));
+            AssertBencodexEqual(longText, trie.Get(new KeyBytes(0xaa, 0xbb)));
+            AssertBencodexEqual(complexDict, trie.Get(new KeyBytes(0x12, 0x34)));
         }
     }
 }


### PR DESCRIPTION
Long overdue change to `ITrie`. Performance-wise, new `ITrie.Get(KeyBytes)` is not that significantly better as the overhead was minimal.

However, `MerkleTrie.Get()` can be more than twice as fast, depending on the environment and the number of `KeyBytes` given.

In order to leverage this properly, `IAccount.GetStates()` and `IAccount.GetState()` should refer to different `ITrie.Get()`. Depending on where the parallelism should reside, it might even be a good idea to get rid of `ITrie.Get(IReadOnlyList<KeyBytes>)`. 🙄