### PR TITLE
♻️ `ActionEvaluator` context scoping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,12 +20,21 @@ be compatible with this version,  specifically, those that ran with
  -  Changed `TxInvoice` to no longer allow having the null-ness of
     `MaxGasPrice` and `GasLimit` to be different, i.e. either both should be
     null or both should not be null at the same time.  [[#3529]]
+ -  (Libplanet.Action) Changed `IActionContext` to inherit `ITxContext`.
+    The following properties of `IActionContext` have moved to `ITxContext`:
+    `Signer`, `TxId`, `Miner`, `BlockIndex`, and `BlockProtocolVersion`.
+    [[#3530]]
+ -  (Libplanet.Action) Changed `IAccount.Mint()`, `IAccount.Burn()`, and
+    `IAccount.Transfer()` to accept `ITxContext` instead of `IActionContext`
+    as its parameter.  [[#3530]]
 
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  (Libplanet.Action) Added `ITxContext` interface.  [[#3530]]
 
 ### Behavioral changes
 
@@ -37,6 +46,7 @@ be compatible with this version,  specifically, those that ran with
 
 [#3523]: https://github.com/planetarium/libplanet/pull/3523
 [#3529]: https://github.com/planetarium/libplanet/pull/3529
+[#3530]: https://github.com/planetarium/libplanet/pull/3530
 [Libplanet 2.0.0]: https://www.nuget.org/packages/Libplanet/2.0.0
 
 

--- a/Libplanet.Action.Tests/ActionContextTest.cs
+++ b/Libplanet.Action.Tests/ActionContextTest.cs
@@ -31,11 +31,12 @@ namespace Libplanet.Action.Tests
             foreach (var (seed, expected) in testCases)
             {
                 var context = new ActionContext(
-                    signer: _address,
-                    txid: _txid,
-                    miner: _address,
-                    blockIndex: 1,
-                    blockProtocolVersion: Block.CurrentProtocolVersion,
+                    new TxContext(
+                        signer: _address,
+                        txId: _txid,
+                        miner: _address,
+                        blockIndex: 1,
+                        blockProtocolVersion: Block.CurrentProtocolVersion),
                     previousState: new Account(MockAccountState.Empty),
                     randomSeed: seed,
                     gasLimit: 0
@@ -49,33 +50,35 @@ namespace Libplanet.Action.Tests
         public void GuidShouldBeDeterministic()
         {
             var context1 = new ActionContext(
-                signer: _address,
-                txid: _txid,
-                miner: _address,
-                blockIndex: 1,
-                blockProtocolVersion: Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer: _address,
+                    txId: _txid,
+                    miner: _address,
+                    blockIndex: 1,
+                    blockProtocolVersion: Block.CurrentProtocolVersion),
                 previousState: new Account(MockAccountState.Empty),
                 randomSeed: 0,
-                gasLimit: 0
-            );
+                gasLimit: 0);
 
             var context2 = new ActionContext(
-                signer: _address,
-                txid: _txid,
-                miner: _address,
-                blockIndex: 1,
-                blockProtocolVersion: Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer: _address,
+                    txId: _txid,
+                    miner: _address,
+                    blockIndex: 1,
+                    blockProtocolVersion: Block.CurrentProtocolVersion),
                 previousState: new Account(MockAccountState.Empty),
                 randomSeed: 0,
                 gasLimit: 0
             );
 
             var context3 = new ActionContext(
-                signer: _address,
-                txid: _txid,
-                miner: _address,
-                blockIndex: 1,
-                blockProtocolVersion: Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer: _address,
+                    txId: _txid,
+                    miner: _address,
+                    blockIndex: 1,
+                    blockProtocolVersion: Block.CurrentProtocolVersion),
                 previousState: new Account(MockAccountState.Empty),
                 randomSeed: 1,
                 gasLimit: 0
@@ -110,11 +113,12 @@ namespace Libplanet.Action.Tests
             for (var i = 0; i < 100; i++)
             {
                 var context = new ActionContext(
-                    signer: _address,
-                    txid: _txid,
-                    miner: _address,
-                    blockIndex: 1,
-                    blockProtocolVersion: Block.CurrentProtocolVersion,
+                    new TxContext(
+                        signer: _address,
+                        txId: _txid,
+                        miner: _address,
+                        blockIndex: 1,
+                        blockProtocolVersion: Block.CurrentProtocolVersion),
                     previousState: new Account(MockAccountState.Empty),
                     randomSeed: i,
                     gasLimit: 0

--- a/Libplanet.Action.Tests/ActionEvaluationTest.cs
+++ b/Libplanet.Action.Tests/ActionEvaluationTest.cs
@@ -32,11 +32,12 @@ namespace Libplanet.Action.Tests
             var evaluation = new ActionEvaluation(
                 new DumbAction(address, "item"),
                 new ActionContext(
-                    address,
-                    txid,
-                    address,
-                    1,
-                    Block.CurrentProtocolVersion,
+                    new TxContext(
+                        address,
+                        txid,
+                        address,
+                        1,
+                        Block.CurrentProtocolVersion),
                     new Account(MockAccountState.Empty),
                     123,
                     0),

--- a/Libplanet.Action.Tests/Sys/InitializeTest.cs
+++ b/Libplanet.Action.Tests/Sys/InitializeTest.cs
@@ -45,11 +45,12 @@ namespace Libplanet.Action.Tests.Sys
             var prevState = new Account(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
-                signer: signer,
-                txid: random.NextTxId(),
-                miner: random.NextAddress(),
-                blockIndex: 0,
-                blockProtocolVersion: Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer: signer,
+                    txId: random.NextTxId(),
+                    miner: random.NextAddress(),
+                    blockIndex: 0,
+                    blockProtocolVersion: Block.CurrentProtocolVersion),
                 previousState: prevState,
                 randomSeed: 123,
                 gasLimit: 0);
@@ -72,11 +73,12 @@ namespace Libplanet.Action.Tests.Sys
             var prevState = new Account(MockAccountState.Empty);
             BlockHash genesisHash = random.NextBlockHash();
             var context = new ActionContext(
-                signer: signer,
-                txid: random.NextTxId(),
-                miner: random.NextAddress(),
-                blockIndex: 10,
-                blockProtocolVersion: Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer: signer,
+                    txId: random.NextTxId(),
+                    miner: random.NextAddress(),
+                    blockIndex: 10,
+                    blockProtocolVersion: Block.CurrentProtocolVersion),
                 previousState: prevState,
                 randomSeed: 123,
                 gasLimit: long.MaxValue);

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.Contracts;
 using System.Threading;
 using Libplanet.Action.State;
 using Libplanet.Crypto;

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -6,6 +6,9 @@ using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// Implements <see cref="IActionContext"/>.
+    /// </summary>
     internal class ActionContext : IActionContext
     {
         public static readonly AsyncLocal<GasMeter> GetGasMeter = new AsyncLocal<GasMeter>();

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -10,23 +10,17 @@ namespace Libplanet.Action
     {
         public static readonly AsyncLocal<GasMeter> GetGasMeter = new AsyncLocal<GasMeter>();
 
+        private readonly ITxContext _txContext;
+
         private readonly long _gasLimit;
 
         public ActionContext(
-            Address signer,
-            TxId? txid,
-            Address miner,
-            long blockIndex,
-            int blockProtocolVersion,
+            ITxContext txContext,
             IAccount previousState,
             int randomSeed,
             long gasLimit)
         {
-            Signer = signer;
-            TxId = txid;
-            Miner = miner;
-            BlockIndex = blockIndex;
-            BlockProtocolVersion = blockProtocolVersion;
+            _txContext = txContext;
             PreviousState = previousState;
             RandomSeed = randomSeed;
             _gasLimit = gasLimit;
@@ -35,19 +29,19 @@ namespace Libplanet.Action
         }
 
         /// <inheritdoc cref="IActionContext.Signer"/>
-        public Address Signer { get; }
+        public Address Signer => _txContext.Signer;
 
         /// <inheritdoc cref="IActionContext.TxId"/>
-        public TxId? TxId { get; }
+        public TxId? TxId => _txContext.TxId;
 
         /// <inheritdoc cref="IActionContext.Miner"/>
-        public Address Miner { get; }
+        public Address Miner => _txContext.Miner;
 
         /// <inheritdoc cref="IActionContext.BlockIndex"/>
-        public long BlockIndex { get; }
+        public long BlockIndex => _txContext.BlockIndex;
 
         /// <inheritdoc cref="IActionContext.BlockProtocolVersion"/>
-        public int BlockProtocolVersion { get; }
+        public int BlockProtocolVersion => _txContext.BlockProtocolVersion;
 
         /// <inheritdoc cref="IActionContext.PreviousState"/>
         public IAccount PreviousState { get; }

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -189,11 +189,12 @@ namespace Libplanet.Action
                 long actionGasLimit)
             {
                 return new ActionContext(
-                    signer: tx?.Signer ?? blockHeader.Miner,
-                    txid: tx?.Id ?? null,
-                    miner: blockHeader.Miner,
-                    blockIndex: blockHeader.Index,
-                    blockProtocolVersion: blockHeader.ProtocolVersion,
+                    new TxContext(
+                        signer: tx?.Signer ?? blockHeader.Miner,
+                        txId: tx?.Id ?? null,
+                        miner: blockHeader.Miner,
+                        blockIndex: blockHeader.Index,
+                        blockProtocolVersion: blockHeader.ProtocolVersion),
                     previousState: prevState,
                     randomSeed: randomSeed,
                     gasLimit: actionGasLimit);
@@ -243,11 +244,12 @@ namespace Libplanet.Action
             IActionContext CreateActionContext(IAccount newPrevState)
             {
                 return new ActionContext(
-                    signer: inputContext.Signer,
-                    txid: inputContext.TxId,
-                    miner: inputContext.Miner,
-                    blockIndex: inputContext.BlockIndex,
-                    blockProtocolVersion: inputContext.BlockProtocolVersion,
+                    new TxContext(
+                        signer: inputContext.Signer,
+                        txId: inputContext.TxId,
+                        miner: inputContext.Miner,
+                        blockIndex: inputContext.BlockIndex,
+                        blockProtocolVersion: inputContext.BlockProtocolVersion),
                     previousState: newPrevState,
                     randomSeed: inputContext.RandomSeed,
                     gasLimit: inputContext.GasLimit());

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -183,37 +183,28 @@ namespace Libplanet.Action
             IImmutableList<IAction> actions,
             ILogger? logger = null)
         {
-            IActionContext CreateActionContext(
-                IAccount prevState,
-                int randomSeed,
-                long actionGasLimit)
-            {
-                return new ActionContext(
-                    new TxContext(
-                        signer: tx?.Signer ?? blockHeader.Miner,
-                        txId: tx?.Id ?? null,
-                        miner: blockHeader.Miner,
-                        blockIndex: blockHeader.Index,
-                        blockProtocolVersion: blockHeader.ProtocolVersion),
-                    previousState: prevState,
-                    randomSeed: randomSeed,
-                    gasLimit: actionGasLimit);
-            }
-
-            long gasLimit = tx?.GasLimit ?? long.MaxValue;
+            ITxContext txContext = new TxContext(
+                signer: tx?.Signer ?? blockHeader.Miner,
+                txId: tx?.Id ?? null,
+                miner: blockHeader.Miner,
+                blockIndex: blockHeader.Index,
+                blockProtocolVersion: blockHeader.ProtocolVersion);
 
             byte[] preEvaluationHashBytes = blockHeader.PreEvaluationHash.ToByteArray();
             byte[] signature = tx?.Signature ?? Array.Empty<byte>();
             int seed = GenerateRandomSeed(preEvaluationHashBytes, signature, 0);
+            long gasLimit = tx?.GasLimit ?? long.MaxValue;
 
             IAccount state = previousState;
             foreach (IAction action in actions)
             {
-                IActionContext context = CreateActionContext(state, seed, gasLimit);
                 (ActionEvaluation Evaluation, long NextGasLimit) result = EvaluateAction(
                     blockHeader,
                     tx,
-                    context,
+                    txContext,
+                    state,
+                    seed,
+                    gasLimit,
                     action,
                     logger);
 
@@ -229,31 +220,27 @@ namespace Libplanet.Action
             }
         }
 
+        // FIXME: Argument blockHeader is passed on purely for logging.
         internal static (ActionEvaluation Evaluation, long NextGasLimit) EvaluateAction(
             IPreEvaluationBlockHeader blockHeader,
             ITransaction? tx,
-            IActionContext context,
+            ITxContext txContext,
+            IAccount prevState,
+            int randomSeed,
+            long gasLimit,
             IAction action,
             ILogger? logger = null)
         {
-            IActionContext inputContext = context;
+            IActionContext inputContext = new ActionContext(
+                txContext,
+                prevState,
+                randomSeed,
+                gasLimit);
+            IActionContext context = inputContext;
+
             IAccount state = inputContext.PreviousState;
             Exception? exc = null;
             IFeeCollector feeCollector = new FeeCollector(context, tx?.MaxGasPrice);
-
-            IActionContext CreateActionContext(IAccount newPrevState)
-            {
-                return new ActionContext(
-                    new TxContext(
-                        signer: inputContext.Signer,
-                        txId: inputContext.TxId,
-                        miner: inputContext.Miner,
-                        blockIndex: inputContext.BlockIndex,
-                        blockProtocolVersion: inputContext.BlockProtocolVersion),
-                    previousState: newPrevState,
-                    randomSeed: inputContext.RandomSeed,
-                    gasLimit: inputContext.GasLimit());
-            }
 
             try
             {
@@ -261,7 +248,11 @@ namespace Libplanet.Action
                 stopwatch.Start();
                 AccountMetrics.Initialize();
                 state = feeCollector.Mortgage(state);
-                context = CreateActionContext(state);
+                context = new ActionContext(
+                    txContext: txContext,
+                    previousState: state,
+                    randomSeed: randomSeed,
+                    gasLimit: gasLimit);
                 feeCollector = feeCollector.Next(context);
                 state = action.Execute(context);
                 logger?
@@ -288,8 +279,8 @@ namespace Libplanet.Action
                     e,
                     message,
                     action,
-                    tx?.Id,
-                    blockHeader.Index,
+                    txContext.TxId,
+                    txContext.BlockIndex,
                     ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray));
                 throw;
             }
@@ -303,8 +294,8 @@ namespace Libplanet.Action
                     e,
                     message,
                     action,
-                    tx?.Id,
-                    blockHeader.Index,
+                    txContext.TxId,
+                    txContext.BlockIndex,
                     ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray));
                 var innerMessage =
                     $"The action {action} (block #{blockHeader.Index}, " +
@@ -317,8 +308,8 @@ namespace Libplanet.Action
                 exc = new UnexpectedlyTerminatedActionException(
                     innerMessage,
                     blockHeader.PreEvaluationHash,
-                    blockHeader.Index,
-                    tx?.Id,
+                    txContext.BlockIndex,
+                    txContext.TxId,
                     null,
                     action,
                     e);

--- a/Libplanet.Action/IActionContext.cs
+++ b/Libplanet.Action/IActionContext.cs
@@ -1,8 +1,5 @@
 using System.Diagnostics.Contracts;
 using Libplanet.Action.State;
-using Libplanet.Crypto;
-using Libplanet.Types.Blocks;
-using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
@@ -10,47 +7,8 @@ namespace Libplanet.Action
     /// Contextual data determined by a transaction and a block.
     /// Passed to <see cref="IAction.Execute(IActionContext)"/> method.
     /// </summary>
-    public interface IActionContext
+    public interface IActionContext : ITxContext
     {
-        /// <summary>
-        /// The <see cref="Transaction.Signer"/> of the <see cref="Transaction"/> that contains
-        /// the <see cref="IAction"/> to be executed.  If the <see cref="IAction"/> is
-        /// not part of a <see cref="Transaction"/>, e.g. <see cref="IBlockPolicy.BlockAction"/>,
-        /// this is set to <see cref="Block.Miner"/> instead.
-        /// </summary>
-        [Pure]
-        Address Signer { get; }
-
-        /// <summary>
-        /// The <see cref="Transaction.Id"/> of the <see cref="Transaction"/> that contains
-        /// the <see cref="IAction"/>.  If the <see cref="IAction"/> is not part of
-        /// a <see cref="Transaction"/>, e.g. <see cref="IBlockPolicy.BlockAction"/>,
-        /// this is set to <see langword="null"/>.
-        /// </summary>
-        [Pure]
-        TxId? TxId { get; }
-
-        /// <summary>
-        /// The <see cref="Block.Miner"/> of the <see cref="Block"/> that contains
-        /// the <see cref="IAction"/>.
-        /// </summary>
-        [Pure]
-        Address Miner { get; }
-
-        /// <summary>
-        /// The <see cref="Block.Index"/> of the <see cref="Block"/> that contains
-        /// the <see cref="IAction"/>.
-        /// </summary>
-        [Pure]
-        long BlockIndex { get; }
-
-        /// <summary>
-        /// The <see cref="Block.ProtocolVersion"/> of the <see cref="Block"/> that contains
-        /// the <see cref="IAction"/>.
-        /// </summary>
-        [Pure]
-        int BlockProtocolVersion { get; }
-
         /// <summary>
         /// A null delta of states, which means it represents the states
         /// before <see cref="IAction"/> executes.

--- a/Libplanet.Action/IActionContext.cs
+++ b/Libplanet.Action/IActionContext.cs
@@ -1,12 +1,19 @@
 using System.Diagnostics.Contracts;
 using Libplanet.Action.State;
+using Libplanet.Types.Blocks;
+using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
     /// <summary>
-    /// Contextual data determined by a transaction and a block.
+    /// <summary>
+    /// Contextual data determined by a <see cref="Transaction"/>,
+    /// a <see cref="PreEvaluationBlockHeader"/>, and <see cref="IAction"/>
+    /// (in particular, the <see cref="IAction"/>'s offset within the
+    /// <see cref="Transaction"/>).
     /// Passed to <see cref="IAction.Execute(IActionContext)"/> method.
     /// </summary>
+    /// <seealso cref="ITxContext"/>
     public interface IActionContext : ITxContext
     {
         /// <summary>

--- a/Libplanet.Action/ITxContext.cs
+++ b/Libplanet.Action/ITxContext.cs
@@ -6,9 +6,12 @@ using Libplanet.Types.Tx;
 namespace Libplanet.Action
 {
     /// <summary>
-    /// Contextual data determined by a transaction and a block.
-    /// Passed to <see cref="IAction.Execute(IActionContext)"/> method.
+    /// Contextual data determined by a <see cref="Transaction"/> and
+    /// a <see cref="PreEvaluationBlockHeader"/>.
+    /// Passed to <see cref="IAction.Execute(IActionContext)"/> method as part of the
+    /// <see cref="IActionContext"/> argument.
     /// </summary>
+    /// <seealso cref="IActionContext"/>
     public interface ITxContext
     {
         /// <summary>

--- a/Libplanet.Action/ITxContext.cs
+++ b/Libplanet.Action/ITxContext.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.Contracts;
+using Libplanet.Crypto;
+using Libplanet.Types.Blocks;
+using Libplanet.Types.Tx;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// Contextual data determined by a transaction and a block.
+    /// Passed to <see cref="IAction.Execute(IActionContext)"/> method.
+    /// </summary>
+    public interface ITxContext
+    {
+        /// <summary>
+        /// The <see cref="Transaction.Signer"/> of the <see cref="Transaction"/> that contains
+        /// the <see cref="IAction"/> to be executed.  If the <see cref="IAction"/> is
+        /// not part of a <see cref="Transaction"/>, e.g. <see cref="IBlockPolicy.BlockAction"/>,
+        /// this is set to <see cref="Block.Miner"/> instead.
+        /// </summary>
+        [Pure]
+        Address Signer { get; }
+
+        /// <summary>
+        /// The <see cref="Transaction.Id"/> of the <see cref="Transaction"/> that contains
+        /// the <see cref="IAction"/>.  If the <see cref="IAction"/> is not part of
+        /// a <see cref="Transaction"/>, e.g. <see cref="IBlockPolicy.BlockAction"/>,
+        /// this is set to <see langword="null"/>.
+        /// </summary>
+        [Pure]
+        TxId? TxId { get; }
+
+        /// <summary>
+        /// The <see cref="Block.Miner"/> of the <see cref="Block"/> that contains
+        /// the <see cref="IAction"/>.
+        /// </summary>
+        [Pure]
+        Address Miner { get; }
+
+        /// <summary>
+        /// The <see cref="Block.Index"/> of the <see cref="Block"/> that contains
+        /// the <see cref="IAction"/>.
+        /// </summary>
+        [Pure]
+        long BlockIndex { get; }
+
+        /// <summary>
+        /// The <see cref="Block.ProtocolVersion"/> of the <see cref="Block"/> that contains
+        /// the <see cref="IAction"/>.
+        /// </summary>
+        [Pure]
+        int BlockProtocolVersion { get; }
+    }
+}

--- a/Libplanet.Action/State/Account.cs
+++ b/Libplanet.Action/State/Account.cs
@@ -112,7 +112,7 @@ namespace Libplanet.Action.State
         /// <inheritdoc/>
         [Pure]
         public IAccount MintAsset(
-            IActionContext context, Address recipient, FungibleAssetValue value)
+            ITxContext context, Address recipient, FungibleAssetValue value)
         {
             if (value.Sign <= 0)
             {
@@ -161,7 +161,7 @@ namespace Libplanet.Action.State
         /// <inheritdoc/>
         [Pure]
         public IAccount TransferAsset(
-            IActionContext context,
+            ITxContext context,
             Address sender,
             Address recipient,
             FungibleAssetValue value,
@@ -172,7 +172,7 @@ namespace Libplanet.Action.State
         /// <inheritdoc/>
         [Pure]
         public IAccount BurnAsset(
-            IActionContext context, Address owner, FungibleAssetValue value)
+            ITxContext context, Address owner, FungibleAssetValue value)
         {
             string msg;
 

--- a/Libplanet.Action/State/IAccount.cs
+++ b/Libplanet.Action/State/IAccount.cs
@@ -78,8 +78,8 @@ namespace Libplanet.Action.State
         /// Mints the fungible asset <paramref name="value"/> (i.e., in-game monetary),
         /// and give it to the <paramref name="recipient"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IActionContext"/> of the <see cref="IAction"/>
-        /// executing this method.</param>
+        /// <param name="context">The <see cref="ITxContext"/> of the <see cref="IAction"/>
+        /// executing this method to validate the authority.</param>
         /// <param name="recipient">The address who receives the minted asset.</param>
         /// <param name="value">The asset value to mint.</param>
         /// <returns>A new <see cref="IAccount"/> instance that the given <paramref
@@ -101,8 +101,8 @@ namespace Libplanet.Action.State
         /// Transfers the fungible asset <paramref name="value"/> (i.e., in-game monetary)
         /// from the <paramref name="sender"/> to the <paramref name="recipient"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IActionContext"/> of the <see cref="IAction"/>
-        /// executing this method.</param>
+        /// <param name="context">The <see cref="ITxContext"/> of the <see cref="IAction"/>
+        /// executing this method to determine its behavior for backward compatibility.</param>
         /// <param name="sender">The address who sends the fungible asset to
         /// the <paramref name="recipient"/>.</param>
         /// <param name="recipient">The address who receives the fungible asset from
@@ -120,7 +120,7 @@ namespace Libplanet.Action.State
         /// the <paramref name="allowNegativeBalance"/> option is turned off.</exception>
         /// <remarks>
         /// The behavior is different depending on <paramref name="context"/>'s
-        /// <see cref="IActionContext.BlockProtocolVersion"/>.  There is a bug for version 0
+        /// <see cref="ITxContext.BlockProtocolVersion"/>.  There is a bug for version 0
         /// where this may not act as intended.  Such behavior is left intact for backward
         /// compatibility.
         /// </remarks>
@@ -137,8 +137,8 @@ namespace Libplanet.Action.State
         /// Burns the fungible asset <paramref name="value"/> (i.e., in-game monetary) from
         /// <paramref name="owner"/>'s balance.
         /// </summary>
-        /// <param name="context">The <see cref="IActionContext"/> of the <see cref="IAction"/>
-        /// executing this method.</param>
+        /// <param name="context">The <see cref="ITxContext"/> of the <see cref="IAction"/>
+        /// executing this method to validate the authority.</param>
         /// <param name="owner">The address who owns the fungible asset to burn.</param>
         /// <param name="value">The fungible asset <paramref name="value"/> to burn.</param>
         /// <returns>A new <see cref="IAccount"/> instance that the given <paramref

--- a/Libplanet.Action/State/IAccount.cs
+++ b/Libplanet.Action/State/IAccount.cs
@@ -95,7 +95,7 @@ namespace Libplanet.Action.State
         /// <see cref="Currency.MaximumSupply"/>.</exception>
         [Pure]
         IAccount MintAsset(
-            IActionContext context, Address recipient, FungibleAssetValue value);
+            ITxContext context, Address recipient, FungibleAssetValue value);
 
         /// <summary>
         /// Transfers the fungible asset <paramref name="value"/> (i.e., in-game monetary)
@@ -126,7 +126,7 @@ namespace Libplanet.Action.State
         /// </remarks>
         [Pure]
         IAccount TransferAsset(
-            IActionContext context,
+            ITxContext context,
             Address sender,
             Address recipient,
             FungibleAssetValue value,
@@ -152,7 +152,7 @@ namespace Libplanet.Action.State
         /// has insufficient balance than <paramref name="value"/> to burn.</exception>
         [Pure]
         IAccount BurnAsset(
-            IActionContext context, Address owner, FungibleAssetValue value);
+            ITxContext context, Address owner, FungibleAssetValue value);
 
         /// <summary>
         /// Sets <paramref name="validator"/> to the stored <see cref="ValidatorSet"/>.

--- a/Libplanet.Action/TxContext.cs
+++ b/Libplanet.Action/TxContext.cs
@@ -1,0 +1,35 @@
+using Libplanet.Crypto;
+using Libplanet.Types.Blocks;
+using Libplanet.Types.Tx;
+
+namespace Libplanet.Action
+{
+    internal class TxContext : ITxContext
+    {
+        public TxContext(
+            IPreEvaluationBlockHeader blockHeader,
+            ITransaction? transaction)
+        {
+            Signer = transaction?.Signer ?? blockHeader.Miner;
+            TxId = transaction?.Id;
+            Miner = blockHeader.Miner;
+            BlockIndex = blockHeader.Index;
+            BlockProtocolVersion = blockHeader.ProtocolVersion;
+        }
+
+        /// <inheritdoc cref="IActionContext.Signer"/>
+        public Address Signer { get; }
+
+        /// <inheritdoc cref="IActionContext.TxId"/>
+        public TxId? TxId { get; }
+
+        /// <inheritdoc cref="IActionContext.Miner"/>
+        public Address Miner { get; }
+
+        /// <inheritdoc cref="IActionContext.BlockIndex"/>
+        public long BlockIndex { get; }
+
+        /// <inheritdoc cref="IActionContext.BlockProtocolVersion"/>
+        public int BlockProtocolVersion { get; }
+    }
+}

--- a/Libplanet.Action/TxContext.cs
+++ b/Libplanet.Action/TxContext.cs
@@ -7,14 +7,17 @@ namespace Libplanet.Action
     internal class TxContext : ITxContext
     {
         public TxContext(
-            IPreEvaluationBlockHeader blockHeader,
-            ITransaction? transaction)
+            Address signer,
+            TxId? txId,
+            Address miner,
+            long blockIndex,
+            int blockProtocolVersion)
         {
-            Signer = transaction?.Signer ?? blockHeader.Miner;
-            TxId = transaction?.Id;
-            Miner = blockHeader.Miner;
-            BlockIndex = blockHeader.Index;
-            BlockProtocolVersion = blockHeader.ProtocolVersion;
+            Signer = signer;
+            TxId = txId;
+            Miner = miner;
+            BlockIndex = blockIndex;
+            BlockProtocolVersion = blockProtocolVersion;
         }
 
         /// <inheritdoc cref="IActionContext.Signer"/>

--- a/Libplanet.Action/TxContext.cs
+++ b/Libplanet.Action/TxContext.cs
@@ -1,9 +1,11 @@
 using Libplanet.Crypto;
-using Libplanet.Types.Blocks;
 using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// Implements <see cref="ITxContext"/>.
+    /// </summary>
     internal class TxContext : ITxContext
     {
         public TxContext(

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -174,7 +174,7 @@ public class StateQueryTest
         Assert.Equal("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233", validatorDict["publicKey"]);
         Assert.Equal(new BigInteger(1), validatorDict["power"]);
     }
-    
+
     [Fact]
     public async Task ThrowExecutionErrorIfViolateMutualExclusive()
     {
@@ -194,7 +194,7 @@ public class StateQueryTest
         ", source: source);
         Assert.IsType<ExecutionErrors>(result.Errors);
     }
-    
+
     [Fact]
     public async Task StatesBySrh()
     {
@@ -345,7 +345,7 @@ public class StateQueryTest
         Assert.Equal("032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233", validatorDict["publicKey"]);
         Assert.Equal(new BigInteger(1), validatorDict["power"]);
     }
-    
+
 
     private class MockChainStates : IBlockChainStates
     {
@@ -366,7 +366,7 @@ public class StateQueryTest
         public ValidatorSet GetValidatorSet(BlockHash? offset) =>
             GetAccountState(offset).GetValidatorSet();
 
-        public IAccountState GetAccountState(BlockHash? offset) => 
+        public IAccountState GetAccountState(BlockHash? offset) =>
             new MockAccount(offset, null);
 
         public IAccountState GetAccountState(HashDigest<SHA256>? hash) =>
@@ -400,18 +400,18 @@ public class StateQueryTest
             throw new System.NotImplementedException();
         }
 
-        public IAccount MintAsset(IActionContext context, Address recipient, FungibleAssetValue value)
+        public IAccount MintAsset(ITxContext context, Address recipient, FungibleAssetValue value)
         {
             throw new System.NotImplementedException();
         }
 
-        public IAccount TransferAsset(IActionContext context, Address sender, Address recipient,
+        public IAccount TransferAsset(ITxContext context, Address sender, Address recipient,
             FungibleAssetValue value, bool allowNegativeBalance = false)
         {
             throw new System.NotImplementedException();
         }
 
-        public IAccount BurnAsset(IActionContext context, Address owner, FungibleAssetValue value)
+        public IAccount BurnAsset(ITxContext context, Address owner, FungibleAssetValue value)
         {
             throw new System.NotImplementedException();
         }

--- a/Libplanet.Tests/Action/AccountDiffTest.cs
+++ b/Libplanet.Tests/Action/AccountDiffTest.cs
@@ -143,11 +143,12 @@ namespace Libplanet.Tests.Action
 
         public IActionContext CreateActionContext(Address signer, ITrie trie) =>
             new ActionContext(
-                signer,
-                null,
-                signer,
-                0,
-                Block.CurrentProtocolVersion,
+                new TxContext(
+                    signer,
+                    null,
+                    signer,
+                    0,
+                    Block.CurrentProtocolVersion),
                 new Account(new AccountState(trie)),
                 0,
                 0);

--- a/Libplanet.Tests/Action/AccountV0Test.cs
+++ b/Libplanet.Tests/Action/AccountV0Test.cs
@@ -22,11 +22,12 @@ namespace Libplanet.Tests.Action
         public override IActionContext CreateContext(
             IAccount delta, Address signer) =>
             new ActionContext(
-                signer,
-                null,
-                signer,
-                0,
-                ProtocolVersion,
+                new TxContext(
+                    signer,
+                    null,
+                    signer,
+                    0,
+                    ProtocolVersion),
                 delta,
                 0,
                 0);

--- a/Libplanet.Tests/Action/AccountV1Test.cs
+++ b/Libplanet.Tests/Action/AccountV1Test.cs
@@ -25,11 +25,12 @@ namespace Libplanet.Tests.Action
         public override IActionContext CreateContext(
             IAccount delta, Address signer) =>
             new ActionContext(
-                signer,
-                null,
-                signer,
-                0,
-                ProtocolVersion,
+                new TxContext(
+                    signer,
+                    null,
+                    signer,
+                    0,
+                    ProtocolVersion),
                 delta,
                 0,
                 0);

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -20,11 +20,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
 
         private static ICommittedActionContext _actionContext =
             new CommittedActionContext(new ActionContext(
-                default,
-                default,
-                default,
-                Block.CurrentProtocolVersion,
-                default,
+                new TxContext(
+                    default,
+                    default,
+                    default,
+                    default,
+                    Block.CurrentProtocolVersion),
                 _account,
                 default,
                 0));

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -66,11 +66,12 @@ namespace Libplanet.Tests.Blockchain.Renderers
             LogEvent firstLog = null;
             ICommittedActionContext actionContext =
                 new CommittedActionContext(new ActionContext(
-                    default,
-                    default,
-                    default,
-                    Block.CurrentProtocolVersion,
-                    123,
+                    new TxContext(
+                        default,
+                        default,
+                        default,
+                        123,
+                        Block.CurrentProtocolVersion),
                     _account,
                     default,
                     0));


### PR DESCRIPTION
We've been kicking this can down the road for far too long. The recurring cost induced by the lack of an additional scope seems far too great (yet I suspect it'll incur even more down the road when we try to implement PoS).

The problem is essentially trying to do **everything** with `IActionContext` which is single-scoped, while the data structure and its evaluation is three-layered, i.e. `Block`, `Transaction`, and `Action`.

I've tried to leave much of the API intact as much as possible.