### PR TITLE
🧹 Partial removal of `Bencodex.Types.Dictionary.GetValue<T>()` usage

### DIFF
--- a/Libplanet.Types/Consensus/Validator.cs
+++ b/Libplanet.Types/Consensus/Validator.cs
@@ -14,8 +14,8 @@ namespace Libplanet.Types.Consensus
     /// </summary>
     public class Validator : IEquatable<Validator>, IBencodable
     {
-        private static readonly byte[] PublicKeyKey = { 0x50 }; // 'P'
-        private static readonly byte[] PowerKey = { 0x70 }; // 'p'
+        private static readonly Binary PublicKeyKey = new Binary(new byte[] { 0x50 }); // 'P'
+        private static readonly Binary PowerKey = new Binary(new byte[] { 0x70 });     // 'p'
 
         /// <summary>
         /// Creates an instance of <see cref="Validator"/>, with given <paramref name="publicKey"/>
@@ -53,8 +53,8 @@ namespace Libplanet.Types.Consensus
 
         private Validator(Bencodex.Types.Dictionary bencoded)
             : this(
-                new PublicKey(bencoded.GetValue<Binary>(PublicKeyKey).ByteArray),
-                new BigInteger(bencoded.GetValue<Integer>(PowerKey)))
+                new PublicKey(((Binary)bencoded[PublicKeyKey]).ByteArray),
+                (Integer)bencoded[PowerKey])
         {
         }
 

--- a/Libplanet.Types/Consensus/Vote.cs
+++ b/Libplanet.Types/Consensus/Vote.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Types.Consensus
     /// </summary>
     public class Vote : IVoteMetadata, IEquatable<Vote>, IBencodable
     {
-        private static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        private static readonly Binary SignatureKey = new Binary(new byte[] { 0x53 }); // 'S'
 
         private static readonly Codec _codec = new Codec();
         private readonly VoteMetadata _metadata;
@@ -80,7 +80,7 @@ namespace Libplanet.Types.Consensus
             : this(
                 new VoteMetadata((IValue)encoded),
                 encoded.ContainsKey(SignatureKey)
-                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    ? ((Binary)encoded[SignatureKey]).ByteArray
                     : ImmutableArray<byte>.Empty)
         {
         }

--- a/Libplanet.Types/Consensus/VoteMetadata.cs
+++ b/Libplanet.Types/Consensus/VoteMetadata.cs
@@ -15,12 +15,23 @@ namespace Libplanet.Types.Consensus
     public class VoteMetadata : IVoteMetadata, IEquatable<VoteMetadata>, IBencodable
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
-        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
-        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
-        private static readonly byte[] BlockHashKey = { 0x68 };             // 'h'
-        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
-        private static readonly byte[] FlagKey = { 0x46 };                  // 'F'
+        private static readonly Binary HeightKey =
+            new Binary(new byte[] { 0x48 }); // 'H'
+
+        private static readonly Binary RoundKey =
+            new Binary(new byte[] { 0x52 }); // 'R'
+
+        private static readonly Binary TimestampKey =
+            new Binary(new byte[] { 0x74 }); // 't'
+
+        private static readonly Binary BlockHashKey =
+            new Binary(new byte[] { 0x68 }); // 'h'
+
+        private static readonly Binary ValidatorPublicKeyKey =
+            new Binary(new byte[] { 0x50 }); // 'P'
+
+        private static readonly Binary FlagKey =
+            new Binary(new byte[] { 0x46 }); // 'F'
 
         private static readonly Codec _codec = new Codec();
 
@@ -94,16 +105,16 @@ namespace Libplanet.Types.Consensus
 #pragma warning disable SA1118 // The parameter spans multiple lines
         private VoteMetadata(Bencodex.Types.Dictionary bencoded)
             : this(
-                height: bencoded.GetValue<Integer>(HeightKey),
-                round: bencoded.GetValue<Integer>(RoundKey),
-                blockHash: new BlockHash(bencoded.GetValue<IValue>(BlockHashKey)),
+                height: (Integer)bencoded[HeightKey],
+                round: (Integer)bencoded[RoundKey],
+                blockHash: new BlockHash(bencoded[BlockHashKey]),
                 timestamp: DateTimeOffset.ParseExact(
-                    bencoded.GetValue<Text>(TimestampKey),
+                    (Text)bencoded[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
-                    bencoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
-                flag: (VoteFlag)(long)bencoded.GetValue<Integer>(FlagKey))
+                    ((Binary)bencoded[ValidatorPublicKeyKey]).ByteArray),
+                flag: (VoteFlag)(int)(Integer)bencoded[FlagKey])
         {
         }
 #pragma warning restore SA1118

--- a/Libplanet/Consensus/Maj23.cs
+++ b/Libplanet/Consensus/Maj23.cs
@@ -19,8 +19,8 @@ namespace Libplanet.Consensus
     public class Maj23 : IEquatable<Maj23>
     {
         // FIXME: This should be private.  Left as internal for testing reasons.
-        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
-        private static Codec _codec = new Codec();
+        internal static readonly Binary SignatureKey = new Binary(new byte[] { 0x53 }); // 'S'
+        private static readonly Codec _codec = new Codec();
 
         private readonly Maj23Metadata _maj23Metadata;
 
@@ -62,7 +62,7 @@ namespace Libplanet.Consensus
             : this(
                 new Maj23Metadata(encoded),
                 encoded.ContainsKey(SignatureKey)
-                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    ? ((Binary)encoded[SignatureKey]).ByteArray
                     : ImmutableArray<byte>.Empty)
         {
         }

--- a/Libplanet/Consensus/Maj23Metadata.cs
+++ b/Libplanet/Consensus/Maj23Metadata.cs
@@ -13,14 +13,25 @@ namespace Libplanet.Consensus
     public class Maj23Metadata : IEquatable<Maj23Metadata>
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
-        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
-        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
-        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
-        private static readonly byte[] BlockHashKey = { 0x42 };             // 'B'
-        private static readonly byte[] FlagKey = { 0x46 };                  // 'F'
+        private static readonly Binary HeightKey =
+            new Binary(new byte[] { 0x48 }); // 'H'
 
-        private static Codec _codec = new Codec();
+        private static readonly Binary RoundKey =
+            new Binary(new byte[] { 0x52 }); // 'R'
+
+        private static readonly Binary TimestampKey =
+            new Binary(new byte[] { 0x74 }); // 't'
+
+        private static readonly Binary ValidatorPublicKeyKey =
+            new Binary(new byte[] { 0x50 }); // 'P'
+
+        private static readonly Binary BlockHashKey =
+            new Binary(new byte[] { 0x42 }); // 'B'
+
+        private static readonly Binary FlagKey =
+            new Binary(new byte[] { 0x46 }); // 'F'
+
+        private static readonly Codec _codec = new Codec();
 
         public Maj23Metadata(
             long height,
@@ -61,16 +72,16 @@ namespace Libplanet.Consensus
 #pragma warning disable SA1118 // The parameter spans multiple lines
         public Maj23Metadata(Dictionary encoded)
             : this(
-                height: encoded.GetValue<Integer>(HeightKey),
-                round: encoded.GetValue<Integer>(RoundKey),
-                blockHash: new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                height: (Integer)encoded[HeightKey],
+                round: (Integer)encoded[RoundKey],
+                blockHash: new BlockHash(encoded[BlockHashKey]),
                 timestamp: DateTimeOffset.ParseExact(
-                    encoded.GetValue<Text>(TimestampKey),
+                    (Text)encoded[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
-                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
-                flag: (VoteFlag)(int)encoded.GetValue<Integer>(FlagKey).Value)
+                    ((Binary)encoded[ValidatorPublicKeyKey]).ByteArray),
+                flag: (VoteFlag)(int)(Integer)encoded[FlagKey])
         {
         }
 #pragma warning restore SA1118

--- a/Libplanet/Consensus/Proposal.cs
+++ b/Libplanet/Consensus/Proposal.cs
@@ -21,8 +21,8 @@ namespace Libplanet.Consensus
     public class Proposal : IEquatable<Proposal>
     {
         // FIXME: This should be private.  Left as internal for testing reasons.
-        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
-        private static Codec _codec = new Codec();
+        internal static readonly Binary SignatureKey = new Binary(new byte[] { 0x53 }); // 'S'
+        private static readonly Codec _codec = new Codec();
 
         private readonly ProposalMetadata _proposalMetadata;
 
@@ -64,7 +64,7 @@ namespace Libplanet.Consensus
             : this(
                 new ProposalMetadata(encoded),
                 encoded.ContainsKey(SignatureKey)
-                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    ? ((Binary)encoded[SignatureKey]).ByteArray
                     : ImmutableArray<byte>.Empty)
         {
         }

--- a/Libplanet/Consensus/ProposalClaim.cs
+++ b/Libplanet/Consensus/ProposalClaim.cs
@@ -22,8 +22,8 @@ namespace Libplanet.Consensus
     public class ProposalClaim : IEquatable<ProposalClaim>
     {
         // FIXME: This should be private.  Left as internal for testing reasons.
-        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
-        private static Codec _codec = new Codec();
+        internal static readonly Binary SignatureKey = new Binary(new byte[] { 0x53 }); // 'S'
+        private static readonly Codec _codec = new Codec();
 
         private readonly ProposalClaimMetadata _metadata;
 
@@ -65,7 +65,7 @@ namespace Libplanet.Consensus
             : this(
                 new ProposalClaimMetadata(encoded),
                 encoded.ContainsKey(SignatureKey)
-                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    ? ((Binary)encoded[SignatureKey]).ByteArray
                     : ImmutableArray<byte>.Empty)
         {
         }

--- a/Libplanet/Consensus/ProposalClaimMetadata.cs
+++ b/Libplanet/Consensus/ProposalClaimMetadata.cs
@@ -17,13 +17,22 @@ namespace Libplanet.Consensus
     public class ProposalClaimMetadata : IEquatable<ProposalClaimMetadata>
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
-        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
-        private static readonly byte[] BlockHashKey = { 0x68 };             // 'h'
-        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
-        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
+        private static readonly Binary HeightKey =
+            new Binary(new byte[] { 0x48 }); // 'H'
 
-        private static Codec _codec = new Codec();
+        private static readonly Binary RoundKey =
+            new Binary(new byte[] { 0x52 }); // 'R'
+
+        private static readonly Binary BlockHashKey =
+            new Binary(new byte[] { 0x68 }); // 'h'
+
+        private static readonly Binary TimestampKey =
+            new Binary(new byte[] { 0x74 }); // 't'
+
+        private static readonly Binary ValidatorPublicKeyKey =
+            new Binary(new byte[] { 0x50 }); // 'P'
+
+        private static readonly Codec _codec = new Codec();
 
         /// <summary>
         /// Instantiates <see cref="ProposalClaimMetadata"/> with given parameters.
@@ -74,15 +83,15 @@ namespace Libplanet.Consensus
 #pragma warning disable SA1118 // The parameter spans multiple lines
         public ProposalClaimMetadata(Dictionary encoded)
             : this(
-                height: encoded.GetValue<Integer>(HeightKey),
-                round: encoded.GetValue<Integer>(RoundKey),
-                blockHash: new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                height: (Integer)encoded[HeightKey],
+                round: (Integer)encoded[RoundKey],
+                blockHash: new BlockHash(encoded[BlockHashKey]),
                 timestamp: DateTimeOffset.ParseExact(
-                    encoded.GetValue<Text>(TimestampKey),
+                    (Text)encoded[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
-                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray))
+                    ((Binary)encoded[ValidatorPublicKeyKey]).ByteArray))
         {
         }
 #pragma warning restore SA1118

--- a/Libplanet/Consensus/ProposalMetadata.cs
+++ b/Libplanet/Consensus/ProposalMetadata.cs
@@ -17,14 +17,25 @@ namespace Libplanet.Consensus
     public class ProposalMetadata : IEquatable<ProposalMetadata>
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
-        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
-        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
-        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
-        private static readonly byte[] BlockKey = { 0x42 };                 // 'B'
-        private static readonly byte[] ValidRoundKey = { 0x56 };            // 'V'
+        private static readonly Binary HeightKey =
+            new Binary(new byte[] { 0x48 }); // 'H'
 
-        private static Codec _codec = new Codec();
+        private static readonly Binary RoundKey =
+            new Binary(new byte[] { 0x52 }); // 'R'
+
+        private static readonly Binary TimestampKey =
+            new Binary(new byte[] { 0x74 }); // 't'
+
+        private static readonly Binary ValidatorPublicKeyKey =
+            new Binary(new byte[] { 0x50 }); // 'P'
+
+        private static readonly Binary BlockKey =
+            new Binary(new byte[] { 0x42 }); // 'B'
+
+        private static readonly Binary ValidRoundKey =
+            new Binary(new byte[] { 0x56 }); // 'V'
+
+        private static readonly Codec _codec = new Codec();
 
         /// <summary>
         /// Instantiates <see cref="ProposalMetadata"/> with given parameters.
@@ -90,16 +101,16 @@ namespace Libplanet.Consensus
 #pragma warning disable SA1118 // The parameter spans multiple lines
         public ProposalMetadata(Dictionary encoded)
             : this(
-                height: encoded.GetValue<Integer>(HeightKey),
-                round: encoded.GetValue<Integer>(RoundKey),
+                height: (Integer)encoded[HeightKey],
+                round: (Integer)encoded[RoundKey],
                 timestamp: DateTimeOffset.ParseExact(
-                    encoded.GetValue<Text>(TimestampKey),
+                    (Text)encoded[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
-                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
-                marshaledBlock: encoded.GetValue<Binary>(BlockKey),
-                validRound: encoded.GetValue<Integer>(ValidRoundKey))
+                    ((Binary)encoded[ValidatorPublicKeyKey]).ByteArray),
+                marshaledBlock: ((Binary)encoded[BlockKey]).ToByteArray(),
+                validRound: (Integer)encoded[ValidRoundKey])
         {
         }
 #pragma warning restore SA1118

--- a/Libplanet/Consensus/VoteSetBits.cs
+++ b/Libplanet/Consensus/VoteSetBits.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Consensus
     public class VoteSetBits : IEquatable<VoteSetBits>
     {
         // FIXME: This should be private.  Left as internal for testing reasons.
-        internal static readonly byte[] SignatureKey = { 0x53 }; // 'S'
+        internal static readonly Binary SignatureKey = new Binary(new byte[] { 0x53 }); // 'S'
         private static Codec _codec = new Codec();
 
         private readonly VoteSetBitsMetadata _voteSetBitsMetadata;
@@ -62,7 +62,7 @@ namespace Libplanet.Consensus
             : this(
                 new VoteSetBitsMetadata(encoded),
                 encoded.ContainsKey(SignatureKey)
-                    ? encoded.GetValue<Binary>(SignatureKey).ToImmutableArray()
+                    ? ((Binary)encoded[SignatureKey]).ByteArray
                     : ImmutableArray<byte>.Empty)
         {
         }

--- a/Libplanet/Consensus/VoteSetBitsMetadata.cs
+++ b/Libplanet/Consensus/VoteSetBitsMetadata.cs
@@ -15,15 +15,28 @@ namespace Libplanet.Consensus
     public class VoteSetBitsMetadata : IEquatable<VoteSetBitsMetadata>
     {
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-        private static readonly byte[] HeightKey = { 0x48 };                // 'H'
-        private static readonly byte[] RoundKey = { 0x52 };                 // 'R'
-        private static readonly byte[] TimestampKey = { 0x74 };             // 't'
-        private static readonly byte[] ValidatorPublicKeyKey = { 0x50 };    // 'P'
-        private static readonly byte[] BlockHashKey = { 0x42 };             // 'B'
-        private static readonly byte[] FlagKey = { 0x46 };                  // 'F'
-        private static readonly byte[] VoteBitsKey = { 0x56 };              // 'V'
+        private static readonly Binary HeightKey =
+            new Binary(new byte[] { 0x48 }); // 'H'
 
-        private static Codec _codec = new Codec();
+        private static readonly Binary RoundKey =
+            new Binary(new byte[] { 0x52 }); // 'R'
+
+        private static readonly Binary TimestampKey =
+            new Binary(new byte[] { 0x74 }); // 't'
+
+        private static readonly Binary ValidatorPublicKeyKey =
+            new Binary(new byte[] { 0x50 }); // 'P'
+
+        private static readonly Binary BlockHashKey =
+            new Binary(new byte[] { 0x42 }); // 'B'
+
+        private static readonly Binary FlagKey =
+            new Binary(new byte[] { 0x46 }); // 'F'
+
+        private static readonly Binary VoteBitsKey =
+            new Binary(new byte[] { 0x56 }); // 'V'
+
+        private static readonly Codec _codec = new Codec();
 
         public VoteSetBitsMetadata(
             long height,
@@ -66,17 +79,17 @@ namespace Libplanet.Consensus
 #pragma warning disable SA1118 // The parameter spans multiple lines
         public VoteSetBitsMetadata(Dictionary encoded)
             : this(
-                height: encoded.GetValue<Integer>(HeightKey),
-                round: encoded.GetValue<Integer>(RoundKey),
-                blockHash: new BlockHash(encoded.GetValue<Binary>(BlockHashKey).ByteArray),
+                height: (Integer)encoded[HeightKey],
+                round: (Integer)encoded[RoundKey],
+                blockHash: new BlockHash(encoded[BlockHashKey]),
                 timestamp: DateTimeOffset.ParseExact(
-                    encoded.GetValue<Text>(TimestampKey),
+                    (Text)encoded[TimestampKey],
                     TimestampFormat,
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
-                    encoded.GetValue<Binary>(ValidatorPublicKeyKey).ByteArray),
-                flag: (VoteFlag)(int)encoded.GetValue<Integer>(FlagKey).Value,
-                voteBits: encoded.GetValue<List>(VoteBitsKey)
+                    ((Binary)encoded[ValidatorPublicKeyKey]).ByteArray),
+                flag: (VoteFlag)(int)(Integer)encoded[FlagKey],
+                voteBits: ((List)encoded[VoteBitsKey])
                     .Select(bit => (bool)(Bencodex.Types.Boolean)bit))
         {
         }


### PR DESCRIPTION
🧹 In preparation for removal of such method in [bencodex.net](https://github.com/planetarium/bencodex.net).