### PR TITLE
➕  introduce: `RocksDb` instance type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,12 @@ To be released.
 
 ### Added APIs
 
+ -  (Libplanet.RocksDBStore) Added `RocksDBInstanceType` enum.  [[#3488]]
+ -  (Libplanet.RocksDBStore) Changed `RocksDBStore` and `RocksDBKeyValueStore`
+    to accept `RocksDBInstanceType` type `instanceType` parameter instead of
+    `@readonly` parameter in their constructor.
+    [[#3488], [RocksDb Instance Types]]
+
 ### Behavioral changes
 
 ### Bug fixes
@@ -45,9 +51,11 @@ To be released.
 [#3480]: https://github.com/planetarium/libplanet/pull/3480
 [#3485]: https://github.com/planetarium/libplanet/pull/3485
 [#3486]: https://github.com/planetarium/libplanet/pull/3486
+[#3487]: https://github.com/planetarium/libplanet/pull/3487
+[#3488]: https://github.com/planetarium/libplanet/pull/3488
 [`RocksDb`]: https://www.nuget.org/packages/RocksDB
 [`RocksDBSharp`]: https://www.nuget.org/packages/Planetarium.RocksDbSharp
-[#3487]: https://github.com/planetarium/libplanet/pull/3487
+[RocksDb Instance Types]: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
 
 
 Version 3.7.1

--- a/Libplanet.Common/NameValueCollectionExtensions.cs
+++ b/Libplanet.Common/NameValueCollectionExtensions.cs
@@ -11,6 +11,58 @@ namespace Libplanet.Common
     public static class NameValueCollectionExtensions
     {
         /// <summary>
+        /// Tries to get the text associated with the specified <paramref name="name"/> as
+        /// given <see cref="Enum"/> type <typeparamref name="T"/> value from the specified
+        /// name-value <paramref name="collection"/>.
+        /// </summary>
+        /// <param name="collection">The <see cref="NameValueCollection"/> that contains the entry
+        /// to find.</param>
+        /// <param name="name">The <see cref="string"/> key of the entry that contains the value to
+        /// find.</param>
+        /// <typeparam name="T">The <see cref="Enum"/> type to parse to.</typeparam>
+        /// <returns>A <typeparamref name="T"/> value converted from the text value associated with
+        /// the specified key <paramref name="name"/> from the <paramref name="collection"/>,
+        /// if found; otherwise, <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown when the value cannot be parsed to type
+        /// <typeparamref name="T"/>.</exception>
+        /// <remarks>This method assumes the <paramref name="collection"/> contains zero or
+        /// one entry for the specified <paramref name="name"/>.</remarks>
+        public static T? GetEnum<T>(this NameValueCollection collection, string name)
+            where T : struct, Enum
+            => collection.Get(name) is { } value
+                ? (T?)(Enum.TryParse(value, out T result) ? result : throw new ArgumentException())
+                : (T?)null;
+
+        /// <summary>
+        /// Tries to get the text associated with the specified <paramref name="name"/> as
+        /// given <see cref="Enum"/> type <typeparamref name="T"/> value from the specified
+        /// name-value <paramref name="collection"/>.
+        /// </summary>
+        /// <param name="collection">The <see cref="NameValueCollection"/> that contains the entry
+        /// to find.</param>
+        /// <param name="name">The <see cref="string"/> key of the entry that contains the value to
+        /// find.</param>
+        /// <param name="defaultValue">Returns this value if the specified key
+        /// <paramref name="name"/> is not found in the <paramref name="collection"/>, or
+        /// the associated value cannot be parsed to type <typeparamref name="T"/>.</param>
+        /// <typeparam name="T">The <see cref="Enum"/> type to parse to.</typeparam>
+        /// <returns>A <typeparamref name="T"/> value converted from the text value associated with
+        /// the specified key <paramref name="name"/> from the <paramref name="collection"/>,
+        /// if found; otherwise, <see langword="defaultValue"/>.</returns>
+        public static T GetEnum<T>(this NameValueCollection collection, string name, T defaultValue)
+            where T : struct, Enum
+        {
+            try
+            {
+                return GetEnum<T>(collection, name) ?? defaultValue;
+            }
+            catch (ArgumentException)
+            {
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
         /// Tries to get the numeric text associated with the specified <paramref name="name"/> as
         /// an <see cref="int"/> value from the specified name-value <paramref name="collection"/>.
         /// </summary>

--- a/Libplanet.RocksDBStore.Tests/RocksDBKeyValueStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBKeyValueStoreTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.RocksDBStore.Tests
                 Path.GetTempPath(),
                 $"rocksdb_key_value_test_{Guid.NewGuid()}");
             var primaryRocksDb = new RocksDBKeyValueStore(basePath);
-            var readonlyRocksDb = new RocksDBKeyValueStore(basePath, RocksDbInstanceType.ReadOnly);
+            var readonlyRocksDb = new RocksDBKeyValueStore(basePath, RocksDBInstanceType.ReadOnly);
 
             var key = new KeyBytes("new");
             var value = new byte[] { 1, 2, 3 };
@@ -53,7 +53,7 @@ namespace Libplanet.RocksDBStore.Tests
             var primaryRocksDb = new RocksDBKeyValueStore(basePath);
             var secondaryRocksDb = new RocksDBKeyValueStore(
                 basePath,
-                RocksDbInstanceType.Secondary);
+                RocksDBInstanceType.Secondary);
 
             var key = new KeyBytes("new");
             var value = new byte[] { 1, 2, 3 };

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -278,19 +278,5 @@ namespace Libplanet.RocksDBStore.Tests
                 Directory.Delete(path, true);
             }
         }
-
-        private long ToInt64(byte[] value)
-        {
-            byte[] bytes = new byte[sizeof(long)];
-            value.CopyTo(bytes, 0);
-
-            // Use Big-endian to order index lexicographically.
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(bytes);
-            }
-
-            return BitConverter.ToInt64(bytes, 0);
-        }
     }
 }

--- a/Libplanet.RocksDBStore/RocksDBInstanceType.cs
+++ b/Libplanet.RocksDBStore/RocksDBInstanceType.cs
@@ -7,7 +7,7 @@ namespace Libplanet.RocksDBStore
     /// href="https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances">
     /// RocksDB's document</a> for more details.
     /// </summary>
-    public enum RocksDbInstanceType
+    public enum RocksDBInstanceType
     {
         /// <summary>
         /// Primary instance.

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -75,14 +75,19 @@ namespace Libplanet.RocksDBStore
         /// Creates a new <see cref="RocksDBKeyValueStore"/>.
         /// </summary>
         /// <param name="path">The path of the storage file will be saved.</param>
-        /// <param name="readonly">If it is true, it will open rocksdb in read-only mode.</param>
-        public RocksDBKeyValueStore(string path, bool @readonly = false)
+        /// <param name="type">Choose type of <see cref="RocksDbInstanceType"/>.</param>
+        public RocksDBKeyValueStore(
+            string path,
+            RocksDbInstanceType type = RocksDbInstanceType.Primary)
         {
             var options = new DbOptions()
                 .SetCreateIfMissing();
 
-            _keyValueDb = RocksDBUtils.OpenRocksDb(options, path, @readonly: @readonly);
+            _keyValueDb = RocksDBUtils.OpenRocksDb(options, path, type: type);
+            Type = type;
         }
+
+        public RocksDbInstanceType Type { get; }
 
         /// <inheritdoc/>
         public byte[] Get(in KeyBytes key) => _keyValueDb.Get(key.ToByteArray())
@@ -144,6 +149,11 @@ namespace Libplanet.RocksDBStore
             {
                 yield return new KeyBytes(it.Key());
             }
+        }
+
+        public void TryCatchUpWithPrimary()
+        {
+            _keyValueDb.TryCatchUpWithPrimary();
         }
     }
 }

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -75,10 +75,10 @@ namespace Libplanet.RocksDBStore
         /// Creates a new <see cref="RocksDBKeyValueStore"/>.
         /// </summary>
         /// <param name="path">The path of the storage file will be saved.</param>
-        /// <param name="type">Choose type of <see cref="RocksDbInstanceType"/>.</param>
+        /// <param name="type">Choose type of <see cref="RocksDBInstanceType"/>.</param>
         public RocksDBKeyValueStore(
             string path,
-            RocksDbInstanceType type = RocksDbInstanceType.Primary)
+            RocksDBInstanceType type = RocksDBInstanceType.Primary)
         {
             var options = new DbOptions()
                 .SetCreateIfMissing();
@@ -87,7 +87,7 @@ namespace Libplanet.RocksDBStore
             Type = type;
         }
 
-        public RocksDbInstanceType Type { get; }
+        public RocksDBInstanceType Type { get; }
 
         /// <inheritdoc/>
         public byte[] Get(in KeyBytes key) => _keyValueDb.Get(key.ToByteArray())

--- a/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBKeyValueStore.cs
@@ -75,7 +75,8 @@ namespace Libplanet.RocksDBStore
         /// Creates a new <see cref="RocksDBKeyValueStore"/>.
         /// </summary>
         /// <param name="path">The path of the storage file will be saved.</param>
-        /// <param name="type">Choose type of <see cref="RocksDBInstanceType"/>.</param>
+        /// <param name="type">Determines the instance type of the internal <see cref="RocksDb"/>
+        /// instances.  <see cref="RocksDBInstanceType.Primary"/> by default.</param>
         public RocksDBKeyValueStore(
             string path,
             RocksDBInstanceType type = RocksDBInstanceType.Primary)

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -1373,7 +1373,9 @@ namespace Libplanet.RocksDBStore
             int txEpochUnitSeconds = query.GetInt32("tx-epoch-unit-secs", 86400);
             int blockEpochUnitSeconds = query.GetInt32("block-epoch-unit-secs", 86400);
             int dbConnectionCacheSize = query.GetInt32("connection-cache", 100);
-            var parse = Enum.TryParse(query.Get("instance-type"), out RocksDBInstanceType type);
+            RocksDBInstanceType instanceType = query.GetEnum<RocksDBInstanceType>(
+                "instance-type", RocksDBInstanceType.Primary);
+
             string statesKvPath = query.Get("states-dir") ?? StatesKvPathDefault;
             var store = new RocksDBStore(
                 storeUri.LocalPath,
@@ -1385,12 +1387,12 @@ namespace Libplanet.RocksDBStore
                 txEpochUnitSeconds,
                 blockEpochUnitSeconds,
                 dbConnectionCacheSize,
-                parse ? type : RocksDBInstanceType.Primary);
+                instanceType);
             string statesDirPath = Path.Combine(storeUri.LocalPath, statesKvPath);
             var stateStore = new TrieStateStore(
                 new RocksDBKeyValueStore(
                     statesDirPath,
-                    parse ? type : RocksDBInstanceType.Primary));
+                    instanceType));
             return (store, stateStore);
         }
 

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -113,8 +113,6 @@ namespace Libplanet.RocksDBStore
         private static readonly byte[] ChainBlockCommitKeyPrefix = { (byte)'M' };
         private static readonly byte[] BlockCommitKeyPrefix = { (byte)'m' };
 
-        private static readonly byte[] EmptyBytes = Array.Empty<byte>();
-
         private static readonly Codec Codec = new Codec();
 
         private readonly ILogger _logger;
@@ -165,7 +163,8 @@ namespace Libplanet.RocksDBStore
         /// containing blocks.  86,400 seconds by default.</param>
         /// <param name="dbConnectionCacheSize">The capacity of the block and transaction
         /// RocksDB connection cache. 100 by default.</param>
-        /// <param name="type">Choose type of <see cref="RocksDBInstanceType"/>.</param>
+        /// <param name="type">Determines the instance type of the internal <see cref="RocksDb"/>
+        /// instances.  <see cref="RocksDBInstanceType.Primary"/> by default.</param>
         public RocksDBStore(
             string path,
             int blockCacheSize = 512,

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -125,7 +125,7 @@ namespace Libplanet.RocksDBStore
         private readonly DbOptions _options;
         private readonly ColumnFamilyOptions _colOptions;
         private readonly string _path;
-        private readonly RocksDbInstanceType _instanceType;
+        private readonly RocksDBInstanceType _instanceType;
         private readonly int _txEpochUnitSeconds;
         private readonly int _blockEpochUnitSeconds;
 
@@ -165,7 +165,7 @@ namespace Libplanet.RocksDBStore
         /// containing blocks.  86,400 seconds by default.</param>
         /// <param name="dbConnectionCacheSize">The capacity of the block and transaction
         /// RocksDB connection cache. 100 by default.</param>
-        /// <param name="type">Choose type of <see cref="RocksDbInstanceType"/>.</param>
+        /// <param name="type">Choose type of <see cref="RocksDBInstanceType"/>.</param>
         public RocksDBStore(
             string path,
             int blockCacheSize = 512,
@@ -176,7 +176,7 @@ namespace Libplanet.RocksDBStore
             int txEpochUnitSeconds = 86400,
             int blockEpochUnitSeconds = 86400,
             int dbConnectionCacheSize = 100,
-            RocksDbInstanceType type = RocksDbInstanceType.Primary
+            RocksDBInstanceType type = RocksDBInstanceType.Primary
         )
         {
             _logger = Log.ForContext<RocksDBStore>();
@@ -1373,7 +1373,7 @@ namespace Libplanet.RocksDBStore
             int txEpochUnitSeconds = query.GetInt32("tx-epoch-unit-secs", 86400);
             int blockEpochUnitSeconds = query.GetInt32("block-epoch-unit-secs", 86400);
             int dbConnectionCacheSize = query.GetInt32("connection-cache", 100);
-            var parse = Enum.TryParse(query.Get("instance-type"), out RocksDbInstanceType type);
+            var parse = Enum.TryParse(query.Get("instance-type"), out RocksDBInstanceType type);
             string statesKvPath = query.Get("states-dir") ?? StatesKvPathDefault;
             var store = new RocksDBStore(
                 storeUri.LocalPath,
@@ -1385,12 +1385,12 @@ namespace Libplanet.RocksDBStore
                 txEpochUnitSeconds,
                 blockEpochUnitSeconds,
                 dbConnectionCacheSize,
-                parse ? type : RocksDbInstanceType.Primary);
+                parse ? type : RocksDBInstanceType.Primary);
             string statesDirPath = Path.Combine(storeUri.LocalPath, statesKvPath);
             var stateStore = new TrieStateStore(
                 new RocksDBKeyValueStore(
                     statesDirPath,
-                    parse ? type : RocksDbInstanceType.Primary));
+                    parse ? type : RocksDBInstanceType.Primary));
             return (store, stateStore);
         }
 

--- a/Libplanet.RocksDBStore/RocksDBUtils.cs
+++ b/Libplanet.RocksDBStore/RocksDBUtils.cs
@@ -10,7 +10,7 @@ namespace Libplanet.RocksDBStore
             DbOptions options,
             string dbPath,
             ColumnFamilies? columnFamilies = null,
-            RocksDbInstanceType type = RocksDbInstanceType.Primary)
+            RocksDBInstanceType type = RocksDBInstanceType.Primary)
         {
             if (!Directory.Exists(dbPath))
             {
@@ -19,12 +19,12 @@ namespace Libplanet.RocksDBStore
 
             return type switch
             {
-                RocksDbInstanceType.Primary => columnFamilies is null
+                RocksDBInstanceType.Primary => columnFamilies is null
                     ? RocksDb.Open(options, dbPath) : RocksDb.Open(options, dbPath, columnFamilies),
-                RocksDbInstanceType.ReadOnly => columnFamilies is null
+                RocksDBInstanceType.ReadOnly => columnFamilies is null
                     ? RocksDb.OpenReadOnly(options, dbPath, false)
                     : RocksDb.OpenReadOnly(options, dbPath, columnFamilies, false),
-                RocksDbInstanceType.Secondary => columnFamilies is null
+                RocksDBInstanceType.Secondary => columnFamilies is null
                     ? RocksDb.OpenAsSecondary(options, dbPath, CreateSecondaryPath(dbPath))
                     : RocksDb.OpenAsSecondary(
                         options,
@@ -37,7 +37,7 @@ namespace Libplanet.RocksDBStore
 
         private static string CreateSecondaryPath(string dbPath)
         {
-            string secondaryPath = Path.Combine(dbPath, $"secondary-{Guid.NewGuid()}");
+            string secondaryPath = Path.Combine(dbPath, $"SECONDARY-{Guid.NewGuid()}");
             if (!Directory.Exists(secondaryPath))
             {
                 Directory.CreateDirectory(secondaryPath);

--- a/Libplanet.RocksDBStore/RocksDbInstanceType.cs
+++ b/Libplanet.RocksDBStore/RocksDbInstanceType.cs
@@ -1,0 +1,27 @@
+namespace Libplanet.RocksDBStore
+{
+    /// <summary>
+    /// Represent <see cref="RocksDbSharp.RocksDb"/>'s instance type.
+    /// <see cref="RocksDbSharp.RocksDb"/> can be instantiated as primary, read-only, or secondary.
+    /// Please refer a <a
+    /// href="https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances">
+    /// RocksDB's document</a> for more details.
+    /// </summary>
+    public enum RocksDbInstanceType
+    {
+        /// <summary>
+        /// Primary instance.
+        /// </summary>
+        Primary,
+
+        /// <summary>
+        /// ReadOnly instance.
+        /// </summary>
+        ReadOnly,
+
+        /// <summary>
+        /// Secondary instance.
+        /// </summary>
+        Secondary,
+    }
+}


### PR DESCRIPTION
**Caution: Merge https://github.com/planetarium/libplanet/pull/3487 first**

# Context
`RocksDb` has 3 instance types: `Primary`, `ReadOnly`, and `Secondary`. [(see also)](https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances) But we support only `Primary` and `ReadOnly` right now.

For more scalable rocksdb, we introduce the `Secondary` instance type on `Libplanet.RocksDBStore`.