### PR TITLE
Workaround for yarn install fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Libplanet.Tools"
   ],
   "scripts": {
-    "build": "_libplanet_build=1 yarn workspaces foreach -p -A run build",
+    "build": "printf \"\\033[41;97mLibplanet note: currently, it is expected for `yarn build` to fail on the first run and succeed on the second run due to an unknown issue unrelated to the codebase (see issue #3492,) so the build phase runs twice. Whenever the culprit is specified please remove this message and the duplicate call.\\033[0m\n\" >&2 && _libplanet_build=1 yarn workspaces foreach -p -A run build || _libplanet_build=1 yarn workspaces foreach -p -A run build",
     "pack-all": "yarn workspaces foreach -p -A --include @planetarium/\\* pack",
     "postinstall": "env | grep -E '^_libplanet_build=1$' || yarn build && echo ran yarn build",
     "prepack": "printf \"\\033[41;97mLibplanet note: `yarn pack` is not allowed on the project root level, as it produces useless empty package. use `yarn pack-all` instead.\\033[0m\n\" > /dev/stderr && false",


### PR DESCRIPTION
See #3492. Running the command twice is presented as a temporary workaround until the culprit is found.