### PR TITLE
🔨 @planetarium/tx: export encodeFungibleAssetValue

### DIFF
--- a/@planetarium/tx/src/index.ts
+++ b/@planetarium/tx/src/index.ts
@@ -3,6 +3,7 @@ export {
   type Currency,
   encodeCurrency,
   type FungibleAssetValue,
+  encodeFungibleAssetValue,
   getCurrencyHash,
   getMajorUnit,
   getMinorUnit,


### PR DESCRIPTION
Since the `encodeFungibleAssetValue` is not exported, users should import the function from the internal path like `@planetarium/tx/dist/assets...`. And it doesn't work in ESM mode. This pull request just re-exports the function to make users use it easily.