### PR TITLE
Use Nodejs 18

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
       with:
         registry-url: 'https://registry.npmjs.org'
         scope: '@planetarium'
-        node-version: 'lts/*'
+        node-version: 18
     - id: determine-version
       run: node scripts/determine-version.js
     - shell: bash


### PR DESCRIPTION
Since Node.js 20 became LTS, the `Build artifact and push` workflow has started to fail. I'm not sure about the relationship between the LTS release and the failure from `.pnp.cjs` file. Anyway, because the package deployment should be fixed, this pull request fixes the Nodejs' version to `18` from `lts/*`.

You can see the CI works at https://github.com/planetarium/libplanet/actions/runs/6687408748/job/18168014391?pr=3466.

When this pull request is merged, #3460 will be closed. And a new issue will be opened with `ci(gh-actions): use Nodejs 20 in CI`.

## Notes

- `yarn / @planetarium/cli installation test` jobs are failing because the `3.7.0` tag was pushed but the packages were not deployed.