### PR TITLE
Refactor `IBlockChainStates` interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,10 @@ To be released.
     method.
     [[#3540]]
  -  Removed `BlockChain.GetBalance(Address, Currency, Address)` method.
-    Instead, added `BlockChain.GetBalance(Address, Address, Currency)` method.
+    Instead, added `BlockChain.GetBalance(Address, Currency)` method.
     [[#3583]]
  -  Removed `BlockChain.GetTotalSupply(Currency, Address)` method.
-    Instead, added `BlockChain.GetTotalSupply(Address, Currency)` method.
+    Instead, added `BlockChain.GetTotalSupply(Currency)` method.
     [[#3583]]
  -  (Libplanet.Action) Changed `ActionEvaluator` to accept `IWorld`
     instead of `IAccount`.  [[#3462]]
@@ -41,19 +41,16 @@ To be released.
      -  Added `IBlockChainStates.GetAccountState(Address, BlockHash?)` method.
      -  Added `IBlockChainStates.GetState(BlockHash?, Address, Address)` method.
      -  Added `IBlockChainStates.GetState(HashDigest<SHA256>?, Address)` method.
-     -  Added
-        `IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)`
+     -  Added `IBlockChainStates.GetBalance(BlockHash?, Address, Currency)`
         method.
      -  Added
         `IBlockChainStates.GetBalance(HashDigest<SHA256>?, Address, Currency)`
         method.
-     -  Added
-        `IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)`
-        method.
+     -  Added `IBlockChainStates.GetTotalSupply(BlockHash?, Currency)` method.
      -  Added
         `IBlockChainStates.GetTotalSupply(HashDigest<SHA256>?, Currency)`
         method.
-     -  Added `IBlockChainStates.GetValidatorSet(BlockHash?, Address)` method.
+     -  Added `IBlockChainStates.GetValidatorSet(BlockHash?)` method.
      -  Added `IBlockChainStates.GetValidatorSet(HashDigest<SHA256>?)` method.
      -  Removed `IBlockChainStates.GetAccountState(BlockHash?)` method.
      -  Removed `IBlockChainStates.GetState(Address, BlockHash?)` method.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@ To be released.
     `BlockChain.EvaluateBlock(IPreEvaluationBlock, out HashDigest<SHA256>)`
     method.
     [[#3540]]
+ -  Removed `BlockChain.GetBalance(Address, Currency, Address)` method.
+    Instead, added `BlockChain.GetBalance(Address, Address, Currency)` method.
+    [[#3583]]
+ -  Removed `BlockChain.GetTotalSupply(Currency, Address)` method.
+    Instead, added `BlockChain.GetTotalSupply(Address, Currency)` method.
+    [[#3583]]
  -  (Libplanet.Action) Changed `ActionEvaluator` to accept `IWorld`
     instead of `IAccount`.  [[#3462]]
  -  (Libplanet.Action) `IActionEvaluator.OutputState` became `IWorld`.
@@ -29,24 +35,25 @@ To be released.
      -  `IFeeCollector.Mortgage()`
      -  `IFeeCollector.Refund()`
      -  `IFeeCollector.Reward()`
- -  (Libplanet.Action) `IBlockChainStates` interface has modified.  [[#3462]]
+ -  (Libplanet.Action) `IBlockChainStates` interface has modified.
+    [[#3462], [#3583]]
      -  Added `IBlockChainStates.GetWorldState()` method.
      -  Added `IBlockChainStates.GetAccountState(Address, BlockHash?)` method.
-     -  Added `IBlockChainStates.GetState(Address, Address, BlockHash?)` method.
-     -  Added `IBlockChainStates.GetState(Address, HashDigest<SHA256>?)` method.
+     -  Added `IBlockChainStates.GetState(BlockHash?, Address, Address)` method.
+     -  Added `IBlockChainStates.GetState(HashDigest<SHA256>?, Address)` method.
      -  Added
-        `IBlockChainStates.GetBalance(Address, Currency, Address, BlockHash?)`
+        `IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)`
         method.
      -  Added
-        `IBlockChainStates.GetBalance(Address, Currency, HashDigest<SHA256>?)`
+        `IBlockChainStates.GetBalance(HashDigest<SHA256>?, Address, Currency)`
         method.
      -  Added
-        `IBlockChainStates.GetTotalSupply(Currency, Address, BlockHash?)`
+        `IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)`
         method.
      -  Added
-        `IBlockChainStates.GetTotalSupply(Currency, HashDigest<SHA256>?)`
+        `IBlockChainStates.GetTotalSupply(HashDigest<SHA256>?, Currency)`
         method.
-     -  Added `IBlockChainStates.GetValidatorSet(Address, BlockHash?)` method.
+     -  Added `IBlockChainStates.GetValidatorSet(BlockHash?, Address)` method.
      -  Added `IBlockChainStates.GetValidatorSet(HashDigest<SHA256>?)` method.
      -  Removed `IBlockChainStates.GetAccountState(BlockHash?)` method.
      -  Removed `IBlockChainStates.GetState(Address, BlockHash?)` method.
@@ -118,6 +125,7 @@ To be released.
 [#3512]: https://github.com/planetarium/libplanet/pull/3512
 [#3524]: https://github.com/planetarium/libplanet/pull/3524
 [#3540]: https://github.com/planetarium/libplanet/pull/3540
+[#3583]: https://github.com/planetarium/libplanet/pull/3583
 
 
 Version 3.9.1

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -136,26 +136,25 @@ namespace Libplanet.Action.State
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="address">The owner <see cref="Address"/> to query.</param>
         /// <param name="currency">The currency type to query.</param>
         /// <returns>The <paramref name="address"/>'s balance for <paramref name="currency"/>
-        /// at <paramref name="offset"/> and <paramref name="accountAddress"/>.
+        /// at <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/>
         /// for <paramref name="currency"/>.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
-        /// <paramref name="offset"/> and <paramref name="accountAddress"/> cannot be created.
+        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>
+        /// cannot be created.
         /// </exception>
         FungibleAssetValue GetBalance(
             BlockHash? offset,
-            Address accountAddress,
             Address address,
             Currency currency);
 
         /// <summary>
         /// Gets <paramref name="address"/>'s balance for given <paramref name="currency"/> in the
-        /// <see cref="BlockChain"/> at <paramref name="offset"/>.
+        /// <see cref="BlockChain"/> at <paramref name="stateRootHash"/>.
         /// </summary>
         /// <param name="stateRootHash">The state root hash of the <see cref="ITrie"/> to fetch
         /// the balance from.</param>
@@ -178,27 +177,26 @@ namespace Libplanet.Action.State
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="currency">The currency type to query.</param>
         /// <returns>The total supply value of <paramref name="currency"/> at
-        /// <paramref name="offset"/> and <paramref name="accountAddress"/>
+        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>
         /// in <see cref="FungibleAssetValue"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/>
         /// for <paramref name="currency"/>.</returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
-        /// <paramref name="offset"/> and <paramref name="accountAddress"/> cannot be created.
+        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>
+        /// cannot be created.
         /// </exception>
         /// <exception cref="TotalSupplyNotTrackableException">Thrown when
         /// given <paramref name="currency"/>'s <see cref="Currency.TotalSupplyTrackable"/>
         /// is <see langword="false"/>.</exception>
         FungibleAssetValue GetTotalSupply(
             BlockHash? offset,
-            Address accountAddress,
             Currency currency);
 
         /// <summary>
-        /// Gets the total supply of a <paramref name="currency"/> in the
-        /// <see cref="BlockChain"/> at <paramref name="offset"/>, and if not found, returns 0.
+        /// Gets the total supply of a <paramref name="currency"/> in the <see cref="BlockChain"/>
+        /// at <paramref name="stateRootHash"/>, and if not found, returns 0.
         /// </summary>
         /// <param name="stateRootHash">The state root hash of the <see cref="ITrie"/> to fetch
         /// the total supply from.</param>
@@ -222,14 +220,14 @@ namespace Libplanet.Action.State
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <returns>The validator set of type <see cref="ValidatorSet"/> at
-        /// <paramref name="offset"/> and <paramref name="accountAddress"/>.
+        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
-        /// <paramref name="offset"/> and <paramref name="accountAddress"/> cannot be created.
+        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>
+        /// cannot be created.
         /// </exception>
-        ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress);
+        ValidatorSet GetValidatorSet(BlockHash? offset);
 
         /// <summary>
         /// Returns the validator set in the

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -60,10 +60,10 @@ namespace Libplanet.Action.State
         /// Returns the <see cref="IAccountState"/> in the <see cref="BlockChain"/>
         /// at <paramref name="offset"/>.
         /// </summary>
-        /// <param name="address">The <see cref="Address"/> of <see cref="IAccountState"/>
-        /// to be returned.</param>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
         /// for which to create an <see cref="IAccountState"/>.</param>
+        /// <param name="address">The <see cref="Address"/> of <see cref="IAccountState"/>
+        /// to be returned.</param>
         /// <returns>
         /// The <see cref="IAccountState"/> at <paramref name="offset"/>.
         /// </returns>
@@ -80,7 +80,7 @@ namespace Libplanet.Action.State
         /// </list>
         /// </exception>
         /// <seealso cref="IAccountState"/>
-        IAccountState GetAccountState(Address address, BlockHash? offset);
+        IAccountState GetAccountState(BlockHash? offset, Address address);
 
         /// <summary>
         /// Returns the <see cref="IAccountState"/> in the <see cref="BlockChain"/>
@@ -97,11 +97,11 @@ namespace Libplanet.Action.State
         /// <summary>
         /// Gets a state associated to specified <paramref name="address"/>.
         /// </summary>
-        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
-        /// <param name="accountAddress">The <see cref="Address"/> of the account to fetch
-        /// the state from.</param>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the state from.</param>
+        /// <param name="accountAddress">The <see cref="Address"/> of the account to fetch
+        /// the state from.</param>
+        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
         /// <returns>The state associated to specified <paramref name="address"/>.
         /// An absent state is represented as <see langword="null"/>.
         /// </returns>
@@ -117,28 +117,28 @@ namespace Libplanet.Action.State
         ///     </description></item>
         /// </list>
         /// </exception>
-        IValue? GetState(Address address, Address accountAddress, BlockHash? offset);
+        IValue? GetState(BlockHash? offset, Address accountAddress, Address address);
 
         /// <summary>
         /// Gets a state associated to specified <paramref name="address"/>.
         /// </summary>
-        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
         /// <param name="stateRootHash">The <see cref="HashDigest{SHA256}"/> of the root hash
         /// for which to create an <see cref="IAccountState"/>.</param>
+        /// <param name="address">The <see cref="Address"/> of the state to query.</param>
         /// <returns>The state associated to specified <paramref name="address"/>.
         /// An absent state is represented as <see langword="null"/>.
         /// </returns>
-        IValue? GetState(Address address, HashDigest<SHA256>? stateRootHash);
+        IValue? GetState(HashDigest<SHA256>? stateRootHash, Address address);
 
         /// <summary>
         /// Gets <paramref name="address"/>'s balance for given <paramref name="currency"/> in the
         /// <see cref="BlockChain"/> at <paramref name="offset"/>.
         /// </summary>
-        /// <param name="address">The owner <see cref="Address"/> to query.</param>
-        /// <param name="currency">The currency type to query.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
+        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
+        /// <param name="address">The owner <see cref="Address"/> to query.</param>
+        /// <param name="currency">The currency type to query.</param>
         /// <returns>The <paramref name="address"/>'s balance for <paramref name="currency"/>
         /// at <paramref name="offset"/> and <paramref name="accountAddress"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/>
@@ -148,19 +148,19 @@ namespace Libplanet.Action.State
         /// <paramref name="offset"/> and <paramref name="accountAddress"/> cannot be created.
         /// </exception>
         FungibleAssetValue GetBalance(
-            Address address,
-            Currency currency,
+            BlockHash? offset,
             Address accountAddress,
-            BlockHash? offset);
+            Address address,
+            Currency currency);
 
         /// <summary>
         /// Gets <paramref name="address"/>'s balance for given <paramref name="currency"/> in the
         /// <see cref="BlockChain"/> at <paramref name="offset"/>.
         /// </summary>
-        /// <param name="address">The owner <see cref="Address"/> to query.</param>
-        /// <param name="currency">The currency type to query.</param>
         /// <param name="stateRootHash">The state root hash of the <see cref="ITrie"/> to fetch
         /// the balance from.</param>
+        /// <param name="address">The owner <see cref="Address"/> to query.</param>
+        /// <param name="currency">The currency type to query.</param>
         /// <returns>The <paramref name="address"/>'s balance for <paramref name="currency"/>
         /// at <paramref name="stateRootHash"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/> for <paramref name="currency"/>.
@@ -168,18 +168,18 @@ namespace Libplanet.Action.State
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
         /// <paramref name="stateRootHash"/> cannot be created.</exception>
         FungibleAssetValue GetBalance(
+            HashDigest<SHA256>? stateRootHash,
             Address address,
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash);
+            Currency currency);
 
         /// <summary>
         /// Gets the total supply of a <paramref name="currency"/> in the
         /// <see cref="BlockChain"/> at <paramref name="offset"/>, and if not found, returns 0.
         /// </summary>
-        /// <param name="currency">The currency type to query.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
+        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
+        /// <param name="currency">The currency type to query.</param>
         /// <returns>The total supply value of <paramref name="currency"/> at
         /// <paramref name="offset"/> and <paramref name="accountAddress"/>
         /// in <see cref="FungibleAssetValue"/>.
@@ -192,17 +192,17 @@ namespace Libplanet.Action.State
         /// given <paramref name="currency"/>'s <see cref="Currency.TotalSupplyTrackable"/>
         /// is <see langword="false"/>.</exception>
         FungibleAssetValue GetTotalSupply(
-            Currency currency,
+            BlockHash? offset,
             Address accountAddress,
-            BlockHash? offset);
+            Currency currency);
 
         /// <summary>
         /// Gets the total supply of a <paramref name="currency"/> in the
         /// <see cref="BlockChain"/> at <paramref name="offset"/>, and if not found, returns 0.
         /// </summary>
-        /// <param name="currency">The currency type to query.</param>
         /// <param name="stateRootHash">The state root hash of the <see cref="ITrie"/> to fetch
         /// the total supply from.</param>
+        /// <param name="currency">The currency type to query.</param>
         /// <returns>The total supply value of <paramref name="currency"/> at
         /// <paramref name="stateRootHash"/> in <see cref="FungibleAssetValue"/>.
         /// If absent, returns 0 <see cref="FungibleAssetValue"/>
@@ -213,25 +213,23 @@ namespace Libplanet.Action.State
         /// given <paramref name="currency"/>'s <see cref="Currency.TotalSupplyTrackable"/>
         /// is <see langword="false"/>.</exception>
         FungibleAssetValue GetTotalSupply(
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash);
+            HashDigest<SHA256>? stateRootHash,
+            Currency currency);
 
         /// <summary>
         /// Returns the validator set in the
         /// <see cref="BlockChain"/> at <paramref name="offset"/>.
         /// </summary>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
         /// the states from.</param>
+        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <returns>The validator set of type <see cref="ValidatorSet"/> at
         /// <paramref name="offset"/> and <paramref name="accountAddress"/>.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
         /// <paramref name="offset"/> and <paramref name="accountAddress"/> cannot be created.
         /// </exception>
-        ValidatorSet GetValidatorSet(
-            Address accountAddress,
-            BlockHash? offset);
+        ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress);
 
         /// <summary>
         /// Returns the validator set in the
@@ -244,7 +242,6 @@ namespace Libplanet.Action.State
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
         /// <paramref name="stateRootHash"/> cannot be created.</exception>
-        ValidatorSet GetValidatorSet(
-            HashDigest<SHA256>? stateRootHash);
+        ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash);
     }
 }

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -436,18 +436,18 @@ public class StateQueryTest
             new MockAccount().GetBalance(address, currency);
 
         public FungibleAssetValue GetBalance(
-            BlockHash? offset, Address accountAddress, Address address, Currency currency) =>
+            BlockHash? offset, Address address, Currency currency) =>
             new MockAccount().GetBalance(address, currency);
 
         public FungibleAssetValue GetTotalSupply(HashDigest<SHA256>? hash, Currency currency) =>
             new MockAccount().GetTotalSupply(currency);
 
-        public FungibleAssetValue GetTotalSupply(BlockHash? offset, Address accountAddress, Currency currency) =>
+        public FungibleAssetValue GetTotalSupply(BlockHash? offset, Currency currency) =>
             new MockAccount().GetTotalSupply(currency);
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? hash) =>
             new MockAccount().GetValidatorSet();
 
-        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress) =>
+        public ValidatorSet GetValidatorSet(BlockHash? offset) =>
             new MockAccount().GetValidatorSet();
     }
 

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.cs
@@ -422,32 +422,32 @@ public class StateQueryTest
         public IAccountState GetAccountState(HashDigest<SHA256>? hash)
             => new MockAccount();
 
-        public IAccountState GetAccountState(Address address, BlockHash? blockHash)
+        public IAccountState GetAccountState(BlockHash? blockHash, Address address)
             => new MockAccount();
 
-        public IValue GetState(Address address, HashDigest<SHA256>? hash)
+        public IValue GetState(HashDigest<SHA256>? hash, Address address)
             => new MockAccount().GetState(address);
 
-        public IValue GetState(Address address, Address accountAddress, BlockHash? offset)
+        public IValue GetState(BlockHash? offset, Address accountAddress, Address address)
             => new MockAccount().GetState(address);
 
         public FungibleAssetValue GetBalance(
-            Address address, Currency currency, HashDigest<SHA256>? hash) =>
+            HashDigest<SHA256>? hash, Address address, Currency currency) =>
             new MockAccount().GetBalance(address, currency);
 
         public FungibleAssetValue GetBalance(
-            Address address, Currency currency, Address accountAddress, BlockHash? offset) =>
+            BlockHash? offset, Address accountAddress, Address address, Currency currency) =>
             new MockAccount().GetBalance(address, currency);
 
-        public FungibleAssetValue GetTotalSupply(Currency currency, HashDigest<SHA256>? hash) =>
+        public FungibleAssetValue GetTotalSupply(HashDigest<SHA256>? hash, Currency currency) =>
             new MockAccount().GetTotalSupply(currency);
 
-        public FungibleAssetValue GetTotalSupply(Currency currency, Address accountAddress, BlockHash? offset) =>
+        public FungibleAssetValue GetTotalSupply(BlockHash? offset, Address accountAddress, Currency currency) =>
             new MockAccount().GetTotalSupply(currency);
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? hash) =>
             new MockAccount().GetValidatorSet();
 
-        public ValidatorSet GetValidatorSet(Address accountAddress, BlockHash? offset) =>
+        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress) =>
             new MockAccount().GetValidatorSet();
     }
 

--- a/Libplanet.Tests/Action/AccountTest.cs
+++ b/Libplanet.Tests/Action/AccountTest.cs
@@ -234,11 +234,11 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,
-                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
+                chain.GetBalance(_addr[0], DumbAction.DumbCurrency)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * -5,
-                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[1], DumbAction.DumbCurrency)
+                chain.GetBalance(_addr[1], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet.Tests/Action/AccountTest.cs
+++ b/Libplanet.Tests/Action/AccountTest.cs
@@ -234,11 +234,11 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,
-                chain.GetBalance(_addr[0], DumbAction.DumbCurrency, ReservedAddresses.LegacyAccount)
+                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * -5,
-                chain.GetBalance(_addr[1], DumbAction.DumbCurrency, ReservedAddresses.LegacyAccount)
+                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[1], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet.Tests/Action/AccountV0Test.cs
+++ b/Libplanet.Tests/Action/AccountV0Test.cs
@@ -78,7 +78,7 @@ namespace Libplanet.Tests.Action
             chain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,
-                chain.GetBalance(_addr[0], DumbAction.DumbCurrency, ReservedAddresses.LegacyAccount)
+                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet.Tests/Action/AccountV0Test.cs
+++ b/Libplanet.Tests/Action/AccountV0Test.cs
@@ -78,7 +78,7 @@ namespace Libplanet.Tests.Action
             chain.Append(block, TestUtils.CreateBlockCommit(block));
             Assert.Equal(
                 DumbAction.DumbCurrency * 6,
-                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
+                chain.GetBalance(_addr[0], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet.Tests/Action/AccountV1Test.cs
+++ b/Libplanet.Tests/Action/AccountV1Test.cs
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,
-                chain.GetBalance(_addr[0], DumbAction.DumbCurrency, ReservedAddresses.LegacyAccount)
+                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet.Tests/Action/AccountV1Test.cs
+++ b/Libplanet.Tests/Action/AccountV1Test.cs
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Action
             );
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,
-                chain.GetBalance(ReservedAddresses.LegacyAccount, _addr[0], DumbAction.DumbCurrency)
+                chain.GetBalance(_addr[0], DumbAction.DumbCurrency)
             );
 
             return chain;

--- a/Libplanet/Blockchain/BlockChain.States.cs
+++ b/Libplanet/Blockchain/BlockChain.States.cs
@@ -27,9 +27,9 @@ namespace Libplanet.Blockchain
         /// <returns>The current world state.</returns>
         public IWorldState GetWorldState() => GetWorldState(Tip.Hash);
 
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(Address, BlockHash?)"/>
-        public IAccountState GetAccountState(Address address, BlockHash? offset)
-            => _blockChainStates.GetAccountState(address, offset);
+        /// <inheritdoc cref="IBlockChainStates.GetAccountState(BlockHash?, Address)"/>
+        public IAccountState GetAccountState(BlockHash? offset, Address address)
+            => _blockChainStates.GetAccountState(offset, address);
 
         /// <inheritdoc cref="IBlockChainStates.GetAccountState(HashDigest{SHA256}?)"/>
         public IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash)
@@ -42,95 +42,95 @@ namespace Libplanet.Blockchain
         /// <param name="address">An <see cref="Address"/> to get the account states of.</param>
         /// <returns>The current account state of given <paramref name="address"/>.</returns>
         public IAccountState GetAccountState(Address address)
-            => GetAccountState(address, Tip.Hash);
+            => GetAccountState(Tip.Hash, address);
 
-        /// <inheritdoc cref="IBlockChainStates.GetState(Address, Address, BlockHash?)"/>
-        public IValue GetState(Address address, Address accountAddress, BlockHash? offset)
-            => _blockChainStates.GetState(address, accountAddress, offset);
+        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address, Address)"/>
+        public IValue GetState(BlockHash? offset, Address accountAddress, Address address)
+            => _blockChainStates.GetState(offset, accountAddress, address);
 
-        /// <inheritdoc cref="IBlockChainStates.GetState(Address, HashDigest{SHA256}?)"/>
-        public IValue GetState(Address address, HashDigest<SHA256>? stateRootHash)
-            => _blockChainStates.GetState(address, stateRootHash);
+        /// <inheritdoc cref="IBlockChainStates.GetState(HashDigest{SHA256}?, Address)"/>
+        public IValue GetState(HashDigest<SHA256>? stateRootHash, Address address)
+            => _blockChainStates.GetState(stateRootHash, address);
 
         /// <summary>
         /// Gets the current state of given <paramref name="address"/> and
         /// <paramref name="accountAddress"/> in the <see cref="BlockChain"/>.
         /// </summary>
-        /// <param name="address">An <see cref="Address"/> to get the states of.</param>
         /// <param name="accountAddress">An <see cref="Address"/> to get the states from.</param>
+        /// <param name="address">An <see cref="Address"/> to get the states of.</param>
         /// <returns>The current state of given <paramref name="address"/> and
         /// <paramref name="accountAddress"/>.  This can be <see langword="null"/>
         /// if <paramref name="address"/> or <paramref name="accountAddress"/> has no value.
         /// </returns>
-        public IValue GetState(Address address, Address accountAddress)
-            => GetState(address, accountAddress, Tip.Hash);
+        public IValue GetState(Address accountAddress, Address address)
+            => GetState(Tip.Hash, accountAddress, address);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(Address, Currency, Address, BlockHash?)"/>
+        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
-            Address address,
-            Currency currency,
+            BlockHash? offset,
             Address accountAddress,
-            BlockHash? offset)
-            => _blockChainStates.GetBalance(address, currency, accountAddress, offset);
+            Address address,
+            Currency currency)
+            => _blockChainStates.GetBalance(offset, accountAddress, address, currency);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(Address, Currency, HashDigest{SHA256}?)"/>
+        /// "IBlockChainStates.GetBalance(HashDigest{SHA256}?, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
+            HashDigest<SHA256>? stateRootHash,
             Address address,
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash)
-            => _blockChainStates.GetBalance(address, currency, stateRootHash);
+            Currency currency)
+            => _blockChainStates.GetBalance(stateRootHash, address, currency);
 
         /// <summary>
         /// Queries <paramref name="address"/>'s current balance of the <paramref name="currency"/>
         /// in the <see cref="BlockChain"/>.
         /// </summary>
+        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="address">The owner <see cref="Address"/> to query.</param>
         /// <param name="currency">The currency type to query.</param>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <returns>The <paramref name="address"/>'s current balance.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> of
         /// <paramref name="accountAddress"/> cannot be created.
         /// </exception>
         public FungibleAssetValue GetBalance(
-            Address address,
-            Currency currency,
-            Address accountAddress)
-            => GetBalance(address, currency, accountAddress, Tip.Hash);
-
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(Currency, Address, BlockHash?)"/>
-        public FungibleAssetValue GetTotalSupply(
-            Currency currency,
             Address accountAddress,
-            BlockHash? offset)
-            => _blockChainStates.GetTotalSupply(currency, accountAddress, offset);
+            Address address,
+            Currency currency)
+            => GetBalance(Tip.Hash, accountAddress, address, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(Currency, HashDigest{SHA256}?)"/>
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash)
-            => _blockChainStates.GetTotalSupply(currency, stateRootHash);
+            BlockHash? offset,
+            Address accountAddress,
+            Currency currency)
+            => _blockChainStates.GetTotalSupply(offset, accountAddress, currency);
+
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(HashDigest{SHA256}?, Currency)"/>
+        public FungibleAssetValue GetTotalSupply(
+            HashDigest<SHA256>? stateRootHash,
+            Currency currency)
+            => _blockChainStates.GetTotalSupply(stateRootHash, currency);
 
         /// <summary>
         /// Gets the current total supply of a <paramref name="currency"/> in the
         /// <see cref="BlockChain"/>.
         /// </summary>
-        /// <param name="currency">The currency type to query.</param>
         /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
+        /// <param name="currency">The currency type to query.</param>
         /// <returns>The total supply value of <paramref name="currency"/> at
         /// <see cref="BlockChain.Tip"/> and <paramref name="accountAddress"/>
         /// in <see cref="FungibleAssetValue"/>.</returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> of
         /// <paramref name="accountAddress"/> cannot be created.
         /// </exception>
-        public FungibleAssetValue GetTotalSupply(Currency currency, Address accountAddress)
-            => GetTotalSupply(currency, accountAddress, Tip.Hash);
+        public FungibleAssetValue GetTotalSupply(Address accountAddress, Currency currency)
+            => GetTotalSupply(Tip.Hash, accountAddress, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(Address, BlockHash?)" />
-        public ValidatorSet GetValidatorSet(Address accountAddress, BlockHash? offset)
-            => _blockChainStates.GetValidatorSet(accountAddress, offset);
+        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?, Address)" />
+        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress)
+            => _blockChainStates.GetValidatorSet(offset, accountAddress);
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)" />
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash)
@@ -147,7 +147,7 @@ namespace Libplanet.Blockchain
         /// <paramref name="accountAddress"/> cannot be created.
         /// </exception>
         public ValidatorSet GetValidatorSet(Address accountAddress)
-            => GetValidatorSet(accountAddress, Tip.Hash);
+            => GetValidatorSet(Tip.Hash, accountAddress);
 
         /// <summary>
         /// Returns the validator set in the
@@ -164,7 +164,7 @@ namespace Libplanet.Blockchain
         /// cannot be created.
         /// </exception>
         public ValidatorSet GetValidatorSet(BlockHash? offset)
-            => GetValidatorSet(ReservedAddresses.LegacyAccount, offset);
+            => GetValidatorSet(offset, ReservedAddresses.LegacyAccount);
 
         /// <summary>
         /// Returns the current validator set in the <see cref="BlockChain"/>.

--- a/Libplanet/Blockchain/BlockChain.States.cs
+++ b/Libplanet/Blockchain/BlockChain.States.cs
@@ -66,13 +66,12 @@ namespace Libplanet.Blockchain
             => GetState(Tip.Hash, accountAddress, address);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)"/>
+        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
             BlockHash? offset,
-            Address accountAddress,
             Address address,
             Currency currency)
-            => _blockChainStates.GetBalance(offset, accountAddress, address, currency);
+            => _blockChainStates.GetBalance(offset, address, currency);
 
         /// <inheritdoc cref=
         /// "IBlockChainStates.GetBalance(HashDigest{SHA256}?, Address, Currency)"/>
@@ -86,26 +85,23 @@ namespace Libplanet.Blockchain
         /// Queries <paramref name="address"/>'s current balance of the <paramref name="currency"/>
         /// in the <see cref="BlockChain"/>.
         /// </summary>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="address">The owner <see cref="Address"/> to query.</param>
         /// <param name="currency">The currency type to query.</param>
         /// <returns>The <paramref name="address"/>'s current balance.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> of
-        /// <paramref name="accountAddress"/> cannot be created.
+        /// <see cref="ReservedAddresses.LegacyAccount"/> cannot be created.
         /// </exception>
         public FungibleAssetValue GetBalance(
-            Address accountAddress,
             Address address,
             Currency currency)
-            => GetBalance(Tip.Hash, accountAddress, address, currency);
+            => GetBalance(Tip.Hash, address, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)"/>
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
             BlockHash? offset,
-            Address accountAddress,
             Currency currency)
-            => _blockChainStates.GetTotalSupply(offset, accountAddress, currency);
+            => _blockChainStates.GetTotalSupply(offset, currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(HashDigest{SHA256}?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
@@ -117,54 +113,22 @@ namespace Libplanet.Blockchain
         /// Gets the current total supply of a <paramref name="currency"/> in the
         /// <see cref="BlockChain"/>.
         /// </summary>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
         /// <param name="currency">The currency type to query.</param>
         /// <returns>The total supply value of <paramref name="currency"/> at
-        /// <see cref="BlockChain.Tip"/> and <paramref name="accountAddress"/>
-        /// in <see cref="FungibleAssetValue"/>.</returns>
+        /// <see cref="BlockChain.Tip"/> in <see cref="FungibleAssetValue"/>.</returns>
         /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> of
-        /// <paramref name="accountAddress"/> cannot be created.
+        /// <see cref="ReservedAddresses.LegacyAccount"/> cannot be created.
         /// </exception>
-        public FungibleAssetValue GetTotalSupply(Address accountAddress, Currency currency)
-            => GetTotalSupply(Tip.Hash, accountAddress, currency);
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+            => GetTotalSupply(Tip.Hash, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?, Address)" />
-        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress)
-            => _blockChainStates.GetValidatorSet(offset, accountAddress);
+        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?)" />
+        public ValidatorSet GetValidatorSet(BlockHash? offset)
+            => _blockChainStates.GetValidatorSet(offset);
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)" />
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash)
             => _blockChainStates.GetValidatorSet(stateRootHash);
-
-        /// <summary>
-        /// Returns the current validator set in the <see cref="BlockChain"/>.
-        /// </summary>
-        /// <param name="accountAddress">The account <see cref="Address"/> to query from.</param>
-        /// <returns>The validator set of type <see cref="ValidatorSet"/> at
-        /// <see cref="BlockChain.Tip"/> and <paramref name="accountAddress"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> of
-        /// <paramref name="accountAddress"/> cannot be created.
-        /// </exception>
-        public ValidatorSet GetValidatorSet(Address accountAddress)
-            => GetValidatorSet(Tip.Hash, accountAddress);
-
-        /// <summary>
-        /// Returns the validator set in the
-        /// <see cref="BlockChain"/> at <paramref name="offset"/> and
-        /// <see cref="ReservedAddresses.LegacyAccount"/>.
-        /// </summary>
-        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
-        /// the states from.</param>
-        /// <returns>The validator set of type <see cref="ValidatorSet"/> at
-        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <see cref="IAccount"/> at
-        /// <paramref name="offset"/> and <see cref="ReservedAddresses.LegacyAccount"/>
-        /// cannot be created.
-        /// </exception>
-        public ValidatorSet GetValidatorSet(BlockHash? offset)
-            => GetValidatorSet(offset, ReservedAddresses.LegacyAccount);
 
         /// <summary>
         /// Returns the current validator set in the <see cref="BlockChain"/>.
@@ -176,6 +140,6 @@ namespace Libplanet.Blockchain
         /// <see cref="ReservedAddresses.LegacyAccount"/> cannot be created.
         /// </exception>
         public ValidatorSet GetValidatorSet()
-            => GetValidatorSet(ReservedAddresses.LegacyAccount);
+            => GetValidatorSet(Tip.Hash);
     }
 }

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -34,55 +34,55 @@ namespace Libplanet.Blockchain
         public IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash)
             => new WorldBaseState(GetTrie(stateRootHash), _stateStore);
 
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(Address, BlockHash?)"/>
-        public IAccountState GetAccountState(Address address, BlockHash? offset)
+        /// <inheritdoc cref="IBlockChainStates.GetAccountState(BlockHash?, Address)"/>
+        public IAccountState GetAccountState(BlockHash? offset, Address address)
             => GetWorldState(offset).GetAccount(address);
 
         /// <inheritdoc cref="IBlockChainStates.GetAccountState(HashDigest{SHA256}?)"/>
         public IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash)
             => new AccountState(GetTrie(stateRootHash));
 
-        /// <inheritdoc cref="IBlockChainStates.GetState(Address, Address, BlockHash?)"/>
-        public IValue? GetState(Address address, Address accountAddress, BlockHash? offset)
-            => GetAccountState(accountAddress, offset).GetState(address);
+        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address, Address)"/>
+        public IValue? GetState(BlockHash? offset, Address accountAddress, Address address)
+            => GetAccountState(offset, accountAddress).GetState(address);
 
-        /// <inheritdoc cref="IBlockChainStates.GetState(Address, HashDigest{SHA256}?)"/>
-        public IValue? GetState(Address address, HashDigest<SHA256>? stateRootHash)
+        /// <inheritdoc cref="IBlockChainStates.GetState(HashDigest{SHA256}?, Address)"/>
+        public IValue? GetState(HashDigest<SHA256>? stateRootHash, Address address)
             => GetAccountState(stateRootHash).GetState(address);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(Address, Currency, Address, BlockHash?)"/>
+        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
-            Address address,
-            Currency currency,
+            BlockHash? offset,
             Address accountAddress,
-            BlockHash? offset)
-            => GetAccountState(accountAddress, offset).GetBalance(address, currency);
+            Address address,
+            Currency currency)
+            => GetAccountState(offset, accountAddress).GetBalance(address, currency);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(Address, Currency, HashDigest{SHA256}?)"/>
+        /// "IBlockChainStates.GetBalance(HashDigest{SHA256}?, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
+            HashDigest<SHA256>? stateRootHash,
             Address address,
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash)
+            Currency currency)
             => GetAccountState(stateRootHash).GetBalance(address, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(Currency, Address, BlockHash?)"/>
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
-            Currency currency,
+            BlockHash? offset,
             Address accountAddress,
-            BlockHash? offset)
-            => GetAccountState(accountAddress, offset).GetTotalSupply(currency);
+            Currency currency)
+            => GetAccountState(offset, accountAddress).GetTotalSupply(currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(Currency, HashDigest{SHA256}?)"/>
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(HashDigest{SHA256}?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
-            Currency currency,
-            HashDigest<SHA256>? stateRootHash)
+            HashDigest<SHA256>? stateRootHash,
+            Currency currency)
             => GetAccountState(stateRootHash).GetTotalSupply(currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(Address,BlockHash?)"/>
-        public ValidatorSet GetValidatorSet(Address accountAddress, BlockHash? offset)
-            => GetAccountState(accountAddress, offset).GetValidatorSet();
+        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?, Address)"/>
+        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress)
+            => GetAccountState(offset, accountAddress).GetValidatorSet();
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)"/>
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash)

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -51,13 +51,13 @@ namespace Libplanet.Blockchain
             => GetAccountState(stateRootHash).GetState(address);
 
         /// <inheritdoc cref=
-        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Address, Currency)"/>
+        /// "IBlockChainStates.GetBalance(BlockHash?, Address, Currency)"/>
         public FungibleAssetValue GetBalance(
             BlockHash? offset,
-            Address accountAddress,
             Address address,
             Currency currency)
-            => GetAccountState(offset, accountAddress).GetBalance(address, currency);
+            => GetAccountState(offset, ReservedAddresses.LegacyAccount)
+                .GetBalance(address, currency);
 
         /// <inheritdoc cref=
         /// "IBlockChainStates.GetBalance(HashDigest{SHA256}?, Address, Currency)"/>
@@ -67,12 +67,11 @@ namespace Libplanet.Blockchain
             Currency currency)
             => GetAccountState(stateRootHash).GetBalance(address, currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Address, Currency)"/>
+        /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
             BlockHash? offset,
-            Address accountAddress,
             Currency currency)
-            => GetAccountState(offset, accountAddress).GetTotalSupply(currency);
+            => GetAccountState(offset, ReservedAddresses.LegacyAccount).GetTotalSupply(currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(HashDigest{SHA256}?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
@@ -80,9 +79,9 @@ namespace Libplanet.Blockchain
             Currency currency)
             => GetAccountState(stateRootHash).GetTotalSupply(currency);
 
-        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?, Address)"/>
-        public ValidatorSet GetValidatorSet(BlockHash? offset, Address accountAddress)
-            => GetAccountState(offset, accountAddress).GetValidatorSet();
+        /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?)"/>
+        public ValidatorSet GetValidatorSet(BlockHash? offset)
+            => GetAccountState(offset, ReservedAddresses.LegacyAccount).GetValidatorSet();
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)"/>
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash)


### PR DESCRIPTION
This PR refactors `IBlockChainStates` interface's parameter order as following order.

- `BlockHash` > `AccountAddress` > `Address`
- `StateRootHash` > `Address`