### PR TITLE
Cherry-pick #3353 to 3.1.1 version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,12 @@ Libplanet changelog
 Version 3.1.1
 -------------
 
-To be released.
+ -  Fixed a bug where `Swarm` checks block existent when preloading.
+    [[#3253], [#3353], [#3360]]
+
+[#3253]: https://github.com/planetarium/libplanet/issues/3253
+[#3353]: https://github.com/planetarium/libplanet/pull/3353
+[#3360]: https://github.com/planetarium/libplanet/pull/3360
 
 
 Version 3.1.0

--- a/Libplanet.Net/Swarm.BlockSync.cs
+++ b/Libplanet.Net/Swarm.BlockSync.cs
@@ -89,7 +89,7 @@ namespace Libplanet.Net
             try
             {
                 var blockCompletion = new BlockCompletion<BoundPeer>(
-                    completionPredicate: BlockChain.Store.ContainsBlock,
+                    completionPredicate: BlockChain.ContainsBlock,
                     window: InitialBlockDownloadWindow
                 );
                 var demandBlockHashes = GetDemandBlockHashes(


### PR DESCRIPTION
This pull request just cherry-picks #3353 changes to the 3.1-maintenance branch to release 3.1.1 patch version. (because I suffer from the BlockCandidate bug...)