### PR TITLE
♻️ Disallow creation of new `Transaction`s with a non-empty `UpdatedAddresses`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Removed `updatedAddresses` parameter from `BlockChain.MakeTransaction()`
+    [[#3480]]
+ -  Removed `updatedAddresses` parameter from `Transaction.Create()`.  [[#3480]]
+ -  Removed `updatedAddresses` parameter from all `TxInvoice()`.  [[#3480]]
  -  Removed `Rehearsal` property from `IActionContext` and
     `ICommittedActionContext`.  [[#3485]]
  -  (Libplanet.Crypto) Removed `ToAddress()` extension method for
@@ -31,6 +35,7 @@ To be released.
 
 ### CLI tools
 
+[#3480]: https://github.com/planetarium/libplanet/pull/3480
 [#3485]: https://github.com/planetarium/libplanet/pull/3485
 [#3486]: https://github.com/planetarium/libplanet/pull/3486
 

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -189,16 +189,20 @@ public class GeneratedBlockChainFixture
         var random = new System.Random(seed);
         var addr = pk.Address;
         var bal = (int)(Chain.GetBalance(addr, TestCurrency).MajorUnit & int.MaxValue);
-        return Transaction.Create(
-            nonce,
-            pk,
-            Chain.Genesis.Hash,
-            random.Next() % 2 == 0
-                ? GetRandomActions(random.Next()).ToPlainValues()
-                : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues(),
-            null,
-            null,
-            GetRandomAddresses(random.Next()));
+        return
+        new Transaction(
+            new UnsignedTx(
+                new TxInvoice(
+                    genesisHash: Chain.Genesis.Hash,
+                    updatedAddresses: GetRandomAddresses(random.Next()),
+                    timestamp: DateTimeOffset.UtcNow,
+                    actions: new TxActionList(random.Next() % 2 == 0
+                        ? GetRandomActions(random.Next()).ToPlainValues()
+                        : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues()),
+                    maxGasPrice: null,
+                    gasLimit: null),
+                new TxSigningMetadata(pk.PublicKey, nonce)),
+            pk);
     }
 
     private ImmutableArray<SimpleAction> GetRandomActions(int seed)

--- a/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/Commands/StoreCommandTest.cs
@@ -369,8 +369,6 @@ public class StoreCommandTest : IDisposable
             new[] { new Utils.DummyAction() }.ToPlainValues(),
             null,
             null,
-            null,
-            DateTimeOffset.UtcNow
-        );
+            DateTimeOffset.UtcNow);
     }
 }

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -367,7 +366,6 @@ namespace Libplanet.Net.Tests.Consensus
             var unsignedInvalidTx = new UnsignedTx(
                 new TxInvoice(
                     blockChain.Genesis.Hash,
-                    ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow,
                     new TxActionList((IValue)List.Empty.Add(new Text("Foo")))), // Invalid action
                 new TxSigningMetadata(txSigner.PublicKey, 0));

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -362,9 +361,7 @@ namespace Libplanet.Net.Tests.Consensus
                 nonce: 0,
                 privateKey: TestUtils.PrivateKeys[1],
                 genesisHash: blockChain.Genesis.Hash,
-                actions: new[] { action }.ToPlainValues(),
-                updatedAddresses: ImmutableHashSet.Create(DelayAction.TrivialUpdatedAddress)
-            );
+                actions: new[] { action }.ToPlainValues());
             blockChain.StageTransaction(tx);
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -466,9 +466,7 @@ namespace Libplanet.Net.Tests
                     new[] { action }.ToPlainValues(),
                     null,
                     null,
-                    ImmutableHashSet<Address>.Empty,
-                    DateTimeOffset.UtcNow
-                );
+                    DateTimeOffset.UtcNow);
 
                 Block block = minerChain.ProposeBlock(
                     ChainPrivateKey,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -277,32 +277,50 @@ namespace Libplanet.Tests.Action
 
             Transaction[] block1Txs =
             {
-                Transaction.Create(
-                    nonce: 0,
-                    privateKey: _txFx.PrivateKey1,
-                    genesisHash: genesis.Hash,
-                    actions: new[]
-                    {
-                        MakeAction(addresses[0], 'A', addresses[1]),
-                        MakeAction(addresses[1], 'B', addresses[2]),
-                    }.ToPlainValues(),
-                    updatedAddresses: new[] { addresses[0], addresses[1] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(2)),
-                Transaction.Create(
-                    nonce: 0,
-                    privateKey: _txFx.PrivateKey2,
-                    genesisHash: genesis.Hash,
-                    actions: new[]
-                    {
-                        MakeAction(addresses[2], 'C', addresses[3]),
-                    }.ToPlainValues(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(4)),
-                Transaction.Create(
-                    nonce: 0,
-                    privateKey: _txFx.PrivateKey3,
-                    genesisHash: genesis.Hash,
-                    actions: Array.Empty<DumbAction>().ToPlainValues(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(7)),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: new[]
+                            {
+                                addresses[0],
+                                addresses[1],
+                            }.ToImmutableHashSet(),
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(2),
+                            actions: new TxActionList(new[]
+                            {
+                                MakeAction(addresses[0], 'A', addresses[1]),
+                                MakeAction(addresses[1], 'B', addresses[2]),
+                            }.ToPlainValues()),
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey1.PublicKey, 0)),
+                    _txFx.PrivateKey1),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: ImmutableHashSet<Address>.Empty,
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(4),
+                            actions: new TxActionList(new[]
+                            {
+                                MakeAction(addresses[2], 'C', addresses[3]),
+                            }.ToPlainValues()),
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey2.PublicKey, 0)),
+                    _txFx.PrivateKey2),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: ImmutableHashSet<Address>.Empty,
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(7),
+                            actions: TxActionList.Empty,
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey3.PublicKey, 0)),
+                    _txFx.PrivateKey3),
             };
             foreach ((var tx, var i) in block1Txs.Zip(
                 Enumerable.Range(0, block1Txs.Length), (x, y) => (x, y)))
@@ -384,37 +402,55 @@ namespace Libplanet.Tests.Action
                 // Note that these timestamps in themselves does not have any meanings but are
                 // only arbitrary.  These purpose to make their evaluation order in a block
                 // equal to the order we (the test) intend:
-                Transaction.Create(
-                    0,
-                    _txFx.PrivateKey1,
-                    genesis.Hash,
-                    new[] { MakeAction(addresses[0], 'D') }.ToPlainValues(),
-                    updatedAddresses: new[] { addresses[0] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(1)),
-                Transaction.Create(
-                    0,
-                    _txFx.PrivateKey2,
-                    genesis.Hash,
-                    new[] { MakeAction(addresses[3], 'E') }.ToPlainValues(),
-                    updatedAddresses: new[] { addresses[3] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(2)),
-                Transaction.Create(
-                    0,
-                    _txFx.PrivateKey3,
-                    genesis.Hash,
-                    new[]
-                    {
-                        new DumbAction(
-                            addresses[4],
-                            "RecordRehearsal",
-                            transferFrom: addresses[0],
-                            transferTo: addresses[4],
-                            transferAmount: 8,
-                            recordRehearsal: true,
-                            recordRandom: true),
-                    }.ToPlainValues(),
-                    updatedAddresses: new[] { addresses[4] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(4)),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: new[] { addresses[0] }.ToImmutableHashSet(),
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(1),
+                            actions: new TxActionList(new[]
+                            {
+                                MakeAction(addresses[0], 'D'),
+                            }.ToPlainValues()),
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey1.PublicKey, 0)),
+                    _txFx.PrivateKey1),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: new[] { addresses[3] }.ToImmutableHashSet(),
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(2),
+                            actions: new TxActionList(new[]
+                            {
+                                MakeAction(addresses[3], 'E'),
+                            }.ToPlainValues()),
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey2.PublicKey, 0)),
+                    _txFx.PrivateKey2),
+                new Transaction(
+                    new UnsignedTx(
+                        new TxInvoice(
+                            genesisHash: genesis.Hash,
+                            updatedAddresses: new[] { addresses[4] }.ToImmutableHashSet(),
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(4),
+                            actions: new TxActionList(new[]
+                            {
+                                new DumbAction(
+                                    addresses[4],
+                                    "RecordRehearsal",
+                                    transferFrom: addresses[0],
+                                    transferTo: addresses[4],
+                                    transferAmount: 8,
+                                    recordRehearsal: true,
+                                    recordRandom: true),
+                            }.ToPlainValues()),
+                            maxGasPrice: null,
+                            gasLimit: null),
+                        new TxSigningMetadata(_txFx.PrivateKey3.PublicKey, 0)),
+                    _txFx.PrivateKey3),
             };
             foreach ((var tx, var i) in block2Txs.Zip(
                 Enumerable.Range(0, block2Txs.Length), (x, y) => (x, y)))
@@ -623,7 +659,6 @@ namespace Libplanet.Tests.Action
                 new[] { action }.ToPlainValues(),
                 null,
                 null,
-                ImmutableHashSet<Address>.Empty,
                 DateTimeOffset.UtcNow);
             var txs = new Transaction[] { tx };
             var hash = new BlockHash(GetRandomBytes(BlockHash.Size));
@@ -838,17 +873,22 @@ namespace Libplanet.Tests.Action
                     .Select(signerNoncePair =>
                     {
                         Address targetAddress = signerNoncePair.signer.Address;
-                        return Transaction.Create(
-                            nonce: signerNoncePair.nonce,
-                            privateKey: signerNoncePair.signer,
-                            genesisHash: null,
-                            actions: new[]
-                            {
-                                new RandomAction(signerNoncePair.signer.Address),
-                            }.ToPlainValues(),
-                            updatedAddresses: ImmutableHashSet.Create(targetAddress),
-                            timestamp: epoch
-                        );
+                        return new Transaction(
+                            new UnsignedTx(
+                                new TxInvoice(
+                                    genesisHash: null,
+                                    updatedAddresses: ImmutableHashSet.Create(targetAddress),
+                                    timestamp: epoch,
+                                    actions: new TxActionList(new[]
+                                    {
+                                        new RandomAction(signerNoncePair.signer.Address),
+                                    }.ToPlainValues()),
+                                    maxGasPrice: null,
+                                    gasLimit: null),
+                                new TxSigningMetadata(
+                                    signerNoncePair.signer.PublicKey,
+                                    signerNoncePair.nonce)),
+                            signerNoncePair.signer);
                     }).ToImmutableArray();
 
             // Rearrange transactions so that transactions are not grouped by signers

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -639,17 +639,13 @@ namespace Libplanet.Tests.Blockchain
                     nonce: 0,
                     privateKey: txSigner,
                     genesisHash: _blockChain.Genesis.Hash,
-                    actions: Array.Empty<DumbAction>().ToPlainValues(),
-                    updatedAddresses: ImmutableHashSet<Address>.Empty
-                ),
+                    actions: Array.Empty<DumbAction>().ToPlainValues()),
                 invalidTx,
                 Transaction.Create(
                     nonce: 2,
                     privateKey: txSigner,
                     genesisHash: _blockChain.Genesis.Hash,
-                    actions: Array.Empty<DumbAction>().ToPlainValues(),
-                    updatedAddresses: ImmutableHashSet<Address>.Empty
-                ),
+                    actions: Array.Empty<DumbAction>().ToPlainValues()),
             }.OrderBy(tx => tx.Id);
 
             var metadata = new BlockMetadata(

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -628,7 +628,6 @@ namespace Libplanet.Tests.Blockchain
             var unsignedInvalidTx = new UnsignedTx(
                 new TxInvoice(
                     _blockChain.Genesis.Hash,
-                    ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow,
                     new TxActionList((IValue)List.Empty.Add(new Text("Foo")))), // Invalid action
                 new TxSigningMetadata(txSigner.PublicKey, 1));

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -35,9 +35,7 @@ namespace Libplanet.Tests.Blockchain
                     Array.Empty<DumbAction>().ToPlainValues(),
                     null,
                     null,
-                    null,
-                    ts ?? DateTimeOffset.UtcNow
-                );
+                    ts ?? DateTimeOffset.UtcNow);
 
             PrivateKey a = new PrivateKey();
             PrivateKey b = new PrivateKey();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -665,7 +665,6 @@ namespace Libplanet.Tests.Blockchain
             var unsignedInvalidTx = new UnsignedTx(
                 new TxInvoice(
                     _blockChain.Genesis.Hash,
-                    ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow,
                     new TxActionList((IValue)List.Empty.Add(new Text("Foo")))), // Invalid action
                 new TxSigningMetadata(keyB.PublicKey, 1));

--- a/Libplanet.Tests/Blocks/BlockContentTest.cs
+++ b/Libplanet.Tests/Blocks/BlockContentTest.cs
@@ -78,9 +78,11 @@ namespace Libplanet.Tests.Blocks
                 new UnsignedTx(
                     new TxInvoice(
                         genesisHash: GenesisHash,
-                        updatedAddresses: new[] { Block1Tx1.Signer },
-                        timestamp: Block1Tx1.Timestamp
-                    ),
+                        updatedAddresses: new AddressSet(new[] { Block1Tx1.Signer }),
+                        timestamp: Block1Tx1.Timestamp,
+                        actions: TxActionList.Empty,
+                        maxGasPrice: null,
+                        gasLimit: null),
                     new TxSigningMetadata(Block1Tx1.PublicKey, nonce: 1L)
                 ),
                 signature: ByteUtil.ParseHexToImmutable(
@@ -111,9 +113,11 @@ namespace Libplanet.Tests.Blocks
                 new UnsignedTx(
                     new TxInvoice(
                         genesisHash: GenesisHash,
-                        updatedAddresses: new[] { Block1Tx1.Signer },
-                        timestamp: Block1Tx1.Timestamp
-                    ),
+                        updatedAddresses: new AddressSet(new[] { Block1Tx1.Signer }),
+                        timestamp: Block1Tx1.Timestamp,
+                        actions: TxActionList.Empty,
+                        maxGasPrice: null,
+                        gasLimit: null),
                     new TxSigningMetadata(Block1Tx1.PublicKey, nonce: 3L)
                 ),
                 signature: ByteUtil.ParseHexToImmutable(

--- a/Libplanet.Tests/Fixtures/BlockContentFixture.cs
+++ b/Libplanet.Tests/Fixtures/BlockContentFixture.cs
@@ -74,13 +74,14 @@ namespace Libplanet.Tests.Fixtures
                 new UnsignedTx(
                     new TxInvoice(
                         genesisHash: GenesisHash,
-                        updatedAddresses: new[] { Block1Tx0Key.Address },
+                        updatedAddresses: new AddressSet(new[] { Block1Tx0Key.Address }),
                         timestamp: new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, default),
                         actions: new TxActionList(new IAction[]
                         {
                             Arithmetic.Add(10), Arithmetic.Add(50), Arithmetic.Sub(25),
-                        }.ToPlainValues())
-                    ),
+                        }.ToPlainValues()),
+                        maxGasPrice: null,
+                        gasLimit: null),
                     new TxSigningMetadata(Block1Tx0Key.PublicKey, nonce: 0L)
                 ),
                 signature: ByteUtil.ParseHexToImmutable(
@@ -94,19 +95,18 @@ namespace Libplanet.Tests.Fixtures
                 new UnsignedTx(
                     new TxInvoice(
                         genesisHash: GenesisHash,
-                        updatedAddresses: new[] { Block1Tx1Key.Address },
+                        updatedAddresses: new AddressSet(new[] { Block1Tx1Key.Address }),
                         timestamp: new DateTimeOffset(2021, 9, 6, 17, 0, 1, 1, default),
                         actions: new TxActionList(new IAction[]
                         {
                             Arithmetic.Add(30),
-                        }.ToPlainValues())
-                    ),
-                    new TxSigningMetadata(Block1Tx1Key.PublicKey, nonce: 1L)
-                ),
+                        }.ToPlainValues()),
+                        maxGasPrice: null,
+                        gasLimit: null),
+                    new TxSigningMetadata(Block1Tx1Key.PublicKey, nonce: 1L)),
                 signature: ByteUtil.ParseHexToImmutable(
                     "3045022100abe3caabf2a46a297f2e4496f2c46d7e2f723e75fc42025d19f3ed7fce382" +
-                    "d4e02200ffd36f7bef759b6c7ab43bc0f8959a0c463f88fd0f1faeaa209a8661506c4f0"
-                )
+                    "d4e02200ffd36f7bef759b6c7ab43bc0f8959a0c463f88fd0f1faeaa209a8661506c4f0")
             );
 
             var block1Transactions = new List<Transaction>() { Block1Tx0, Block1Tx1 }

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -57,16 +57,12 @@ namespace Libplanet.Tests.Fixtures
                 .Select(pair => new { State = (BigInteger)pair.State, pair.Key })
                 .Select(pair => new { Action = Arithmetic.Add(pair.State), pair.Key })
                 .Select(pair =>
-                    Transaction.Create(
-                        0,
-                        pair.Key,
-                        null,
-                        new[] { pair.Action }.ToPlainValues(),
-                        null,
-                        null,
-                        ImmutableHashSet<Address>.Empty.Add(pair.Key.Address)
-                    )
-                )
+                    new Transaction(
+                        new UnsignedTx(
+                            new TxInvoice(
+                                actions: new TxActionList(new[] { pair.Action.PlainValue })),
+                            new TxSigningMetadata(pair.Key.PublicKey, 0)),
+                        pair.Key))
                 .OrderBy(tx => tx.Id)
                 .ToImmutableArray();
             Miner = new PrivateKey();

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -219,7 +219,6 @@ namespace Libplanet.Tests.Store
                 actions?.ToPlainValues() ?? Array.Empty<DumbAction>().ToPlainValues(),
                 null,
                 null,
-                updatedAddresses,
                 timestamp
             );
         }

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -741,9 +741,7 @@ namespace Libplanet.Tests.Store
                     new[] { action }.ToPlainValues(),
                     null,
                     null,
-                    ImmutableHashSet<Address>.Empty,
-                    DateTimeOffset.UtcNow
-                );
+                    DateTimeOffset.UtcNow);
             }
 
             const int taskCount = 5;

--- a/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
+++ b/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
@@ -34,8 +34,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             var privateKey =
                 new PrivateKey("51fb8c2eb261ed761429c297dd1f8952c8ce327d2ec2ec5bcc7728e3362627c2");
             Transaction tx = invoice.Sign(privateKey, 123L);

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -137,7 +137,6 @@ namespace Libplanet.Tests.Tx
                 }.Select(x => x.PlainValue),
                 null,
                 null,
-                ImmutableHashSet<Address>.Empty,
                 timestamp
             );
 
@@ -179,25 +178,8 @@ namespace Libplanet.Tests.Tx
                 0,
                 _fx.PrivateKey1,
                 null,
-                Array.Empty<DumbAction>().Select(x => x.PlainValue)
-            );
+                Array.Empty<DumbAction>().Select(x => x.PlainValue));
             Assert.Empty(emptyTx.UpdatedAddresses);
-
-            Address updatedAddr = new PrivateKey().Address;
-            var txWithAddr = Transaction.Create(
-                0,
-                _fx.PrivateKey1,
-                null,
-                _fx.TxWithActions.Actions,
-                null,
-                null,
-                new[] { updatedAddr }.ToImmutableHashSet()
-            );
-
-            Assert.Equal(
-                new[] { updatedAddr }.ToHashSet(),
-                txWithAddr.UpdatedAddresses.ToHashSet()
-            );
         }
 
         [Fact]
@@ -210,9 +192,7 @@ namespace Libplanet.Tests.Tx
                 null,
                 Array.Empty<DumbAction>().Select(x => x.PlainValue),
                 null,
-                null,
-                ImmutableHashSet<Address>.Empty
-            );
+                null);
             DateTimeOffset rightAfter = DateTimeOffset.UtcNow;
 
             Assert.InRange(tx.Timestamp, rightBefore, rightAfter);
@@ -230,7 +210,6 @@ namespace Libplanet.Tests.Tx
                     Array.Empty<DumbAction>().Select(x => x.PlainValue),
                     null,
                     null,
-                    ImmutableHashSet<Address>.Empty,
                     DateTimeOffset.UtcNow
                 )
             );

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -344,8 +344,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             var privateKey =
                 new PrivateKey("51fb8c2eb261ed761429c297dd1f8952c8ce327d2ec2ec5bcc7728e3362627c2");
             PublicKey publicKey = privateKey.PublicKey;
@@ -372,10 +373,11 @@ namespace Libplanet.Tests.Tx
             {
                 var diffInvoice = new TxInvoice(
                     i == 0 ? (BlockHash?)null : invoice.GenesisHash,
-                    i == 1 ? null : invoice.UpdatedAddresses,
-                    i == 2 ? (DateTimeOffset?)DateTimeOffset.MinValue : invoice.Timestamp,
-                    i == 3 ? null : invoice.Actions
-                );
+                    i == 1 ? AddressSet.Empty : invoice.UpdatedAddresses,
+                    i == 2 ? DateTimeOffset.MinValue : invoice.Timestamp,
+                    i == 3 ? TxActionList.Empty : invoice.Actions,
+                    null,
+                    null);
                 var diffSigningMetadata = new TxSigningMetadata(
                     i == 4 ? wrongKey.PublicKey : signingMetadata.PublicKey,
                     i == 5 ? 456L : signingMetadata.Nonce
@@ -422,8 +424,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             var privateKey =
                 new PrivateKey("51fb8c2eb261ed761429c297dd1f8952c8ce327d2ec2ec5bcc7728e3362627c2");
             PublicKey publicKey = privateKey.PublicKey;

--- a/Libplanet.Tests/Tx/TxFixture.cs
+++ b/Libplanet.Tests/Tx/TxFixture.cs
@@ -80,16 +80,18 @@ namespace Libplanet.Tests.Tx
                     ZoneId = 10,
                 },
             };
-            TxWithActions = Transaction.Create(
-                0,
-                PrivateKey1,
-                genesisHash,
-                actions.ToPlainValues(),
-                updatedAddresses: ImmutableHashSet.Create(
-                    new Address("c2a86014073d662a4a9bfcf9cb54263dfa4f5cbc")
-                ),
-                timestamp: timestamp
-            );
+            TxWithActions = new Transaction(
+                new UnsignedTx(
+                    new TxInvoice(
+                        genesisHash: genesisHash,
+                        updatedAddresses: ImmutableHashSet.Create(
+                            new Address("c2a86014073d662a4a9bfcf9cb54263dfa4f5cbc")),
+                        timestamp: timestamp,
+                        actions: new TxActionList(actions.ToPlainValues()),
+                        maxGasPrice: null,
+                        gasLimit: null),
+                    new TxSigningMetadata(PrivateKey1.PublicKey, 0)),
+                PrivateKey1);
         }
 
         public PrivateKey PrivateKey1 { get; }

--- a/Libplanet.Tests/Tx/TxInvoiceTest.cs
+++ b/Libplanet.Tests/Tx/TxInvoiceTest.cs
@@ -36,8 +36,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             Assert.Equal(genesisHash, invoice.GenesisHash);
             Assert.True(updatedAddresses.SetEquals(invoice.UpdatedAddresses));
             Assert.Equal(timestamp, invoice.Timestamp);
@@ -75,8 +76,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             var copy = new TxInvoice(original);
             Assert.Equal(genesisHash, copy.GenesisHash);
             Assert.True(updatedAddresses.SetEquals(copy.UpdatedAddresses));
@@ -109,14 +111,16 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             var invoice2 = new TxInvoice(
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             Assert.True(invoice1.Equals(invoice2));
             Assert.True(invoice1.Equals((object)invoice2));
             Assert.Equal(invoice1.GetHashCode(), invoice2.GetHashCode());
@@ -131,9 +135,9 @@ namespace Libplanet.Tests.Tx
             {
                 var invoice = new TxInvoice(
                    i == 0 ? (BlockHash?)null : genesisHash,
-                   i == 1 ? null : updatedAddresses,
-                   i == 2 ? (DateTimeOffset?)DateTimeOffset.MinValue : timestamp,
-                   i == 3 ? null : actions,
+                   i == 1 ? (IImmutableSet<Address>)AddressSet.Empty : updatedAddresses,
+                   i == 2 ? DateTimeOffset.MinValue : timestamp,
+                   i == 3 ? TxActionList.Empty : actions,
                    i == 4 ? (FungibleAssetValue?)null : FungibleAssetValue.FromRawValue(
                        Currency.Uncapped(
                            "FOO",

--- a/Libplanet.Tests/Tx/UnsignedTxTest.cs
+++ b/Libplanet.Tests/Tx/UnsignedTxTest.cs
@@ -41,8 +41,9 @@ namespace Libplanet.Tests.Tx
                 genesisHash,
                 updatedAddresses,
                 timestamp,
-                actions
-            );
+                actions,
+                null,
+                null);
             _signingMetadata = new TxSigningMetadata(PublicKey, 123L);
         }
 
@@ -120,10 +121,11 @@ namespace Libplanet.Tests.Tx
             {
                 var diffInvoice = new TxInvoice(
                     i == 0 ? (BlockHash?)null : _invoice.GenesisHash,
-                    i == 1 ? null : _invoice.UpdatedAddresses,
-                    i == 2 ? (DateTimeOffset?)DateTimeOffset.MinValue : _invoice.Timestamp,
-                    i == 3 ? null : _invoice.Actions
-                );
+                    i == 1 ? AddressSet.Empty : _invoice.UpdatedAddresses,
+                    i == 2 ? DateTimeOffset.MinValue : _invoice.Timestamp,
+                    i == 3 ? TxActionList.Empty : _invoice.Actions,
+                    null,
+                    null);
                 var diffSigningMetadata = new TxSigningMetadata(
                     i == 4 ? wrongKey.PublicKey : _signingMetadata.PublicKey,
                     i == 5 ? 456L : _signingMetadata.Nonce

--- a/Libplanet.Types/AssemblyInfo.cs
+++ b/Libplanet.Types/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
+[assembly: InternalsVisibleTo("Libplanet.Explorer.Tests")]

--- a/Libplanet.Types/AssemblyInfo.cs
+++ b/Libplanet.Types/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Libplanet.Tests")]

--- a/Libplanet.Types/Tx/ITxInvoice.cs
+++ b/Libplanet.Types/Tx/ITxInvoice.cs
@@ -19,10 +19,21 @@ namespace Libplanet.Types.Tx
     public interface ITxInvoice : IEquatable<ITxInvoice>
     {
         /// <summary>
-        /// An approximated list of addresses whose states would be affected by actions in this
-        /// transaction.  However, it could be wrong.
+        /// <para>
+        /// A deprecated property which was used as an approximated list of addresses whose states
+        /// would be affected by actions in this transaction.
+        /// </para>
+        /// <para>
+        /// This is no longer officially supported in the sense that a <see cref="Transaction"/>
+        /// cannot be created with a non-empty set of <see cref="Address"/>es through normal means
+        /// (i.e. using intended APIs).
+        /// </para>
+        /// <para>
+        /// It is still possible to create a <see cref="Transaction"/> through other means,
+        /// such as creating a payload directly by assigning appropriate values and signing
+        /// an "unsigned transaction".  This is not recommended.
+        /// </para>
         /// </summary>
-        // See also https://github.com/planetarium/libplanet/issues/368
         IImmutableSet<Address> UpdatedAddresses { get; }
 
         /// <summary>

--- a/Libplanet.Types/Tx/Transaction.cs
+++ b/Libplanet.Types/Tx/Transaction.cs
@@ -233,8 +233,6 @@ namespace Libplanet.Types.Tx
         /// <param name="maxGasPrice"> The maximum gas price this transaction can pay fee.</param>
         /// <param name="gasLimit"> The maximum amount of gas this transaction can consume.
         /// </param>
-        /// <param name="updatedAddresses"><see cref="Address"/>es whose
-        /// states affected by <paramref name="actions"/>.</param>
         /// <param name="timestamp">The time this <see cref="Transaction"/>
         /// is created and signed.  This goes to the <see cref="Timestamp"/>
         /// property.  If <see langword="null"/> (which is default) is passed this will
@@ -251,7 +249,6 @@ namespace Libplanet.Types.Tx
             IEnumerable<IValue> actions,
             FungibleAssetValue? maxGasPrice = null,
             long? gasLimit = null,
-            IImmutableSet<Address>? updatedAddresses = null,
             DateTimeOffset? timestamp = null) =>
             Create(
                 nonce,
@@ -260,7 +257,6 @@ namespace Libplanet.Types.Tx
                 new TxActionList(actions),
                 maxGasPrice,
                 gasLimit,
-                updatedAddresses,
                 timestamp);
 
         /// <summary>
@@ -310,7 +306,6 @@ namespace Libplanet.Types.Tx
             TxActionList actions,
             FungibleAssetValue? maxGasPrice = null,
             long? gasLimit = null,
-            IImmutableSet<Address>? updatedAddresses = null,
             DateTimeOffset? timestamp = null)
         {
             if (privateKey is null)
@@ -320,7 +315,6 @@ namespace Libplanet.Types.Tx
 
             var draftInvoice = new TxInvoice(
                 genesisHash,
-                updatedAddresses ?? ImmutableHashSet<Address>.Empty,
                 timestamp ?? DateTimeOffset.UtcNow,
                 actions,
                 maxGasPrice,

--- a/Libplanet.Types/Tx/Transaction.cs
+++ b/Libplanet.Types/Tx/Transaction.cs
@@ -261,8 +261,7 @@ namespace Libplanet.Types.Tx
                 maxGasPrice,
                 gasLimit,
                 updatedAddresses,
-                timestamp
-            );
+                timestamp);
 
         /// <summary>
         /// Encodes this <see cref="Transaction"/> into a <see cref="byte"/> array.

--- a/Libplanet.Types/Tx/TxInvoice.cs
+++ b/Libplanet.Types/Tx/TxInvoice.cs
@@ -23,7 +23,6 @@ namespace Libplanet.Types.Tx
         /// Creates a new <see cref="TxInvoice"/> instance by filling data for its fields.
         /// </summary>
         /// <param name="genesisHash">The value for <see cref="GenesisHash"/>.</param>
-        /// <param name="updatedAddresses">The value for <see cref="UpdatedAddresses"/>.</param>
         /// <param name="timestamp">The value for <see cref="Timestamp"/>.</param>
         /// <param name="actions">The value of <see cref="Actions"/>.</param>
         /// <param name="maxGasPrice">The value of <see cref="MaxGasPrice"/>.</param>
@@ -31,6 +30,74 @@ namespace Libplanet.Types.Tx
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="updatedAddresses"/>
         /// or <paramref name="actions"/> is <see langword="null"/>.</exception>
         public TxInvoice(
+            BlockHash? genesisHash,
+            DateTimeOffset timestamp,
+            TxActionList actions,
+            FungibleAssetValue? maxGasPrice,
+            long? gasLimit)
+        {
+            GenesisHash = genesisHash;
+            UpdatedAddresses = ImmutableHashSet<Address>.Empty;
+            Timestamp = timestamp;
+            Actions = actions ?? throw new ArgumentNullException(nameof(actions));
+            MaxGasPrice = maxGasPrice;
+            GasLimit = gasLimit;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TxInvoice"/> instance by filling data for its fields.  There
+        /// are some default values for some fields.
+        /// </summary>
+        /// <param name="genesisHash">The value for <see cref="GenesisHash"/>.</param>
+        /// <param name="timestamp">The value for <see cref="Timestamp"/>.
+        /// Time of creation by default.</param>
+        /// <param name="actions">The value of <see cref="Actions"/>.
+        /// <see cref="TxActionList"/> by default.</param>
+        /// <param name="maxGasPrice">The value of <see cref="MaxGasPrice"/>.</param>
+        /// <param name="gasLimit">The value of <see langword="Gas"/> limit.</param>
+        public TxInvoice(
+            BlockHash? genesisHash = null,
+            DateTimeOffset? timestamp = null,
+            TxActionList? actions = null,
+            FungibleAssetValue? maxGasPrice = null,
+            long? gasLimit = null)
+            : this(
+                genesisHash,
+                timestamp ?? DateTimeOffset.UtcNow,
+                actions ?? TxActionList.Empty,
+                maxGasPrice,
+                gasLimit)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TxInvoice"/> instance by copying everything from another
+        /// <paramref name="invoice"/>.
+        /// </summary>
+        /// <param name="invoice">Another invoice to copy data from.</param>
+        public TxInvoice(ITxInvoice invoice)
+            : this(
+                  genesisHash: invoice.GenesisHash,
+                  updatedAddresses: invoice.UpdatedAddresses,
+                  timestamp: invoice.Timestamp,
+                  actions: invoice.Actions,
+                  maxGasPrice: invoice.MaxGasPrice,
+                  gasLimit: invoice.GasLimit)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TxInvoice"/> instance by filling data for its fields.
+        /// </summary>
+        /// <param name="genesisHash">The value for <see cref="GenesisHash"/>.</param>
+        /// <param name="updatedAddresses">The value for <see cref="UpdatedAddresses"/>.</param>
+        /// <param name="timestamp">The value for <see cref="Timestamp"/>.</param>
+        /// <param name="actions">The value of <see cref="Actions"/>.</param>
+        /// <param name="maxGasPrice">The value of <see cref="MaxGasPrice"/>.</param>
+        /// <param name="gasLimit">The value of <see langword="Gas"/> limit.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="updatedAddresses"/>
+        /// or <paramref name="actions"/> is <see langword="null"/>.</exception>
+        internal TxInvoice(
             BlockHash? genesisHash,
             IImmutableSet<Address> updatedAddresses,
             DateTimeOffset timestamp,
@@ -51,54 +118,6 @@ namespace Libplanet.Types.Tx
             Actions = actions ?? throw new ArgumentNullException(nameof(actions));
             MaxGasPrice = maxGasPrice;
             GasLimit = gasLimit;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="TxInvoice"/> instance by filling data for its fields.  There
-        /// are some default values for some fields.
-        /// </summary>
-        /// <param name="genesisHash">The value for <see cref="GenesisHash"/>.</param>
-        /// <param name="updatedAddresses">The value for <see cref="UpdatedAddresses"/>.
-        /// Empty by default.</param>
-        /// <param name="timestamp">The value for <see cref="Timestamp"/>.
-        /// Time of creation by default.</param>
-        /// <param name="actions">The value of <see cref="Actions"/>.
-        /// <see cref="TxActionList"/> by default.</param>
-        /// <param name="maxGasPrice">The value of <see cref="MaxGasPrice"/>.</param>
-        /// <param name="gasLimit">The value of <see langword="Gas"/> limit.</param>
-        public TxInvoice(
-            BlockHash? genesisHash = null,
-            IEnumerable<Address>? updatedAddresses = null,
-            DateTimeOffset? timestamp = null,
-            TxActionList? actions = null,
-            FungibleAssetValue? maxGasPrice = null,
-            long? gasLimit = null
-        )
-            : this(
-                genesisHash,
-                updatedAddresses?.ToImmutableHashSet() ?? ImmutableHashSet<Address>.Empty,
-                timestamp ?? DateTimeOffset.UtcNow,
-                actions ?? TxActionList.Empty,
-                maxGasPrice,
-                gasLimit
-            )
-        {
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="TxInvoice"/> instance by copying everything from another
-        /// <paramref name="invoice"/>.
-        /// </summary>
-        /// <param name="invoice">Another invoice to copy data from.</param>
-        public TxInvoice(ITxInvoice invoice)
-            : this(
-                  genesisHash: invoice.GenesisHash,
-                  updatedAddresses: invoice.UpdatedAddresses,
-                  timestamp: invoice.Timestamp,
-                  actions: invoice.Actions,
-                  maxGasPrice: invoice.MaxGasPrice,
-                  gasLimit: invoice.GasLimit)
-        {
         }
 
         /// <inheritdoc cref="ITxInvoice.GenesisHash" />

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -671,8 +671,6 @@ namespace Libplanet.Blockchain
         /// <param name="maxGasPrice"> The maximum gas price this transaction can pay fee. </param>
         /// <param name="gasLimit"> The maximum amount of gas this transaction can consume.
         /// </param>
-        /// <param name="updatedAddresses"><see cref="Address"/>es whose states affected by
-        /// <paramref name="actions"/>.</param>
         /// <param name="timestamp">The time this <see cref="Transaction"/> is created and
         /// signed.</param>
         /// <returns>A created new <see cref="Transaction"/> signed by the given
@@ -682,7 +680,6 @@ namespace Libplanet.Blockchain
             IEnumerable<IAction> actions,
             FungibleAssetValue? maxGasPrice = null,
             long? gasLimit = null,
-            IImmutableSet<Address> updatedAddresses = null,
             DateTimeOffset? timestamp = null)
         {
             timestamp = timestamp ?? DateTimeOffset.UtcNow;
@@ -696,7 +693,6 @@ namespace Libplanet.Blockchain
                     actions.Select(x => x.PlainValue),
                     maxGasPrice,
                     gasLimit,
-                    updatedAddresses,
                     timestamp);
                 StageTransaction(tx);
                 return tx;


### PR DESCRIPTION
This partially deprecates uses of `Transaction.UpdatedAddresses` property. It is no longer allowed to create a `Transaction` with non-empty `UpdatedAddresses` property through normal means.

As it is still possible to create a `Transaction` with a non-empty `UpdatedAddresses` (in particular, when unmarshalling a marshalled `Transaction`) most `Transaction`s used in tests are left intact (especially those using fixtures) to keep the old behavior intact.