### PR TITLE
🐛 Fix `ITrie.Get()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 3.3.1
 
 To be released.
 
+-  (Libplanet.Store) Fixed a bug where `ITrie.Get()` could wrongly retrieve
+   an `IValue` from a non-existent path.  [[#3420]]
+
+[#3420]: https://github.com/planetarium/libplanet/pull/3420
+
 
 Version 3.3.0
 -------------

--- a/Libplanet.Store/Trie/MerkleTrie.Path.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Path.cs
@@ -9,7 +9,9 @@ namespace Libplanet.Store.Trie
             node switch
             {
                 null => null,
-                ValueNode valueNode => valueNode.Value,
+                ValueNode valueNode => !cursor.RemainingAnyNibbles
+                    ? valueNode.Value
+                    : null,
                 ShortNode shortNode => cursor.RemainingNibblesStartWith(shortNode.Key)
                     ? ResolveToValue(shortNode.Value, cursor.Next(shortNode.Key.Length))
                     : null,

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -289,6 +289,22 @@ namespace Libplanet.Tests.Store.Trie
         }
 
         [Fact]
+        public void ResolveToValueAtTheEndOfShortNode()
+        {
+            IStateStore stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            ITrie trie = stateStore.GetStateRoot(null);
+
+            KeyBytes key00 = new KeyBytes(new byte[] { 0x00 });
+            IValue value00 = new Text("00");
+            KeyBytes key0000 = new KeyBytes(new byte[] { 0x00, 0x00 });
+
+            trie = trie.Set(key00, value00);
+            trie = stateStore.Commit(trie);
+
+            Assert.Null(trie.Get(key0000));
+        }
+
+        [Fact]
         public void SetValueToExtendedKey()
         {
             IStateStore stateStore = new TrieStateStore(new MemoryKeyValueStore());


### PR DESCRIPTION
Seems like the bug has been present since before 3.3.0. Fixes a possible early termination while traversing an `ITrie` due to a missing constraint.

For example, a `ValueNode` at path `1234` could be fetched at the end of a `ShortNode` with path `12345678`. 🙄