### PR TITLE
🧹 Leaner `IBlockChainStates`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,8 +38,7 @@ To be released.
  -  (Libplanet.Action) `IBlockChainStates` interface has modified.
     [[#3462], [#3583]]
      -  Added `IBlockChainStates.GetWorldState()` method.
-     -  Added `IBlockChainStates.GetAccountState(Address, BlockHash?)` method.
-     -  Added `IBlockChainStates.GetState(BlockHash?, Address, Address)` method.
+     -  Added `IBlockChainStates.GetState(BlockHash?, Address)` method.
      -  Added `IBlockChainStates.GetState(HashDigest<SHA256>?, Address)` method.
      -  Added `IBlockChainStates.GetBalance(BlockHash?, Address, Currency)`
         method.

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -57,49 +57,9 @@ namespace Libplanet.Action.State
         IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash);
 
         /// <summary>
-        /// Returns the <see cref="IAccountState"/> in the <see cref="BlockChain"/>
-        /// at <paramref name="offset"/>.
-        /// </summary>
-        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
-        /// for which to create an <see cref="IAccountState"/>.</param>
-        /// <param name="address">The <see cref="Address"/> of <see cref="IAccountState"/>
-        /// to be returned.</param>
-        /// <returns>
-        /// The <see cref="IAccountState"/> at <paramref name="offset"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/> is not
-        /// <see langword="null"/> and one of the following is true.
-        /// <list type="bullet">
-        ///     <item><description>
-        ///         Corresponding <see cref="Block"/> is not found in the <see cref="IStore"/>.
-        ///     </description></item>
-        ///     <item><description>
-        ///         Corresponding <see cref="Block"/> is found but its state root is not found
-        ///         in the <see cref="IStateStore"/>.
-        ///     </description></item>
-        /// </list>
-        /// </exception>
-        /// <seealso cref="IAccountState"/>
-        IAccountState GetAccountState(BlockHash? offset, Address address);
-
-        /// <summary>
-        /// Returns the <see cref="IAccountState"/> in the <see cref="BlockChain"/>
-        /// of root hash <paramref name="stateRootHash"/>.
-        /// </summary>
-        /// <param name="stateRootHash">The <see cref="HashDigest{SHA256}"/> of the root hash
-        /// for which to create an <see cref="IAccountState"/>.</param>
-        /// <returns>
-        /// The <see cref="IAccountState"/> of state root hash <paramref name="stateRootHash"/>.
-        /// </returns>
-        /// <seealso cref="IAccountState"/>
-        IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash);
-
-        /// <summary>
         /// Gets a state associated to specified <paramref name="address"/>.
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to fetch
-        /// the state from.</param>
-        /// <param name="accountAddress">The <see cref="Address"/> of the account to fetch
         /// the state from.</param>
         /// <param name="address">The <see cref="Address"/> of the state to query.</param>
         /// <returns>The state associated to specified <paramref name="address"/>.
@@ -117,7 +77,7 @@ namespace Libplanet.Action.State
         ///     </description></item>
         /// </list>
         /// </exception>
-        IValue? GetState(BlockHash? offset, Address accountAddress, Address address);
+        IValue? GetState(BlockHash? offset, Address address);
 
         /// <summary>
         /// Gets a state associated to specified <paramref name="address"/>.

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
@@ -43,17 +43,11 @@ public partial class StateQueryTest
         public IWorldState GetWorldState(BlockHash? blockHash) =>
             new MockWorld(ToStateRootHash(blockHash));
 
-        public IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash) =>
-            new MockAccount(stateRootHash);
-
-        public IAccountState GetAccountState(BlockHash? blockHash, Address address) =>
-            GetWorldState(blockHash).GetAccount(address);
-
         public IValue GetState(HashDigest<SHA256>? stateRootHash, Address address) =>
             new MockAccount(stateRootHash).GetState(address);
 
-        public IValue GetState(BlockHash? offset, Address accountAddress, Address address) =>
-            GetWorldState(offset).GetAccount(accountAddress).GetState(address);
+        public IValue GetState(BlockHash? blockHash, Address address) =>
+            new MockAccount(ToStateRootHash(blockHash)).GetState(address);
 
         public FungibleAssetValue GetBalance(
             HashDigest<SHA256>? stateRootHash, Address address, Currency currency) =>

--- a/Libplanet/Blockchain/BlockChain.States.cs
+++ b/Libplanet/Blockchain/BlockChain.States.cs
@@ -27,43 +27,24 @@ namespace Libplanet.Blockchain
         /// <returns>The current world state.</returns>
         public IWorldState GetWorldState() => GetWorldState(Tip.Hash);
 
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(BlockHash?, Address)"/>
-        public IAccountState GetAccountState(BlockHash? offset, Address address)
-            => _blockChainStates.GetAccountState(offset, address);
-
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(HashDigest{SHA256}?)"/>
-        public IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash)
-            => _blockChainStates.GetAccountState(stateRootHash);
-
-        /// <summary>
-        /// Gets the current account state of given <paramref name="address"/> in the
-        /// <see cref="BlockChain"/>.
-        /// </summary>
-        /// <param name="address">An <see cref="Address"/> to get the account states of.</param>
-        /// <returns>The current account state of given <paramref name="address"/>.</returns>
-        public IAccountState GetAccountState(Address address)
-            => GetAccountState(Tip.Hash, address);
-
-        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address, Address)"/>
-        public IValue GetState(BlockHash? offset, Address accountAddress, Address address)
-            => _blockChainStates.GetState(offset, accountAddress, address);
+        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address)"/>
+        public IValue GetState(BlockHash? offset, Address address) =>
+            _blockChainStates.GetState(offset, address);
 
         /// <inheritdoc cref="IBlockChainStates.GetState(HashDigest{SHA256}?, Address)"/>
-        public IValue GetState(HashDigest<SHA256>? stateRootHash, Address address)
-            => _blockChainStates.GetState(stateRootHash, address);
+        public IValue GetState(HashDigest<SHA256>? stateRootHash, Address address) =>
+            _blockChainStates.GetState(stateRootHash, address);
 
         /// <summary>
-        /// Gets the current state of given <paramref name="address"/> and
-        /// <paramref name="accountAddress"/> in the <see cref="BlockChain"/>.
+        /// Gets the current state of given <paramref name="address"/>
+        /// in the <see cref="BlockChain"/>.
         /// </summary>
-        /// <param name="accountAddress">An <see cref="Address"/> to get the states from.</param>
         /// <param name="address">An <see cref="Address"/> to get the states of.</param>
-        /// <returns>The current state of given <paramref name="address"/> and
-        /// <paramref name="accountAddress"/>.  This can be <see langword="null"/>
-        /// if <paramref name="address"/> or <paramref name="accountAddress"/> has no value.
+        /// <returns>The current state of given <paramref name="address"/>.
+        /// This can be <see langword="null"/> if <paramref name="address"/> has no value.
         /// </returns>
-        public IValue GetState(Address accountAddress, Address address)
-            => GetState(Tip.Hash, accountAddress, address);
+        public IValue GetState(Address address)
+            => GetState(Tip.Hash, address);
 
         /// <inheritdoc cref=
         /// "IBlockChainStates.GetBalance(BlockHash?, Address, Currency)"/>

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -34,21 +34,17 @@ namespace Libplanet.Blockchain
         public IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash)
             => new WorldBaseState(GetTrie(stateRootHash), _stateStore);
 
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(BlockHash?, Address)"/>
-        public IAccountState GetAccountState(BlockHash? offset, Address address)
-            => GetWorldState(offset).GetAccount(address);
-
-        /// <inheritdoc cref="IBlockChainStates.GetAccountState(HashDigest{SHA256}?)"/>
-        public IAccountState GetAccountState(HashDigest<SHA256>? stateRootHash)
-            => new AccountState(GetTrie(stateRootHash));
-
-        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address, Address)"/>
-        public IValue? GetState(BlockHash? offset, Address accountAddress, Address address)
-            => GetAccountState(offset, accountAddress).GetState(address);
+        /// <inheritdoc cref="IBlockChainStates.GetState(BlockHash?, Address)"/>
+        public IValue? GetState(BlockHash? offset, Address address) =>
+            GetWorldState(offset)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetState(address);
 
         /// <inheritdoc cref="IBlockChainStates.GetState(HashDigest{SHA256}?, Address)"/>
-        public IValue? GetState(HashDigest<SHA256>? stateRootHash, Address address)
-            => GetAccountState(stateRootHash).GetState(address);
+        public IValue? GetState(HashDigest<SHA256>? stateRootHash, Address address) =>
+            GetWorldState(stateRootHash)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetState(address);
 
         /// <inheritdoc cref=
         /// "IBlockChainStates.GetBalance(BlockHash?, Address, Currency)"/>
@@ -84,13 +80,16 @@ namespace Libplanet.Blockchain
                 .GetTotalSupply(currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?)"/>
-        public ValidatorSet GetValidatorSet(BlockHash? offset) => GetWorldState(offset)
-            .GetAccount(ReservedAddresses.LegacyAccount)
-            .GetValidatorSet();
+        public ValidatorSet GetValidatorSet(BlockHash? offset) =>
+            GetWorldState(offset)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetValidatorSet();
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)"/>
         public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash) =>
-            GetAccountState(stateRootHash).GetValidatorSet();
+            GetWorldState(stateRootHash)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetValidatorSet();
 
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -56,7 +56,8 @@ namespace Libplanet.Blockchain
             BlockHash? offset,
             Address address,
             Currency currency)
-            => GetAccountState(offset, ReservedAddresses.LegacyAccount)
+            => GetWorldState(offset)
+                .GetAccount(ReservedAddresses.LegacyAccount)
                 .GetBalance(address, currency);
 
         /// <inheritdoc cref=
@@ -64,28 +65,32 @@ namespace Libplanet.Blockchain
         public FungibleAssetValue GetBalance(
             HashDigest<SHA256>? stateRootHash,
             Address address,
-            Currency currency)
-            => GetAccountState(stateRootHash).GetBalance(address, currency);
+            Currency currency) => GetWorldState(stateRootHash)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetBalance(address, currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(BlockHash?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
             BlockHash? offset,
-            Currency currency)
-            => GetAccountState(offset, ReservedAddresses.LegacyAccount).GetTotalSupply(currency);
+            Currency currency) => GetWorldState(offset)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetTotalSupply(currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetTotalSupply(HashDigest{SHA256}?, Currency)"/>
         public FungibleAssetValue GetTotalSupply(
             HashDigest<SHA256>? stateRootHash,
-            Currency currency)
-            => GetAccountState(stateRootHash).GetTotalSupply(currency);
+            Currency currency) => GetWorldState(stateRootHash)
+                .GetAccount(ReservedAddresses.LegacyAccount)
+                .GetTotalSupply(currency);
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(BlockHash?)"/>
-        public ValidatorSet GetValidatorSet(BlockHash? offset)
-            => GetAccountState(offset, ReservedAddresses.LegacyAccount).GetValidatorSet();
+        public ValidatorSet GetValidatorSet(BlockHash? offset) => GetWorldState(offset)
+            .GetAccount(ReservedAddresses.LegacyAccount)
+            .GetValidatorSet();
 
         /// <inheritdoc cref="IBlockChainStates.GetValidatorSet(HashDigest{SHA256}?)"/>
-        public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash)
-            => GetAccountState(stateRootHash).GetValidatorSet();
+        public ValidatorSet GetValidatorSet(HashDigest<SHA256>? stateRootHash) =>
+            GetAccountState(stateRootHash).GetValidatorSet();
 
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>


### PR DESCRIPTION
Also with more consistent API. 😶

For example, most methods use either `BlockHash` or `HashDigest<SHA256>` as a reference point in time, but a method pair such as `GetState(BlockHash, Address)` and `GetState(HashDigest<SHA256>, Address, Address)` is quite **confusing** as to what it does and/or how `IBlockChainStates` was designed. 🙄