### PR TITLE
Expose `txPriority` parameter for customized transaction selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,12 @@ To be released.
         for `StateQuery.validators` field.
      -  Added `accountStateRootHash` of type `HashDigest<SHA256>?` argument
         for `StateQuery.validators` field.
+ -  (Libplanet.Net) Added `txPriority` parameter to `ConsensusContext`
+    constructor.  [[#3546]]
+ -  (Libplanet.Net) Added `txPriority` parameter to `Context` constructor.
+    [[#3546]]
+ -  (Libplanet.Net) Added `TxPriority` property to `ConsensusReactorOption`
+    class.  [[#3546]]
 
 ### Behavioral changes
 
@@ -118,6 +124,7 @@ To be released.
 [#3512]: https://github.com/planetarium/libplanet/pull/3512
 [#3524]: https://github.com/planetarium/libplanet/pull/3524
 [#3540]: https://github.com/planetarium/libplanet/pull/3540
+[#3546]: https://github.com/planetarium/libplanet/pull/3546
 
 
 Version 3.9.0

--- a/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -10,6 +10,7 @@ using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
+using Libplanet.Types.Tx;
 using Serilog;
 
 namespace Libplanet.Net.Consensus
@@ -25,6 +26,7 @@ namespace Libplanet.Net.Consensus
         private readonly BlockChain _blockChain;
         private readonly ILogger _logger;
 
+#pragma warning disable MEN002
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsensusReactor"/> class.
         /// </summary>
@@ -45,6 +47,11 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="contextTimeoutOption">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="ConsensusStep"/>.</param>
+        /// <param name="txPriority">An optional comparer for give certain transactions to
+        /// priority to belong to the block.  It will be passed as
+        /// <see cref="Consensus.ConsensusContext(IConsensusMessageCommunicator,BlockChain,PrivateKey,TimeSpan,ContextTimeoutOption,IComparer{Transaction})"/>
+        /// 's parameter.</param>
+#pragma warning restore MEN002
         public ConsensusReactor(
             ITransport consensusTransport,
             BlockChain blockChain,
@@ -52,7 +59,8 @@ namespace Libplanet.Net.Consensus
             ImmutableList<BoundPeer> validatorPeers,
             ImmutableList<BoundPeer> seedPeers,
             TimeSpan newHeightDelay,
-            ContextTimeoutOption contextTimeoutOption)
+            ContextTimeoutOption contextTimeoutOption,
+            IComparer<Transaction>? txPriority = null)
         {
             validatorPeers ??= ImmutableList<BoundPeer>.Empty;
             seedPeers ??= ImmutableList<BoundPeer>.Empty;
@@ -71,7 +79,8 @@ namespace Libplanet.Net.Consensus
                 blockChain,
                 privateKey,
                 newHeightDelay,
-                contextTimeoutOption);
+                contextTimeoutOption,
+                txPriority);
 
             _logger = Log
                 .ForContext("Tag", "Consensus")

--- a/Libplanet.Net/Consensus/ConsensusReactorOption.cs
+++ b/Libplanet.Net/Consensus/ConsensusReactorOption.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using Libplanet.Blockchain;
 using Libplanet.Crypto;
 using Libplanet.Net.Messages;
 using Libplanet.Net.Transports;
+using Libplanet.Types.Tx;
 
 namespace Libplanet.Net.Consensus
 {
@@ -45,5 +48,11 @@ namespace Libplanet.Net.Consensus
         /// A timeout second and multiplier value for used in <see cref="Context"/>.
         /// </summary>
         public ContextTimeoutOption ContextTimeoutOptions { get; set; }
+
+        /// <summary>
+        /// An optional comparer for give certain transactions to priority to belong to the block.
+        /// </summary>
+        /// <seealso cref="BlockChain.GatherTransactionsToPropose(long,IComparer{Transaction})"/>
+        public IComparer<Transaction>? TxPriorityComparer { get; set; }
     }
 }

--- a/Libplanet.Net/Swarm.cs
+++ b/Libplanet.Net/Swarm.cs
@@ -117,7 +117,8 @@ namespace Libplanet.Net
                     consensusReactorOption.ConsensusPeers,
                     consensusReactorOption.SeedPeers,
                     consensusReactorOption.TargetBlockInterval,
-                    consensusReactorOption.ContextTimeoutOptions);
+                    consensusReactorOption.ContextTimeoutOptions,
+                    consensusReactorOption.TxPriorityComparer);
             }
         }
 


### PR DESCRIPTION
- Added `txPriority` as an argument in the public constructor API.
- This allows external callers to specify the priority for including transactions in the block to propose.

-----

(DX Team Jira issue card PDX-231)