### PR TITLE
✨ Add `IAccount.RemoveState()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ be compatible with this version,  specifically, those that ran with
  -  (Libplanet.Store) Removed `BaseNode`.  [[#3574]]
  -  (Libplanet.Store) Added `ITrie.Remove()` interface method.  [[#3576]]
  -  (Libplanet.Store) Added `FullNode.RemoveChild()` method.  [[#3576]]
+ -  (Libplanet.Action) Added `IAccount.RemoveState()` interface method.
+    [[#3577]]
 
 [#3559]: https://github.com/planetarium/libplanet/pull/3559
 [#3560]: https://github.com/planetarium/libplanet/pull/3560
@@ -51,6 +53,7 @@ be compatible with this version,  specifically, those that ran with
 [#3573]: https://github.com/planetarium/libplanet/pull/3573
 [#3574]: https://github.com/planetarium/libplanet/pull/3574
 [#3576]: https://github.com/planetarium/libplanet/pull/3576
+[#3577]: https://github.com/planetarium/libplanet/pull/3577
 
 
 Version 3.9.2

--- a/Libplanet.Action/State/Account.cs
+++ b/Libplanet.Action/State/Account.cs
@@ -52,6 +52,8 @@ namespace Libplanet.Action.State
         [Pure]
         public IAccount SetState(Address address, IValue state) => UpdateState(address, state);
 
+        /// <inheritdoc/>
+        [Pure]
         public IAccount RemoveState(Address address) => UpdateState(address, null);
 
         /// <inheritdoc/>

--- a/Libplanet.Action/State/Account.cs
+++ b/Libplanet.Action/State/Account.cs
@@ -52,6 +52,8 @@ namespace Libplanet.Action.State
         [Pure]
         public IAccount SetState(Address address, IValue state) => UpdateState(address, state);
 
+        public IAccount RemoveState(Address address) => UpdateState(address, null);
+
         /// <inheritdoc/>
         [Pure]
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
@@ -182,11 +184,15 @@ namespace Libplanet.Action.State
         [Pure]
         private Account UpdateState(
             Address address,
-            IValue value) =>
-            new Account(
-                new AccountState(
-                    Trie.Set(ToStateKey(address), value)),
-                TotalUpdatedFungibleAssets);
+            IValue? value) => value is { } v
+                ? new Account(
+                    new AccountState(
+                        Trie.Set(ToStateKey(address), v)),
+                    TotalUpdatedFungibleAssets)
+                : new Account(
+                    new AccountState(
+                        Trie.Remove(ToStateKey(address))),
+                    TotalUpdatedFungibleAssets);
 
         [Pure]
         private Account UpdateFungibleAssets(

--- a/Libplanet.Action/State/IAccount.cs
+++ b/Libplanet.Action/State/IAccount.cs
@@ -67,6 +67,8 @@ namespace Libplanet.Action.State
         [Pure]
         IAccount SetState(Address address, IValue state);
 
+        IAccount RemoveState(Address address);
+
         /// <summary>
         /// Mints the fungible asset <paramref name="value"/> (i.e., in-game monetary),
         /// and give it to the <paramref name="recipient"/>.

--- a/Libplanet.Action/State/IAccount.cs
+++ b/Libplanet.Action/State/IAccount.cs
@@ -67,6 +67,21 @@ namespace Libplanet.Action.State
         [Pure]
         IAccount SetState(Address address, IValue state);
 
+        /// <summary>
+        /// Gets a new instance that the account state of the given
+        /// <paramref name="address"/> is removed.
+        /// </summary>
+        /// <param name="address">The <see cref="Address"/> referring
+        /// the account to remove its state.</param>
+        /// <returns>A new <see cref="IAccount"/> instance that
+        /// the account state of the given <paramref name="address"/>
+        /// is removed.</returns>
+        /// <remarks>
+        /// This method method does not manipulate the instance,
+        /// but returns a new <see cref="IAccount"/> instance
+        /// with updated states instead.
+        /// </remarks>
+        [Pure]
         IAccount RemoveState(Address address);
 
         /// <summary>

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -398,6 +398,11 @@ public class StateQueryTest
             throw new System.NotImplementedException();
         }
 
+        public IAccount RemoveState(Address address)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public IAccount MintAsset(IActionContext context, Address recipient, FungibleAssetValue value)
         {
             throw new System.NotImplementedException();

--- a/Libplanet.Tests/Action/AccountTest.cs
+++ b/Libplanet.Tests/Action/AccountTest.cs
@@ -144,6 +144,23 @@ namespace Libplanet.Tests.Action
         }
 
         [Fact]
+        public void RemoveState()
+        {
+            IAccount a = _initAccount.SetState(_addr[0], (Text)"A");
+            a = a.SetState(_addr[1], (Text)"B");
+            Assert.Equal((Text)"A", a.GetState(_addr[0]));
+            Assert.Equal((Text)"B", a.GetState(_addr[1]));
+
+            a = a.RemoveState(_addr[0]);
+            Assert.Null(a.GetState(_addr[0]));
+            Assert.Equal((Text)"B", a.GetState(_addr[1]));
+
+            a = a.RemoveState(_addr[1]);
+            Assert.Null(a.GetState(_addr[0]));
+            Assert.Null(a.GetState(_addr[1]));
+        }
+
+        [Fact]
         public virtual void FungibleAssets()
         {
             IAccount a = _initAccount.TransferAsset(


### PR DESCRIPTION
Related to #3576. Allows access to newly added `ITrie.Remove()` from `IAccount.RemoveState()`.