### PR TITLE
🔧  fix: catch throws for sure

### DIFF
--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -382,8 +382,12 @@ namespace Libplanet.Net.Tests
             );
 
             await Task.Delay(100);
-            cts.Cancel();
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            {
+                cts.Cancel();
+                return task;
+            });
             CleaningSwarm(swarm);
         }
 


### PR DESCRIPTION
# Context
[Libplanet.Net.Tests.SwarmTest.Cancel](https://github.com/planetarium/libplanet/blob/eed6a69dbfa910db1a2d00eaa5df55f002197a65/Libplanet.Net.Tests/SwarmTest.cs#L374) is flaky. And I'm suspicious it is a timing issue.

# Rationale
To make sure, I move `cts.Cancel()` to an anonymous method.