### PR TITLE
@planetarium/tx: Remove useless template variable

### DIFF
--- a/@planetarium/tx/src/tx/signed.ts
+++ b/@planetarium/tx/src/tx/signed.ts
@@ -1,16 +1,16 @@
-import { BencodexDictionary, Dictionary, encode } from "@planetarium/bencodex";
 import { Account, Address, Signature } from "@planetarium/account";
-import { type UnsignedTx, encodeUnsignedTx } from "./unsigned.js";
+import { BencodexDictionary, Dictionary, encode } from "@planetarium/bencodex";
 import { bytesEqual } from "../bytes.js";
+import { type UnsignedTx, encodeUnsignedTx } from "./unsigned.js";
 
 const SIGNATURE_KEY = new Uint8Array([0x53]); // 'S'
 
-export type SignedTx<T extends UnsignedTx> = T & { signature: Signature };
+export type SignedTx = UnsignedTx & { signature: Signature };
 
 export async function signTx(
   tx: UnsignedTx,
   signAccount: Account
-): Promise<SignedTx<typeof tx>> {
+): Promise<SignedTx> {
   if (
     !bytesEqual(
       tx.publicKey,
@@ -34,9 +34,7 @@ export async function signTx(
   };
 }
 
-export function encodeSignedTx<T extends UnsignedTx>(
-  tx: SignedTx<T>
-): Dictionary {
+export function encodeSignedTx(tx: SignedTx): Dictionary {
   const dict = encodeUnsignedTx(tx);
   const sig = tx.signature.toBytes();
   return new BencodexDictionary([...dict, [SIGNATURE_KEY, sig]]);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,12 @@ To be released.
  -  (Libplanet.Action) Type of `Initialize.States` property became
     `IImmutableDictionary<Address, IImmutableDictionary<Address, IValue>>?`.
     (was `IImmutableDictionary<Address, IValue>?`)  [[#3462]]
-
+ -  (Libplanet.Action) New property `SystemAccounts` added to
+    `IActionContext` interface.  [[#3494]]
+ -  (Libplanet.Action) New property `SystemAccountsGetter` added to
+    `IBlockPolicy` interface.  [[#3494]]
+ -  (@planetarium/tx)  Remove the `T` generic argument of `SignedTx<T>`.
+    [[#3512]]
 
 ### Backward-incompatible network protocol changes
 
@@ -118,8 +123,9 @@ To be released.
 ### CLI tools
 
 [#3462]: https://github.com/planetarium/libplanet/pull/3462
+[#3494]: https://github.com/planetarium/libplanet/pull/3494
+[#3512]: https://github.com/planetarium/libplanet/pull/3512
 [#3524]: https://github.com/planetarium/libplanet/pull/3524
-
 
 Version 3.7.0
 -------------


### PR DESCRIPTION
Since `SystemAction` and `CustomAction` are unified, there is only `UnsignedTx`, not `UnsignedTxWithCustomActions` & `UnsignedTxWithSystemAction`. So `SignedTx<T>`'s `T` generic argument became useless. This pull request just cleans up it.