### PR TITLE
Fix `AccountMetrics` to initialize

### DIFF
--- a/Libplanet.Action/AccountMetrics.cs
+++ b/Libplanet.Action/AccountMetrics.cs
@@ -7,5 +7,11 @@ namespace Libplanet.Action
     {
         public static readonly AsyncLocal<Stopwatch> GetStateTimer = new AsyncLocal<Stopwatch>();
         public static readonly AsyncLocal<int> GetStateCount = new AsyncLocal<int>();
+
+        public static void Initialize()
+        {
+            GetStateTimer.Value = new Stopwatch();
+            GetStateCount.Value = 0;
+        }
     }
 }

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -252,6 +252,7 @@ namespace Libplanet.Action
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
+                AccountMetrics.Initialize();
                 state = feeCollector.Mortgage(state);
                 context = CreateActionContext(state);
                 feeCollector = feeCollector.Next(context);


### PR DESCRIPTION
Since `AccountMetrics.GetStateTimer` cannot be initialized, log always returns null value.
Fix above to log properly.