### PR TITLE
🚀  release: 4.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,7 @@ Libplanet changelog
 Version 4.1.0
 -------------
 
-To be released.
-
-### Deprecated APIs
+Released on March 8, 2024.
 
 ### Backward-incompatible API changes
 
@@ -32,8 +30,6 @@ To be released.
      - Changed `extra` parameter type of `AppProtocolVersion.Sign` method
        from `IValue` to `IValue?`.
 
-### Backward-incompatible storage format changes
-
 ### Added APIs
 
  -  (Libplanet.Store.Remote) Introduce
@@ -46,11 +42,6 @@ To be released.
  -  (Libplanet.Store) Optimized `ITrie.IterateNodes()` to greatly
     reduce the amount of memory used.  [[#3687]]
 
-### Bug fixes
-
-### Dependencies
-
-### CLI tools
 
 [#3622]: https://github.com/planetarium/libplanet/pull/3622
 [#3644]: https://github.com/planetarium/libplanet/pull/3644


### PR DESCRIPTION
### Backward-incompatible API changes

 -  Removed the '#nullable disable' from 3 projects
    (Action, Common, Explorer). [[#3622]]
 -  Removed the '#nullable disable' from the Libplanet.Store project. [[#3644]]
 -  Removed the '#nullable disable' from the Libplanet.RocksDBStore project.
    [[#3651]]
 -  Removed `BaseIndex` class and changed `BlockSet` base class from
    `BaseIndex<BlockHash, Block>` to `IReadOnlyDictionary<BlockHash, Block>`.
    [[#3686]]

### Backward-incompatible network protocol changes

 -  (Libplanet.Net) Changed some types due to removal of 'nullable keyword'.
    [[#3669]]
     - Changed `blocks` parameter type of `Branch` class constructor from
       `IEnumerable<(Block, BlockCommit)>` to
       `IEnumerable<(Block, BlockCommit?)>`.
     - Changed `AppProtocolVersion.Extra` field type from `IValue` to `IValue?`.
     - Changed `extra` parameter type of `AppProtocolVersion` class constructor
       from `IValue` to `IValue?`.
     - Changed `extra` parameter type of `AppProtocolVersion.Sign` method
       from `IValue` to `IValue?`.

### Added APIs

 -  (Libplanet.Store.Remote) Introduce
    `Libplanet.Store.Server.RemoteKeyValueService`  [[#3688]]
 -  (Libplanet.Store.Remote) Introduce
   `Libplanet.Store.Client.RemoteKeyValueStore`  [[#3688]]

### Behavioral changes

 -  (Libplanet.Store) Optimized `ITrie.IterateNodes()` to greatly
    reduce the amount of memory used.  [[#3687]]