### PR TITLE
♻️ Additional error logging for better debugging

### DIFF
--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -120,6 +120,18 @@ namespace Libplanet.Action
 
                 return ToCommittedEvaluation(block, evaluations, baseStateRootHash);
             }
+            catch (Exception e)
+            {
+                const string errorMessage =
+                    "Failed to evaluate block #{BlockIndex} pre-evaluation hash " +
+                    "pre-evaluation has {PreEvaluationHash}";
+                _logger.Error(
+                    e,
+                    errorMessage,
+                    block.Index,
+                    ByteUtil.Hex(block.PreEvaluationHash.ByteArray));
+                throw;
+            }
             finally
             {
                 _logger


### PR DESCRIPTION
♻️ It turns out there are cases where `ActionEvaluator` fails to evaluate a `IPreEvaluationBlock` but no logging occurs. 😥