### PR TITLE
♻️ Refactored `PruneStates()`

### DIFF
--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -22,7 +22,8 @@ namespace Libplanet.Store
         ITrie GetStateRoot(HashDigest<SHA256>? stateRootHash);
 
         /// <summary>
-        /// Prunes the states no more used from the state store.
+        /// Prunes all states that aren't reachable
+        /// from <paramref name="survivingStateRootHashes"/>.
         /// </summary>
         /// <param name="survivingStateRootHashes">The state root hashes <em>not</em> to prune.
         /// These state root hashes are guaranteed to survive after pruning.</param>

--- a/Libplanet.Store/IStateStore.cs
+++ b/Libplanet.Store/IStateStore.cs
@@ -27,6 +27,11 @@ namespace Libplanet.Store
         /// </summary>
         /// <param name="survivingStateRootHashes">The state root hashes <em>not</em> to prune.
         /// These state root hashes are guaranteed to survive after pruning.</param>
+        /// <remarks>
+        /// As <see cref="Bencodex"/> fingerprinting has been removed and is no longer supported,
+        /// any <see cref="IStateStore"/> with fingerprinted states stored may no longer work
+        /// as expected once pruned.
+        /// </remarks>
         void PruneStates(IImmutableSet<HashDigest<SHA256>> survivingStateRootHashes);
 
         /// <summary>

--- a/Libplanet.Store/Trie/MerkleTrie.cs
+++ b/Libplanet.Store/Trie/MerkleTrie.cs
@@ -179,12 +179,6 @@ namespace Libplanet.Store.Trie
             }
         }
 
-        internal IEnumerable<HashDigest<SHA256>> IterateHashNodes()
-        {
-            return IterateNodes().Where(pair => pair.Node is HashNode)
-                .Select(pair => ((HashNode)pair.Node).HashDigest);
-        }
-
         /// <summary>
         /// Iterates over <see cref="KeyBytes"/> and <see cref="byte[]"/> pairs stored
         /// necessary to fully represent this <see cref="ITrie"/>.

--- a/Libplanet.Store/TrieStateStore.cs
+++ b/Libplanet.Store/TrieStateStore.cs
@@ -70,8 +70,7 @@ namespace Libplanet.Store
             {
                 // FIXME: Bencodex fingerprints also should be tracked.
                 //        https://github.com/planetarium/libplanet/issues/1653
-                if (stateKey.Length != HashDigest<SHA256>.Size ||
-                    survivalNodes.Contains(stateKey))
+                if (survivalNodes.Contains(stateKey))
                 {
                     continue;
                 }


### PR DESCRIPTION
Since `Bencodex`'s fingerprinting was removed, [libplanet](https://github.com/planetarium/libplanet) has lost its support for backward compatibility with `IStateStore` that has used fingerprinting at some point (sadly which is the case for 9c). Preserving `IStateStore` compatibility was never properly implemented in the first place, so this haphazardly implemented incomplete feature has been removed. 😑

I don't think `PruneStates()` can be implemented properly in any useful manner. As `IStateStore` grows, `PruneStates()` will always be too slow to use unless the `IStateStore` in question is pruned frequently and continuously. Using `CopyStates()` and replacing the original `IStateStore` with a copied `IStateStore` will always be a more practical solution for this purpose.