### PR TITLE
✨ Add `Trie.Remove()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,7 +38,7 @@ be compatible with this version,  specifically, those that ran with
  -  (Libplanet.Store) Changed `FullNode` to no longer inherit `BaseNode`.
     [[#3574]]
  -  (Libplanet.Store) Removed `BaseNode`.  [[#3574]]
- -  (Libplanet.Store) Added `ITrie.SetNull()` interface method.  [[#3576]]
+ -  (Libplanet.Store) Added `ITrie.Remove()` interface method.  [[#3576]]
  -  (Libplanet.Store) Added `FullNode.RemoveChild()` method.  [[#3576]]
 
 [#3559]: https://github.com/planetarium/libplanet/pull/3559

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@ be compatible with this version,  specifically, those that ran with
  -  (Libplanet.Store) Changed `FullNode` to no longer inherit `BaseNode`.
     [[#3574]]
  -  (Libplanet.Store) Removed `BaseNode`.  [[#3574]]
+ -  (Libplanet.Store) Added `ITrie.SetNull()` interface method.  [[#3576]]
+ -  (Libplanet.Store) Added `FullNode.RemoveChild()` method.  [[#3576]]
 
 [#3559]: https://github.com/planetarium/libplanet/pull/3559
 [#3560]: https://github.com/planetarium/libplanet/pull/3560
@@ -48,6 +50,7 @@ be compatible with this version,  specifically, those that ran with
 [#3572]: https://github.com/planetarium/libplanet/pull/3572
 [#3573]: https://github.com/planetarium/libplanet/pull/3573
 [#3574]: https://github.com/planetarium/libplanet/pull/3574
+[#3576]: https://github.com/planetarium/libplanet/pull/3576
 
 
 Version 3.9.2

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -40,8 +40,8 @@ namespace Libplanet.Store.Trie
         bool Recorded { get; }
 
         /// <summary>
-        /// Stores the <paramref name="value"/> to the
-        /// node corresponding to given <paramref name="key"/> <em>in memory</em>.
+        /// Stores the <paramref name="value"/> at the path corresponding to
+        /// given <paramref name="key"/> <em>in memory</em>.
         /// </summary>
         /// <param name="key">The unique key to associate with the <paramref name="value"/>.</param>
         /// <param name="value">The value to store.</param>
@@ -50,10 +50,24 @@ namespace Libplanet.Store.Trie
         /// <returns>Returns new updated <see cref="ITrie"/>.</returns>
         /// <remarks>
         /// This <em>should not</em> actually write anything to storage.
+        /// Stored <paramref name="value"/> is actually written to storage when
+        /// <see cref="IStateStore.Commit"/> is called.
         /// </remarks>
         /// <seealso cref="IStateStore.Commit"/>
         ITrie Set(in KeyBytes key, IValue value);
 
+        /// <summary>
+        /// Removes the value at the path corresponding to given <paramref name="key"/>
+        /// <em>in memory</em>.
+        /// </summary>
+        /// <param name="key">The unique key to associate with the <paramref name="value"/>.</param>
+        /// <returns>Returns new updated <see cref="ITrie"/>.</returns>
+        /// <remarks>
+        /// This <em>should not</em> actually remove anything from storage.
+        /// Value at the marked path given by <paramref name="key"/> is actually removed from
+        /// storage when <see cref="IStateStore.Commit"/> is called.
+        /// </remarks>
+        /// <seealso cref="IStateStore.Commit"/>
         ITrie SetNull(in KeyBytes key);
 
         /// <summary>

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -54,6 +54,8 @@ namespace Libplanet.Store.Trie
         /// <seealso cref="IStateStore.Commit"/>
         ITrie Set(in KeyBytes key, IValue value);
 
+        ITrie SetNull(in KeyBytes key);
+
         /// <summary>
         /// Gets the values stored with <paramref name="key"/> in <see cref="Set"/>.
         /// </summary>

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -68,7 +68,7 @@ namespace Libplanet.Store.Trie
         /// storage when <see cref="IStateStore.Commit"/> is called.
         /// </remarks>
         /// <seealso cref="IStateStore.Commit"/>
-        ITrie SetNull(in KeyBytes key);
+        ITrie Remove(in KeyBytes key);
 
         /// <summary>
         /// Gets the values stored with <paramref name="key"/> in <see cref="Set"/>.

--- a/Libplanet.Store/Trie/ITrie.cs
+++ b/Libplanet.Store/Trie/ITrie.cs
@@ -64,8 +64,10 @@ namespace Libplanet.Store.Trie
         /// <returns>Returns new updated <see cref="ITrie"/>.</returns>
         /// <remarks>
         /// This <em>should not</em> actually remove anything from storage.
-        /// Value at the marked path given by <paramref name="key"/> is actually removed from
-        /// storage when <see cref="IStateStore.Commit"/> is called.
+        /// The removal of the value at the marked path given by <paramref name="key"/> is actually
+        /// recorded to storage when <see cref="IStateStore.Commit"/> is called.
+        /// Regardless, there is actually no removal of any value from storage even when
+        /// <see cref="IStateStore.Commit"/> is called.
         /// </remarks>
         /// <seealso cref="IStateStore.Commit"/>
         ITrie Remove(in KeyBytes key);

--- a/Libplanet.Store/Trie/MerkleTrie.Remove.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Remove.cs
@@ -132,6 +132,7 @@ namespace Libplanet.Store.Trie
                 //   - If the child is either a value node or a full node, return a short node
                 //     with the nibble as its key.
                 (INode child, int index) = childrenWithIndices.Single();
+                child = child is HashNode hn ? UnhashNode(hn) : child;
                 return index == FullNode.ChildrenCount - 1
                     ? child
                     : child is ShortNode sn

--- a/Libplanet.Store/Trie/MerkleTrie.Remove.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Remove.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Libplanet.Store.Trie.Nodes;
+
+namespace Libplanet.Store.Trie
+{
+    public partial class MerkleTrie
+    {
+        private INode? RemoveFromRoot(in PathCursor cursor)
+        {
+            if (Root is null)
+            {
+                return Root;
+            }
+            else
+            {
+                return Remove(Root, cursor);
+            }
+        }
+
+        private INode? Remove(INode node, in PathCursor cursor)
+        {
+            switch (node)
+            {
+                case HashNode hashNode:
+                    return RemoveFromHashNode(hashNode, cursor);
+                case ValueNode valueNode:
+                    return RemoveFromValueNode(valueNode, cursor);
+                case ShortNode shortNode:
+                    return RemoveFromShortNode(shortNode, cursor);
+                case FullNode fullNode:
+                    return RemoveFromFullNode(fullNode, cursor);
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private INode? RemoveFromHashNode(HashNode hashNode, PathCursor cursor) =>
+            Remove(UnhashNode(hashNode), cursor);
+
+        private INode? RemoveFromValueNode(ValueNode valueNode, PathCursor cursor) =>
+            cursor.RemainingAnyNibbles
+                ? valueNode
+                : null;
+
+        private INode? RemoveFromShortNode(ShortNode shortNode, PathCursor cursor)
+        {
+            // Two cases are possible:
+            // - common prefix length == short node's key length: remove directly from short node's
+            //   value
+            // - common prefix length < short node's key length: do nothing since it is
+            //   trying to remove value from a non-existant path
+            Nibbles commonNibbles = cursor.GetCommonStartingNibbles(shortNode.Key);
+            PathCursor nextCursor = cursor.Next(commonNibbles.Length);
+
+            if (commonNibbles.Length == shortNode.Key.Length)
+            {
+                INode? processedValue = Remove(shortNode.Value, nextCursor);
+                if (processedValue is { } node)
+                {
+                    switch (node)
+                    {
+                        case HashNode _:
+                            throw new ArgumentException();
+                        case ValueNode vn:
+                            return new ShortNode(shortNode.Key, vn);
+                        case FullNode fn:
+                            return new ShortNode(shortNode.Key, fn);
+                        case ShortNode sn:
+                            return new ShortNode(shortNode.Key.AddRange(sn.Key), sn.Value);
+                        default:
+                            throw new InvalidTrieNodeException(
+                                $"Unsupported node value: {node.ToBencodex().Inspect()}");
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return shortNode;
+            }
+        }
+
+        private INode RemoveFromFullNode(FullNode fullNode, PathCursor cursor)
+        {
+            if (cursor.RemainingAnyNibbles)
+            {
+                byte nextNibble = cursor.NextNibble;
+                if (fullNode.Children[nextNibble] is { } child)
+                {
+                    INode? processedChild = Remove(child, cursor.Next(1));
+                    return processedChild is { } node
+                        ? fullNode.SetChild(
+                            nextNibble,
+                            node)
+                        : ReduceFullNode(fullNode.RemoveChild(nextNibble));
+                }
+                else
+                {
+                    return fullNode;
+                }
+            }
+            else
+            {
+                return ReduceFullNode(fullNode.RemoveChild(FullNode.ChildrenCount - 1));
+            }
+        }
+
+        private INode ReduceFullNode(FullNode fullNode)
+        {
+            (INode, int)[] childrenWithIndices = fullNode.Children
+                .Select((child, i) => (child, i))
+                .Where(pair => pair.child is INode)
+                .ToArray()!;
+            int childrenCount = childrenWithIndices.Length;
+            if (childrenCount == 0)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(fullNode)} must have at least 1 child: {childrenCount}");
+            }
+            else if (childrenCount == 1)
+            {
+                // Possible cases:
+                // - If only the value remains, it is equivalent to a value node.
+                // - If only nibble + child remains:
+                //   - If the child is a short node, combine with a nibble to make
+                //     a "longer" short node.
+                //   - If the child is either a value node or a full node, return a short node
+                //     with the nibble as its key.
+                (INode child, int index) = childrenWithIndices.Single();
+                return index == FullNode.ChildrenCount - 1
+                    ? child
+                    : child is ShortNode sn
+                        ? new ShortNode(
+                            new Nibbles(new byte[] { (byte)index }.ToImmutableArray())
+                                .AddRange(sn.Key),
+                            sn.Value)
+                        : new ShortNode(
+                            new Nibbles(new byte[] { (byte)index }.ToImmutableArray()),
+                            child);
+            }
+            else
+            {
+                return fullNode;
+            }
+        }
+    }
+}

--- a/Libplanet.Store/Trie/MerkleTrie.Remove.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Remove.cs
@@ -50,7 +50,7 @@ namespace Libplanet.Store.Trie
             // - common prefix length == short node's key length: remove directly from short node's
             //   value
             // - common prefix length < short node's key length: do nothing since it is
-            //   trying to remove value from a non-existant path
+            //   trying to remove value from a non-existent path
             Nibbles commonNibbles = cursor.GetCommonStartingNibbles(shortNode.Key);
             PathCursor nextCursor = cursor.Next(commonNibbles.Length);
 

--- a/Libplanet.Store/Trie/MerkleTrie.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.cs
@@ -96,6 +96,12 @@ namespace Libplanet.Store.Trie
             return new MerkleTrie(KeyValueStore, newRootNode, _cache);
         }
 
+        public ITrie SetNull(in KeyBytes key)
+        {
+            INode? newRootNode = RemoveFromRoot(new PathCursor(key));
+            return new MerkleTrie(KeyValueStore, newRootNode, _cache);
+        }
+
         /// <inheritdoc cref="ITrie.Get(KeyBytes)"/>
         public IValue? Get(KeyBytes key) => ResolveToValue(Root, new PathCursor(key));
 

--- a/Libplanet.Store/Trie/MerkleTrie.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.cs
@@ -96,8 +96,8 @@ namespace Libplanet.Store.Trie
             return new MerkleTrie(KeyValueStore, newRootNode, _cache);
         }
 
-        /// <inheritdoc cref="ITrie.SetNull"/>
-        public ITrie SetNull(in KeyBytes key)
+        /// <inheritdoc cref="ITrie.Remove"/>
+        public ITrie Remove(in KeyBytes key)
         {
             INode? newRootNode = RemoveFromRoot(new PathCursor(key));
             return new MerkleTrie(KeyValueStore, newRootNode, _cache);

--- a/Libplanet.Store/Trie/MerkleTrie.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.cs
@@ -79,7 +79,7 @@ namespace Libplanet.Store.Trie
 
         private IKeyValueStore KeyValueStore { get; }
 
-        /// <inheritdoc/>
+        /// <inheritdoc cref="ITrie.Set"/>
         public ITrie Set(in KeyBytes key, IValue value)
         {
             if (value is null)
@@ -96,6 +96,7 @@ namespace Libplanet.Store.Trie
             return new MerkleTrie(KeyValueStore, newRootNode, _cache);
         }
 
+        /// <inheritdoc cref="ITrie.SetNull"/>
         public ITrie SetNull(in KeyBytes key)
         {
             INode? newRootNode = RemoveFromRoot(new PathCursor(key));
@@ -129,6 +130,7 @@ namespace Libplanet.Store.Trie
             }
         }
 
+        /// <inheritdoc cref="ITrie.IterateNodes"/>
         public IEnumerable<(Nibbles Path, INode Node)> IterateNodes()
         {
             if (Root is null)

--- a/Libplanet.Store/Trie/Nodes/FullNode.cs
+++ b/Libplanet.Store/Trie/Nodes/FullNode.cs
@@ -34,6 +34,11 @@ namespace Libplanet.Store.Trie.Nodes
             return new FullNode(Children.SetItem(index, childNode));
         }
 
+        public FullNode RemoveChild(int index)
+        {
+            return new FullNode(Children.SetItem(index, null));
+        }
+
         /// <inheritdoc cref="IEquatable{T}.Equals"/>
         public bool Equals(FullNode? other)
         {

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -367,7 +367,7 @@ namespace Libplanet.Tests.Store.Trie
             trie = trie.Set(key, value);
             trie = stateStore.Commit(trie);
             Assert.NotEqual(nullTrieHash, trie.Hash);
-            trie = trie.SetNull(key);
+            trie = trie.Remove(key);
             trie = stateStore.Commit(trie);
             Assert.Null(trie.Root);
             Assert.Equal(nullTrieHash, trie.Hash);
@@ -380,7 +380,7 @@ namespace Libplanet.Tests.Store.Trie
             trie = trie.Set(key00, value00);
             trie = stateStore.Commit(trie);
             Assert.NotEqual(nullTrieHash, trie.Hash);
-            trie = trie.SetNull(key00);
+            trie = trie.Remove(key00);
             trie = stateStore.Commit(trie);
             Assert.Null(trie.Root);
             Assert.Equal(nullTrieHash, trie.Hash);
@@ -400,7 +400,7 @@ namespace Libplanet.Tests.Store.Trie
             trie = trie.Set(key00, value00);
             trie = trie.Set(key0000, value0000);
             trie = stateStore.Commit(trie);
-            trie = trie.SetNull(key00);
+            trie = trie.Remove(key00);
             trie = stateStore.Commit(trie);
             Assert.Equal(value0000, trie.Get(key0000));
             Assert.Equal(expectedNodeCount, trie.IterateNodes().Count());
@@ -420,7 +420,7 @@ namespace Libplanet.Tests.Store.Trie
             trie = trie.Set(key00, value00);
             trie = trie.Set(key0000, value0000);
             trie = stateStore.Commit(trie);
-            trie = trie.SetNull(key0000);
+            trie = trie.Remove(key0000);
             trie = stateStore.Commit(trie);
             Assert.Equal(value00, Assert.Single(trie.IterateValues()).Value);
             Assert.Equal(expectedNodeCount, trie.IterateNodes().Count());
@@ -433,8 +433,8 @@ namespace Libplanet.Tests.Store.Trie
             trie = trie.Set(key00, value00);
             trie = trie.Set(key0000, value0000);
             trie = stateStore.Commit(trie);
-            trie = trie.SetNull(key00);
-            trie = trie.SetNull(key0000);
+            trie = trie.Remove(key00);
+            trie = trie.Remove(key0000);
             trie = stateStore.Commit(trie);
             Assert.Null(trie.Root);
             Assert.Equal(nullTrieHash, trie.Hash);
@@ -466,7 +466,7 @@ namespace Libplanet.Tests.Store.Trie
             kvs.Reverse();
             foreach (var kv in kvs)
             {
-                trie = trie.SetNull(kv.Key);
+                trie = trie.Remove(kv.Key);
                 trie = stateStore.Commit(trie);
                 var tuple = expected.Pop();
 

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -429,10 +429,13 @@ namespace Libplanet.Tests.Store.Trie
 
             // Add two values to make full node + short node
             // and remove both to get a null node.
+            // Also checks that once stored values are not actually removed from the
+            // underlying key value store.
             trie = stateStore.GetStateRoot(null);
             trie = trie.Set(key00, value00);
             trie = trie.Set(key0000, value0000);
             trie = stateStore.Commit(trie);
+            HashDigest<SHA256> hash = trie.Hash; // A reference to an earlier point in time.
             trie = trie.Remove(key00);
             trie = trie.Remove(key0000);
             trie = stateStore.Commit(trie);
@@ -440,6 +443,9 @@ namespace Libplanet.Tests.Store.Trie
             Assert.Equal(nullTrieHash, trie.Hash);
             Assert.Empty(trie.IterateNodes());
             Assert.Empty(trie.IterateValues());
+            trie = stateStore.GetStateRoot(hash);
+            Assert.Equal(value00, trie.Get(key00)); // Nothing is actually removed from storage.
+            Assert.Equal(value0000, trie.Get(key0000));
 
             // Add randomized kvs and remove kvs in order.
             // The way the test is set up, identical kv pairs shouldn't matter.

--- a/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
+++ b/Libplanet.Tests/Store/Trie/MerkleTrieTest.cs
@@ -443,9 +443,10 @@ namespace Libplanet.Tests.Store.Trie
 
             // Add randomized kvs and remove kvs in order.
             // The way the test is set up, identical kv pairs shouldn't matter.
+            Random random = new Random();
             List<(KeyBytes Key, Text Value)> kvs = Enumerable
                 .Range(0, 100)
-                .Select(_ => TestUtils.GetRandomBytes(10))
+                .Select(_ => TestUtils.GetRandomBytes(random.Next(2, 10)))
                 .Select(bytes => (new KeyBytes(bytes), new Text(ByteUtil.Hex(bytes))))
                 .ToList();
             Stack<(HashDigest<SHA256>, int, int)> expected =


### PR DESCRIPTION
Finally adds "value removal" to `ITrie`.
Added `ITrie.SetNull()` and `FullNode.RemoveChild()` as separate methods in order to keep backwards compatibility as much as possible.

I'll add `IAccount.RemoveState()` in a separate PR.