### PR TITLE
Fix bug on gossip denial

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 3.8.1
 
 To be released.
 
+ -  (Libplanet.Net) Fixed a bug where `GossipConsensusMessageCommunicator`
+    does not clear `_peerCatchupRounds` on `OnStartHeight()`.  [[#3519]]
+ -  (Libplanet.Net) `GossipConsensusMessageCommunicator` now filters
+    `ConsensusVoteMsg` which height is different from latest `Context`.
+    [[#3519]]
+
+[#3519]: https://github.com/planetarium/libplanet/pull/3519
+
 
 Version 3.8.0
 -------------


### PR DESCRIPTION
There's a bug on gossip denial, and this PR fixes it.

Though adding `_peerCatchupRounds.Clear()` on `GossipConsensusMessageCommunicator.cs L69` is enough to solve the problem, added some height validation not to be confused.
(This will be needless after sync between `Gossip` and `HeightVoteSet`)

This PR Resolves
- https://github.com/planetarium/libplanet/issues/3518