### PR TITLE
🐛 Fixed `IStateStore.Commit()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Version 3.9.5
 
 To be released.
 
+ -  (Libplanet.Store) Changed `IStateStore.Commit()` to return an `ITrie`
+    with either its `Root` as `null` or a `HashNode`.  [[#3610]]
+
 
 Version 3.9.4
 -------------

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Store
         /// <see cref="ITrie.Hash"/>.
         /// </summary>
         /// <param name="trie">The <see cref="ITrie"/> to commit.</param>
-        /// <returns>The committed <see cref="ITrie"/>.  The commited <see cref="ITrie"/>'s
+        /// <returns>The committed <see cref="ITrie"/>.  The committed <see cref="ITrie"/>'s
         /// <see cref="ITrie.Root"/> is guaranteed to be either <see langword="null"/>
         /// or a <see cref="HashNode"/>.</returns>
         /// <remarks>

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Common;
 using Libplanet.Store.Trie;
+using Libplanet.Store.Trie.Nodes;
 
 namespace Libplanet.Store
 {
@@ -34,7 +35,9 @@ namespace Libplanet.Store
         /// <see cref="ITrie.Hash"/>.
         /// </summary>
         /// <param name="trie">The <see cref="ITrie"/> to commit.</param>
-        /// <returns>The committed <see cref="ITrie"/>.</returns>
+        /// <returns>The committed <see cref="ITrie"/>.  The commited <see cref="ITrie"/>'s
+        /// <see cref="ITrie.Root"/> is guaranteed to be either <see langword="null"/>
+        /// or a <see cref="HashNode"/>.</returns>
         /// <remarks>
         /// Given <paramref name="trie"/> must have originated from the same instance
         /// (or with an instance with the same reference to an <see cref="IKeyValueStore"/>).

--- a/Libplanet.Store/Trie/MerkleTrie.Diff.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Diff.cs
@@ -61,7 +61,7 @@ namespace Libplanet.Store.Trie
                                     }
 
                                 case ShortNode shortNode:
-                                    queue.Enqueue((shortNode.Value!, path.AddRange(shortNode.Key)));
+                                    queue.Enqueue((shortNode.Value, path.AddRange(shortNode.Key)));
                                     continue;
 
                                 case FullNode fullNode:
@@ -104,7 +104,7 @@ namespace Libplanet.Store.Trie
                             continue;
 
                         case ShortNode shortNode:
-                            queue.Enqueue((shortNode.Value!, path.AddRange(shortNode.Key)));
+                            queue.Enqueue((shortNode.Value, path.AddRange(shortNode.Key)));
                             continue;
 
                         case FullNode fullNode:

--- a/Libplanet.Store/Trie/MerkleTrie.Insert.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.Insert.cs
@@ -94,7 +94,7 @@ namespace Libplanet.Store.Trie
                     ? fullNode.SetChild(
                         newChildIndex,
                         new ShortNode(newShortNodeKey, shortNode.Value))
-                    : fullNode.SetChild(newChildIndex, shortNode.Value!);
+                    : fullNode.SetChild(newChildIndex, shortNode.Value);
 
                 // Handles value node.
                 // Assumes next cursor nibble (including non-remaining case)

--- a/Libplanet.Store/TrieStateStore.Commit.cs
+++ b/Libplanet.Store/TrieStateStore.Commit.cs
@@ -36,9 +36,10 @@ namespace Libplanet.Store
                 {
                     IValue bencoded = newRoot.ToBencodex();
                     byte[] serialized = _codec.Encode(bencoded);
-                    byte[] hash = SHA256.Create().ComputeHash(serialized);
+                    HashDigest<SHA256> hashDigest = HashDigest<SHA256>.DeriveFrom(serialized);
 
-                    writeBatch.Add(new KeyBytes(hash), serialized);
+                    writeBatch.Add(new KeyBytes(hashDigest.ByteArray), serialized);
+                    newRoot = new HashNode(hashDigest);
                 }
 
                 writeBatch.Flush();

--- a/Libplanet.Tests/Store/TrieStateStoreCommitTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreCommitTest.cs
@@ -62,7 +62,7 @@ namespace Libplanet.Tests.Store
         }
 
         [Fact]
-        public void CommitedNonEmptyTrieRootIsHashNode()
+        public void CommittedNonEmptyTrieRootIsHashNode()
         {
             IKeyValueStore keyValueStore = new MemoryKeyValueStore();
             IStateStore stateStore = new TrieStateStore(keyValueStore);

--- a/Libplanet.Tests/Store/TrieStateStoreCommitTest.cs
+++ b/Libplanet.Tests/Store/TrieStateStoreCommitTest.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Linq;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Common;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
+using Libplanet.Store.Trie.Nodes;
 using Xunit;
 
 namespace Libplanet.Tests.Store
@@ -20,6 +22,7 @@ namespace Libplanet.Tests.Store
 
             Assert.Null(emptyTrie.Root);
             Assert.True(stateStore.GetStateRoot(emptyRootHash).Recorded);
+            Assert.Null(stateStore.GetStateRoot(emptyRootHash).Root);
             Assert.False(keyValueStore.Exists(new KeyBytes(emptyRootHash.ByteArray)));
 
             emptyTrie = stateStore.Commit(emptyTrie);
@@ -56,6 +59,20 @@ namespace Libplanet.Tests.Store
             Assert.Equal(2, trie.IterateValues().Count());
             Assert.Equal(new Text("2c73"), trie.Get(new KeyBytes(new byte[] { 0x2c, 0x73 })));
             Assert.Equal(new Text("234f"), trie.Get(new KeyBytes(new byte[] { 0x23, 0x4f })));
+        }
+
+        [Fact]
+        public void CommitedNonEmptyTrieRootIsHashNode()
+        {
+            IKeyValueStore keyValueStore = new MemoryKeyValueStore();
+            IStateStore stateStore = new TrieStateStore(keyValueStore);
+            ITrie trie = stateStore.GetStateRoot(null);
+            trie = trie.Set(new KeyBytes(Array.Empty<byte>()), new Integer(1));
+            trie = stateStore.Commit(trie);
+            HashNode root = Assert.IsType<HashNode>(trie.Root);
+            trie = stateStore.GetStateRoot(trie.Hash);
+            Assert.IsType<HashNode>(trie.Root);
+            Assert.Equal(root, trie.Root);
         }
     }
 }


### PR DESCRIPTION
With better specification. 😶
This only affects edge cases where the committed `ITrie` is so small its entire `IValue` encoding length is than `HashDigest<SHA256>.Size`. There are possible cases where other storage related methods may fail due to this.