### PR TITLE
🧹 Removed unnecessary methods and properties from `IWorldDelta`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ To be released.
     methods from `IAccount` to `IWorld`.  [[#3694], [#3697]]
  -  (Libplanet.Action) Removed `TotalSupplyDiff`, `FungibleAssetValueDiff`,
     and `ValidatorDiff` properties from `AccountDiff`.  [[#3694], [#3697]]
+ -  (Libplanet.Action) Removed `Uncommitted` property and `CommitAccount()`
+    method from `IWorldDelta`.  [[#3694], [#3699]]
 
 ### Backward-incompatible network protocol changes
 
@@ -33,6 +35,7 @@ To be released.
 
 [#3694]: https://github.com/planetarium/libplanet/issues/3694
 [#3697]: https://github.com/planetarium/libplanet/pull/3697
+[#3699]: https://github.com/planetarium/libplanet/pull/3699
 
 
 Version 4.1.0

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -579,28 +579,23 @@ namespace Libplanet.Action
                 new WorldBaseState(
                     stateStore.Commit(prevWorld.GetAccount(ReservedAddresses.LegacyAccount).Trie),
                     stateStore),
-                prevWorld.Delta.CommitAccount(ReservedAddresses.LegacyAccount),
+                new WorldDelta(),
                 prevWorld.TotalUpdatedFungibleAssets);
         }
 
         private static IWorld CommitWorld(IWorld prevWorld, IStateStore stateStore)
         {
             var worldTrie = prevWorld.Trie;
-            var worldDelta = prevWorld.Delta;
-            foreach (var account in prevWorld.Delta.Uncommitted)
+            foreach (var account in prevWorld.Delta.Accounts)
             {
                 var accountTrie = stateStore.Commit(account.Value.Trie);
                 worldTrie = worldTrie.Set(
                     ToStateKey(account.Key), new Binary(accountTrie.Hash.ByteArray));
-                worldDelta = worldDelta.SetAccount(
-                    account.Key,
-                    new Account(new AccountState(accountTrie)));
-                worldDelta = worldDelta.CommitAccount(account.Key);
             }
 
             return new World(
                 new WorldBaseState(stateStore.Commit(worldTrie), stateStore),
-                worldDelta,
+                new WorldDelta(),
                 prevWorld.TotalUpdatedFungibleAssets);
         }
 

--- a/Libplanet.Action/State/IWorldDelta.cs
+++ b/Libplanet.Action/State/IWorldDelta.cs
@@ -14,14 +14,6 @@ namespace Libplanet.Action.State
         IImmutableDictionary<Address, IAccount> Accounts { get; }
 
         /// <summary>
-        /// A dictionary representing changed account states for each <see cref="Address"/>.
-        /// Elements of this collection are removed when <see cref="CommitAccount"/> called
-        /// by corresponding <see cref="Address"/>.
-        /// </summary>
-        [Pure]
-        IImmutableDictionary<Address, IAccount> Uncommitted { get; }
-
-        /// <summary>
         /// Set account on both of <see cref="Accounts"/> and <see cref="Uncommitted"/>
         /// dictionaries. If <see cref="IAccount"/> already exists on
         /// <paramref name="address"/>, update with new <paramref name="account"/>.
@@ -31,19 +23,5 @@ namespace Libplanet.Action.State
         /// <returns>New <see cref="IWorldDelta"/> that account is properly set.</returns>
         [Pure]
         IWorldDelta SetAccount(Address address, IAccount account);
-
-        /// <summary>
-        /// Remove item from <see cref="Uncommitted"/> dictionary where its key is
-        /// <paramref name="address"/>.
-        /// </summary>
-        /// <param name="address"><see cref="Address"/> of <see cref="IAccount"/> to
-        /// remove from <see cref="Uncommitted"/>.</param>
-        /// <returns>
-        /// New <see cref="IWorldDelta"/> item of <paramref name="address"/> removed from
-        /// <see cref="Uncommitted"/>.
-        /// If corresponding uncommitted does not exist, returns identical one.
-        /// </returns>
-        [Pure]
-        IWorldDelta CommitAccount(Address address);
     }
 }

--- a/Libplanet.Action/State/WorldDelta.cs
+++ b/Libplanet.Action/State/WorldDelta.cs
@@ -6,51 +6,23 @@ namespace Libplanet.Action.State
 {
     public class WorldDelta : IWorldDelta
     {
-        private readonly IImmutableDictionary<Address, AccountItem> _accounts;
+        private readonly IImmutableDictionary<Address, IAccount> _accounts;
 
         public WorldDelta()
         {
-            _accounts = ImmutableDictionary<Address, AccountItem>.Empty;
+            _accounts = ImmutableDictionary<Address, IAccount>.Empty;
         }
 
-        private WorldDelta(IImmutableDictionary<Address, AccountItem> accounts)
+        private WorldDelta(IImmutableDictionary<Address, IAccount> accounts)
         {
             _accounts = accounts;
         }
 
         /// <inheritdoc cref="IWorldDelta.Accounts"/>
-        public IImmutableDictionary<Address, IAccount> Accounts
-            => _accounts
-                .ToImmutableDictionary(item => item.Key, item => item.Value.Account);
-
-        /// <inheritdoc cref="IWorldDelta.Uncommitted"/>
-        public IImmutableDictionary<Address, IAccount> Uncommitted
-            => _accounts
-                .Where(item => !item.Value.Committed)
-                .ToImmutableDictionary(item => item.Key, item => item.Value.Account);
+        public IImmutableDictionary<Address, IAccount> Accounts => _accounts;
 
         /// <inheritdoc cref="IWorldDelta.SetAccount"/>
         public IWorldDelta SetAccount(Address address, IAccount account)
-            => new WorldDelta(_accounts.SetItem(address, new AccountItem(account, false)));
-
-        /// <inheritdoc cref="IWorldDelta.CommitAccount"/>
-        public IWorldDelta CommitAccount(Address address)
-            => _accounts.TryGetValue(address, out AccountItem accountItem)
-                ? new WorldDelta(
-                    _accounts.SetItem(address, new AccountItem(accountItem.Account, true)))
-                : this;
-
-        internal struct AccountItem
-        {
-            public AccountItem(IAccount account, bool committed)
-            {
-                Account = account;
-                Committed = committed;
-            }
-
-            public IAccount Account { get; }
-
-            public bool Committed { get; set; }
-        }
+            => new WorldDelta(_accounts.SetItem(address, account));
     }
 }


### PR DESCRIPTION
🧹 Closes #3694.
Since `TotalUpdatedFungibleAssets` have moved to `IWorld`, `IWorldDelta` can be cleared during commit. 🙂
