### PR TITLE
Use longer timeout for KMS test

### DIFF
--- a/@planetarium/account-aws-kms/vitest.config.ts
+++ b/@planetarium/account-aws-kms/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     cache: false,
-    testTimeout: 30000,
+    testTimeout: 45000,
     alias: {
       "#crypto": "./src/crypto/node.ts",
     },


### PR DESCRIPTION
30000ms -> 45000ms 

This resolves flakiness of test from latency of AWS KMS.