### PR TITLE
✨ introduce: `IAccountStore`

### DIFF
--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -76,7 +76,9 @@ namespace Libplanet.Action
 
         /// <inheritdoc cref="IActionEvaluator.Evaluate"/>
         [Pure]
-        public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
+        public IReadOnlyList<IActionEvaluation> Evaluate(
+            HashDigest<SHA256>? root,
+            IPreEvaluationBlock block)
         {
             _logger.Information(
                 "Evaluating actions in the block #{BlockIndex} " +

--- a/Libplanet.Action/IActionEvaluator.cs
+++ b/Libplanet.Action/IActionEvaluator.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Security.Cryptography;
 using Libplanet.Action.Loader;
+using Libplanet.Common;
 using Libplanet.Types.Blocks;
 
 namespace Libplanet.Action
@@ -17,6 +19,9 @@ namespace Libplanet.Action
         /// <summary>
         /// The main entry point for evaluating a <see cref="IPreEvaluationBlock"/>.
         /// </summary>
+        /// <param name="root">
+        /// The root hash of the <see cref="IPreEvaluationBlock"/> to evaluate.
+        /// </param>
         /// <param name="block">The block to evaluate.</param>
         /// <returns> The result of evaluating every <see cref="IAction"/> related to
         /// <paramref name="block"/> as an <see cref="IReadOnlyList{T}"/> of
@@ -29,6 +34,8 @@ namespace Libplanet.Action
         /// the end.</para>
         /// </remarks>
         [Pure]
-        IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block);
+        IReadOnlyList<IActionEvaluation> Evaluate(
+            HashDigest<SHA256>? root,
+            IPreEvaluationBlock block);
     }
 }

--- a/Libplanet.Action/State/AccountStore.cs
+++ b/Libplanet.Action/State/AccountStore.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Security.Cryptography;
+using Libplanet.Common;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.Action.State
+{
+    public class AccountStore : IAccountStore
+    {
+        private readonly IStateStore _stateStore;
+
+        public AccountStore(IStateStore stateStore)
+        {
+            _stateStore = stateStore;
+        }
+
+        /// <inheritdoc />
+        public IAccountState GetAccountState(HashDigest<SHA256>? rootHash) =>
+            new Account(GetTrie(rootHash));
+
+        /// <inheritdoc />
+        public ITrie Commit(IAccount account) =>
+            _stateStore.Commit(account.Trie);
+
+        private ITrie GetTrie(HashDigest<SHA256>? rootHash)
+        {
+            if (!(rootHash is { } hash))
+            {
+                return _stateStore.GetStateRoot(null);
+            }
+
+            if (_stateStore.ContainsStateRoot(hash))
+            {
+                return _stateStore.GetStateRoot(hash);
+            }
+
+            throw new ArgumentException(
+                $"Could not find state root {hash} in {nameof(IStateStore)}.");
+        }
+    }
+}

--- a/Libplanet.Action/State/IAccountStore.cs
+++ b/Libplanet.Action/State/IAccountStore.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using Libplanet.Common;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.Action.State
+{
+    /// <summary>
+    /// An interface for the account's state store.
+    /// </summary>
+    public interface IAccountStore
+    {
+        /// <summary>
+        /// Returns the <see cref="IAccountState"/> associated with <paramref name="rootHash"/>.
+        /// </summary>
+        /// <param name="rootHash">
+        /// The root hash of the state trie.
+        /// </param>
+        /// <returns>
+        /// The <see cref="IAccountState"/> associated with <paramref name="rootHash"/>.
+        /// </returns>
+        IAccountState GetAccountState(HashDigest<SHA256>? rootHash);
+
+        /// <summary>
+        /// Commit the <paramref name="account"/> to the store.
+        /// And return the next <see cref="ITrie"/> instance.
+        /// </summary>
+        /// <param name="account">
+        /// The <see cref="IAccount"/> to commit.
+        /// </param>
+        /// <returns>
+        /// The next <see cref="ITrie"/> instance.
+        /// </returns>
+        ITrie Commit(IAccount account);
+    }
+}

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Bencodex.Types;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
@@ -150,5 +152,15 @@ namespace Libplanet.Action.State
         /// </exception>
         /// <seealso cref="IAccountState"/>
         IAccountState GetAccountState(BlockHash? offset);
+
+        /// <summary>
+        /// Get the state root hash of the <see cref="BlockHash"/> at <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="offset"> The <see cref="BlockHash"/> of the <see cref="Block"/> to
+        /// fetch the state root hash from.</param>
+        /// <returns>
+        /// The state root hash of the <see cref="BlockHash"/> at <paramref name="offset"/>.
+        /// </returns>
+        HashDigest<SHA256> GetStateRootHash(BlockHash? offset);
     }
 }

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -1,8 +1,8 @@
 using BenchmarkDotNet.Attributes;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
-using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
@@ -30,7 +30,7 @@ namespace Libplanet.Benchmarks
                 fx.GenesisBlock,
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
-                    blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                    accountStore: new AccountStore(fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();
         }

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -1,8 +1,8 @@
 using BenchmarkDotNet.Attributes;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
-using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
 using Libplanet.Tests.Store;
@@ -36,7 +36,7 @@ namespace Libplanet.Benchmarks
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
-                    blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
+                    accountStore: new AccountStore(_fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             var key = new PrivateKey();
             for (var i = 0; i < 500; i++)

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -1,8 +1,8 @@
 using BenchmarkDotNet.Attributes;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
-using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
@@ -29,7 +29,7 @@ namespace Libplanet.Benchmarks
                 fx.GenesisBlock,
                 new ActionEvaluator(
                     policyBlockActionGetter: _ => null,
-                    blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                    accountStore: new AccountStore(fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();
         }

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -10,6 +10,7 @@ using GraphQL.Server;
 using GraphQL.Utilities;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Common;
@@ -227,7 +228,7 @@ If omitted (default) explorer only the local blockchain store.")]
                         blockChainStates,
                         new ActionEvaluator(
                             _ => policy.BlockAction,
-                            blockChainStates,
+                            new AccountStore(stateStore),
                             new SingleActionLoader(typeof(NullAction))));
                 Startup.PreloadedSingleton = false;
                 Startup.BlockChainSingleton = blockChain;

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Sys;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -85,7 +86,7 @@ public class GeneratedBlockChainFixture
         IStore store = new MemoryStore();
         var actionEvaluator = new ActionEvaluator(
             _ => policy.BlockAction,
-            new BlockChainStates(store, stateStore),
+            new AccountStore(stateStore),
             TypedActionLoader.Create(typeof(SimpleAction).Assembly, typeof(SimpleAction)));
         Block genesisBlock = BlockChain.ProposeGenesisBlock(
             actionEvaluator,

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using GraphQL;
@@ -9,6 +10,7 @@ using GraphQL.Execution;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Libplanet.Blockchain.Policies;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Libplanet.Types.Blocks;
@@ -193,6 +195,9 @@ public class StateQueryTest
             GetAccountState(offset).GetValidatorSet();
 
         public IAccountState GetAccountState(BlockHash? offset) => new MockAccount(offset);
+
+        public HashDigest<SHA256> GetStateRootHash(BlockHash? offset) =>
+            GetAccountState(offset).Trie.Hash;
 
         public ITrie GetTrie(BlockHash? offset)
         {

--- a/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -13,6 +13,7 @@ using ImmutableTrie;
 using global::Cocona;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Sys;
 using Libplanet.Blockchain;
 using Libplanet.Crypto;
@@ -157,8 +158,8 @@ public class BlockCommand
         var blockAction = blockPolicyParams.GetBlockAction();
         var actionEvaluator = new ActionEvaluator(
             _ => blockAction,
-            new BlockChainStates(
-                new MemoryStore(), new TrieStateStore(new DefaultKeyValueStore(null))),
+            new AccountStore(
+                new TrieStateStore(new DefaultKeyValueStore(null))),
             new SingleActionLoader(typeof(NullAction)));
         Block genesis = BlockChain.ProposeGenesisBlock(
             actionEvaluator, privateKey: key, transactions: txs);

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -67,7 +68,7 @@ namespace Libplanet.Net.Tests.Consensus
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => TestUtils.Policy.BlockAction,
-                        blockChainStates: new BlockChainStates(stores[i], stateStore),
+                        accountStore: new AccountStore(stateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             }
 

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -465,7 +466,7 @@ namespace Libplanet.Net.Tests
                     fxs[i].GenesisBlock,
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => policy.BlockAction,
-                        blockChainStates: new BlockChainStates(fxs[i].Store, fxs[i].StateStore),
+                        accountStore: new AccountStore(fxs[i].StateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 swarms[i] = await CreateSwarm(blockChains[i]).ConfigureAwait(false);
             }

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -87,7 +88,7 @@ namespace Libplanet.RocksDBStore.Tests
                     Fx.GenesisBlock,
                     new ActionEvaluator(
                         policyBlockActionGetter: _ => null,
-                        blockChainStates: new BlockChainStates(store, stateStore),
+                        accountStore: new AccountStore(stateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 store.Dispose();
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -374,7 +375,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         _ => policy.BlockAction,
-                        blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                        accountStore: new AccountStore(fx.StateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
                 var validTx = blockChain.MakeTransaction(validKey, new DumbAction[] { });
@@ -497,6 +498,7 @@ namespace Libplanet.Tests.Blockchain
             var policy = new NullBlockPolicy(
                     new BlockPolicyViolationException(string.Empty));
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
+            var accountStore = new AccountStore(_fx.StateStore);
             var blockChain = new BlockChain(
                 policy,
                 new VolatileStagePolicy(),
@@ -506,7 +508,7 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     _ => policy.BlockAction,
-                    blockChainStates,
+                    accountStore,
                     new SingleActionLoader(typeof(DumbAction))));
             Assert.Throws<BlockPolicyViolationException>(
                 () => blockChain.Append(_fx.Block1, TestUtils.CreateBlockCommit(_fx.Block1)));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -125,7 +126,7 @@ namespace Libplanet.Tests.Blockchain
                 var policy = new BlockPolicy();
                 var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
-                    new BlockChainStates(fx.Store, fx.StateStore),
+                    new AccountStore(fx.StateStore),
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = BlockChain.ProposeGenesisBlock(
                     actionEvaluator,
@@ -165,7 +166,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         _ => policy.BlockAction,
-                        blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                        accountStore: new AccountStore(fx.StateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var txs = new[]
                 {
@@ -347,7 +348,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         _ => policy.BlockAction,
-                        blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                        accountStore: new AccountStore(fx.StateStore),
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
                 var validTx = blockChain.MakeTransaction(validKey, new DumbAction[] { });
@@ -459,7 +460,7 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     _ => policy.BlockAction,
-                    blockChainStates,
+                    new AccountStore(_fx.StateStore),
                     new SingleActionLoader(typeof(DumbAction))));
 
             blockChain.MakeTransaction(privateKey2, new[] { new DumbAction(address2, "baz") });

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -182,7 +183,7 @@ namespace Libplanet.Tests.Blockchain
             IStore store = new MemoryStore();
             var actionEvaluator = new ActionEvaluator(
                 _ => policy.BlockAction,
-                new BlockChainStates(store, stateStore),
+                new AccountStore(stateStore),
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisBlock = TestUtils.ProposeGenesisBlock(
                 actionEvaluator,
@@ -217,6 +218,7 @@ namespace Libplanet.Tests.Blockchain
                 policy.BlockInterval
             );
             var blockChainStates = new BlockChainStates(store, stateStore);
+            var accountStore = new AccountStore(stateStore);
             var chain2 = new BlockChain(
                 policyWithBlockAction,
                 new VolatileStagePolicy(),
@@ -226,7 +228,7 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     _ => policyWithBlockAction.BlockAction,
-                    blockChainStates,
+                    accountStore,
                     new SingleActionLoader(typeof(DumbAction))));
             Assert.Throws<InvalidBlockStateRootHashException>(() =>
                 chain2.Append(block1, TestUtils.CreateBlockCommit(block1)));

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -43,7 +44,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     _ => _policy.BlockAction,
-                    blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
+                    accountStore: new AccountStore(_fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
         }
 

--- a/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -32,7 +33,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     _ => _policy.BlockAction,
-                    blockChainStates: new BlockChainStates(_fx.Store, _fx.StateStore),
+                    accountStore: new AccountStore(_fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _key = new PrivateKey();
             _txs = Enumerable.Range(0, 5).Select(i =>

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -43,7 +44,7 @@ namespace Libplanet.Tests.Blocks
             {
                 var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
-                    new BlockChainStates(fx.Store, fx.StateStore),
+                    new AccountStore(fx.StateStore),
                     new SingleActionLoader(typeof(Arithmetic)));
                 Block genesis = preEvalGenesis.Sign(
                     _contents.GenesisKey,
@@ -106,7 +107,7 @@ namespace Libplanet.Tests.Blocks
             {
                 var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
-                    blockChainStates: new BlockChainStates(fx.Store, fx.StateStore),
+                    accountStore: new AccountStore(fx.StateStore),
                     actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)));
                 HashDigest<SHA256> genesisStateRootHash =
                     BlockChain.DetermineGenesisStateRootHash(

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -76,7 +76,7 @@ namespace Libplanet.Tests.Fixtures
             StateStore = new TrieStateStore(KVStore);
             var actionEvaluator = new ActionEvaluator(
                 _ => policy.BlockAction,
-                new BlockChainStates(Store, StateStore),
+                new AccountStore(StateStore),
                 new SingleActionLoader(typeof(Arithmetic)));
             Genesis = TestUtils.ProposeGenesisBlock(
                 actionEvaluator,

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Common;
@@ -105,7 +106,7 @@ namespace Libplanet.Tests.Store
                 validatorSet: TestUtils.ValidatorSet);
             var actionEvaluator = new ActionEvaluator(
                 _ => blockAction,
-                new BlockChainStates(new MemoryStore(), stateStore),
+                new AccountStore(stateStore),
                 new SingleActionLoader(typeof(DumbAction)));
             GenesisBlock = preEval.Sign(
                 Proposer,

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1027,7 +1027,7 @@ namespace Libplanet.Tests.Store
                 var preEval = ProposeGenesis(proposer: GenesisProposer.PublicKey);
                 var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
-                    new BlockChainStates(s1, fx.StateStore),
+                    new AccountStore(fx.StateStore),
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = preEval.Sign(
                     GenesisProposer,

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -18,6 +18,7 @@ using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Sys;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
@@ -607,9 +608,10 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             };
 
             var blockChainStates = new BlockChainStates(store, stateStore);
+            var accountStore = new AccountStore(stateStore);
             var actionEvaluator = new ActionEvaluator(
                     _ => policy.BlockAction,
-                    blockChainStates: blockChainStates,
+                    accountStore: accountStore,
                     actionTypeLoader: new SingleActionLoader(typeof(T)));
 
             if (genesisBlock is null)

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -72,7 +72,7 @@ namespace Libplanet.Blockchain
                     nameof(preEvaluationBlock));
             }
 
-            return actionEvaluator.Evaluate(preEvaluationBlock);
+            return actionEvaluator.Evaluate(null, preEvaluationBlock);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Libplanet.Blockchain
         /// <seealso cref="ValidateBlockStateRootHash"/>
         [Pure]
         public IReadOnlyList<IActionEvaluation> EvaluateBlock(IPreEvaluationBlock block) =>
-            ActionEvaluator.Evaluate(block);
+            ActionEvaluator.Evaluate(_blockChainStates.GetStateRootHash(block.PreviousHash), block);
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -175,7 +175,8 @@ namespace Libplanet.Blockchain
                 {
                     Block block = Store.GetBlock(hash);
                     ImmutableList<IActionEvaluation> evaluations =
-                        ActionEvaluator.Evaluate(block).ToImmutableList();
+                        ActionEvaluator.Evaluate(_blockChainStates.GetStateRootHash(hash), block)
+                            .ToImmutableList();
 
                     count += RenderActions(
                         evaluations: evaluations,
@@ -215,7 +216,9 @@ namespace Libplanet.Blockchain
 
             if (evaluations is null)
             {
-                evaluations = ActionEvaluator.Evaluate(block);
+                evaluations = ActionEvaluator.Evaluate(
+                    _blockChainStates.GetStateRootHash(block.PreviousHash),
+                    block);
             }
 
             long count = 0;

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using Bencodex.Types;
 using Libplanet.Action;
@@ -563,6 +564,9 @@ namespace Libplanet.Blockchain
         /// <inheritdoc cref="IBlockChainStates.GetAccountState" />
         public IAccountState GetAccountState(BlockHash? offset) =>
             _blockChainStates.GetAccountState(offset);
+
+        public HashDigest<SHA256> GetStateRootHash(BlockHash? offset) =>
+            _blockChainStates.GetStateRootHash(offset);
 
         /// <summary>
         /// Queries the recorded <see cref="TxExecution"/> for a successful or failed

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
@@ -51,6 +53,9 @@ namespace Libplanet.Blockchain
         /// <inheritdoc cref="IBlockChainStates.GetAccountState"/>
         public IAccountState GetAccountState(BlockHash? offset) =>
             new Account(GetTrie(offset));
+
+        public HashDigest<SHA256> GetStateRootHash(BlockHash? offset) =>
+            GetTrie(offset).Hash;
 
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>

--- a/Libplanet/Blockchain/NullChainStates.cs
+++ b/Libplanet/Blockchain/NullChainStates.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
+using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
 using Libplanet.Types.Blocks;
@@ -13,6 +16,7 @@ namespace Libplanet.Blockchain
     {
         public static readonly NullChainStates Instance = new NullChainStates();
         private static readonly IKeyValueStore _keyValueStore = new MemoryKeyValueStore();
+        private static readonly IStateStore _stateStore = new TrieStateStore(_keyValueStore);
 
         private NullChainStates()
         {
@@ -38,5 +42,10 @@ namespace Libplanet.Blockchain
 
         public IAccountState GetAccountState(BlockHash? offset) =>
             new Account(new MerkleTrie(_keyValueStore));
+
+        public HashDigest<SHA256> GetStateRootHash(BlockHash? offset) =>
+            GetAccountState(offset).Trie.Hash;
+
+        public IStateStore GetStateStore() => _stateStore;
     }
 }


### PR DESCRIPTION
# Context
Now `ActionEvaluator` needs `IStateStore` but it is too raw data type for use in `ActionEvaluator`.
So, introduce `IAccountStore`, instead of `IBlockChainStates`.

# Rationale
`IAccountStore` is a kind of management `IAccount`, `IAccountState`. it will replace `IBlockChainStates`.
The next step is to move `IBlockChainStates` to `Libplanet` and remove the `Libplanet.Action` dependency from `Libplanet`.