### PR TITLE
⏪ Revert changes to `IActionEvaluator` interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,18 +11,13 @@ To be released.
 ### Backward-incompatible API changes
 
  -  Bumped `BlockMetadata.CurrentProtocolVersion` to 5.  [[#3524]]
- -  Removed `BlockChain.EvaluateBlock(IPreEvaluationBlock)` method.
-    Instead, added
-    `BlockChain.EvaluateBlock(IPreEvaluationBlock, out HashDigest<SHA256>)`
-    method.
-    [[#3540]]
  -  Removed `BlockChain.GetBalance(Address, Currency, Address)` method.
     [[#3583]]
  -  Removed `BlockChain.GetTotalSupply(Currency, Address)` method.
     [[#3583]]
  -  (Libplanet.Action) Changed `ActionEvaluator` to accept `IWorld`
     instead of `IAccount`.  [[#3462]]
- -  (Libplanet.Action) `IActionEvaluator.OutputState` became `IWorld`.
+ -  (Libplanet.Action) `IActionEvaluation.OutputState` became `IWorld`.
     (was `IAccount`)  [[#3462]]
  -  (Libplanet.Action) `IAction.Execute()` became to return `IWorld`.
     (was `IAccount`)  [[#3462]]
@@ -49,12 +44,6 @@ To be released.
      -  Removed `IBlockChainStates.GetValidatorSet(BlockHash?)` method.
  -  (@planetarium/tx)  Remove the `T` generic argument of `SignedTx<T>`.
     [[#3512]]
- -  (Libplanet.Action)
-    Removed `ActionEvaluator.Evaluate(IPreEvaluationBlock)` method.
-    Instead, added
-    `ActionEvaluator.Evaluate(IPreEvaluationBlock, out HashDigest<SHA256>)`
-    method.
-    [[#3540]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -98,8 +98,7 @@ namespace Libplanet.Action
         [Pure]
         public IReadOnlyList<ICommittedActionEvaluation> Evaluate(
             IPreEvaluationBlock block,
-            HashDigest<SHA256>? baseStateRootHash,
-            out HashDigest<SHA256> stateRootHash)
+            HashDigest<SHA256>? baseStateRootHash)
         {
             _logger.Information(
                 "Evaluating actions in the block #{BlockIndex} " +
@@ -137,9 +136,6 @@ namespace Libplanet.Action
                 }
 
                 var committed = ToCommittedEvaluation(block, evaluations, baseStateRootHash);
-                stateRootHash = committed.Count > 0
-                    ? committed.Last().OutputState
-                    : previousState.Trie.Hash;
                 return committed;
             }
             catch (Exception e)

--- a/Libplanet.Action/IActionEvaluator.cs
+++ b/Libplanet.Action/IActionEvaluator.cs
@@ -23,8 +23,6 @@ namespace Libplanet.Action
         /// <param name="block">The block to evaluate.</param>
         /// <param name="baseStateRootHash">The base state to use when evaluating
         /// <paramref name="block"/>.</param>
-        /// <param name="stateRootHash">
-        /// Determined state root hash of the given <paramref name="block"/>.</param>
         /// <returns> The result of evaluating every <see cref="IAction"/> related to
         /// <paramref name="block"/> as an <see cref="IReadOnlyList{T}"/> of
         /// <see cref="ICommittedActionEvaluation"/>s.</returns>
@@ -42,7 +40,6 @@ namespace Libplanet.Action
         [Pure]
         IReadOnlyList<ICommittedActionEvaluation> Evaluate(
             IPreEvaluationBlock block,
-            HashDigest<SHA256>? baseStateRootHash,
-            out HashDigest<SHA256> stateRootHash);
+            HashDigest<SHA256>? baseStateRootHash);
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -697,7 +697,7 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.StageTransaction(txA1);
             Block block = _blockChain.ProposeBlock(miner);
             IReadOnlyList<ICommittedActionEvaluation> actionEvaluations =
-                _blockChain.EvaluateBlock(block, out _);
+                _blockChain.EvaluateBlock(block);
             Assert.Equal(0L, _blockChain.Tip.Index);
             _blockChain.Append(
                 block,
@@ -756,7 +756,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [SkippableFact]
-        public void MigrateStateWithoutAction()
+        public void DoesNotMigrateStateWithoutAction()
         {
             var policy = new BlockPolicy(
                 blockAction: null,
@@ -811,7 +811,7 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableList<Transaction>.Empty,
                 TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(emptyBlock, TestUtils.CreateBlockCommit(emptyBlock));
-            Assert.False(blockChain.GetWorldState().Legacy);
+            Assert.True(blockChain.GetWorldState().Legacy);
         }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -175,7 +175,7 @@ namespace Libplanet.Blockchain
                     HashDigest<SHA256>? baseStateRootHash =
                         Store.GetStateRootHash(block.PreviousHash);
                     IReadOnlyList<ICommittedActionEvaluation> evaluations =
-                        ActionEvaluator.Evaluate(block, baseStateRootHash, out _);
+                        ActionEvaluator.Evaluate(block, baseStateRootHash);
 
                     RenderActions(
                         evaluations: evaluations,


### PR DESCRIPTION
⏪ This changes (removes) the assumption that a block's output state's version is the same as the block's protocol version.

The rationale being:
- This **does not change** the fact that when evaluating a block, every `IAction` inside the block expects a state that has the same version as the block's protocol version (for those with version number greater than or equal to 5). This is because migration happens during the preparation phase.
- As far as I know, the assumption, for example, that the output state of a block with protocol version `5` has a state version `5` is not used anywhere (there may be certain cases where this may be useful, but the development/overhead cost is too great to impose such restriction). The first point, that is, every `IAction` in any block with protocol version `5` can assume a state of version `5` as its input **can be satisfied regardless** of whether output state version should match the block protocol version or not.
- The state version should be just that, without its meaning tied to outside context. In that regard, less assumptions, the better.

It is of my opinion that when we have something like

```csharp
IWorld world = GetWorld(block.StateRootHash);
```

the internal interpretation of retrieved `ITrie` should solely depend on `ITrie`'s version.

This changes the behavior **only when** an empty block (a block without any transaction **and** without policy block action is involved).