### PR TITLE
✨ New state querying scheme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ be compatible with this version,  specifically, those that ran with
     `Libplanet.Explorer.Executable`.  [[#3564]]
  -  Changed `TxInvoice` to no longer allow negative values for
     `MaxGasPrice` and `GasLimit`.  [[#3567]]
+ -  (Libplanet.Explorer) Added `AccountStateType` class.  [[#3570]]
+ -  (Libplanet.Explorer) Added `account` and `accounts` query to `StateQuery`.
+    [[#3570]]
  -  (Libplanet.Store) Changed `ShortNode` to no longer inherit `BaseNode`.
     `ShortNode.Value` is no longer nullable.  [[#3572]]
  -  (Libplanet.Store) Removed `FullNode()` and added `FullNode.Empty`.
@@ -53,6 +56,7 @@ be compatible with this version,  specifically, those that ran with
 [#3562]: https://github.com/planetarium/libplanet/pull/3562
 [#3564]: https://github.com/planetarium/libplanet/pull/3564
 [#3567]: https://github.com/planetarium/libplanet/pull/3567
+[#3570]: https://github.com/planetarium/libplanet/pull/3570
 [#3572]: https://github.com/planetarium/libplanet/pull/3572
 [#3573]: https://github.com/planetarium/libplanet/pull/3573
 [#3574]: https://github.com/planetarium/libplanet/pull/3574

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
+using Bencodex;
 using Bencodex.Types;
 using GraphQL;
 using GraphQL.Execution;
@@ -14,15 +15,266 @@ using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
 using Libplanet.Explorer.Queries;
 using Libplanet.Store.Trie;
+using Libplanet.Store.Trie.Nodes;
 using Xunit;
 using static Libplanet.Explorer.Tests.GraphQLTestUtils;
 using Libplanet.Common;
 using System.Security.Cryptography;
+using System;
 
 namespace Libplanet.Explorer.Tests.Queries;
 
 public class StateQueryTest
 {
+    private static readonly Codec _codec = new Codec();
+
+    [Fact]
+    public async Task AccountByBlockHashThenStateAndStates()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            account (blockHash: ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"") {
+                state (address: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"") {
+                    hex
+                }
+                states (addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""]) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        IDictionary<string, object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["account"]);
+
+        IDictionary<string, object> state =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["state"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(state["hex"]));
+
+        object[] states =
+            Assert.IsAssignableFrom<object[]>(account["states"]);
+        Assert.Equal(2, states.Length);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])["hex"]));
+        Assert.Null(states[1]);
+    }
+
+    [Fact]
+    public async Task AccountByBlockHashThenBalanceAndBalances()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            account (blockHash: ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"") {
+                balance (
+                    address: ""0x5003712B63baAB98094aD678EA2B24BcE445D076""
+                    currencyHash: ""84ba810ca5ac342c122eb7ef455939a8a05d1d40""
+                ) {
+                    hex
+                }
+                balances (
+                    addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""]
+                    currencyHash: ""84ba810ca5ac342c122eb7ef455939a8a05d1d40""
+                ) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        IDictionary<string, object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["account"]);
+
+        IDictionary<string, object> balance =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["balance"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(new Integer(123))),
+            Assert.IsAssignableFrom<string>(balance["hex"]));
+
+        object[] balances =
+            Assert.IsAssignableFrom<object[]>(account["balances"]);
+        Assert.Equal(2, balances.Length);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(new Integer(123))),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(balances[0])["hex"]));
+
+        // FIXME: Due to dumb mocking. We need to overhaul mocking.
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(new Integer(123))),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(balances[1])["hex"]));
+    }
+
+    [Fact]
+    public async Task AccountByBlockHashThenTotalSupply()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            account (blockHash: ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"") {
+                totalSupply (
+                    currencyHash: ""84ba810ca5ac342c122eb7ef455939a8a05d1d40""
+                ) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        IDictionary<string, object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["account"]);
+
+        IDictionary<string, object> totalSupply =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["totalSupply"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(new Integer(10000))),
+            Assert.IsAssignableFrom<string>(totalSupply["hex"]));
+    }
+
+    [Fact]
+    public async Task AccountByStateRootHashThenStateAndStates()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            account (stateRootHash: ""c33b27773104f75ac9df5b0533854108bd498fab31e5236b6f1e1f6404d5ef64"") {
+                state (address: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"") {
+                    hex
+                }
+                states (addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""]) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        IDictionary<string, object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["account"]);
+
+        IDictionary<string, object> state =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["state"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(state["hex"]));
+
+        object[] states =
+            Assert.IsAssignableFrom<object[]>(account["states"]);
+        Assert.Equal(2, states.Length);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])["hex"]));
+        Assert.Null(states[1]);
+    }
+
+    // FIXME: We need proper mocks to test more complex scenarios.
+    [Fact]
+    public async Task AccountsByBlockHashesThenStateAndStates()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            accounts (blockHashes: [""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""]) {
+                state (address: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"") {
+                    hex
+                }
+                states (addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""]) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        object[] accounts =
+            Assert.IsAssignableFrom<object[]>(resultDict["accounts"]);
+
+        IDictionary<string,object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(Assert.Single(accounts));
+        IDictionary<string, object> state =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["state"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(state["hex"]));
+
+        object[] states =
+            Assert.IsAssignableFrom<object[]>(account["states"]);
+        Assert.Equal(2, states.Length);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])["hex"]));
+        Assert.Null(states[1]);
+    }
+
+    // FIXME: We need proper mocks to test more complex scenarios.
+    [Fact]
+    public async Task AccountsByStateRootHashesThenStateAndStates()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            accounts (stateRootHashes: [""c33b27773104f75ac9df5b0533854108bd498fab31e5236b6f1e1f6404d5ef64""]) {
+                state (address: ""0x5003712B63baAB98094aD678EA2B24BcE445D076"") {
+                    hex
+                }
+                states (addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""]) {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        object[] accounts =
+            Assert.IsAssignableFrom<object[]>(resultDict["accounts"]);
+
+        IDictionary<string,object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(Assert.Single(accounts));
+        IDictionary<string, object> state =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["state"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(state["hex"]));
+
+        object[] states =
+            Assert.IsAssignableFrom<object[]>(account["states"]);
+        Assert.Equal(2, states.Length);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(Null.Value)),
+            Assert.IsAssignableFrom<string>(
+                Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])["hex"]));
+        Assert.Null(states[1]);
+    }
+
     [Fact]
     public async Task States()
     {
@@ -350,11 +602,6 @@ public class StateQueryTest
 
         public IAccountState GetAccountState(HashDigest<SHA256>? hash) =>
             new MockAccount(null, hash);
-
-        public ITrie GetTrie(BlockHash? offset)
-        {
-            throw new System.NotImplementedException();
-        }
     }
 
     private class MockAccount : IAccount
@@ -365,7 +612,7 @@ public class StateQueryTest
             StateRootHash = stateRootHash ?? default;
         }
 
-        public ITrie Trie { get; }
+        public ITrie Trie => new MockTrie(StateRootHash);
 
         public BlockHash BlockHash { get; }
 
@@ -433,5 +680,43 @@ public class StateQueryTest
                         new BigInteger(1)),
                 })
                 : new ValidatorSet();
+    }
+
+    private class MockTrie : ITrie
+    {
+        private readonly HashDigest<SHA256>? _stateRootHash;
+
+        public MockTrie(HashDigest<SHA256>? stateRootHash)
+        {
+            _stateRootHash = stateRootHash;
+        }
+
+        public INode Root => throw new NotSupportedException();
+
+        public HashDigest<SHA256> Hash => throw new NotSupportedException();
+
+        public bool Recorded => throw new NotSupportedException();
+
+        public ITrie Set(in KeyBytes key, IValue value) => throw new NotSupportedException();
+
+        public IValue Get(KeyBytes key) => _stateRootHash is { }
+            ? key.Length == (HashDigest<SHA1>.Size * 2 + 2) // Length for total supply key
+                ? new Integer(10000)
+                : new Integer(123)
+            : null;
+
+        public IReadOnlyList<IValue> Get(IReadOnlyList<KeyBytes> keys) =>
+            throw new NotSupportedException();
+
+        public INode GetNode(Nibbles nibbles) => throw new NotSupportedException();
+
+        public IEnumerable<(KeyBytes Path, IValue Value)> IterateValues() =>
+            throw new NotSupportedException();
+
+        public IEnumerable<(Nibbles Path, INode Node)> IterateNodes() =>
+            throw new NotSupportedException();
+
+        public IEnumerable<(KeyBytes Path, IValue TargetValue, IValue SourceValue)> Diff(ITrie other) =>
+            throw new NotSupportedException();
     }
 }

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -733,6 +733,8 @@ public class StateQueryTest
 
         public ITrie Set(in KeyBytes key, IValue value) => throw new NotSupportedException();
 
+        public ITrie Remove(in KeyBytes key) => throw new NotSupportedException();
+
         public IValue Get(KeyBytes key)
         {
             if (_stateRootHash is { })

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -150,6 +150,40 @@ public class StateQueryTest
     }
 
     [Fact]
+    public async Task AccountByBlockHashThenValidatorSet()
+    {
+        IBlockChainStates source = new MockChainStates();
+        ExecutionResult result = await ExecuteQueryAsync<StateQuery>(@"
+        {
+            account (blockHash: ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"") {
+                validatorSet {
+                    hex
+                }
+            }
+        }
+        ", source: source);
+
+        Assert.Null(result.Errors);
+        ExecutionNode resultData = Assert.IsAssignableFrom<ExecutionNode>(result.Data);
+        IDictionary<string, object> resultDict =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
+        IDictionary<string, object> account =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(resultDict["account"]);
+
+        IDictionary<string, object> totalSupply =
+            Assert.IsAssignableFrom<IDictionary<string, object>>(account["validatorSet"]);
+        Assert.Equal(
+            ByteUtil.Hex(_codec.Encode(new ValidatorSet(new List<Validator>
+                {
+                    new(
+                        PublicKey.FromHex(
+                            "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"),
+                        new BigInteger(1)),
+                }).Bencoded)),
+            Assert.IsAssignableFrom<string>(totalSupply["hex"]));
+    }
+
+    [Fact]
     public async Task AccountByStateRootHashThenStateAndStates()
     {
         IBlockChainStates source = new MockChainStates();
@@ -699,11 +733,33 @@ public class StateQueryTest
 
         public ITrie Set(in KeyBytes key, IValue value) => throw new NotSupportedException();
 
-        public IValue Get(KeyBytes key) => _stateRootHash is { }
-            ? key.Length == (HashDigest<SHA1>.Size * 2 + 2) // Length for total supply key
-                ? new Integer(10000)
-                : new Integer(123)
-            : null;
+        public IValue Get(KeyBytes key)
+        {
+            if (_stateRootHash is { })
+            {
+                if (key.Length == 3) // Length for validator set key
+                {
+                    return new ValidatorSet(new List<Validator>
+                    {
+                        new(
+                            PublicKey.FromHex(
+                                "032038e153d344773986c039ba5dbff12ae70cfdf6ea8beb7c5ea9b361a72a9233"),
+                            new BigInteger(1)),
+                    }).Bencoded;
+                }
+
+                if (key.Length == (HashDigest<SHA1>.Size * 2 + 2)) // Length for total supply key
+                {
+                    return new Integer(10000);
+                }
+
+                return new Integer(123); // Assume we are looking for balance.
+            }
+            else
+            {
+                return null;
+            }
+        }
 
         public IReadOnlyList<IValue> Get(IReadOnlyList<KeyBytes> keys) =>
             throw new NotSupportedException();

--- a/Libplanet.Explorer/GraphTypes/AccountStateType.cs
+++ b/Libplanet.Explorer/GraphTypes/AccountStateType.cs
@@ -1,0 +1,189 @@
+using System.Linq;
+using System.Security.Cryptography;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Action.State;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.Explorer.GraphTypes
+{
+    public class AccountStateType : ObjectGraphType<IAccountState>
+    {
+        private const byte _underScore = 95;  // '_'
+
+        private static readonly byte[] _conversionTable =
+        {
+            48,  // '0'
+            49,  // '1'
+            50,  // '2'
+            51,  // '3'
+            52,  // '4'
+            53,  // '5'
+            54,  // '6'
+            55,  // '7'
+            56,  // '8'
+            57,  // '9'
+            97,  // 'a'
+            98,  // 'b'
+            99,  // 'c'
+            100, // 'd'
+            101, // 'e'
+            102, // 'f'
+        };
+
+        public AccountStateType()
+        {
+            Name = "AccountState";
+            Description =
+                "Represents raw account state.  This is meant to represent a raw storage state " +
+                "void of any application layer context and/or logic.  In particular, " +
+                "this does not deal with currency directly, which requires additional " +
+                "information on currency such as its ticker and possible minters, etc.";
+
+            Field<NonNullGraphType<HashDigestType<SHA256>>>(
+                name: "stateRootHash",
+                description: "The state root hash associated with this account state.",
+                resolve: context => context.Source.Trie.Hash
+            );
+
+            Field<BencodexValueType>(
+                name: "state",
+                description: "The state at given address.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "address",
+                        Description = "The address to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.GetState(context.GetArgument<Address>("address"))
+            );
+
+            Field<NonNullGraphType<ListGraphType<BencodexValueType>>>(
+                name: "states",
+                description: "The states at given addresses.",
+                arguments: new QueryArguments(
+                    new QueryArgument<
+                        NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>
+                    {
+                        Name = "addresses",
+                        Description = "The list of addresses to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.GetArgument<Address[]>("addresses")
+                        .Select(address => context.Source.GetState(address))
+                        .ToArray()
+            );
+
+            Field<BencodexValueType>(
+                name: "balance",
+                description: "Balance at given address and currency hash pair.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "address",
+                        Description = "The address to look up.",
+                    },
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.Trie.Get(ToFungibleAssetKey(
+                        context.GetArgument<Address>("address"),
+                        context.GetArgument<HashDigest<SHA1>>("currencyHash")))
+            );
+
+            Field<NonNullGraphType<ListGraphType<BencodexValueType>>>(
+                name: "balances",
+                description: "Balances at given addresses and currency hash pair.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<
+                        ListGraphType<NonNullGraphType<AddressType>>>>
+                    {
+                        Name = "addresses",
+                        Description = "The list of addresses to look up.",
+                    },
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.GetArgument<Address[]>("addresses")
+                        .Select(address => context.Source.Trie.Get(
+                            ToFungibleAssetKey(
+                                address, context.GetArgument<HashDigest<SHA1>>("currencyHash"))))
+            );
+
+            Field<BencodexValueType>(
+                name: "totalSupply",
+                description: "Total supply in circulation, if recorded, for given currency hash.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.Trie.Get(ToTotalSupplyKey(
+                        context.GetArgument<HashDigest<SHA1>>("currencyHash")))
+            );
+
+            Field<BencodexValueType>(
+                name: "validatorSet",
+                description: "The validator set.",
+                resolve: context => context.Source.GetValidatorSet().Bencoded
+            );
+        }
+
+        internal static KeyBytes ToFungibleAssetKey(Address address, HashDigest<SHA1> currencyHash)
+        {
+            var addressBytes = address.ByteArray;
+            var currencyBytes = currencyHash.ByteArray;
+            byte[] buffer = new byte[addressBytes.Length * 2 + currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            for (int i = 0; i < addressBytes.Length; i++)
+            {
+                buffer[1 + i * 2] = _conversionTable[addressBytes[i] >> 4];
+                buffer[1 + i * 2 + 1] = _conversionTable[addressBytes[i] & 0xf];
+            }
+
+            var offset = addressBytes.Length * 2;
+            buffer[offset + 1] = _underScore;
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[offset + 2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[offset + 2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
+        }
+
+        internal static KeyBytes ToTotalSupplyKey(HashDigest<SHA1> currencyHash)
+        {
+            var currencyBytes = currencyHash.ByteArray;
+            byte[] buffer = new byte[currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            buffer[1] = _underScore;
+
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
+        }
+    }
+}

--- a/Libplanet.Explorer/GraphTypes/AccountStateType.cs
+++ b/Libplanet.Explorer/GraphTypes/AccountStateType.cs
@@ -11,6 +11,9 @@ namespace Libplanet.Explorer.GraphTypes
 {
     public class AccountStateType : ObjectGraphType<IAccountState>
     {
+        internal static readonly KeyBytes ValidatorSetKey =
+            new KeyBytes(new byte[] { _underScore, _underScore, _underScore });
+
         private const byte _underScore = 95;  // '_'
 
         private static readonly byte[] _conversionTable =
@@ -37,10 +40,12 @@ namespace Libplanet.Explorer.GraphTypes
         {
             Name = "AccountState";
             Description =
-                "Represents raw account state.  This is meant to represent a raw storage state " +
+                "Represents a raw account state.  This is meant to represent a raw storage state " +
                 "void of any application layer context and/or logic.  In particular, " +
-                "this does not deal with currency directly, which requires additional " +
-                "information on currency such as its ticker and possible minters, etc.";
+                "this does not deal with currency or fungible asset value directly, " +
+                "which requires additional information on currency such as its ticker " +
+                "and possible minters, etc. while interpreting the data retrieved " +
+                "with the provided contextual information. The same is true for validator sets.";
 
             Field<NonNullGraphType<HashDigestType<SHA256>>>(
                 name: "stateRootHash",
@@ -141,7 +146,7 @@ namespace Libplanet.Explorer.GraphTypes
             Field<BencodexValueType>(
                 name: "validatorSet",
                 description: "The validator set.",
-                resolve: context => context.Source.GetValidatorSet().Bencoded
+                resolve: context => context.Source.Trie.Get(ValidatorSetKey)
             );
         }
 

--- a/Libplanet.Explorer/Queries/StateQuery.cs
+++ b/Libplanet.Explorer/Queries/StateQuery.cs
@@ -44,7 +44,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
                 }
         );
 
-        Field<NonNullGraphType<AccountStateType>>(
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<AccountStateType>>>>(
             name: "accounts",
             description:
                 "Gets the account states associated with given block hashes " +

--- a/Libplanet.Explorer/Queries/StateQuery.cs
+++ b/Libplanet.Explorer/Queries/StateQuery.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Cryptography;
 using GraphQL;
 using GraphQL.Types;
@@ -15,6 +16,68 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
     public StateQuery()
     {
         Name = "StateQuery";
+        Field<NonNullGraphType<AccountStateType>>(
+            name: "account",
+            description:
+                "Gets the account state associated with given block hash or state root hash. " +
+                "Exactly one of the arguments must be specified.",
+            arguments: new QueryArguments(
+                new QueryArgument<BlockHashType>
+                {
+                    Name = "blockHash",
+                    Description = "A block hash to use as a pointer.",
+                },
+                new QueryArgument<HashDigestType<SHA256>>
+                {
+                    Name = "stateRootHash",
+                    Description = "A state root hash to use as a pointer.",
+                }
+            ),
+            resolve: context => (
+                context.GetArgument<BlockHash?>("blockHash"),
+                context.GetArgument<HashDigest<SHA256>?>("stateRootHash")) switch
+                {
+                    ({ } blockHash, null) => context.Source.GetAccountState(blockHash),
+                    (null, { } stateRootHash) => context.Source.GetAccountState(stateRootHash),
+                    _ => throw new ExecutionError(
+                        "Exactly one of blockHash and stateRootHash must be specified."),
+                }
+        );
+
+        Field<NonNullGraphType<AccountStateType>>(
+            name: "accounts",
+            description:
+                "Gets the account states associated with given block hashes " +
+                "or state root hashes. Exactly one of the arguments must be specified.",
+            arguments: new QueryArguments(
+                new QueryArgument<ListGraphType<NonNullGraphType<BlockHashType>>>
+                {
+                    Name = "blockHashes",
+                    Description = "A list of block hashes to use as pointers.",
+                },
+                new QueryArgument<ListGraphType<NonNullGraphType<HashDigestType<SHA256>>>>
+                {
+                    Name = "stateRootHashes",
+                    Description = "A list of state root hashes to use as pointers.",
+                }
+            ),
+            resolve: context => (
+                context.GetArgument<BlockHash[]?>("blockHashes"),
+                context.GetArgument<HashDigest<SHA256>[]?>("stateRootHashes")) switch
+                {
+                    ({ } blockHashes, null) =>
+                        blockHashes
+                            .Select(blockHash => context.Source.GetAccountState(blockHash))
+                            .ToArray(),
+                    (null, { } stateRootHashes) =>
+                        stateRootHashes
+                            .Select(stateRootHash => context.Source.GetAccountState(stateRootHash))
+                            .ToArray(),
+                    _ => throw new ExecutionError(
+                        "Exactly one of blockHashes and stateRootHashes must be specified."),
+                }
+        );
+
         Field<NonNullGraphType<ListGraphType<LegacyBencodexValueType>>>(
             "states",
             arguments: new QueryArguments(


### PR DESCRIPTION
Adds more modular and reusable `AccountStateType` to GraphQL queries.

As seen in its implementation, this is pretty lousy. I tried to remove `Currency`/`FungibleAssetValue` context from state query, but this has resulted in severe API inconsistency. 😥

This issue is mainly due to `IAccount` having two roles:
- Knowing the data model stored in the database: Where to retrieve the data by using an "appropriate" key-conversion.
- Interpreting the retrieved data: Implicitly converting `null` to zero-amount `FungibleAssetValue` for given `Currency`.

As it stands, there is **no possible way** to know (although whether this is necessary might be debatable) how `Currency` related data is stored within the storage entirely from the library side ([libplanet]) or the client side ([lib9c]).
- When retrieving a `FungibleAssetValue` from an `Address` and a `Currency` pair, one cannot actually know whether the underlying data is `0` or `null`. Considering how it is treated, `Currency` is inherently a client-side provided context. This itself isn't much of a problem, if we think of `IAccount` as an interface to obfuscate the underlying data (or logic).
- On the other hand, [libplanet]'s current API is built in such a way that it is not even possible to retrieve the underlying `Currency`'s raw value (in `IValue`) without the information of `Currency` being provided in its entirety, even though what is only needed is `Currency.Hash`.

Further examples of API inconsistency among across different types of queries are:
- Even though the basic unit of `GetState()` is getting a single `IValue` from an address, we only have `states` and is missing `state`. Furthermore, an `IValue` is returned implicitly as base64 format.
- On the other hand, `Currency` related queries require an actual instance of `Currency` as stated above, and returns an interpreted `FungibleAssetValue` instance. Again, as stated above, there is no way to actually know its raw value (`Integer`).
- As for `ValidatorSet`, again, it is returned as a `ValidatorSetType` instance.

The purpose of this new `AccountStateType` is to provide a way to query raw underlying data **in a consistent manner reflecting the underlying data structure** so that the interpretation can be done at another layer by post processing the result.

Seems like maintaining cost of improper mock/fixture has surpassed creating a proper one from scratch. If it wasn't for pending 4.0 release, I would've created a new one, but had to scrap it. 😕

[libplanet]: https://github.com/planetarium/libplanet
[lib9c]: https://github.com/planetarium/lib9c