### PR TITLE
♻️ Update `TxInvoice` specification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,20 @@ Version 3.9.0
 
 To be released.
 
+Due to changes in [#3529], a network ran with a prior version may not
+be compatible with this version,  specifically, those that ran with
+[Libplanet 2.0.0] and onwards prior to this release that have included
+`Transaction`s that aren't compatible with the updated specification in [#3529].
+
 ### Deprecated APIs
 
 ### Backward-incompatible API changes
 
  -  (Libplanet.Action) Removed `hashedSignature` of type `byte[]` parameter
     from `ActionEvaluator.GenerateRandomSeed()`.  [[#3523]]
+ -  Changed `TxInvoice` to no longer allow having the null-ness of
+    `MaxGasPrice` and `GasLimit` to be different, i.e. either both should be
+    null or both should not be null at the same time.  [[#3529]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +36,8 @@ To be released.
 ### CLI tools
 
 [#3523]: https://github.com/planetarium/libplanet/pull/3523
+[#3529]: https://github.com/planetarium/libplanet/pull/3529
+[Libplanet 2.0.0]: https://www.nuget.org/packages/Libplanet/2.0.0
 
 
 Version 3.8.1

--- a/Libplanet.Tests/Tx/TxInvoiceTest.cs
+++ b/Libplanet.Tests/Tx/TxInvoiceTest.cs
@@ -131,20 +131,21 @@ namespace Libplanet.Tests.Tx
 
             Assert.False(invoice1.Equals(null));
 
-            for (int i = 0; i < 6; i++)
+            for (int i = 0; i < 5; i++)
             {
+                // NOTE: Non-null cases for MaxGasPrice and GasLimit are flipped as existing
+                // mock object has respective values set to null.
                 var invoice = new TxInvoice(
-                   i == 0 ? (BlockHash?)null : genesisHash,
-                   i == 1 ? (IImmutableSet<Address>)AddressSet.Empty : updatedAddresses,
-                   i == 2 ? DateTimeOffset.MinValue : timestamp,
-                   i == 3 ? TxActionList.Empty : actions,
-                   i == 4 ? (FungibleAssetValue?)null : FungibleAssetValue.FromRawValue(
-                       Currency.Uncapped(
-                           "FOO",
-                           18,
-                           new PrivateKey().Address),
-                       100),
-                   i == 5 ? (long?)null : 10);
+                    i == 0 ? (BlockHash?)null : genesisHash,
+                    i == 1 ? (IImmutableSet<Address>)AddressSet.Empty : updatedAddresses,
+                    i == 2 ? DateTimeOffset.MinValue : timestamp,
+                    i == 3 ? TxActionList.Empty : actions,
+                    i == 4
+                        ? FungibleAssetValue.FromRawValue(
+                            Currency.Uncapped("FOO", 18, new PrivateKey().Address),
+                            100)
+                        : (FungibleAssetValue?)null,
+                    i == 4 ? 10 : (long?)null);
                 Assert.False(invoice1.Equals(invoice));
                 Assert.False(invoice1.Equals((object)invoice));
                 Assert.NotEqual(invoice1.GetHashCode(), invoice.GetHashCode());

--- a/Libplanet.Types/Tx/TxInvoice.cs
+++ b/Libplanet.Types/Tx/TxInvoice.cs
@@ -28,6 +28,9 @@ namespace Libplanet.Types.Tx
         /// <param name="gasLimit">The value of <see langword="Gas"/> limit.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="updatedAddresses"/>
         /// or <paramref name="actions"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <see langword="null"/>-ness of
+        /// <paramref name="maxGasPrice"/> and <paramref name="gasLimit"/> are not the same.
+        /// </exception>
         public TxInvoice(
             BlockHash? genesisHash,
             DateTimeOffset timestamp,

--- a/Libplanet.Types/Tx/TxInvoice.cs
+++ b/Libplanet.Types/Tx/TxInvoice.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -35,13 +34,14 @@ namespace Libplanet.Types.Tx
             TxActionList actions,
             FungibleAssetValue? maxGasPrice,
             long? gasLimit)
+            : this(
+                genesisHash,
+                ImmutableHashSet<Address>.Empty,
+                timestamp,
+                actions,
+                maxGasPrice,
+                gasLimit)
         {
-            GenesisHash = genesisHash;
-            UpdatedAddresses = ImmutableHashSet<Address>.Empty;
-            Timestamp = timestamp;
-            Actions = actions ?? throw new ArgumentNullException(nameof(actions));
-            MaxGasPrice = maxGasPrice;
-            GasLimit = gasLimit;
         }
 
         /// <summary>
@@ -97,6 +97,9 @@ namespace Libplanet.Types.Tx
         /// <param name="gasLimit">The value of <see langword="Gas"/> limit.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="updatedAddresses"/>
         /// or <paramref name="actions"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <see langword="null"/>-ness of
+        /// <paramref name="maxGasPrice"/> and <paramref name="gasLimit"/> are not the same.
+        /// </exception>
         internal TxInvoice(
             BlockHash? genesisHash,
             IImmutableSet<Address> updatedAddresses,
@@ -108,6 +111,13 @@ namespace Libplanet.Types.Tx
             if (updatedAddresses is null)
             {
                 throw new ArgumentNullException(nameof(updatedAddresses));
+            }
+            else if (maxGasPrice is null ^ gasLimit is null)
+            {
+                throw new ArgumentException(
+                    $"Either {nameof(maxGasPrice)} (null: {maxGasPrice is null}) and " +
+                    $"{nameof(gasLimit)} (null: {gasLimit is null}) must be both null " +
+                    $"or both non-null.");
             }
 
             GenesisHash = genesisHash;

--- a/Libplanet.Types/Tx/TxInvoice.cs
+++ b/Libplanet.Types/Tx/TxInvoice.cs
@@ -115,7 +115,8 @@ namespace Libplanet.Types.Tx
             {
                 throw new ArgumentNullException(nameof(updatedAddresses));
             }
-            else if (maxGasPrice is null ^ gasLimit is null)
+
+            if (maxGasPrice is null ^ gasLimit is null)
             {
                 throw new ArgumentException(
                     $"Either {nameof(maxGasPrice)} (null: {maxGasPrice is null}) and " +


### PR DESCRIPTION
Allowing all possible combinations of `null` and non-`null` leads to some non-sensical scenarios concerning fee collection.
This strictly prohibits such possibility by restricting possible cases.

- Both `MaxGasPrice` and `GasLimit` are `null`: This is allowed for backward compatibility.
- Both `MaxGasPrice` and `GasLimit` are non-`null`: This is used for "normal" fee collection process.

As [Lib9c](https://github.com/planetarium/lib9c) started to filter those `Transaction`s with either `MaxGasPrice` and `GasLimit` being `null` at the same time as `MaxGasPrice` and `GasLimit` were introduced, we can safely assume all `Transaction`s included in 9c chain are among the types listed above.