### PR TITLE
♻️ Commit once for `IActionEvaluation`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,12 +12,6 @@ To be released.
 
  -  Added `IBlockChainStates.GetAccountState(HashDigest<SHA256>?)`
     interface method.  [[#3425]]
- -  Changed `IActionRenderer.RenderAction(IValue, IActionContext, IAccount)`
-    to `IActionRenderer.RenderAction(IValue, IActionRenderContext,
-    HashDigest<SHA256>)`.  [[#3427]]
- -  Changed `IActionRenderer.RenderActionError(IValue, IActionContext,
-    Exception)` to `IActionRenderer.RenderActionError(IValue,
-    IActionRenderContext, Exception)`.  [[#3427]]
  -  Removed `TxFailure.ExceptionMetadata` property.  [[#3428]]
  -  Removed `ISerializable` interface from `TxExecution`, `TxSuccess`,
     and `TxFailure`.  [[#3428]]
@@ -32,6 +26,12 @@ To be released.
     and added `TxResult.ExceptionNames` of type `List<string?>?`.  [[#3429]]
  -  (Libplanet.Explorer) Removed `TxResult.UpdatedStates` and
     `TxResult.UpdatedFungibleAssets`.  [[#3429]]
+ -  Changed `IActionRenderer.RenderAction(IValue, IActionContext, IAccount)`
+    to `IActionRenderer.RenderAction(IValue, ICommittedActionContext,
+    HashDigest<SHA256>)`.  [[#3431]]
+ -  Changed `IActionRenderer.RenderActionError(IValue, IActionContext,
+    Exception)` to `IActionRenderer.RenderActionError(IValue,
+    ICommittedActionContext, Exception)`.  [[#3431]]
 
 ### Backward-incompatible network protocol changes
 
@@ -40,7 +40,8 @@ To be released.
 ### Added APIs
 
  -  Added `AccountDiff` class.  [[#3424]]
- -  Added `IActionRenderContext` interface.  [[#3427]]
+ -  Added `ICommittedActionContext` interface.  [[#3431]]
+ -  Added `ICommittedActionEvaluation` interface.  [[#3431]]
 
 ### Behavioral changes
 
@@ -52,9 +53,9 @@ To be released.
 
 [#3424]: https://github.com/planetarium/libplanet/pull/3424
 [#3425]: https://github.com/planetarium/libplanet/pull/3425
-[#3427]: https://github.com/planetarium/libplanet/pull/3427
 [#3428]: https://github.com/planetarium/libplanet/pull/3428
 [#3429]: https://github.com/planetarium/libplanet/pull/3429
+[#3431]: https://github.com/planetarium/libplanet/pull/3431
 
 
 Version 3.3.1

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -69,6 +69,7 @@ namespace Libplanet.Action
         /// <inheritdoc cref="IActionContext.UseGas(long)"/>
         public void UseGas(long gas) => GetGasMeter.Value?.UseGas(gas);
 
+        /// <inheritdoc cref="IActionContext.GetUnconsumedContext"/>
         [Pure]
         public IActionContext GetUnconsumedContext() =>
             new ActionContext(

--- a/Libplanet.Action/CommittedActionContext.cs
+++ b/Libplanet.Action/CommittedActionContext.cs
@@ -78,5 +78,19 @@ namespace Libplanet.Action
         /// <inheritdoc cref="ICommittedActionContext.BlockAction"/>
         [Pure]
         public bool BlockAction { get; }
+
+        /// <inheritdoc cref="ICommittedActionContext.Copy"/>
+        [Pure]
+        public ICommittedActionContext Copy() =>
+            new CommittedActionContext(
+                Signer,
+                TxId,
+                Miner,
+                BlockIndex,
+                BlockProtocolVersion,
+                Rehearsal,
+                PreviousState,
+                new Random(Random.Seed),
+                BlockAction);
     }
 }

--- a/Libplanet.Action/CommittedActionContext.cs
+++ b/Libplanet.Action/CommittedActionContext.cs
@@ -6,9 +6,9 @@ using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
-    public class ActionRenderContext : IActionRenderContext
+    public class CommittedActionContext : ICommittedActionContext
     {
-        public ActionRenderContext(IActionContext context)
+        public CommittedActionContext(IActionContext context)
             : this(
                 signer: context.Signer,
                 txId: context.TxId,
@@ -22,7 +22,7 @@ namespace Libplanet.Action
         {
         }
 
-        public ActionRenderContext(
+        public CommittedActionContext(
             Address signer,
             TxId? txId,
             Address miner,
@@ -44,38 +44,38 @@ namespace Libplanet.Action
             BlockAction = blockAction;
         }
 
-        /// <inheritdoc cref="IActionRenderContext.Signer"/>
+        /// <inheritdoc cref="ICommittedActionContext.Signer"/>
         [Pure]
         public Address Signer { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.TxId"/>
+        /// <inheritdoc cref="ICommittedActionContext.TxId"/>
         [Pure]
         public TxId? TxId { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.Miner"/>
+        /// <inheritdoc cref="ICommittedActionContext.Miner"/>
         [Pure]
         public Address Miner { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.BlockIndex"/>
+        /// <inheritdoc cref="ICommittedActionContext.BlockIndex"/>
         [Pure]
         public long BlockIndex { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.BlockProtocolVersion"/>
+        /// <inheritdoc cref="ICommittedActionContext.BlockProtocolVersion"/>
         [Pure]
         public int BlockProtocolVersion { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.Rehearsal"/>
+        /// <inheritdoc cref="ICommittedActionContext.Rehearsal"/>
         [Pure]
         public bool Rehearsal { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.PreviousState"/>
+        /// <inheritdoc cref="ICommittedActionContext.PreviousState"/>
         [Pure]
         public HashDigest<SHA256> PreviousState { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.Random"/>
+        /// <inheritdoc cref="ICommittedActionContext.Random"/>
         public IRandom Random { get; }
 
-        /// <inheritdoc cref="IActionRenderContext.BlockAction"/>
+        /// <inheritdoc cref="ICommittedActionContext.BlockAction"/>
         [Pure]
         public bool BlockAction { get; }
     }

--- a/Libplanet.Action/CommittedActionEvaluation.cs
+++ b/Libplanet.Action/CommittedActionEvaluation.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Common;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// A record type to represent an evaluation plan and result of
+    /// a single action.
+    /// </summary>
+    public class CommittedActionEvaluation : ICommittedActionEvaluation
+    {
+        /// <summary>
+        /// Creates an <see cref="CommittedActionEvaluation"/> instance
+        /// with filling properties.
+        /// </summary>
+        /// <param name="action">An action to evaluate.</param>
+        /// <param name="inputContext">An input <see cref="IActionContext"/> to
+        /// evaluate <paramref name="action"/>.</param>
+        /// <param name="outputState">The result states that
+        /// <paramref name="action"/> makes.</param>
+        /// <param name="exception">An exception that has risen during evaluating a given
+        /// <paramref name="action"/>.</param>
+        public CommittedActionEvaluation(
+            IValue action,
+            ICommittedActionContext inputContext,
+            HashDigest<SHA256> outputState,
+            Exception? exception = null)
+        {
+            Action = action;
+            InputContext = inputContext;
+            OutputState = outputState;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// An action to evaluate.
+        /// </summary>
+        public IValue Action { get; }
+
+        /// <summary>
+        /// An input <see cref="ICommittedActionContext"/> to evaluate
+        /// <see cref="Action"/>.
+        /// </summary>
+        /// <remarks>Its <see cref="ICommittedActionContext.Random"/> property
+        /// is not consumed yet.</remarks>
+        public ICommittedActionContext InputContext { get; }
+
+        /// <summary>
+        /// The result states that <see cref="Action"/> makes.
+        /// </summary>
+        public HashDigest<SHA256> OutputState { get; }
+
+        /// <summary>
+        /// An exception that had risen during evaluation.
+        /// </summary>
+        public Exception? Exception { get; }
+    }
+}

--- a/Libplanet.Action/ICommittedActionContext.cs
+++ b/Libplanet.Action/ICommittedActionContext.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Action
     /// <summary>
     /// Contextual data determined by a transaction and a block for rendering.
     /// </summary>
-    public interface IActionRenderContext
+    public interface ICommittedActionContext
     {
         /// <summary>
         /// The <see cref="Transaction.Signer"/> of the <see cref="Transaction"/> that contains

--- a/Libplanet.Action/ICommittedActionContext.cs
+++ b/Libplanet.Action/ICommittedActionContext.cs
@@ -82,5 +82,7 @@ namespace Libplanet.Action
         /// </summary>
         [Pure]
         bool BlockAction { get; }
+
+        ICommittedActionContext Copy();
     }
 }

--- a/Libplanet.Action/ICommittedActionEvaluation.cs
+++ b/Libplanet.Action/ICommittedActionEvaluation.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Common;
+
+namespace Libplanet.Action
+{
+    public interface ICommittedActionEvaluation
+    {
+        /// <summary>
+        /// An action data to evaluate. When the
+        /// <see cref="InputContext"/>.<see cref="IActionContext.BlockAction"/> is true,
+        /// use <see cref="IBlockPolicy.BlockAction"/> instead of trying deserialization.
+        /// </summary>
+        public IValue Action { get; }
+
+        /// <summary>
+        /// An input <see cref="IActionContext"/> to evaluate
+        /// <see cref="Action"/>.
+        /// </summary>
+        /// <remarks>Its <see cref="IActionContext.Random"/> property
+        /// is not consumed yet.</remarks>
+        public ICommittedActionContext InputContext { get; }
+
+        /// <summary>
+        /// The result states that <see cref="Action"/> makes.
+        /// </summary>
+        public HashDigest<SHA256> OutputState { get; }
+
+        /// <summary>
+        /// An exception that had risen during evaluation.
+        /// </summary>
+        public Exception? Exception { get; }
+    }
+}

--- a/Libplanet.Action/Random.cs
+++ b/Libplanet.Action/Random.cs
@@ -1,6 +1,3 @@
-#nullable disable
-using System;
-
 namespace Libplanet.Action
 {
     internal class Random : System.Random, IRandom

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -610,7 +610,8 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.StageTransaction(txA0);
             _blockChain.StageTransaction(txA1);
             Block block = _blockChain.ProposeBlock(miner);
-            IReadOnlyList<IActionEvaluation> actionEvaluations = _blockChain.EvaluateBlock(block);
+            (IReadOnlyList<ICommittedActionEvaluation> actionEvaluations, _) =
+                _blockChain.ToCommittedEvaluation(block, _blockChain.EvaluateBlock(block));
             Assert.Equal(0L, _blockChain.Tip.Index);
             _blockChain.Append(
                 block,

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -18,8 +18,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private static IAccount _account = new Account(MockAccountState.Empty);
 
-        private static IActionRenderContext _actionContext =
-            new ActionRenderContext(new ActionContext(
+        private static ICommittedActionContext _actionContext =
+            new CommittedActionContext(new ActionContext(
                 default,
                 default,
                 default,
@@ -43,7 +43,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionRenderer()
         {
-            (IValue, IActionRenderContext, HashDigest<SHA256>)? record = null;
+            (IValue, ICommittedActionContext, HashDigest<SHA256>)? record = null;
             var renderer = new AnonymousActionRenderer
             {
                 ActionRenderer = (action, context, nextState) =>
@@ -65,7 +65,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
         [Fact]
         public void ActionErrorRenderer()
         {
-            (IValue, IActionRenderContext, Exception)? record = null;
+            (IValue, ICommittedActionContext, Exception)? record = null;
             var renderer = new AnonymousActionRenderer
             {
                 ActionErrorRenderer = (action, context, exception) =>

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -68,8 +68,8 @@ namespace Libplanet.Tests.Blockchain.Renderers
         {
             bool called = false;
             LogEvent firstLog = null;
-            IActionRenderContext actionContext =
-                new ActionRenderContext(new ActionContext(
+            ICommittedActionContext actionContext =
+                new CommittedActionContext(new ActionContext(
                     default,
                     default,
                     default,
@@ -83,7 +83,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             IActionRenderer actionRenderer;
             if (error)
             {
-                Action<IValue, IActionRenderContext, Exception> render = (action, cxt, e) =>
+                Action<IValue, ICommittedActionContext, Exception> render = (action, cxt, e) =>
                 {
                     LogEvent[] logs = LogEvents.ToArray();
                     Assert.Single(logs);
@@ -104,7 +104,7 @@ namespace Libplanet.Tests.Blockchain.Renderers
             }
             else
             {
-                Action<IValue, IActionRenderContext, HashDigest<SHA256>> render =
+                Action<IValue, ICommittedActionContext, HashDigest<SHA256>> render =
                     (action, cxt, next) =>
                     {
                         LogEvent[] logs = LogEvents.ToArray();

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -233,7 +233,7 @@ namespace Libplanet.Blockchain
                     {
                         renderer.RenderAction(
                             evaluation.Action,
-                            new ActionRenderContext(
+                            new CommittedActionContext(
                                 signer: evaluation.InputContext.Signer,
                                 txId: evaluation.InputContext.TxId,
                                 miner: evaluation.InputContext.Miner,
@@ -249,7 +249,7 @@ namespace Libplanet.Blockchain
                     {
                         renderer.RenderActionError(
                             evaluation.Action,
-                            new ActionRenderContext(
+                            new CommittedActionContext(
                                 signer: evaluation.InputContext.Signer,
                                 txId: evaluation.InputContext.TxId,
                                 miner: evaluation.InputContext.Miner,

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -5,10 +5,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Libplanet.Action;
-using Libplanet.Action.State;
 using Libplanet.Blockchain.Renderers;
 using Libplanet.Store;
-using Libplanet.Store.Trie;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Tx;
 
@@ -175,9 +173,10 @@ namespace Libplanet.Blockchain
                     Block block = Store.GetBlock(hash);
                     ImmutableList<IActionEvaluation> evaluations =
                         ActionEvaluator.Evaluate(block).ToImmutableList();
+                    (var committedEvaluations, _) = ToCommittedEvaluation(block, evaluations);
 
                     RenderActions(
-                        evaluations: evaluations,
+                        evaluations: committedEvaluations,
                         block: block);
                 }
 
@@ -200,9 +199,14 @@ namespace Libplanet.Blockchain
         /// <see langword="null"/>, evaluate actions of the <paramref name="block"/> again.</param>
         /// <param name="block"><see cref="Block"/> to render actions.</param>
         internal void RenderActions(
-            IReadOnlyList<IActionEvaluation> evaluations,
+            IReadOnlyList<ICommittedActionEvaluation> evaluations,
             Block block)
         {
+            if (evaluations is null)
+            {
+                throw new NullReferenceException(nameof(evaluations));
+            }
+
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
             _logger.Debug(
@@ -210,59 +214,26 @@ namespace Libplanet.Blockchain
                 block.Index,
                 block.Hash);
 
-            if (evaluations is null)
-            {
-                evaluations = ActionEvaluator.Evaluate(block);
-            }
-
             long count = 0;
-            ITrie trie = GetAccountState(block.PreviousHash).Trie;
             foreach (var evaluation in evaluations)
             {
-                ITrie nextTrie = trie;
-                foreach (var kv in evaluation.OutputState.Delta.ToRawDelta())
-                {
-                    nextTrie = nextTrie.Set(kv.Key, kv.Value);
-                }
-
-                nextTrie = StateStore.Commit(nextTrie);
-
                 foreach (IActionRenderer renderer in ActionRenderers)
                 {
                     if (evaluation.Exception is null)
                     {
                         renderer.RenderAction(
                             evaluation.Action,
-                            new CommittedActionContext(
-                                signer: evaluation.InputContext.Signer,
-                                txId: evaluation.InputContext.TxId,
-                                miner: evaluation.InputContext.Miner,
-                                blockIndex: evaluation.InputContext.BlockIndex,
-                                blockProtocolVersion: evaluation.InputContext.BlockProtocolVersion,
-                                rehearsal: evaluation.InputContext.Rehearsal,
-                                previousState: trie.Hash,
-                                random: evaluation.InputContext.GetUnconsumedContext().Random,
-                                blockAction: evaluation.InputContext.BlockAction),
-                            nextTrie.Hash);
+                            evaluation.InputContext.Copy(),
+                            evaluation.OutputState);
                     }
                     else
                     {
                         renderer.RenderActionError(
                             evaluation.Action,
-                            new CommittedActionContext(
-                                signer: evaluation.InputContext.Signer,
-                                txId: evaluation.InputContext.TxId,
-                                miner: evaluation.InputContext.Miner,
-                                blockIndex: evaluation.InputContext.BlockIndex,
-                                blockProtocolVersion: evaluation.InputContext.BlockProtocolVersion,
-                                rehearsal: evaluation.InputContext.Rehearsal,
-                                previousState: trie.Hash,
-                                random: evaluation.InputContext.GetUnconsumedContext().Random,
-                                blockAction: evaluation.InputContext.BlockAction),
+                            evaluation.InputContext.Copy(),
                             evaluation.Exception);
                     }
 
-                    trie = nextTrie;
                     count++;
                 }
             }

--- a/Libplanet/Blockchain/BlockChain.Validate.cs
+++ b/Libplanet/Blockchain/BlockChain.Validate.cs
@@ -318,7 +318,7 @@ namespace Libplanet.Blockchain
         /// <seealso cref="EvaluateBlock"/>
         /// <seealso cref="DetermineBlockStateRootHash"/>
         internal void ValidateBlockStateRootHash(
-            Block block, out IReadOnlyList<IActionEvaluation> evaluations)
+            Block block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
             var rootHash = DetermineBlockStateRootHash(block, out evaluations);
             if (!rootHash.Equals(block.StateRootHash))

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -964,7 +964,7 @@ namespace Libplanet.Blockchain
             Block block,
             BlockCommit blockCommit,
             bool render,
-            IReadOnlyList<IActionEvaluation> actionEvaluations = null
+            IReadOnlyList<ICommittedActionEvaluation> actionEvaluations = null
         )
         {
             if (Count == 0)

--- a/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AnonymousActionRenderer.cs
@@ -30,16 +30,16 @@ namespace Libplanet.Blockchain.Renderers
     {
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="RenderAction(IValue, IActionRenderContext, HashDigest{SHA256})"/>.
+        /// <see cref="RenderAction(IValue, ICommittedActionContext, HashDigest{SHA256})"/>.
         /// </summary>
-        public Action<IValue, IActionRenderContext, HashDigest<SHA256>>? ActionRenderer
+        public Action<IValue, ICommittedActionContext, HashDigest<SHA256>>? ActionRenderer
             { get; set; }
 
         /// <summary>
         /// A callback function to be invoked together with
-        /// <see cref="RenderActionError(IValue, IActionRenderContext, Exception)"/>.
+        /// <see cref="RenderActionError(IValue, ICommittedActionContext, Exception)"/>.
         /// </summary>
-        public Action<IValue, IActionRenderContext, Exception>? ActionErrorRenderer { get; set; }
+        public Action<IValue, ICommittedActionContext, Exception>? ActionErrorRenderer { get; set; }
 
         /// <summary>
         /// A callback function to be invoked together with
@@ -50,16 +50,16 @@ namespace Libplanet.Blockchain.Renderers
         /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState
         ) =>
             ActionRenderer?.Invoke(action, context, nextState);
 
         /// <inheritdoc
-        /// cref="IActionRenderer.RenderActionError(IValue, IActionRenderContext, Exception)"/>
+        /// cref="IActionRenderer.RenderActionError(IValue, ICommittedActionContext, Exception)"/>
         public void RenderActionError(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             Exception exception) =>
                 ActionErrorRenderer?.Invoke(action, context, exception);
 

--- a/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/AtomicActionRenderer.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Blockchain.Renderers
     /// </remarks>
     public sealed class AtomicActionRenderer : IActionRenderer
     {
-        private readonly List<(IValue, IActionRenderContext, HashDigest<SHA256>)> _eventBuffer;
+        private readonly List<(IValue, ICommittedActionContext, HashDigest<SHA256>)> _eventBuffer;
         private TxId? _lastTxId;
         private bool _errored;
 
@@ -36,7 +36,7 @@ namespace Libplanet.Blockchain.Renderers
         {
             ActionRenderer = actionRenderer;
             _lastTxId = null;
-            _eventBuffer = new List<(IValue, IActionRenderContext, HashDigest<SHA256>)>();
+            _eventBuffer = new List<(IValue, ICommittedActionContext, HashDigest<SHA256>)>();
             _errored = false;
         }
 
@@ -62,7 +62,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState
         )
         {
@@ -84,7 +84,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <inheritdoc cref="IActionRenderer.RenderActionError"/>
         public void RenderActionError(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             Exception exception)
         {
             if (!context.TxId.Equals(_lastTxId))
@@ -104,7 +104,7 @@ namespace Libplanet.Blockchain.Renderers
 
         private void FlushBuffer(
             TxId? newTxId,
-            Action<IValue, IActionRenderContext, HashDigest<SHA256>> render
+            Action<IValue, ICommittedActionContext, HashDigest<SHA256>> render
         )
         {
             if (!_errored)

--- a/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/RecordingActionRenderer.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public virtual void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState
         )
         {
@@ -80,7 +80,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <inheritdoc cref="IActionRenderer.RenderActionError"/>
         public virtual void RenderActionError(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             Exception exception
         ) =>
             _records.Add(

--- a/Libplanet/Blockchain/Renderers/Debug/RenderRecord.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/RenderRecord.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 long index,
                 string stackTrace,
                 IValue action,
-                IActionRenderContext context,
+                ICommittedActionContext context,
                 bool unrender = false
             )
                 : base(index, stackTrace)
@@ -58,7 +58,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
             /// <summary>
             /// The action evaluation context.
             /// </summary>
-            public IActionRenderContext Context { get; }
+            public ICommittedActionContext Context { get; }
 
             /// <summary>
             /// Whether it is not an unrender event, but a render event.
@@ -94,7 +94,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 long index,
                 string stackTrace,
                 IValue action,
-                IActionRenderContext context,
+                ICommittedActionContext context,
                 HashDigest<SHA256> nextState,
                 bool unrender = false
             )
@@ -130,7 +130,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
                 long index,
                 string stackTrace,
                 IValue action,
-                IActionRenderContext context,
+                ICommittedActionContext context,
                 Exception exception,
                 bool unrender = false
             )

--- a/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/Debug/ValidatingActionRenderer.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public override void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState
         )
         {
@@ -55,7 +55,7 @@ namespace Libplanet.Blockchain.Renderers.Debug
         /// <inheritdoc cref="IActionRenderer.RenderActionError"/>
         public override void RenderActionError(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             Exception exception
         )
         {

--- a/Libplanet/Blockchain/Renderers/IActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/IActionRenderer.cs
@@ -66,7 +66,7 @@ namespace Libplanet.Blockchain.Renderers
         /// </remarks>
         void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Libplanet.Blockchain.Renderers
         /// (where its second parameter <c>newTip</c> contains a transaction the <paramref
         /// name="action"/> belongs to).
         /// </remarks>
-        void RenderActionError(IValue action, IActionRenderContext context, Exception exception);
+        void RenderActionError(IValue action, ICommittedActionContext context, Exception exception);
 
         /// <summary>
         /// Does things that should be done right all actions in a new <see cref="Block"/> are

--- a/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
+++ b/Libplanet/Blockchain/Renderers/LoggedActionRenderer.cs
@@ -71,7 +71,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <inheritdoc cref="IActionRenderer.RenderAction"/>
         public void RenderAction(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             HashDigest<SHA256> nextState
         ) =>
             LogActionRendering(
@@ -84,7 +84,7 @@ namespace Libplanet.Blockchain.Renderers
         /// <inheritdoc cref="IActionRenderer.RenderActionError"/>
         public void RenderActionError(
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             Exception exception
         ) =>
             LogActionRendering(
@@ -97,7 +97,7 @@ namespace Libplanet.Blockchain.Renderers
         private void LogActionRendering(
             string methodName,
             IValue action,
-            IActionRenderContext context,
+            ICommittedActionContext context,
             System.Action callback
         )
         {


### PR DESCRIPTION
While committing, converts `IActionEvaluation`s to `ICommittedActionEvaluation`s. This should be temporary and be removed (or rather `IActionEvaluation` should be changed to match `ICommittedActionEvaluation`s format) once the commit process moves to `IActionEvaluator`.