### PR TITLE
Adjust timing of the state migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Removed `BlockChainStates` class.  [[#3462]]
+ -  Bumped `BlockMetadata.CurrentProtocolVersion` to 5.  [[#3524]]
  -  (Libplanet.Action) Changed `ActionEvaluator` to accept `IWorld`
     instead of `IAccount`.  [[#3462]]
  -  (Libplanet.Action) `IActionEvaluator.OutputState` became `IWorld`.
@@ -76,6 +77,7 @@ To be released.
 
 ### Added APIs
 
+ -  Added `BlockMetadaLegacyStateVersion` constant.  [[#3524]]
  -  (Libplanet.Action) Added `IWorld` interface and its implementation.
     [[#3462]]
      -  Added `World` class.
@@ -117,6 +119,7 @@ To be released.
 ### CLI tools
 
 [#3462]: https://github.com/planetarium/libplanet/pull/3462
+[#3524]: https://github.com/planetarium/libplanet/pull/3524
 
 
 Version 3.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,7 +77,7 @@ To be released.
 
 ### Added APIs
 
- -  Added `BlockMetadaLegacyStateVersion` constant.  [[#3524]]
+ -  Added `BlockMetadata.LegacyStateVersion` constant.  [[#3524]]
  -  (Libplanet.Action) Added `IWorld` interface and its implementation.
     [[#3462]]
      -  Added `World` class.

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -228,7 +228,7 @@ namespace Libplanet.Net.Tests.Consensus
             var invalidBlock = blockChain.EvaluateAndSign(
                 new BlockContent(
                     new BlockMetadata(
-                        protocolVersion: BlockMetadata.CurrentProtocolVersion - 1,
+                        protocolVersion: BlockMetadata.CurrentProtocolVersion,
                         index: blockChain.Tip.Index + 2,
                         timestamp: blockChain.Tip.Timestamp.Subtract(TimeSpan.FromSeconds(1)),
                         miner: TestUtils.PrivateKeys[1].PublicKey.ToAddress(),

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "df91283da7f6bace4ec5ff7c4990594e9725f534665bb52fd40b17b337b86d07")),
+                    "53278bbaa07aa9559569f3a37eef7cf9820bff84e14a472f417b80a42d312f09")),
                 message.Id);
         }
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -402,14 +402,14 @@ namespace Libplanet.Tests.Action
                     genesis.Hash,
                     new[] { MakeAction(addresses[0], 'D') }.ToPlainValues(),
                     updatedAddresses: new[] { addresses[0] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(1)),
+                    timestamp: DateTimeOffset.MinValue.AddSeconds(3)),
                 Transaction.Create(
                     0,
                     _txFx.PrivateKey2,
                     genesis.Hash,
                     new[] { MakeAction(addresses[3], 'E') }.ToPlainValues(),
                     updatedAddresses: new[] { addresses[3] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(2)),
+                    timestamp: DateTimeOffset.MinValue.AddSeconds(4)),
                 Transaction.Create(
                     0,
                     _txFx.PrivateKey3,
@@ -426,7 +426,7 @@ namespace Libplanet.Tests.Action
                             recordRandom: true),
                     }.ToPlainValues(),
                     updatedAddresses: new[] { addresses[4] }.ToImmutableHashSet(),
-                    timestamp: DateTimeOffset.MinValue.AddSeconds(4)),
+                    timestamp: DateTimeOffset.MinValue.AddSeconds(2)),
             };
             foreach ((var tx, var i) in block2Txs.Zip(
                 Enumerable.Range(0, block2Txs.Length), (x, y) => (x, y)))

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -783,17 +783,6 @@ namespace Libplanet.Tests.Blockchain
                 actionEvaluator,
                 renderers: new[] { new LoggedActionRenderer(renderer, Log.Logger) });
             Assert.True(blockChain.GetWorldState().Legacy);
-            var emptyBlockContent = new BlockContent(
-                new BlockMetadata(
-                    protocolVersion: BlockMetadata.LegacyStateVersion,
-                    index: 0L,
-                    timestamp: DateTimeOffset.UtcNow,
-                    miner: fx.Proposer.ToAddress(),
-                    publicKey: fx.Proposer.PublicKey,
-                    previousHash: null,
-                    txHash: BlockContent.DeriveTxHash(txs),
-                    lastCommit: null),
-                transactions: txs);
             var emptyBlock = blockChain.ProposeBlock(
                 fx.Proposer,
                 ImmutableList<Transaction>.Empty,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -5,10 +5,10 @@ using System.Linq;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Common;
 using Libplanet.Crypto;
-using Libplanet.Store;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Tx;
 using Xunit;
@@ -127,12 +127,17 @@ namespace Libplanet.Tests.Blockchain
                 { MinerReward.RewardRecordAddress, (Text)$"{minerAddress},{minerAddress}" },
             };
 
+            IValue legacyStateRootRaw = _fx.StateStore.GetStateRoot(block1.StateRootHash)
+                .Get(ToStateKey(ReservedAddresses.LegacyAccount));
+            Assert.NotNull(legacyStateRootRaw);
+            var legacyStateRoot =
+                new HashDigest<SHA256>(((Binary)legacyStateRootRaw).ByteArray);
             foreach (KeyValuePair<Address, IValue> pair in expectedStates)
             {
                 AssertBencodexEqual(
                     pair.Value,
                     _fx.StateStore
-                        .GetStateRoot(block1.StateRootHash)
+                        .GetStateRoot(legacyStateRoot)
                         .Get(new[] { ToStateKey(pair.Key) })[0]
                 );
             }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.Proposer);
             _blockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-            Block block2 = _blockChain.EvaluateAndSign(
+            Assert.Throws<ApplicationException>(() => _blockChain.EvaluateAndSign(
                 new BlockContent(
                     new BlockMetadata(
                         protocolVersion: protocolVersion - 1,
@@ -64,10 +64,7 @@ namespace Libplanet.Tests.Blockchain
                         previousHash: block1.Hash,
                         txHash: null,
                         lastCommit: null)).Propose(),
-                _fx.Proposer);
-
-            Assert.Throws<InvalidBlockProtocolVersionException>(() =>
-                _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2)));
+                _fx.Proposer));
             Assert.Throws<InvalidBlockProtocolVersionException>(() =>
             {
                 Block block3 = _blockChain.EvaluateAndSign(

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -120,7 +120,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", BlockMetadata.CurrentProtocolVersion)
                 .Add(
                     "transaction_fingerprint",
                     ParseHex("3d8e87977b1142863435b9385657e69557df8951a0698e9719f7d06c5fb8db1f"));
@@ -146,7 +146,7 @@ namespace Libplanet.Tests.Blocks
                     "transaction_fingerprint",
                     ParseHex("654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0")
                 )
-                .Add("protocol_version", 4);
+                .Add("protocol_version", BlockMetadata.CurrentProtocolVersion);
             AssertBencodexEqual(
                 expectedBlock1,
                 Block1Metadata.MakeCandidateData(new Nonce(new byte[] { 0xff, 0xef, 0x01, 0xcc }))
@@ -239,13 +239,13 @@ namespace Libplanet.Tests.Blocks
 
             HashDigest<SHA256> hash = GenesisMetadata.DerivePreEvaluationHash(default);
             AssertBytesEqual(
-                FromHex("d6c03233c2fbe96c57c823c5edc679810f1714dceef7a466a3f7a6659af9fe17"),
+                FromHex("a6aabc92ffeae68bb0ed426736eceefcc416158170bd33744b4920d3207e0702"),
                 hash.ByteArray);
 
             hash = Block1Metadata.DerivePreEvaluationHash(
                 new Nonce(FromHex("e7c1adf92c65d35aaae5")));
             AssertBytesEqual(
-                FromHex("9ae70453c854c69c03e9841e117d269b97615dcf4f580fb99577d981d3f61ebf"),
+                FromHex("68ee32560911ed89c89e0adf9eceec2a388d9aba165cd5387055fdfd9e5ee85e"),
                 hash.ByteArray);
         }
 

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -64,7 +64,7 @@ namespace Libplanet.Tests.Blocks
                     "public_key",
                     ParseHex("0200e02709cc0c051dc105188c454a2e7ef7b36b85da34529d3abc1968167cf54f")
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", BlockMetadata.CurrentProtocolVersion)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray)
                 .Add(
                     "transaction_fingerprint",
@@ -99,7 +99,7 @@ namespace Libplanet.Tests.Blocks
                         "654698d34b6d9a55b0c93e4ffb2639278324868c91965bc5f96cb3071d6903a0"
                     )
                 )
-                .Add("protocol_version", 4)
+                .Add("protocol_version", BlockMetadata.CurrentProtocolVersion)
                 .Add("state_root_hash", default(HashDigest<SHA256>).ByteArray);
             var block1 = new PreEvaluationBlockHeader(
                 _contents.Block1Metadata,
@@ -169,8 +169,8 @@ namespace Libplanet.Tests.Blocks
 
             // Same as block1.MakeSignature(_contents.Block1Key, arbitraryHash)
             ImmutableArray<byte> validSig = ByteUtil.ParseHexToImmutable(
-                "3044022100b285f684fe94524aa725c6b69cb858370f85af56420d275410e148b0ad18" +
-                "b3d9021f324c828b1dd949ebf73591bc0ac8858debae7c5aabc420fd4a1cec53d61e60"
+                "3044022070295135bbe705ca79723cbad8bc8c958c6d2e8a8a17d77ecde23135757779" +
+                "e402207ba382b665c7960b3c036ddde850641b8782db6042eb74f68b65c16fdb06b146"
             );
 
             AssertBytesEqual(
@@ -205,22 +205,22 @@ namespace Libplanet.Tests.Blocks
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("fecb4bff71ac372a3a14080af55d63c4d8058458206267b41d9e7f98f962b907"),
+                fromHex("f51cc0cbfcf2d99d698792130abcab9e4ce5ca33c147272d397ccc0c36a29104"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("dfd589064f9127a1b0c99f792776de1006a0a5c89cea00b3c72c635ca56d3b55"),
+                fromHex("27ffab04780cd9b254e911e78adf98b189dcbfc15c90f3983ecc6738592faf75"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("68a92bf6032b87cd42e5b21d8845aa73e727866037eb61de20546885f7801510"),
+                fromHex("bbdd2ff76f7207534dc2f3a5dec7ed9ebd9ac81d64a1224eb0a76d4e300cb6b4"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("d1cc52736d25293415eb276a245db7cd1ad4c90c14c22516f3eeccdbc206ff8d"),
+                fromHex("b1e65ad6a55eb39db936bc0d4ae1e1526ecce97fa4e50f993f46781c37166c19"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash))
@@ -230,19 +230,19 @@ namespace Libplanet.Tests.Blocks
                 _contents.Block1Metadata,
                 _contents.Block1Metadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("9c999d048603c32369bcd982ac2488f8d2782f339f0296ad537d4f039984dc47"),
+                fromHex("4b6b0261d090214093bb9f00c545370500aded8f632a0ae058238f67a786ae36"),
                 block1.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("1ff0ca42037e91a07db6b42a2f0aadc7fc1249900033718d783334a90a333892"),
+                fromHex("f1a1b865f56103798fe6df04dac39378de70094dd79b7a5f5114db12bb4b20a0"),
                 block1.DeriveBlockHash(default, block1.MakeSignature(_contents.Block1Key, default))
             );
             AssertBytesEqual(
-                fromHex("5e63ed240742d7dac4b7f290f5a7afc51e2d410b13d2ad9690e56ac66486b23d"),
+                fromHex("119d9e28fc4feb5756da29d3e0dd40f92d03c54e2b7b7ff0d3b2b01751623ce6"),
                 block1.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("54f7572223e4d642ca8772378528120392a9997655860a6ec108f3e4d8c1cc14"),
+                fromHex("df2d543374588f4e869d3c77c47b2200a0bca2729d904b349090afe919afef1c"),
                 block1.DeriveBlockHash(
                     arbitraryHash, block1.MakeSignature(_contents.Block1Key, arbitraryHash)
                 )

--- a/Libplanet.Types/Blocks/BlockMetadata.cs
+++ b/Libplanet.Types/Blocks/BlockMetadata.cs
@@ -19,12 +19,17 @@ namespace Libplanet.Types.Blocks
         /// <summary>
         /// The latest protocol version.
         /// </summary>
-        public const int CurrentProtocolVersion = 4;
+        public const int CurrentProtocolVersion = 5;
 
         /// <summary>
         /// The last PoW protocol version.
         /// </summary>
         public const int PoWProtocolVersion = 3;
+
+        /// <summary>
+        /// The last protocol version with union state model.
+        /// </summary>
+        public const int LegacyStateVersion = 4;
 
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();


### PR DESCRIPTION
Migrate legacy states to `World-Account`-based structure when evaluating block with protocol version `5`.