### PR TITLE
♻️ `MerkleTrie` overhaul

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,10 +26,18 @@ To be released.
 
 ### Behavioral changes
 
+ -  (Libplanet.Store) Changed `ShortNode` to no longer accept empty `byte`
+    arrays.  [[#3390]]
+
 ### Bug fixes
 
  -  (Libplanet.Store) Fixed `Equals()` for `FullNode` and `ShortNode`.
     [[#3377]]
+ -  (Libplanet.Store) Fixed a bug where adding two `byte` arrays as keys
+    with one being a subsequence of the other would break `MerkleTrie`
+    and lose data.  [[#3390]]
+ -  (Libplanet.Store) Fixed a bug where when trying to add a value to
+    an existing `FullNode` would throw an `Exception`.  [[#3390]]
 
 ### Dependencies
 
@@ -39,6 +47,7 @@ To be released.
 [#3356]: https://github.com/planetarium/libplanet/pull/3356
 [#3361]: https://github.com/planetarium/libplanet/pull/3361
 [#3377]: https://github.com/planetarium/libplanet/pull/3377
+[#3390]: https://github.com/planetarium/libplanet/pull/3390
 [RocksDB Read Only]: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
 
 

--- a/Libplanet.Store/Trie/MerkleTrie.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
@@ -97,20 +96,7 @@ namespace Libplanet.Store.Trie
         }
 
         /// <inheritdoc cref="ITrie.Get(KeyBytes)"/>
-        public IValue? Get(KeyBytes key)
-        {
-            PathResolution resolution = ResolvePath(Root, new PathCursor(key, _secure));
-            while (resolution.Next is (HashDigest<SHA256> nodeHash, PathCursor cursor))
-            {
-                KeyBytes nextNodeHash = new KeyBytes(nodeHash.ByteArray);
-                byte[] nodeValue = KeyValueStore.Get(nextNodeHash);
-                IValue intermediateEncoding = _codec.Decode(nodeValue);
-                INode? nextNode = NodeDecoder.Decode(intermediateEncoding);
-                resolution = ResolvePath(nextNode, cursor);
-            }
-
-            return resolution.Value;
-        }
+        public IValue? Get(KeyBytes key) => ResolvePath(Root, new PathCursor(key, _secure));
 
         /// <inheritdoc cref="ITrie.Get(IReadOnlyList{KeyBytes})"/>
         public IReadOnlyList<IValue?> Get(IReadOnlyList<KeyBytes> keys)

--- a/Libplanet.Store/Trie/MerkleTrieExtensions.cs
+++ b/Libplanet.Store/Trie/MerkleTrieExtensions.cs
@@ -56,7 +56,9 @@ namespace Libplanet.Store.Trie
         {
             if (keyBytes.Length % 2 == 1)
             {
-                throw new ArgumentException(nameof(keyBytes));
+                throw new ArgumentException(
+                    $"Given {nameof(keyBytes)} must be of even length: {keyBytes.Length}",
+                    nameof(keyBytes));
             }
 
             ImmutableArray<byte> bytes = keyBytes.ByteArray;

--- a/Libplanet.Store/Trie/Nodes/BaseNode.cs
+++ b/Libplanet.Store/Trie/Nodes/BaseNode.cs
@@ -2,6 +2,9 @@ using Bencodex.Types;
 
 namespace Libplanet.Store.Trie.Nodes
 {
+    /// <summary>
+    /// Represents a node in MPT that can have a value.
+    /// </summary>
     public abstract class BaseNode : INode
     {
         protected BaseNode(INode? value)

--- a/Libplanet.Store/Trie/Nodes/NodeDecoder.cs
+++ b/Libplanet.Store/Trie/Nodes/NodeDecoder.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Store.Trie.Nodes
     {
         public static INode? Decode(IValue value)
         {
-            if (value is Bencodex.Types.List list)
+            if (value is List list)
             {
                 switch (list.Count)
                 {
@@ -48,13 +48,12 @@ namespace Libplanet.Store.Trie.Nodes
             // but there is no way to present null.
             return new FullNode(list
                 .Select(DecodeRef)
-                .Take(FullNode.ChildrenCount)
                 .ToImmutableArray());
         }
 
         private static ShortNode DecodeShort(List list)
         {
-            if (!(list[0] is Binary path))
+            if (!(list[0] is Binary nibbles))
             {
                 throw new InvalidTrieNodeException(
                     $"Expected `{nameof(ShortNode)}.{nameof(ShortNode.Key)}`'s serialization type" +
@@ -64,7 +63,7 @@ namespace Libplanet.Store.Trie.Nodes
             // Get referenced node corresponding.
             var refNode = DecodeRef(list[1]);
 
-            return new ShortNode(path.ByteArray, refNode);
+            return new ShortNode(nibbles.ByteArray, refNode);
         }
 
         private static INode? DecodeRef(IValue value)

--- a/Libplanet.Store/Trie/Nodes/ShortNode.cs
+++ b/Libplanet.Store/Trie/Nodes/ShortNode.cs
@@ -10,7 +10,9 @@ namespace Libplanet.Store.Trie.Nodes
         public ShortNode(in ImmutableArray<byte> key, INode? value)
             : base(value)
         {
-            Key = key;
+            Key = key.IsDefaultOrEmpty
+                ? throw new ArgumentException($"Given {nameof(key)} cannot be empty", nameof(key))
+                : key;
         }
 
         // FIXME: We should declare a custom value type to represent nibbles...
@@ -44,6 +46,6 @@ namespace Libplanet.Store.Trie.Nodes
 
         /// <inheritdoc cref="INode.ToBencodex()"/>
         public override IValue ToBencodex() =>
-            new Bencodex.Types.List(new Binary(Key), Value?.ToBencodex() ?? Null.Value);
+            new List(new Binary(Key), Value?.ToBencodex() ?? Null.Value);
     }
 }

--- a/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieExtensionsTest.cs
@@ -41,11 +41,12 @@ namespace Libplanet.Tests.Store.Trie
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             MerkleTrie trie = new MerkleTrie(keyValueStore);
 
-            trie = (MerkleTrie)trie.Set(new KeyBytes(0x01), Null.Value)
-                    .Set(new KeyBytes(0x02), Null.Value)
-                    .Set(new KeyBytes(0x03), Null.Value)
-                    .Set(new KeyBytes(0x04), Null.Value)
-                    .Set(new KeyBytes(0xbe, 0xef), Dictionary.Empty);
+            trie = (MerkleTrie)trie
+                .Set(new KeyBytes(0x01), Null.Value)
+                .Set(new KeyBytes(0x02), Null.Value)
+                .Set(new KeyBytes(0x03), Null.Value)
+                .Set(new KeyBytes(0x04), Null.Value)
+                .Set(new KeyBytes(0xbe, 0xef), Dictionary.Empty);
 
             Dictionary<KeyBytes, IValue> states =
                 trie.ListAllStates().ToDictionary(pair => pair.Key, pair => pair.Value);

--- a/Libplanet.Tests/Store/Trie/MerkleTriePathCursorTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTriePathCursorTest.cs
@@ -28,30 +28,6 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [Fact]
-        public void FromNibbles()
-        {
-            ImmutableArray<byte> nibbles = ParseHexToImmutable("0c0f0e0d04040600");
-            PathCursor cursor = PathCursor.FromNibbles(nibbles);
-            AssertBytesEqual(ParseHexToImmutable("cfed4460"), cursor.Bytes);
-            Assert.Equal(8, cursor.NibbleLength);
-            Assert.Equal(0, cursor.NibbleOffset);
-
-            cursor = PathCursor.FromNibbles(nibbles, 1);
-            AssertBytesEqual(ParseHexToImmutable("cfed4460"), cursor.Bytes);
-            Assert.Equal(8, cursor.NibbleLength);
-            Assert.Equal(1, cursor.NibbleOffset);
-
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                _ = PathCursor.FromNibbles(nibbles, -1);
-            });
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                _ = PathCursor.FromNibbles(nibbles, 9);
-            });
-        }
-
-        [Fact]
         public void Next()
         {
             var cursor = new PathCursor(KeyBytes.FromHex("cfed4460"), false);
@@ -110,12 +86,6 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Equal(0xe, cursor.NibbleAt(2));
             Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(-1); });
             Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(8); });
-
-            cursor = PathCursor.FromNibbles(ParseHexToImmutable("0c0f0e0d040406"), 3);
-            Assert.Equal(0xd, cursor.NibbleAt(0));
-            Assert.Equal(0x4, cursor.NibbleAt(1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(-1); });
-            Assert.Throws<ArgumentOutOfRangeException>(() => { cursor.NibbleAt(5); });
         }
 
         [Fact]

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -212,5 +212,45 @@ namespace Libplanet.Tests.Store.Trie
             AssertBencodexEqual(longText, trie.Get(new KeyBytes(0xaa, 0xbb)));
             AssertBencodexEqual(complexDict, trie.Get(new KeyBytes(0x12, 0x34)));
         }
+
+        [Fact]
+        public void SetValueToExtendedKey()
+        {
+            ITrie trie = new MerkleTrie(new MemoryKeyValueStore());
+            KeyBytes key00 = new KeyBytes(new byte[] { 0x00 });
+            IValue value00 = new Text("00");
+            KeyBytes key0000 = new KeyBytes(new byte[] { 0x00, 0x00 });
+            IValue value0000 = new Text("0000");
+
+            trie = trie.Set(key00, value00);
+            trie = trie.Set(key0000, value0000);
+            trie = trie.Commit();
+
+            Assert.Equal(2, ((MerkleTrie)trie).ListAllStates().Count());
+            Assert.Equal(value00, trie.Get(key00));
+            Assert.Equal(value0000, trie.Get(key0000));
+        }
+
+        [Fact]
+        public void SetValueToFullNode()
+        {
+            ITrie trie = new MerkleTrie(new MemoryKeyValueStore());
+            KeyBytes key00 = new KeyBytes(new byte[] { 0x00 });
+            IValue value00 = new Text("00");
+            KeyBytes key0000 = new KeyBytes(new byte[] { 0x00, 0x00 });
+            IValue value0000 = new Text("0000");
+            KeyBytes key0010 = new KeyBytes(new byte[] { 0x00, 0x10 });
+            IValue value0010 = new Text("0010");
+
+            trie = trie.Set(key0000, value0000);
+            trie = trie.Set(key0010, value0010);
+            trie = trie.Set(key00, value00);
+            trie = trie.Commit();
+
+            Assert.Equal(3, ((MerkleTrie)trie).ListAllStates().Count());
+            Assert.Equal(value00, trie.Get(key00));
+            Assert.Equal(value0000, trie.Get(key0000));
+            Assert.Equal(value0010, trie.Get(key0010));
+        }
     }
 }

--- a/Libplanet.Tests/Store/Trie/TrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/TrieTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
@@ -57,8 +56,6 @@ namespace Libplanet.Tests.Store.Trie
         public void Commit(int addressCount)
         {
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
-            var codec = new Codec();
-
             ITrie trieA = new MerkleTrie(keyValueStore);
 
             var addresses = new Address[addressCount];


### PR DESCRIPTION
Some notes on performance:

- `MerkleTrie.Get()` has become slightly slower.
  - This is possibly due to using recursion on path resolution instead of a for loop with custom data `struct`ure.
- `MerkleTrie.Set()` and `MerkleTrie.Commit()` has become slightly faster.
  - Probably because of lower amount of recursion and removal of `PathCursor`'s internal `byte` array copying.

I doubt the performance change is significant.

I could probably optimize this a bit, but I'd say its good enough for now. 🙄
Should be tested on a live chain before this gets merged. It isn't still clear that resulting trie layout will have
"the canonical layout", but the updated version is quite a bit more constrained than the existing one, which
heavily relied on code path and `KeyConverter` not producing a `KeyBytes` that is a subsequence of another `KeyBytes`. 😐

PS. We can now also set a value to an empty key. I'm not sure if this should be allowed. 🙄