### PR TITLE
🧹 Fix `BlockChain.DetermineStateRootHash`

### DIFF
--- a/Libplanet.Store/StoreExtensions.cs
+++ b/Libplanet.Store/StoreExtensions.cs
@@ -61,12 +61,18 @@ namespace Libplanet.Store
         /// If <see langword="null"/> is present, <see langword="null"/> is returned.</param>
         /// <returns>The state root hash of the block, or <see langword="null"/> if the block is
         /// not found or <paramref name="blockHash"/> is <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="blockHash"/> is
+        /// not <see langword="null"/> but the corresponding block is not found in store.
+        /// </exception>
         public static HashDigest<SHA256>? GetStateRootHash(
             this IStore store,
             BlockHash? blockHash
         ) =>
-            blockHash is { } hash && store.GetBlockDigest(hash) is BlockDigest digest
-                ? digest.StateRootHash
+            blockHash is { } hash
+                ? store.GetBlockDigest(hash) is BlockDigest digest
+                    ? digest.StateRootHash
+                    : throw new ArgumentException(
+                        $"Given {nameof(blockHash)} was not found in storage: {hash}")
                 : (HashDigest<SHA256>?)null;
     }
 }

--- a/Libplanet.Store/StoreExtensions.cs
+++ b/Libplanet.Store/StoreExtensions.cs
@@ -58,9 +58,10 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="store">The store that blocks are stored.</param>
         /// <param name="blockHash">The hash of the block to get the state root hash of.
-        /// If <see langword="null"/> is present, <see langword="null"/> is returned.</param>
-        /// <returns>The state root hash of the block, or <see langword="null"/> if the block is
-        /// not found or <paramref name="blockHash"/> is <see langword="null"/>.</returns>
+        /// This can be <see langword="null"/>.</param>
+        /// <returns>The state root hash of the block associated with <paramref name="blockHash"/>
+        /// if found or <see langword="null"/> if <paramref name="blockHash"/> is itself
+        /// <see langword="null"/>.</returns>
         /// <exception cref="ArgumentException">Thrown when <paramref name="blockHash"/> is
         /// not <see langword="null"/> but the corresponding block is not found in store.
         /// </exception>

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -138,7 +137,7 @@ namespace Libplanet.Blockchain
                         "did not produce any action evaluations",
                         block.Index,
                         block.PreEvaluationHash);
-                    return Store.GetStateRootHash(block.PreviousHash) ?? default;
+                    return StateStore.GetStateRoot(Store.GetStateRootHash(block.PreviousHash)).Hash;
                 }
             }
             finally


### PR DESCRIPTION
Resolves #3394.

Not the best looking solution. 🙄
This covers an edge case where a genesis `Block` is completely empty.