### PR TITLE
♻️ Removed updated addresses from `IRichStore`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,10 +15,15 @@ To be released.
     now one can choose its representation format.  [[#3560]]
  -  (Libplanet.Explorer) Added `HelperQuery`, a collection of utility like
     queries.  [[#3561]]
+ -  (Libplanet.Explorer) Removed `IRichStore.StoreUpdatedAddressReferences()`
+    and `IterateUpdatedAddressReferences()` interface methods.  [[#3562]]
+ -  (Libplanet.Explorer) Removed `involvedAddress` argument from all
+    `TransactionQuery` query methods.  [[#3562]]
 
 [#3559]: https://github.com/planetarium/libplanet/pull/3559
 [#3560]: https://github.com/planetarium/libplanet/pull/3560
 [#3561]: https://github.com/planetarium/libplanet/pull/3561
+[#3562]: https://github.com/planetarium/libplanet/pull/3562
 
 
 Version 3.9.2

--- a/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/TransactionQueryGeneratedTest.cs
@@ -112,100 +112,88 @@ public class TransactionQueryGeneratedTest
         Address? involvedAddress)
     {
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, false, null, null);
+            blocksToTest, signer, false, null, null);
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, true, null, null);
+            blocksToTest, signer, true, null, null);
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, false, blocksToTest.Length / 4, null);
+            blocksToTest, signer, false, blocksToTest.Length / 4, null);
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             false,
             blocksToTest.Length / 4 - blocksToTest.Length,
             null);
         Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
             await ExecuteTransactionsQueryAsync(
-                signer, involvedAddress, false, blocksToTest.Length / 4, null),
+                signer, false, blocksToTest.Length / 4, null),
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 false,
                 blocksToTest.Length / 4 - blocksToTest.Length,
                 null));
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, true, blocksToTest.Length / 4, null);
+            blocksToTest, signer, true, blocksToTest.Length / 4, null);
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             true,
             blocksToTest.Length / 4 - blocksToTest.Length,
             null);
         Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
             await ExecuteTransactionsQueryAsync(
-                signer, involvedAddress, true, blocksToTest.Length / 4, null),
+                signer, true, blocksToTest.Length / 4, null),
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 true,
                 blocksToTest.Length / 4 - blocksToTest.Length,
                 null));
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, false, null, blocksToTest.Length / 4);
+            blocksToTest, signer, false, null, blocksToTest.Length / 4);
         await AssertAgainstTransactionsQuery(
-            blocksToTest, signer, involvedAddress, true, null, blocksToTest.Length / 4);
+            blocksToTest, signer, true, null, blocksToTest.Length / 4);
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             false,
             blocksToTest.Length / 3,
             blocksToTest.Length / 4);
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             false,
             blocksToTest.Length / 3 - blocksToTest.Length,
             blocksToTest.Length / 4);
         Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 false,
                 blocksToTest.Length / 3,
                 blocksToTest.Length / 4),
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 false,
                 blocksToTest.Length / 3 - blocksToTest.Length,
                 blocksToTest.Length / 4));
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             true,
             blocksToTest.Length / 3,
             blocksToTest.Length / 4);
         await AssertAgainstTransactionsQuery(
             blocksToTest,
             signer,
-            involvedAddress,
             true,
             blocksToTest.Length / 3 - blocksToTest.Length,
             blocksToTest.Length / 4);
         Assert.Equal<IEnumerable<(string Id, string? BlockHash)>>(
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 true,
                 blocksToTest.Length / 3,
                 blocksToTest.Length / 4),
             await ExecuteTransactionsQueryAsync(
                 signer,
-                involvedAddress,
                 true,
                 blocksToTest.Length / 3 - blocksToTest.Length,
                 blocksToTest.Length / 4));
@@ -214,7 +202,6 @@ public class TransactionQueryGeneratedTest
     private async Task AssertAgainstTransactionsQuery(
         IReadOnlyList<Block> blocksToTest,
         Address? signer,
-        Address? involvedAddress,
         bool desc,
         int? offset,
         int? limit)
@@ -237,10 +224,6 @@ public class TransactionQueryGeneratedTest
         {
             txs = txs.Where(tx => tx.Signer.Equals(signerVal));
         }
-        else if (involvedAddress is { } involvedAddressVal)
-        {
-            txs = txs.Where(tx => tx.UpdatedAddresses.Contains(involvedAddressVal));
-        }
 
         if (limit is { } limitVal)
         {
@@ -249,7 +232,7 @@ public class TransactionQueryGeneratedTest
 
         var expected = txs.ToImmutableArray();
         var actual =
-            await ExecuteTransactionsQueryAsync(signer, involvedAddress, desc, offset, limit);
+            await ExecuteTransactionsQueryAsync(signer, desc, offset, limit);
 
         foreach (var i in Enumerable.Range(0, actual.Length))
         {
@@ -269,7 +252,6 @@ public class TransactionQueryGeneratedTest
     private async Task<ImmutableArray<(string Id, string? BlockHash)>>
         ExecuteTransactionsQueryAsync(
             Address? signer,
-            Address? involvedAddress,
             bool desc,
             int? offset,
             int? limit)
@@ -278,7 +260,6 @@ public class TransactionQueryGeneratedTest
         {{
             transactions(
                 {(signer is { } signerVal ? @$"signer: ""{signerVal}""" : "")}
-                {(involvedAddress is { } invVal ? @$"involvedAddress: ""{invVal}""" : "")}
                 desc: {(desc ? "true" : "false")}
                 offset: {offset?.ToString(CultureInfo.InvariantCulture) ?? "0"}
                 {(limit is { } limitVal ? $"limit: {limitVal}" : "")}

--- a/Libplanet.Explorer/Queries/ExplorerQuery.cs
+++ b/Libplanet.Explorer/Queries/ExplorerQuery.cs
@@ -97,7 +97,7 @@ namespace Libplanet.Explorer.Queries
         }
 
         internal static IEnumerable<Transaction> ListTransactions(
-            Address? signer, Address? involved, bool desc, long offset, int? limit)
+            Address? signer, bool desc, long offset, int? limit)
         {
             Block tip = Chain.Tip;
             long tipIndex = tip.Index;
@@ -143,7 +143,7 @@ namespace Libplanet.Explorer.Queries
             {
                 foreach (var tx in desc ? block.Transactions.Reverse() : block.Transactions)
                 {
-                    if (IsValidTransaction(tx, signer, involved))
+                    if (IsValidTransaction(tx, signer))
                     {
                         yield return tx;
                         limit--;
@@ -159,7 +159,7 @@ namespace Libplanet.Explorer.Queries
         }
 
         internal static IEnumerable<Transaction> ListStagedTransactions(
-            Address? signer, Address? involved, bool desc, int offset, int? limit)
+            Address? signer, bool desc, int offset, int? limit)
         {
             if (offset < 0)
             {
@@ -169,7 +169,7 @@ namespace Libplanet.Explorer.Queries
             }
 
             var stagedTxs = Chain.StagePolicy.Iterate(Chain)
-                .Where(tx => IsValidTransaction(tx, signer, involved))
+                .Where(tx => IsValidTransaction(tx, signer))
                 .Skip(offset);
 
             stagedTxs = desc ? stagedTxs.OrderByDescending(tx => tx.Timestamp)
@@ -202,17 +202,11 @@ namespace Libplanet.Explorer.Queries
 
         private static bool IsValidTransaction(
             Transaction tx,
-            Address? signer,
-            Address? involved)
+            Address? signer)
         {
             if (signer is { } signerVal)
             {
                 return tx.Signer.Equals(signerVal);
-            }
-
-            if (involved is { } involvedVal)
-            {
-                return tx.UpdatedAddresses.Contains(involvedVal);
             }
 
             return true;

--- a/Libplanet.Explorer/Queries/ExplorerQuery.cs
+++ b/Libplanet.Explorer/Queries/ExplorerQuery.cs
@@ -121,12 +121,6 @@ namespace Libplanet.Explorer.Queries
                         .IterateSignerReferences(
                             (Address)signer, desc, (int)offset, limit ?? int.MaxValue);
                 }
-                else if (!(involved is null))
-                {
-                    txIds = richStore
-                        .IterateUpdatedAddressReferences(
-                            (Address)involved, desc, (int)offset, limit ?? int.MaxValue);
-                }
                 else
                 {
                     txIds = richStore

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -36,11 +36,6 @@ namespace Libplanet.Explorer.Queries
                         Name = "signer",
                         DefaultValue = null,
                     },
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "involvedAddress",
-                        DefaultValue = null,
-                    },
                     new QueryArgument<BooleanGraphType>
                     {
                         Name = "desc",
@@ -56,12 +51,11 @@ namespace Libplanet.Explorer.Queries
                 resolve: context =>
                 {
                     var signer = context.GetArgument<Address?>("signer");
-                    var involved = context.GetArgument<Address?>("involvedAddress");
                     bool desc = context.GetArgument<bool>("desc");
                     long offset = context.GetArgument<long>("offset");
                     int? limit = context.GetArgument<int?>("limit");
 
-                    return ExplorerQuery.ListTransactions(signer, involved, desc, offset, limit);
+                    return ExplorerQuery.ListTransactions(signer, desc, offset, limit);
                 }
             );
 
@@ -73,11 +67,6 @@ namespace Libplanet.Explorer.Queries
                         Name = "signer",
                         DefaultValue = null,
                     },
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "involvedAddress",
-                        DefaultValue = null,
-                    },
                     new QueryArgument<BooleanGraphType>
                     {
                         Name = "desc",
@@ -93,14 +82,12 @@ namespace Libplanet.Explorer.Queries
                 resolve: context =>
                 {
                     var signer = context.GetArgument<Address?>("signer");
-                    var involved = context.GetArgument<Address?>("involvedAddress");
                     bool desc = context.GetArgument<bool>("desc");
                     int offset = context.GetArgument<int>("offset");
                     int? limit = context.GetArgument<int?>("limit", null);
 
                     return ExplorerQuery.ListStagedTransactions(
                         signer,
-                        involved,
                         desc,
                         offset,
                         limit

--- a/Libplanet.Explorer/Store/IRichStore.cs
+++ b/Libplanet.Explorer/Store/IRichStore.cs
@@ -24,16 +24,5 @@ namespace Libplanet.Explorer.Store
             bool desc,
             int offset = 0,
             int limit = int.MaxValue);
-
-        void StoreUpdatedAddressReferences(
-            TxId txId,
-            long txNonce,
-            Address updatedAddress);
-
-        IEnumerable<TxId> IterateUpdatedAddressReferences(
-            Address updatedAddress,
-            bool desc,
-            int offset = 0,
-            int limit = int.MaxValue);
     }
 }


### PR DESCRIPTION
`UpdatedAddresses` has pretty much lost its meaning, and is no longer used. There really isn't any reason to index this property anymore. 😗

Unless there is a plan to use `IRichStore`, we should remove `IRichStore` entirely if we get a chance.

- `TxId` to `BlockHash` mapping is already being handled by `IStore` (although, `IStore`'s version has its own problems).
- The only remaining functionality not supported by `IStore` directly is `Address` (signer) to `TxId` mapping.

My personal thought on this matter is that there should be a clear distinction between what should be the "core" functionalities of `IStore` (necessary for `BlockChain`'s operation) and "auxiliary" functionalities.

For instance, `TxId` -> `BlockHash` indexing, `Address` -> `TxId` indexing, and `TxResult` all could be considered non-essential. That is, [Libplanet](https://github.com/planetarium/libplanet)'s `BlockChain` would have no problem running without these. 😐

If we had a clearly defined separate interface for these functionalities, then we could **safely assume** that these indexing services are purely auxiliary and **may not be complete**.