### PR TITLE
🔀 ci: use large runner

### DIFF
--- a/.github/workflows/benchmarks-merged.yml
+++ b/.github/workflows/benchmarks-merged.yml
@@ -16,9 +16,10 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
+#       opt-out until we have a macos self-hosted runner
+#       - macos-latest
+        - linux-8cores
+        - windows-8cores
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -14,9 +14,10 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
+#       opt-out until we have a macos self-hosted runner
+#       - macos-latest
+        - linux-8cores
+        - windows-8cores
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
SSIA

Note we do not have the `macos-8cores`. For effectiveness, opt out of the macos benchmark until we introduce macos self-hosted large runner. 