### PR TITLE
Introduce `VolatileKeyValueStore`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Store) Added `VolatileKeyValueStore` class.  [[#3361]]
+ -  (Libplanet.Store) Changed `IStateStore.GetStateRoot(HashDigest<SHA256>?)`
+    to `IStateStore.GetStateRoot(HashDigest<SHA256>?, bool)`.  [[#3361]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -46,6 +50,7 @@ Released on August 10, 2023.
 [#3347]: https://github.com/planetarium/libplanet/pull/3347
 [#3357]: https://github.com/planetarium/libplanet/pull/3357
 [#3359]: https://github.com/planetarium/libplanet/pull/3359
+[#3361]: https://github.com/planetarium/libplanet/pull/3361
 
 
 Version 3.1.2

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -495,7 +495,7 @@ If omitted (default) explorer only the local blockchain store.")]
 
         private class NoOpStateStore : IStateStore
         {
-            public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash) => null;
+            public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash, bool readOnly) => null;
 
             public void PruneStates(IImmutableSet<HashDigest<SHA256>> survivingStateRootHashes)
             {

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -16,9 +16,11 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="stateRootHash">The state root hash of the state root trie to get.
         /// If <see langword="null"/> is passed the empty state root trie is returned.</param>
+        /// <param name="readOnly">Whether the <see cref="ITrie"/> returned is read-only
+        /// in the sense that nothing gets written to the storage.</param>
         /// <returns>The state root trie of the <paramref name="stateRootHash"/>.
         /// If <see langword="null"/> is passed the empty state root trie is returned.</returns>
-        ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash);
+        ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash, bool readOnly = false);
 
         /// <summary>
         /// Prunes the states no more used from the state store.

--- a/Libplanet.Store/Trie/VolatileKeyValueStore.cs
+++ b/Libplanet.Store/Trie/VolatileKeyValueStore.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Libplanet.Store.Trie
+{
+    /// <summary>
+    /// A volitile read-only <see cref="IKeyValueStore"/>.  This is mainly a thinly wrapped
+    /// <see cref="IKeyValueStore"/> and it is read-only in the sense that it does not make
+    /// any changes to the underlying internal <see cref="IKeyValueStore"/> that it is given.
+    /// </summary>
+    /// <remarks>
+    /// Deletion of keys is not supported.
+    /// </remarks>
+    public class VolatileKeyValueStore : IKeyValueStore
+    {
+        private IKeyValueStore _base;
+        private ConcurrentDictionary<KeyBytes, byte[]> _delta;
+        private bool _disposed;
+
+        internal VolatileKeyValueStore(IKeyValueStore baseKeyValueStore)
+        {
+            _base = baseKeyValueStore;
+            _delta = new ConcurrentDictionary<KeyBytes, byte[]>();
+            _disposed = false;
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Get"/>
+        public byte[] Get(in KeyBytes key)
+        {
+            return _delta.TryGetValue(key, out var value)
+                ? value
+                : _base.Get(key);
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Get"/>
+        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
+        {
+            return keys
+                .Distinct()
+                .Select(key => new KeyValuePair<KeyBytes, byte[]>(
+                    key,
+                    _delta.TryGetValue(key, out var value) ? value : _base.Get(key)))
+                .ToImmutableDictionary();
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Set"/>
+        public void Set(in KeyBytes key, byte[] value)
+        {
+            _delta[key] = value;
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Set"/>
+        public void Set(IDictionary<KeyBytes, byte[]> values)
+        {
+            foreach (var kv in values)
+            {
+                _delta[kv.Key] = kv.Value;
+            }
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Delete"/>
+        public void Delete(in KeyBytes key)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Delete"/>
+        public void Delete(IEnumerable<KeyBytes> keys)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.Exists"/>
+        public bool Exists(in KeyBytes key)
+        {
+            return _delta.ContainsKey(key) || _base.Exists(key);
+        }
+
+        /// <inheritdoc cref="IKeyValueStore.ListKeys"/>
+        public IEnumerable<KeyBytes> ListKeys()
+        {
+            return _delta.Keys.Concat(_base.ListKeys()).Distinct();
+        }
+
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
+        void IDisposable.Dispose()
+        {
+            if (!_disposed)
+            {
+                _base.Dispose();
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/Libplanet.Store/TrieStateStore.cs
+++ b/Libplanet.Store/TrieStateStore.cs
@@ -133,13 +133,17 @@ namespace Libplanet.Store
             _logger.Verbose("Finished {MethodName}()", nameof(CopyStates));
         }
 
-        /// <inheritdoc cref="IStateStore.GetStateRoot(HashDigest{SHA256}?)"/>
-        public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash) =>
-            new MerkleTrie(
-                StateKeyValueStore,
-                stateRootHash is { } hash ? new HashNode(hash) : null,
-                Secure
-            );
+        /// <inheritdoc cref="IStateStore.GetStateRoot(HashDigest{SHA256}?, bool)"/>
+        public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash, bool readOnly = false) =>
+            readOnly
+                ? new MerkleTrie(
+                    new VolatileKeyValueStore(StateKeyValueStore),
+                    stateRootHash is { } h1 ? new HashNode(h1) : null,
+                    Secure)
+                : new MerkleTrie(
+                    StateKeyValueStore,
+                    stateRootHash is { } h2 ? new HashNode(h2) : null,
+                    Secure);
 
         /// <inheritdoc cref="System.IDisposable.Dispose()"/>
         public void Dispose()

--- a/Libplanet.Tests/Store/StateStoreTracker.cs
+++ b/Libplanet.Tests/Store/StateStoreTracker.cs
@@ -16,10 +16,10 @@ namespace Libplanet.Tests.Store
             _stateStore = stateStore;
         }
 
-        public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash)
+        public ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash, bool readOnly = false)
         {
             Log(nameof(GetStateRoot), stateRootHash);
-            return _stateStore.GetStateRoot(stateRootHash);
+            return _stateStore.GetStateRoot(stateRootHash, readOnly);
         }
 
         public void PruneStates(IImmutableSet<HashDigest<SHA256>> survivingStateRootHashes)

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -100,7 +100,7 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [SkippableFact]
-        public void Delete()
+        public virtual void Delete()
         {
             foreach (KeyBytes key in PreStoredDataKeys)
             {
@@ -114,7 +114,7 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [SkippableFact]
-        public void DeleteMany()
+        public virtual void DeleteMany()
         {
             KeyBytes[] nonExistentKeys = Enumerable.Range(0, 10)
                 .Select(_ => NewRandomKey())

--- a/Libplanet.Tests/Store/Trie/VolatileKeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/VolatileKeyValueStoreTest.cs
@@ -1,0 +1,38 @@
+using System;
+using Libplanet.Store.Trie;
+using Xunit;
+
+namespace Libplanet.Tests.Store.Trie
+{
+    public class VolatileKeyValueStoreTest : KeyValueStoreTest, IDisposable
+    {
+        private readonly VolatileKeyValueStore _volatileKeyValueStore;
+
+        public VolatileKeyValueStoreTest()
+        {
+            // Memory mode.
+            KeyValueStore = _volatileKeyValueStore =
+                new VolatileKeyValueStore(new DefaultKeyValueStore(null));
+            InitializePreStoredData();
+        }
+
+        [SkippableFact]
+        public override void Delete()
+        {
+            Assert.Throws<NotSupportedException>(
+                () => KeyValueStore.Delete(new KeyBytes(TestUtils.GetRandomBytes(8))));
+        }
+
+        [SkippableFact]
+        public override void DeleteMany()
+        {
+            Assert.Throws<NotSupportedException>(
+                () => KeyValueStore.Delete(new[] { new KeyBytes(TestUtils.GetRandomBytes(8)) }));
+        }
+
+        public void Dispose()
+        {
+            _volatileKeyValueStore.Dispose();
+        }
+    }
+}

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -73,17 +73,20 @@ namespace Libplanet.Blockchain
         ///     </description></item>
         /// </list>
         /// </exception>
+        /// <remarks>
+        /// An <see cref="ITrie"/> returned by this method is read-only.
+        /// </remarks>
         private ITrie GetStateRoot(BlockHash? offset)
         {
             if (!(offset is { } hash))
             {
-                return _stateStore.GetStateRoot(null);
+                return _stateStore.GetStateRoot(null, readOnly: true);
             }
             else if (_store.GetStateRootHash(hash) is { } stateRootHash)
             {
                 if (_stateStore.ContainsStateRoot(stateRootHash))
                 {
-                    return _stateStore.GetStateRoot(stateRootHash);
+                    return _stateStore.GetStateRoot(stateRootHash, readOnly: true);
                 }
                 else
                 {


### PR DESCRIPTION
Not quite usable yet since `IActionEvaluator` does not have direct access to `IStateStore`. Probably we'd want to change `IBlockChainStates` to give only read-only state view. 🙄