### PR TITLE
Removed '#nullable disable' from the Libplanet.Strun project

### DIFF
--- a/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -5,7 +5,8 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/Libplanet.Stun.Tests/Stun/Messages/StunMessageTest.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/StunMessageTest.cs
@@ -101,8 +101,13 @@ namespace Libplanet.Stun.Tests.Messages
 
         private class AttributeComparer : IEqualityComparer<Attribute>
         {
-            public bool Equals(Attribute x, Attribute y)
+            public bool Equals(Attribute? x, Attribute? y)
             {
+                if (x is null || y is null)
+                {
+                    return false;
+                }
+
                 return x.ToByteArray().SequenceEqual(y.ToByteArray());
             }
 

--- a/Libplanet.Stun.Tests/Stun/Messages/TestStunContext.cs
+++ b/Libplanet.Stun.Tests/Stun/Messages/TestStunContext.cs
@@ -1,13 +1,15 @@
+using System;
+
 namespace Libplanet.Stun.Tests.Messages
 {
     internal class TestStunContext : IStunContext
     {
-        public string Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
-        public string Password { get; set; }
+        public string Password { get; set; } = string.Empty;
 
-        public string Realm { get; set; }
+        public string Realm { get; set; } = string.Empty;
 
-        public byte[] Nonce { get; set; }
+        public byte[] Nonce { get; set; } = Array.Empty<byte>();
     }
 }

--- a/Libplanet.Stun/Stun/Attributes/Attribute.cs
+++ b/Libplanet.Stun/Stun/Attributes/Attribute.cs
@@ -1,4 +1,4 @@
-#nullable disable
+using System;
 using System.IO;
 
 namespace Libplanet.Stun.Attributes
@@ -139,7 +139,9 @@ namespace Libplanet.Stun.Attributes
 
         public abstract AttributeType Type { get; }
 
-        public byte[] ToByteArray(byte[] transactionId = null)
+        public byte[] ToByteArray() => ToByteArray(Array.Empty<byte>());
+
+        public byte[] ToByteArray(byte[] transactionId)
         {
             var payload = EncodePayload(transactionId);
             using var ms = new MemoryStream();

--- a/Libplanet.Stun/Stun/Attributes/ConnectionId.cs
+++ b/Libplanet.Stun/Stun/Attributes/ConnectionId.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Attributes
 {
     public class ConnectionId : Attribute

--- a/Libplanet.Stun/Stun/Attributes/ErrorCode.cs
+++ b/Libplanet.Stun/Stun/Attributes/ErrorCode.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.IO;
 using System.Text;
 

--- a/Libplanet.Stun/Stun/Attributes/Fingerprint.cs
+++ b/Libplanet.Stun/Stun/Attributes/Fingerprint.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Attributes
 {
     public class Fingerprint : Attribute

--- a/Libplanet.Stun/Stun/Attributes/Lifetime.cs
+++ b/Libplanet.Stun/Stun/Attributes/Lifetime.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Attributes
 {
     public class Lifetime : Attribute

--- a/Libplanet.Stun/Stun/Attributes/MessageIntegrity.cs
+++ b/Libplanet.Stun/Stun/Attributes/MessageIntegrity.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Security.Cryptography;
 using System.Text;
 

--- a/Libplanet.Stun/Stun/Attributes/Nonce.cs
+++ b/Libplanet.Stun/Stun/Attributes/Nonce.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Attributes
 {
     public class Nonce : Attribute

--- a/Libplanet.Stun/Stun/Attributes/Realm.cs
+++ b/Libplanet.Stun/Stun/Attributes/Realm.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Text;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/Attributes/RequestedTransport.cs
+++ b/Libplanet.Stun/Stun/Attributes/RequestedTransport.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Attributes
 {
     public class RequestedTransport : Attribute

--- a/Libplanet.Stun/Stun/Attributes/Software.cs
+++ b/Libplanet.Stun/Stun/Attributes/Software.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Text;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/Attributes/StunAddressExtensions.cs
+++ b/Libplanet.Stun/Stun/Attributes/StunAddressExtensions.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.IO;
 using System.Linq;
@@ -93,11 +92,21 @@ namespace Libplanet.Stun.Attributes
         }
 
         public static IPEndPoint DecodeStunAddress(
-            this byte[] encoded, byte[] transactionId
-        )
+            this byte[] encoded)
+        {
+            return DecodeStunAddress(encoded, Array.Empty<byte>(), inTransaction: false);
+        }
+
+        public static IPEndPoint DecodeStunAddress(
+            this byte[] encoded, byte[] transactionId)
+        {
+            return DecodeStunAddress(encoded, transactionId, inTransaction: true);
+        }
+
+        private static IPEndPoint DecodeStunAddress(
+            this byte[] encoded, byte[] transactionId, bool inTransaction)
         {
             uint cookie = StunMessage.MagicCookie.ToUInt();
-            bool inTransaction = transactionId != null;
 
             using var ms = new MemoryStream(encoded);
             ms.ReadByte();
@@ -110,7 +119,7 @@ namespace Libplanet.Stun.Attributes
                 ? (int)(portBytes.ToUShort() ^ (cookie >> 16))
                 : portBytes.ToUShort();
 
-            byte[] addrBytes = null;
+            byte[] addrBytes = Array.Empty<byte>();
             switch (family)
             {
                 case StunAf.IpV4:

--- a/Libplanet.Stun/Stun/Attributes/Username.cs
+++ b/Libplanet.Stun/Stun/Attributes/Username.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Text;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/Attributes/XorMappedAddress.cs
+++ b/Libplanet.Stun/Stun/Attributes/XorMappedAddress.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Net;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/Attributes/XorPeerAddress.cs
+++ b/Libplanet.Stun/Stun/Attributes/XorPeerAddress.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Net;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/Attributes/XorRelayedAddress.cs
+++ b/Libplanet.Stun/Stun/Attributes/XorRelayedAddress.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Net;
 
 namespace Libplanet.Stun.Attributes

--- a/Libplanet.Stun/Stun/IStunContext.cs
+++ b/Libplanet.Stun/Stun/IStunContext.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun
 {
     public interface IStunContext

--- a/Libplanet.Stun/Stun/Messages/AllocateErrorResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/AllocateErrorResponse.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using Libplanet.Stun.Attributes;
 
 namespace Libplanet.Stun.Messages
@@ -13,8 +12,8 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                ErrorCode attr = GetAttribute<ErrorCode>();
-                return attr.Code;
+                ErrorCode? attr = GetAttribute<ErrorCode>();
+                return attr?.Code ?? 0;
             }
         }
 
@@ -22,8 +21,8 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                ErrorCode attr = GetAttribute<ErrorCode>();
-                return attr?.Reason;
+                ErrorCode? attr = GetAttribute<ErrorCode>();
+                return attr?.Reason ?? string.Empty;
             }
         }
 
@@ -31,8 +30,8 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                Attributes.Nonce attr = GetAttribute<Attributes.Nonce>();
-                return attr?.Value;
+                Nonce? attr = GetAttribute<Nonce>();
+                return attr?.Value ?? System.Array.Empty<byte>();
             }
         }
 
@@ -40,8 +39,8 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                Realm attr = GetAttribute<Realm>();
-                return attr?.Value;
+                Realm? attr = GetAttribute<Realm>();
+                return attr?.Value ?? string.Empty;
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/AllocateRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/AllocateRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using Libplanet.Stun.Attributes;
 

--- a/Libplanet.Stun/Stun/Messages/AllocateSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/AllocateSuccessResponse.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Net;
 using Libplanet.Stun.Attributes;
 
@@ -14,7 +13,7 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                return GetAttribute<XorRelayedAddress>()?.EndPoint;
+                return GetAttribute<XorRelayedAddress>()!.EndPoint;
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/BindingRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/BindingRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using Libplanet.Stun.Attributes;
 

--- a/Libplanet.Stun/Stun/Messages/BindingSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/BindingSuccessResponse.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Net;
 using Libplanet.Stun.Attributes;
 
@@ -14,7 +13,7 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                return GetAttribute<XorMappedAddress>()?.EndPoint;
+                return GetAttribute<XorMappedAddress>()!.EndPoint;
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/ConnectRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/ConnectRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using System.Net;
 using Libplanet.Stun.Attributes;

--- a/Libplanet.Stun/Stun/Messages/ConnectSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/ConnectSuccessResponse.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Messages
 {
     public class ConnectSuccessResponse : StunMessage

--- a/Libplanet.Stun/Stun/Messages/ConnectionAttempt.cs
+++ b/Libplanet.Stun/Stun/Messages/ConnectionAttempt.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using Libplanet.Stun.Attributes;
 
 namespace Libplanet.Stun.Messages
@@ -14,7 +13,7 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                return GetAttribute<ConnectionId>()?.Value;
+                return GetAttribute<ConnectionId>()!.Value;
             }
         }
     }

--- a/Libplanet.Stun/Stun/Messages/ConnectionBindRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/ConnectionBindRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using Libplanet.Stun.Attributes;
 

--- a/Libplanet.Stun/Stun/Messages/ConnectionBindSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/ConnectionBindSuccessResponse.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Messages
 {
     public class ConnectionBindSuccessResponse : StunMessage

--- a/Libplanet.Stun/Stun/Messages/CreatePermissionErrorResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/CreatePermissionErrorResponse.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Messages
 {
     public class CreatePermissionErrorResponse : StunMessage

--- a/Libplanet.Stun/Stun/Messages/CreatePermissionRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/CreatePermissionRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using System.Net;
 using Libplanet.Stun.Attributes;

--- a/Libplanet.Stun/Stun/Messages/CreatePermissionSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/CreatePermissionSuccessResponse.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace Libplanet.Stun.Messages
 {
     public class CreatePermissionSuccessResponse : StunMessage

--- a/Libplanet.Stun/Stun/Messages/RefreshErrorResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/RefreshErrorResponse.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using Libplanet.Stun.Attributes;
 
 namespace Libplanet.Stun.Messages
@@ -13,7 +12,7 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                ErrorCode attr = GetAttribute<ErrorCode>();
+                ErrorCode attr = GetAttribute<ErrorCode>()!;
                 return attr.Code;
             }
         }
@@ -22,7 +21,7 @@ namespace Libplanet.Stun.Messages
         {
             get
             {
-                Nonce attr = GetAttribute<Nonce>();
+                Nonce attr = GetAttribute<Nonce>()!;
                 return attr.Value;
             }
         }

--- a/Libplanet.Stun/Stun/Messages/RefreshRequest.cs
+++ b/Libplanet.Stun/Stun/Messages/RefreshRequest.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections.Generic;
 using Libplanet.Stun.Attributes;
 

--- a/Libplanet.Stun/Stun/Messages/RefreshSuccessResponse.cs
+++ b/Libplanet.Stun/Stun/Messages/RefreshSuccessResponse.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using Libplanet.Stun.Attributes;
 
 namespace Libplanet.Stun.Messages
@@ -9,6 +8,6 @@ namespace Libplanet.Stun.Messages
 
         public override MessageMethod Method => MessageMethod.Refresh;
 
-        public int Lifetime => GetAttribute<Lifetime>().Value;
+        public int Lifetime => GetAttribute<Lifetime>()!.Value;
     }
 }


### PR DESCRIPTION
Removed the ``#nullable enable`` keyword defined at the top of some files in the ``Stun project`` and fixed a build error.