### PR TITLE
✨ Added `TxStatus.INCLUDED`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 3.9.1
 
 To be released.
 
+ -  (Libplanet.Explorer) Added `INCLUDED` to `TxStatus` enum.  [[#3542]]
+
+[#3542]: https://github.com/planetarium/libplanet/pull/3542
+
 
 Version 3.9.0
 -------------

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -170,8 +170,7 @@ public class GeneratedBlockChainFixture
                 ? GetRandomActions().ToPlainValues()
                 : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues(),
             null,
-            null,
-            GetRandomAddresses());
+            null);
     }
 
     private ImmutableArray<SimpleAction> GetRandomActions()
@@ -180,14 +179,6 @@ public class GeneratedBlockChainFixture
             .Range(0, Random.Next(10))
             .Select(_ => SimpleAction.GetAction(Random.Next()))
             .ToImmutableArray();
-    }
-
-    private IImmutableSet<Address> GetRandomAddresses()
-    {
-        return Enumerable
-            .Range(0, Random.Next(PrivateKeys.Length - 1) + 1)
-            .Select(_ => PrivateKeys[Random.Next(PrivateKeys.Length)].ToAddress())
-            .ToImmutableHashSet();
     }
 
     private void AddBlock(ImmutableArray<Transaction> transactions)

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -12,7 +12,6 @@ using Libplanet.Types.Assets;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
 using Libplanet.Types.Tx;
-using Libplanet.Consensus;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 
@@ -29,15 +28,8 @@ public class GeneratedBlockChainFixture
     public ImmutableDictionary<Address, ImmutableArray<Block>>
         MinedBlocks { get; private set; }
 
-    public ImmutableDictionary<
-            Address,
-            ImmutableArray<Transaction>>
+    public ImmutableDictionary<Address, ImmutableArray<Transaction>>
         SignedTxs { get; private set; }
-
-    public ImmutableDictionary<
-            Address,
-            ImmutableArray<Transaction>>
-        InvolvedTxs { get; private set; }
 
     public GeneratedBlockChainFixture(
         int seed,
@@ -61,14 +53,6 @@ public class GeneratedBlockChainFixture
                     pk.Address,
                     ImmutableArray<Block>.Empty));
         SignedTxs = PrivateKeys.Aggregate(
-            ImmutableDictionary<
-                Address,
-                ImmutableArray<Transaction>>.Empty,
-            (dict, pk) =>
-                dict.SetItem(
-                    pk.Address,
-                    ImmutableArray<Transaction>.Empty));
-        InvolvedTxs = PrivateKeys.Aggregate(
             ImmutableDictionary<
                 Address,
                 ImmutableArray<Transaction>>.Empty,
@@ -160,7 +144,9 @@ public class GeneratedBlockChainFixture
     }
 
     private ImmutableArray<Transaction> GetRandomTransactions(
-        int seed, int maxCount, bool giveMax = false)
+        int seed,
+        int maxCount,
+        bool giveMax = false)
     {
         var random = new System.Random(seed);
         var nonces = ImmutableDictionary<PrivateKey, long>.Empty;
@@ -183,8 +169,7 @@ public class GeneratedBlockChainFixture
             .ToImmutableArray();
     }
 
-    private Transaction
-        GetRandomTransaction(int seed, PrivateKey pk, long nonce)
+    private Transaction GetRandomTransaction(int seed, PrivateKey pk, long nonce)
     {
         var random = new System.Random(seed);
         var addr = pk.Address;
@@ -266,10 +251,5 @@ public class GeneratedBlockChainFixture
                         .Add(tx)
                         .OrderBy(tx => tx.Nonce)
                         .ToImmutableArray()));
-        InvolvedTxs = transactions.Aggregate(
-            InvolvedTxs,
-            (dict, tx) => tx.UpdatedAddresses.Aggregate(
-                dict,
-                (dict, addr) => dict.SetItem(addr, dict[addr].Add(tx))));
     }
 }

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -57,11 +57,11 @@ public class GeneratedBlockChainFixture
             .ToImmutableArray();
         MinedBlocks = PrivateKeys
             .ToImmutableDictionary(
-                key => key.ToAddress(),
+                key => key.Address,
                 key => ImmutableArray<Block>.Empty);
         SignedTxs = PrivateKeys
             .ToImmutableDictionary(
-                key => key.ToAddress(),
+                key => key.Address,
                 key => ImmutableArray<Transaction>.Empty);
 
         var privateKey = new PrivateKey();
@@ -115,10 +115,10 @@ public class GeneratedBlockChainFixture
                 AddBlock(actionsForTransactions
                     .Select(actions =>
                         Transaction.Create(
-                            Chain.GetNextTxNonce(pk.ToAddress()),
-                            pk,
-                            Chain.Genesis.Hash,
-                            actions.ToPlainValues()))
+                            nonce: Chain.GetNextTxNonce(pk.Address),
+                            privateKey: pk,
+                            genesisHash: Chain.Genesis.Hash,
+                            actions: actions.ToPlainValues()))
                     .ToImmutableArray());
             }
         }
@@ -134,7 +134,7 @@ public class GeneratedBlockChainFixture
                 var pk = PrivateKeys[Random.Next(PrivateKeys.Length)];
                 if (!nonces.TryGetValue(pk, out var nonce))
                 {
-                    nonce = Chain.GetNextTxNonce(pk.ToAddress());
+                    nonce = Chain.GetNextTxNonce(pk.Address);
                 }
 
                 nonces = nonces.SetItem(pk, nonce + 1);
@@ -148,14 +148,14 @@ public class GeneratedBlockChainFixture
     private Transaction GetRandomTransaction(PrivateKey pk, long nonce)
     {
         return Transaction.Create(
-            nonce,
-            pk,
-            Chain.Genesis.Hash,
-            Random.Next() % 2 == 0
+            nonce: nonce,
+            privateKey: pk,
+            genesisHash: Chain.Genesis.Hash,
+            actions: Random.Next() % 2 == 0
                 ? GetRandomActions().ToPlainValues()
                 : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues(),
-            null,
-            null);
+            maxGasPrice: null,
+            gasLimit: null);
     }
 
     private ImmutableArray<SimpleAction> GetRandomActions()
@@ -197,8 +197,8 @@ public class GeneratedBlockChainFixture
                         VoteFlag.PreCommit).Sign(pk)).ToImmutableArray()));
         MinedBlocks = MinedBlocks
             .SetItem(
-                proposer.ToAddress(),
-                MinedBlocks[proposer.ToAddress()].Add(block));
+                proposer.Address,
+                MinedBlocks[proposer.Address].Add(block));
         SignedTxs = transactions.Aggregate(
             SignedTxs,
             (dict, tx) =>

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -25,11 +25,15 @@ public class GeneratedBlockChainFixture
 
     public ImmutableArray<PrivateKey> PrivateKeys { get; }
 
+    public int MaxTxCount { get; }
+
     public ImmutableDictionary<Address, ImmutableArray<Block>>
         MinedBlocks { get; private set; }
 
     public ImmutableDictionary<Address, ImmutableArray<Transaction>>
         SignedTxs { get; private set; }
+
+    private Random Random { get; }
 
     public GeneratedBlockChainFixture(
         int seed,
@@ -41,9 +45,11 @@ public class GeneratedBlockChainFixture
         ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>?
             txActionsForSuffixBlocks = null)
     {
-        var random = new System.Random(seed);
+        var store = new MemoryStore();
         var stateStore = new TrieStateStore(new MemoryKeyValueStore());
 
+        Random = new Random(seed);
+        MaxTxCount = maxTxCount;
         PrivateKeys = Enumerable
             .Range(0, privateKeyCount)
             .Select(_ => new PrivateKey())
@@ -62,7 +68,6 @@ public class GeneratedBlockChainFixture
             blockInterval: TimeSpan.FromMilliseconds(1),
             getMaxTransactionsPerBlock: _ => int.MaxValue,
             getMaxTransactionsBytes: _ => long.MaxValue);
-        IStore store = new MemoryStore();
         var actionEvaluator = new ActionEvaluator(
             _ => policy.BlockAction,
             stateStore,
@@ -92,7 +97,6 @@ public class GeneratedBlockChainFixture
             stateStore,
             genesisBlock,
             actionEvaluator);
-
         MinedBlocks = MinedBlocks.SetItem(
             Chain.Genesis.Miner,
             ImmutableArray<Block>.Empty.Add(Chain.Genesis));
@@ -101,9 +105,8 @@ public class GeneratedBlockChainFixture
         {
             foreach (var actionsForTransactions in txActionsForPrefixBlocksVal)
             {
-                var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+                var pk = PrivateKeys[Random.Next(PrivateKeys.Length)];
                 AddBlock(
-                    random.Next(),
                     actionsForTransactions.Select(actions =>
                             Transaction.Create(
                                 Chain.GetNextTxNonce(pk.Address),
@@ -116,41 +119,34 @@ public class GeneratedBlockChainFixture
 
         while (Chain.Count < blockCount + (txActionsForPrefixBlocks?.Length ?? 0) + 1)
         {
-            AddBlock(
-                random.Next(),
-                GetRandomTransactions(random.Next(), maxTxCount, Chain.Count == 1));
+            AddBlock(GetRandomTransactions());
         }
 
         if (txActionsForSuffixBlocks is { } txActionsForSuffixBlocksVal)
         {
             foreach (var actionsForTransactions in txActionsForSuffixBlocksVal)
             {
-                var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
-                AddBlock(
-                    random.Next(),
-                    actionsForTransactions.Select(actions =>
-                            Transaction.Create(
-                                Chain.GetNextTxNonce(pk.Address),
-                                pk,
-                                Chain.Genesis.Hash,
-                                actions.ToPlainValues()))
-                        .ToImmutableArray());
+                var pk = PrivateKeys[Random.Next(PrivateKeys.Length)];
+                AddBlock(actionsForTransactions
+                    .Select(actions =>
+                        Transaction.Create(
+                            Chain.GetNextTxNonce(pk.ToAddress()),
+                            pk,
+                            Chain.Genesis.Hash,
+                            actions.ToPlainValues()))
+                    .ToImmutableArray());
             }
         }
     }
 
-    private ImmutableArray<Transaction> GetRandomTransactions(
-        int seed,
-        int maxCount,
-        bool giveMax = false)
+    private ImmutableArray<Transaction> GetRandomTransactions()
     {
-        var random = new System.Random(seed);
         var nonces = ImmutableDictionary<PrivateKey, long>.Empty;
         return Enumerable
-            .Range(0, giveMax ? maxCount : random.Next(maxCount))
+            .Range(0, Random.Next(MaxTxCount))
             .Select(_ =>
             {
-                var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+                var pk = PrivateKeys[Random.Next(PrivateKeys.Length)];
                 if (!nonces.TryGetValue(pk, out var nonce))
                 {
                     nonce = Chain.GetNextTxNonce(pk.ToAddress());
@@ -158,68 +154,56 @@ public class GeneratedBlockChainFixture
 
                 nonces = nonces.SetItem(pk, nonce + 1);
 
-                return GetRandomTransaction(random.Next(), pk, nonce);
+                return GetRandomTransaction(pk, nonce);
             })
             .OrderBy(tx => tx.Id)
             .ToImmutableArray();
     }
 
-    private Transaction GetRandomTransaction(int seed, PrivateKey pk, long nonce)
+    private Transaction GetRandomTransaction(PrivateKey pk, long nonce)
     {
-        var random = new System.Random(seed);
-        var addr = pk.Address;
-        var bal = (int)(Chain.GetBalance(addr, TestCurrency).MajorUnit & int.MaxValue);
-        return
-        new Transaction(
-            new UnsignedTx(
-                new TxInvoice(
-                    genesisHash: Chain.Genesis.Hash,
-                    updatedAddresses: GetRandomAddresses(random.Next()),
-                    timestamp: DateTimeOffset.UtcNow,
-                    actions: new TxActionList(random.Next() % 2 == 0
-                        ? GetRandomActions(random.Next()).ToPlainValues()
-                        : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues()),
-                    maxGasPrice: null,
-                    gasLimit: null),
-                new TxSigningMetadata(pk.PublicKey, nonce)),
-            pk);
+        return Transaction.Create(
+            nonce,
+            pk,
+            Chain.Genesis.Hash,
+            Random.Next() % 2 == 0
+                ? GetRandomActions().ToPlainValues()
+                : ImmutableHashSet<SimpleAction>.Empty.ToPlainValues(),
+            null,
+            null,
+            GetRandomAddresses());
     }
 
-    private ImmutableArray<SimpleAction> GetRandomActions(int seed)
+    private ImmutableArray<SimpleAction> GetRandomActions()
     {
-        var random = new System.Random(seed);
         return Enumerable
-            .Range(0, random.Next(10))
-            .Select(_ => SimpleAction.GetAction(random.Next()))
+            .Range(0, Random.Next(10))
+            .Select(_ => SimpleAction.GetAction(Random.Next()))
             .ToImmutableArray();
     }
 
-    private IImmutableSet<Address> GetRandomAddresses(int seed)
+    private IImmutableSet<Address> GetRandomAddresses()
     {
-        var random = new System.Random(seed);
         return Enumerable
-            .Range(0, random.Next(PrivateKeys.Length - 1) + 1)
-            .Select(_ => PrivateKeys[random.Next(PrivateKeys.Length)].ToAddress())
+            .Range(0, Random.Next(PrivateKeys.Length - 1) + 1)
+            .Select(_ => PrivateKeys[Random.Next(PrivateKeys.Length)].ToAddress())
             .ToImmutableHashSet();
     }
 
-    private void AddBlock(
-        int seed,
-        ImmutableArray<Transaction> transactions)
+    private void AddBlock(ImmutableArray<Transaction> transactions)
     {
-        var random = new System.Random(seed);
-        var pk = PrivateKeys[random.Next(PrivateKeys.Length)];
+        var proposer = PrivateKeys[Random.Next(PrivateKeys.Length)];
         var block = Chain.EvaluateAndSign(
             new BlockContent(
                 new BlockMetadata(
                     Chain.Tip.Index + 1,
                     DateTimeOffset.UtcNow,
-                    pk.PublicKey,
+                    proposer.PublicKey,
                     Chain.Tip.Hash,
                     BlockContent.DeriveTxHash(transactions),
                     Chain.Store.GetChainBlockCommit(Chain.Store.GetCanonicalChainId()!.Value)),
                 transactions).Propose(),
-            pk);
+            proposer);
         Chain.Append(
             block,
             new BlockCommit(
@@ -235,8 +219,10 @@ public class GeneratedBlockChainFixture
                         DateTimeOffset.UtcNow,
                         pk.PublicKey,
                         VoteFlag.PreCommit).Sign(pk)).ToImmutableArray()));
-        MinedBlocks =
-            MinedBlocks.SetItem(pk.Address, MinedBlocks[pk.Address].Add(block));
+        MinedBlocks = MinedBlocks
+            .SetItem(
+                proposer.ToAddress(),
+                MinedBlocks[proposer.ToAddress()].Add(block));
         SignedTxs = transactions.Aggregate(
             SignedTxs,
             (dict, tx) =>

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -41,10 +41,11 @@ public class GeneratedBlockChainFixture
         int maxTxCount = 20,
         int privateKeyCount = 10,
         ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>?
-            txActionsForPrefixBlocks = null,
-        ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>?
             txActionsForSuffixBlocks = null)
     {
+        txActionsForSuffixBlocks ??=
+            ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>.Empty;
+
         var store = new MemoryStore();
         var stateStore = new TrieStateStore(new MemoryKeyValueStore());
 
@@ -101,23 +102,7 @@ public class GeneratedBlockChainFixture
             Chain.Genesis.Miner,
             ImmutableArray<Block>.Empty.Add(Chain.Genesis));
 
-        if (txActionsForPrefixBlocks is { } txActionsForPrefixBlocksVal)
-        {
-            foreach (var actionsForTransactions in txActionsForPrefixBlocksVal)
-            {
-                var pk = PrivateKeys[Random.Next(PrivateKeys.Length)];
-                AddBlock(
-                    actionsForTransactions.Select(actions =>
-                            Transaction.Create(
-                                Chain.GetNextTxNonce(pk.Address),
-                                pk,
-                                Chain.Genesis.Hash,
-                                actions.ToPlainValues()))
-                        .ToImmutableArray());
-            }
-        }
-
-        while (Chain.Count < blockCount + (txActionsForPrefixBlocks?.Length ?? 0) + 1)
+        while (Chain.Count < blockCount)
         {
             AddBlock(GetRandomTransactions());
         }

--- a/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/TxResultTypeTest.cs
@@ -55,9 +55,9 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                         ["txStatus"] = "SUCCESS",
                         ["blockIndex"] = 0L,
                         ["blockHash"] = "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
-                        ["inputState"] = 
+                        ["inputState"] =
                             "7146ddfb3594089795f6992a668a3ce7fde089aacdda68075e1bc37b14ebb06f",
-                        ["outputState"] = 
+                        ["outputState"] =
                             "72bb2e17da644cbca9045f5e689fae0323b6af56a0acab9fd828d2243b50df1c",
                         ["exceptionNames"] = new string[] { "" },
                     }
@@ -71,16 +71,34 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                             "7146ddfb3594089795f6992a668a3ce7fde089aacdda68075e1bc37b14ebb06f"),
                         HashDigest<SHA256>.FromString(
                             "7146ddfb3594089795f6992a668a3ce7fde089aacdda68075e1bc37b14ebb06f"),
-                        new List<string>() { "" }
+                        new List<string>() { "SomeException" }
                     ),
                     new Dictionary<string, object> {
                         ["txStatus"] = "FAILURE",
                         ["blockIndex"] = 0L,
-                        ["inputState"] = 
+                        ["inputState"] =
                             "7146ddfb3594089795f6992a668a3ce7fde089aacdda68075e1bc37b14ebb06f",
-                        ["outputState"] = 
+                        ["outputState"] =
                             "7146ddfb3594089795f6992a668a3ce7fde089aacdda68075e1bc37b14ebb06f",
                         ["blockHash"] = "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        ["exceptionNames"] = new string[] { "SomeException" },
+                    }
+                },
+                new object[] {
+                    new TxResult(
+                        TxStatus.INCLUDED,
+                        0,
+                        "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        null,
+                        null,
+                        new List<string>() { "" }
+                    ),
+                    new Dictionary<string, object> {
+                        ["txStatus"] = "INCLUDED",
+                        ["blockIndex"] = 0L,
+                        ["blockHash"] = "45bcaa4c0b00f4f31eb61577e595ea58fb69c7df3ee612aa6eea945bbb0ce39d",
+                        ["inputState"] = null,
+                        ["outputState"] = null,
                         ["exceptionNames"] = new string[] { "" },
                     }
                 },

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
@@ -30,10 +30,13 @@ public class TransactionQueryGeneratedTest
             ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>.Empty
                 .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
                     .Add(ImmutableArray<SimpleAction>.Empty
+                        .Add(new SimpleAction0())
                         .Add(new SimpleAction0())))     // Successful action transaction
                 .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
                     .Add(ImmutableArray<SimpleAction>.Empty
-                        .Add(new SimpleAction0Fail()))) // Failed action transaction
+                        .Add(new SimpleAction0())
+                        .Add(new SimpleAction0Fail())
+                        .Add(new SimpleAction0()))) // Failed action transaction
                 .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
                     .Add(ImmutableArray<SimpleAction>.Empty))); // Empty action transaction
         Source = new MockBlockChainContext(Fx.Chain);
@@ -62,18 +65,19 @@ public class TransactionQueryGeneratedTest
         Assert.Equal("SUCCESS", queryResult.TxStatus);
         Assert.Equal(successBlock.Index, queryResult.BlockIndex);
         Assert.Equal(successBlock.Hash.ToString(), queryResult.BlockHash);
-        Assert.Equal(new string?[] { null }, queryResult.ExceptionNames);
+        Assert.Equal(new string?[] { null , null }, queryResult.ExceptionNames);
         queryResult = await ExecuteTransactionResultQueryAsync(failTx.Id);
         Assert.Equal("FAILURE", queryResult.TxStatus);
         Assert.Equal(failBlock.Index, queryResult.BlockIndex);
         Assert.Equal(failBlock.Hash.ToString(), queryResult.BlockHash);
         Assert.Equal(
-            new string[] { "Libplanet.Action.State.CurrencyPermissionException" },
+            new string?[] { null, "Libplanet.Action.State.CurrencyPermissionException", null },
             queryResult.ExceptionNames);
         queryResult = await ExecuteTransactionResultQueryAsync(emptyTx.Id);
         Assert.Equal("INCLUDED", queryResult.TxStatus);
         Assert.Equal(emptyBlock.Index, queryResult.BlockIndex);
         Assert.Equal(emptyBlock.Hash.ToString(), queryResult.BlockHash);
+        Assert.Null(queryResult.ExceptionNames);
         queryResult = await ExecuteTransactionResultQueryAsync(new TxId());
         Assert.Equal("INVALID", queryResult.TxStatus);
         Assert.Null(queryResult.BlockIndex);

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
@@ -27,18 +27,15 @@ public class TransactionQueryGeneratedTest
         Fx = new GeneratedBlockChainFixture(
             new System.Random().Next(),
             txActionsForSuffixBlocks:
-            ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>
-                .Empty
-                .Add(ImmutableArray<ImmutableArray<SimpleAction>>
-                    .Empty
-                    .Add(ImmutableArray<SimpleAction>
-                        .Empty
-                        .Add(new SimpleAction0())))
-                .Add(ImmutableArray<ImmutableArray<SimpleAction>>
-                    .Empty
-                    .Add(ImmutableArray<SimpleAction>
-                        .Empty
-                        .Add(new SimpleAction0Fail()))));
+            ImmutableArray<ImmutableArray<ImmutableArray<SimpleAction>>>.Empty
+                .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
+                    .Add(ImmutableArray<SimpleAction>.Empty
+                        .Add(new SimpleAction0())))     // Successful action transaction
+                .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
+                    .Add(ImmutableArray<SimpleAction>.Empty
+                        .Add(new SimpleAction0Fail()))) // Failed action transaction
+                .Add(ImmutableArray<ImmutableArray<SimpleAction>>.Empty
+                    .Add(ImmutableArray<SimpleAction>.Empty))); // Empty action transaction
         Source = new MockBlockChainContext(Fx.Chain);
         var _ = new ExplorerQuery(Source);
         QueryGraph = new TransactionQuery(Source);
@@ -47,11 +44,12 @@ public class TransactionQueryGeneratedTest
     [Fact]
     public async Task TransactionResult()
     {
-        var failBlock = Fx.Chain.Tip;
-        var failTx = failBlock.Transactions.First();
-        var successBlock =
-            Fx.Chain.Store.GetBlock(failBlock.PreviousHash!.Value);
-        var successTx = successBlock.Transactions.First();
+        var emptyBlock = Fx.Chain.Tip;
+        var emptyTx = emptyBlock.Transactions[0];
+        var failBlock = Fx.Chain.Store.GetBlock(emptyBlock.PreviousHash!.Value);
+        var failTx = failBlock.Transactions[0];
+        var successBlock = Fx.Chain.Store.GetBlock(failBlock.PreviousHash!.Value);
+        var successTx = successBlock.Transactions[0];
         var pk = Fx.PrivateKeys[0];
         var stagingTx = Transaction.Create(
             Fx.Chain.GetNextTxNonce(pk.Address),
@@ -72,6 +70,10 @@ public class TransactionQueryGeneratedTest
         Assert.Equal(
             new string[] { "Libplanet.Action.State.CurrencyPermissionException" },
             queryResult.ExceptionNames);
+        queryResult = await ExecuteTransactionResultQueryAsync(emptyTx.Id);
+        Assert.Equal("INCLUDED", queryResult.TxStatus);
+        Assert.Equal(emptyBlock.Index, queryResult.BlockIndex);
+        Assert.Equal(emptyBlock.Hash.ToString(), queryResult.BlockHash);
         queryResult = await ExecuteTransactionResultQueryAsync(new TxId());
         Assert.Equal("INVALID", queryResult.TxStatus);
         Assert.Null(queryResult.BlockIndex);

--- a/Libplanet.Explorer/GraphTypes/TxStatusType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxStatusType.cs
@@ -1,4 +1,7 @@
 using GraphQL.Types;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Types.Tx;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -10,19 +13,46 @@ namespace Libplanet.Explorer.GraphTypes
         INVALID,
 
         /// <summary>
-        /// The Transaction do not executed yet.
+        /// The Transaction is currently staged.
         /// </summary>
         STAGING,
 
         /// <summary>
-        /// The Transaction is success.
+        /// The <see cref="Transaction"/> was successfully executed.
+        /// Specifically, this means that there is a record of the execution of
+        /// said <see cref="Transaction"/> that can be found that indicates its execution
+        /// was success.  In particular, for this to be the case, the <see cref="Transaction"/>
+        /// must have included one or more <see cref="IAction"/>s and the execution of
+        /// every <see cref="IAction"/> was successful.
         /// </summary>
         SUCCESS,
 
         /// <summary>
-        /// The Transaction is failure.
+        /// The <see cref="Transaction"/> failed to execute without an error.
+        /// Specifically, this means that there is a record of the execution of
+        /// said <see cref="Transaction"/> that can be found that indicates its execution
+        /// was a failure.  In particular, for this to be the case, the <see cref="Transaction"/>
+        /// must have included one or more <see cref="IAction"/>s and an execution of
+        /// of at least one <see cref="IAction"/> was a failure.
         /// </summary>
         FAILURE,
+
+        /// <summary>
+        /// The <see cref="Transaction"/> is found in the <see cref="BlockChain"/> but its
+        /// execution result cannot be determined.  This can happen due to one of
+        /// the two following reaons:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         The <see cref="Transaction"/> is an empty <see cref="Transaction"/>
+        ///         that does not contain any <see cref="IAction"/>s.
+        ///     </description></item>
+        ///     <item><description>
+        ///         The execution record of <see cref="Transaction"/> is simply missing for
+        ///         some other reason.
+        ///     </description></item>
+        /// </list>
+        /// </summary>
+        INCLUDED,
     }
 
     public class TxStatusType : EnumerationGraphType<TxStatus>

--- a/Libplanet.Explorer/GraphTypes/TxStatusType.cs
+++ b/Libplanet.Explorer/GraphTypes/TxStatusType.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Explorer.GraphTypes
         /// <summary>
         /// The <see cref="Transaction"/> is found in the <see cref="BlockChain"/> but its
         /// execution result cannot be determined.  This can happen due to one of
-        /// the two following reaons:
+        /// the two following reasons:
         /// <list type="bullet">
         ///     <item><description>
         ///         The <see cref="Transaction"/> is an empty <see cref="Transaction"/>

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -223,25 +223,27 @@ namespace Libplanet.Explorer.Queries
                     var blockChain = _context.BlockChain;
                     var store = _context.Store;
                     var index = _context.Index;
-                    var txId = new TxId(
-                        ByteUtil.ParseHex(context.GetArgument<string>("txId"))
-                    );
-                    BlockHash? txExecutedBlockHash = null;
-                    if (
-                        index is not null
-                        && index.TryGetContainedBlockHashById(txId, out var hash))
-                    {
-                        txExecutedBlockHash = hash;
-                    }
-                    else if (
-                        index is null
-                        && store.GetFirstTxIdBlockHashIndex(txId)
-                            is { } txExecutedBlockHashFromStore)
-                    {
-                        txExecutedBlockHash = txExecutedBlockHashFromStore;
-                    }
+                    var txId = new TxId(ByteUtil.ParseHex(context.GetArgument<string>("txId")));
 
-                    if (txExecutedBlockHash is not { } txExecutedBlockHashValue)
+                    if (GetBlockContainingTx(_context, txId) is { } block)
+                    {
+                        return _context.BlockChain.GetTxExecution(block.Hash, txId) is { } execution
+                            ? new TxResult(
+                                execution.Fail ? TxStatus.FAILURE : TxStatus.SUCCESS,
+                                block.Index,
+                                block.Hash.ToString(),
+                                execution.InputState,
+                                execution.OutputState,
+                                execution.ExceptionNames)
+                            : new TxResult(
+                                TxStatus.INCLUDED,
+                                block.Index,
+                                block.Hash.ToString(),
+                                null,
+                                null,
+                                null);
+                    }
+                    else
                     {
                         return blockChain.GetStagedTransactionIds().Contains(txId)
                             ? new TxResult(
@@ -259,37 +261,43 @@ namespace Libplanet.Explorer.Queries
                                 null,
                                 null);
                     }
-
-                    try
-                    {
-                        var execution = blockChain.GetTxExecution(
-                            txExecutedBlockHashValue,
-                            txId
-                        );
-                        var txExecutedBlock = blockChain[txExecutedBlockHashValue];
-
-                        return new TxResult(
-                            execution.Fail ? TxStatus.FAILURE : TxStatus.SUCCESS,
-                            txExecutedBlock.Index,
-                            txExecutedBlock.Hash.ToString(),
-                            execution.InputState,
-                            execution.OutputState,
-                            execution.ExceptionNames);
-                    }
-                    catch (Exception)
-                    {
-                        return new TxResult(
-                            TxStatus.INVALID,
-                            null,
-                            null,
-                            null,
-                            null,
-                            null);
-                    }
                 }
             );
 
             Name = "TransactionQuery";
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Block"/> from the context <see cref="BlockChain"/> containing
+        /// given <paramref name="txId"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="IBlockChainContext"/> to use as context.</param>
+        /// <param name="txId">The target <see cref="TxId"/> that a <see cref="Block"/>
+        /// must contain.</param>
+        /// <returns>The <see cref="Block"/> containing <paramref name="txId"/> if found,
+        /// otherwise <see langword="null"/>.</returns>
+        private static Block GetBlockContainingTx(IBlockChainContext context, TxId txId)
+        {
+            if (context.Index is { } index)
+            {
+                if (index.TryGetContainedBlockHashById(txId, out var blockHash))
+                {
+                    return context.BlockChain[blockHash];
+                }
+            }
+            else
+            {
+                var blockHashCandidates = context.Store.IterateTxIdBlockHashIndex(txId);
+                foreach (var blockHashCandidate in blockHashCandidates)
+                {
+                    if (context.BlockChain.ContainsBlock(blockHashCandidate))
+                    {
+                        return context.BlockChain[blockHashCandidate];
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Since `Libplanet.Explorer` is half broken, this doesn't work properly on 9c-mainnet. Appropriate changes should be made in `TransactionHeadlessQuery` on the [9c-headless](https://github.com/planetarium/NineChronicles.Headless) side to utilize this feature. 🙄