### PR TITLE
ci(gh-actions): bump tj-actions/changed-files action 

### DIFF
--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -21,7 +21,7 @@ jobs:
     - run: yarn install --immutable  # TODO: cache and apply --immutable-cache --check-cache
     - run: yarn build
     - id: account-aws-kms-changes
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v41.0.1
       with:
         files: "@planetarium/account-aws-kms"
     - name: Run yarn test w/o AWS cred for PR unrelated to account-aws-kms


### PR DESCRIPTION
I got an alert from GitHub about https://github.com/advisories/GHSA-mcph-m25j-8j63. As I understood there are no parts to be injected like the examples but I don't think I'll be able to recognize it when I use it in the future, so I proactively upgrade the version.