### PR TITLE
♻️ Refactor `KeyConverters`

### DIFF
--- a/Libplanet.Action.Tests/Mocks/MockAccountState.cs
+++ b/Libplanet.Action.Tests/Mocks/MockAccountState.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Action.Tests.Mocks
             addresses.Select(GetState).ToList();
 
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
-            Trie.Get(KeyConverters.ToFungibleAssetKey(address, currency)) is Integer rawValue
+            Trie.Get(KeyConverters.ToFungibleAssetKey(address, currency.Hash)) is Integer rawValue
                 ? FungibleAssetValue.FromRawValue(currency, rawValue)
                 : currency * 0;
 
@@ -108,7 +108,7 @@ namespace Libplanet.Action.Tests.Mocks
         public MockAccountState SetBalance(
             (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
             new MockAccountState(Trie.Set(
-                KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency),
+                KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency.Hash),
                 new Integer(rawAmount)));
 
         public MockAccountState AddBalance(Address address, FungibleAssetValue amount) =>
@@ -122,7 +122,7 @@ namespace Libplanet.Action.Tests.Mocks
             (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
             SetBalance(
                 pair,
-                (Trie.Get(KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency)) is
+                (Trie.Get(KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency.Hash)) is
                     Integer amount ? amount : 0) + rawAmount);
 
         public MockAccountState SubtractBalance(
@@ -137,7 +137,7 @@ namespace Libplanet.Action.Tests.Mocks
             (Address Address, Currency Currency) pair, BigInteger rawAmount) =>
             SetBalance(
                 pair,
-                (Trie.Get(KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency)) is
+                (Trie.Get(KeyConverters.ToFungibleAssetKey(pair.Address, pair.Currency.Hash)) is
                     Integer amount ? amount : 0) - rawAmount);
 
         public MockAccountState TransferBalance(

--- a/Libplanet.Action.Tests/Mocks/MockAccountState.cs
+++ b/Libplanet.Action.Tests/Mocks/MockAccountState.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Action.Tests.Mocks
                 throw new TotalSupplyNotTrackableException(msg, currency);
             }
 
-            return Trie.Get(KeyConverters.ToTotalSupplyKey(currency)) is Integer rawValue
+            return Trie.Get(KeyConverters.ToTotalSupplyKey(currency.Hash)) is Integer rawValue
                 ? FungibleAssetValue.FromRawValue(currency, rawValue)
                 : currency * 0;
         }
@@ -156,7 +156,8 @@ namespace Libplanet.Action.Tests.Mocks
                 ? !(currency.MaximumSupply is FungibleAssetValue maximumSupply) ||
                     rawAmount <= maximumSupply.RawValue
                     ? new MockAccountState(
-                        Trie.Set(KeyConverters.ToTotalSupplyKey(currency), new Integer(rawAmount)))
+                        Trie.Set(
+                            KeyConverters.ToTotalSupplyKey(currency.Hash), new Integer(rawAmount)))
                     : throw new ArgumentException(
                         $"Given {currency}'s total supply is capped at {maximumSupply.RawValue} " +
                         $"and cannot be set to {rawAmount}.")
@@ -169,7 +170,7 @@ namespace Libplanet.Action.Tests.Mocks
         public MockAccountState AddTotalSupply(Currency currency, BigInteger rawAmount) =>
             SetTotalSupply(
                 currency,
-                (Trie.Get(KeyConverters.ToTotalSupplyKey(currency)) is
+                (Trie.Get(KeyConverters.ToTotalSupplyKey(currency.Hash)) is
                     Integer amount ? amount : 0) + rawAmount);
 
         public MockAccountState SubtractTotalSupply(FungibleAssetValue amount) =>
@@ -178,7 +179,7 @@ namespace Libplanet.Action.Tests.Mocks
         public MockAccountState SubtractTotalSupply(Currency currency, BigInteger rawAmount) =>
             SetTotalSupply(
                 currency,
-                (Trie.Get(KeyConverters.ToTotalSupplyKey(currency)) is
+                (Trie.Get(KeyConverters.ToTotalSupplyKey(currency.Hash)) is
                     Integer amount ? amount : 0) - rawAmount);
 
         public MockAccountState SetValidator(Validator validator) =>

--- a/Libplanet.Action.Tests/State/KeyConvertersTest.cs
+++ b/Libplanet.Action.Tests/State/KeyConvertersTest.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Action.State.Tests
             Assert.Equal(
                 new KeyBytes(
                     $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}"),
-                KeyConverters.ToFungibleAssetKey(address, currency));
+                KeyConverters.ToFungibleAssetKey(address, currency.Hash));
 
             Assert.Equal(
                 new KeyBytes($"__{ByteUtil.Hex(currency.Hash.ByteArray)}"),

--- a/Libplanet.Action.Tests/State/KeyConvertersTest.cs
+++ b/Libplanet.Action.Tests/State/KeyConvertersTest.cs
@@ -29,7 +29,7 @@ namespace Libplanet.Action.State.Tests
 
             Assert.Equal(
                 new KeyBytes($"__{ByteUtil.Hex(currency.Hash.ByteArray)}"),
-                KeyConverters.ToTotalSupplyKey(currency));
+                KeyConverters.ToTotalSupplyKey(currency.Hash));
 
             Assert.Equal(
                 new KeyBytes("___"),

--- a/Libplanet.Action/State/Account.cs
+++ b/Libplanet.Action/State/Account.cs
@@ -198,7 +198,7 @@ namespace Libplanet.Action.State
                 new AccountState(
                     Trie
                         .Set(ToFungibleAssetKey(address, currency), new Integer(amount))
-                        .Set(ToTotalSupplyKey(currency), new Integer(sa))),
+                        .Set(ToTotalSupplyKey(currency.Hash), new Integer(sa))),
                 TotalUpdatedFungibleAssets.Add((address, currency)))
             : new Account(
                 new AccountState(

--- a/Libplanet.Action/State/Account.cs
+++ b/Libplanet.Action/State/Account.cs
@@ -197,12 +197,12 @@ namespace Libplanet.Action.State
             ? new Account(
                 new AccountState(
                     Trie
-                        .Set(ToFungibleAssetKey(address, currency), new Integer(amount))
+                        .Set(ToFungibleAssetKey(address, currency.Hash), new Integer(amount))
                         .Set(ToTotalSupplyKey(currency.Hash), new Integer(sa))),
                 TotalUpdatedFungibleAssets.Add((address, currency)))
             : new Account(
                 new AccountState(
-                    Trie.Set(ToFungibleAssetKey(address, currency), new Integer(amount))),
+                    Trie.Set(ToFungibleAssetKey(address, currency.Hash), new Integer(amount))),
                 TotalUpdatedFungibleAssets.Add((address, currency)));
 
         [Pure]

--- a/Libplanet.Action/State/AccountState.cs
+++ b/Libplanet.Action/State/AccountState.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Action.State
         /// <inheritdoc cref="IAccountState.GetBalance"/>
         public FungibleAssetValue GetBalance(Address address, Currency currency)
         {
-            IValue? value = Trie.Get(ToFungibleAssetKey(address, currency));
+            IValue? value = Trie.Get(ToFungibleAssetKey(address, currency.Hash));
             return value is Integer i
                 ? FungibleAssetValue.FromRawValue(currency, i)
                 : currency * 0;

--- a/Libplanet.Action/State/AccountState.cs
+++ b/Libplanet.Action/State/AccountState.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Action.State
                 throw TotalSupplyNotTrackableException.WithDefaultMessage(currency);
             }
 
-            IValue? value = Trie.Get(ToTotalSupplyKey(currency));
+            IValue? value = Trie.Get(ToTotalSupplyKey(currency.Hash));
             return value is Integer i
                 ? FungibleAssetValue.FromRawValue(currency, i)
                 : currency * 0;

--- a/Libplanet.Action/State/KeyConverters.cs
+++ b/Libplanet.Action/State/KeyConverters.cs
@@ -2,7 +2,6 @@ using System.Security.Cryptography;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
-using Libplanet.Types.Assets;
 
 namespace Libplanet.Action.State
 {
@@ -48,11 +47,11 @@ namespace Libplanet.Action.State
             return new KeyBytes(buffer);
         }
 
-        // $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}"
-        internal static KeyBytes ToFungibleAssetKey(Address address, Currency currency)
+        // $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currencyHash.ByteArray)}"
+        internal static KeyBytes ToFungibleAssetKey(Address address, HashDigest<SHA1> currencyHash)
         {
             var addressBytes = address.ByteArray;
-            var currencyBytes = currency.Hash.ByteArray;
+            var currencyBytes = currencyHash.ByteArray;
             byte[] buffer = new byte[addressBytes.Length * 2 + currencyBytes.Length * 2 + 2];
 
             buffer[0] = _underScore;

--- a/Libplanet.Action/State/KeyConverters.cs
+++ b/Libplanet.Action/State/KeyConverters.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
@@ -71,14 +73,10 @@ namespace Libplanet.Action.State
             return new KeyBytes(buffer);
         }
 
-        internal static KeyBytes ToFungibleAssetKey(
-            (Address Address, Currency Currency) pair) =>
-            ToFungibleAssetKey(pair.Address, pair.Currency);
-
-        // $"__{ByteUtil.Hex(currency.Hash.ByteArray)}"
-        internal static KeyBytes ToTotalSupplyKey(Currency currency)
+        // $"__{ByteUtil.Hex(currencyHash.ByteArray)}"
+        internal static KeyBytes ToTotalSupplyKey(HashDigest<SHA1> currencyHash)
         {
-            var currencyBytes = currency.Hash.ByteArray;
+            var currencyBytes = currencyHash.ByteArray;
             byte[] buffer = new byte[currencyBytes.Length * 2 + 2];
 
             buffer[0] = _underScore;

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -378,16 +378,16 @@ namespace Libplanet.Tests.Action
                 dirty1[ToStateKey(DumbAction.RandomRecordsAddress)]);
             Assert.Equal(
                 (Integer)new FungibleAssetValue(DumbAction.DumbCurrency, -5, 0).RawValue,
-                dirty1[ToFungibleAssetKey(addresses[0], DumbAction.DumbCurrency)]);
+                dirty1[ToFungibleAssetKey(addresses[0], DumbAction.DumbCurrency.Hash)]);
             Assert.Equal(
                 (Integer)new FungibleAssetValue(DumbAction.DumbCurrency).RawValue,
-                dirty1[ToFungibleAssetKey(addresses[1], DumbAction.DumbCurrency)]);
+                dirty1[ToFungibleAssetKey(addresses[1], DumbAction.DumbCurrency.Hash)]);
             Assert.Equal(
                 (Integer)new FungibleAssetValue(DumbAction.DumbCurrency).RawValue,
-                dirty1[ToFungibleAssetKey(addresses[2], DumbAction.DumbCurrency)]);
+                dirty1[ToFungibleAssetKey(addresses[2], DumbAction.DumbCurrency.Hash)]);
             Assert.Equal(
                 (Integer)new FungibleAssetValue(DumbAction.DumbCurrency, 5, 0).RawValue,
-                dirty1[ToFungibleAssetKey(addresses[3], DumbAction.DumbCurrency)]);
+                dirty1[ToFungibleAssetKey(addresses[3], DumbAction.DumbCurrency.Hash)]);
 
             Transaction[] block2Txs =
             {


### PR DESCRIPTION
Current implementation drags `Currency` context to an unnecessarily low level. Ideally, `KeyConverters` should only deal with `byte[]` types. 🙄