### PR TITLE
Fix Mortgage not to clean TotalUpdatedFungibleAssets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 4.0.6
 
 To be released.
 
+ -  (Libplanet.Action) Fixed a bug where `FeeCollector.Mortgage()`
+    unintentionally resets accumulated `Account.TotalUpdatedFungibleAssets`.
+    [[#3680]]
+
+[#3680]: https://github.com/planetarium/libplanet/pull/3680
+
 
 Version 4.0.5
 -------------

--- a/Libplanet.Action/FeeCollector.cs
+++ b/Libplanet.Action/FeeCollector.cs
@@ -81,7 +81,7 @@ namespace Libplanet.Action
                 throw new InsufficientBalanceException(msg, _context.Signer, balance);
             }
 
-            IAccount nextAccount = new Account(account).BurnAsset(
+            IAccount nextAccount = account.BurnAsset(
                 _context,
                 _context.Signer,
                 realGasPrice * _context.GasLimit());


### PR DESCRIPTION
`TotalUpdatedFungibleAssets` has been omitted since replacement of `Account` has been happend on `Mortgage`.
This makes `TotalUpdatedFungibleAssets` of transactions untractable, except last transaction of block.

This was an unintended error, so fix on this PR.