### PR TITLE
🧹 Removed unused `IKeyValueStore.Get()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  (Libplanet.Store) Removed `ITrie.Commit()`.  [[#3392]]
  -  (Libplanet.Store) Added `IStateStore.Commit()`.  [[#3398]]
+ -  (Libplanet.Store) Removed `IKeyValueStore.Get(IEnumerable<KeyBytes> keys)`.
+    [[#3362], [#3340]]
 
 ### Backward-incompatible network protocol changes
 
@@ -44,10 +46,12 @@ To be released.
 
 [#3354]: https://github.com/planetarium/libplanet/issues/3354
 [#3356]: https://github.com/planetarium/libplanet/pull/3356
+[#3362]: https://github.com/planetarium/libplanet/issues/3362
 [#3377]: https://github.com/planetarium/libplanet/pull/3377
 [#3390]: https://github.com/planetarium/libplanet/pull/3390
 [#3392]: https://github.com/planetarium/libplanet/pull/3392
 [#3398]: https://github.com/planetarium/libplanet/pull/3398
+[#3340]: https://github.com/planetarium/libplanet/pull/3340
 [RocksDB Read Only]: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
 
 

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Libplanet.Store.Trie;
 using RocksDbSharp;
 
@@ -97,23 +95,6 @@ namespace Libplanet.RocksDBStore
         /// <inheritdoc/>
         public byte[] Get(in KeyBytes key) => _keyValueDb.Get(key.ToByteArray())
             ?? throw new KeyNotFoundException($"No such key: ${key}.");
-
-        /// <inheritdoc cref="IKeyValueStore.Get(IEnumerable{KeyBytes})"/>
-        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
-        {
-            byte[][] keyArray = keys.Select(k => k.ToByteArray()).ToArray();
-            KeyValuePair<byte[], byte[]?>[] pairs = _keyValueDb.MultiGet(keyArray);
-            var dictBuilder = ImmutableDictionary.CreateBuilder<KeyBytes, byte[]>();
-            foreach (KeyValuePair<byte[], byte[]?> pair in pairs)
-            {
-                if (pair.Value is { } b)
-                {
-                    dictBuilder[new KeyBytes(pair.Key)] = b;
-                }
-            }
-
-            return dictBuilder.ToImmutable();
-        }
 
         /// <inheritdoc/>
         public void Set(in KeyBytes key, byte[] value)

--- a/Libplanet.Store/Trie/CacheableKeyValueStore.cs
+++ b/Libplanet.Store/Trie/CacheableKeyValueStore.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using LruCacheNet;
 
 namespace Libplanet.Store.Trie
@@ -40,27 +39,6 @@ namespace Libplanet.Store.Trie
             }
 
             throw new KeyNotFoundException($"No such key: ${key}.");
-        }
-
-        /// <inheritdoc cref="IKeyValueStore.Get(IEnumerable{KeyBytes})"/>
-        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
-        {
-            var dictBuilder = ImmutableDictionary.CreateBuilder<KeyBytes, byte[]>();
-            var uncached = new HashSet<KeyBytes>();
-            foreach (KeyBytes key in keys)
-            {
-                if (_cache.TryGetValue(key, out byte[]? value) && value is { } v)
-                {
-                    dictBuilder[key] = v;
-                }
-                else
-                {
-                    uncached.Add(key);
-                }
-            }
-
-            dictBuilder.AddRange(_keyValueStore.Get(uncached));
-            return dictBuilder.ToImmutable();
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Store/Trie/DefaultKeyValueStore.cs
+++ b/Libplanet.Store/Trie/DefaultKeyValueStore.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Zio;
@@ -107,23 +106,6 @@ namespace Libplanet.Store.Trie
             return _root.FileExists(path)
                 ? _root.ReadAllBytes(path)
                 : throw new KeyNotFoundException($"No such key: {key}.");
-        }
-
-        /// <inheritdoc cref="IKeyValueStore.Get(IEnumerable{KeyBytes})"/>
-        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
-        {
-            // We don't optimize this method because it is not used in production.
-            var dictBuilder = ImmutableDictionary.CreateBuilder<KeyBytes, byte[]>();
-            foreach (KeyBytes key in keys)
-            {
-                var path = DataPath(key);
-                if (_root.FileExists(path))
-                {
-                    dictBuilder[key] = _root.ReadAllBytes(path);
-                }
-            }
-
-            return dictBuilder.ToImmutable();
         }
 
         /// <inheritdoc/>

--- a/Libplanet.Store/Trie/IKeyValueStore.cs
+++ b/Libplanet.Store/Trie/IKeyValueStore.cs
@@ -17,16 +17,6 @@ namespace Libplanet.Store.Trie
         public byte[] Get(in KeyBytes key);
 
         /// <summary>
-        /// Gets multiple values associated with the specified keys at once.
-        /// </summary>
-        /// <param name="keys">Keys whose values to get.  The order of keys does not matter.
-        /// Duplicate keys after their first occurrence are ignored.</param>
-        /// <returns>Values associated the specified <paramref name="keys"/>.  Non-existent
-        /// <paramref name="keys"/> are omitted (rather than being filled with
-        /// <see langword="null"/>).</returns>
-        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys);
-
-        /// <summary>
         /// Sets the value to the key.  If the key already exists, the value is overwritten.
         /// </summary>
         /// <param name="key">The key of the value to set.</param>

--- a/Libplanet.Store/Trie/MemoryKeyValueStore.cs
+++ b/Libplanet.Store/Trie/MemoryKeyValueStore.cs
@@ -26,21 +26,6 @@ namespace Libplanet.Store.Trie
         byte[] IKeyValueStore.Get(in KeyBytes key) =>
             _dictionary[key];
 
-        /// <inheritdoc cref="IKeyValueStore.Get(IEnumerable{KeyBytes})"/>
-        public IReadOnlyDictionary<KeyBytes, byte[]> Get(IEnumerable<KeyBytes> keys)
-        {
-            var dictBuilder = ImmutableDictionary.CreateBuilder<KeyBytes, byte[]>();
-            foreach (KeyBytes key in keys)
-            {
-                if (_dictionary.TryGetValue(key, out byte[]? value) && value is { } v)
-                {
-                    dictBuilder[key] = v;
-                }
-            }
-
-            return dictBuilder.ToImmutable();
-        }
-
         /// <inheritdoc/>
         void IKeyValueStore.Set(in KeyBytes key, byte[] value) =>
             _dictionary[key] = value;

--- a/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
+++ b/Libplanet.Tests/Store/Trie/KeyValueStoreTest.cs
@@ -38,22 +38,6 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [SkippableFact]
-        public void GetMany()
-        {
-            KeyBytes[] nonExistentKeys = Enumerable.Range(0, 10)
-                .Select(_ => NewRandomKey())
-                .ToArray();
-            KeyBytes[] keys = PreStoredDataKeys
-                .Concat(PreStoredDataKeys.Take(PreStoredDataCount / 2))
-                .Concat(nonExistentKeys)
-                .ToArray();
-            IReadOnlyDictionary<KeyBytes, byte[]> result = KeyValueStore.Get(keys);
-            Assert.Equal(PreStoredDataCount, result.Count);
-            Assert.All(PreStoredDataKeys, k => Assert.Contains(k, result));
-            Assert.All(nonExistentKeys, k => Assert.DoesNotContain(k, result));
-        }
-
-        [SkippableFact]
         public void Set()
         {
             var key = new KeyBytes(Random.NextBytes(PreStoredDataKeySize));


### PR DESCRIPTION
Closes #3362.

Probably a relic from the past where `IKeyValueStore` was being used directly. I can't quite see a specific use-case where this method might be handy. If we want multi-get at `IKeyValueStore` level instead of `ITrie` layer for performance reasons, then we might want to guarantee the ordering with `null`able return values. 🙄