### PR TITLE
replace: use `RocksDb` instead `Planetarium.RocksDbSharp`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ commands:
       - run:
           name: Install lib6c-dev (for RocksDBSharp)
           shell: bash
-          command: apt update -y && apt install -y libc6-dev
+          command: apt update -y && apt install -y libc6-dev liblz4-dev zlib1g-dev libsnappy-dev libzstd-dev
       - netcore_test_base:
           collect_tests_from: "<<parameters.collect_tests_from>>"
           locale: "<<parameters.locale>>"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,12 @@ To be released.
 
 ### Backward-incompatible storage format changes
 
+  -  (Libplanet.Store) Changed `Libplanet.RocksDBStore` to use
+     [`RocksDb`] instead of [`RocksDBSharp`].
+     *Note* Cannot read new version of `Libplanet.RocksDBStore`
+     storage from under `Libplanet.RocksDBStore` version 3.6.1.
+     [[#1848], [#3487]]
+
 ### Added APIs
 
 ### Behavioral changes
@@ -35,10 +41,13 @@ To be released.
 
 ### CLI tools
 
+[#1848]: https://github.com/planetarium/libplanet/issues/1848
 [#3480]: https://github.com/planetarium/libplanet/pull/3480
 [#3485]: https://github.com/planetarium/libplanet/pull/3485
 [#3486]: https://github.com/planetarium/libplanet/pull/3486
-
+[`RocksDb`]: https://www.nuget.org/packages/RocksDB
+[`RocksDBSharp`]: https://www.nuget.org/packages/Planetarium.RocksDbSharp
+[#3487]: https://github.com/planetarium/libplanet/pull/3487
 
 Version 3.7.0
 -------------

--- a/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -48,7 +48,7 @@
       runtime; build; native; contentfiles; analyzers; buildtransitive
     </IncludeAssets>
   </PackageReference>
-  <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.6-planetarium" />
+  <PackageReference Include="RocksDB" Version="8.5.3.42578" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -123,6 +123,7 @@ namespace Libplanet.RocksDBStore
         private readonly LruCache<BlockHash, BlockDigest> _blockCache;
 
         private readonly DbOptions _options;
+        private readonly ColumnFamilyOptions _colOptions;
         private readonly string _path;
         private readonly bool _readonly;
         private readonly int _txEpochUnitSeconds;
@@ -210,20 +211,24 @@ namespace Libplanet.RocksDBStore
                     nameof(blockEpochUnitSeconds));
             _options = new DbOptions()
                 .SetCreateIfMissing();
+            _colOptions = new ColumnFamilyOptions();
 
             if (maxTotalWalSize is ulong maxTotalWalSizeValue)
             {
                 _options = _options.SetMaxTotalWalSize(maxTotalWalSizeValue);
+                _colOptions = _colOptions.SetMaxTotalWalSize(maxTotalWalSizeValue);
             }
 
             if (keepLogFileNum is ulong keepLogFileNumValue)
             {
                 _options = _options.SetKeepLogFileNum(keepLogFileNumValue);
+                _colOptions = _colOptions.SetKeepLogFileNum(keepLogFileNumValue);
             }
 
             if (maxLogFileSize is ulong maxLogFileSizeValue)
             {
                 _options = _options.SetMaxLogFileSize(maxLogFileSizeValue);
+                _colOptions = _colOptions.SetMaxLogFileSize(maxLogFileSizeValue);
             }
 
             _blockIndexDb = RocksDBUtils.OpenRocksDb(
@@ -270,12 +275,13 @@ namespace Libplanet.RocksDBStore
         public static bool MigrateChainDBFromColumnFamilies(string path)
         {
             var opt = new DbOptions();
+            var colOpt = new ColumnFamilyOptions();
             opt.SetCreateIfMissing();
             List<string> cfns = RocksDb.ListColumnFamilies(opt, path).ToList();
             var cfs = new ColumnFamilies();
             foreach (string name in cfns)
             {
-                cfs.Add(name, opt);
+                cfs.Add(name, colOpt);
             }
 
             RocksDb db = RocksDb.Open(opt, path, cfs);
@@ -1521,7 +1527,7 @@ namespace Libplanet.RocksDBStore
 
             foreach (string name in listColumnFamilies)
             {
-                columnFamilies.Add(name, _options);
+                columnFamilies.Add(name, _colOptions);
             }
 
             return columnFamilies;


### PR DESCRIPTION
# Context
Our [Planetarium.RocksDbSharp](https://github.com/planetarium/rocksdb-sharp) is no longer a follow-up original [RocksDB](https://github.com/facebook/rocksdb) version.
But we need a new version of `RocksDB` for our new feature. So we decided to change to [RocksDb](https://github.com/curiosity-ai/rocksdb-sharp) by Curiosity-AI for the backend.

# Relative
close https://github.com/planetarium/libplanet/issues/1848