### PR TITLE
♻️ ⏪ Revert changes for old queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,10 @@ be compatible with this version,  specifically, those that ran with
  -  (Libplanet.Store) Added `FullNode.RemoveChild()` method.  [[#3576]]
  -  (Libplanet.Action) Added `IAccount.RemoveState()` interface method.
     [[#3577]]
+ -  (Libplanet.Explorer) Added `LegacyBencodexValueType` class that is
+    a copy of an old `BencodexValueType` with its name changed
+    for backwards compatibility.  Changed old `states` query
+    to use `LegacyBencodexValueType` instead of `BencodexValueType`.  [[#3579]]
 
 [#3559]: https://github.com/planetarium/libplanet/pull/3559
 [#3560]: https://github.com/planetarium/libplanet/pull/3560
@@ -54,6 +58,7 @@ be compatible with this version,  specifically, those that ran with
 [#3574]: https://github.com/planetarium/libplanet/pull/3574
 [#3576]: https://github.com/planetarium/libplanet/pull/3576
 [#3577]: https://github.com/planetarium/libplanet/pull/3577
+[#3579]: https://github.com/planetarium/libplanet/pull/3579
 
 
 Version 3.9.2

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -33,9 +33,7 @@ public class StateQueryTest
                  addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""],
                  offsetBlockHash:
                      ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b""
-            ) {
-                hex
-            }
+            )
         }
         ", source: source);
         Assert.Null(result.Errors);
@@ -45,14 +43,7 @@ public class StateQueryTest
         object[] states =
             Assert.IsAssignableFrom<object[]>(resultDict["states"]);
         Assert.Equal(2, states.Length);
-        Assert.Equal(
-            new Dictionary<string, object>()
-            {
-                { "hex", "6e" },
-            },
-            Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])
-        );
-        Assert.Null(states[1]);
+        Assert.Equal(new[] { new byte[] { 110, }, null }, states);
     }
 
     [Fact]
@@ -186,9 +177,7 @@ public class StateQueryTest
                      ""01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"",
                  offsetStateRootHash:
                      ""c33b27773104f75ac9df5b0533854108bd498fab31e5236b6f1e1f6404d5ef64""
-            ) {
-                hex
-            }
+            )
         }
         ", source: source);
         Assert.IsType<ExecutionErrors>(result.Errors);
@@ -205,9 +194,7 @@ public class StateQueryTest
                  addresses: [""0x5003712B63baAB98094aD678EA2B24BcE445D076"", ""0x0000000000000000000000000000000000000000""],
                  offsetStateRootHash:
                      ""c33b27773104f75ac9df5b0533854108bd498fab31e5236b6f1e1f6404d5ef64""
-            ) {
-                hex
-            }
+            )
         }
         ", source: source);
         Assert.Null(result.Errors);
@@ -216,15 +203,7 @@ public class StateQueryTest
             Assert.IsAssignableFrom<IDictionary<string, object>>(resultData!.ToValue());
         object[] states =
             Assert.IsAssignableFrom<object[]>(resultDict["states"]);
-        Assert.Equal(2, states.Length);
-        Assert.Equal(
-            new Dictionary<string, object>()
-            {
-                { "hex", "6e" },
-            },
-            Assert.IsAssignableFrom<IDictionary<string, object>>(states[0])
-        );
-        Assert.Null(states[1]);
+        Assert.Equal(new[] { new byte[] { 110, }, null }, states);
     }
 
     [Fact]

--- a/Libplanet.Explorer/GraphTypes/LegacyBencodexValueType.cs
+++ b/Libplanet.Explorer/GraphTypes/LegacyBencodexValueType.cs
@@ -1,0 +1,51 @@
+using System;
+using Bencodex;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using Libplanet.Common;
+
+namespace Libplanet.Explorer.GraphTypes
+{
+    public class LegacyBencodexValueType : StringGraphType
+    {
+        private static readonly Codec _codec = new();
+
+        public LegacyBencodexValueType()
+        {
+            Name = "LegacyBencodexValue";
+        }
+
+        public override object? Serialize(object? value)
+        {
+            if (value is Bencodex.Types.IValue iv)
+            {
+                return _codec.Encode(iv);
+            }
+
+            return value;
+        }
+
+        public override object? ParseValue(object? value)
+        {
+            return value switch
+            {
+                null => null,
+                string hex => _codec.Decode(ByteUtil.ParseHex(hex)),
+                _ => throw new ArgumentException(
+                    $"Expected a hexadecimal string but {value}",
+                    nameof(value)
+                ),
+            };
+        }
+
+        public override object? ParseLiteral(IValue? value)
+        {
+            if (value is StringValue)
+            {
+                return ParseValue(value.Value);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Libplanet.Explorer/Queries/StateQuery.cs
+++ b/Libplanet.Explorer/Queries/StateQuery.cs
@@ -15,7 +15,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
     public StateQuery()
     {
         Name = "StateQuery";
-        Field<NonNullGraphType<ListGraphType<BencodexValueType>>>(
+        Field<NonNullGraphType<ListGraphType<LegacyBencodexValueType>>>(
             "states",
             arguments: new QueryArguments(
                 new QueryArgument<NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>


### PR DESCRIPTION
This should resolve the backwards compatibility issue with services already using the `states` query.
It needs to be phased out anyway, so might as well keep it. 🙄

P.S. From what I gather, `LegacyBencodexValueType` was implemented wrongly in the first place (serialization and parse mismatch, implicit base64 representation in playground, etc.). Hence, resulting in such an awkward way to force backwards compatibility in this PR. 😐