### PR TITLE
Removal of '#nullable disable' from the Libplanet.Net project (etc)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,17 @@ To be released.
 
 ### Backward-incompatible network protocol changes
 
+ -  (Libplanet.Net) Changed some types due to removal of 'nullable keyword'.
+    [[#3669]]
+     - Changed `blocks` parameter type of `Branch` class constructor from
+       `IEnumerable<(Block, BlockCommit)>` to
+       `IEnumerable<(Block, BlockCommit?)>`.
+     - Changed `AppProtocolVersion.Extra` field type from `IValue` to `IValue?`.
+     - Changed `extra` parameter type of `AppProtocolVersion` class constructor
+       from `IValue` to `IValue?`.
+     - Changed `extra` parameter type of `AppProtocolVersion.Sign` method
+       from `IValue` to `IValue?`.
+
 ### Backward-incompatible storage format changes
 
 ### Added APIs
@@ -33,6 +44,7 @@ To be released.
 [#3622]: https://github.com/planetarium/libplanet/pull/3622
 [#3644]: https://github.com/planetarium/libplanet/pull/3644
 [#3651]: https://github.com/planetarium/libplanet/pull/3651
+[#3669]: https://github.com/planetarium/libplanet/pull/3669
 
 
 Version 4.0.4

--- a/Libplanet.Net.Tests/BlockCandidateTableTest.cs
+++ b/Libplanet.Net.Tests/BlockCandidateTableTest.cs
@@ -24,14 +24,14 @@ namespace Libplanet.Net.Tests
 
             // Ignore existing key
             var firstBranch = new Branch(
-                new List<(Block, BlockCommit)>
+                new List<(Block, BlockCommit?)>
                 {
                     (_fx.Block2, TestUtils.CreateBlockCommit(_fx.Block2)),
                     (_fx.Block3, TestUtils.CreateBlockCommit(_fx.Block3)),
                     (_fx.Block4, TestUtils.CreateBlockCommit(_fx.Block4)),
                 });
             var secondBranch = new Branch(
-                new List<(Block, BlockCommit)>
+                new List<(Block, BlockCommit?)>
                 {
                     (_fx.Block3, TestUtils.CreateBlockCommit(_fx.Block3)),
                     (_fx.Block4, TestUtils.CreateBlockCommit(_fx.Block4)),

--- a/Libplanet.Net/AppProtocolVersion.cs
+++ b/Libplanet.Net/AppProtocolVersion.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
@@ -34,7 +33,7 @@ namespace Libplanet.Net
         /// Optional extra data about the version.  This can be used for any purpose
         /// by apps, such as a URL to download the software.
         /// </summary>
-        public readonly IValue Extra;
+        public readonly IValue? Extra;
 
         /// <summary>
         /// A signer who claims presence of a version.
@@ -54,7 +53,7 @@ namespace Libplanet.Net
         /// <param name="signer">Gets the <see cref="Signer"/>.</param>
         public AppProtocolVersion(
             int version,
-            IValue extra,
+            IValue? extra,
             ImmutableArray<byte> signature,
             Address signer
         )
@@ -121,7 +120,7 @@ namespace Libplanet.Net
         /// <returns>A signed version claim.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="signer"/> is
         /// <see langword="null"/>.</exception>
-        public static AppProtocolVersion Sign(PrivateKey signer, int version, IValue extra = null)
+        public static AppProtocolVersion Sign(PrivateKey signer, int version, IValue? extra = null)
         {
             if (signer is null)
             {
@@ -201,7 +200,7 @@ namespace Libplanet.Net
                 throw new FormatException($"Failed to parse a signature: {token}", e);
             }
 
-            IValue extra = null;
+            IValue? extra = null;
             if (pos >= 0)
             {
                 pos++;
@@ -246,7 +245,7 @@ namespace Libplanet.Net
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is AppProtocolVersion other && Equals(other);
 
         /// <inheritdoc/>
@@ -279,7 +278,7 @@ namespace Libplanet.Net
         /// </summary>
         /// <returns>A deterministic message to sign.</returns>
         [Pure]
-        private static byte[] GetMessage(int version, IValue extra)
+        private static byte[] GetMessage(int version, IValue? extra)
         {
             byte[] msg = NetworkOrderBitsConverter.GetBytes(version);
             if (!(extra is null))

--- a/Libplanet.Net/AssemblyInfo.cs
+++ b/Libplanet.Net/AssemblyInfo.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Libplanet.Benchmarks")]

--- a/Libplanet/Blockchain/Branch.cs
+++ b/Libplanet/Blockchain/Branch.cs
@@ -28,9 +28,9 @@ namespace Libplanet.Blockchain
         ///     </description></item>
         /// </list>
         /// </exception>
-        public Branch(IEnumerable<(Block, BlockCommit)> blocks)
+        public Branch(IEnumerable<(Block, BlockCommit?)> blocks)
         {
-            ImmutableArray<(Block, BlockCommit)> sorted =
+            ImmutableArray<(Block, BlockCommit?)> sorted =
                 blocks.OrderBy(block => block.Item1.Index).ToImmutableArray();
             if (!sorted.Any())
             {
@@ -71,6 +71,6 @@ namespace Libplanet.Blockchain
         ///     </description></item>
         /// </list>
         /// </summary>
-        public ImmutableArray<(Block, BlockCommit)> Blocks { get; }
+        public ImmutableArray<(Block, BlockCommit?)> Blocks { get; }
     }
 }


### PR DESCRIPTION
🔪 This PR contains only other changes, excluding code related to swarm and transfer.