### PR TITLE
Add metadata for tries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Bumped `BlockMetadata.CurrentProtocolVersion` to 5.  [[#3524]]
+ -  Removed `BlockChain.EvaluateBlock(IPreEvaluationBlock)` method.
+    Instead, added
+    `BlockChain.EvaluateBlock(IPreEvaluationBlock, out HashDigest<SHA256>)`
+    method.
+    [[#3540]]
  -  (Libplanet.Action) Changed `ActionEvaluator` to accept `IWorld`
     instead of `IAccount`.  [[#3462]]
  -  (Libplanet.Action) `IActionEvaluator.OutputState` became `IWorld`.
@@ -74,6 +79,12 @@ To be released.
     `IBlockPolicy` interface.  [[#3494]]
  -  (@planetarium/tx)  Remove the `T` generic argument of `SignedTx<T>`.
     [[#3512]]
+ -  (Libplanet.Action)
+    Removed `ActionEvaluator.Evaluate(IPreEvaluationBlock)` method.
+    Instead, added
+    `ActionEvaluator.Evaluate(IPreEvaluationBlock, out HashDigest<SHA256>)`
+    method.
+    [[#3540]]
 
 ### Backward-incompatible network protocol changes
 
@@ -126,6 +137,7 @@ To be released.
 [#3494]: https://github.com/planetarium/libplanet/pull/3494
 [#3512]: https://github.com/planetarium/libplanet/pull/3512
 [#3524]: https://github.com/planetarium/libplanet/pull/3524
+[#3540]: https://github.com/planetarium/libplanet/pull/3540
 
 Version 3.7.0
 -------------

--- a/Libplanet.Action.Tests/State/AccountBaseStateTest.cs
+++ b/Libplanet.Action.Tests/State/AccountBaseStateTest.cs
@@ -1,0 +1,27 @@
+using Libplanet.Action.State;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Blocks;
+using Xunit;
+
+namespace Libplanet.Action.Tests.State
+{
+    public class AccountBaseStateTest
+    {
+        private readonly IKeyValueStore _kvStore;
+
+        public AccountBaseStateTest()
+        {
+            _kvStore = new MemoryKeyValueStore();
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            ITrie trie = new MerkleTrie(_kvStore);
+            trie = trie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.World));
+            Assert.Throws<ArgumentException>(() => new AccountBaseState(trie));
+        }
+    }
+}

--- a/Libplanet.Action.Tests/State/WorldBaseStateTest.cs
+++ b/Libplanet.Action.Tests/State/WorldBaseStateTest.cs
@@ -1,0 +1,106 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Blocks;
+using Xunit;
+using static Libplanet.Action.State.KeyConverters;
+
+namespace Libplanet.Action.Tests.State
+{
+    public class WorldBaseStateTest
+    {
+        private readonly IKeyValueStore _kvStore;
+        private readonly IStateStore _stateStore;
+
+        public WorldBaseStateTest()
+        {
+            _kvStore = new MemoryKeyValueStore();
+            _stateStore = new TrieStateStore(_kvStore);
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            ITrie trie = new MerkleTrie(_kvStore);
+            trie = trie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.Account));
+            Assert.Throws<ArgumentException>(() => new WorldBaseState(trie, _stateStore));
+            trie = new MerkleTrie(_kvStore);
+            var legacyBaseState = new WorldBaseState(trie, _stateStore);
+            Assert.True(legacyBaseState.Legacy);
+            trie = new MerkleTrie(_kvStore);
+            trie = trie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.World));
+            var modernBaseState = new WorldBaseState(trie, _stateStore);
+            Assert.False(modernBaseState.Legacy);
+        }
+
+        [Fact]
+        public void Metadata()
+        {
+            var accountAddress = new Address(TestUtils.GetRandomBytes(20));
+            var address = new Address(TestUtils.GetRandomBytes(20));
+            ITrie accountTrie = new MerkleTrie(_kvStore);
+            accountTrie = accountTrie.Set(ToStateKey(address), (Text)"foo");
+            accountTrie = accountTrie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.Account));
+            accountTrie = _stateStore.Commit(accountTrie);
+            ITrie worldTrie = new MerkleTrie(_kvStore);
+            worldTrie = worldTrie.Set(
+                ToStateKey(accountAddress),
+                (Binary)accountTrie.Hash.ByteArray);
+            worldTrie = worldTrie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.World));
+            worldTrie = _stateStore.Commit(worldTrie);
+            var stateRoot = worldTrie.Hash;
+            var world = new World(new WorldBaseState(
+                _stateStore.GetStateRoot(stateRoot),
+                _stateStore));
+            Assert.Equal(worldTrie.Hash, world.Trie.Hash);
+            Assert.False(world.Legacy);
+            var account = world.GetAccount(accountAddress);
+            Assert.Equal(accountTrie.Hash, account.Trie.Hash);
+            Assert.Equal(
+                (Text)"foo",
+                world.GetAccount(accountAddress).GetState(address));
+        }
+
+        [Fact]
+        public void MetadataLegacy()
+        {
+            var accountAddress = ReservedAddresses.LegacyAccount;
+            var address = new Address(TestUtils.GetRandomBytes(20));
+            ITrie accountTrie = new MerkleTrie(_kvStore);
+            accountTrie = accountTrie.Set(ToStateKey(address), (Text)"foo");
+            accountTrie = accountTrie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.Account));
+            accountTrie = _stateStore.Commit(accountTrie);
+            ITrie worldTrie = new MerkleTrie(_kvStore);
+            worldTrie = worldTrie.Set(
+                ToStateKey(accountAddress),
+                (Binary)accountTrie.Hash.ByteArray);
+            worldTrie = worldTrie.SetMetadata(new TrieMetadata(
+                BlockMetadata.CurrentProtocolVersion,
+                TrieType.World));
+            worldTrie = _stateStore.Commit(worldTrie);
+            var stateRoot = worldTrie.Hash;
+            var world = new World(new WorldBaseState(
+                _stateStore.GetStateRoot(stateRoot),
+                _stateStore));
+            Assert.Equal(worldTrie.Hash, world.Trie.Hash);
+            Assert.False(world.Legacy);
+            var account = world.GetAccount(accountAddress);
+            Assert.Equal(accountTrie.Hash, account.Trie.Hash);
+            Assert.Equal(
+                (Text)"foo",
+                world.GetAccount(accountAddress).GetState(address));
+        }
+    }
+}

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -82,7 +82,8 @@ namespace Libplanet.Action
         [Pure]
         public IReadOnlyList<ICommittedActionEvaluation> Evaluate(
             IPreEvaluationBlock block,
-            HashDigest<SHA256>? baseStateRootHash)
+            HashDigest<SHA256>? baseStateRootHash,
+            out HashDigest<SHA256> stateRootHash)
         {
             _logger.Information(
                 "Evaluating actions in the block #{BlockIndex} " +
@@ -118,7 +119,11 @@ namespace Libplanet.Action
                     evaluations = evaluations.Add(EvaluatePolicyBlockAction(block, previousState));
                 }
 
-                return ToCommittedEvaluation(block, evaluations, baseStateRootHash);
+                var committed = ToCommittedEvaluation(block, evaluations, baseStateRootHash);
+                stateRootHash = committed.Count > 0
+                    ? committed.Last().OutputState
+                    : previousState.Trie.Hash;
+                return committed;
             }
             finally
             {

--- a/Libplanet.Action/IActionEvaluator.cs
+++ b/Libplanet.Action/IActionEvaluator.cs
@@ -23,6 +23,8 @@ namespace Libplanet.Action
         /// <param name="block">The block to evaluate.</param>
         /// <param name="baseStateRootHash">The base state to use when evaluating
         /// <paramref name="block"/>.</param>
+        /// <param name="stateRootHash">
+        /// Determined state root hash of the given <paramref name="block"/>.</param>
         /// <returns> The result of evaluating every <see cref="IAction"/> related to
         /// <paramref name="block"/> as an <see cref="IReadOnlyList{T}"/> of
         /// <see cref="ICommittedActionEvaluation"/>s.</returns>
@@ -40,6 +42,7 @@ namespace Libplanet.Action
         [Pure]
         IReadOnlyList<ICommittedActionEvaluation> Evaluate(
             IPreEvaluationBlock block,
-            HashDigest<SHA256>? baseStateRootHash);
+            HashDigest<SHA256>? baseStateRootHash,
+            out HashDigest<SHA256> stateRootHash);
     }
 }

--- a/Libplanet.Action/State/AccountBaseState.cs
+++ b/Libplanet.Action/State/AccountBaseState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bencodex.Types;
@@ -21,6 +22,12 @@ namespace Libplanet.Action.State
         {
             _trie = trie;
             _cache = new AccountStateCache();
+            if (trie.GetMetadata() is { } metadata && metadata.Type != TrieType.Account)
+            {
+                throw new ArgumentException(
+                    "Given trie is not an IAccount instance.",
+                    nameof(trie));
+            }
         }
 
         /// <inheritdoc cref="IAccountState.Trie"/>

--- a/Libplanet.Action/State/TrieExtensions.cs
+++ b/Libplanet.Action/State/TrieExtensions.cs
@@ -1,0 +1,30 @@
+using Bencodex.Types;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.Action.State
+{
+    internal static class TrieExtensions
+    {
+        public static readonly KeyBytes Key = new KeyBytes(new byte[] { });
+
+        public static TrieMetadata? GetMetadata(this ITrie trie)
+        {
+            if (trie.Get(Key) is { } value)
+            {
+                return new TrieMetadata(value);
+            }
+
+            return null;
+        }
+
+        public static ITrie SetMetadata(this ITrie trie, TrieMetadata metadata)
+        {
+            return trie.Set(Key, metadata.Bencoded);
+        }
+
+        public static ITrie SetMetadata(this ITrie trie, IValue encoded)
+        {
+            return trie.Set(Key, encoded);
+        }
+    }
+}

--- a/Libplanet.Action/State/TrieMetadata.cs
+++ b/Libplanet.Action/State/TrieMetadata.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Numerics;
+using Bencodex.Types;
+
+namespace Libplanet.Action.State
+{
+    public class TrieMetadata
+    {
+        public TrieMetadata(int version, TrieType type)
+        {
+            Version = version;
+            Type = type;
+        }
+
+        public TrieMetadata(IValue value)
+        {
+            if (!(value is List list))
+            {
+                throw new ArgumentException(
+                    $"The given value is not a list: {value}",
+                    nameof(value)
+                );
+            }
+
+            Version = ((Integer)list[0]).Value;
+            Type = (TrieType)(int)((Integer)list[1]).Value;
+        }
+
+        public BigInteger Version { get; }
+
+        public TrieType Type { get; }
+
+        public IValue Bencoded => new List((Integer)Version, (Integer)(int)Type);
+    }
+}

--- a/Libplanet.Action/State/TrieType.cs
+++ b/Libplanet.Action/State/TrieType.cs
@@ -1,0 +1,18 @@
+using Bencodex.Types;
+
+namespace Libplanet.Action.State
+{
+    public enum TrieType
+    {
+        /// <summary>
+        /// The trie is <see cref="IWorld"/>, which has state root hashes of
+        /// <see cref="IAccount"/>s as its child.
+        /// </summary>
+        World = 0x00,
+
+        /// <summary>
+        /// The trie is <see cref="IAccount"/>, which has <see cref="IValue"/>s as its child.
+        /// </summary>
+        Account = 0x01,
+    }
+}

--- a/Libplanet.Action/State/WorldBaseState.cs
+++ b/Libplanet.Action/State/WorldBaseState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -22,19 +23,28 @@ namespace Libplanet.Action.State
         {
             Trie = trie;
             _stateStore = stateStore;
-            Legacy = Trie
-                .Get(new[]
+            Legacy = true;
+            if (trie.
+                    GetMetadata() is { } metadata)
+            {
+                if (metadata.Type != TrieType.World)
                 {
-                    ToStateKey(ReservedAddresses.LegacyAccount),
-                })
-                .Any(v => v == null);
+                    throw new ArgumentException(
+                        "Given trie is not an IWorld instance.",
+                        nameof(trie));
+                }
+                else
+                {
+                    Legacy = false;
+                }
+            }
         }
 
         /// <inheritdoc cref="IWorldState.Trie"/>
         public ITrie Trie { get; }
 
         /// <inheritdoc cref="IWorldState.Legacy"/>
-        public bool Legacy { get; }
+        public bool Legacy { get; private set; }
 
         /// <inheritdoc cref="IWorldState.GetAccount"/>
         public IAccount GetAccount(Address address) => GetAccounts(new[] { address }).First();

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -100,13 +100,13 @@ namespace Libplanet.Tests.Action
 
             for (int i = 0; i < repeatCount; ++i)
             {
-                var actionEvaluations = actionEvaluator.Evaluate(noStateRootBlock, null);
+                var actionEvaluations = actionEvaluator.Evaluate(noStateRootBlock, null, out _);
                 generatedRandomNumbers.Add(
                     (Integer)new WorldBaseState(
                         stateStore.GetStateRoot(actionEvaluations[0].OutputState), stateStore)
                             .GetAccount(ReservedAddresses.LegacyAccount)
                             .GetState(txAddress));
-                actionEvaluations = actionEvaluator.Evaluate(stateRootBlock, null);
+                actionEvaluations = actionEvaluator.Evaluate(stateRootBlock, null, out _);
                 generatedRandomNumbers.Add(
                     (Integer)new WorldBaseState(
                         stateStore.GetStateRoot(actionEvaluations[0].OutputState), stateStore)
@@ -152,7 +152,7 @@ namespace Libplanet.Tests.Action
             chain.Append(block, CreateBlockCommit(block));
 
             var evaluations = chain.ActionEvaluator.Evaluate(
-                chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash));
+                chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash), out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
@@ -194,7 +194,7 @@ namespace Libplanet.Tests.Action
             Block block = chain.ProposeBlock(new PrivateKey());
             chain.Append(block, CreateBlockCommit(block));
             var evaluations = chain.ActionEvaluator.Evaluate(
-                chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash));
+                chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash), out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
@@ -252,7 +252,7 @@ namespace Libplanet.Tests.Action
                     previousState: previousState).ToList());
             Assert.Throws<OutOfMemoryException>(
                 () => chain.ActionEvaluator.Evaluate(
-                    block, chain.Store.GetStateRootHash(block.PreviousHash)).ToList());
+                    block, chain.Store.GetStateRootHash(block.PreviousHash), out _).ToList());
         }
 
         [Fact]
@@ -1043,7 +1043,7 @@ namespace Libplanet.Tests.Action
             Block block = chain.ProposeBlock(miner);
 
             var evaluations = chain.ActionEvaluator.Evaluate(
-                block, chain.Store.GetStateRootHash(block.PreviousHash));
+                block, chain.Store.GetStateRootHash(block.PreviousHash), out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
@@ -1112,7 +1112,8 @@ namespace Libplanet.Tests.Action
 
             var evaluations = chain.ActionEvaluator.Evaluate(
                 block,
-                chain.Store.GetStateRootHash(block.PreviousHash));
+                chain.Store.GetStateRootHash(block.PreviousHash),
+                out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
@@ -1184,7 +1185,7 @@ namespace Libplanet.Tests.Action
             Block block = chain.ProposeBlock(miner);
 
             var evaluations = chain.ActionEvaluator.Evaluate(
-                block, chain.Store.GetStateRootHash(block.PreviousHash));
+                block, chain.Store.GetStateRootHash(block.PreviousHash), out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);
@@ -1246,7 +1247,7 @@ namespace Libplanet.Tests.Action
             Block block = chain.ProposeBlock(miner);
 
             var evaluations = chain.ActionEvaluator.Evaluate(
-                block, chain.Store.GetStateRootHash(block.PreviousHash));
+                block, chain.Store.GetStateRootHash(block.PreviousHash), out _);
 
             Assert.False(evaluations[0].InputContext.BlockAction);
             Assert.Single(evaluations);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -671,7 +671,7 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.StageTransaction(txA1);
             Block block = _blockChain.ProposeBlock(miner);
             IReadOnlyList<ICommittedActionEvaluation> actionEvaluations =
-                _blockChain.EvaluateBlock(block);
+                _blockChain.EvaluateBlock(block, out _);
             Assert.Equal(0L, _blockChain.Tip.Index);
             _blockChain.Append(
                 block,

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -738,7 +738,7 @@ namespace Libplanet.Tests.Blockchain
         public void MigrateStateWithoutAction()
         {
             var policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                blockAction: null,
                 getMaxTransactionsBytes: _ => 50 * 1024);
             var stagePolicy = new VolatileStagePolicy();
             var fx = GetStoreFixture(policy.BlockAction);

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Blockchain
                     nameof(preEvaluationBlock));
             }
 
-            return actionEvaluator.Evaluate(preEvaluationBlock, null);
+            return actionEvaluator.Evaluate(preEvaluationBlock, null, out _);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Libplanet.Blockchain
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-                evaluations = EvaluateBlock(block);
+                evaluations = EvaluateBlock(block, out HashDigest<SHA256> stateRootHash);
 
                 _logger.Debug(
                     "Took {DurationMs} ms to evaluate block #{BlockIndex} " +
@@ -113,9 +113,7 @@ namespace Libplanet.Blockchain
                     block.PreEvaluationHash,
                     evaluations.Count);
 
-                return evaluations.Count > 0
-                    ? evaluations.Last().OutputState
-                    : GetWorldState(block.PreviousHash).Trie.Hash;
+                return stateRootHash;
             }
             finally
             {
@@ -127,14 +125,21 @@ namespace Libplanet.Blockchain
         /// Evaluates the <see cref="IAction"/>s in given <paramref name="block"/>.
         /// </summary>
         /// <param name="block">The <see cref="IPreEvaluationBlock"/> to execute.</param>
+        /// <param name="stateRootHash">
+        /// Determined state root hash of the given <paramref name="block"/>.</param>
         /// <returns>An <see cref="IReadOnlyList{T}"/> of <ses cref="ICommittedActionEvaluation"/>s
         /// for given <paramref name="block"/>.</returns>
         /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
         /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
         /// <seealso cref="ValidateBlockStateRootHash"/>
         [Pure]
-        public IReadOnlyList<ICommittedActionEvaluation> EvaluateBlock(IPreEvaluationBlock block) =>
-            ActionEvaluator.Evaluate(block, Store.GetStateRootHash(block.PreviousHash));
+        public IReadOnlyList<ICommittedActionEvaluation> EvaluateBlock(
+            IPreEvaluationBlock block,
+            out HashDigest<SHA256> stateRootHash) =>
+            ActionEvaluator.Evaluate(
+                block,
+                Store.GetStateRootHash(block.PreviousHash),
+                out stateRootHash);
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -175,7 +175,7 @@ namespace Libplanet.Blockchain
                     HashDigest<SHA256>? baseStateRootHash =
                         Store.GetStateRootHash(block.PreviousHash);
                     IReadOnlyList<ICommittedActionEvaluation> evaluations =
-                        ActionEvaluator.Evaluate(block, baseStateRootHash);
+                        ActionEvaluator.Evaluate(block, baseStateRootHash, out _);
 
                     RenderActions(
                         evaluations: evaluations,


### PR DESCRIPTION
This PR adds metadata to trie, which to address of length 0, cannot be created through provided APIs.

Afterwards, `World` will be treated as `non-legacy` if given trie has metadata. If not, the trie will be treated as legacy.